### PR TITLE
[fetch] Reject aborted requests with an AbortError and give FetchError a name

### DIFF
--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -359,6 +359,7 @@ export function test({ describe, expect, it, ...t }) {
         }
       }
       expect(error).not.toBeNull();
+      expect(error.name).toBe('AbortError');
     });
 
     it('should abort request with AbortSignal.timeout', async () => {
@@ -376,6 +377,8 @@ export function test({ describe, expect, it, ...t }) {
       expect(error).not.toBeNull();
       expect(signal.aborted).toBe(true);
       expect(signal.reason.name).toBe('TimeoutError');
+      // The spec rejects with the signal's reason, so a timeout is not an AbortError.
+      expect(error).toBe(signal.reason);
     });
 
     it('should abort request with AbortSignal.any', async () => {
@@ -394,6 +397,8 @@ export function test({ describe, expect, it, ...t }) {
       }
       expect(error).not.toBeNull();
       expect(signal.aborted).toBe(true);
+      expect(error.name).toBe('AbortError');
+      expect(error).toBe(signal.reason);
     });
 
     it('should abort streaming request', async () => {
@@ -422,6 +427,7 @@ export function test({ describe, expect, it, ...t }) {
         }
       }
       expect(error).not.toBeNull();
+      expect(error.name).toBe('AbortError');
       expect(hasReceivedChunk).toBe(true);
     });
 
@@ -453,7 +459,7 @@ export function test({ describe, expect, it, ...t }) {
         }
       }
       expect(error).not.toBeNull();
-      expect(error.message).toContain('Fetch request has been canceled');
+      expect(error.name).toBe('AbortError');
       expect(hasReceivedChunk).toBe(false);
     });
   });

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -48,7 +48,7 @@ console.log(buffer.length); // 512
 
 > **Note:** On Android and iOS, `expo/fetch` is also installed as the global `fetch`. This means any calls to `fetch(...)` without importing from `expo/fetch` use the same WinterCG-compliant implementation. To keep React Native's built-in `fetch` as the global, set `EXPO_PUBLIC_USE_RN_FETCH=1` in your [environment variables](/guides/environment-variables/). Named imports from `expo/fetch` continue to work regardless of this flag.
 
-Rejections carry a `name` you can branch on. A request stopped through an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) rejects with that signal's `reason`, which is an `AbortError` for `controller.abort()` and a `TimeoutError` for `AbortSignal.timeout()`. Every other failure, such as a dropped connection, rejects with a `FetchError`. The same applies to a body read that fails after the response has arrived, so `response.text()`, `response.json()`, `response.arrayBuffer()`, `response.blob()` and the body stream all report failures the same way.
+Rejections carry a `name` you can branch on. A request stopped through an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) rejects with that signal's `reason`, which is an `AbortError` for `controller.abort()` and a `TimeoutError` for `AbortSignal.timeout()`. On Android and iOS, every other failure, such as a dropped connection, rejects with a `FetchError`. On web, `expo/fetch` is the platform's own `fetch`, so those failures reject with a `TypeError`. The same applies to a body read that fails after the response has arrived, so `response.text()`, `response.json()`, `response.arrayBuffer()`, `response.blob()`, and the body stream all report failures the same way.
 
 ```ts Telling an abort from a network failure
 import { fetch } from 'expo/fetch';
@@ -58,13 +58,14 @@ const controller = new AbortController();
 try {
   const resp = await fetch('https://httpbin.org/get', { signal: controller.signal });
   console.log(await resp.json());
-} catch (error) {
+} catch (error: any) {
   if (error.name === 'AbortError') {
     // The request was canceled on purpose, usually not worth reporting.
   } else if (error.name === 'TimeoutError') {
     // The signal passed to fetch came from AbortSignal.timeout().
   } else {
-    // A FetchError: the request or the body read failed.
+    // A FetchError on Android and iOS, a TypeError on web: the request
+    // or the body read failed.
     console.error(error);
   }
 }

--- a/docs/pages/versions/unversioned/sdk/expo.mdx
+++ b/docs/pages/versions/unversioned/sdk/expo.mdx
@@ -48,6 +48,28 @@ console.log(buffer.length); // 512
 
 > **Note:** On Android and iOS, `expo/fetch` is also installed as the global `fetch`. This means any calls to `fetch(...)` without importing from `expo/fetch` use the same WinterCG-compliant implementation. To keep React Native's built-in `fetch` as the global, set `EXPO_PUBLIC_USE_RN_FETCH=1` in your [environment variables](/guides/environment-variables/). Named imports from `expo/fetch` continue to work regardless of this flag.
 
+Rejections carry a `name` you can branch on. A request stopped through an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal) rejects with that signal's `reason`, which is an `AbortError` for `controller.abort()` and a `TimeoutError` for `AbortSignal.timeout()`. Every other failure, such as a dropped connection, rejects with a `FetchError`. The same applies to a body read that fails after the response has arrived, so `response.text()`, `response.json()`, `response.arrayBuffer()`, `response.blob()` and the body stream all report failures the same way.
+
+```ts Telling an abort from a network failure
+import { fetch } from 'expo/fetch';
+
+const controller = new AbortController();
+
+try {
+  const resp = await fetch('https://httpbin.org/get', { signal: controller.signal });
+  console.log(await resp.json());
+} catch (error) {
+  if (error.name === 'AbortError') {
+    // The request was canceled on purpose, usually not worth reporting.
+  } else if (error.name === 'TimeoutError') {
+    // The signal passed to fetch came from AbortSignal.timeout().
+  } else {
+    // A FetchError: the request or the body read failed.
+    console.error(error);
+  }
+}
+```
+
 ### Encoding APIs
 
 `TextEncoder` and `TextDecoder` are built-in APIs that provide a way to encode and decode text in various character encodings. They are available on all platforms. Refer to the [browser and server runtime support](https://caniuse.com/textencoder) for web and Node.js.

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -5,12 +5,12 @@
 ### 🛠 Breaking changes
 
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
+- Give `expo/fetch` errors a `name`, so an aborted request rejects with the signal's reason (an `AbortError`, or a `TimeoutError` from `AbortSignal.timeout()`) like React Native's `fetch` does, and any other failure rejects with a `FetchError`. ([#48251](https://github.com/expo/expo/pull/48251) by [@0xLuca](https://github.com/0xLuca))
 
 ### 🎉 New features
 
 ### 🐛 Bug fixes
 
-- Give `expo/fetch` errors a `name`, so an aborted request rejects with the signal's reason (an `AbortError`, or a `TimeoutError` from `AbortSignal.timeout()`) like React Native's `fetch` does, and any other failure rejects with a `FetchError`. ([#48251](https://github.com/expo/expo/pull/48251) by [@0xLuca](https://github.com/0xLuca))
 - [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered. ([#48230](https://github.com/expo/expo/pull/48230) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Give `expo/fetch` errors a `name`, so an aborted request rejects with the signal's reason (an `AbortError`, or a `TimeoutError` from `AbortSignal.timeout()`) like React Native's `fetch` does, and any other failure rejects with a `FetchError`. ([#48251](https://github.com/expo/expo/pull/48251) by [@0xLuca](https://github.com/0xLuca))
 - [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered. ([#48230](https://github.com/expo/expo/pull/48230) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed expo-fetch race condition causing out-of-order delivery of initial chunks ([#42161](https://github.com/expo/expo/pull/42161) by [@matthieugicquel](https://github.com/matthieugicquel))
 - [iOS] Pass the React runtime scheduler to `ExpoModulesCore` through a weak handle, so dispatching onto the JS thread during a reload no longer risks calling into a scheduler the React instance already destroyed. ([#47492](https://github.com/expo/expo/pull/47492) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo/src/winter/fetch/FetchErrors.ts
+++ b/packages/expo/src/winter/fetch/FetchErrors.ts
@@ -1,6 +1,9 @@
+import { DOMException } from '../DOMException';
+
 export class FetchError extends Error {
   constructor(message: string, { cause, stack }: { cause?: unknown; stack?: string } = {}) {
     super(`fetch failed: ${message}`);
+    this.name = 'FetchError';
     this.cause = cause;
     this.stack = stack;
   }
@@ -8,4 +11,14 @@ export class FetchError extends Error {
   static createFromError(error: Error): FetchError {
     return new FetchError(error.message, { cause: error.cause, stack: error.stack });
   }
+}
+
+/**
+ * Returns the value an aborted request rejects with. The spec rejects with the signal's own
+ * reason, so `AbortSignal.timeout()` surfaces as a `TimeoutError` rather than an `AbortError`.
+ * React Native's `AbortController` polyfill has no `reason`, hence the fallback.
+ */
+export function createAbortError(signal?: AbortSignal | null): unknown {
+  const reason = signal != null && 'reason' in signal ? signal.reason : undefined;
+  return reason ?? new DOMException('The operation was aborted.', 'AbortError');
 }

--- a/packages/expo/src/winter/fetch/FetchErrors.ts
+++ b/packages/expo/src/winter/fetch/FetchErrors.ts
@@ -19,6 +19,7 @@ export class FetchError extends Error {
  * React Native's `AbortController` polyfill has no `reason`, hence the fallback.
  */
 export function createAbortError(signal?: AbortSignal | null): unknown {
-  const reason = signal != null && 'reason' in signal ? signal.reason : undefined;
-  return reason ?? new DOMException('The operation was aborted.', 'AbortError');
+  return signal != null && 'reason' in signal
+    ? signal.reason
+    : new DOMException('The operation was aborted.', 'AbortError');
 }

--- a/packages/expo/src/winter/fetch/FetchResponse.ts
+++ b/packages/expo/src/winter/fetch/FetchResponse.ts
@@ -1,4 +1,5 @@
 import { ExpoFetchModule } from './ExpoFetchModule';
+import { createAbortError, FetchError } from './FetchErrors';
 import type { NativeHeadersType, NativeResponse } from './NativeRequest';
 import { createReactNativeBlobAsync, isReactNativeBlobGlobal } from './createBlob';
 
@@ -163,7 +164,10 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
     metadata: null,
   };
 
-  constructor(private readonly abortCleanupFunction: AbortSubscriptionCleanupFunction) {
+  constructor(
+    private readonly abortCleanupFunction: AbortSubscriptionCleanupFunction,
+    private readonly signal?: AbortSignal | null
+  ) {
     super();
     this.addListener('readyForJSFinalization', this.finalize);
   }
@@ -230,7 +234,7 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
                 return;
               }
               isControllerClosed = true;
-              controller.error(new Error(error));
+              controller.error(this.createBodyError(new Error(error)));
             });
           },
 
@@ -338,7 +342,11 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
       return body.readAsBuffer();
     }
 
-    return super.arrayBuffer();
+    try {
+      return await super.arrayBuffer();
+    } catch (e: unknown) {
+      throw this.createBodyError(e);
+    }
   }
 
   override async text(): Promise<string> {
@@ -351,7 +359,11 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
       return new TextDecoder().decode(await body.readAsBuffer());
     }
 
-    return super.text();
+    try {
+      return await super.text();
+    } catch (e: unknown) {
+      throw this.createBodyError(e);
+    }
   }
 
   toString(): string {
@@ -413,6 +425,17 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
     state.body.cloned = true;
 
     return clone;
+  }
+
+  // A body read fails through the same states a request does, so it reports the same errors:
+  // the signal's reason when the caller aborted, a `FetchError` for anything else.
+  private createBodyError(error: unknown): unknown {
+    if (this.signal?.aborted) {
+      return createAbortError(this.signal);
+    }
+    return error instanceof Error
+      ? FetchError.createFromError(error)
+      : new FetchError(String(error));
   }
 
   private checkBodyUsedError(method: string): void {

--- a/packages/expo/src/winter/fetch/__tests__/FetchErrors-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchErrors-test.ts
@@ -1,0 +1,50 @@
+/// <reference types="node" />
+
+/** @jest-environment node */
+
+import { DOMException } from '../../DOMException';
+import { createAbortError, FetchError } from '../FetchErrors';
+
+describe('FetchError', () => {
+  it('carries a name so callers can tell it apart from other errors', () => {
+    const error = new FetchError('The network connection was lost.');
+    expect(error.name).toBe('FetchError');
+    expect(error.message).toBe('fetch failed: The network connection was lost.');
+  });
+
+  it('keeps the name, cause and stack when created from another error', () => {
+    const cause = new Error('root cause');
+    const source = new Error('The network connection was lost.', { cause });
+    const error = FetchError.createFromError(source);
+
+    expect(error.name).toBe('FetchError');
+    expect(error.message).toBe('fetch failed: The network connection was lost.');
+    expect(error.cause).toBe(cause);
+    expect(error.stack).toBe(source.stack);
+  });
+});
+
+describe('createAbortError', () => {
+  it('returns the reason the signal was aborted with', () => {
+    const controller = new AbortController();
+    const reason = new Error('replaced by a newer request');
+    controller.abort(reason);
+
+    expect(createAbortError(controller.signal)).toBe(reason);
+  });
+
+  it('falls back to an AbortError when the signal has no reason', () => {
+    // React Native's AbortController polyfill does not implement `reason`.
+    const signal = { aborted: true } as unknown as AbortSignal;
+    const error = createAbortError(signal) as DOMException;
+
+    expect(error).toBeInstanceOf(DOMException);
+    expect(error.name).toBe('AbortError');
+    expect(error.code).toBe(20);
+    expect(error.message).toBe('The operation was aborted.');
+  });
+
+  it('falls back to an AbortError when there is no signal', () => {
+    expect((createAbortError() as DOMException).name).toBe('AbortError');
+  });
+});

--- a/packages/expo/src/winter/fetch/__tests__/FetchErrors-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchErrors-test.ts
@@ -33,6 +33,13 @@ describe('createAbortError', () => {
     expect(createAbortError(controller.signal)).toBe(reason);
   });
 
+  it('passes a nullish reason through instead of replacing it', () => {
+    const controller = new AbortController();
+    controller.abort(null);
+
+    expect(createAbortError(controller.signal)).toBeNull();
+  });
+
   it('falls back to an AbortError when the signal has no reason', () => {
     // React Native's AbortController polyfill does not implement `reason`.
     const signal = { aborted: true } as unknown as AbortSignal;

--- a/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
@@ -16,6 +16,14 @@ jest.mock('../ExpoFetchModule', () => {
     private listeners = new Map<string, Set<(...args: any[]) => void>>();
     private _bodyUsed = false;
 
+    // Set by tests to fail a buffered read the way native does once the request
+    // errors after the response was delivered.
+    bodyReadError: Error | null = null;
+
+    // Set by tests to keep the body streaming instead of completing at once, so
+    // didFailWithError can arrive while a reader is waiting.
+    liveStream = false;
+
     // Getters on the prototype, like the real native binding, so super.x works.
     get _rawHeaders(): [string, string][] {
       return [['content-type', 'text/plain']];
@@ -65,6 +73,9 @@ jest.mock('../ExpoFetchModule', () => {
 
     async arrayBuffer(): Promise<ArrayBuffer> {
       this._bodyUsed = true;
+      if (this.bodyReadError) {
+        throw this.bodyReadError;
+      }
       return helloWorld.buffer.slice(
         helloWorld.byteOffset,
         helloWorld.byteOffset + helloWorld.byteLength
@@ -73,11 +84,14 @@ jest.mock('../ExpoFetchModule', () => {
 
     async text(): Promise<string> {
       this._bodyUsed = true;
+      if (this.bodyReadError) {
+        throw this.bodyReadError;
+      }
       return new TextDecoder().decode(helloWorld);
     }
 
     async startStreaming(): Promise<Uint8Array | null> {
-      return helloWorld;
+      return this.liveStream ? null : helloWorld;
     }
 
     cancelStreaming() {}
@@ -94,8 +108,14 @@ jest.mock('../ExpoFetchModule', () => {
   };
 });
 
-function makeResponse(): FetchResponse {
-  return new FetchResponse(() => {});
+function makeResponse(signal?: AbortSignal): FetchResponse {
+  return new FetchResponse(() => {}, signal);
+}
+
+// Waits for the body stream's pull to run, so an event emitted afterwards
+// reaches a reader that is genuinely waiting for data.
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('FetchResponse', () => {
@@ -315,6 +335,72 @@ describe('FetchResponse', () => {
       const cloned = response.clone();
       await cloned.arrayBuffer();
       expect(response.bodyUsed).toBe(false);
+    });
+
+    it('rejects text() with a named FetchError when the read fails', async () => {
+      const response = makeResponse();
+      (response as any).bodyReadError = new Error('The network connection was lost.');
+
+      await expect(response.text()).rejects.toMatchObject({
+        name: 'FetchError',
+        message: 'fetch failed: The network connection was lost.',
+      });
+    });
+
+    it('rejects arrayBuffer() with a named FetchError when the read fails', async () => {
+      const response = makeResponse();
+      (response as any).bodyReadError = new Error('The network connection was lost.');
+
+      await expect(response.arrayBuffer()).rejects.toMatchObject({
+        name: 'FetchError',
+        message: 'fetch failed: The network connection was lost.',
+      });
+    });
+
+    it('rejects text() with an AbortError when the caller aborted', async () => {
+      const controller = new AbortController();
+      const response = makeResponse(controller.signal);
+      (response as any).bodyReadError = new Error('Fetch request has been canceled');
+      controller.abort();
+
+      await expect(response.text()).rejects.toMatchObject({ name: 'AbortError' });
+    });
+
+    it('rejects arrayBuffer() with the reason the caller aborted with', async () => {
+      const controller = new AbortController();
+      const reason = new Error('replaced by a newer request');
+      const response = makeResponse(controller.signal);
+      (response as any).bodyReadError = new Error('Fetch request has been canceled');
+      controller.abort(reason);
+
+      await expect(response.arrayBuffer()).rejects.toBe(reason);
+    });
+
+    it('errors the body stream with a named FetchError', async () => {
+      const response = makeResponse();
+      (response as any).liveStream = true;
+      const read = response.body!.getReader().read();
+      await flush();
+
+      (response as any).emit('didFailWithError', 'The network connection was lost.');
+
+      await expect(read).rejects.toMatchObject({
+        name: 'FetchError',
+        message: 'fetch failed: The network connection was lost.',
+      });
+    });
+
+    it('errors the body stream with an AbortError when the caller aborted', async () => {
+      const controller = new AbortController();
+      const response = makeResponse(controller.signal);
+      (response as any).liveStream = true;
+      const read = response.body!.getReader().read();
+      await flush();
+
+      controller.abort();
+      (response as any).emit('didFailWithError', 'Fetch request has been canceled');
+
+      await expect(read).rejects.toMatchObject({ name: 'AbortError' });
     });
 
     it('lets both tee() branches read the body and flips bodyUsed', async () => {

--- a/packages/expo/src/winter/fetch/__tests__/fetch-test.native.ts
+++ b/packages/expo/src/winter/fetch/__tests__/fetch-test.native.ts
@@ -1,0 +1,158 @@
+/// <reference types="node" />
+
+/** @jest-environment node */
+
+import { ExpoFetchModule } from '../ExpoFetchModule';
+import { fetch } from '../fetch';
+
+globalThis.ReadableStream = require('node:stream/web').ReadableStream;
+globalThis.TextDecoder = require('node:util').TextDecoder;
+globalThis.TextEncoder = require('node:util').TextEncoder;
+
+jest.mock('../ExpoFetchModule', () => {
+  class StubNativeResponse {
+    private listeners = new Map<string, Set<(...args: any[]) => void>>();
+
+    get _rawHeaders(): [string, string][] {
+      return [['content-type', 'text/plain']];
+    }
+    get status(): number {
+      return 200;
+    }
+    get statusText(): string {
+      return 'OK';
+    }
+    get url(): string {
+      return 'https://example.test/';
+    }
+    get redirected(): boolean {
+      return false;
+    }
+    get bodyUsed(): boolean {
+      return false;
+    }
+
+    addListener(event: string, listener: (...args: any[]) => void) {
+      if (!this.listeners.has(event)) {
+        this.listeners.set(event, new Set());
+      }
+      this.listeners.get(event)!.add(listener);
+    }
+
+    removeListener(event: string, listener: (...args: any[]) => void) {
+      this.listeners.get(event)?.delete(listener);
+    }
+
+    removeAllListeners(event: string) {
+      this.listeners.delete(event);
+    }
+  }
+
+  // Mirrors the native request: `start` stays pending until the response is
+  // received or the request errors, and `cancel` errors it.
+  class StubNativeRequest {
+    static last: StubNativeRequest | null = null;
+
+    private settle: { resolve: () => void; reject: (error: Error) => void } | null = null;
+
+    constructor() {
+      StubNativeRequest.last = this;
+    }
+
+    start(): Promise<void> {
+      return new Promise<void>((resolve, reject) => {
+        this.settle = { resolve, reject };
+      });
+    }
+
+    cancel() {
+      this.settle?.reject(new Error('Fetch request has been canceled'));
+    }
+
+    // Test helpers
+    receiveResponse() {
+      this.settle?.resolve();
+    }
+
+    failWith(error: Error) {
+      this.settle?.reject(error);
+    }
+  }
+
+  return {
+    ExpoFetchModule: {
+      NativeRequest: StubNativeRequest,
+      NativeResponse: StubNativeResponse,
+      unstable_createBlobData: jest.fn(async () => 'mock-blob-id'),
+    },
+  };
+});
+
+const NativeRequestStub = ExpoFetchModule.NativeRequest as any;
+
+// Lets `fetch` reach `request.start()` before the test drives the request.
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('fetch', () => {
+  it('resolves with a response once the response is received', async () => {
+    const promise = fetch('https://example.test/');
+    await flush();
+    NativeRequestStub.last.receiveResponse();
+
+    const response = await promise;
+    expect(response.status).toBe(200);
+  });
+
+  it('rejects with a named FetchError when the request fails', async () => {
+    const promise = fetch('https://example.test/');
+    await flush();
+    NativeRequestStub.last.failWith(new Error('The network connection was lost.'));
+
+    await expect(promise).rejects.toMatchObject({
+      name: 'FetchError',
+      message: 'fetch failed: The network connection was lost.',
+    });
+  });
+
+  it('rejects with an AbortError when the signal is already aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      fetch('https://example.test/', { signal: controller.signal })
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('rejects with the reason the signal was already aborted with', async () => {
+    const controller = new AbortController();
+    const reason = new Error('replaced by a newer request');
+    controller.abort(reason);
+
+    await expect(fetch('https://example.test/', { signal: controller.signal })).rejects.toBe(
+      reason
+    );
+  });
+
+  it('rejects with an AbortError when the request is aborted in flight', async () => {
+    const controller = new AbortController();
+    const promise = fetch('https://example.test/', { signal: controller.signal });
+    await flush();
+
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('rejects with the abort reason when the request is aborted in flight', async () => {
+    const controller = new AbortController();
+    const reason = new Error('user left the screen');
+    const promise = fetch('https://example.test/', { signal: controller.signal });
+    await flush();
+
+    controller.abort(reason);
+
+    await expect(promise).rejects.toBe(reason);
+  });
+});

--- a/packages/expo/src/winter/fetch/fetch.ts
+++ b/packages/expo/src/winter/fetch/fetch.ts
@@ -1,5 +1,5 @@
 import { ExpoFetchModule } from './ExpoFetchModule';
-import { FetchError } from './FetchErrors';
+import { createAbortError, FetchError } from './FetchErrors';
 import { FetchResponse, type AbortSubscriptionCleanupFunction } from './FetchResponse';
 import type { NativeRequest, NativeRequestInit } from './NativeRequest';
 import {
@@ -58,7 +58,7 @@ export async function fetch(
 
   const response = new FetchResponse(() => {
     abortSubscription?.();
-  });
+  }, signal);
 
   const request = new ExpoFetchModule.NativeRequest(response) as NativeRequest;
 
@@ -75,7 +75,7 @@ export async function fetch(
   };
 
   if (signal && signal.aborted) {
-    throw new FetchError('The operation was aborted.');
+    throw createAbortError(signal);
   }
   abortSubscription = addAbortSignalListener(signal, () => {
     request.cancel();
@@ -83,6 +83,9 @@ export async function fetch(
   try {
     await request.start(`${url}`, nativeRequestInit, requestBody);
   } catch (e: unknown) {
+    if (signal?.aborted) {
+      throw createAbortError(signal);
+    }
     if (e instanceof Error) {
       throw FetchError.createFromError(e);
     } else {


### PR DESCRIPTION
# Why

Fixes the second half of #48124, which @zoontek asked for a PR on. The first half landed in #48230, and this branch is rebased on it.

`FetchError` never set `name`, so it inherited `'Error'` and every rejection out of `expo/fetch` looked alike. On Android and iOS `expo/fetch` is installed as the global `fetch`, and the React Native `fetch` it replaces (whatwg-fetch) rejects aborts with `new DOMException('Aborted', 'AbortError')`. So the standard `err.name === 'AbortError'` check, which works against RN's fetch and every browser, silently stops working once `expo/fetch` takes over the global, and there is no documented alternative for telling an abort from a network failure.

Everything needed to do this properly is already in the package: `src/winter/DOMException.ts` is installed as the global `DOMException`, and `src/winter/AbortSignal.ts` gives `AbortSignal.timeout()` a `reason` of a `TimeoutError`.

| | before | after |
| --- | --- | --- |
| `controller.abort()` | `Error: fetch failed: Fetch request has been canceled` | `AbortError: The operation was aborted.` |
| `controller.abort(reason)` | same as above | rejects with `reason` |
| `AbortSignal.timeout()` | same as above | `TimeoutError: The signal timed out.` (the signal's own `reason`) |
| dropped connection | `Error: fetch failed: ...` | `FetchError: fetch failed: ...` |

# How

`FetchErrors.ts` sets `this.name = 'FetchError'` and adds `createAbortError(signal)`, which returns the signal's own `reason` per the spec and falls back to a `DOMException` named `AbortError` (React Native's `AbortController` polyfill, `abort-controller@3`, does not implement `reason`). It mirrors the private `getAbortReason` in `AbortSignal.ts`.

`fetch.ts` throws that for an already-aborted signal and for a `start()` rejection while the signal is aborted; anything else keeps the existing `FetchError` wrapping.

`FetchResponse.ts` takes the signal as an optional second constructor argument and routes `text()`, `arrayBuffer()` and the body stream's `didFailWithError` through one `createBodyError` mapper, so a body read that fails after the response arrived reports what the request itself would. `json()`, `blob()`, `bytes()` and `formData()` funnel through those two, and clones are unaffected because they read through the original's teed stream, which is already mapped.

Worth flagging for the changelog placement: this is a bug fix in the sense that the errors were unusable, but it does change what an aborted request rejects with. `FetchError` is not exported from `expo/fetch` (`src/winter/fetch/index.ts` exports only `./fetch` and `./fetch.types`), so no caller can hold an `instanceof` reference to it, but code matching on the old `'fetch failed: Fetch request has been canceled'` message string would need to move to `err.name`. Happy to move the entry under breaking changes if you prefer.

# Test Plan

Unit tests, `packages/expo`:

- new `__tests__/FetchErrors-test.ts`: `name` on `FetchError` and `createFromError`, plus the three `createAbortError` branches (signal reason, no reason, no signal).
- new `__tests__/fetch-test.native.ts`: a stub `NativeRequest` whose `start` stays pending until the test resolves, cancels or fails it, covering the pre-aborted signal, a custom abort reason, an abort in flight and a plain failure. Native-only, since `../fetch` resolves to `fetch.web.ts` on the Node and Web jest projects.
- `__tests__/FetchResponse-test.ts`: six cases for buffered reads and the body stream, with and without an aborted signal.

`pnpm test`, `pnpm typecheck`, `pnpm lint` and `pnpm format` pass in `packages/expo` and `apps/test-suite`.

`apps/test-suite/tests/Fetch.ts`: the five abort tests asserted only that something threw. They now assert `error.name`, and the `AbortSignal.timeout` and `AbortSignal.any` cases assert `error === signal.reason`. The one assertion that had to change is `should abort streaming request before receiving chunks`, which matched the old message.

On device, iPhone, the minimal repro app from #48124 with these three files patched into its `node_modules` (JS only, so Metro picks them up without a rebuild):

| Test | Result |
| --- | --- |
| 1. control, complete response | `resolved` |
| 3. socket dies mid body, read through `res.body` | `rejected` `FetchError: fetch failed: The network connection was lost.` |
| 6. socket dies with no body bytes | `rejected` `FetchError: fetch failed: unexpectedexception cannot parse response ...` |
| 7. `abort()` before the response arrives | `rejected` `AbortError: The operation was aborted.` |
| 8. `AbortSignal.timeout()` before the response | `rejected` `TimeoutError: The signal timed out.` |
| 9. `abort()` while a stream read is pending | `rejected` `AbortError: The operation was aborted.` |

Tests 2, 4 and 5 of that app read the body with `text()` and still hang there, because that device build is the released `expo@57.0.8`, which predates #48230. Now that #48230 is in, those promises reject and run through the same `createBodyError` path that tests 3 and 6 exercise above, and the unit tests cover it directly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
