### PR TITLE
[ui][ios] Fix presses dropping on RN content hosted in RNHostView

### DIFF
--- a/apps/native-component-list/src/screens/UI/HostingRNViewsScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/HostingRNViewsScreen.ios.tsx
@@ -6,14 +6,19 @@ import {
   List,
   Section,
   RNHostView,
+  ScrollView,
+  LazyHStack,
 } from '@expo/ui/swift-ui';
 import { frame, padding } from '@expo/ui/swift-ui/modifiers';
 import { useState } from 'react';
 import { Text as RNText, View, Pressable } from 'react-native';
 
+const LAZY_STACK_BUTTONS = ['Button One', 'Button Two', 'Button Three', 'Button Four'];
+
 export default function HostingRNViewsScreen() {
   const [counter, setCounter] = useState(0);
   const [boxSize, setBoxSize] = useState(200);
+  const [lastPress, setLastPress] = useState<{ label: string; count: number } | null>(null);
 
   return (
     <Host style={{ flex: 1 }}>
@@ -57,6 +62,38 @@ export default function HostingRNViewsScreen() {
                 </Pressable>
               </RNHostView>
             </HStack>
+          </VStack>
+        </Section>
+        <Section title="Pressables inside a SwiftUI LazyHStack">
+          <VStack spacing={12} modifiers={[padding({ all: 12 })]}>
+            <SwiftUIText>
+              {`Presses must fire even with slight finger movement (#48131). Last press: ${lastPress ? `${lastPress.label} (${lastPress.count})` : 'none'}`}
+            </SwiftUIText>
+            <ScrollView axes="horizontal">
+              <LazyHStack spacing={12}>
+                {LAZY_STACK_BUTTONS.map((label) => (
+                  <RNHostView key={label} matchContents>
+                    <Pressable
+                      onPress={() =>
+                        setLastPress((prev) => ({
+                          label,
+                          count: prev?.label === label ? prev.count + 1 : 1,
+                        }))
+                      }
+                      style={{
+                        width: 144,
+                        height: 56,
+                        borderRadius: 999,
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                        backgroundColor: '#9B59B6',
+                      }}>
+                      <RNText style={{ color: 'white', fontWeight: '600' }}>{label}</RNText>
+                    </Pressable>
+                  </RNHostView>
+                ))}
+              </LazyHStack>
+            </ScrollView>
           </VStack>
         </Section>
         <Section title="Dynamically increasing size">

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `Pressable` (and other responder-based touchables) hosted in `RNHostView` dropping presses on any finger movement. ([#48131](https://github.com/expo/expo/issues/48131) by [@BrianUribe6](https://github.com/BrianUribe6)) ([#48217](https://github.com/expo/expo/pull/48217) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [iOS] Fix `Pressable` (and other responder-based touchables) hosted in `RNHostView` dropping presses on any finger movement. ([#48131](https://github.com/expo/expo/issues/48131) by [@BrianUribe6](https://github.com/BrianUribe6)) ([#48259](https://github.com/expo/expo/pull/48259) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets. ([#48243](https://github.com/expo/expo/pull/48243) by [@Elehiggle](https://github.com/Elehiggle))
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
 - [Android] Fix unexpected resize when opening the calendar from spinner mode on Android. ([#47273](https://github.com/expo/expo/issues/47273) by [@TomCorvus](https://github.com/TomCorvus)) ([#48125](https://github.com/expo/expo/pull/48125) by [@dileepapeiris](https://github.com/dileepapeiris))

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
@@ -4,6 +4,122 @@
 #import <ExpoModulesCore/Platform.h>
 #import <React/RCTSurfaceTouchHandler.h>
 
+// We put a custom RCTSurfaceTouchHandler in RNHostView. 
+// The role of this handler is to dispatch touch events to JS so press handlers works.
+// This is required for two reasons.
+// 1. Touch events in a SwiftUI bottomsheet are not passed to JS as iOS mounts it in a separate window.
+// 2. Touch events received by JS have wrong pageX and pageY as RNHostViews are positioned by SwiftUI instead of Yoga so Pressable events get cancelled.
+//    pageX/pageY are anchored to the view the dispatching handler is attached to:
+//    https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L60
+// So we attach a custom touch handler and add `RootNodeKind` trait to RNHostView. This makes it behave like Modal in RN.
+// We further customise the RCTSurfaceTouchHandler by overriding `canBePreventedByGestureRecognizer` to cancel the RN attached surface level touch handlers
+// (the stock implementation defers to any recognizer outside its own subtree:
+// https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L385).
+// This is required as RNHostView can be put into a regular UIKit/SwiftUI hierarchy in same window so all the touch handlers can fire. 
+// We don't want parent touch handlers to fire as they will carry wrong pageX/pageY.
+// The same pattern is done for Android's RNHostView. There `onChildStartedNativeGesture` cancels the parent handlers.
+// Here we also make sure that the parent handlers are activated again once the gesture is completed by this touch handler.
+@interface ExpoUISurfaceTouchHandler : RCTSurfaceTouchHandler
+@end
+
+@implementation ExpoUISurfaceTouchHandler {
+  // Ancestor handlers disabled while a gesture is in progress. Weak: the surface (or modal host)
+  // owning them can unmount mid-gesture.
+  NSHashTable<RCTSurfaceTouchHandler *> *_suppressedAncestorHandlers;
+}
+
+static BOOL ExpoUIAllTouchesAreCancelledOrEnded(NSSet<UITouch *> *touches)
+{
+  for (UITouch *touch in touches) {
+    if (touch.phase == UITouchPhaseBegan || touch.phase == UITouchPhaseMoved || touch.phase == UITouchPhaseStationary) {
+      return NO;
+    }
+  }
+  return YES;
+}
+
+- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer
+{
+  if ([preventingGestureRecognizer isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+    return NO;
+  }
+  // The base class routes `shouldRequireFailureOfGestureRecognizer:` through this method, so
+  // this also stops the handler from waiting for the surface root handler to fail.
+  return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [self suppressAncestorTouchHandlers];
+  [super touchesBegan:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesEnded:touches withEvent:event];
+
+  if (ExpoUIAllTouchesAreCancelledOrEnded(event.allTouches)) {
+    [self unsuppressAncestorTouchHandlers];
+  }
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesCancelled:touches withEvent:event];
+
+  if (ExpoUIAllTouchesAreCancelledOrEnded(event.allTouches)) {
+    [self unsuppressAncestorTouchHandlers];
+  }
+}
+
+- (void)reset
+{
+  [super reset];
+  [self unsuppressAncestorTouchHandlers];
+}
+
+- (void)detachFromView:(UIView *)view
+{
+  // The host can unmount mid-gesture; don't leave the surface root handler disabled.
+  [self unsuppressAncestorTouchHandlers];
+  [super detachFromView:view];
+}
+
+- (void)dealloc
+{
+  [self unsuppressAncestorTouchHandlers];
+}
+
+- (void)suppressAncestorTouchHandlers
+{
+  if (_suppressedAncestorHandlers.count > 0) {
+    return;
+  }
+  if (_suppressedAncestorHandlers == nil) {
+    _suppressedAncestorHandlers = [NSHashTable weakObjectsHashTable];
+  }
+  // Disable every RN surface handler above us (the surface root's, a modal host's, and any
+  // enclosing `RNHostView`'s) so none of them dispatches a parallel surface-coordinate stream.
+  for (UIView *ancestor = self.view.superview; ancestor != nil; ancestor = ancestor.superview) {
+    for (UIGestureRecognizer *recognizer in ancestor.gestureRecognizers) {
+      if ([recognizer isKindOfClass:[RCTSurfaceTouchHandler class]] && recognizer.enabled) {
+        recognizer.enabled = NO;
+        [_suppressedAncestorHandlers addObject:(RCTSurfaceTouchHandler *)recognizer];
+      }
+    }
+  }
+}
+
+- (void)unsuppressAncestorTouchHandlers
+{
+  for (RCTSurfaceTouchHandler *handler in _suppressedAncestorHandlers) {
+    handler.enabled = YES;
+  }
+  [_suppressedAncestorHandlers removeAllObjects];
+}
+
+@end
+
 @implementation ExpoUITouchHandlerHelper
 
 + (nullable UIGestureRecognizer *)createAndAttachTouchHandlerForView:(UIView *)view {
@@ -12,7 +128,7 @@
       return nil;
     }
   }
-  RCTSurfaceTouchHandler *touchHandler = [[RCTSurfaceTouchHandler alloc] init];
+  RCTSurfaceTouchHandler *touchHandler = [[ExpoUISurfaceTouchHandler alloc] init];
   [touchHandler attachToView:view];
   return touchHandler;
 }

--- a/packages/expo-ui/ios/RNHostView.swift
+++ b/packages/expo-ui/ios/RNHostView.swift
@@ -5,6 +5,10 @@ import ExpoModulesCore
 
 internal final class RNHostViewProps: ExpoSwiftUI.ViewProps {
   @Field var matchContents: Bool = false
+  // Consumed by `ExpoViewShadowNode` in C++, which marks the shadow node with the `RootNodeKind`
+  // trait so `measure()` reports coordinates in the same space as the touches dispatched by the
+  // handler attached below. Declared here only so React Native forwards the prop to native.
+  @Field var layoutRoot: Bool = false
 }
 
 struct RNHostView: ExpoSwiftUI.View {

--- a/packages/expo-ui/src/swift-ui/RNHostView.tsx
+++ b/packages/expo-ui/src/swift-ui/RNHostView.tsx
@@ -20,6 +20,10 @@ export function RNHostView(props: RNHostViewProps) {
   return (
     <RNHostNativeView
       {...props}
+      // The host dispatches touches to the hosted content from its own touch handler, so touch
+      // coordinates are relative to the host. Mark the shadow node as a layout root so `measure()`
+      // reports the same coordinate space; otherwise `Pressable` cancels the press on any movement.
+      layoutRoot
       // `matchContents` can only be used once on mount
       // So we force unmount when it changes to prevent unexpected layout
       key={props.matchContents ? 'matchContents' : 'noMatchContents'}


### PR DESCRIPTION
# Why

Fixes the iOS side of https://github.com/expo/expo/issues/48131. Android was fixed in #48217.

We put a custom `RCTSurfaceTouchHandler` in `RNHostView`. The role of this handler is to dispatch touch events to JS so press handlers work. This is required for two reasons.

1. Touch events in a SwiftUI bottom sheet are not passed to JS, as iOS mounts the sheet in a separate view hierarchy (a presented view controller) outside the RN root view, so the root touch handler never sees those touches.
2. Touch events received by JS have wrong `pageX`/`pageY`, as `RNHostView`s are positioned by SwiftUI instead of Yoga, so `Pressable` events get cancelled on any finger movement. `pageX`/`pageY` are anchored to the view the dispatching handler is attached to: https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L60

# How

- We attach a custom touch handler and add the `RootNodeKind` trait to `RNHostView` (via the `layoutRoot` prop from #48217). This makes it behave like `Modal` in RN, so touches and `measure()` share the host's coordinate space.
- We further customize the handler by overriding `canBePreventedByGestureRecognizer` so RN's surface-level touch handlers can't preempt it (the stock implementation yields to any recognizer outside its own subtree: https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L385), and we disable ancestor surface handlers while a hosted gesture is in flight. This is required because `RNHostView` can sit in a regular UIKit/SwiftUI hierarchy in the same window, so all the touch handlers can fire, and the parent handlers would carry wrong `pageX`/`pageY`.
- Parent handlers are re-enabled once the gesture completes (touch end/cancel, `reset`, detach, dealloc), so the root surface never stays blocked.
- The same pattern is used on Android's `RNHostView`. There `onChildStartedNativeGesture` silences the parent handlers.
- Add a hosted `Pressable` in `LazyHStack` regression example.

# Test Plan

- bare-expo NCL: Put a Pressable in RNHostView in a SwiftUI hierarchy -> press in on a button -> move finger out of the view -> bring finger back on the view and press out, the press should fire.




# TLDR

This makes `RNHostView` mimic the pattern used by RN Modal. One difference with RN Modal is that we need to Host the view in same hierarchy vs in a separate window, so we need to also disable the existing surface touch handlers.