### PR TITLE
[expo-type-information] Better optionals handling

### DIFF
--- a/packages/expo-type-information/__tests__/TestModule.swift
+++ b/packages/expo-type-information/__tests__/TestModule.swift
@@ -98,6 +98,21 @@ public class TestModule: Module {
       return TestEnum.simpleCase
     }
 
+    Function("TestNullableReturn") { () -> String? in
+      return nil
+    }
+
+    Function("TestOptionalArguments") { (a: Int?, b: [String?], c: ValueOrUndefined<Int>) -> Double? in
+      return nil
+    }
+
+    Function("TestMixedOptionalArguments") { (a: Int, b: String?, c: Double, d: Bool?, e: [Int]?) in
+    }
+
+    Function("TestSharedRef") { (ref: SharedRef<UIImage>) -> SharedRef<UIImage> in
+      return ref
+    }
+
     AsyncFunction("TestSimpleAsyncFunction") { (a: String, b: String) async ->  String in
       return a + b
     }

--- a/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
+++ b/packages/expo-type-information/__tests__/__snapshots__/typeInformation.test.ts.snap
@@ -137,6 +137,20 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   )[][];
   TestFunctionReturningRecord(): TestRecord;
   TestFunctionReturningEnum(): TestEnum;
+  TestNullableReturn(): string | null;
+  TestOptionalArguments(
+    a: number | null,
+    b: (string | null)[],
+    c: number | undefined
+  ): number | null;
+  TestMixedOptionalArguments(
+    a: number,
+    b: string | null,
+    c: number,
+    d?: boolean,
+    e?: number[]
+  ): unknown /*The type couldn't be resolved automatically.*/;
+  TestSharedRef(ref: SharedRef<any>): SharedRef<any>;
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
@@ -241,6 +255,28 @@ export function TestFunctionReturningRecord() {
 export function TestFunctionReturningEnum() {
   return TestModule.TestFunctionReturningEnum();
 }
+export function TestNullableReturn() {
+  return TestModule.TestNullableReturn();
+}
+export function TestOptionalArguments(
+  a: number | null,
+  b: (string | null)[],
+  c: number | undefined
+) {
+  return TestModule.TestOptionalArguments(a, b, c);
+}
+export function TestMixedOptionalArguments(
+  a: number,
+  b: string | null,
+  c: number,
+  d?: boolean,
+  e?: number[]
+) {
+  return TestModule.TestMixedOptionalArguments(a, b, c, d, e);
+}
+export function TestSharedRef(ref: SharedRef<any>) {
+  return TestModule.TestSharedRef(ref);
+}
 
 export async function TestSimpleAsyncFunction(a: string, b: string) {
   return TestModule.TestSimpleAsyncFunction(a, b);
@@ -339,6 +375,7 @@ import type {
   BarcodeType
 } from './Common.types';
 import type { ColorValue } from 'react-native';
+import type { SharedRef } from 'expo';
 import { NativeModule, requireNativeModule } from 'expo';
 import { TestClassWithConstructor, TestBasicClass, TestEmptyClass } from './TestModule.types';
 export declare class TestModule extends NativeModule<TestModuleEvents> {
@@ -378,6 +415,20 @@ export declare class TestModule extends NativeModule<TestModuleEvents> {
   )[][];
   TestFunctionReturningRecord(): TestRecord;
   TestFunctionReturningEnum(): TestEnum;
+  TestNullableReturn(): string | null;
+  TestOptionalArguments(
+    a: number | null,
+    b: (string | null)[],
+    c: number | undefined
+  ): number | null;
+  TestMixedOptionalArguments(
+    a: number,
+    b: string | null,
+    c: number,
+    d?: boolean,
+    e?: number[]
+  ): unknown /*The type couldn't be resolved automatically.*/;
+  TestSharedRef(ref: SharedRef<any>): SharedRef<any>;
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
@@ -578,6 +629,10 @@ export function TestTypeCombinations(a: number[][][]): (string | {
 })[][] { return []; }
 export function TestFunctionReturningRecord(): TestRecord { return { basicString: "", basicStringInitialized: "", basicIntInferred: 0, basicDoubleInferred: 0, basicStringInferred: "", enumInferred: TestEnum.simpleCase, complexEnumInferred: TestEnum.simpleCase, recordInferred: { field1: 0, field2: "" }, optionalInt: 0, letDoubleBinding: 0 }; }
 export function TestFunctionReturningEnum(): TestEnum { return TestEnum.simpleCase; }
+export function TestNullableReturn(): string | null { return ""; }
+export function TestOptionalArguments(a: number | null, b: (string | null)[], c: number | undefined): number | null { return 0; }
+export function TestMixedOptionalArguments(a: number, b: string | null, c: number, d?: boolean, e?: number[]): unknown /*The type couldn't be resolved automatically.*/ { return; }
+export function TestSharedRef(ref: SharedRef<any>): SharedRef<any> { return {}; }
 
 
 export async function TestSimpleAsyncFunction(a: string, b: string): Promise<string> { return ""; }
@@ -664,6 +719,10 @@ export function TestParametrizedTypes(a) { return ""; }
 export function TestTypeCombinations(a) { return []; }
 export function TestFunctionReturningRecord() { return { basicString: "", basicStringInitialized: "", basicIntInferred: 0, basicDoubleInferred: 0, basicStringInferred: "", enumInferred: TestEnum.simpleCase, complexEnumInferred: TestEnum.simpleCase, recordInferred: { field1: 0, field2: "" }, optionalInt: 0, letDoubleBinding: 0 }; }
 export function TestFunctionReturningEnum() { return TestEnum.simpleCase; }
+export function TestNullableReturn() { return ""; }
+export function TestOptionalArguments(a, b, c) { return 0; }
+export function TestMixedOptionalArguments(a, b, c, d, e) { return; }
+export function TestSharedRef(ref) { return {}; }
 export async function TestSimpleAsyncFunction(a, b) { return ""; }
 export async function TestAsyncFunctionPromiseArgument1() { return ""; }
 export async function TestAsyncFunctionPromiseArgument2() { }
@@ -810,6 +869,20 @@ export declare class TestModuleNativeModuleType extends NativeModule<TestModuleE
   )[][];
   TestFunctionReturningRecord(): TestRecord;
   TestFunctionReturningEnum(): TestEnum;
+  TestNullableReturn(): string | null;
+  TestOptionalArguments(
+    a: number | null,
+    b: (string | null)[],
+    c: number | undefined
+  ): number | null;
+  TestMixedOptionalArguments(
+    a: number,
+    b: string | null,
+    c: number,
+    d?: boolean,
+    e?: number[]
+  ): unknown /*The type couldn't be resolved automatically.*/;
+  TestSharedRef(ref: SharedRef<any>): SharedRef<any>;
   TestSimpleAsyncFunction(a: string, b: string): Promise<string>;
   TestAsyncFunctionPromiseArgument1(): Promise<string>;
   TestAsyncFunctionPromiseArgument2(): Promise<void>;
@@ -1004,7 +1077,7 @@ exports[`Same type information 1`] = `
           "parameters": [],
           "returnType": {
             "kind": 0,
-            "type": 8,
+            "type": 9,
           },
         },
       ],
@@ -1207,7 +1280,7 @@ exports[`Same type information 1`] = `
           "name": "UntypedConstant",
           "type": {
             "kind": 0,
-            "type": 8,
+            "type": 9,
           },
         },
       ],
@@ -1288,7 +1361,7 @@ exports[`Same type information 1`] = `
           "parameters": [],
           "returnType": {
             "kind": 0,
-            "type": 7,
+            "type": 8,
           },
         },
         {
@@ -1591,6 +1664,150 @@ exports[`Same type information 1`] = `
             "type": "TestEnum",
           },
         },
+        {
+          "arguments": [],
+          "isStatic": false,
+          "name": "TestNullableReturn",
+          "parameters": [],
+          "returnType": {
+            "kind": 5,
+            "type": {
+              "kind": 0,
+              "type": 1,
+            },
+          },
+        },
+        {
+          "arguments": [
+            {
+              "name": "a",
+              "type": {
+                "kind": 5,
+                "type": {
+                  "kind": 0,
+                  "type": 2,
+                },
+              },
+            },
+            {
+              "name": "b",
+              "type": {
+                "kind": 6,
+                "type": {
+                  "kind": 5,
+                  "type": {
+                    "kind": 0,
+                    "type": 1,
+                  },
+                },
+              },
+            },
+            {
+              "name": "c",
+              "type": {
+                "kind": 3,
+                "type": {
+                  "types": [
+                    {
+                      "kind": 0,
+                      "type": 2,
+                    },
+                    {
+                      "kind": 0,
+                      "type": 5,
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+          "isStatic": false,
+          "name": "TestOptionalArguments",
+          "parameters": [],
+          "returnType": {
+            "kind": 5,
+            "type": {
+              "kind": 0,
+              "type": 2,
+            },
+          },
+        },
+        {
+          "arguments": [
+            {
+              "name": "a",
+              "type": {
+                "kind": 0,
+                "type": 2,
+              },
+            },
+            {
+              "name": "b",
+              "type": {
+                "kind": 5,
+                "type": {
+                  "kind": 0,
+                  "type": 1,
+                },
+              },
+            },
+            {
+              "name": "c",
+              "type": {
+                "kind": 0,
+                "type": 2,
+              },
+            },
+            {
+              "name": "d",
+              "type": {
+                "kind": 5,
+                "type": {
+                  "kind": 0,
+                  "type": 3,
+                },
+              },
+            },
+            {
+              "name": "e",
+              "type": {
+                "kind": 5,
+                "type": {
+                  "kind": 6,
+                  "type": {
+                    "kind": 0,
+                    "type": 2,
+                  },
+                },
+              },
+            },
+          ],
+          "isStatic": false,
+          "name": "TestMixedOptionalArguments",
+          "parameters": [],
+          "returnType": {
+            "kind": 0,
+            "type": 9,
+          },
+        },
+        {
+          "arguments": [
+            {
+              "name": "ref",
+              "type": {
+                "kind": 1,
+                "type": 7,
+              },
+            },
+          ],
+          "isStatic": false,
+          "name": "TestSharedRef",
+          "parameters": [],
+          "returnType": {
+            "kind": 1,
+            "type": 7,
+          },
+        },
       ],
       "name": "TestModule",
       "properties": [],
@@ -1615,7 +1832,7 @@ exports[`Same type information 1`] = `
                   "name": "view",
                   "type": {
                     "kind": 0,
-                    "type": 8,
+                    "type": 9,
                   },
                 },
                 {
@@ -1634,7 +1851,7 @@ exports[`Same type information 1`] = `
                   "name": "view",
                   "type": {
                     "kind": 0,
-                    "type": 8,
+                    "type": 9,
                   },
                 },
                 {
@@ -1653,7 +1870,7 @@ exports[`Same type information 1`] = `
                   "name": "view",
                   "type": {
                     "kind": 0,
-                    "type": 8,
+                    "type": 9,
                   },
                 },
                 {
@@ -1672,7 +1889,7 @@ exports[`Same type information 1`] = `
                   "name": "view",
                   "type": {
                     "kind": 0,
-                    "type": 8,
+                    "type": 9,
                   },
                 },
                 {
@@ -1691,7 +1908,7 @@ exports[`Same type information 1`] = `
                   "name": "view",
                   "type": {
                     "kind": 0,
-                    "type": 8,
+                    "type": 9,
                   },
                 },
                 {

--- a/packages/expo-type-information/src/mockgen.ts
+++ b/packages/expo-type-information/src/mockgen.ts
@@ -93,6 +93,8 @@ function getBasicTypeMockLiteral(type: BasicType): ts.Expression | undefined {
       return undefined;
     case BasicType.OBJECT:
       return ts.factory.createObjectLiteralExpression();
+    case BasicType.NULL:
+      return ts.factory.createNull();
   }
 }
 
@@ -140,6 +142,7 @@ const CONVERTIBLE_TYPE_MOCK: Record<ConvertibleType, () => ts.Expression> = {
       ts.factory.createBlock([])
     ),
   [ConvertibleType.UINT8_ARRAY]: () => ts.factory.createArrayLiteralExpression([]),
+  [ConvertibleType.SHARED_REF]: () => ts.factory.createObjectLiteralExpression([]),
 };
 
 function getConvertibleTypeMockLiteral(type: ConvertibleType): ts.Expression {

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -1,5 +1,4 @@
 import { execSync, exec } from 'child_process';
-import { assert } from 'console';
 import fs from 'fs';
 import { promisify } from 'util';
 import YAML from 'yaml';
@@ -227,15 +226,14 @@ function mapParametrizedTypeToTsType(parametrizedType: ParametrizedType): Type {
       kind: TypeKind.SUM,
       type: { types: parametrizedType.types },
     };
-  } else if ('ValueOrUndefined' === parametrizedType.name) {
-    assert(1 === parametrizedType.types.length);
+  } else if (parametrizedType.name === 'ValueOrUndefined') {
     return {
       kind: TypeKind.SUM,
       type: {
         types: [parametrizedType.types[0]!, { kind: TypeKind.BASIC, type: BasicType.UNDEFINED }],
       },
     };
-  } else if ('SharedRef' === parametrizedType.name) {
+  } else if (parametrizedType.name === 'SharedRef') {
     return {
       kind: TypeKind.CONVERTIBLE,
       // TODO(@HubertBer) Ignore the typing of `SharedRef` for now, need to handle it better in the future.

--- a/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
+++ b/packages/expo-type-information/src/swift/sourcekittenTypeInformation.ts
@@ -1,4 +1,5 @@
 import { execSync, exec } from 'child_process';
+import { assert } from 'console';
 import fs from 'fs';
 import { promisify } from 'util';
 import YAML from 'yaml';
@@ -220,6 +221,34 @@ const convertibleTypesConversions = new Map<string, ConvertibleType>([
   ['Data', ConvertibleType.UINT8_ARRAY],
 ]);
 
+function mapParametrizedTypeToTsType(parametrizedType: ParametrizedType): Type {
+  if (isEitherTypeIdentifier(parametrizedType.name)) {
+    return {
+      kind: TypeKind.SUM,
+      type: { types: parametrizedType.types },
+    };
+  } else if ('ValueOrUndefined' === parametrizedType.name) {
+    assert(1 === parametrizedType.types.length);
+    return {
+      kind: TypeKind.SUM,
+      type: {
+        types: [parametrizedType.types[0]!, { kind: TypeKind.BASIC, type: BasicType.UNDEFINED }],
+      },
+    };
+  } else if ('SharedRef' === parametrizedType.name) {
+    return {
+      kind: TypeKind.CONVERTIBLE,
+      // TODO(@HubertBer) Ignore the typing of `SharedRef` for now, need to handle it better in the future.
+      type: ConvertibleType.SHARED_REF,
+    };
+  }
+
+  return {
+    kind: TypeKind.PARAMETRIZED,
+    type: parametrizedType,
+  };
+}
+
 function mapSwiftTypeToTsType(type?: string): Type {
   if (!type) {
     return { kind: TypeKind.BASIC, type: BasicType.UNRESOLVED };
@@ -252,17 +281,7 @@ function mapSwiftTypeToTsType(type?: string): Type {
 
   if (isParametrizedType(type)) {
     const parametrizedType = unwrapParametrizedType(type);
-    if (isEitherTypeIdentifier(parametrizedType.name)) {
-      return {
-        kind: TypeKind.SUM,
-        type: { types: parametrizedType.types },
-      };
-    }
-
-    return {
-      kind: TypeKind.PARAMETRIZED,
-      type: parametrizedType,
-    };
+    return mapParametrizedTypeToTsType(parametrizedType);
   }
 
   const tsBasicType = basicTypesConversions.get(type);
@@ -664,11 +683,16 @@ async function parseModuleClassStructure(
 
   const removeImplicitThis = (functionDeclaration: FunctionDeclaration) => {
     const firstArg = functionDeclaration.arguments[0];
+    const firstArgIsNotAnnotated =
+      firstArg &&
+      firstArg.type.kind === TypeKind.BASIC &&
+      firstArg.type.type === BasicType.UNRESOLVED;
     if (
-      functionDeclaration.isStatic ||
-      firstArg === undefined ||
-      firstArg.type.kind !== TypeKind.IDENTIFIER ||
-      firstArg.type.type !== name
+      !firstArgIsNotAnnotated &&
+      (functionDeclaration.isStatic ||
+        firstArg === undefined ||
+        firstArg.type.kind !== TypeKind.IDENTIFIER ||
+        firstArg.type.type !== name)
     ) {
       return;
     }

--- a/packages/expo-type-information/src/typeInformation.types.ts
+++ b/packages/expo-type-information/src/typeInformation.types.ts
@@ -109,6 +109,7 @@ export enum BasicType {
   BOOLEAN,
   VOID,
   UNDEFINED,
+  NULL,
   NEVER,
   OBJECT,
   /** Represents a type that couldn't be resolved */
@@ -126,6 +127,7 @@ export enum ConvertibleType {
   CG_VECTOR,
   CG_RECT,
   JS_FUNCTION,
+  SHARED_REF,
 }
 
 /**

--- a/packages/expo-type-information/src/typescriptGeneration.ts
+++ b/packages/expo-type-information/src/typescriptGeneration.ts
@@ -138,6 +138,7 @@ const BASIC_TYPE_MAP: Record<BasicType, ts.KeywordTypeSyntaxKind> = {
   [BasicType.NEVER]: ts.SyntaxKind.NeverKeyword,
   [BasicType.OBJECT]: ts.SyntaxKind.ObjectKeyword,
   [BasicType.UNRESOLVED]: ts.SyntaxKind.UndefinedKeyword, // This is handled separately
+  [BasicType.NULL]: ts.SyntaxKind.UndefinedKeyword, // This is handled separately
 };
 
 function mapBasicTypeToTypeNode(basicType: BasicType): ts.TypeNode {
@@ -147,6 +148,9 @@ function mapBasicTypeToTypeNode(basicType: BasicType): ts.TypeNode {
       ts.SyntaxKind.MultiLineCommentTrivia,
       "The type couldn't be resolved automatically."
     );
+  }
+  if (basicType === BasicType.NULL) {
+    return ts.factory.createLiteralTypeNode(ts.factory.createNull());
   }
 
   return ts.factory.createKeywordTypeNode(BASIC_TYPE_MAP[basicType]);
@@ -182,6 +186,8 @@ const CONVERTIBLE_TYPE_MAP: Record<ConvertibleType, () => ts.TypeNode> = {
       createPropertySignature({ name: 'height', typeNode: numberKeywordType() }),
     ]),
   [ConvertibleType.JS_FUNCTION]: () => createAnyFunctionTypeNode({ returnType: anyKeywordType() }),
+  [ConvertibleType.SHARED_REF]: () =>
+    ts.factory.createTypeReferenceNode('SharedRef', [anyKeywordType()]),
 };
 
 function mapConvertibleTypeToTypeNode(convertibleType: ConvertibleType): ts.TypeNode {
@@ -215,13 +221,10 @@ export function mapTypeToTsTypeNode(type: Type): ts.TypeNode {
     }
     // Technically this one should only be the top one and it should be handled somewhere else
     // for example when creating argument adding the '?' token.
-    //
-    // However we can just make it (type | undefined) in here.
-    // TODO(@HubertBer): Maybe also need null?
     case TypeKind.OPTIONAL:
       return ts.factory.createUnionTypeNode([
         mapTypeToTsTypeNode(type.type as Type),
-        mapBasicTypeToTypeNode(BasicType.UNDEFINED),
+        mapBasicTypeToTypeNode(BasicType.NULL),
       ]);
     case TypeKind.PARAMETRIZED:
       return ts.factory.createTypeReferenceNode(
@@ -590,20 +593,44 @@ function buildNativeModuleClassDeclaration({
   ];
 }
 
-function buildArgumentDeclarationAndName(arg: Argument): {
+// Index of the first argument in the trailing run of optionals.
+function firstTrailingOptionalIndex(args: Argument[]): number {
+  let index = args.length;
+  while (index > 0 && args[index - 1]!.type.kind === TypeKind.OPTIONAL) {
+    index -= 1;
+  }
+  return index;
+}
+
+function buildArgumentDeclarationAndName(
+  arg: Argument,
+  isTrailingOptional: boolean
+): {
   argDeclaration: ts.ParameterDeclaration;
   argName: string;
 } {
   const argName = arg.name ?? '_' + getNextFreeId();
+  const useQuestionToken = isTrailingOptional && arg.type.kind === TypeKind.OPTIONAL;
   const argDeclaration = createParameter({
     name: argName,
-    type: mapTypeToTsTypeNode(arg.type),
+    questionToken: useQuestionToken
+      ? ts.factory.createToken(ts.SyntaxKind.QuestionToken)
+      : undefined,
+
+    type: useQuestionToken
+      ? // The type is optional, need to get to its inner type.
+        mapTypeToTsTypeNode(arg.type.type as Type)
+      : mapTypeToTsTypeNode(arg.type),
   });
   return { argDeclaration, argName };
 }
 
-function buildArgumentDeclaration(arg: Argument): ts.ParameterDeclaration {
-  return buildArgumentDeclarationAndName(arg).argDeclaration;
+function buildArgumentDeclarations(args: Argument[]): ts.ParameterDeclaration[] {
+  const trailingOptionalsStart = firstTrailingOptionalIndex(args);
+  return args.map(
+    (arg, index) =>
+      buildArgumentDeclarationAndName(arg, index >= trailingOptionalsStart).argDeclaration
+  );
 }
 
 export type buildFunctionOptions = {
@@ -645,7 +672,7 @@ export function buildFunction({
     returnTypeNode = undefined;
   }
   const argumentDeclarations =
-    overrideArgumentDeclarations ?? functionDeclaration.arguments.map(buildArgumentDeclaration);
+    overrideArgumentDeclarations ?? buildArgumentDeclarations(functionDeclaration.arguments);
 
   if (method) {
     return ts.factory.createMethodDeclaration(
@@ -676,7 +703,7 @@ export function buildConstructor(
 ): ts.ClassElement {
   return ts.factory.createConstructorDeclaration(
     undefined,
-    constructor.arguments.map(buildArgumentDeclaration),
+    buildArgumentDeclarations(constructor.arguments),
     declaration ? undefined : ts.factory.createBlock([])
   );
 }
@@ -1067,6 +1094,7 @@ function baseIdentifierFileMap(): IdentifierDeclarationImportMap {
     ['requireNativeView', 'expo'],
     ['requireNativeModule', 'expo'],
     ['NativeModule', 'expo'],
+    ['SharedRef', 'expo'],
   ]);
 }
 
@@ -1321,8 +1349,12 @@ function buildStableNativeModuleInterface(ctx: GenerationContext): ts.Node[] {
     (isAsync: boolean) => (functionDeclaration: FunctionDeclaration) => {
       const argumentDeclarations = [];
       const argumentNames = [];
-      for (const arg of functionDeclaration.arguments) {
-        const { argDeclaration, argName } = buildArgumentDeclarationAndName(arg);
+      const trailingOptionalsStart = firstTrailingOptionalIndex(functionDeclaration.arguments);
+      for (const [index, arg] of functionDeclaration.arguments.entries()) {
+        const { argDeclaration, argName } = buildArgumentDeclarationAndName(
+          arg,
+          index >= trailingOptionalsStart
+        );
         argumentDeclarations.push(argDeclaration);
         argumentNames.push(argName);
       }


### PR DESCRIPTION
# Why
Need to handle optionals, `ValueOrUndefined`, `SharedRef`.

# How
Handle optional arguments such that only trailing optionals get the `?`, handle `ValueOrUndefined`. 
Add `SharedRef` partial handling -- emit `SharedRef<any>` in TypeScript for now.

For example
```
Function("TestMixedOptionalArguments") { (a: Int, b: String?, c: Double, d: Bool?, e: [Int]?) in
}
```
is translated to
```
TestMixedOptionalArguments(
  a: number,
  b: string | null,
  c: number,
  d?: boolean,
  e?: number[]
): unknown /*The type couldn't be resolved automatically.*/;
```

# Test Plan
- [x] Added tests and updated snapshots
- [x] checked manually on packages `expo-contacts`, `expo-file-system` 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
