### PR TITLE
[ios][autolinking] Honor DEBUG in the generated provider's debug gate

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Emit `#if DEBUG || EXPO_CONFIGURATION_DEBUG` in the generated modules provider, so debug-only modules (`expo-dev-menu`, `expo-dev-launcher`) still register in debug builds of a project that never ran `pod install` — for example a SwiftPM app, where the CocoaPods project integrator never sets `EXPO_CONFIGURATION_DEBUG`. ([#48254](https://github.com/expo/expo/pull/48254) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Propagate `buildFromSource` across the precompiled dependency graph, so building a prebuilt dependency from source (e.g. `react-native-worklets`) also forces its dependents (e.g. `react-native-reanimated`) to build from source, instead of linking a prebuilt XCFramework against a source-built dependency. ([#48041](https://github.com/expo/expo/pull/48041) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Pass target name to the generateModulesProviderCommand to match it against inline modules targets, when checking if inline modules should be autolinked with that target. ([#47502](https://github.com/expo/expo/pull/47502) by [@HubertBer](https://github.com/HubertBer))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Emit `#if DEBUG || EXPO_CONFIGURATION_DEBUG` in the generated modules provider, so debug-only modules (`expo-dev-menu`, `expo-dev-launcher`) still register in debug builds of a project that never ran `pod install` — for example a SwiftPM app, where the CocoaPods project integrator never sets `EXPO_CONFIGURATION_DEBUG`. ([#48254](https://github.com/expo/expo/pull/48254) by [@chrfalch](https://github.com/chrfalch))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-modules-autolinking/src/platforms/__tests__/apple-test.ts
+++ b/packages/expo-modules-autolinking/src/platforms/__tests__/apple-test.ts
@@ -2,8 +2,10 @@ import { vol } from 'memfs';
 import path from 'path';
 
 import { ExpoModuleConfig } from '../../ExpoModuleConfig';
+import type { ModuleDescriptorIos } from '../../types';
 import {
   formatArrayOfReactDelegateHandler,
+  generateModulesProviderAsync,
   getSwiftModuleNames,
   resolveExtraBuildDependenciesAsync,
   resolveModuleAsync,
@@ -212,6 +214,57 @@ describe(resolveModuleAsync, () => {
       reactDelegateHandlers: [],
       debugOnly: false,
     });
+  });
+});
+
+describe(generateModulesProviderAsync, () => {
+  const targetPath = '/app/ios/ExpoModulesProvider.swift';
+
+  const commonModule: ModuleDescriptorIos = {
+    packageName: 'expo-constants',
+    pods: [{ podName: 'EXConstants', podspecDir: '/path/to/expo/packages/expo-constants/ios' }],
+    flags: { inhibit_warnings: false },
+    modules: [{ name: null, class: 'ConstantsModule' }],
+    swiftModuleNames: ['EXConstants'],
+    appDelegateSubscribers: [],
+    reactDelegateHandlers: [],
+    debugOnly: false,
+  };
+
+  const debugOnlyModule: ModuleDescriptorIos = {
+    packageName: 'expo-dev-menu',
+    pods: [{ podName: 'EXDevMenu', podspecDir: '/path/to/expo/packages/expo-dev-menu/ios' }],
+    flags: { inhibit_warnings: false },
+    modules: [{ name: null, class: 'DevMenuModule' }],
+    swiftModuleNames: ['EXDevMenu'],
+    appDelegateSubscribers: ['DevMenuAppDelegateSubscriber'],
+    reactDelegateHandlers: ['DevMenuReactDelegateHandler'],
+    debugOnly: true,
+  };
+
+  async function generateAsync(modules: ModuleDescriptorIos[]) {
+    await generateModulesProviderAsync(modules, targetPath, null, {
+      watchedDirectories: [],
+      inlineModulesTargets: { targets: [] },
+      targetPath,
+      appRoot: '/app',
+    });
+    return vol.readFileSync(targetPath, 'utf8') as string;
+  }
+
+  it('gates the debug-only import list on DEBUG as well as EXPO_CONFIGURATION_DEBUG', async () => {
+    const content = await generateAsync([debugOnlyModule]);
+    expect(content).toContain('#if DEBUG || EXPO_CONFIGURATION_DEBUG\ninternal import EXDevMenu');
+  });
+
+  it('gates every debug-only registration branch on DEBUG as well as EXPO_CONFIGURATION_DEBUG', async () => {
+    const content = await generateAsync([commonModule, debugOnlyModule]);
+
+    // The import list plus the three getters that split debug-only registration.
+    expect(content.match(/#if DEBUG \|\| EXPO_CONFIGURATION_DEBUG/g)).toHaveLength(4);
+    // A gate resting on EXPO_CONFIGURATION_DEBUG alone is unset under SwiftPM,
+    // where no pod install runs the project integrator.
+    expect(content).not.toMatch(/#if EXPO_CONFIGURATION_DEBUG/);
   });
 });
 

--- a/packages/expo-modules-autolinking/src/platforms/apple/apple.ts
+++ b/packages/expo-modules-autolinking/src/platforms/apple/apple.ts
@@ -321,20 +321,27 @@ export function formatArrayOfReactDelegateHandler(modules: ModuleDescriptorIos[]
 ${indent.repeat(2)}]`;
 }
 
+// `EXPO_CONFIGURATION_DEBUG` is set by the CocoaPods project integrator, so it is
+// never defined where no `pod install` runs — notably a SwiftPM app, which would
+// silently get release registration in a debug build. `DEBUG` covers that case;
+// the two are kept together because `DEBUG` alone is not dependable across
+// projects (https://github.com/expo/expo/pull/17378). Mirrors `Logger.swift`.
+const DEBUG_CONFIGURATION_CONDITION = 'DEBUG || EXPO_CONFIGURATION_DEBUG';
+
 function wrapInDebugConfigurationCheck(
   indentationLevel: number,
   debugBlock: string,
   releaseBlock: string | null = null
 ) {
   if (releaseBlock) {
-    return `${indent.repeat(indentationLevel)}#if EXPO_CONFIGURATION_DEBUG\n${indent.repeat(
+    return `${indent.repeat(indentationLevel)}#if ${DEBUG_CONFIGURATION_CONDITION}\n${indent.repeat(
       indentationLevel
     )}${debugBlock}\n${indent.repeat(indentationLevel)}#else\n${indent.repeat(
       indentationLevel
     )}${releaseBlock}\n${indent.repeat(indentationLevel)}#endif`;
   }
 
-  return `${indent.repeat(indentationLevel)}#if EXPO_CONFIGURATION_DEBUG\n${indent.repeat(
+  return `${indent.repeat(indentationLevel)}#if ${DEBUG_CONFIGURATION_CONDITION}\n${indent.repeat(
     indentationLevel
   )}${debugBlock}\n${indent.repeat(indentationLevel)}#endif`;
 }


### PR DESCRIPTION
# Why

The generated `ExpoModulesProvider.swift` gates debug-only module registration on a single signal, `#if EXPO_CONFIGURATION_DEBUG`. That flag is set exclusively by the CocoaPods project integrator — `set_autolinking_configuration` in `scripts/ios/project_integrator.rb`, called from `cocoapods/user_project_integrator.rb`.

Nothing else defines it. So the gate is not really asking "is this a debug build?"; it is asking "did CocoaPods tell me this is a debug build?" Any Apple project that reaches the generator without a `pod install` compiles the release branch of every gate, and the two packages declaring `apple.debugOnly` — `expo-dev-menu` and `expo-dev-launcher` — do not register. Silently, with no build error.

`expo-modules-core` already treats one signal as insufficient: `Logger.swift:17` gates on `#if DEBUG || EXPO_CONFIGURATION_DEBUG`. This PR brings the generated provider in line with it.

**What this PR does not fix.** The case that surfaced this was SwiftPM, but that is not a user-visible bug today and this PR should not be read as fixing one. The SwiftPM autolinking path is not on `main`, and `expo-dev-menu` / `expo-dev-launcher` have neither a precompiled artifact nor a checked-in `Package.swift`, so a SwiftPM app including the dev client fails in the plugin before a provider is generated. Making the dev client consumable under SwiftPM is separate work. The justification here is the narrower one above: the provider should not depend on CocoaPods to know its own build configuration.

# How

Emit `#if DEBUG || EXPO_CONFIGURATION_DEBUG`, matching `Logger.swift:17`.

Both conditions are kept deliberately. `EXPO_CONFIGURATION_*` was introduced in #17378 precisely because `DEBUG` "works only in some projects … the flag might be unset depending on the build settings", so this adds a second signal rather than replacing the first.

**Behavior change worth a reviewer's eye:** Xcodeproj's `debug?` tests `GCC_PREPROCESSOR_DEFINITIONS` for `DEBUG=1` (xcodeproj 1.28.1, `lib/xcodeproj/project/object/build_configuration.rb`), not the configuration name. A `Staging` configuration copied from `Debug` therefore keeps `DEBUG=1`, already receives `EXPO_CONFIGURATION_DEBUG` today, and is unaffected by this change.

The newly affected class is narrower: a configuration that sets Swift's `DEBUG` compilation condition but omits `DEBUG=1` from `GCC_PREPROCESSOR_DEFINITIONS` will now register `debugOnly` modules where it previously did not. The `OR` cannot regress the other direction: any configuration receiving `EXPO_CONFIGURATION_DEBUG` today keeps it.

**Known limitation, not addressed here.** Registration and linking still key off different signals. The pod is *linked* when the configuration name contains `Debug` (`scripts/ios/autolinking_manager.rb:91`); registration keys off the preprocessor definitions above. A release build that deliberately links the dev client therefore still will not register it, because both signals remain proxies for the build configuration rather than checks on what is actually present. Closing that gap means replacing the proxy — for example a per-module `#if canImport(EXDevMenu)`, which asks about linkage directly. That is a larger change to the generator's shape and belongs in its own PR; this one does not make that case worse.

# Test Plan

Two tests in `src/platforms/__tests__/apple-test.ts`, exercising `generateModulesProviderAsync` through the existing memfs setup, each written red first:

- the debug-only import list carries the combined condition
- all four gates (import list plus the three getters that split registration) carry it, and no gate rests on `EXPO_CONFIGURATION_DEBUG` alone

Red, before the change:

```
● generateModulesProviderAsync › gates the debug-only import list on DEBUG as well as EXPO_CONFIGURATION_DEBUG
  expect(content).toContain('#if DEBUG || EXPO_CONFIGURATION_DEBUG\ninternal import EXDevMenu')
● generateModulesProviderAsync › gates every debug-only registration branch on DEBUG as well as EXPO_CONFIGURATION_DEBUG
  Received has value: null
Tests: 2 failed, 11 passed, 13 total
```

Green, after:

```
Test Suites: 1 failed, 21 passed, 22 total
Tests:       2 failed, 246 passed, 248 total
Snapshots:   54 passed, 54 total
```

The one failing suite is `e2e/__tests__/precompiled-derivations-test.ts` (2 tests). It fails the same way on a clean `main` and is unrelated to this change.

Also clean: `tsc -p tsconfig.json` and `oxlint`. No existing snapshot covered the gate, so none needed updating.

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [x] Built, type-checked, linted, and tested the changed package
- [ ] Conforms with the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — n/a, no docs change
