### PR TITLE
feat(cli): Support `Forwarded` header as canonical host throughout

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
 - Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))
 - Emit relative asset URLs and `bundleUrl` in manifest responses conditionally ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
+- Resolve `hostUri`, `debuggerHost`, and `/_expo/link` deep links from forwarded request addresses ([#48267](https://github.com/expo/expo/pull/48267) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -5,6 +5,7 @@ import * as Log from '../../log';
 import type { GatewayInfo } from '../../utils/ip';
 import { getGateway, getGatewayAsync } from '../../utils/ip';
 import { debugEvent } from './events';
+import type { ForwardedRequestInfo } from './middleware/resolveForwarded';
 
 export interface CreateURLOptions {
   /** URL scheme to use when opening apps in custom runtimes. */
@@ -13,6 +14,8 @@ export interface CreateURLOptions {
   hostType?: 'localhost' | 'lan' | 'tunnel';
   /** Requested hostname. */
   hostname?: string | null;
+  /** Address the client used to reach the dev server, from a forwarded request */
+  forwarded?: ForwardedRequestInfo | null;
 }
 
 interface UrlComponents {
@@ -77,13 +80,12 @@ export class UrlCreator {
       return null;
     }
 
-    const manifestUrl = this.constructUrl({
-      ...options,
-      scheme: this.defaults?.hostType === 'tunnel' ? 'https' : 'http',
-    });
-    const devClientUrl = `${protocol}://expo-development-client/?url=${encodeURIComponent(
-      manifestUrl
-    )}`;
+    // We fallback to the assumed scheme based on whether we have our own proxy (a tunnel)
+    const scheme =
+      options?.forwarded?.protocol ?? (this.defaults?.hostType === 'tunnel' ? 'https' : 'http');
+    const manifestUrl = this.constructUrl({ ...options, scheme });
+    const manifestUrlEncoded = encodeURIComponent(manifestUrl);
+    const devClientUrl = `${protocol}://expo-development-client/?url=${manifestUrlEncoded}`;
     debugEvent('dev_client_url', { url: devClientUrl, manifestUrl });
     return devClientUrl;
   }
@@ -128,6 +130,14 @@ export class UrlCreator {
       return getUrlComponentsFromProxyUrl(options, proxyURL);
     }
 
+    // A forwarded request tells us an address the client can reach, which beats anything we can infer
+    if (options.forwarded) {
+      const authorityComponents = getUrlComponentsFromAuthority(options, options.forwarded);
+      if (authorityComponents) {
+        return authorityComponents;
+      }
+    }
+
     // Ngrok.
     if (options.hostType === 'tunnel') {
       const components = this.getTunnelUrlComponents(options);
@@ -149,6 +159,23 @@ export class UrlCreator {
       protocol: options.scheme ?? 'http',
     };
   }
+}
+
+function getUrlComponentsFromAuthority(
+  options: Pick<CreateURLOptions, 'scheme'>,
+  forwarded: ForwardedRequestInfo
+): UrlComponents | null {
+  const { authority } = forwarded;
+  if (!authority) {
+    return null;
+  }
+  const scheme = options.scheme ?? forwarded.protocol ?? 'http';
+  const parsed = new URL(`${scheme}://${forwarded.authority}`);
+  return {
+    hostname: parsed.hostname,
+    port: parsed.port,
+    protocol: scheme,
+  };
 }
 
 function getUrlComponentsFromProxyUrl(

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -98,10 +98,10 @@ describe('constructUrl', () => {
   it(`uses the forwarded authority without a port`, () => {
     expect(
       createDefaultCreator().constructUrl({
-        scheme: '',
+        scheme: 'http',
         forwarded: { authority: 'proxy.test', protocol: undefined },
       })
-    ).toMatchInlineSnapshot(`"proxy.test"`);
+    ).toMatchInlineSnapshot(`"http://proxy.test"`);
   });
   it(`uses the forwarded authority over a requested hostname and the tunnel`, () => {
     expect(

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -91,13 +91,16 @@ describe('constructUrl', () => {
     expect(
       createDefaultCreator().constructUrl({
         scheme: 'http',
-        forwarded: { authority: 'proxy.test:4443' },
+        forwarded: { authority: 'proxy.test:4443', protocol: undefined },
       })
     ).toMatchInlineSnapshot(`"http://proxy.test:4443"`);
   });
   it(`uses the forwarded authority without a port`, () => {
     expect(
-      createDefaultCreator().constructUrl({ scheme: '', forwarded: { authority: 'proxy.test' } })
+      createDefaultCreator().constructUrl({
+        scheme: '',
+        forwarded: { authority: 'proxy.test', protocol: undefined },
+      })
     ).toMatchInlineSnapshot(`"proxy.test"`);
   });
   it(`uses the forwarded authority over a requested hostname and the tunnel`, () => {
@@ -105,19 +108,21 @@ describe('constructUrl', () => {
       createDefaultCreator().constructUrl({
         hostname: 'foobar.dev',
         hostType: 'tunnel',
-        forwarded: { authority: 'proxy.test:4443' },
+        forwarded: { authority: 'proxy.test:4443', protocol: undefined },
       })
     ).toMatchInlineSnapshot(`"http://proxy.test:4443"`);
   });
   it(`ignores a forwarded protocol without an authority`, () => {
     expect(
-      createDefaultCreator().constructUrl({ forwarded: { protocol: 'https' } })
+      createDefaultCreator().constructUrl({
+        forwarded: { authority: undefined, protocol: 'https' },
+      })
     ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
   });
   it(`keeps the proxy url over the forwarded authority`, () => {
     expect(
       createDefaultCreator({ getProxyUrl: () => 'http://expo.dev' }).constructUrl({
-        forwarded: { authority: 'proxy.test:4443' },
+        forwarded: { authority: 'proxy.test:4443', protocol: undefined },
       })
     ).toMatchInlineSnapshot(`"http://expo.dev"`);
   });

--- a/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/UrlCreator-test.ts
@@ -57,6 +57,16 @@ describe('constructDevClientUrl', () => {
       `"bacon://expo-development-client/?url=http%3A%2F%2F100.100.1.100%3A8081"`
     );
   });
+  it(`uses the forwarded address`, () => {
+    expect(
+      createDefaultCreator().constructDevClientUrl({
+        scheme: 'bacon',
+        forwarded: { authority: 'proxy.test:4443', protocol: 'https' },
+      })
+    ).toMatchInlineSnapshot(
+      `"bacon://expo-development-client/?url=https%3A%2F%2Fproxy.test%3A4443"`
+    );
+  });
   it(`creates tunnel`, () => {
     expect(
       createDefaultCreator().constructDevClientUrl({ scheme: 'bacon', hostType: 'tunnel' })
@@ -77,6 +87,40 @@ describe('constructDevClientUrl', () => {
 });
 
 describe('constructUrl', () => {
+  it(`uses the forwarded authority`, () => {
+    expect(
+      createDefaultCreator().constructUrl({
+        scheme: 'http',
+        forwarded: { authority: 'proxy.test:4443' },
+      })
+    ).toMatchInlineSnapshot(`"http://proxy.test:4443"`);
+  });
+  it(`uses the forwarded authority without a port`, () => {
+    expect(
+      createDefaultCreator().constructUrl({ scheme: '', forwarded: { authority: 'proxy.test' } })
+    ).toMatchInlineSnapshot(`"proxy.test"`);
+  });
+  it(`uses the forwarded authority over a requested hostname and the tunnel`, () => {
+    expect(
+      createDefaultCreator().constructUrl({
+        hostname: 'foobar.dev',
+        hostType: 'tunnel',
+        forwarded: { authority: 'proxy.test:4443' },
+      })
+    ).toMatchInlineSnapshot(`"http://proxy.test:4443"`);
+  });
+  it(`ignores a forwarded protocol without an authority`, () => {
+    expect(
+      createDefaultCreator().constructUrl({ forwarded: { protocol: 'https' } })
+    ).toMatchInlineSnapshot(`"http://100.100.1.100:8081"`);
+  });
+  it(`keeps the proxy url over the forwarded authority`, () => {
+    expect(
+      createDefaultCreator({ getProxyUrl: () => 'http://expo.dev' }).constructUrl({
+        forwarded: { authority: 'proxy.test:4443' },
+      })
+    ).toMatchInlineSnapshot(`"http://expo.dev"`);
+  });
   it(`skips default port with proxy url`, () => {
     expect(
       createDefaultCreator({ getProxyUrl: () => 'http://expo.dev' }).constructUrl({})

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1358,12 +1358,14 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       );
 
       const deepLinkMiddleware = new RuntimeRedirectMiddleware(this.projectRoot, {
-        getLocation: ({ runtime }) => {
+        getLocation: ({ runtime, forwarded }) => {
           if (runtime === 'custom') {
-            return this.urlCreator?.constructDevClientUrl();
+            return this.urlCreator?.constructDevClientUrl({ forwarded });
           } else {
             return this.urlCreator?.constructUrl({
-              scheme: 'exp',
+              // Expo Go maps the `exps` scheme to HTTPS, which `exp` can't express.
+              scheme: forwarded?.protocol === 'https' ? 'exps' : 'exp',
+              forwarded,
             });
           }
         },

--- a/packages/@expo/cli/src/start/server/middleware/CorsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/CorsMiddleware.ts
@@ -1,6 +1,23 @@
 import type { ExpoConfig } from '@expo/config';
 
+import { parseForwardedRequestInfo } from './resolveForwarded';
 import type { ServerRequest, ServerResponse } from './server.types';
+
+/**
+ * Normalize a forwarded address to a `host` comparable with an `Origin` header, dropping the port
+ * when it's the default for the protocol, as the browser does.
+ */
+function getForwardedHost(req: ServerRequest): string | null {
+  const forwarded = parseForwardedRequestInfo(req);
+  if (!forwarded?.authority) {
+    return null;
+  }
+  try {
+    return new URL(`${forwarded.protocol ?? 'http'}://${forwarded.authority}`).host;
+  } catch {
+    return null;
+  }
+}
 
 const DEFAULT_ALLOWED_CORS_HOSTS = [
   'devtools', // Support local Chrome DevTools `devtools://devtools`
@@ -43,7 +60,9 @@ export function createCorsMiddleware(exp: ExpoConfig) {
   return (req: ServerRequest, res: ServerResponse, next: (err?: Error) => void) => {
     if (typeof req.headers.origin === 'string') {
       const { host, hostname } = new URL(req.headers.origin);
-      const isSameOrigin = host === req.headers.host;
+      // A forwarded request reaches us with the proxy's address in `Origin` and, depending on the
+      // proxy, our own address in `Host`. Both name this dev server, so both count as same-origin.
+      const isSameOrigin = host === req.headers.host || host === getForwardedHost(req);
       const isLocalhost = _isLocalHostname(hostname);
       const isAllowedHost = allowedHosts.includes(host) || isLocalhost;
       if (!isSameOrigin && !isAllowedHost) {

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -17,6 +17,7 @@ import { stripPort } from '../../../utils/url';
 import type { ManifestRequestInfo } from './ManifestMiddleware';
 import { ManifestMiddleware } from './ManifestMiddleware';
 import { manifestDebugEvent } from './events';
+import { parseForwardedRequestInfo } from './resolveForwarded';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { resolveRuntimeVersionWithExpoUpdatesAsync } from './resolveRuntimeVersionWithExpoUpdatesAsync';
 import type { ServerRequest } from './server.types';
@@ -51,14 +52,6 @@ export enum ResponseContentType {
 interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
   responseContentType: ResponseContentType;
   expectSignature: string | null;
-}
-
-function shouldUseRelativeManifestUrls(req: ServerRequest): boolean {
-  return !!(
-    req.headers['forwarded'] ||
-    req.headers['x-forwarded-host'] ||
-    req.headers['x-forwarded-proto']
-  );
 }
 
 export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
@@ -102,14 +95,15 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     }
 
     const expectSignature = req.headers['expo-expect-signature'];
+    const forwarded = parseForwardedRequestInfo(req);
 
     return {
       responseContentType,
       platform,
       expectSignature: expectSignature ? String(expectSignature) : null,
       hostname: stripPort(req.headers['host']),
-      protocol: req.headers['x-forwarded-proto'] as 'http' | 'https' | undefined,
-      ...(shouldUseRelativeManifestUrls(req) ? { shouldUseRelativeManifestUrls: true } : null),
+      protocol: forwarded?.protocol,
+      forwarded,
     };
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig, ExpoGoConfig, PackageJSONConfig, ProjectConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { posix } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { resolve } from 'url';
@@ -9,6 +10,7 @@ import { getActorDisplayName, getUserAsync } from '../../../api/user/user';
 import { isEnableHermesManaged } from '../../../export/exportHermes';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
+import { toPosixPath } from '../../../utils/filePath';
 import * as ProjectDevices from '../../project/devices';
 import type { UrlCreator } from '../UrlCreator';
 import { getRouterDirectoryModuleIdWithManifest } from '../metro/router';
@@ -24,6 +26,7 @@ import {
   createBundleUrlPathFromExpoConfig,
 } from './metroOptions';
 import { resolveGoogleServicesFile, resolveManifestAssets } from './resolveAssets';
+import type { ForwardedRequestInfo } from './resolveForwarded';
 import type { RuntimePlatform } from './resolvePlatform';
 import { parsePlatformHeader } from './resolvePlatform';
 import type { ServerNext, ServerRequest, ServerResponse } from './server.types';
@@ -46,8 +49,8 @@ export interface ManifestRequestInfo {
   hostname?: string | null;
   /** The protocol used to request the manifest */
   protocol?: 'http' | 'https';
-  /** Whether URL-valued manifest fields should be emitted relative to the manifest URL. */
-  shouldUseRelativeManifestUrls?: boolean;
+  /** How the client addressed this dev server, when the request was forwarded */
+  forwarded?: ForwardedRequestInfo | undefined | null;
 }
 
 /** Project related info. */
@@ -59,6 +62,17 @@ export type ResponseProjectSettings = {
 };
 
 export const DEVELOPER_TOOL = 'expo-cli';
+
+/**
+ * Convert a project-relative asset path to the path component of an asset URL.
+ *
+ * Asset paths come from the app config, so they may be written as `./assets/icon.png` and may use
+ * Windows separators. Both forms are normalized here, since these paths are joined into URLs that
+ * clients resolve against the manifest URL.
+ */
+function toAssetUrlPath(assetPath: string): string {
+  return posix.normalize(toPosixPath(assetPath)).replace(/^\//, '');
+}
 
 export type ManifestMiddlewareOptions = {
   /** Should start the dev servers in development mode (minify). */
@@ -97,10 +111,10 @@ export abstract class ManifestMiddleware<
     platform,
     hostname,
     protocol,
-    shouldUseRelativeManifestUrls,
+    forwarded,
   }: Pick<
     TManifestRequestInfo,
-    'hostname' | 'platform' | 'protocol' | 'shouldUseRelativeManifestUrls'
+    'hostname' | 'platform' | 'protocol' | 'forwarded'
   >): Promise<ResponseProjectSettings> {
     // Read the config
     const projectConfig = getConfig(this.projectRoot);
@@ -117,14 +131,17 @@ export abstract class ManifestMiddleware<
     const user = await getUserAsync();
     const username = getActorDisplayName(user);
 
+    // We emit relative URLs if the client reported a forwarded authority
+    const shouldUseRelativeManifestUrls = !!forwarded?.authority;
+    // `hostUri` and `debuggerHost` can only hold an authority, so they can't be made relative
+    const hostUri = forwarded?.authority ?? this.options.constructUrl({ scheme: '', hostname });
+
     // Create the manifest and set fields within it
     const expoGoConfig = this.getExpoGoConfig({
       mainModuleName,
-      hostname,
+      debuggerHost: hostUri,
       username: username !== 'anonymous' ? username : undefined,
     });
-
-    const hostUri = this.options.constructUrl({ scheme: '', hostname });
 
     const absoluteBundleUrl = this._getBundleUrl({
       platform,
@@ -244,16 +261,17 @@ export abstract class ManifestMiddleware<
 
   private getExpoGoConfig({
     mainModuleName,
-    hostname,
+    debuggerHost,
     username,
   }: {
     mainModuleName: string;
-    hostname?: string | null;
+    /** The authority the client can reach this dev server on, e.g. `localhost:8081`. */
+    debuggerHost: string;
     username?: string;
   }): ExpoGoConfig {
     return {
       // localhost:8081
-      debuggerHost: this.options.constructUrl({ scheme: '', hostname }),
+      debuggerHost,
       // Required for Expo Go to function.
       developer: {
         tool: DEVELOPER_TOOL,
@@ -270,12 +288,13 @@ export abstract class ManifestMiddleware<
     };
   }
 
-  /** Resolve all assets and set them on the manifest as URLs */
+  /** Convert an absolute URL to one relative to the root of the dev server. */
   private toPathRelativeUrl(url: string): string {
     const parsedUrl = new URL(url);
     return parsedUrl.pathname.replace(/^\//, '') + parsedUrl.search + parsedUrl.hash;
   }
 
+  /** Resolve all assets and set them on the manifest as URLs */
   private async mutateManifestWithAssetsAsync(
     manifest: ExpoConfig,
     bundleUrl: string,
@@ -283,16 +302,18 @@ export abstract class ManifestMiddleware<
   ) {
     await resolveManifestAssets(this.projectRoot, {
       manifest,
-      resolver: async (path) => {
-        if (shouldUseRelativeManifestUrls) {
-          return this.options.isNativeWebpack ? path : 'assets/' + path;
-        }
+      resolver: async (assetPath) => {
         if (this.options.isNativeWebpack) {
           // When using our custom dev server, just do assets normally
           // without the `assets/` subpath redirect.
-          return resolve(bundleUrl!.match(/^https?:\/\/.*?\//)![0], path);
+          return shouldUseRelativeManifestUrls
+            ? toAssetUrlPath(assetPath)
+            : resolve(bundleUrl!.match(/^https?:\/\/.*?\//)![0], assetPath);
         }
-        return bundleUrl!.match(/^https?:\/\/.*?\//)![0] + 'assets/' + path;
+        const assetUrlPath = 'assets/' + toAssetUrlPath(assetPath);
+        return shouldUseRelativeManifestUrls
+          ? assetUrlPath
+          : bundleUrl!.match(/^https?:\/\/.*?\//)![0] + assetUrlPath;
       },
     });
     // The server normally inserts this but if we're offline we'll do it here

--- a/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/RuntimeRedirectMiddleware.ts
@@ -2,6 +2,8 @@ import { parse } from 'url';
 
 import * as Log from '../../../log';
 import { disableResponseCache, ExpoMiddleware } from './ExpoMiddleware';
+import type { ForwardedRequestInfo } from './resolveForwarded';
+import { parseForwardedRequestInfo } from './resolveForwarded';
 import type { RuntimePlatform } from './resolvePlatform';
 import {
   assertMissingRuntimePlatform,
@@ -26,7 +28,10 @@ export class RuntimeRedirectMiddleware extends ExpoMiddleware {
     protected projectRoot: string,
     protected options: {
       onDeepLink?: DeepLinkHandler;
-      getLocation: (props: { runtime: RuntimeTarget }) => string | null | undefined;
+      getLocation: (props: {
+        runtime: RuntimeTarget;
+        forwarded: ForwardedRequestInfo | null;
+      }) => string | null | undefined;
     }
   ) {
     super(projectRoot, [LinkEndpoint]);
@@ -42,7 +47,10 @@ export class RuntimeRedirectMiddleware extends ExpoMiddleware {
 
     this.options.onDeepLink?.({ runtime, platform });
 
-    const redirect = this.options.getLocation({ runtime });
+    const redirect = this.options.getLocation({
+      runtime,
+      forwarded: parseForwardedRequestInfo(req),
+    });
     if (!redirect) {
       Log.warn(
         `[redirect middleware]: Unable to determine redirect location for runtime '${runtime}' and platform '${platform}'`

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/CorsMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/CorsMiddleware-test.ts
@@ -58,6 +58,42 @@ describe(createCorsMiddleware, () => {
     expect(next.mock.calls[0][0]).not.toBeInstanceOf(Error);
   });
 
+  it('should allow requests from origin same as the forwarded host', () => {
+    const origin = 'https://proxy.test';
+    middleware(
+      asRequest({
+        url: 'http://localhost:8081/',
+        headers: {
+          host: 'localhost:8081',
+          origin,
+          forwarded: 'host=proxy.test;proto=https',
+        },
+      }),
+      res,
+      next
+    );
+    expect(next).toHaveBeenCalled();
+    expect(next.mock.calls[0][0]).not.toBeInstanceOf(Error);
+    // The dev server is the origin here, so it doesn't widen CORS beyond the browser's default.
+    expect(resHeaders['Access-Control-Allow-Origin']).toBeUndefined();
+  });
+
+  it('should reject requests from an origin other than the forwarded host', () => {
+    middleware(
+      asRequest({
+        url: 'http://localhost:8081/',
+        headers: {
+          host: 'localhost:8081',
+          origin: 'https://evil.test',
+          forwarded: 'host=proxy.test;proto=https',
+        },
+      }),
+      res,
+      next
+    );
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
   it('should allow CORS from devtools://devtools', () => {
     const origin = 'devtools://devtools';
     middleware(asRequest({ url: 'http://localhost:8081/', headers: { origin } }), res, next);

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -171,7 +171,7 @@ describe('getParsedHeaders', () => {
     });
   });
 
-  it('requests relative manifest URLs when forwarding headers are present', () => {
+  it('parses the forwarded address when forwarding headers are present', () => {
     expect(
       middleware.getParsedHeaders(
         asReq({
@@ -179,15 +179,27 @@ describe('getParsedHeaders', () => {
           headers: {
             host: 'localhost:8081',
             'expo-platform': 'ios',
-            forwarded: 'host=proxy.test;proto=https',
+            forwarded: 'host="proxy.test:4443";proto=https',
           },
         })
       )
     ).toMatchObject({
       hostname: 'localhost',
       platform: 'ios',
-      shouldUseRelativeManifestUrls: true,
+      protocol: 'https',
+      forwarded: { authority: 'proxy.test:4443', protocol: 'https' },
     });
+  });
+
+  it('omits the forwarded address for direct requests', () => {
+    expect(
+      middleware.getParsedHeaders(
+        asReq({
+          url: 'http://localhost:3000',
+          headers: { host: 'localhost:8081', 'expo-platform': 'ios' },
+        })
+      )
+    ).not.toHaveProperty('forwarded');
   });
 });
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -103,6 +103,8 @@ describe('getParsedHeaders', () => {
       responseContentType: ResponseContentType.TEXT_PLAIN,
       hostname: null,
       platform: 'ios',
+      protocol: undefined,
+      forwarded: null,
     });
   });
 
@@ -116,6 +118,8 @@ describe('getParsedHeaders', () => {
       expectSignature: null,
       hostname: null,
       platform: 'android',
+      protocol: undefined,
+      forwarded: null,
     });
   });
 
@@ -132,6 +136,8 @@ describe('getParsedHeaders', () => {
       expectSignature: null,
       hostname: null,
       platform: 'android',
+      protocol: undefined,
+      forwarded: null,
     });
 
     expect(
@@ -146,6 +152,8 @@ describe('getParsedHeaders', () => {
       expectSignature: null,
       hostname: null,
       platform: 'android',
+      protocol: undefined,
+      forwarded: null,
     });
   });
 
@@ -168,6 +176,8 @@ describe('getParsedHeaders', () => {
       hostname: 'localhost',
       // We don't care much about the platform here since it's already tested.
       platform: 'ios',
+      protocol: undefined,
+      forwarded: null,
     });
   });
 
@@ -191,7 +201,7 @@ describe('getParsedHeaders', () => {
     });
   });
 
-  it('omits the forwarded address for direct requests', () => {
+  it('returns a null forwarded address for direct requests', () => {
     expect(
       middleware.getParsedHeaders(
         asReq({
@@ -199,7 +209,12 @@ describe('getParsedHeaders', () => {
           headers: { host: 'localhost:8081', 'expo-platform': 'ios' },
         })
       )
-    ).not.toHaveProperty('forwarded');
+    ).toMatchObject({
+      hostname: 'localhost',
+      platform: 'ios',
+      protocol: undefined,
+      forwarded: null,
+    });
   });
 });
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -294,13 +294,14 @@ describe('_resolveProjectSettingsAsync', () => {
     const settings = await middleware._resolveProjectSettingsAsync({
       hostname: 'localhost',
       platform: 'android',
-      forwarded: { protocol: 'https' },
-    } as any);
+      protocol: 'https',
+      forwarded: { authority: undefined, protocol: 'https' },
+    });
 
     expect(settings.hostUri).toBe('fake.mock:8081');
     expect(settings.expoGoConfig.debuggerHost).toBe('fake.mock:8081');
-    // The bundle URL stays relative, since the request was still forwarded.
-    expect(settings.bundleUrl).toBe('index.bundle');
+    // The bundle URL stays absolute, since no forwarded authority was reported.
+    expect(settings.bundleUrl).toBe('https://fake.mock:8081/index.bundle');
   });
   it(`normalizes relative asset paths`, async () => {
     const middleware = new MockManifestMiddleware('/', {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -242,7 +242,7 @@ describe('_resolveProjectSettingsAsync', () => {
     // Limit this to a single call since it can get expensive.
     expect(getConfig).toHaveBeenCalledTimes(1);
   });
-  it(`returns relative bundle and asset URLs when requested`, async () => {
+  it(`returns relative bundle and asset URLs for forwarded requests`, async () => {
     const middleware = new MockManifestMiddleware('/', {
       constructUrl: jest.fn(() => 'http://fake.mock'),
       mode: 'development',
@@ -258,7 +258,7 @@ describe('_resolveProjectSettingsAsync', () => {
     const settings = await middleware._resolveProjectSettingsAsync({
       hostname: 'localhost',
       platform: 'android',
-      shouldUseRelativeManifestUrls: true,
+      forwarded: { authority: 'proxy.test:4443', protocol: 'https' },
     } as any);
 
     expect(settings.bundleUrl).toBe(
@@ -266,7 +266,81 @@ describe('_resolveProjectSettingsAsync', () => {
     );
 
     const resolver = jest.mocked(resolveManifestAssets).mock.calls?.[0]?.[1].resolver;
-    await expect(resolver?.('./assets/icon.png')).resolves.toBe('assets/./assets/icon.png');
+    await expect(resolver?.('./assets/icon.png')).resolves.toBe('assets/assets/icon.png');
+  });
+  it(`returns the forwarded authority as hostUri and debuggerHost`, async () => {
+    const constructUrl = jest.fn(() => 'http://fake.mock');
+    const middleware = new MockManifestMiddleware('/', { constructUrl, mode: 'development' });
+
+    middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
+
+    const settings = await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+      forwarded: { authority: 'proxy.test:4443', protocol: 'https' },
+    } as any);
+
+    expect(settings.hostUri).toBe('proxy.test:4443');
+    expect(settings.expoGoConfig.debuggerHost).toBe('proxy.test:4443');
+  });
+  it(`falls back to the dev server address when only the protocol was forwarded`, async () => {
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'fake.mock:8081'),
+      mode: 'development',
+    });
+
+    middleware._getBundleUrl = jest.fn(() => 'https://fake.mock:8081/index.bundle');
+
+    const settings = await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+      forwarded: { protocol: 'https' },
+    } as any);
+
+    expect(settings.hostUri).toBe('fake.mock:8081');
+    expect(settings.expoGoConfig.debuggerHost).toBe('fake.mock:8081');
+    // The bundle URL stays relative, since the request was still forwarded.
+    expect(settings.bundleUrl).toBe('index.bundle');
+  });
+  it(`normalizes relative asset paths`, async () => {
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'http://fake.mock'),
+      mode: 'development',
+    });
+
+    jest.mocked(resolveManifestAssets).mockClear();
+    middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
+
+    await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+      forwarded: { authority: 'proxy.test' },
+    } as any);
+
+    const resolver = jest.mocked(resolveManifestAssets).mock.calls?.[0]?.[1].resolver;
+    await expect(resolver?.('assets/icon.png')).resolves.toBe('assets/assets/icon.png');
+    await expect(resolver?.('./assets/icon.png')).resolves.toBe('assets/assets/icon.png');
+    await expect(resolver?.('assets\\icon.png')).resolves.toBe('assets/assets/icon.png');
+    await expect(resolver?.('./nested/../assets/icon.png')).resolves.toBe('assets/assets/icon.png');
+  });
+  it(`normalizes absolute asset URLs the same way`, async () => {
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'http://fake.mock'),
+      mode: 'development',
+    });
+
+    jest.mocked(resolveManifestAssets).mockClear();
+    middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
+
+    await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+    } as any);
+
+    const resolver = jest.mocked(resolveManifestAssets).mock.calls?.[0]?.[1].resolver;
+    await expect(resolver?.('./assets/icon.png')).resolves.toBe(
+      'http://fake.mock/assets/assets/icon.png'
+    );
   });
   it(`returns the project settings for Webpack dev servers`, async () => {
     const middleware = new MockManifestMiddleware('/', {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/RuntimeRedirectMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/RuntimeRedirectMiddleware-test.ts
@@ -58,7 +58,7 @@ describe('handleRequestAsync', () => {
     expect(response.end).toHaveBeenCalledWith();
     expect(response.setHeader).toHaveBeenCalledTimes(4);
     expect(response.setHeader).toHaveBeenNthCalledWith(1, 'Location', 'mock-location-expo');
-    expect(getLocation).toHaveBeenCalledWith({ runtime: 'expo' });
+    expect(getLocation).toHaveBeenCalledWith({ runtime: 'expo', forwarded: null });
     expect(onDeepLink).toHaveBeenCalledWith({ runtime: 'expo', platform: 'android' });
   });
 
@@ -80,7 +80,7 @@ describe('handleRequestAsync', () => {
     expect(response.end).toHaveBeenCalledWith();
     expect(response.setHeader).toHaveBeenCalledTimes(4);
     expect(response.setHeader).toHaveBeenNthCalledWith(1, 'Location', 'mock-location-expo');
-    expect(getLocation).toHaveBeenCalledWith({ runtime: 'expo' });
+    expect(getLocation).toHaveBeenCalledWith({ runtime: 'expo', forwarded: null });
     expect(onDeepLink).toHaveBeenCalledWith({ runtime: 'expo', platform: 'android' });
   });
 
@@ -98,7 +98,23 @@ describe('handleRequestAsync', () => {
     expect(response.end).toHaveBeenCalledWith();
     expect(response.setHeader).toHaveBeenCalledTimes(4);
     expect(response.setHeader).toHaveBeenNthCalledWith(1, 'Location', 'mock-location-custom');
-    expect(getLocation).toHaveBeenCalledWith({ runtime: 'custom' });
+    expect(getLocation).toHaveBeenCalledWith({ runtime: 'custom', forwarded: null });
     expect(onDeepLink).toHaveBeenCalledWith({ runtime: 'custom', platform: 'ios' });
+  });
+
+  it('passes the forwarded address to the location resolver', async () => {
+    const { middleware, getLocation } = createMiddleware();
+
+    await middleware.handleRequestAsync(
+      asReq({
+        url: 'http://localhost:8081/_expo/link?platform=ios',
+        headers: { forwarded: 'host="proxy.test:4443";proto=https' },
+      }),
+      createMockResponse()
+    );
+    expect(getLocation).toHaveBeenCalledWith({
+      runtime: 'expo',
+      forwarded: { authority: 'proxy.test:4443', protocol: 'https' },
+    });
   });
 });

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/resolveForwarded-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/resolveForwarded-test.ts
@@ -1,0 +1,83 @@
+import { parseForwardedRequestInfo } from '../resolveForwarded';
+import type { ServerRequest } from '../server.types';
+
+const asReq = (headers: Record<string, string>) => ({ headers }) as unknown as ServerRequest;
+
+describe(parseForwardedRequestInfo, () => {
+  it(`returns null when the request was not forwarded`, () => {
+    expect(parseForwardedRequestInfo(asReq({ host: 'localhost:8081' }))).toBeNull();
+  });
+
+  it(`parses the RFC 7239 "Forwarded" header`, () => {
+    expect(
+      parseForwardedRequestInfo(asReq({ forwarded: 'host="proxy.test:4443";proto=https' }))
+    ).toEqual({ authority: 'proxy.test:4443', protocol: 'https' });
+  });
+
+  it(`parses unquoted and reordered "Forwarded" parameters`, () => {
+    expect(
+      parseForwardedRequestInfo(asReq({ forwarded: 'for=192.0.2.1;proto=http;host=proxy.test' }))
+    ).toEqual({ authority: 'proxy.test', protocol: 'http' });
+  });
+
+  it(`uses the first element when a proxy chain appended to "Forwarded"`, () => {
+    expect(
+      parseForwardedRequestInfo(
+        asReq({ forwarded: 'host="proxy.test:4443";proto=https, host=inner.test;proto=http' })
+      )
+    ).toEqual({ authority: 'proxy.test:4443', protocol: 'https' });
+  });
+
+  it(`falls back to the "X-Forwarded-*" headers`, () => {
+    expect(
+      parseForwardedRequestInfo(
+        asReq({ 'x-forwarded-host': 'proxy.test:4443', 'x-forwarded-proto': 'https' })
+      )
+    ).toEqual({ authority: 'proxy.test:4443', protocol: 'https' });
+  });
+
+  it(`uses the first value of comma-separated "X-Forwarded-*" headers`, () => {
+    expect(
+      parseForwardedRequestInfo(
+        asReq({ 'x-forwarded-host': 'proxy.test, inner.test', 'x-forwarded-proto': 'https, http' })
+      )
+    ).toEqual({ authority: 'proxy.test', protocol: 'https' });
+  });
+
+  it(`prefers "Forwarded" over the "X-Forwarded-*" headers`, () => {
+    expect(
+      parseForwardedRequestInfo(
+        asReq({
+          forwarded: 'host=proxy.test;proto=https',
+          'x-forwarded-host': 'ignored.test',
+          'x-forwarded-proto': 'http',
+        })
+      )
+    ).toEqual({ authority: 'proxy.test', protocol: 'https' });
+  });
+
+  it(`returns the protocol alone when no host was forwarded`, () => {
+    expect(parseForwardedRequestInfo(asReq({ 'x-forwarded-proto': 'https' }))).toEqual({
+      protocol: 'https',
+    });
+  });
+
+  it(`returns the authority alone when no protocol was forwarded`, () => {
+    expect(parseForwardedRequestInfo(asReq({ 'x-forwarded-host': 'proxy.test:4443' }))).toEqual({
+      authority: 'proxy.test:4443',
+    });
+  });
+
+  it(`normalizes the authority and drops anything but host and port`, () => {
+    expect(
+      parseForwardedRequestInfo(asReq({ 'x-forwarded-host': 'user@Proxy.TEST:4443/../evil' }))
+    ).toEqual({ authority: 'proxy.test:4443' });
+  });
+
+  it(`ignores unusable values`, () => {
+    expect(parseForwardedRequestInfo(asReq({ 'x-forwarded-host': '' }))).toBeNull();
+    expect(parseForwardedRequestInfo(asReq({ 'x-forwarded-host': 'not a host' }))).toBeNull();
+    expect(parseForwardedRequestInfo(asReq({ 'x-forwarded-proto': 'gopher' }))).toBeNull();
+    expect(parseForwardedRequestInfo(asReq({ forwarded: 'for=192.0.2.1' }))).toBeNull();
+  });
+});

--- a/packages/@expo/cli/src/start/server/middleware/resolveForwarded.ts
+++ b/packages/@expo/cli/src/start/server/middleware/resolveForwarded.ts
@@ -1,0 +1,95 @@
+import type { ServerRequest } from './server.types';
+
+/** How a client reached this dev server, as reported by the request itself */
+export interface ForwardedRequestInfo {
+  authority: string | undefined;
+  protocol: 'http' | 'https' | undefined;
+}
+
+function splitOutsideQuotes(value: string, separator: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let isQuoted = false;
+  for (let index = 0; index < value.length; index++) {
+    const char = value[index];
+    if (char === '"' && value[index - 1] !== '\\') {
+      isQuoted = !isQuoted;
+    } else if (char === separator && !isQuoted) {
+      parts.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+  parts.push(value.slice(start));
+  return parts;
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+  }
+  return trimmed;
+}
+
+function parseForwardedHeader(header: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  const firstElement = splitOutsideQuotes(header, ',')[0] ?? '';
+  for (const pair of splitOutsideQuotes(firstElement, ';')) {
+    const separatorIndex = pair.indexOf('=');
+    if (separatorIndex > 0) {
+      const key = pair.slice(0, separatorIndex).trim().toLowerCase();
+      params[key] = unquote(pair.slice(separatorIndex + 1));
+    }
+  }
+  return params;
+}
+
+function firstHeaderValue(value: string | string[] | undefined): string | undefined {
+  const header = Array.isArray(value) ? value[0] : value;
+  return header ? splitOutsideQuotes(header, ',')[0]?.trim() : undefined;
+}
+
+function coerceAuthority(authority: string | undefined): string | undefined {
+  if (!authority) {
+    return undefined;
+  }
+  try {
+    return new URL(`http://${authority}`).host || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function coerceProtocol(protocol: string | undefined): 'http' | 'https' | undefined {
+  // NOTE(@kitten): We should never receive "exp" or "exps" here, but account for them anyway for completeness
+  switch (protocol?.toLowerCase()) {
+    case 'http':
+    case 'exp':
+      return 'http';
+    case 'https':
+    case 'exps':
+      return 'https';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolve how the client addressed this dev server from the `Forwarded` (RFC 7239) header, falling
+ * back to the `X-Forwarded-Host` and `X-Forwarded-Proto` headers.
+ *
+ * Returns `null` when the request carries no usable forwarding info, meaning the request reached
+ * the dev server directly and its own address may be used.
+ */
+export function parseForwardedRequestInfo(req: ServerRequest): ForwardedRequestInfo | null {
+  const headers = req.headers ?? {};
+  const forwardedStr = firstHeaderValue(headers['forwarded']);
+  const forwarded = forwardedStr ? parseForwardedHeader(forwardedStr) : null;
+  const authority = coerceAuthority(
+    forwarded?.host ?? firstHeaderValue(headers['x-forwarded-host'])
+  );
+  const protocol = coerceProtocol(
+    forwarded?.proto ?? firstHeaderValue(headers['x-forwarded-proto'])
+  );
+  return authority || protocol ? { authority, protocol } : null;
+}


### PR DESCRIPTION
# Why

Stacked on #47255 (follow-up)
Related to #48236

After the prior PR that adds the `Forwarded` header and delivers relative manifest URLs, we have to address remaining cases that continue to serve either an absolute URL or an authority/host and can't be updated (or have to react to proxies explicitly)

This essentially means carrying `Forwarded` support through to more places in the CLI.

# How

- Implement `Forwarded` parser, falling back to `X-Forwarded-Host` / `X-Forwarded-Proto`
  - NOTE: There's support for the latter headers already in some places, but this wasn't consistent and now also needs to be updated with the former
- Include `Forwarded` reported host in CORS check (allow as origin, since `Origin` might differ from `Forwarded` due to proxies)
- Carry `Forwarded` through to manifest middlewares and redirect middlewares
- Adjust the reported `debuggerHost` in the manifest according to `Forwarded` header

# Test Plan

- Unit tests added
- Manually test `POST /manifest 'expo-platform: ios'` requests with `Forwarded` headers, altering the outputs

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
