### PR TITLE
[expo-file-system] Fix copyAsync losing Photos edits for ph:// assets on iOS

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@CoffeeFlux](https://github.com/CoffeeFlux))
+- Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#48248](https://github.com/expo/expo/pull/48248) by [@CoffeeFlux](https://github.com/CoffeeFlux))
 - Fixed iOS file previews rejecting a new preview while the previous Quick Look dismissal animation is still finishing. ([#47947](https://github.com/expo/expo/pull/47947) by [@eliotgevers](https://github.com/eliotgevers))
 - Added `./next` subpath to package `exports` field to resolve Metro bundler warning. ([#44793](https://github.com/expo/expo/pull/44793) by [@chang-in](https://github.com/chang-in))
 - Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support. ([#47176](https://github.com/expo/expo/pull/47176) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@CoffeeFlux](https://github.com/CoffeeFlux))
 - Fixed iOS file previews rejecting a new preview while the previous Quick Look dismissal animation is still finishing. ([#47947](https://github.com/expo/expo/pull/47947) by [@eliotgevers](https://github.com/eliotgevers))
 - Added `./next` subpath to package `exports` field to resolve Metro bundler warning. ([#44793](https://github.com/expo/expo/pull/44793) by [@chang-in](https://github.com/chang-in))
 - Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support. ([#47176](https://github.com/expo/expo/pull/47176) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
@@ -86,9 +86,19 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
       return
     }
 
-    let firstResource = PHAssetResource.assetResources(for: asset).first
+    // An edited asset carries both its original resource (`.photo`/`.video`) and the
+    // rendered current version (`.fullSizePhoto`/`.fullSizeVideo`). `.first` returns
+    // the original, which silently discards any edits made in Photos, so prefer the
+    // full-size rendition when one exists.
+    let resources = PHAssetResource.assetResources(for: asset)
+    let firstResource = resources.first { $0.type == .fullSizePhoto }
+      ?? resources.first { $0.type == .fullSizeVideo }
+      ?? resources.first
     if let firstResource {
-      resourceManager.writeData(for: firstResource, toFile: toUrl, options: nil) { error in
+      let resourceOptions = PHAssetResourceRequestOptions()
+      // Assets that only exist in iCloud have no local resource data to write.
+      resourceOptions.isNetworkAccessAllowed = true
+      resourceManager.writeData(for: firstResource, toFile: toUrl, options: resourceOptions) { error in
         if error != nil {
           promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
           return

--- a/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
+++ b/packages/expo-file-system/ios/Legacy/FileSystemHelpers.swift
@@ -87,18 +87,22 @@ internal func copyPHAsset(fromUrl: URL, toUrl: URL, with resourceManager: PHAsse
     }
 
     // An edited asset carries both its original resource (`.photo`/`.video`) and the
-    // rendered current version (`.fullSizePhoto`/`.fullSizeVideo`). `.first` returns
-    // the original, which silently discards any edits made in Photos, so prefer the
-    // full-size rendition when one exists.
+    // rendered current version (`.fullSizePhoto`/`.fullSizeVideo`). Prefer the
+    // rendition matching the asset's media type, since an edited video can also
+    // include a `.fullSizePhoto` poster image.
     let resources = PHAssetResource.assetResources(for: asset)
-    let firstResource = resources.first { $0.type == .fullSizePhoto }
-      ?? resources.first { $0.type == .fullSizeVideo }
+    let isVideo = asset.mediaType == .video
+    let editedResourceType: PHAssetResourceType = isVideo ? .fullSizeVideo : .fullSizePhoto
+    let originalResourceType: PHAssetResourceType = isVideo ? .video : .photo
+    let resource =
+      resources.first { $0.type == editedResourceType }
+      ?? resources.first { $0.type == originalResourceType }
       ?? resources.first
-    if let firstResource {
+    if let resource {
       let resourceOptions = PHAssetResourceRequestOptions()
       // Assets that only exist in iCloud have no local resource data to write.
       resourceOptions.isNetworkAccessAllowed = true
-      resourceManager.writeData(for: firstResource, toFile: toUrl, options: resourceOptions) { error in
+      resourceManager.writeData(for: resource, toFile: toUrl, options: resourceOptions) { error in
         if error != nil {
           promise.reject(FailedToCopyAssetException(fromUrl.absoluteString))
           return


### PR DESCRIPTION
# Why

`FileSystem.copyAsync()` on an iOS `ph://` URI copies the asset's **unedited original**, silently discarding any edits made in the Photos app. Cropping a photo and then copying it yields the pre-crop image.

Reported in #39353, which was auto-closed as stale without triage. The behaviour is unchanged on SDK 57.

Reproduction: https://github.com/CoffeeFlux/expo-copy-bug-demo (blank SDK 57 app; runs the check on launch)

The repro compares three values per asset — `PHAsset.pixelWidth/Height` from `getAssetsAsync` (ground truth for the current rendition), the dimensions of `getAssetInfoAsync().localUri`, and the dimensions of what `copyAsync` produces. Cropping changes pixel dimensions, so the mismatch is measurable rather than a visual judgement, and unedited photos serve as controls.

**Before** (iPad mini 5, iPadOS 26.5.2, `expo@57.0.8`, `expo-file-system@57.0.1`):

```
IMG_0002.JPG expected=2448x3264 localUri=2448x3264 copyAsync=2448x3264 :: match      (control, unedited)
IMG_0001.JPG expected=2448x3264 localUri=2448x3264 copyAsync=2448x3264 :: match      (control, unedited)
IMG_0003.JPG expected=2448x2186 localUri=2448x2186 copyAsync=2448x3264 :: MISMATCH   (cropped)
```

Only the edited asset diverges, and it comes back at exactly the original dimensions. `localUri` resolves to `.../PhotoData/Mutations/DCIM/100APPLE/IMG_0003/Adjustments/FullSizeRender.jpg`, so the rendered current version exists and is reachable.

# How

In `copyPHAsset` (`ios/Legacy/FileSystemHelpers.swift`):

```swift
let firstResource = PHAssetResource.assetResources(for: asset).first
```

For an edited asset, `PHAssetResource.assetResources(for:)` returns both the original (`.photo`) and the rendered current version (`.fullSizePhoto`). `.first` returns the original. This prefers `.fullSizePhoto`/`.fullSizeVideo` when present and falls back to the previous behaviour otherwise, so unedited assets are unaffected.

It also passes `isNetworkAccessAllowed` on the resource request. With `options: nil`, an asset that exists only in iCloud has no local resource data and the copy fails outright rather than fetching it.

One note for anyone tracing this: `copyAsync` early-returns to `copyPHAsset` at `FileSystemLegacyModule.swift:147`, so `EXFileSystemAssetLibraryHandler.copy` — which sits just below and also appears to handle `ph://` — is dead code on this path.

# Test Plan

Ran the linked repro on an iPad mini (5th generation), iPadOS 26.5.2, against a photo cropped in Photos and saved over the original, with two untouched photos as controls.

**After:**

```
IMG_0002.JPG expected=2448x3264 localUri=2448x3264 copyAsync=2448x3264 :: match
IMG_0001.JPG expected=2448x3264 localUri=2448x3264 copyAsync=2448x3264 :: match
IMG_0003.JPG expected=2448x2186 localUri=2448x2186 copyAsync=2448x2186 :: match
```

The edited asset now matches and both controls are unchanged.

Caveat worth flagging: I verified the `.fullSizePhoto` change on device, but I had no iCloud-only asset available to exercise the `isNetworkAccessAllowed` change. It is reasoned rather than observed — happy to drop it into a separate PR if you would rather keep this one strictly to what has been measured. Video assets were likewise not tested; `.fullSizeVideo` is included for symmetry.

# Checklist

- [x] Documented my changes in the `CHANGELOG.md` of the relevant package
- [x] Tested on iOS (physical device)