### PR TITLE
[ui][ios] Fix TextField selection crash on external text writes

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a `TextField` selection crash when JavaScript replaces the text while the user types, by using the clamped selection binding on all OS versions and clearing the selection on external writes. ([#48274](https://github.com/expo/expo/issues/48274) by [@realZachi](https://github.com/realZachi)) ([#48277](https://github.com/expo/expo/pull/48277) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `Pressable` (and other responder-based touchables) hosted in `RNHostView` dropping presses on any finger movement. ([#48131](https://github.com/expo/expo/issues/48131) by [@BrianUribe6](https://github.com/BrianUribe6)) ([#48217](https://github.com/expo/expo/pull/48217) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets. ([#48243](https://github.com/expo/expo/pull/48243) by [@Elehiggle](https://github.com/Elehiggle))
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-ui/ios/TextFieldView.swift
+++ b/packages/expo-ui/ios/TextFieldView.swift
@@ -219,16 +219,10 @@ private struct StatefulSelectableTextField: View {
     )
   }
 
-  private var selectionBinding: Binding<SwiftUI.TextSelection?> {
-    if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
-      return $localSelection
-    }
-    return clampedSelectionBinding
-  }
-
-  // iOS 18 SwiftUI can throw an out-of-bounds exception when selection becomes invalid after text is changed programmatically.
+  // SwiftUI can throw an out-of-bounds exception when selection becomes invalid after text is changed programmatically.
   // Resetting to nil avoids passing SwiftUI the stale selection.
   // https://github.com/expo/expo/issues/47434
+  // https://github.com/expo/expo/issues/48274
   // https://github.com/swiftlang/swift/issues/82359#issuecomment-3038538035
   private var clampedSelectionBinding: Binding<SwiftUI.TextSelection?> {
     Binding(
@@ -251,7 +245,7 @@ private struct StatefulSelectableTextField: View {
     TextField(
       promptText == nil ? props.placeholder : "",
       text: textBinding,
-      selection: selectionBinding,
+      selection: clampedSelectionBinding,
       prompt: promptText,
       axis: swiftUIAxis
     )
@@ -278,7 +272,11 @@ private struct StatefulSelectableTextField: View {
       props.onSelectionChange(["start": start, "end": end])
     }
     .onChange(of: state.value as? String) { newValue in
-      guard userMutatingState else { return }
+      guard userMutatingState else {
+        // The text was replaced from JS; drop the selection so indices built for the old string are never validated against the new one.
+        localSelection = nil
+        return
+      }
       if let max = props.maxLength, let str = newValue, str.count > max {
         state.value = String(str.prefix(max))
         return


### PR DESCRIPTION
# Why

Fixes - https://github.com/expo/expo/issues/48274

- `TextField` crashes when a JS write replaces the text while the user is typing. The selection still holds `String.Index` values created for the old text, and `text.distance` traps on them in the selection observer.
- #47447 kept the raw `$localSelection` binding on iOS 26+, so the stale selection was still passed back to SwiftUI there.

# How

- Use the clamped selection binding on all OS versions.
- Clear `localSelection` when the text changes without `userMutatingState` (external JS write), so stale indices never reach `text.distance`. Matches UIKit/RN `TextInput` behavior - a programmatic text replace collapses the selection and moves the caret to the end.

# Test Plan

- Not reproduced locally, the crash reports in the issue are TestFlight builds on iOS 26.5. This applies the mitigation the reporter runs in production.
- Repro path: MRE from https://github.com/LEFTEQ/expo-ui-textfield-selection-crash (external write echo into a focused multiline field).
