### PR TITLE
[docs] Add Expo Go version mismatch troubleshooting

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -436,6 +436,7 @@ export const general = [
         makePage('troubleshooting/application-has-not-been-registered.mdx'),
         makePage('troubleshooting/clear-cache-macos-linux.mdx'),
         makePage('troubleshooting/clear-cache-windows.mdx'),
+        makePage('troubleshooting/expo-go-version-mismatch.mdx'),
         makePage('troubleshooting/react-native-version-mismatch.mdx'),
         makePage('troubleshooting/proxies.mdx'),
       ]),

--- a/docs/pages/develop/development-builds/faq.mdx
+++ b/docs/pages/develop/development-builds/faq.mdx
@@ -66,11 +66,13 @@ Both [Android App Links](/linking/android-app-links/) and [iOS Universal Links](
 
 </Collapsible>
 
-<Collapsible summary="Open projects using other SDK versions (iOS device only)">
+<Collapsible summary="Open projects using other SDK versions">
 
-Expo Go can only support one SDK version at a time, and only that version is available to install from the app stores. The store version of Expo Go currently supports SDK 54.
+Each build of Expo Go supports one SDK version. The project and Expo Go SDK versions must match.
 
-If you're developing on an Android device, Android Emulator, or iOS Simulator, a compatible version of Expo Go can be [downloaded and installed](https://expo.dev/go). You can also use the [`expo-go` CLI](/develop/tools/#expo-go-cli) to download a specific version. The only platform where this is impossible is iPhone devices because Apple does not support side-loading other versions of apps.
+On an Android device, Android Emulator, or iOS Simulator, install a compatible version from [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli). On a physical iPhone or iPad, projects using SDK 55 or later can install a compatible build from [sign.expo.dev](https://sign.expo.dev/).
+
+See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) for platform-specific instructions.
 
 </Collapsible>
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -205,7 +205,7 @@ When running a project that was created for an unsupported SDK version in Expo G
 "Project is incompatible with this version of Expo Go"
 ```
 
-The correct fix depends on whether you are using a physical iOS device, an Android device, or a simulator. See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) to install a compatible version or upgrade your project.
+The correct fix depends on whether you are using an Android device, a physical iOS device, or a simulator. See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) to install a compatible version or upgrade your project.
 
 </Collapsible>
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -205,9 +205,7 @@ When running a project that was created for an unsupported SDK version in Expo G
 "Project is incompatible with this version of Expo Go"
 ```
 
-To fix this, upgrading your project to a [supported SDK version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) is recommended. If you want to learn how to do it, see [Upgrade the project to a new SDK Version](#how-do-i-upgrade-my-project-from).
-
-Alternatively, you can use `expo-go` CLI to download the version of Expo Go that matches your project's SDK version.
+The correct fix depends on whether you are using a physical iOS device, an Android device, or a simulator. See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) to install a compatible version or upgrade your project.
 
 </Collapsible>
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -19,7 +19,7 @@ This project requires a newer version of Expo Go.
 
 ## Why this happens
 
-Each build of Expo Go includes one Expo SDK version. The project's SDK version is determined by the version of the `expo` package in **package.json**. The project and Expo Go SDK versions must match.
+Each build of Expo Go includes one Expo SDK version. The `expo` package version in **package.json** sets the project's SDK version. The project and Expo Go SDK versions must match.
 
 The Apple App Store and Google Play Store versions of Expo Go can lag behind a newly released SDK. If your project uses the new SDK, the store may not offer a compatible Expo Go build yet.
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -1,0 +1,59 @@
+---
+title: '"Project is incompatible with this version of Expo Go" error'
+sidebar_title: Expo Go version mismatch
+description: Learn why an Expo project is incompatible with the installed version of Expo Go and how to install a compatible version.
+---
+
+Expo Go displays this error when the Expo SDK version in a project does not match the SDK version included in the installed Expo Go app:
+
+```text
+Project is incompatible with this version of Expo Go
+```
+
+You may also see one of these messages:
+
+```text
+The project you requested requires a newer version of Expo Go.
+This project requires a newer version of Expo Go.
+```
+
+## Why this happens
+
+Each build of Expo Go includes one Expo SDK version. The project's SDK version is determined by the version of the `expo` package in **package.json**. The project and Expo Go SDK versions must match.
+
+The Apple App Store and Google Play Store versions of Expo Go can lag behind a newly released SDK. If your project uses the new SDK, the store may not offer a compatible Expo Go build yet.
+
+## Install a compatible version of Expo Go
+
+Use the instructions for the device where you are testing your project.
+
+### Physical iPhone or iPad
+
+For projects using SDK 55 or later, open [sign.expo.dev](https://sign.expo.dev/), select the SDK version used by your project, and follow the steps to install that Expo Go build on your device.
+
+This installer uses your Apple ID's free developer provisioning, so it does not require a paid Apple Developer Program membership. The certificate is valid for about seven days. Return to [sign.expo.dev](https://sign.expo.dev/) to re-sign and reinstall Expo Go when the certificate expires.
+
+For projects using SDK 54 or earlier, you cannot install an older version of Expo Go on a physical iOS device. Upgrade the project, use an Android device or iOS Simulator, or create a development build.
+
+### Android device, Android Emulator, or iOS Simulator
+
+Visit [expo.dev/go](https://expo.dev/go), select the SDK version used by your project and your target platform, then install the compatible Expo Go build.
+
+You can also use the [`expo-go` CLI](/develop/tools/#expo-go-cli) to download a specific version.
+
+After installing the compatible build, restart the development server with `npx expo start` and open the project again.
+
+## If the versions should already match
+
+If the error remains after installing the correct Expo Go build:
+
+1. Check the `expo` dependency in **package.json** to confirm the project's SDK version.
+2. If **app.json** contains an `sdkVersion` field, remove it or make sure that it matches the `expo` dependency.
+3. Run `npx expo-doctor@latest` to check for dependency version issues.
+4. Run `npx expo install --fix` to align package versions with the installed Expo SDK.
+
+## Upgrade the project or use a development build
+
+You can [upgrade the project to a newer Expo SDK](/workflow/upgrading-expo-sdk-walkthrough/) instead of installing another version of Expo Go.
+
+Expo Go is a learning environment and sandbox. For a production project, [create a development build](/develop/development-builds/introduction/) so the native app and its dependencies are controlled by your project.

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -43,7 +43,7 @@ You can also use the [`expo-go` CLI](/develop/tools/#expo-go-cli) to download a 
 
 After installing the compatible build, restart the development server with `npx expo start` and open the project again.
 
-## If the versions should already match
+## Check the project's SDK version
 
 If the error remains after installing the correct Expo Go build:
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -21,7 +21,7 @@ This project requires a newer version of Expo Go.
 
 Each build of Expo Go includes one Expo SDK version. The `expo` package version in **package.json** sets the project's SDK version. The project and Expo Go SDK versions must match.
 
-The Apple App Store and Google Play Store versions of Expo Go can lag behind a newly released SDK. If your project uses the new SDK, the store may not offer a compatible Expo Go build yet.
+Expo Go on the Apple App Store stops at SDK 54, and SDK 55 and later are not available there. The Google Play version can also lag behind a new SDK release. If your project uses a newer SDK than the store build, use one of the options below instead of waiting for a store update.
 
 ## Install a compatible version of Expo Go
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -33,7 +33,9 @@ For projects using SDK 55 or later, open [sign.expo.dev](https://sign.expo.dev/)
 
 This installer uses your Apple ID's free developer provisioning, so it does not require a paid Apple Developer Program membership. The certificate is valid for about seven days. Return to [sign.expo.dev](https://sign.expo.dev/) to re-sign and reinstall Expo Go when the certificate expires.
 
-For projects using SDK 54 or earlier, you cannot install an older version of Expo Go on a physical iOS device. Upgrade the project, use an Android device or iOS Simulator, or create a development build.
+For projects using SDK 54, install Expo Go from the Apple App Store. You can also use [`eas go`](https://expo.fyi/deploy-expo-go-testflight) to build Expo Go for SDK 54 or later and distribute it through your TestFlight internal team, which needs an Apple Developer Program membership.
+
+For projects using SDK 53 or earlier, you cannot install an older version of Expo Go on a physical iOS device. Upgrade the project, use an Android device or iOS Simulator, or create a development build.
 
 ### Android device, Android Emulator, or iOS Simulator
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -50,7 +50,7 @@ After installing the compatible build, restart the development server with `npx 
 If the error remains after installing the correct Expo Go build:
 
 1. Check the `expo` dependency in **package.json** to confirm the project's SDK version.
-2. If **app.json** contains an `sdkVersion` field, remove it or make sure that it matches the `expo` dependency.
+2. If your [app config](/workflow/configuration/) contains an `sdkVersion` field, remove it or make sure that it matches the `expo` dependency.
 3. Run `npx expo-doctor@latest` to check for dependency version issues.
 4. Run `npx expo install --fix` to align package versions with the installed Expo SDK.
 

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -62,6 +62,13 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
 />
 
 <BoxLink
+  title='"Project is incompatible with this version of Expo Go" error'
+  description="Learn how to install a version of Expo Go that is compatible with your project's Expo SDK version."
+  href="/troubleshooting/expo-go-version-mismatch/"
+  Icon={BookOpen02Icon}
+/>
+
+<BoxLink
   title='"React Native version mismatch" errors'
   description="Learn about what React Native version mismatch means and how to resolve it in an Expo or React Native app."
   href="/troubleshooting/react-native-version-mismatch/"

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -12,7 +12,7 @@ import { Step } from '~/ui/components/Step';
 
 With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
 
-If you are looking to install a specific version of Expo Go, visit [expo.dev/go](https://expo.dev/go) or use [`expo-go` CLI](/develop/tools/#expo-go-cli). It supports downloads for Android devices/emulators and iOS simulators. However, due to iOS platform restrictions, only the latest version of Expo Go is available for installation on physical iOS devices.
+If you are looking to install a specific version of Expo Go on an Android device, Android Emulator, or iOS Simulator, visit [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli). On a physical iPhone or iPad, projects using SDK 55 or later can install a compatible build from [sign.expo.dev](https://sign.expo.dev/). See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) for more information.
 
 ## How to upgrade to the latest SDK version
 


### PR DESCRIPTION
# Why

Kapa gave a generic answer to a common Expo Go SDK mismatch and missed the physical iOS solution. This adds a canonical docs answer that leads with the correct device-specific fix.

Context:

- [Original Discord conversation](https://discord.com/channels/695411232856997968/1529295268623679590)
- [Ryan's feedback on Kapa's answer](https://discord.com/channels/695411232856997968/1529295268623679590/1531481929457729756)

# How

- Added a troubleshooting page with the exact error messages and fixes for physical iOS devices, Android devices, and simulators.
- Documented `sign.expo.dev` for physical iOS devices using SDK 55 or later.
- Linked the answer from navigation and replaced stale guidance elsewhere in the docs.

# Test Plan

- `bun run lint`
- `bun run lint-links`
- `bun run lint-prose`
- Verified the new page and overview link locally on desktop and mobile.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
