### PR TITLE
[android][expo-go] Remove three React Native fork patches

### DIFF
--- a/apps/bare-expo/android/gradle.properties
+++ b/apps/bare-expo/android/gradle.properties
@@ -79,3 +79,6 @@ android.enableMinifyInReleaseBuilds=true
 
 # List of directories watched for local modules.
 expo.inlineModules.watchedDirectories=["../native-component-list/src/screens/inlineModules/inlineModulesExamples"]
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/apps/eas-expo-go/scripts/eas-build-pre-install.sh
+++ b/apps/eas-expo-go/scripts/eas-build-pre-install.sh
@@ -38,6 +38,11 @@ git submodule update --init
 # The react-native submodule uses yarn internally.
 yarn --cwd $ROOT_DIR/react-native-lab/react-native install --frozen-lockfile
 
+# Build the codegen CLI. Its output is no longer committed to the submodule, and yarn does not run
+# the package's own prepare script for a workspace package, so nothing else creates it. Every
+# module's generateCodegenSchemaFromJavaScript task reads react-native-codegen/lib directly.
+yarn --cwd $ROOT_DIR/react-native-lab/react-native/packages/react-native-codegen build
+
 if [ -n "${EAS_BUILD_NPM_CACHE_URL-}" ]; then
   sed -i -e "s#https://registry.yarnpkg.com#$EAS_BUILD_NPM_CACHE_URL#g" $ROOT_DIR/yarn.lock || true
 fi

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -87,6 +87,10 @@ allprojects {
   }
 }
 
+project(":packages:react-native:ReactAndroid").afterEvaluate { reactAndroid ->
+  reactAndroid.tasks.named("buildCodegenCLI").configure { it.enabled = false }
+}
+
 // This var needs to be defined outside any "remove_from_here" comment blocks
 // because the "*/" in there could affect the resulted code by closing the comment to early.
 def ktlintTarget = '**/*.kt'

--- a/apps/expo-go/android/gradle.properties
+++ b/apps/expo-go/android/gradle.properties
@@ -44,3 +44,6 @@ expo.devmenu.configureInRelease=true
 
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=warn
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
+++ b/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/RNViewShotModule.java
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.uimanager.UIManagerHelper;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.common.UIManagerType;
 
 import java.io.File;
@@ -100,13 +99,8 @@ public class RNViewShotModule extends NativeRNViewShotSpec {
                     snapshotContentContainer, reactContext, activity, handleGLSurfaceView, promise, executor
             );
 
-            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-                UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
-                ((FabricUIManager)uiManager).addUIBlock(uiBlock);
-            } else {
-                final UIManagerModule uiManager = this.reactContext.getNativeModule(UIManagerModule.class);
-                uiManager.addUIBlock(uiBlock);
-            }
+            UIManager uiManager = UIManagerHelper.getUIManager(context, UIManagerType.FABRIC);
+            ((FabricUIManager) uiManager).addUIBlock(uiBlock);
         } catch (final Throwable ex) {
             Log.e(NAME, "Failed to snapshot view tag " + tag, ex);
             promise.reject(ViewShot.ERROR_UNABLE_TO_SNAPSHOT, "Failed to snapshot view tag " + tag);

--- a/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
+++ b/apps/expo-go/modules/react-native-view-shot/android/src/main/java/fr/greweb/reactnativeviewshot/ViewShot.java
@@ -27,8 +27,6 @@ import android.widget.ScrollView;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.fabric.interop.UIBlockViewResolver;
-import com.facebook.react.uimanager.NativeViewHierarchyManager;
-import com.facebook.react.uimanager.UIBlock;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -58,7 +56,7 @@ import static android.view.View.VISIBLE;
 /**
  * Snapshot utility class allow to screenshot a view.
  */
-public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBlock {
+public class ViewShot implements com.facebook.react.fabric.interop.UIBlock {
     //region Constants
     /**
      * Tag fort Class logs.
@@ -183,18 +181,13 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
     //region Overrides
     @Override
-    public void execute(final NativeViewHierarchyManager nativeViewHierarchyManager) {
-        executeImpl(nativeViewHierarchyManager, null);
-    }
-
-    @Override
     public void execute(@NonNull UIBlockViewResolver uiBlockViewResolver) {
-        executeImpl(null, uiBlockViewResolver);
+        executeImpl(uiBlockViewResolver);
     }
     //endregion
 
     //region Implementation
-    private void executeImpl(final NativeViewHierarchyManager nativeViewHierarchyManager, final UIBlockViewResolver uiBlockViewResolver) {
+    private void executeImpl(final UIBlockViewResolver uiBlockViewResolver) {
         executor.execute(new Runnable () {
             @Override
             public void run() {
@@ -203,10 +196,8 @@ public class ViewShot implements UIBlock, com.facebook.react.fabric.interop.UIBl
 
                     if (tag == -1) {
                         view = currentActivity.getWindow().getDecorView().findViewById(android.R.id.content);
-                    } else if (uiBlockViewResolver != null) {
-                        view = uiBlockViewResolver.resolveView(tag);
                     } else {
-                        view = nativeViewHierarchyManager.resolveView(tag);
+                        view = uiBlockViewResolver.resolveView(tag);
                     }
 
                     if (view == null) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "setup:docs": "./scripts/download-dependencies.sh --docs",
     "setup:native": "./scripts/download-dependencies.sh --native && ./scripts/setup-react-android.sh",
-    "install:react-native-lab": "(([ \"$(ls -A react-native-lab/react-native)\" ] && (yarn --cwd react-native-lab/react-native install --frozen-lockfile || true)) || echo \"Skipping installing Node modules in react-native-lab/react-native (directory empty)\")",
+    "install:react-native-lab": "(([ \"$(ls -A react-native-lab/react-native)\" ] && (yarn --cwd react-native-lab/react-native install --frozen-lockfile || true) && yarn --cwd react-native-lab/react-native/packages/react-native-codegen build) || echo \"Skipping installing Node modules in react-native-lab/react-native (directory empty)\")",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1",
     "build": "turbo build",
     "typecheck": "turbo typecheck",


### PR DESCRIPTION
## Why

Three React Native fork patches. Two had no consumers anywhere in the repo, and one committed roughly 35k lines of generated codegen output into the fork.

## How

`react-native-view-shot` uses `FabricUIManager` directly, since Expo Go is bridgeless-only. Expo Go disables the `buildCodegenCLI` task from its own `build.gradle` instead of the fork committing `lib/` output.

Removed from the fork: the unused `NetworkingModule.client` visibility widening, the `NativeViewHierarchyManager` legacy-class restore, and the tracked codegen output. The submodule bump also picks up an upstream `0.86-stable` merge that touches CI workflows only.

## Test Plan

Expo Go builds, and view-shot captures verified working.
