### PR TITLE
[android][expo-go] Extend DevSupportManagerBase instead of BridgelessDevSupportManager

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
@@ -2,8 +2,9 @@ package host.exp.exponent.modules.perfmonitor
 
 import android.content.Context
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.SurfaceDelegateFactory
-import com.facebook.react.devsupport.BridgelessDevSupportManager
+import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.ReactInstanceDevHelper
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
@@ -24,7 +25,7 @@ internal class ExpoBridgelessDevSupportManager(
   devLoadingViewManager: DevLoadingViewManager?,
   pausedInDebuggerOverlayManager: PausedInDebuggerOverlayManager?
 ) :
-  BridgelessDevSupportManager(
+  DevSupportManagerBase(
     applicationContext,
     reactInstanceManagerHelper,
     packagerPathForJSBundleName,
@@ -40,6 +41,16 @@ internal class ExpoBridgelessDevSupportManager(
 
   private val perfController = PerfMonitorController(applicationContext) {
     devSettings.isFpsDebugEnabled = false
+  }
+
+  // Kept as "Bridgeless" because it keys persisted dev support state.
+  override val uniqueTag: String
+    get() = "Bridgeless"
+
+  override fun handleReloadJS() {
+    UiThreadUtil.assertOnUiThread()
+    hideRedboxDialog()
+    reactInstanceDevHelper.reload("ExpoBridgelessDevSupportManager.handleReloadJS()")
   }
 
   override fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean) {


### PR DESCRIPTION
## Why

The fork made `BridgelessDevSupportManager` non-final so Expo Go could subclass it, but `DevSupportManagerBase` is already public and abstract with a single abstract member.

## How

`ExpoBridgelessDevSupportManager` extends `DevSupportManagerBase` directly, which is what `expo-dev-launcher` already does.

Removed from the fork: that visibility widening, plus the dead dev-menu floating action button plumbing across 5 files, superseded by expo-dev-menu's own implementation.

## Test Plan

Expo Go builds, and the dev menu verified working.
