### PR TITLE
[iOS] Fix "type of expression is ambiguous without a type annotation" in ExpoModulesJSI on Xcode 26.2

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the `Build ExpoModulesJSI xcframework` phase failing with "type of expression is ambiguous without a type annotation" on Xcode 26.2 by qualifying the `abs` call in `JavaScriptCodable+Date.swift` as `Swift.abs` — under C++ interop the unqualified call is ambiguous with the C/C++ overloads. ([#48261](https://github.com/expo/expo/pull/48261) by [@Bram-dc](https://github.com/Bram-dc))
 - [iOS] Fixed a use-after-free when a `JavaScriptPromise` outlives its runtime (e.g. an async function's promise held by a completion handler that fires after `reloadAsync()`) by having the runtime's `LongLivedObjectCollection` own its JSI values and release them on the JavaScript thread when the wrapper is dropped or at teardown, instead of against a freed runtime. ([#47521](https://github.com/expo/expo/pull/47521) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a standalone `JavaScriptRuntime` leaking its underlying Hermes runtime: a runtime it creates itself is now destroyed on `deinit`, while runtimes adopted from elsewhere (e.g. React Native) are left untouched. ([#47515](https://github.com/expo/expo/pull/47515) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed `Build ExpoModulesJSI xcframework` build phase failing on Xcode 26 because the nested SwiftPM build ignored `-derivedDataPath` and wrote products outside the expected location. ([#46326](https://github.com/expo/expo/issues/46326) by [@Kurogoma4D](https://github.com/Kurogoma4D))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Date.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Coding/JavaScriptCodable+Date.swift
@@ -50,7 +50,7 @@ let maxJavaScriptDateMilliseconds: Double = 8_640_000_000_000_000
 /// faithful to `new Date(number)`; the `Date`/string branches pass an already-clipped `getTime()` through.
 @usableFromInline
 func dateFromMilliseconds(_ milliseconds: Double) throws -> Date {
-  guard milliseconds.isFinite, abs(milliseconds) <= maxJavaScriptDateMilliseconds else {
+  guard milliseconds.isFinite, Swift.abs(milliseconds) <= maxJavaScriptDateMilliseconds else {
     throw InvalidDateException()
   }
   return Date(timeIntervalSince1970: milliseconds.rounded(.towardZero) / 1000.0)


### PR DESCRIPTION
# Why

Fixes #47957 (closed, but `main` still ships the bare `abs`).

Archiving an app with Xcode 26.2 fails in the `[CP-User] Build ExpoModulesJSI xcframework` phase with:

```
type of expression is ambiguous without a type annotation
```

at `JavaScriptCodable+Date.swift:53`. `ExpoModulesJSI` builds with C++ interop enabled, and under the Swift compiler shipped in Xcode 26.2 the unqualified `abs(milliseconds)` is ambiguous between `Swift.abs` and the C/C++ stdlib overloads the interop brings into scope.

# How

Qualify the call as `Swift.abs`. No behavior change.

# Test Plan

We ship this exact change as a pnpm patch on `expo-modules-jsi@57.0.4`:

- Without it, `eas build` (local) on Xcode 26.2 fails to archive with the error above — same report as #47957.
- With it, the `Build ExpoModulesJSI xcframework` phase and the full iOS archive succeed for both the `ios-arm64` device slice and the simulator slice, and the JSI package compiles with no further ambiguity errors.
