### PR TITLE
[core][iOS] Prevent infinite recursion for convertibles with the default convertResult

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -57,6 +57,7 @@
 - [iOS] Fix Expo DevTools Network response bodies for JSON content types with parameters. ([#46336](https://github.com/expo/expo/pull/46336) by [@SJvaca30](https://github.com/SJvaca30))
 - [iOS] Resolve the key window across connected scenes in `currentViewController()` so it keeps working with multiple scenes, and expose `Utilities.keyWindow()` for modules to reuse. ([#46956](https://github.com/expo/expo/pull/46956) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix a crash on `Updates.reloadAsync()` where the previous `AppContext` could deallocate before the old runtime finished tearing down, releasing cached JSI objects against a dying runtime on the wrong thread. Its lifetime is now tied to the runtime via native state attached to the `global.expo` object. ([#47051](https://github.com/expo/expo/issues/47051) by [@HaiyiMei](https://github.com/HaiyiMei)) ([#47080](https://github.com/expo/expo/pull/47080), [#47098](https://github.com/expo/expo/pull/47098) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed a stack overflow crash when converting to JavaScript a `Convertible` value that keeps the default `convertResult` implementation, such as `CMTime`. The value now converts to `undefined` and logs a warning. ([#48266](https://github.com/expo/expo/pull/48266) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -101,7 +101,12 @@ internal struct DynamicConvertibleType: AnyDynamicType {
       return result
     }
     if let result = value as? AnyArgument {
-      return try type(of: result).getDynamicType().castToJS(result, appContext: appContext)
+      let dynamicType = type(of: result).getDynamicType()
+      // A `Convertible` that keeps the default `convertResult` returns the value unchanged,
+      // so redispatching it into the same dynamic type would recurse until the stack overflows.
+      if !dynamicType.equals(self) {
+        return try dynamicType.castToJS(result, appContext: appContext)
+      }
     }
     return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
   }

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -488,6 +488,21 @@ struct DynamicTypeTests {
     }
 
     @Test
+    func `does not recurse for a convertible with the default convertResult`() throws {
+      struct SelfConvertible: Convertible {
+        static func convert(from value: Any?, appContext: AppContext) throws -> SelfConvertible {
+          return SelfConvertible()
+        }
+      }
+
+      // The default `convertResult` returns the value unchanged, so redispatching it into
+      // the same dynamic type can never make progress and must fall back to `undefined`.
+      let result = try (~SelfConvertible.self).convertToJS(SelfConvertible(), appContext: appContext)
+
+      #expect(result.isUndefined() == true)
+    }
+
+    @Test
     func `returns formatted record directly to JS while preserving formatter behavior`() throws {
       struct TestRecord: Record {
         @Field var a: String = "a"


### PR DESCRIPTION
# Why

`DynamicConvertibleType.serializeConvertedValue` redispatches an `AnyArgument` result into the dynamic type of its concrete type. For a `Convertible` that keeps the default `convertResult`, the conversion returns the value unchanged, so the redispatch re-enters the same dynamic type until the stack overflows.

#48240 fixes this for `Date` by giving it a proper `convertResult`. This PR adds the structural guard so the remaining types with the default implementation (`CMTime`, SwiftUI `Color`, `UnitPoint`, and any third-party `Convertible`) crash no more. Related issue: #48239.

# How

`serializeConvertedValue` now skips the redispatch when it would target the same dynamic type, since a same-type redispatch can never make progress. The value falls through to `Conversions.unknownToJavaScriptValue`, which logs a warning naming the native type and returns `undefined`. Cross-type conversion chains still work because each dynamic type only blocks re-entry into itself.

# Test Plan

Added a regression test that converts a test-local `Convertible` with the default `convertResult`. Before the guard, the test crashed the bundle with SIGBUS (stack overflow). After the guard:

- `xcodebuild test -workspace BareExpo.xcworkspace -scheme ExpoModulesCore-Unit-Tests -only-testing:ExpoModulesCore-Unit-Tests/DynamicTypeTests`: 77 passed, 0 failed.
- Full `ExpoModulesCore-Unit-Tests` scheme: 782 passed, 0 failed.
