### PR TITLE
[android][expo-go] Create React surfaces through the public ReactHost API

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -28,7 +28,6 @@ import com.facebook.react.interfaces.fabric.ReactSurface
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import com.facebook.react.modules.core.PermissionAwareActivity
 import com.facebook.react.modules.core.PermissionListener
-import com.facebook.react.runtime.ReactSurfaceImpl
 import de.greenrobot.event.EventBus
 import expo.modules.core.interfaces.Package
 import expo.modules.manifests.core.Manifest
@@ -449,12 +448,11 @@ abstract class ReactNativeActivity :
     devSettings?.setExponentActivityId(activityId)
 
     val appKey = manifest!!.getAppKey()
-    val surface = ReactSurfaceImpl.createWithView(
+    val surface = reactHost.createSurface(
       this,
       appKey ?: KernelConstants.DEFAULT_APPLICATION_KEY,
       initialProps(bundle)
     )
-    surface.attach(reactHost)
     surface.start()
     reactSurface = surface
     reactHost.onHostResume(this, this)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -20,8 +20,6 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.interfaces.fabric.ReactSurface
-import com.facebook.react.runtime.ReactHostImpl
-import com.facebook.react.runtime.ReactSurfaceImpl
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import de.greenrobot.event.EventBus
@@ -329,12 +327,14 @@ class Kernel : KernelInterface() {
 
   val surface: ReactSurface
     get() {
-      val surface = ReactSurfaceImpl.createWithView(
+      val host = checkNotNull(reactHost) {
+        "Kernel React host must be created before requesting its surface"
+      }
+      val surface = host.createSurface(
         context,
         KernelConstants.HOME_MODULE_NAME,
         kernelLaunchOptions
       )
-      surface.attach(reactHost as ReactHostImpl)
       surface.start()
       return surface
     }


### PR DESCRIPTION
## Why

The fork widened `ReactSurfaceImpl`'s companion so Expo Go could construct surfaces directly, but `ReactHost.createSurface` is already public.

## How

Create surfaces through `reactHost.createSurface(...)`.

Removed from the fork: the `ReactSurfaceImpl` companion widening, plus two dead patches — the console polyfill inspect-depth change and the `BaseReactPackage.getNativeModuleIterator` widening.

## Test Plan

Expo Go builds and runs.
