### PR TITLE
[docs][ui] Add lazy rendering notes to SDK 57 docs

### DIFF
--- a/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded vertical list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyColumn` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/lazyrow.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/lazyrow.mdx
@@ -12,6 +12,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 A lazily-loaded horizontal list component that only renders visible items for efficient scrolling. See the [official Jetpack Compose documentation](https://developer.android.com/develop/ui/compose/lists) for more information.
 
+> **info** `LazyRow` is not truly lazy yet: the native side only composes visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/lazyhstack.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/lazyhstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyHStack matches the official SwiftUI [LazyHStack API](https://developer.apple.com/documentation/swiftui/lazyhstack) and arranges its children horizontally, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyHStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/lazyvstack.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/lazyvstack.mdx
@@ -11,6 +11,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 
 Expo UI LazyVStack matches the official SwiftUI [LazyVStack API](https://developer.apple.com/documentation/swiftui/lazyvstack) and arranges its children vertically, creating items only as needed (when they become visible during scrolling).
 
+> **info** `LazyVStack` is not truly lazy yet: the native side only builds visible items, but React still creates every child up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/list.mdx
@@ -14,6 +14,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 Expo UI List matches the official SwiftUI [List API](https://developer.apple.com/documentation/swiftui/list) and supports styling via the [`listStyle`](modifiers/#liststylestyle) modifier, various row/section modifiers, as well as selection, reordering, and editing capabilities.
 
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
+
 <ContentSpotlight
   variant="component"
   aspect="landscape"

--- a/docs/pages/versions/v57.0.0/sdk/ui/universal/list.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/universal/list.mdx
@@ -9,7 +9,9 @@ platforms: ['android', 'ios', 'web', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh).`ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+`List` provides a virtualized vertical container of rows, typically populated with [`ListItem`](#listitem) children. It provides the platform-native chrome (separators, inset styling, pull-to-refresh). `ListItem` is a tappable row with `leading`/`trailing`/`supportingText` slots.
+
+> **info** `List` does not lazily render rows yet: React creates every row up front, so large lists can be slow to mount. We are working on improving this. For large lists, we recommend [FlashList](https://shopify.github.io/flash-list/) or [Legend List](https://github.com/LegendApp/legend-list).
 
 ## Installation
 


### PR DESCRIPTION
# Why

The lazy rendering notes added in #46767 exist in the SDK 56 and unversioned docs, but are missing from the SDK 57 docs. #46767 landed on main after the sdk-57 branch was cut, and was not cherry-picked, so the SDK 57 docs cut (#47275) did not include it. Raised on Discord/Slack as a docs gap.

# How

Copied the notes verbatim from the unversioned pages into the six affected v57 pages: universal `List`, SwiftUI `List`, `LazyVStack`, `LazyHStack`, and Jetpack Compose `LazyColumn`, `LazyRow`. Also fixed a missing space in the universal `List` intro.

# Test Plan

Docs-only change. Verified the v57 pages now match the unversioned pages.