### PR TITLE
fix(expo,expo-go,linking,asset,dev-menu): Prefer bundle URL origin over `hostUri` and `debuggerHost` from manifest

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ExperienceActivity.kt
@@ -196,8 +196,9 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
           override fun onManifestCompleted(manifest: Manifest) {
             lifecycleScope.launch {
               try {
-                val bundleUrl = ExponentUrls.toHttp(
-                  ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), this@ExperienceActivity.manifestUrl!!)
+                val bundleUrl = ExponentUrls.bundleUrlFromManifest(
+                  manifest,
+                  this@ExperienceActivity.manifestUrl!!
                 )
                 setManifest(
                   this@ExperienceActivity.manifestUrl!!,
@@ -645,7 +646,7 @@ open class ExperienceActivity : BaseExperienceActivity(), StartReactInstanceDele
     Exponent.instance
       .testPackagerStatus(
         isDebugModeEnabled,
-        manifest!!,
+        ExponentUrls.bundleUrlFromManifest(manifest!!, manifestUrl!!),
         object : Exponent.PackagerStatusCallback {
           override fun onSuccess() {
             reactHost = startReactInstance(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -394,7 +394,7 @@ abstract class ReactNativeActivity :
       jsBundleFilePath = nativeHost.jsBundleFile,
       useDevSupport = nativeHost.useDeveloperSupport,
       devBundleDownloadListener = devBundleDownloadListener,
-      devServerBundleUrl = ExponentUrls.toHttp(manifest!!.getBundleURL())
+      devServerBundleUrl = ExponentUrls.bundleUrlFromManifest(manifest!!, manifestUrl!!)
     )
     devSupportManager = reactHost.devSupportManager
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -83,9 +83,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
         override fun onManifestCompleted(manifest: Manifest) {
           Exponent.instance.runOnUiThread {
             try {
-              val bundleUrl = ExponentUrls.toHttp(
-                ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), manifestUrl!!)
-              )
+              val bundleUrl = ExponentUrls.bundleUrlFromManifest(manifest, manifestUrl!!)
               setManifest(manifestUrl!!, manifest, bundleUrl)
             } catch (e: JSONException) {
               this@InternalHeadlessAppLoader.callback!!.onComplete(false, Exception(e.message))
@@ -197,7 +195,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
   private fun startReactInstance() {
     Exponent.instance.testPackagerStatus(
       isDebugModeEnabled,
-      manifest!!,
+      ExponentUrls.bundleUrlFromManifest(manifest!!, manifestUrl!!),
       object : Exponent.PackagerStatusCallback {
         override fun onSuccess() {
           reactHost = startReactInstance(
@@ -249,7 +247,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
       jsMainModulePath = host.jsMainModuleName,
       jsBundleFilePath = host.jsBundleFile,
       useDevSupport = host.useDeveloperSupport,
-      devServerBundleUrl = ExponentUrls.toHttp(manifest!!.getBundleURL())
+      devServerBundleUrl = ExponentUrls.bundleUrlFromManifest(manifest!!, manifestUrl!!)
     )
 
     (reactHost.devSupportManager as? ExpoGoDevSupportManager)?.exponentActivityId = activityId

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -3,6 +3,7 @@ package host.exp.exponent.kernel
 
 import android.net.Uri
 import expo.modules.jsonutils.require
+import expo.modules.manifests.core.Manifest
 import host.exp.exponent.Constants
 import host.exp.exponent.ExponentManifest
 import okhttp3.Request
@@ -37,6 +38,19 @@ object ExponentUrls {
     } catch (e: Exception) {
       rawUrl
     }
+  }
+
+  /**
+   * The HTTP(S) URL the JS bundle is loaded from, resolved against the URL the manifest was served
+   * from.
+   *
+   * This is the address the device actually reached, so it's what other development server requests
+   * must be built from. It's preferred over the manifest's `debuggerHost`, which holds the address
+   * the development server believes it has, and which is unreachable whenever the server is reached
+   * through something it can't observe, such as a proxy or a tunnel.
+   */
+  @JvmStatic fun bundleUrlFromManifest(manifest: Manifest, manifestUrl: String): String {
+    return toHttp(resolveManifestUrl(manifest.getBundleURL(), manifestUrl))
   }
 
   @JvmStatic fun addExponentHeadersToUrl(urlString: String): Request.Builder {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -693,7 +693,7 @@ class Kernel : KernelInterface() {
     manifest: Manifest,
     existingTask: AppTask?
   ) {
-    val bundleUrl = toHttp(ExponentUrls.resolveManifestUrl(manifest.getBundleURL(), manifestUrl))
+    val bundleUrl = ExponentUrls.bundleUrlFromManifest(manifest, manifestUrl)
     val task = getExperienceActivityTask(manifestUrl)
     task.bundleUrl = bundleUrl
     if (existingTask == null) {

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.os.StrictMode
@@ -281,9 +282,17 @@ class Exponent private constructor(val context: Context, val application: Applic
     fun onFailure(errorMessage: String)
   }
 
+  /**
+   * Check that the development server that serves [bundleUrl] is running.
+   *
+   * The status URL is built from the bundle URL, which is the address this device reached, rather
+   * than from the manifest's `debuggerHost`, which is the address the development server believes it
+   * has. The two differ when the server is reached through a proxy or a tunnel, and only the former
+   * keeps its scheme and port.
+   */
   fun testPackagerStatus(
     isDebug: Boolean,
-    mManifest: Manifest,
+    bundleUrl: String,
     callback: PackagerStatusCallback
   ) {
     if (!isDebug) {
@@ -291,13 +300,19 @@ class Exponent private constructor(val context: Context, val application: Applic
       return
     }
 
-    val debuggerHost = mManifest.getDebuggerHost()
+    val statusUrl = Uri.parse(bundleUrl)
+      .buildUpon()
+      .path("status")
+      .clearQuery()
+      .fragment(null)
+      .build()
+      .toString()
     exponentNetwork.noCacheClient.newCall(
-      Request.Builder().url("http://$debuggerHost/status").build()
+      Request.Builder().url(statusUrl).build()
     ).enqueue(object : Callback {
       override fun onFailure(call: Call, e: IOException) {
         EXL.d(TAG, e.toString())
-        callback.onFailure("Packager is not running at http://$debuggerHost")
+        callback.onFailure("Packager is not running at $statusUrl")
       }
 
       @Throws(IOException::class)
@@ -306,7 +321,7 @@ class Exponent private constructor(val context: Context, val application: Applic
         if (responseString.contains(PACKAGER_RUNNING)) {
           runOnUiThread { callback.onSuccess() }
         } else {
-          callback.onFailure("Packager is not running at http://$debuggerHost")
+          callback.onFailure("Packager is not running at $statusUrl")
         }
       }
     })

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
@@ -169,13 +169,14 @@ public class DevMenuManager: NSObject {
   func openJSInspector() {
     // The bundle URL is the address this device reached the development server on, unlike the
     // manifest URL, which carries the `exp` scheme and may omit the port the bundle was served on.
-    guard let bundleURL = currentBundleURL, let host = bundleURL.host else {
+    guard let bundleURL = currentBundleURL else {
       return
     }
+    let isServed = bundleURL.scheme == "http" || bundleURL.scheme == "https" || bundleURL.scheme == "exps" || bundleURL.scheme == "exp"
     var components = URLComponents()
-    components.scheme = bundleURL.scheme == "https" ? "https" : "http"
-    components.host = host
-    components.port = bundleURL.port
+    components.scheme = bundleURL.scheme == "https" || bundleURL.scheme == "exps" ? "https" : "http"
+    components.host = isServed ? bundleURL.host : "localhost"
+    components.port = isServed ? bundleURL.port : 8081
     components.path = "/_expo/debugger"
     components.queryItems = [
       URLQueryItem(name: "applicationId", value: Bundle.main.bundleIdentifier ?? "")

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
@@ -167,13 +167,20 @@ public class DevMenuManager: NSObject {
   }
 
   func openJSInspector() {
-    guard let manifestURL = currentManifestURL else {
+    // The bundle URL is the address this device reached the development server on, unlike the
+    // manifest URL, which carries the `exp` scheme and may omit the port the bundle was served on.
+    guard let bundleURL = currentBundleURL, let host = bundleURL.host else {
       return
     }
-    let port = manifestURL.port ?? 8081
-    let host = manifestURL.host ?? "localhost"
-    let openURL = "http://\(host):\(port)/_expo/debugger?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
-    guard let url = URL(string: openURL) else { return }
+    var components = URLComponents()
+    components.scheme = bundleURL.scheme == "https" ? "https" : "http"
+    components.host = host
+    components.port = bundleURL.port
+    components.path = "/_expo/debugger"
+    components.queryItems = [
+      URLQueryItem(name: "applicationId", value: Bundle.main.bundleIdentifier ?? "")
+    ]
+    guard let url = components.url else { return }
     let request = NSMutableURLRequest(url: url)
     request.httpMethod = "PUT"
     URLSession.shared.dataTask(with: request as URLRequest).resume()

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXApiUtil.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXApiUtil.swift
@@ -5,6 +5,14 @@ import EXManifests
 @objc(EXApiUtil)
 @objcMembers
 public class ApiUtil: NSObject {
+  // NOTE(@kitten): Keep in sync with Android's `ExponentUrls.HTTPS_HOSTS`
+  private static let httpsHosts = [
+    "exp.host",
+    "exponentjs.com",
+    "u.expo.dev",
+    "staging-u.expo.dev"
+  ]
+
   public static func bundleUrlFromManifest(_ manifest: Manifest) -> URL? {
     return bundleUrlFromManifest(manifest, relativeTo: nil)
   }
@@ -19,10 +27,26 @@ public class ApiUtil: NSObject {
 
   public static func encodedUrlFromString(_ urlString: String, relativeTo baseUrl: URL?) -> URL? {
     let encodedUrlString = urlString.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-    if let baseUrl = baseUrl {
-      return URL(string: urlString, relativeTo: baseUrl)?.absoluteURL
-        ?? URL(string: encodedUrlString, relativeTo: baseUrl)?.absoluteURL
+    let normalizedBaseUrl = baseUrl.flatMap(normalizeExpoScheme)
+    let resolvedUrl: URL?
+    if let normalizedBaseUrl {
+      resolvedUrl = URL(string: urlString, relativeTo: normalizedBaseUrl)?.absoluteURL
+        ?? URL(string: encodedUrlString, relativeTo: normalizedBaseUrl)?.absoluteURL
+    } else {
+      resolvedUrl = URL(string: urlString) ?? URL(string: encodedUrlString)
     }
-    return URL(string: urlString) ?? URL(string: encodedUrlString)
+    return resolvedUrl.flatMap(normalizeExpoScheme)
+  }
+
+  /** Converts schemes to the http(s) schemes used to fetch their resources */
+  private static func normalizeExpoScheme(_ url: URL) -> URL? {
+    guard url.scheme == "exp" || url.scheme == "exps" else {
+      return url
+    }
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
+      return nil
+    }
+    components.scheme = url.scheme == "exps" || httpsHosts.contains(url.host ?? "") ? "https" : "http"
+    return components.url
   }
 }

--- a/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXPackagerLogHelper.swift
+++ b/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXPackagerLogHelper.swift
@@ -121,15 +121,18 @@ import React
   }
 
   private func createSocket() {
-    let serverHost = bundleURL.host ?? "localhost"
-    let serverPort = bundleURL.port ?? Int(kRCTBundleURLProviderDefaultPort)
     let scheme = (bundleURL.scheme == "exps" || bundleURL.scheme == "https") ? "https" : "http"
 
     var components = URLComponents()
-    components.host = serverHost
     components.scheme = scheme
-    components.port = serverPort
     components.path = "/hot"
+    if let serverHost = bundleURL.host {
+      components.host = serverHost
+      components.port = bundleURL.port
+    } else {
+      components.host = "localhost"
+      components.port = Int(kRCTBundleURLProviderDefaultPort)
+    }
 
     if let url = components.url {
       socket = SRWebSocket(url: url)

--- a/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/EXVersionManagerObjC.mm
@@ -268,6 +268,7 @@ RCT_EXTERN void EXRegisterScopedModule(Class, ...);
 
 - (void)_openJsInspector:(NSURL *)bundleURL
 {
+  // TODO(@kitten): This might be unreachable. If it isn't it shouldn't hardcode `http`, but it looks unused to me
   NSInteger port = [[bundleURL port] integerValue] ?: RCT_METRO_PORT;
   NSString *host = [bundleURL host] ?: @"localhost";
   NSString *url =

--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve development asset URLs from the bundle URL instead of the manifest's `debuggerHost` ([#48275](https://github.com/expo/expo/pull/48275) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 57.0.8 - 2026-07-29

--- a/packages/expo-asset/src/AssetSources.ts
+++ b/packages/expo-asset/src/AssetSources.ts
@@ -1,5 +1,6 @@
 import type { PackagerAsset } from '@react-native/assets-registry/registry';
 import { Platform } from 'expo-modules-core';
+import { getBundleOrigin } from 'expo/internal/bundle-origin';
 import { PixelRatio, NativeModules } from 'react-native';
 
 import AssetSourceResolver from './AssetSourceResolver';
@@ -19,6 +20,21 @@ export type AssetSource = {
   uri: string;
   hash: string;
 };
+
+function resolveDevServerUrl(
+  manifest2: NonNullable<ReturnType<typeof getManifest2>>
+): string | null {
+  const bundleOrigin = getBundleOrigin();
+  if (bundleOrigin) {
+    return bundleOrigin;
+  }
+  const debuggerHost = manifest2.extra?.expoGo?.debuggerHost;
+  if (!debuggerHost) {
+    return null;
+  }
+  const scheme = manifestBaseUrl?.startsWith('https://') ? 'https://' : 'http://';
+  return scheme + debuggerHost;
+}
 
 /**
  * Selects the best file for the given asset (ex: choosing the best scale for images) and returns
@@ -56,12 +72,7 @@ export function selectAssetSource(meta: AssetMetadata): AssetSource {
 
   // For assets during development using manifest2, we use the development server's URL origin
   const manifest2 = getManifest2();
-
-  // Use the scheme from manifestBaseUrl (derived from experienceUrl) to support HTTPS dev servers
-  const scheme = manifestBaseUrl?.startsWith('https://') ? 'https://' : 'http://';
-  const devServerUrl = manifest2?.extra?.expoGo?.developer
-    ? scheme + manifest2.extra.expoGo.debuggerHost
-    : null;
+  const devServerUrl = manifest2?.extra?.expoGo?.developer ? resolveDevServerUrl(manifest2) : null;
   if (devServerUrl) {
     const baseUrl = new URL(meta.httpServerLocation + suffix, devServerUrl);
 

--- a/packages/expo-asset/src/__tests__/AssetSources-test.ts
+++ b/packages/expo-asset/src/__tests__/AssetSources-test.ts
@@ -1,5 +1,7 @@
 import { Platform } from 'expo-modules-core';
 
+jest.mock('expo/internal/bundle-origin', () => ({ getBundleOrigin: jest.fn(() => null) }));
+
 const mockFontMetadata = {
   hash: 'cafecafecafecafecafecafecafecafe',
   name: 'test',
@@ -17,6 +19,7 @@ const mockFontMonorepoMetadata = {
 
 describe('selectAssetSource', () => {
   beforeEach(() => {
+    _mockDevServerUrl(null);
     _mockConstants({
       experienceUrl: 'https://example.com/app/expo-manifest.json',
       __unsafeNoWarnManifest2: {},
@@ -360,5 +363,5 @@ function _mockConstants(constants: { [key: string]: any }): void {
 
 /** Mock the origin the running bundle was loaded from. */
 function _mockDevServerUrl(origin: string | null): void {
-  jest.doMock('expo/internal/bundle-origin', () => ({ getBundleOrigin: () => origin }));
+  jest.mocked(require('expo/internal/bundle-origin').getBundleOrigin).mockReturnValue(origin);
 }

--- a/packages/expo-asset/src/__tests__/AssetSources-test.ts
+++ b/packages/expo-asset/src/__tests__/AssetSources-test.ts
@@ -195,6 +195,86 @@ describe('selectAssetSource', () => {
       );
       expect(source.hash).toBe('cafecafecafecafecafecafecafecafe');
     });
+
+    it(`returns a development URI from the bundle URL rather than debuggerHost`, () => {
+      // The dev server may be reached through an address it can't observe itself, so the URL the
+      // bundle was loaded from wins over `debuggerHost`, which may name an unreachable address.
+      _mockConstants({
+        experienceUrl: 'https://proxy.test/app',
+        __unsafeNoWarnManifest2: {
+          extra: {
+            expoGo: {
+              developer: { tool: 'expo-cli' },
+              debuggerHost: '127.0.0.1:8081',
+            },
+          },
+        },
+      });
+      _mockDevServerUrl('https://proxy.test/');
+
+      const AssetSources = require('../AssetSources');
+      const source = AssetSources.selectAssetSource(mockFontMetadata);
+
+      expect(source.uri).toBe(
+        `https://proxy.test/assets/test.ttf?platform=${Platform.OS}&hash=cafecafecafecafecafecafecafecafe`
+      );
+    });
+
+    it(`keeps the bundle URL's port`, () => {
+      _mockConstants({
+        experienceUrl: 'http://proxy.test:4443/app',
+        __unsafeNoWarnManifest2: {
+          extra: {
+            expoGo: {
+              developer: { tool: 'expo-cli' },
+              debuggerHost: '127.0.0.1:8081',
+            },
+          },
+        },
+      });
+      _mockDevServerUrl('http://proxy.test:4443/');
+
+      const AssetSources = require('../AssetSources');
+
+      expect(AssetSources.selectAssetSource(mockFontMonorepoMetadata).uri).toBe(
+        `http://proxy.test:4443/assets/?unstable_path=.%2Ftest.ttf&platform=${Platform.OS}&hash=cafecafecafecafecafecafecafecafe`
+      );
+    });
+
+    it(`falls back to debuggerHost when the bundle wasn't loaded from a server`, () => {
+      _mockConstants({
+        experienceUrl: 'http://127.0.0.1:8081/app',
+        __unsafeNoWarnManifest2: {
+          extra: {
+            expoGo: {
+              developer: { tool: 'expo-cli' },
+              debuggerHost: '127.0.0.1:8081',
+            },
+          },
+        },
+      });
+      _mockDevServerUrl(null);
+
+      const AssetSources = require('../AssetSources');
+
+      expect(AssetSources.selectAssetSource(mockFontMetadata).uri).toBe(
+        `http://127.0.0.1:8081/assets/test.ttf?platform=${Platform.OS}&hash=cafecafecafecafecafecafecafecafe`
+      );
+    });
+
+    it(`ignores the bundle URL for a published app in Expo Go`, () => {
+      // Without a dev server in the manifest the bundle came from a CDN, and assets must not be
+      // resolved against it.
+      _mockConstants({
+        experienceUrl: 'https://exp.host/@test/test',
+        __unsafeNoWarnManifest2: { extra: {} },
+      });
+      _mockDevServerUrl('https://cdn.test/');
+
+      const AssetSources = require('../AssetSources');
+
+      expect(AssetSources.selectAssetSource(mockFontMetadata).uri).toBe('');
+    });
   }
 });
 
@@ -276,4 +356,9 @@ function _mockConstants(constants: { [key: string]: any }): void {
       manifest: { ...Constants.manifest, ...constants.manifest },
     };
   });
+}
+
+/** Mock the origin the running bundle was loaded from. */
+function _mockDevServerUrl(origin: string | null): void {
+  jest.doMock('expo/internal/bundle-origin', () => ({ getBundleOrigin: () => origin }));
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have. ([#47693](https://github.com/expo/expo/pull/47693) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Fixed the dev menu sizing itself from the main screen instead of the app's own window, and the FAB choosing its slide-in edge from the screen rather than its window. ([#48171](https://github.com/expo/expo/pull/48171) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed the dev menu and FAB resolving their scene by filtering all scene types before casting, which could miss a real window scene. ([#48317](https://github.com/expo/expo/pull/48317) by [@alanjhughes](https://github.com/alanjhughes))
+- Open the JS inspector on the origin the bundle was loaded from, keeping its scheme and port ([#48275](https://github.com/expo/expo/pull/48275) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -119,18 +119,29 @@ class DevMenuDevToolsDelegate(
     }
   }
 
+  private fun getDevServerHost(): String? {
+    val sourceUri = reactContext?.sourceURL?.toUri()
+    val scheme = sourceUri?.scheme
+    // A bundle loaded from disk has no reachable origin.
+    if (sourceUri != null && (scheme == "http" || scheme == "https")) {
+      sourceUri.authority?.let { authority ->
+        return "$scheme://$authority"
+      }
+    }
+    val debugServerHost = devSettings?.packagerConnectionSettings?.debugServerHost ?: return null
+    return "http://$debugServerHost"
+  }
+
   @OptIn(DelicateCoroutinesApi::class)
   fun openJSInspector() {
-    val devSettings = devSettings ?: return
     val context = context ?: return
-
-    val metroHost = "http://${devSettings.packagerConnectionSettings.debugServerHost}"
+    val devServerHost = getDevServerHost() ?: return
 
     // We can use GlobalScope here because this operation is not tied to any specific lifecycle.
     // We just want to fire and forget.
     GlobalScope.launch(Dispatchers.Default) {
       try {
-        DevMenuMetroClient.openJSInspector(metroHost, context.packageName)
+        DevMenuMetroClient.openJSInspector(devServerHost, context.packageName)
       } catch (e: Exception) {
         Log.w("DevMenu", "Unable to open js inspector: ${e.message}", e)
       }

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -35,11 +35,18 @@ class DevMenuDevOptionsDelegate {
     guard let bundleURL = appContext?.bundleURL else {
       return
     }
-    let port = bundleURL.port ?? Int(RCT_METRO_PORT)
-    let host = bundleURL.host ?? "localhost"
-    let openURL = "http://\(host):\(port)/_expo/debugger?applicationId=\(Bundle.main.bundleIdentifier ?? "")"
-    guard let url = URL(string: openURL) else {
-      NSLog("[DevMenu] Invalid openJSInspector URL: $@", openURL)
+    // The bundle URL is the address this device reached the development server on, so its scheme and
+    // port are kept. Only its host is assumed when the bundle was loaded from disk.
+    var components = URLComponents()
+    components.scheme = bundleURL.scheme == "https" ? "https" : "http"
+    components.host = bundleURL.host ?? "localhost"
+    components.port = bundleURL.host != nil ? bundleURL.port : Int(RCT_METRO_PORT)
+    components.path = "/_expo/debugger"
+    components.queryItems = [
+      URLQueryItem(name: "applicationId", value: Bundle.main.bundleIdentifier ?? "")
+    ]
+    guard let url = components.url else {
+      NSLog("[DevMenu] Invalid openJSInspector URL: $@", components.description)
       return
     }
     let request = NSMutableURLRequest(url: url)

--- a/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
+++ b/packages/expo-dev-menu/ios/DevMenuDevOptionsDelegate.swift
@@ -35,12 +35,11 @@ class DevMenuDevOptionsDelegate {
     guard let bundleURL = appContext?.bundleURL else {
       return
     }
-    // The bundle URL is the address this device reached the development server on, so its scheme and
-    // port are kept. Only its host is assumed when the bundle was loaded from disk.
+    let isServed = bundleURL.scheme == "http" || bundleURL.scheme == "https" || bundleURL.scheme == "exps" || bundleURL.scheme == "exp"
     var components = URLComponents()
-    components.scheme = bundleURL.scheme == "https" ? "https" : "http"
-    components.host = bundleURL.host ?? "localhost"
-    components.port = bundleURL.host != nil ? bundleURL.port : Int(RCT_METRO_PORT)
+    components.scheme = bundleURL.scheme == "https" || bundleURL.scheme == "exps" ? "https" : "http"
+    components.host = isServed ? bundleURL.host : "localhost"
+    components.port = isServed ? bundleURL.port : Int(RCT_METRO_PORT)
     components.path = "/_expo/debugger"
     components.queryItems = [
       URLQueryItem(name: "applicationId", value: Bundle.main.bundleIdentifier ?? "")

--- a/packages/expo-linking/CHANGELOG.md
+++ b/packages/expo-linking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Create development deep links from the bundle URL's authority instead of the manifest's `hostUri` ([#48275](https://github.com/expo/expo/pull/48275) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 57.0.4 - 2026-07-22

--- a/packages/expo-linking/package.json
+++ b/packages/expo-linking/package.json
@@ -61,6 +61,7 @@
     "expo-module-scripts": "workspace:*"
   },
   "peerDependencies": {
+    "expo": "*",
     "react": "*",
     "react-native": "*"
   }

--- a/packages/expo-linking/src/__tests__/Linking-test.ts
+++ b/packages/expo-linking/src/__tests__/Linking-test.ts
@@ -1,8 +1,18 @@
 import Constants, { ExecutionEnvironment } from 'expo-constants';
+import { Platform } from 'expo-modules-core';
 import { mockProperty, unmockAllProperties } from 'jest-expo';
 
 import * as Linking from '../Linking';
 import type { QueryParams } from '../Linking.types';
+
+jest.mock('expo/internal/bundle-origin', () => ({ getBundleOrigin: jest.fn(() => null) }));
+
+/** Mock the origin the running bundle was loaded from. */
+function mockDevServerUrl(url: string | null): void {
+  jest
+    .mocked(require('expo/internal/bundle-origin').getBundleOrigin)
+    .mockReturnValue(url && new URL(url).origin);
+}
 
 describe('parse', () => {
   beforeAll(() => {
@@ -71,6 +81,66 @@ describe(Linking.createURL, () => {
         });
       }
     );
+  });
+
+  // The web platform has its own `createURL` implementation, which uses `window.location`.
+  const describeNative = Platform.OS === 'web' ? describe.skip : describe;
+
+  describeNative('development server', () => {
+    let rawManifest: any;
+
+    beforeEach(() => {
+      console.warn = jest.fn();
+      Constants.executionEnvironment = ExecutionEnvironment.StoreClient;
+      rawManifest = (Constants as any).__rawManifest_TEST;
+      (Constants as any).__rawManifest_TEST = {
+        metadata: {},
+        extra: {
+          expoClient: { hostUri: '127.0.0.1:8081' },
+          expoGo: { developer: { tool: 'expo-cli' } },
+        },
+      };
+    });
+
+    afterEach(() => {
+      console.warn = consoleWarn;
+      Constants.executionEnvironment = executionEnvironment;
+      (Constants as any).__rawManifest_TEST = rawManifest;
+      mockDevServerUrl(null);
+    });
+
+    it(`prefers the bundle URL authority over hostUri`, () => {
+      // The dev server may be reached through an address it can't observe itself, and `hostUri` then
+      // names an address this device can't reach.
+      mockDevServerUrl('http://proxy.test/');
+      expect(Linking.createURL('some/path')).toBe('exp://proxy.test/--/some/path');
+    });
+
+    it(`keeps the bundle URL's port`, () => {
+      mockDevServerUrl('http://proxy.test:4443/');
+      expect(Linking.createURL('some/path')).toBe('exp://proxy.test:4443/--/some/path');
+    });
+
+    it(`uses the "exps" scheme for an HTTPS dev server`, () => {
+      // Expo Go maps `exps` to HTTPS; `exp` would make it request the dev server over HTTP.
+      mockDevServerUrl('https://proxy.test/');
+      expect(Linking.createURL('some/path')).toBe('exps://proxy.test/--/some/path');
+    });
+
+    it(`falls back to hostUri when the bundle wasn't loaded from a server`, () => {
+      mockDevServerUrl(null);
+      expect(Linking.createURL('some/path')).toBe('exp://127.0.0.1:8081/--/some/path');
+    });
+
+    it(`parses a deep link made against the bundle URL authority`, () => {
+      mockDevServerUrl('http://proxy.test/');
+      expect(Linking.parse('exp://proxy.test/--/test/path?query=param')).toEqual({
+        hostname: null,
+        path: 'test/path',
+        queryParams: { query: 'param' },
+        scheme: 'exp',
+      });
+    });
   });
 
   describe('bare', () => {

--- a/packages/expo-linking/src/createURL.ts
+++ b/packages/expo-linking/src/createURL.ts
@@ -27,8 +27,7 @@ function getDevServerLocation(): { authority: string; isSecure: boolean } | null
   return { authority: host, isSecure: protocol === 'https:' };
 }
 
-function getHostUri(): string | null {
-  const devServer = getDevServerLocation();
+function getHostUri(devServer = getDevServerLocation()): string | null {
   if (devServer) {
     return devServer.authority;
   } else if (Constants.expoConfig?.hostUri) {
@@ -42,8 +41,7 @@ function getHostUri(): string | null {
   }
 }
 
-function isExpoHosted(): boolean {
-  const hostUri = getHostUri();
+function isExpoHosted(hostUri = getHostUri()): boolean {
   return !!(
     hostUri &&
     (/^(.*\.)?(expo\.io|exp\.host|exp\.direct|expo\.test|expo\.dev)(:.*)?(\/.*)?$/.test(hostUri) ||
@@ -105,22 +103,24 @@ export function createURL(
   path: string,
   { scheme, queryParams = {}, isTripleSlashed = false }: CreateURLOptions = {}
 ): string {
+  const devServer = getDevServerLocation();
   let resolvedScheme = resolveScheme({ scheme });
 
   // Expo Go maps the `exps` scheme to HTTPS, which `exp` can't express, so an HTTPS development
   // server needs it to be reached over the scheme it's actually served on.
-  if (!scheme && resolvedScheme === 'exp' && getDevServerLocation()?.isSecure) {
+  if (!scheme && resolvedScheme === 'exp' && devServer?.isSecure) {
     resolvedScheme = 'exps';
   }
 
-  let hostUri = getHostUri() || '';
+  let hostUri = getHostUri(devServer) || '';
+  const expoHosted = isExpoHosted(hostUri);
 
-  if (hasCustomScheme() && isExpoHosted()) {
+  if (hasCustomScheme() && expoHosted) {
     hostUri = '';
   }
 
   if (path) {
-    if (isExpoHosted() && hostUri) {
+    if (expoHosted && hostUri) {
       path = `/--/${removeLeadingSlash(path)}`;
     }
     if (isTripleSlashed && !path.startsWith('/')) {

--- a/packages/expo-linking/src/createURL.ts
+++ b/packages/expo-linking/src/createURL.ts
@@ -4,8 +4,34 @@ import type { CreateURLOptions, ParsedURL } from './Linking.types';
 import { hasCustomScheme, resolveScheme } from './Schemes';
 import { validateURL } from './validateURL';
 
+function getDevServerLocation(): { authority: string; isSecure: boolean } | null {
+  // A published app in Expo Go also loads its bundle from a server, so its origin is not a
+  // development server to link back to.
+  if (!Constants.expoGoConfig?.developer) {
+    return null;
+  }
+  // Required lazily, because reading the bundle URL initializes React Native's native module bridge,
+  // which isn't available in every runtime that loads this file, such as server rendering.
+  let bundleOrigin: string | null = null;
+  try {
+    bundleOrigin = (
+      require('expo/internal/bundle-origin') as typeof import('expo/internal/bundle-origin')
+    ).getBundleOrigin();
+  } catch {
+    return null;
+  }
+  if (!bundleOrigin) {
+    return null;
+  }
+  const { host, protocol } = new URL(bundleOrigin);
+  return { authority: host, isSecure: protocol === 'https:' };
+}
+
 function getHostUri(): string | null {
-  if (Constants.expoConfig?.hostUri) {
+  const devServer = getDevServerLocation();
+  if (devServer) {
+    return devServer.authority;
+  } else if (Constants.expoConfig?.hostUri) {
     return Constants.expoConfig.hostUri;
   } else if (!hasCustomScheme()) {
     // we're probably not using up-to-date xdl, so just fake it for now
@@ -79,7 +105,13 @@ export function createURL(
   path: string,
   { scheme, queryParams = {}, isTripleSlashed = false }: CreateURLOptions = {}
 ): string {
-  const resolvedScheme = resolveScheme({ scheme });
+  let resolvedScheme = resolveScheme({ scheme });
+
+  // Expo Go maps the `exps` scheme to HTTPS, which `exp` can't express, so an HTTPS development
+  // server needs it to be reached over the scheme it's actually served on.
+  if (!scheme && resolvedScheme === 'exp' && getDevServerLocation()?.isSecure) {
+    resolvedScheme = 'exps';
+  }
 
   let hostUri = getHostUri() || '';
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [Internal] Update logbox imports ([#46640](https://github.com/expo/expo/pull/46640) by [@kitten](https://github.com/kitten))
 - Re-export more expo-modules-core APIs ([#45987](https://github.com/expo/expo/pull/45987) by [@Wenszel](https://github.com/Wenszel))
 - Update `URL` and `URLSearchParams` implementation to support IDNA/TR-46 and improve performance. Spec-adherence has increased and few gaps should now be noticeable compared to browsers ([#47813](https://github.com/expo/expo/pull/47813) by [@kitten](https://github.com/kitten))
+- [Internal] Add `getBundleOrigin`, exposed as `expo/internal/bundle-origin` ([#48275](https://github.com/expo/expo/pull/48275) by [@kitten](https://github.com/kitten))
 
 ## 57.0.9 - 2026-07-29
 

--- a/packages/expo/internal/bundle-origin.d.ts
+++ b/packages/expo/internal/bundle-origin.d.ts
@@ -1,0 +1,2 @@
+// WARN: Internal re-export, don't rely on this to be a public API or use it outside of `expo/expo`'s monorepo
+export * from '../src/utils/getBundleOrigin';

--- a/packages/expo/internal/bundle-origin.js
+++ b/packages/expo/internal/bundle-origin.js
@@ -1,0 +1,2 @@
+// WARN: Internal re-export, don't rely on this to be a public API
+module.exports = require('../src/utils/getBundleOrigin');

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -96,6 +96,14 @@
       "expo-source": "./src/winter/installGlobal.ts",
       "default": "./build/winter/installGlobal.js"
     },
+    "./internal/bundle-origin": {
+      "types": {
+        "expo-source": "./src/utils/getBundleOrigin.ts",
+        "default": "./build/utils/getBundleOrigin.d.ts"
+      },
+      "expo-source": "./src/utils/getBundleOrigin.ts",
+      "default": "./build/utils/getBundleOrigin.js"
+    },
     "./internal/*": {
       "types": "./internal/*.d.ts",
       "default": "./internal/*.js"

--- a/packages/expo/src/utils/__tests__/getBundleOrigin.test.ts
+++ b/packages/expo/src/utils/__tests__/getBundleOrigin.test.ts
@@ -1,0 +1,35 @@
+import { getBundleOrigin } from '../getBundleOrigin';
+import { getBundleUrl } from '../getBundleUrl';
+
+jest.mock('../getBundleUrl', () => ({ getBundleUrl: jest.fn() }));
+
+function mockBundleUrl(url: string | null) {
+  jest.mocked(getBundleUrl).mockReturnValue(url);
+}
+
+describe(getBundleOrigin, () => {
+  it(`returns the origin of a bundle served over HTTP`, () => {
+    mockBundleUrl('http://127.0.0.1:8081/index.bundle?platform=ios&dev=true');
+    expect(getBundleOrigin()).toBe('http://127.0.0.1:8081');
+  });
+
+  it(`keeps the scheme of a bundle served over HTTPS`, () => {
+    mockBundleUrl('https://proxy.test/index.bundle?platform=ios');
+    expect(getBundleOrigin()).toBe('https://proxy.test');
+  });
+
+  it(`returns null for a bundle loaded from disk`, () => {
+    mockBundleUrl('file:///var/containers/app/main.jsbundle');
+    expect(getBundleOrigin()).toBeNull();
+  });
+
+  it(`returns null when the bundle URL is unknown`, () => {
+    mockBundleUrl(null);
+    expect(getBundleOrigin()).toBeNull();
+  });
+
+  it(`returns null for an unparseable bundle URL`, () => {
+    mockBundleUrl('not a url');
+    expect(getBundleOrigin()).toBeNull();
+  });
+});

--- a/packages/expo/src/utils/getBundleOrigin.ts
+++ b/packages/expo/src/utils/getBundleOrigin.ts
@@ -1,0 +1,26 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { getBundleUrl } from './getBundleUrl';
+
+/**
+ * Origin the running bundle was served from, or `null` when it wasn't served over HTTP.
+ *
+ * This is the address the runtime actually reached, so it stays correct when a development server is
+ * reached through an address it can't observe itself, such as a proxy or a tunnel. It's the value to
+ * build other development server requests from, in place of an address the server reports for itself.
+ *
+ * A bundle loaded from disk has a `file:` URL, which is no address to resolve anything against.
+ */
+export function getBundleOrigin(): string | null {
+  const bundleUrl = getBundleUrl();
+  if (!bundleUrl) {
+    return null;
+  }
+  try {
+    const { protocol, origin } = new URL(bundleUrl);
+    // e.g. http://localhost:8081
+    return protocol === 'http:' || protocol === 'https:' ? origin : null;
+  } catch {
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4734,6 +4734,9 @@ importers:
 
   packages/expo-linking:
     dependencies:
+      expo:
+        specifier: '*'
+        version: link:../expo
       expo-constants:
         specifier: workspace:~56.0.16
         version: link:../expo-constants


### PR DESCRIPTION
# Why

Stacked on #47255 (follow-up)

We have leftover cases from the manifest update that switches to relative URLs where entries point to a fixed dev server host. These are typically `hostUri` and `debuggerHost`. A few remaining places in the codebase treat these as authoritative, handing control to the dev server on which host to call instead of taking this on themselves.

Like the parent PR, this is problematic, since we have a URL we got the manifest/bundle from already, derived from the request itself, but then disregard it and try to use what the manifest gives us.

`hostUri` and `debuggerHost` are often derived from `X-Forwarded-Host` (or other signals) and once #48267 is merged, will be more accurate in the presence of proxies, however, if we want to behave more like web browsers, it's more correct to simply assume that in development we should use the bundle origin directly. (Since that's where the manifest came from)

# How

- Expose `getBundleOrigin` from `expo/internal/bundle-origin`
  - **Note:** This just exposes what we have for `import.meta.url`, but this isn't shared before
  - I'd love to use `window.location.url` or another global, but that's tied to `@expo/metro-runtime` currently, which also has different logic for this (which we may want to update)
- Use `getBundleOrigin` in `expo-linking` to prefer it there
- Use `getBundleOrigin` in `expo-asset` to prefer it there
- Update `expo-dev-menu` to prefer bundle URL origin over `debuggerHost`
- Update `expo-go` to prefer bundle URL origin over `debuggerHost`
- Fix `expo-go`'s `EXPackagerLogHelper` applying host separately from port

# Test Plan

- Validated a `test-suite` start-up works as expected

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
