### PR TITLE
fix(log-box): Derive dev server request from bundle URL instead of default

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix the web overlay bundle printing a `Deep imports from the 'react-native' package are deprecated` warning on every load. ([#47772](https://github.com/expo/expo/pull/47772) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Resolve development server requests from the URL the bundle was loaded from, instead of the default Metro address ([#48276](https://github.com/expo/expo/pull/48276) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxSurfaceDelegate.kt
+++ b/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxSurfaceDelegate.kt
@@ -74,7 +74,8 @@ class ExpoLogBoxSurfaceDelegate(private val devSupportManager: DevSupportManager
           )
         )
       ),
-      context
+      context,
+      bundleUrl = devSupportManager.currentReactContext?.sourceURL
     )
     rootContainer.addView(webViewWrapper.webView)
     dialog?.setContentView(rootContainer)

--- a/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxWebViewWrapper.kt
+++ b/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxWebViewWrapper.kt
@@ -9,6 +9,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebView.setWebContentsDebuggingEnabled
 import android.webkit.WebViewClient
+import androidx.core.net.toUri
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.google.gson.Gson
 import com.google.gson.JsonObject
@@ -19,7 +20,9 @@ import kotlinx.coroutines.launch
 class ExpoLogBoxWebViewWrapper(
   val actions: Actions,
   val props: Map<String, Any>,
-  val context: Activity
+  val context: Activity,
+  /** URL the running bundle was loaded from, when it was served over HTTP. */
+  private val bundleUrl: String? = null
 ) {
   val webView: WebView = WebView(context).apply {
     setBackgroundColor(Color.BLACK)
@@ -48,6 +51,18 @@ class ExpoLogBoxWebViewWrapper(
     loadUrl("file:///android_asset/ExpoLogBox.bundle/index.html")
   }
 
+  private fun getDevServerOrigin(): String {
+    val bundleUri = bundleUrl?.toUri()
+    val scheme = bundleUri?.scheme
+    // A bundle loaded from disk has no reachable origin.
+    if (bundleUri != null && (scheme == "http" || scheme == "https")) {
+      bundleUri.authority?.let { authority ->
+        return "$scheme://$authority"
+      }
+    }
+    return "http://${AndroidInfoHelpers.getServerHost(context)}"
+  }
+
   private fun initializeLogBoxDomEnvironment() {
     val initialProps = mapOf(
       "names" to actions.getNames(),
@@ -57,7 +72,7 @@ class ExpoLogBoxWebViewWrapper(
     val gson = Gson()
     val jsonObject = gson.toJson(initialProps)
 
-    val devServerOrigin = "http://${AndroidInfoHelpers.getServerHost(context)}"
+    val devServerOrigin = getDevServerOrigin()
     val script = """
             var process=globalThis.process||{};process.env=process.env||{};
             process.env.EXPO_DEV_SERVER_ORIGIN='$devServerOrigin';

--- a/packages/@expo/log-box/ios/ExpoLogBoxController.swift
+++ b/packages/@expo/log-box/ios/ExpoLogBoxController.swift
@@ -5,8 +5,8 @@ import WebKit
 import React
 
 @objc public class ExpoLogBoxScreenProvider: NSObject {
-    @objc public static func makeHostingController(message: String?, stack: [RCTJSStackFrame]?) -> UIViewController {
-        return ExpoLogBoxController(message: message, stack:stack)
+    @objc public static func makeHostingController(message: String?, stack: [RCTJSStackFrame]?, bundleURL: URL?) -> UIViewController {
+        return ExpoLogBoxController(message: message, stack:stack, bundleURL: bundleURL)
     }
 }
 
@@ -17,8 +17,11 @@ struct Colors {
 class ExpoLogBoxController: UIViewController, ExpoLogBoxNativeActionsProtocol {
     private var message: String
     private var stack: [Dictionary<String, Any>]
+    /// URL the running bundle was loaded from, when it was served over HTTP.
+    private var bundleURL: URL?
 
-    init(message: String?, stack: [RCTJSStackFrame]?) {
+    init(message: String?, stack: [RCTJSStackFrame]?, bundleURL: URL?) {
+        self.bundleURL = bundleURL
         self.message = message ?? "Error without message."
         self.stack = stack?.map { frame in
             return [
@@ -36,6 +39,7 @@ class ExpoLogBoxController: UIViewController, ExpoLogBoxNativeActionsProtocol {
     required init?(coder: NSCoder) {
         self.message = "If you see this message this is an issue in ExpoLogBox."
         self.stack = []
+        self.bundleURL = nil
         super.init(coder: coder)
     }
 
@@ -52,7 +56,7 @@ class ExpoLogBoxController: UIViewController, ExpoLogBoxNativeActionsProtocol {
                     "stack": self.stack,
                 ],
             ]
-        ])
+        ], bundleURL: self.bundleURL)
         let webView = webViewWrapper.prepareWebView()
         view.addSubview(webView)
         NSLayoutConstraint.activate([

--- a/packages/@expo/log-box/ios/ExpoLogBoxWebViewWrapper.swift
+++ b/packages/@expo/log-box/ios/ExpoLogBoxWebViewWrapper.swift
@@ -4,7 +4,6 @@
 
 import UIKit
 import WebKit
-import React
 
 protocol ExpoLogBoxNativeActionsProtocol {
     func onReload() -> Void
@@ -36,12 +35,30 @@ class ExpoLogBoxWebViewWrapper: NSObject, WKScriptMessageHandler {
     private let nativeMessageHandlerName = "nativeHandler"
     private let nativeActions: ExpoLogBoxNativeActionsProtocol
     private let props: [String: Any]
+    private let bundleURL: URL?
     private let webView: WKWebView
 
-    init(nativeActions: ExpoLogBoxNativeActionsProtocol, props: [String: Any]) {
+    init(nativeActions: ExpoLogBoxNativeActionsProtocol, props: [String: Any], bundleURL: URL?) {
         self.nativeActions = nativeActions
         self.props = props
+        self.bundleURL = bundleURL
         self.webView = WKWebView(frame: .zero)
+    }
+
+    private var devServerOrigin: String? {
+        guard let bundleURL,
+              let scheme = bundleURL.scheme,
+              scheme == "http" || scheme == "https",
+              let host = bundleURL.host
+        else {
+            return nil
+        }
+        // A bundle URL without a port is served on its scheme's default port, as a development server
+        // behind a TLS-terminating proxy is.
+        guard let port = bundleURL.port else {
+            return "\(scheme)://\(host)"
+        }
+        return "\(scheme)://\(host):\(port)"
     }
 
     func prepareWebView() -> WKWebView {
@@ -55,17 +72,6 @@ class ExpoLogBoxWebViewWrapper: NSObject, WKScriptMessageHandler {
             fatalError("Failed to serialize initProps. This is an issue in ExpoLogBox. Please report it.")
         }
 
-        let devServerOrigin: String? = {
-            guard let bundleUrl = RCTBundleURLProvider.sharedSettings()
-                    .jsBundleURL(forBundleRoot: "unused.name"),
-                  let scheme = bundleUrl.scheme,
-                  let host = bundleUrl.host,
-                  let port = bundleUrl.port
-            else {
-                return nil
-            }
-            return "\(scheme)://\(host):\(port)"
-        }()
         let devServerOriginJsValue: String = devServerOrigin.map { "'\($0)'" } ?? "undefined"
 
         let injectJavascript = """

--- a/packages/@expo/log-box/ios/ExpoRedBoxSwap.mm
+++ b/packages/@expo/log-box/ios/ExpoRedBoxSwap.mm
@@ -1,6 +1,8 @@
 #if !TARGET_OS_MACCATALYST && EXPO_UNSTABLE_LOG_BOX
 
 #import <objc/runtime.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTBundleManager.h>
 #import <React/RCTRedBox.h>
 #import <React/RCTUtils.h>
 #import "ExpoLogBox-Swift.h"
@@ -39,7 +41,10 @@
                        withParsedStack:(NSArray<RCTJSStackFrame *> *)stack
                               isUpdate: (BOOL) isUpdate
                            errorCookie:(int)errorCookie {
-  UIViewController *expoRedBox = [ExpoLogBoxScreenProvider makeHostingControllerWithMessage:message stack:stack];
+  NSURL *bundleURL = self.overrideBundleURL ?: self.bundleManager.bundleURL;
+  UIViewController *expoRedBox = [ExpoLogBoxScreenProvider makeHostingControllerWithMessage:message
+                                                                                     stack:stack
+                                                                                 bundleURL:bundleURL];
   [RCTKeyWindow().rootViewController presentViewController:expoRedBox animated:YES completion:nil];
 }
 


### PR DESCRIPTION
# Why

Stacked on:
- #48275
- #47255

We'll also need to update `@expo/log-box` to derive its target URL from the bundle URL correctly.

# How

- Update web view base URL
- Update stack base URL in log box controller
- Update RedBox base URL

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
