### PR TITLE
[observe] rename `initIntegration` to `registerIntegration`

### DIFF
--- a/docs/pages/eas/observe/integrations/third-party.mdx
+++ b/docs/pages/eas/observe/integrations/third-party.mdx
@@ -19,7 +19,7 @@ Events should describe actionable issues that developers can fix. For example, a
 
 <Prerequisites>
   <Requirement title="Expo SDK 57 and later">
-    Third-party integrations require SDK 57 and later to access `Observe.initIntegration()`.
+    Third-party integrations require SDK 57 and later to access `Observe.registerIntegration()`.
   </Requirement>
   <Requirement title="An app already using EAS Observe">
     Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
@@ -111,9 +111,9 @@ Observe.configure({
 
 <Step label="3">
 
-## Initialize the integration
+## Register the integration
 
-Call `Observe.initIntegration()` with your integration key. The callback receives the configuration for your integration:
+Call `Observe.registerIntegration()` with your integration key. The callback receives the configuration for your integration:
 
 ```ts observe.ts
 export function initObserveIntegration() {
@@ -121,7 +121,7 @@ export function initObserveIntegration() {
   if (typeof window !== 'undefined' && observeModule) {
     const { Observe } = observeModule;
 
-    Observe.initIntegration('your-package', config => {
+    Observe.registerIntegration('your-package', config => {
       if (config) {
         enableObserveIntegration(config === true ? {} : config);
       }

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `Observe.registerIntegration` to register an integration ([#48245](https://github.com/expo/expo/pull/48245), by [@Ubax](https://github.com/Ubax))
+- Add `Observe.registerIntegration` to register an integration ([#48245](https://github.com/expo/expo/pull/48245), [#48268](https://github.com/expo/expo/pull/48268) by [@Ubax](https://github.com/Ubax))
 - Expose `ObserveErrorBoundary`, a React error boundary that records render-phase errors. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
 - Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `Observe.initIntegration` to initialize an integration ([#48245](https://github.com/expo/expo/pull/48245) by [@Ubax](https://github.com/Ubax))
+- Add `Observe.registerIntegration` to register an integration ([#48245](https://github.com/expo/expo/pull/48245), by [@Ubax](https://github.com/Ubax))
 - Expose `ObserveErrorBoundary`, a React error boundary that records render-phase errors. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Add ObserveInteractiveMarker component ([#46909](https://github.com/expo/expo/pull/46909) by [@Ubax](https://github.com/Ubax))
 - Expose configure event ([#47388](https://github.com/expo/expo/pull/47388) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-observe/src/__tests__/registerIntegration.test.native.ts
+++ b/packages/expo-observe/src/__tests__/registerIntegration.test.native.ts
@@ -28,7 +28,7 @@ const mockNative = new Proxy(mockNativeTarget, {
 });
 
 const mockAppMetrics = {
-  initIntegration: jest.fn(),
+  registerIntegration: jest.fn(),
 };
 
 jest.mock('expo', () => ({
@@ -73,12 +73,12 @@ beforeEach(() => {
   configureListeners.clear();
 });
 
-describe('Observe.initIntegration', () => {
+describe('Observe.registerIntegration', () => {
   it('calls the callback synchronously without adding a listener when the key is present', () => {
     integrations = { 'expo-router': true };
     const callback = jest.fn();
 
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     expect(callback).toHaveBeenCalledWith(true);
     expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
@@ -90,7 +90,7 @@ describe('Observe.initIntegration', () => {
       integrations = { 'expo-router': value };
       const callback = jest.fn();
 
-      loadModule().initIntegration('expo-router', callback);
+      loadModule().registerIntegration('expo-router', callback);
 
       expect(callback).not.toHaveBeenCalled();
       expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe('Observe.initIntegration', () => {
     integrations = {};
     const callback = jest.fn();
 
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     expect(callback).not.toHaveBeenCalled();
     expect(mockNativeTarget.addListener).not.toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe('Observe.initIntegration', () => {
   it('adds a listener when the initial integrations value is falsy', () => {
     const callback = jest.fn();
 
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     expect(mockNativeTarget.addListener).toHaveBeenCalledWith(CONFIGURE, expect.any(Function));
     expect(callback).not.toHaveBeenCalled();
@@ -118,7 +118,7 @@ describe('Observe.initIntegration', () => {
 
   it('removes the subscription before calling the callback when an event contains the key', () => {
     const callback = jest.fn(() => expect(remove).toHaveBeenCalledTimes(1));
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     emit({ 'expo-router': true });
 
@@ -128,7 +128,7 @@ describe('Observe.initIntegration', () => {
 
   it('removes the subscription without calling the callback when an event omits the key', () => {
     const callback = jest.fn();
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     emit({});
 
@@ -141,7 +141,7 @@ describe('Observe.initIntegration', () => {
 
   it('calls the callback at most once across multiple events', () => {
     const callback = jest.fn();
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     emit({ 'expo-router': true });
     emit({ 'expo-router': false });
@@ -153,7 +153,7 @@ describe('Observe.initIntegration', () => {
     'removes the subscription without calling the callback when an event value is %s',
     (value) => {
       const callback = jest.fn();
-      loadModule().initIntegration('expo-router', callback);
+      loadModule().registerIntegration('expo-router', callback);
 
       emit({ 'expo-router': value });
 
@@ -166,7 +166,7 @@ describe('Observe.initIntegration', () => {
     const callback = jest.fn(() => {
       throw new Error('callback failed');
     });
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
     expect(() => emit({ 'expo-router': true })).toThrow('callback failed');
     expect(() => emit({ 'expo-router': false })).not.toThrow();
@@ -177,17 +177,17 @@ describe('Observe.initIntegration', () => {
     const config = { filteredParams: ['token'] };
     integrations = { 'expo-router': config };
     const objectCallback = jest.fn();
-    loadModule().initIntegration('expo-router', objectCallback);
+    loadModule().registerIntegration('expo-router', objectCallback);
     expect(objectCallback).toHaveBeenCalledTimes(1);
     expect(objectCallback.mock.calls[0][0]).toBe(config);
   });
 
-  it('does not forward initIntegration to AppMetrics', () => {
+  it('does not forward registerIntegration to AppMetrics', () => {
     const callback = jest.fn();
 
-    loadModule().initIntegration('expo-router', callback);
+    loadModule().registerIntegration('expo-router', callback);
 
-    expect(mockAppMetrics.initIntegration).not.toHaveBeenCalled();
+    expect(mockAppMetrics.registerIntegration).not.toHaveBeenCalled();
     expect(mockNativeTarget.getIntegrations).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -52,11 +52,11 @@ const Observe: ObserveModule = new Proxy(native, {
       return (error: unknown) => reportCaughtError(error);
     }
 
-    if (prop === 'initIntegration') {
+    if (prop === 'registerIntegration') {
       return <K extends keyof ObserveIntegrationsConfig>(
         name: K,
         callback: (config: ObserveIntegrationsConfig[K]) => void
-      ) => initIntegrationImpl(target, name, callback);
+      ) => registerIntegrationImpl(target, name, callback);
     }
 
     // On Android, the native module is a JSI host object, so `prop in target` (and `hasOwnProperty`) report
@@ -70,7 +70,7 @@ const Observe: ObserveModule = new Proxy(native, {
   },
 });
 
-export function initIntegrationImpl<K extends keyof ObserveIntegrationsConfig>(
+export function registerIntegrationImpl<K extends keyof ObserveIntegrationsConfig>(
   target: Pick<ObserveModule, 'addListener' | 'getIntegrations'>,
   name: K,
   callback: (config: ObserveIntegrationsConfig[K]) => void

--- a/packages/expo-observe/src/module.web.ts
+++ b/packages/expo-observe/src/module.web.ts
@@ -16,7 +16,7 @@ class ExpoObserveModule extends NativeModule<ObserveModuleEvents> implements Obs
   getIntegrations(): ObserveIntegrationsConfig {
     return {};
   }
-  initIntegration<K extends keyof ObserveIntegrationsConfig>(
+  registerIntegration<K extends keyof ObserveIntegrationsConfig>(
     name: K,
     callback: (config: ObserveIntegrationsConfig[K]) => void
   ): void {

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -134,12 +134,12 @@ export declare class ObserveModule extends NativeModule<ObserveModuleEvents> {
    *
    * @example
    * ```ts
-   * Observe.initIntegration('expo-router', config => {
+   * Observe.registerIntegration('expo-router', config => {
    *   console.log(config);
    * });
    * ```
    */
-  initIntegration<K extends keyof ObserveIntegrationsConfig>(
+  registerIntegration<K extends keyof ObserveIntegrationsConfig>(
     name: K,
     callback: (config: ObserveIntegrationsConfig[K]) => void
   ): void;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
