### PR TITLE
[test-core] Fix package.json formatting

### DIFF
--- a/packages/expo-modules-test-core/package.json
+++ b/packages/expo-modules-test-core/package.json
@@ -39,11 +39,11 @@
     "xml-js": "^1.6.11",
     "yaml": "^2.8.3"
   },
-  "peerDependencies": {
-    "expo": "*"
-  },
   "devDependencies": {
     "@types/jest": "^29.2.1",
     "expo-module-scripts": "workspace:*"
+  },
+  "peerDependencies": {
+    "expo": "*"
   }
 }


### PR DESCRIPTION
# Why

`et check-packages expo-modules-test-core` fails on `main`. The `format` task reports a format issue in `package.json`.

# How

PR #48224 added a `peerDependencies` block above `devDependencies`. The `oxfmt` check requires these keys in sorted order. The `check-packages` check [failed on that PR](https://github.com/expo/expo/actions/runs/30357068910/job/90267633336) with `expo-modules-test-core#format`, but it was merged anyway. This PR runs `pnpm oxfmt package.json` in the package, which moves `peerDependencies` below `devDependencies`.

# Test Plan

`et check-packages expo-modules-test-core` now passes locally:

```
 Tasks:    2 successful, 2 total
🏁 All checks passed.
```

<!-- disable:changelog-checks -->