### PR TITLE
[android][expo-go] Register an OkHttpClientFactory instead of patching OkHttpClientProvider

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
@@ -4,13 +4,7 @@ package host.exp.exponent
 import android.util.Log
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.common.JavascriptException
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor
-import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor
-import host.exp.exponent.network.ExponentNetwork
 import host.exp.expoview.Exponent
-import okhttp3.CookieJar
-import okhttp3.OkHttpClient
-import java.util.concurrent.TimeUnit
 
 @DoNotStrip
 object ReactNativeStaticHelpers {
@@ -156,26 +150,4 @@ object ReactNativeStaticHelpers {
     }
   }
 
-  private var exponentNetwork: ExponentNetwork? = null
-  fun setExponentNetwork(exponentNetwork: ExponentNetwork?) {
-    this.exponentNetwork = exponentNetwork
-  }
-
-  @DoNotStrip
-  @JvmStatic fun getOkHttpClient(callingClass: Class<*>): Any {
-    // we build the OkHttp client here so that one cache instance is shared by all concurrent OkHttp instances
-    val version = RNObject.versionForClassname(callingClass.name)
-    val cookieJar =
-      RNObject("com.facebook.react.modules.network.ReactCookieJarContainer").loadVersion(version)
-        .construct().get()
-    val client = OkHttpClient.Builder()
-      .connectTimeout(0, TimeUnit.MILLISECONDS)
-      .readTimeout(0, TimeUnit.MILLISECONDS)
-      .writeTimeout(0, TimeUnit.MILLISECONDS)
-      .cookieJar(cookieJar as CookieJar)
-      .cache(exponentNetwork!!.cache)
-      .addInterceptor(ExpoNetworkInspectOkHttpAppInterceptor())
-      .addNetworkInterceptor(ExpoNetworkInspectOkHttpNetworkInterceptor())
-    return client.build()
-  }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -20,6 +20,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.interfaces.fabric.ReactSurface
+import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import de.greenrobot.event.EventBus
@@ -35,7 +36,6 @@ import host.exp.exponent.ExpoUpdatesAppLoader.AppLoaderStatus
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.LauncherActivity
 import host.exp.exponent.RNObject
-import host.exp.exponent.ReactNativeStaticHelpers
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
 import host.exp.exponent.exceptions.ExceptionUtils
@@ -51,6 +51,7 @@ import host.exp.exponent.headless.InternalHeadlessAppLoader
 import host.exp.exponent.kernel.ExponentErrorMessage.Companion.developerErrorMessage
 import host.exp.exponent.kernel.ExponentUrls.toHttp
 import host.exp.exponent.kernel.KernelConstants.ExperienceOptions
+import host.exp.exponent.network.ExpoGoOkHttpClientFactory
 import host.exp.exponent.network.ExponentNetwork
 import host.exp.exponent.notifications.ExponentNotification
 import host.exp.exponent.notifications.ExponentNotificationManager
@@ -136,7 +137,7 @@ class Kernel : KernelInterface() {
   private var hasError = false
 
   private fun updateKernelRNOkHttp() {
-    ReactNativeStaticHelpers.setExponentNetwork(exponentNetwork)
+    OkHttpClientProvider.setOkHttpClientFactory(ExpoGoOkHttpClientFactory(exponentNetwork))
   }
 
   private val kernelInitialURL: String?

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/ExpoGoOkHttpClientFactory.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/ExpoGoOkHttpClientFactory.kt
@@ -1,0 +1,26 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+package host.exp.exponent.network
+
+import com.facebook.react.modules.network.OkHttpClientFactory
+import com.facebook.react.modules.network.ReactCookieJarContainer
+import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor
+import expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpNetworkInterceptor
+import okhttp3.OkHttpClient
+import java.util.concurrent.TimeUnit
+
+/**
+ * Supplies the OkHttp client React Native uses for networking, so that every client it creates shares
+ * Expo Go's single response cache rather than opening one of its own.
+ */
+class ExpoGoOkHttpClientFactory(private val exponentNetwork: ExponentNetwork) : OkHttpClientFactory {
+  override fun createNewNetworkModuleClient(): OkHttpClient =
+    OkHttpClient.Builder()
+      .connectTimeout(0, TimeUnit.MILLISECONDS)
+      .readTimeout(0, TimeUnit.MILLISECONDS)
+      .writeTimeout(0, TimeUnit.MILLISECONDS)
+      .cookieJar(ReactCookieJarContainer())
+      .cache(exponentNetwork.cache)
+      .addInterceptor(ExpoNetworkInspectOkHttpAppInterceptor())
+      .addNetworkInterceptor(ExpoNetworkInspectOkHttpNetworkInterceptor())
+      .build()
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/network/ExponentNetwork.kt
@@ -50,12 +50,12 @@ class ExponentNetwork constructor(
     return clientBuilder
   }
 
-  val cache: Cache
-    get() {
-      val cacheSize = 50 * 1024 * 1024 // 50 MiB
-      val directory = File(context.cacheDir, CACHE_DIR)
-      return Cache(directory, cacheSize.toLong())
-    }
+  // One instance for the whole process. OkHttp's Cache owns an exclusive DiskLruCache over its
+  // directory, so a second instance on the same path risks corrupting it.
+  val cache: Cache by lazy {
+    val cacheSize = 50 * 1024 * 1024 // 50 MiB
+    Cache(File(context.cacheDir, CACHE_DIR), cacheSize.toLong())
+  }
 
   companion object {
     private val TAG = ExponentNetwork::class.java.simpleName


### PR DESCRIPTION
## Why

The fork patched `OkHttpClientProvider.createClient` to reflect back into Expo Go for its OkHttp client. `setOkHttpClientFactory` is the supported seam for this.

## How

Register `ExpoGoOkHttpClientFactory` through `OkHttpClientProvider.setOkHttpClientFactory`.

This also fixes a latent bug it surfaced: `ExponentNetwork.cache` was a getter that constructed a new OkHttp `Cache` on every access, so its "one shared instance" comment was untrue and two instances could end up sharing one `DiskLruCache` directory.

Removed from the fork: the `OkHttpClientProvider.createClient` reflection patch.

## Test Plan

Expo Go builds, and network requests and caching verified working.
