### PR TITLE
[ui][iOS] Fix MaskedView safe area insets

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets.
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
 - [Android] Fix unexpected resize when opening the calendar from spinner mode on Android. ([#47273](https://github.com/expo/expo/issues/47273) by [@TomCorvus](https://github.com/TomCorvus)) ([#48125](https://github.com/expo/expo/pull/48125) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [iOS] Fix `tvOS` build failure in the SwiftUI `menuOrder` modifier — `MenuOrder.priority` is unavailable on tvOS, so it now falls back to `.automatic` there. ([#48111](https://github.com/expo/expo/pull/48111) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -44,7 +44,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets.
+- [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets. ([#48243](https://github.com/expo/expo/pull/48243) by [@Elehiggle](https://github.com/Elehiggle))
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
 - [Android] Fix unexpected resize when opening the calendar from spinner mode on Android. ([#47273](https://github.com/expo/expo/issues/47273) by [@TomCorvus](https://github.com/TomCorvus)) ([#48125](https://github.com/expo/expo/pull/48125) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [iOS] Fix `tvOS` build failure in the SwiftUI `menuOrder` modifier — `MenuOrder.priority` is unavailable on tvOS, so it now falls back to `.automatic` there. ([#48111](https://github.com/expo/expo/pull/48111) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/src/community/masked-view/MaskedView.ios.tsx
+++ b/packages/expo-ui/src/community/masked-view/MaskedView.ios.tsx
@@ -16,7 +16,7 @@ export function MaskedView(props: MaskedViewProps) {
   // and transforms because the inner views inherit layout from `absoluteFill`.
   return (
     <View {...viewProps} style={style}>
-      <Host style={StyleSheet.absoluteFill}>
+      <Host style={StyleSheet.absoluteFill} ignoreSafeArea="all">
         <Mask alignment="topLeading">
           <RNHostView>
             <View style={StyleSheet.absoluteFill}>{children}</View>

--- a/packages/expo-ui/src/community/masked-view/__tests__/MaskedView.test.ios.tsx
+++ b/packages/expo-ui/src/community/masked-view/__tests__/MaskedView.test.ios.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react-native';
+import { View } from 'react-native';
+
+import { MaskedView } from '..';
+import { findNativeViewProps } from '../../../__mocks__/expo';
+
+jest.mock('expo', () => jest.requireActual('../../../__mocks__/expo'));
+
+describe('MaskedView', () => {
+  it('keeps the SwiftUI host inside the React Native layout bounds', () => {
+    render(
+      <MaskedView maskElement={<View />}>
+        <View />
+      </MaskedView>
+    );
+
+    expect(findNativeViewProps('HostView')?.ignoreSafeArea).toBe('all');
+  });
+});


### PR DESCRIPTION
# Why

On iOS, the internal SwiftUI `Host` applies window safe area insets inside the React Native mask bounds. A fixed-size `MaskedView` can therefore clip or resize its content after rotation while its outer frame stays unchanged.

# How

Pass `ignoreSafeArea="all"` to the internal `Host`. React Native owns this frame, so keeping the keyboard safe area would still resize the mask. This matches `Picker`, `Slider`, `SegmentedControl`, `MenuView`, and `DateTimePicker`.

# Test Plan

- Reproduced on an iOS simulator with a 240-point `MaskedView`: after rotating to landscape, the outer frame stayed at 240 points while the hosted content shrank by the window safe area insets.
- The new test fails without the `Host` prop.
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm depscheck`
- `pnpm format`
- `pnpm exec jest --runInBand`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
