### PR TITLE
[iOS] Fix `pod install` crash in `integrate_core_macro_plugins` when a target has no ExpoModulesCore (app extension targets)

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [iOS] Add the missing `ENABLE_CROSS_RUNTIME_STACK_TRACES` flag to the `react-native-worklets` precompile config so its prebuilt XCFramework matches the package's `staticFlags.json`. ([#47478](https://github.com/expo/expo/pull/47478) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Under precompiled modules, preserve a dynamic-framework subgraph set up by an earlier `pre_install` hook (e.g. `@rnmapbox/maps`) — both the dynamic frameworks and the pods that link against them — instead of forcing them back to static libraries. ([#47500](https://github.com/expo/expo/pull/47500) by [@kudo](https://github.com/kudo))
 - [iOS] Raise resource bundle targets to their pod's effective deployment target, fixing builds failing on Xcode 27 for pods whose podspec declares a deployment target below iOS 15.0 (e.g. `ReachabilitySwift`). ([#47562](https://github.com/expo/expo/pull/47562) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fix `pod install` crashing with `undefined method 'sandbox' for nil` in `integrate_core_macro_plugins` when the first integrated target has no `ExpoModulesCore` pod target (e.g. an app extension target such as a notification service extension) and no precompiled `ExpoModulesCore` is available. Skip such targets so a later target derives the macro flags. ([#48270](https://github.com/expo/expo/pull/48270) by [@jddipqd](https://github.com/jddipqd))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -140,6 +140,9 @@ module Expo
       targets.each do |target|
         unless macro_flags
           core_pod_target = target.pod_targets.find { |pod_target| pod_target.name == 'ExpoModulesCore' }
+          # Targets without ExpoModulesCore (e.g. app extension targets) cannot be used
+          # to derive the macro flags, skip them so a later target provides the flags.
+          next if core_pod_target.nil? && Expo::PrecompiledModules.package_root_for('ExpoModulesCore').nil?
           core_src_root = Expo::PrecompiledModules.package_root_for('ExpoModulesCore') ||
             File.realpath(core_pod_target.sandbox.pod_dir(core_pod_target.root_spec.name).to_s)
           macros_plugin_dir = resolve_macros_plugin_dir(core_src_root)


### PR DESCRIPTION
# Why

On a bare-workflow project whose Podfile declares targets that don't use Expo modules
(e.g. OneSignal Notification Service Extension targets), `pod install` crashes during
"Integrating client project":

```
NoMethodError - undefined method `sandbox' for nil:NilClass
node_modules/expo-modules-autolinking/scripts/ios/project_integrator.rb:144:in `block in integrate_core_macro_plugins'
node_modules/expo-modules-autolinking/scripts/ios/project_integrator.rb:140:in `each'
node_modules/expo-modules-autolinking/scripts/ios/project_integrator.rb:140:in `integrate_core_macro_plugins'
```

`integrate_core_macro_plugins` derives `macro_flags` from the **first** iterated aggregate
target:

```ruby
core_pod_target = target.pod_targets.find { |pod_target| pod_target.name == 'ExpoModulesCore' }
core_src_root = Expo::PrecompiledModules.package_root_for('ExpoModulesCore') ||
  File.realpath(core_pod_target.sandbox.pod_dir(core_pod_target.root_spec.name).to_s)
```

When the first target is an app extension target, it has no `ExpoModulesCore` pod target,
so `core_pod_target` is `nil`. If `Expo::PrecompiledModules.package_root_for('ExpoModulesCore')`
also returns `nil`, the fallback dereferences `nil.sandbox` and the install aborts. Whether a
project hits this depends only on the (alphabetical) ordering of its aggregate targets.

Reproduced with: expo 56.0.17 / expo-modules-autolinking 56.0.21, React Native 0.85.3,
CocoaPods 1.15.2, Xcode 26.6, bare workflow, multi-target Podfile (an `abstract_target`
with two app flavor targets, plus two OneSignal extension targets declared outside it).
The same unguarded code is present in `expo-modules-autolinking@57.0.9` and on `main`.

# How

Skip targets that cannot provide `ExpoModulesCore` so a later target derives the macro
flags. Targets skipped this way contain no pod targets depending on `ExpoModulesCore`,
so the per-target loop below would not have applied any flags to them anyway — no
behavior change for setups that work today.

# Test Plan

Verified on the real-world project described above, where `pod install` reproducibly
crashed with the stack trace in **Why**. With this guard applied (via patch-package on
56.0.21, identical code): `pod install` completes (126 Podfile dependencies / 135 pods)
and both app flavors build successfully with `xcodebuild` (Debug, iphonesimulator),
including both OneSignal extension targets. Projects without extension targets are
unaffected — the guard only triggers where the crash currently occurs.

# Checklist

- [x] I added a `CHANGELOG.md` entry and description of my changes
- [x] I ran the code formatter — not applicable (Ruby script + markdown; `pnpm lint`/`format` do not cover these files)
