### PR TITLE
[router] Extract `useHiddenTabRedirect` from `NativeTabs`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
 - Redirect fully guarded navigators to parent ([#47984](https://github.com/expo/expo/pull/47984) by [@Ubax](https://github.com/Ubax))
 - Unset `nativeContainerStyle` in transparent presentations ([#48154](https://github.com/expo/expo/pull/48154) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -1,19 +1,16 @@
 'use client';
 
-import React, { use, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { use, useCallback, useMemo, useRef } from 'react';
 
 import { useRouteNode } from '../Route';
-import { router } from '../imperative-api';
 import type {
   ParamListBase,
   TabNavigationState,
   TabRouterOptions,
 } from '../react-navigation/native';
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
-import type {
-  StandardNavigatorContentProps,
-  StandardNavigatorDescriptor,
-} from '../standard-navigation/types';
+import type { StandardNavigatorContentProps } from '../standard-navigation/types';
+import { useVisibleTabsWithRedirect } from '../standard-navigation/useVisibleTabsWithRedirect';
 import { getAllChildrenNotOfType, getAllChildrenOfType } from '../utils/children';
 import { NativeBottomTabsRouter } from './NativeBottomTabsRouter';
 import { NativeTabTrigger } from './NativeTabTrigger';
@@ -31,6 +28,7 @@ import { convertIconColorPropToObject, convertLabelStylePropToObject } from './u
 
 // In Jetpack Compose, the default back behavior is to go back to the initial route.
 const defaultBackBehavior = 'initialRoute';
+const isNativeTabHidden = (options: NativeTabOptions | undefined) => options?.hidden === true;
 export const NativeTabsContext = React.createContext<boolean>(false);
 
 function NativeTabsContent({
@@ -66,56 +64,31 @@ function NativeTabsContent({
 
   const { routes } = state;
 
+  const { visibleRoutes, visibleFocusedIndex } = useVisibleTabsWithRedirect({
+    routes,
+    focusedRouteKey: routes[state.index]!.key,
+    descriptors,
+    redirectToRouteName,
+    isHidden: isNativeTabHidden,
+  });
   const visibleTabs = useMemo(
     () =>
-      routes
-        // Every filesystem route is registered in state; only routes declared by a
-        // non-hidden <NativeTabs.Trigger> become tab items.
-        .filter((route) => {
-          const descriptor = descriptors[
-            route.key
-          ]! as StandardNavigatorDescriptor<NativeTabOptions>;
-          return descriptor.routeSource === 'layout' && descriptor.options?.hidden !== true;
+      visibleRoutes.map(
+        (route): NativeTabsViewTabItem => ({
+          options: descriptors[route.key]!.options,
+          routeKey: route.key,
+          name: route.name,
+          contentRenderer: () => descriptors[route.key]!.render(),
         })
-        .map(
-          (route): NativeTabsViewTabItem => ({
-            options: descriptors[route.key]!.options,
-            routeKey: route.key,
-            name: route.name,
-            contentRenderer: () => descriptors[route.key]!.render(),
-          })
-        ),
-    [routes, descriptors]
-  );
-  const visibleFocusedTabIndex = useMemo(
-    () => visibleTabs.findIndex((tab) => tab.routeKey === routes[state.index]!.key),
-    [visibleTabs, routes, state.index]
+      ),
+    [descriptors, visibleRoutes]
   );
   const visibleTabsKeys = useMemo(
     () => visibleTabs.map((tab) => tab.routeKey).join(';'),
     [visibleTabs]
   );
 
-  const focusedIndex = visibleFocusedTabIndex >= 0 ? visibleFocusedTabIndex : 0;
-
-  // The focused route can be hidden or have no trigger at all — for example a path pointing at a
-  // route without a tab, or a trigger hidden while focused. Redirect to the router's initial tab,
-  // falling back to the first visible tab. `replace` keeps the unreachable route out of history.
-  // TODO(@ubax): Show a formsheet for hidden tabs which are focused (Tabs + Stack in one).
-  const redirectTabHref = useMemo(() => {
-    const redirectTab =
-      visibleTabs.find(
-        (tab) =>
-          tab.name === redirectToRouteName ||
-          tab.name.replace(/\/index$/, '') === redirectToRouteName
-      ) ?? visibleTabs[0];
-    return routes.find((route) => route.key === redirectTab?.routeKey)?.href;
-  }, [redirectToRouteName, routes, visibleTabs]);
-  useEffect(() => {
-    if (visibleFocusedTabIndex < 0 && redirectTabHref != null) {
-      router.replace(redirectTabHref);
-    }
-  }, [visibleFocusedTabIndex, redirectTabHref]);
+  const focusedIndex = visibleFocusedIndex >= 0 ? visibleFocusedIndex : 0;
 
   const provenanceRef = useRef(0);
 

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { Tabs } from 'react-native-screens';
 
 import { router } from '../../imperative-api';
+import Stack from '../../layouts/StackClient';
 import { Link } from '../../link/Link';
 import { renderRouter } from '../../testing-library';
 import { NativeTabs } from '../NativeTabs';
@@ -362,6 +363,41 @@ describe('Native Bottom Tabs trigger changes', () => {
     for (const call of TabsScreen.mock.calls) {
       expect(call[0].screenKey).toMatch(/^index-[-\w]+/);
     }
+  });
+
+  it('waits for a nested native tabs navigator to regain focus before redirecting', () => {
+    let setHidden!: (hidden: boolean) => void;
+    function TabsLayout() {
+      const [hidden, set] = useState(false);
+      setHidden = set;
+      return (
+        <NativeTabs>
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" hidden={hidden} />
+        </NativeTabs>
+      );
+    }
+    renderRouter(
+      {
+        _layout: () => <Stack />,
+        index: () => <View testID="outside" />,
+        'tabs/_layout': TabsLayout,
+        'tabs/index': () => <View testID="tabs-index" />,
+        'tabs/second': () => <View testID="tabs-second" />,
+      },
+      { initialUrl: '/tabs/second' }
+    );
+
+    act(() => router.push('/'));
+    act(() => setHidden(true));
+
+    expect(screen).toHavePathname('/');
+    expect(screen.getByTestId('outside')).toBeVisible();
+
+    act(() => router.back());
+
+    expect(screen).toHavePathname('/tabs');
+    expect(screen.getByTestId('tabs-index')).toBeVisible();
   });
 
   it('renders no tab UI when every trigger is hidden', () => {

--- a/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
@@ -1,0 +1,147 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { router } from '../../imperative-api';
+import { useIsFocused } from '../../react-navigation/native';
+import { useBuildHref } from '../useBuildHref';
+import { useVisibleTabsWithRedirect } from '../useVisibleTabsWithRedirect';
+
+jest.mock('../../react-navigation/native', () => {
+  const actualNavigation = jest.requireActual(
+    '../../react-navigation/native'
+  ) as typeof import('../../react-navigation/native');
+  return { ...actualNavigation, useIsFocused: jest.fn() };
+});
+jest.mock('../useBuildHref');
+
+const mockedUseIsFocused = useIsFocused as jest.MockedFunction<typeof useIsFocused>;
+const mockedUseBuildHref = useBuildHref as jest.MockedFunction<typeof useBuildHref>;
+
+const routes = [
+  { key: 'home-key', name: 'home' },
+  { key: 'settings-key', name: 'settings/index' },
+  { key: 'hidden-key', name: 'hidden' },
+  { key: 'filesystem-key', name: 'filesystem' },
+];
+const descriptors = {
+  'home-key': { routeSource: 'layout' as const },
+  'settings-key': { routeSource: 'layout' as const },
+  'hidden-key': { routeSource: 'layout' as const, options: { hidden: true } },
+  'filesystem-key': { routeSource: 'filesystem' as const },
+};
+const isHidden = (options: { hidden?: boolean } | undefined) => options?.hidden === true;
+
+let replaceSpy: jest.SpyInstance;
+let buildHref: jest.Mock;
+
+beforeEach(() => {
+  buildHref = jest.fn((route) => `/href/${route.name}`);
+  mockedUseBuildHref.mockReturnValue(buildHref);
+  mockedUseIsFocused.mockReturnValue(true);
+  replaceSpy = jest.spyOn(router, 'replace').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  replaceSpy.mockRestore();
+});
+
+describe('useVisibleTabsWithRedirect', () => {
+  it('returns only visible layout routes and their focused index', () => {
+    const { result } = renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes,
+        focusedRouteKey: 'settings-key',
+        descriptors,
+        isHidden,
+      })
+    );
+
+    expect(result.current).toEqual({
+      visibleRoutes: [routes[0], routes[1]],
+      visibleFocusedIndex: 1,
+    });
+  });
+
+  it('returns -1 when the focused route is not visible', () => {
+    const { result } = renderHook(() =>
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors, isHidden })
+    );
+
+    expect(result.current.visibleFocusedIndex).toBe(-1);
+  });
+
+  it('redirects an unavailable focused route to the configured visible route', () => {
+    renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes,
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+        redirectToRouteName: 'settings',
+        isHidden,
+      })
+    );
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy).toHaveBeenCalledWith('/href/settings/index');
+  });
+
+  it('builds the redirect href from the selected route', () => {
+    renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes,
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+        redirectToRouteName: 'settings',
+        isHidden,
+      })
+    );
+
+    expect(buildHref).toHaveBeenCalledWith(routes[1]);
+  });
+
+  it('falls back to the first visible route when the configured route is unavailable', () => {
+    renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes,
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+        redirectToRouteName: 'missing',
+        isHidden,
+      })
+    );
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy).toHaveBeenCalledWith('/href/home');
+  });
+
+  it('does not redirect when the navigator is unfocused', () => {
+    mockedUseIsFocused.mockReturnValue(false);
+
+    renderHook(() =>
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors, isHidden })
+    );
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when the focused route is visible', () => {
+    renderHook(() =>
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'home-key', descriptors, isHidden })
+    );
+
+    expect(buildHref).toHaveBeenCalledWith(routes[0]);
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when there are no visible routes', () => {
+    renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes: [routes[2]!],
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+        isHidden,
+      })
+    );
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
+++ b/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
@@ -1,0 +1,84 @@
+import { useEffect, useMemo } from 'react';
+
+import { router } from '../imperative-api';
+import {
+  type NavigationRoute,
+  type ParamListBase,
+  type RouteSource,
+  useIsFocused,
+} from '../react-navigation/native';
+import { useBuildHref } from './useBuildHref';
+
+type TabRoute = NavigationRoute<ParamListBase, string>;
+
+type TabDescriptor<Options extends object> = {
+  routeSource?: RouteSource;
+  options?: Options;
+};
+
+/**
+ * Returns the visible layout tabs and their focused index. When the navigator is focused, redirects
+ * an unavailable focused route to `redirectToRouteName` or the first visible tab.
+ */
+export function useVisibleTabsWithRedirect<Route extends TabRoute, Options extends object>({
+  routes,
+  focusedRouteKey,
+  descriptors,
+  redirectToRouteName,
+  isHidden,
+}: {
+  routes: Route[];
+  focusedRouteKey: string;
+  descriptors: Record<string, TabDescriptor<Options>>;
+  redirectToRouteName?: string;
+  // Keep this callback reference-stable to avoid recalculating the visible routes.
+  isHidden?: (options: Options | undefined) => boolean;
+}) {
+  const buildHref = useBuildHref();
+  const isFocused = useIsFocused();
+
+  const visibleRoutes = useMemo(
+    () =>
+      routes.filter((route) => {
+        // Every filesystem route is registered in state; only routes declared by a non-hidden
+        // trigger become tab items.
+        const descriptor = descriptors[route.key];
+        return isDeclaredInLayout(descriptor) && !isHidden?.(descriptor?.options);
+      }),
+    [routes, descriptors, isHidden]
+  );
+  const visibleFocusedIndex = useMemo(
+    () => visibleRoutes.findIndex((route) => route.key === focusedRouteKey),
+    [focusedRouteKey, visibleRoutes]
+  );
+
+  const redirectHref = useMemo(() => {
+    const redirectRoute = findRouteByName(visibleRoutes, redirectToRouteName) ?? visibleRoutes[0];
+    if (redirectRoute) {
+      return buildHref(redirectRoute);
+    }
+    return null;
+  }, [buildHref, redirectToRouteName, visibleRoutes]);
+
+  useEffect(() => {
+    // The focused route can be hidden or have no trigger at all — for example a path pointing at a
+    // route without a tab, or a trigger hidden while focused. Redirect to the router's initial tab,
+    // falling back to the first visible tab. `replace` keeps the unreachable route out of history.
+    // TODO(@ubax): Show a formsheet for hidden tabs which are focused (Tabs + Stack in one).
+    if (isFocused && visibleFocusedIndex < 0 && redirectHref != null) {
+      router.replace(redirectHref);
+    }
+  }, [isFocused, redirectHref, visibleFocusedIndex]);
+
+  return { visibleRoutes, visibleFocusedIndex };
+}
+
+function isDeclaredInLayout<Options extends object>(
+  descriptor: TabDescriptor<Options> | undefined
+): boolean {
+  return descriptor?.routeSource === 'layout';
+}
+
+function findRouteByName<Route extends TabRoute>(routes: Route[], name: string | undefined) {
+  return routes.find((route) => route.name === name || route.name.replace(/\/index$/, '') === name);
+}


### PR DESCRIPTION
# Why

In the follow-up PRs, the detection of `routeNames` changes will be removed. This PR extracts `useVisibleTabsWithRedirect`, so that it can be reused in follow-up changes.

# How

1. Extract `useVisibleTabsWithRedirect` from NativeTabs - this logic will be reused to redirect hidden tabs in headless navigator as well. Hidden in this case means `hidden={true}` or if the route is not specified in the `_layout`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
