### PR TITLE
[router] Add support for replace action in tabs

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [ios] Fix memory leaks in the native toolbar and link preview from strong-reference cycles and closures that strongly captured `self`. ([#47378](https://github.com/expo/expo/pull/47378) by [@Ubax](https://github.com/Ubax))
 - [android][ios] Fix `expo-router/head` and `expo-router/stack` resolution on native platforms. ([#47870](https://github.com/expo/expo/pull/47870) by [@hassankhan](https://github.com/hassankhan))
 - Fix missing subpath warning from Metro when importing from `expo-router/server` ([#48045](https://github.com/expo/expo/pull/48045) by [@hassankhan](https://github.com/hassankhan))
+- Fix `replace` navigation in tabs leaving the replaced route in history. ([#48256](https://github.com/expo/expo/pull/48256) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/__tests__/drawer-router-replace.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/drawer-router-replace.test.ios.tsx
@@ -1,0 +1,34 @@
+import { act, screen } from '@testing-library/react-native';
+
+import { router } from '../imperative-api';
+import { Drawer } from '../layouts/Drawer';
+import { renderRouter } from '../testing-library';
+
+jest.mock('react-native-drawer-layout', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const actual = jest.requireActual(
+    'react-native-drawer-layout'
+  ) as typeof import('react-native-drawer-layout');
+
+  return {
+    ...actual,
+    Drawer: ({ children }: React.PropsWithChildren) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+it('removes the replaced drawer route from history', () => {
+  renderRouter({
+    _layout: () => <Drawer backBehavior="history" />,
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  act(() => router.push('/second'));
+  act(() => router.push('/third'));
+  act(() => router.replace('/'));
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+});

--- a/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
@@ -1,0 +1,40 @@
+import { act, screen } from '@testing-library/react-native';
+
+import { router } from '../imperative-api';
+import { Tabs } from '../layouts/Tabs';
+import { Redirect } from '../link/Link';
+import { renderRouter } from '../testing-library';
+
+it('removes the replaced tab from history', () => {
+  renderRouter({
+    _layout: () => <Tabs backBehavior="history" />,
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  act(() => router.push('/second'));
+  act(() => router.push('/third'));
+  act(() => router.replace('/'));
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+});
+
+it('removes a redirecting tab from history', () => {
+  renderRouter({
+    _layout: () => <Tabs backBehavior="history" />,
+    index: () => null,
+    second: () => null,
+    third: () => null,
+    redirected: () => <Redirect href="/" />,
+  });
+
+  act(() => router.push('/second'));
+  act(() => router.push('/third'));
+  act(() => router.push('/redirected'));
+
+  expect(screen).toHavePathname('/');
+  act(() => router.back());
+  expect(screen).toHavePathname('/third');
+});

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -205,7 +205,7 @@ describe(getNavigateAction, () => {
     expect(result!.type).toBe('JUMP_TO');
   });
 
-  it('REPLACE becomes JUMP_TO when target navigator is drawer', () => {
+  it('preserves REPLACE when target navigator is drawer', () => {
     mockFindDivergentState.mockReturnValue({
       actionState: { routes: [{ name: 'screen1' }] },
       navigationState: {
@@ -222,7 +222,7 @@ describe(getNavigateAction, () => {
 
     const result = getNavigateAction('/screen1', {}, 'REPLACE');
 
-    expect(result!.type).toBe('JUMP_TO');
+    expect(result!.type).toBe('REPLACE');
   });
 
   it('sets target to navigationState.key', () => {

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -78,8 +78,6 @@ export function getNavigateAction(
     type = 'NAVIGATE';
   } else if (navigationState.type === 'expo-tab') {
     type = 'JUMP_TO';
-  } else if (type === 'REPLACE' && navigationState.type === 'drawer') {
-    type = 'JUMP_TO';
   }
 
   if (withAnchor) {

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -242,6 +242,27 @@ describe('Native Bottom Tabs trigger changes', () => {
     expect(screen).toHavePathname('/');
   });
 
+  it('removes a replaced route from tab history', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs backBehavior="history">
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+      notSpecified: () => <View testID="not-specified" />,
+    });
+
+    act(() => router.push('/second'));
+    act(() => router.push('/notSpecified'));
+    expect(screen).toHavePathname('/');
+
+    act(() => router.back());
+    expect(screen).toHavePathname('/second');
+  });
+
   it('respects initialRouteName when redirecting from a route without a visible tab', () => {
     renderRouter(
       {

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -209,6 +209,7 @@ export function DrawerRouter({
 
           return addDrawerToHistory(state);
 
+        case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':
         case 'NAVIGATE_DEPRECATED': {

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -1,6 +1,5 @@
 import { nanoid } from 'nanoid/non-secure';
 
-import type { StackActionType } from '../core';
 import { BaseRouter } from './BaseRouter';
 import { createParamsFromAction } from './createParamsFromAction';
 import type {
@@ -13,12 +12,19 @@ import type {
   Router,
 } from './types';
 
-export type TabActionType = {
-  type: 'JUMP_TO';
-  payload: { name: string; params?: object };
-  source?: string;
-  target?: string;
-};
+export type TabActionType =
+  | {
+      type: 'JUMP_TO';
+      payload: { name: string; params?: object };
+      source?: string;
+      target?: string;
+    }
+  | {
+      type: 'REPLACE';
+      payload: { name: string; params?: object };
+      source?: string;
+      target?: string;
+    };
 
 export type BackBehavior =
   | 'firstRoute'
@@ -61,6 +67,20 @@ export type TabNavigationState<ParamList extends ParamListBase> = Omit<
 
 export type TabActionHelpers<ParamList extends ParamListBase> = {
   /**
+   * Replaces the current tab with another tab.
+   *
+   * @param screen Name of the tab that will replace the current one.
+   * @param [params] Params object for the new tab.
+   */
+  replace<RouteName extends keyof ParamList>(
+    ...args: RouteName extends unknown
+      ? undefined extends ParamList[RouteName]
+        ? [screen: RouteName, params?: ParamList[RouteName]]
+        : [screen: RouteName, params: ParamList[RouteName]]
+      : never
+  ): void;
+
+  /**
    * Jump to an existing tab.
    *
    * @param screen Name of the route to jump to.
@@ -81,6 +101,12 @@ export const TabActions = {
   jumpTo(name: string, params?: object) {
     return {
       type: 'JUMP_TO',
+      payload: { name, params },
+    } as const satisfies TabActionType;
+  },
+  replace(name: string, params?: object) {
+    return {
+      type: 'REPLACE',
       payload: { name, params },
     } as const satisfies TabActionType;
   },
@@ -182,9 +208,16 @@ const changeIndex = (
   };
 };
 
-// TODO(@ubax): unify the logic into single router instead of BaseTabRouter and override
-// TODO(@ubax): add REPLACE action to CommonAction type and handle it in all routers
-function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRouterOptions) {
+/**
+ * TabRouter is considered an internal implementation and its behavior may change without a notice between expo-router's version
+ */
+export function TabRouter({
+  initialRouteName,
+  backBehavior = 'firstRoute',
+}: TabRouterOptions): Router<
+  TabNavigationState<ParamListBase>,
+  TabActionType | CommonNavigationAction
+> {
   const router: Router<
     TabNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
@@ -315,7 +348,12 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
     },
 
     getStateForAction(state, action, { routeParamList, routeGetIdList }) {
+      if (action.target && action.target !== state.key) {
+        return null;
+      }
+
       switch (action.type) {
+        case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':
         case 'NAVIGATE_DEPRECATED': {
@@ -374,12 +412,14 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
             initialRouteName
           );
 
-          return {
+          const result = {
             ...updatedState,
             preloadedRouteKeys: updatedState.preloadedRouteKeys.filter(
               (key) => key !== state.routes[updatedState.index]!.key
             ),
           };
+
+          return action.type === 'REPLACE' ? removeReplacedRouteFromHistory(state, result) : result;
         }
 
         case 'SET_PARAMS':
@@ -495,56 +535,23 @@ function BaseTabRouter({ initialRouteName, backBehavior = 'firstRoute' }: TabRou
   return router;
 }
 
-/**
- * TabRouter is considered an internal implementation and its behavior may change without a notice between expo-router's version
- */
-export function TabRouter(
-  args: TabRouterOptions
-): Router<TabNavigationState<ParamListBase>, TabActionType | CommonNavigationAction> {
-  const base = BaseTabRouter(args);
+function removeReplacedRouteFromHistory(
+  previousState: TabNavigationState<ParamListBase>,
+  nextState: TabNavigationState<ParamListBase>
+) {
+  const replacedRouteKey = previousState.routes[previousState.index]?.key;
+  const focusedRouteKey = nextState.routes[nextState.index]?.key;
+  if (!replacedRouteKey || replacedRouteKey === focusedRouteKey) {
+    return nextState;
+  }
+
+  const replacedIndex = nextState.history.findLastIndex((item) => item.key === replacedRouteKey);
+  if (replacedIndex === -1) {
+    return nextState;
+  }
+
   return {
-    ...base,
-    getStateForAction: (state, action, options) => {
-      if (action.target && action.target !== state.key) {
-        return null;
-      }
-
-      if ((action.type as string) === 'REPLACE') {
-        const replaceAction = action as unknown as Extract<StackActionType, { type: 'REPLACE' }>;
-        // Generate the state as if we were using JUMP_TO
-        let nextState = base.getStateForAction(
-          state,
-          {
-            ...replaceAction,
-            type: 'JUMP_TO',
-          },
-          options
-        );
-
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
-          return null;
-        }
-
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (nextState.index !== 0) {
-          const previousIndex = nextState.index - 1;
-
-          nextState = {
-            ...nextState,
-            key: `${nextState.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...nextState.history.slice(0, previousIndex),
-              ...nextState.history.splice(nextState.index),
-            ],
-          };
-        }
-
-        return nextState;
-      }
-
-      return base.getStateForAction(state, action, options);
-    },
+    ...nextState,
+    history: nextState.history.filter((_, index) => index !== replacedIndex),
   };
 }

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -345,6 +345,52 @@ test('handles navigate action with open drawer', () => {
   });
 });
 
+test('closes open drawer on replace with backBehavior: fullHistory', () => {
+  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+  const options: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        type: 'drawer',
+        preloadedRouteKeys: [],
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+        history: [
+          { type: 'route', key: 'bar' },
+          { type: 'drawer', status: 'open' },
+        ],
+        default: 'closed',
+      },
+      DrawerActions.replace('baz'),
+      options
+    )
+  ).toEqual({
+    stale: false,
+    type: 'drawer',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    preloadedRouteKeys: [],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [{ type: 'route', key: 'baz' }],
+    default: 'closed',
+  });
+});
+
 test('handles open drawer action', () => {
   const router = DrawerRouter({});
   const options: RouterConfigOptions = {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,15 +1,33 @@
 import { expect, jest, test } from '@jest/globals';
+import { expectTypeOf } from 'expect-type';
 
 import {
   CommonActions,
   type ParamListBase,
   type RouterConfigOptions,
   TabActions,
+  type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
 } from '../index';
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
+
+test('types replace action helper params', () => {
+  type Params = {
+    optional: undefined;
+    required: { id: string };
+  };
+
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('optional');
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: '1' });
+  // @ts-expect-error: Required route params cannot be omitted.
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required');
+  // @ts-expect-error: Route params must match the route's param type.
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: 1 });
+  // @ts-expect-error: The route must exist in the param list.
+  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('missing');
+});
 
 test('gets initial state from route names and params with initialRouteName', () => {
   const router = TabRouter({ initialRouteName: 'baz' });
@@ -1053,6 +1071,239 @@ test('ensures unique ID for jump to', () => {
       { type: 'route', key: 'bar-test' },
     ],
   });
+});
+
+test('replaces the focused route when the destination is the first tab', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('bar'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'baz-test' },
+    { type: 'route', key: 'bar-test' },
+  ]);
+});
+
+test('replaces the focused route based on visit history instead of route order', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux', 'foo'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('foo'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'foo-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+});
+
+test('only removes the latest visit when replacing with backBehavior: fullHistory', () => {
+  const router = TabRouter({ backBehavior: 'fullHistory' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('bar'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'baz-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+});
+
+test('replaces the focused route with default backBehavior: firstRoute', () => {
+  const router = TabRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(
+    state,
+    TabActions.replace('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(nextState.index).toBe(2);
+  expect(nextState.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.index).toBe(0);
+});
+
+test('replaces the focused route with backBehavior: order', () => {
+  const router = TabRouter({ backBehavior: 'order' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(
+    state,
+    TabActions.replace('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(nextState.index).toBe(2);
+  expect(nextState.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.index).toBe(0);
+});
+
+test('replaces the focused route with backBehavior: initialRoute', () => {
+  const router = TabRouter({ backBehavior: 'initialRoute', initialRouteName: 'baz' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('bar'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(
+    state,
+    TabActions.replace('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(nextState.index).toBe(2);
+  expect(nextState.history).toEqual([
+    { type: 'route', key: 'baz-test' },
+    { type: 'route', key: 'qux-test' },
+  ]);
+  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.index).toBe(1);
+});
+
+test('replaces the focused route with backBehavior: none', () => {
+  const router = TabRouter({ backBehavior: 'none' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const state = router.getInitialState(options);
+
+  const nextState = router.getStateForAction(
+    state,
+    TabActions.replace('qux'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  expect(nextState.index).toBe(2);
+  expect(nextState.history).toEqual([{ type: 'route', key: 'qux-test' }]);
+  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)).toBeNull();
+});
+
+test('preserves history when replacing a tab with itself', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  let state = router.getInitialState(options);
+  state = router.getStateForAction(
+    state,
+    TabActions.jumpTo('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+
+  const nextState = router.getStateForAction(state, TabActions.replace('baz'), options);
+
+  expect(nextState?.history).toEqual([
+    { type: 'route', key: 'bar-test' },
+    { type: 'route', key: 'baz-test' },
+  ]);
+});
+
+test('preserves the navigator key across repeated replaces', () => {
+  const router = TabRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const initialState = router.getInitialState(options);
+
+  const replacedState = router.getStateForAction(
+    initialState,
+    TabActions.replace('baz'),
+    options
+  ) as TabNavigationState<ParamListBase>;
+  const replacedAgainState = router.getStateForAction(
+    replacedState,
+    TabActions.replace('qux'),
+    options
+  );
+
+  expect(replacedState.key).toBe(initialState.key);
+  expect(replacedAgainState?.key).toBe(initialState.key);
 });
 
 test('handles back action with backBehavior: history', () => {

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -5,8 +5,6 @@ import {
   type TabActionType as RNTabActionType,
   type TabNavigationState,
   type TabRouterOptions as RNTabRouterOptions,
-  type StackActionType,
-  type NavigationAction,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
 import type { TriggerMap } from './common';
@@ -15,12 +13,9 @@ export type ExpoTabRouterOptions = RNTabRouterOptions & {
   triggerMap: TriggerMap;
 };
 
-type ReplaceAction = Extract<StackActionType, { type: 'REPLACE' }>;
-
 export type ExpoTabActionType =
   | RNTabActionType
   | CommonNavigationAction
-  | ReplaceAction
   | {
       type: 'JUMP_TO';
       source?: string;
@@ -41,37 +36,7 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   > = {
     ...rnTabRouter,
     getStateForAction(state, action, options) {
-      if (isReplaceAction(action)) {
-        action = {
-          ...action,
-          type: 'JUMP_TO',
-        };
-        // Generate the state as if we were using JUMP_TO
-        const nextState = rnTabRouter.getStateForAction(state, action, options);
-
-        if (!nextState || nextState.index === undefined || !Array.isArray(nextState.history)) {
-          return null;
-        }
-
-        // We can assert that nextState is TabNavigationState here, because we checked for index and history above
-        state = nextState as TabNavigationState<ParamListBase>;
-
-        // If the state is valid and we didn't JUMP_TO a single history state,
-        // then remove the previous state.
-        if (state.index !== 0) {
-          const previousIndex = state.index - 1;
-
-          state = {
-            ...state,
-            key: `${state.key}-replace`,
-            // Omit the previous history entry that we are replacing
-            history: [
-              ...state.history.slice(0, previousIndex),
-              ...state.history.splice(state.index),
-            ],
-          };
-        }
-      } else if (action.type !== 'JUMP_TO') {
+      if (action.type !== 'JUMP_TO') {
         return rnTabRouter.getStateForAction(state, action, options);
       }
 
@@ -110,8 +75,4 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
   };
 
   return router;
-}
-
-function isReplaceAction(action: NavigationAction): action is ReplaceAction {
-  return action.type === 'REPLACE';
 }


### PR DESCRIPTION
# Why

`TabRouter` does not support `replace` action, which is needed for `Redirect` to work properly

# How

1. Merge `TabRouter` override with `BaseTabRouter`
2. Add support for `replace` in `TabRouter` - tab change + history overwrite
3. Close drawer when replace is dispatched - similar to other actions
4. Update headless tabs router - remove code that is not needed anymore

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
