### PR TITLE
[observe] Add initIntegration function

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add `Observe.initIntegration` to initialize an integration ([#48245](https://github.com/expo/expo/pull/48245) by [@Ubax](https://github.com/Ubax))
 - Expose `ObserveErrorBoundary`, a React error boundary that records render-phase errors. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
 - Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-observe/src/__tests__/initIntegration.test.native.ts
+++ b/packages/expo-observe/src/__tests__/initIntegration.test.native.ts
@@ -1,0 +1,193 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import type { ObserveModuleEvents } from '../types';
+
+export {};
+
+const CONFIGURE = 'configure' satisfies keyof ObserveModuleEvents;
+const configureListeners = new Set<
+  (payload: Parameters<ObserveModuleEvents['configure']>[0]) => void
+>();
+let integrations: Record<string, unknown> | undefined;
+let remove = jest.fn();
+
+const mockNativeTarget = {
+  getIntegrations: jest.fn(() => integrations),
+  addListener: jest.fn(
+    (
+      _event: typeof CONFIGURE,
+      listener: (payload: Parameters<ObserveModuleEvents['configure']>[0]) => void
+    ) => {
+      configureListeners.add(listener);
+      remove = jest.fn(() => configureListeners.delete(listener));
+      return { remove };
+    }
+  ),
+};
+const mockNative = new Proxy(mockNativeTarget, {
+  has: () => true,
+});
+
+const mockAppMetrics = {
+  initIntegration: jest.fn(),
+};
+
+jest.mock('expo', () => ({
+  requireNativeModule: jest.fn(() => mockNative),
+}));
+
+jest.mock('expo-app-metrics', () => ({
+  __esModule: true,
+  default: mockAppMetrics,
+}));
+
+jest.mock('../integrations/expo-router/router', () => ({
+  isRouterInstalled: false,
+}));
+
+jest.mock('../integrations/expo-router/init', () => ({
+  initRouterIntegration: jest.fn(),
+}));
+
+jest.mock('../integrations/react-navigation/reactNavigation', () => ({
+  isReactNavigationInstalled: false,
+}));
+
+jest.mock('../integrations/react-navigation/init', () => ({
+  initReactNavigationIntegration: jest.fn(),
+}));
+
+function loadModule() {
+  return require('../module').default as typeof import('../module').default;
+}
+
+function emit(integrations: Parameters<ObserveModuleEvents['configure']>[0]['integrations']) {
+  for (const listener of [...configureListeners]) {
+    listener({ integrations });
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  integrations = undefined;
+  configureListeners.clear();
+});
+
+describe('Observe.initIntegration', () => {
+  it('calls the callback synchronously without adding a listener when the key is present', () => {
+    integrations = { 'expo-router': true };
+    const callback = jest.fn();
+
+    loadModule().initIntegration('expo-router', callback);
+
+    expect(callback).toHaveBeenCalledWith(true);
+    expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
+  });
+
+  it.each([false, undefined])(
+    'does not call the callback or add a listener when the current value is %s',
+    (value) => {
+      integrations = { 'expo-router': value };
+      const callback = jest.fn();
+
+      loadModule().initIntegration('expo-router', callback);
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not call the callback or add a listener when the initial object omits the key', () => {
+    integrations = {};
+    const callback = jest.fn();
+
+    loadModule().initIntegration('expo-router', callback);
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
+  });
+
+  it('adds a listener when the initial integrations value is falsy', () => {
+    const callback = jest.fn();
+
+    loadModule().initIntegration('expo-router', callback);
+
+    expect(mockNativeTarget.addListener).toHaveBeenCalledWith(CONFIGURE, expect.any(Function));
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('removes the subscription before calling the callback when an event contains the key', () => {
+    const callback = jest.fn(() => expect(remove).toHaveBeenCalledTimes(1));
+    loadModule().initIntegration('expo-router', callback);
+
+    emit({ 'expo-router': true });
+
+    expect(callback).toHaveBeenCalledWith(true);
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the subscription without calling the callback when an event omits the key', () => {
+    const callback = jest.fn();
+    loadModule().initIntegration('expo-router', callback);
+
+    emit({});
+
+    expect(callback).not.toHaveBeenCalled();
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    emit({ 'expo-router': true });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls the callback at most once across multiple events', () => {
+    const callback = jest.fn();
+    loadModule().initIntegration('expo-router', callback);
+
+    emit({ 'expo-router': true });
+    emit({ 'expo-router': false });
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([false, undefined])(
+    'removes the subscription without calling the callback when an event value is %s',
+    (value) => {
+      const callback = jest.fn();
+      loadModule().initIntegration('expo-router', callback);
+
+      emit({ 'expo-router': value });
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(remove).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('leaves no listener behind when the callback throws', () => {
+    const callback = jest.fn(() => {
+      throw new Error('callback failed');
+    });
+    loadModule().initIntegration('expo-router', callback);
+
+    expect(() => emit({ 'expo-router': true })).toThrow('callback failed');
+    expect(() => emit({ 'expo-router': false })).not.toThrow();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes object values through unchanged', () => {
+    const config = { filteredParams: ['token'] };
+    integrations = { 'expo-router': config };
+    const objectCallback = jest.fn();
+    loadModule().initIntegration('expo-router', objectCallback);
+    expect(objectCallback).toHaveBeenCalledTimes(1);
+    expect(objectCallback.mock.calls[0][0]).toBe(config);
+  });
+
+  it('does not forward initIntegration to AppMetrics', () => {
+    const callback = jest.fn();
+
+    loadModule().initIntegration('expo-router', callback);
+
+    expect(mockAppMetrics.initIntegration).not.toHaveBeenCalled();
+    expect(mockNativeTarget.getIntegrations).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -6,7 +6,7 @@ import { isRouterInstalled } from './integrations/expo-router/router';
 import { initReactNavigationIntegration } from './integrations/react-navigation/init';
 import { isReactNavigationInstalled } from './integrations/react-navigation/reactNavigation';
 import { reportCaughtError } from './reportCaughtError';
-import type { ObserveConfig, ObserveModule } from './types';
+import type { ObserveConfig, ObserveIntegrationsConfig, ObserveModule } from './types';
 
 const native = requireNativeModule<ObserveModule>('ExpoObserve');
 
@@ -52,6 +52,13 @@ const Observe: ObserveModule = new Proxy(native, {
       return (error: unknown) => reportCaughtError(error);
     }
 
+    if (prop === 'initIntegration') {
+      return <K extends keyof ObserveIntegrationsConfig>(
+        name: K,
+        callback: (config: ObserveIntegrationsConfig[K]) => void
+      ) => initIntegrationImpl(target, name, callback);
+    }
+
     // On Android, the native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report
     // `true` for names it doesn't implement — a host object has no `has` hook. `Object.keys(target)`
     // goes through `getPropertyNames`, which lists the module's actual members, so use it to forward
@@ -62,5 +69,26 @@ const Observe: ObserveModule = new Proxy(native, {
     return Reflect.get(target, prop, receiver);
   },
 });
+
+export function initIntegrationImpl<K extends keyof ObserveIntegrationsConfig>(
+  target: Pick<ObserveModule, 'addListener' | 'getIntegrations'>,
+  name: K,
+  callback: (config: ObserveIntegrationsConfig[K]) => void
+): void {
+  const integrations = target.getIntegrations();
+  if (integrations) {
+    if (integrations[name]) {
+      callback(integrations[name]);
+    }
+    return;
+  }
+
+  const subscription = target.addListener('configure', ({ integrations }) => {
+    subscription.remove();
+    if (integrations?.[name]) {
+      callback(integrations[name]);
+    }
+  });
+}
 
 export default Observe;

--- a/packages/expo-observe/src/module.web.ts
+++ b/packages/expo-observe/src/module.web.ts
@@ -16,6 +16,12 @@ class ExpoObserveModule extends NativeModule<ObserveModuleEvents> implements Obs
   getIntegrations(): ObserveIntegrationsConfig {
     return {};
   }
+  initIntegration<K extends keyof ObserveIntegrationsConfig>(
+    name: K,
+    callback: (config: ObserveIntegrationsConfig[K]) => void
+  ): void {
+    // Web does not provide integration configuration or emit `configure` events.
+  }
   logEvent(name: string, options?: LogEventOptions): void {
     AppMetrics.logEvent(name, options);
   }

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -127,6 +127,23 @@ export declare class ObserveModule extends NativeModule<ObserveModuleEvents> {
    */
   getIntegrations(): ObserveIntegrationsConfig;
   /**
+   * Invokes a callback once when the named integration configuration becomes available.
+   *
+   * @param name Integration name.
+   * @param callback Function called with the integration configuration.
+   *
+   * @example
+   * ```ts
+   * Observe.initIntegration('expo-router', config => {
+   *   console.log(config);
+   * });
+   * ```
+   */
+  initIntegration<K extends keyof ObserveIntegrationsConfig>(
+    name: K,
+    callback: (config: ObserveIntegrationsConfig[K]) => void
+  ): void;
+  /**
    * Records a log event against the current main session. The event is
    * persisted locally and dispatched on the next `dispatchEvents()` flush.
    *


### PR DESCRIPTION
# Why

In order to simplify the integration for 3rd party libraries.

# How

Expose `initIntegration` via observe proxy. 

It passes the configuration to integration using following approach:
1. If `configure` was already called - check if config exists for current integration. If it does, call the callback
2. If `configure` was not yet called - add listener
3. When it finally is called - check if config exists for current integration. If it does, call the callback. In both cases remove the listener

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
