### PR TITLE
[android][expo-go] Replace dev support fork hooks with public API

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ReactNativeStaticHelpers.kt
@@ -1,104 +1,12 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package host.exp.exponent
 
-import android.util.Log
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.common.JavascriptException
 import host.exp.expoview.Exponent
 
 @DoNotStrip
 object ReactNativeStaticHelpers {
-  private val TAG = ReactNativeStaticHelpers::class.java.simpleName
-
-  @DoNotStrip
-  @JvmStatic fun reloadFromManifest(activityId: Int) {
-    try {
-      Class.forName("host.exp.exponent.kernel.Kernel")
-        .getMethod("reloadVisibleExperience", Int::class.javaPrimitiveType)
-        .invoke(null, activityId)
-    } catch (e: Exception) {
-      Log.e("reloadFromManifest", "Unable to reload visible experience", e)
-    }
-  }
-
-  @DoNotStrip
-  @JvmStatic fun getBundleUrlForActivityId(
-    activityId: Int,
-    host: String?,
-    mainModuleId: String?,
-    bundleTypeId: String?,
-    devMode: Boolean,
-    jsMinify: Boolean
-  ): String? {
-    return try {
-      Class.forName("host.exp.exponent.kernel.Kernel")
-        .getMethod(
-          "getBundleUrlForActivityId",
-          Int::class.javaPrimitiveType,
-          String::class.java,
-          String::class.java,
-          String::class.java,
-          Boolean::class.javaPrimitiveType,
-          Boolean::class.javaPrimitiveType
-        )
-        .invoke(null, activityId, host, mainModuleId, bundleTypeId, devMode, jsMinify) as String
-    } catch (e: Exception) {
-      null
-    }
-  }
-
-  // <= SDK 25
-  @DoNotStrip
-  @JvmStatic fun getBundleUrlForActivityId(
-    activityId: Int,
-    host: String?,
-    jsModulePath: String?,
-    devMode: Boolean,
-    jsMinify: Boolean
-  ): String? {
-    return try {
-      Class.forName("host.exp.exponent.kernel.Kernel")
-        .getMethod(
-          "getBundleUrlForActivityId",
-          Int::class.javaPrimitiveType,
-          String::class.java,
-          String::class.java,
-          Boolean::class.javaPrimitiveType,
-          Boolean::class.javaPrimitiveType
-        )
-        .invoke(null, activityId, host, jsModulePath, devMode, jsMinify) as String
-    } catch (e: Exception) {
-      null
-    }
-  }
-
-  // <= SDK 21
-  @DoNotStrip
-  @JvmStatic fun getBundleUrlForActivityId(
-    activityId: Int,
-    host: String?,
-    jsModulePath: String?,
-    devMode: Boolean,
-    hmr: Boolean,
-    jsMinify: Boolean
-  ): String? {
-    return try {
-      Class.forName("host.exp.exponent.kernel.Kernel")
-        .getMethod(
-          "getBundleUrlForActivityId",
-          Int::class.javaPrimitiveType,
-          String::class.java,
-          String::class.java,
-          Boolean::class.javaPrimitiveType,
-          Boolean::class.javaPrimitiveType,
-          Boolean::class.javaPrimitiveType
-        )
-        .invoke(null, activityId, host, jsModulePath, devMode, hmr, jsMinify) as String
-    } catch (e: Exception) {
-      null
-    }
-  }
-
   @DoNotStrip
   @JvmStatic fun handleReactNativeError(
     errorMessage: String,
@@ -149,5 +57,4 @@ object ReactNativeStaticHelpers {
       null
     }
   }
-
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -20,7 +20,6 @@ import androidx.core.view.contains
 import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext.RCTDeviceEventEmitter
 import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation
-import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer
 import com.facebook.react.devsupport.interfaces.DevSupportManager
@@ -41,11 +40,13 @@ import host.exp.exponent.factories.ReactHostFactory
 import host.exp.exponent.kernel.ExperienceKey
 import host.exp.exponent.kernel.ExponentError
 import host.exp.exponent.kernel.ExponentErrorMessage
+import host.exp.exponent.kernel.ExponentUrls
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.exponent.kernel.KernelConstants.AddedExperienceEventEvent
 import host.exp.exponent.kernel.KernelProvider
 import host.exp.exponent.kernel.services.ErrorRecoveryManager
 import host.exp.exponent.kernel.services.ExpoKernelServiceRegistry
+import host.exp.exponent.modules.perfmonitor.ExpoBridgelessDevSupportManager
 import host.exp.exponent.notifications.ExponentNotification
 import host.exp.exponent.storage.ExponentSharedPreferences
 import host.exp.exponent.utils.BundleJSONConverter
@@ -380,8 +381,7 @@ abstract class ReactNativeActivity :
     )
 
     if (delegate.isDebugModeEnabled) {
-      val debuggerHost = manifest!!.getDebuggerHost()
-      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName!!, nativeHost)
+      Exponent.enableDeveloperSupport(mainModuleName!!, nativeHost)
       DefaultDevLoadingViewImplementation.setDevLoadingEnabled(true)
     } else {
       waitForReactAndFinishLoading()
@@ -393,7 +393,8 @@ abstract class ReactNativeActivity :
       jsMainModulePath = nativeHost.jsMainModuleName,
       jsBundleFilePath = nativeHost.jsBundleFile,
       useDevSupport = nativeHost.useDeveloperSupport,
-      devBundleDownloadListener = devBundleDownloadListener
+      devBundleDownloadListener = devBundleDownloadListener,
+      devServerBundleUrl = ExponentUrls.toHttp(manifest!!.getBundleURL())
     )
     devSupportManager = reactHost.devSupportManager
 
@@ -444,8 +445,7 @@ abstract class ReactNativeActivity :
       return reactHost
     }
 
-    val devSettings = reactHost.devSupportManager?.devSettings as? DevInternalSettings
-    devSettings?.setExponentActivityId(activityId)
+    (reactHost.devSupportManager as? ExpoBridgelessDevSupportManager)?.exponentActivityId = activityId
 
     val appKey = manifest!!.getAppKey()
     val surface = reactHost.createSurface(

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ExpoGoDevSupportFactory.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ExpoGoDevSupportFactory.kt
@@ -14,7 +14,11 @@ import com.facebook.react.packagerconnection.RequestHandler
 import host.exp.exponent.modules.perfmonitor.ExpoBridgelessDevSupportManager
 import versioned.host.exp.exponent.VersionedUtils
 
-class ExpoGoDevSupportFactory(private val devBundleDownloadListener: DevBundleDownloadListener?, private val minNumShakes: Int = 100) : DevSupportManagerFactory {
+class ExpoGoDevSupportFactory(
+  private val devBundleDownloadListener: DevBundleDownloadListener?,
+  private val minNumShakes: Int = 100,
+  private val devServerBundleUrl: String? = null
+) : DevSupportManagerFactory {
   override fun create(
     applicationContext: Context,
     reactInstanceManagerHelper: ReactInstanceDevHelper,
@@ -50,11 +54,13 @@ class ExpoGoDevSupportFactory(private val devBundleDownloadListener: DevBundleDo
       return ReleaseDevSupportManager()
     }
 
+    // Dev support starts disabled so the dev server is in place before the packager connection
+    // opens. Enabling it is what connects, and it would otherwise use the default host.
     return ExpoBridgelessDevSupportManager(
       applicationContext,
       reactInstanceManagerHelper,
       packagerPathForJSBundleName,
-      enableOnCreate,
+      false,
       redBoxHandler,
       this.devBundleDownloadListener,
       this.minNumShakes,
@@ -62,6 +68,9 @@ class ExpoGoDevSupportFactory(private val devBundleDownloadListener: DevBundleDo
       surfaceDelegateFactory,
       devLoadingViewManager,
       pausedInDebuggerOverlayManager
-    )
+    ).apply {
+      devServerBundleUrl?.let { setDevServer(it) }
+      devSupportEnabled = enableOnCreate
+    }
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ReactHostFactory.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/factories/ReactHostFactory.kt
@@ -78,7 +78,8 @@ object ReactHostFactory {
     jsRuntimeFactory: JSRuntimeFactory? = null,
     useDevSupport: Boolean = ReactBuildConfig.DEBUG,
     bindingsInstaller: BindingsInstaller? = null,
-    devBundleDownloadListener: DevBundleDownloadListener? = null
+    devBundleDownloadListener: DevBundleDownloadListener? = null,
+    devServerBundleUrl: String? = null
   ): ReactHostImpl {
     val hostHandlers = ExpoModulesPackage.packageList
       .flatMap { it.createReactNativeHostHandlers(context) }
@@ -109,7 +110,7 @@ object ReactHostFactory {
         Task.UI_THREAD_EXECUTOR,
         true,
         useDevSupport,
-        ExpoGoDevSupportFactory(devBundleDownloadListener)
+        ExpoGoDevSupportFactory(devBundleDownloadListener, devServerBundleUrl = devServerBundleUrl)
       )
 
     hostHandlers.forEach { handler ->

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/headless/InternalHeadlessAppLoader.kt
@@ -3,11 +3,9 @@ package host.exp.exponent.headless
 import android.app.Application
 import android.content.Context
 import android.net.Uri
-import android.util.SparseArray
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.devsupport.DevInternalSettings
 import com.facebook.react.soloader.OpenSourceMergedSoMapping
 import com.facebook.soloader.SoLoader
 import expo.modules.apploader.AppLoaderProvider
@@ -24,6 +22,7 @@ import host.exp.exponent.experience.ExpoGoReactNativeHost
 import host.exp.exponent.factories.ReactHostFactory
 import host.exp.exponent.kernel.ExponentUrls
 import host.exp.exponent.kernel.KernelConstants
+import host.exp.exponent.modules.perfmonitor.ExpoBridgelessDevSupportManager
 import host.exp.exponent.storage.ExponentDB
 import host.exp.exponent.storage.ExponentDBObject
 import host.exp.exponent.taskManager.AppLoaderInterface
@@ -84,9 +83,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
         override fun onManifestCompleted(manifest: Manifest) {
           Exponent.instance.runOnUiThread {
             try {
-              val bundleUrl = ExponentUrls.toHttp(manifest.getBundleURL())
-              activityIdToBundleUrl.put(activityId, bundleUrl)
-              setManifest(manifestUrl!!, manifest, bundleUrl)
+              setManifest(manifestUrl!!, manifest, ExponentUrls.toHttp(manifest.getBundleURL()))
             } catch (e: JSONException) {
               this@InternalHeadlessAppLoader.callback!!.onComplete(false, Exception(e.message))
             }
@@ -240,9 +237,7 @@ class InternalHeadlessAppLoader(private val context: Context) :
     )
 
     if (delegate.isDebugModeEnabled) {
-      val debuggerHost = manifest!!.getDebuggerHost()
-      val mainModuleName = manifest!!.getMainModuleName()
-      Exponent.enableDeveloperSupport(debuggerHost, mainModuleName, host)
+      Exponent.enableDeveloperSupport(manifest!!.getMainModuleName(), host)
     }
 
     val reactHost = ReactHostFactory.getDefaultReactHost(
@@ -250,12 +245,11 @@ class InternalHeadlessAppLoader(private val context: Context) :
       packageList = host.packages,
       jsMainModulePath = host.jsMainModuleName,
       jsBundleFilePath = host.jsBundleFile,
-      useDevSupport = host.useDeveloperSupport
+      useDevSupport = host.useDeveloperSupport,
+      devServerBundleUrl = ExponentUrls.toHttp(manifest!!.getBundleURL())
     )
 
-    val devSupportManager = reactHost.devSupportManager
-    val devSettings = devSupportManager?.devSettings as? DevInternalSettings
-    devSettings?.setExponentActivityId(activityId)
+    (reactHost.devSupportManager as? ExpoBridgelessDevSupportManager)?.exponentActivityId = activityId
 
     // keep a reference in app record, so it can be invalidated through AppRecord.invalidate()
     appRecord!!.setReactHost(reactHost)
@@ -302,15 +296,5 @@ class InternalHeadlessAppLoader(private val context: Context) :
 
   companion object {
     private const val READY_FOR_BUNDLE = "headlessAppReadyForBundle"
-
-    private val activityIdToBundleUrl = SparseArray<String>()
-
-    fun hasBundleUrlForActivityId(activityId: Int): Boolean {
-      return activityId < -1 && activityIdToBundleUrl[activityId] != null
-    }
-
-    fun getBundleUrlForActivityId(activityId: Int): String? {
-      return activityIdToBundleUrl[activityId]
-    }
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/Kernel.kt
@@ -47,7 +47,6 @@ import host.exp.exponent.experience.HomeActivity
 import host.exp.exponent.experience.KernelData
 import host.exp.exponent.experience.KernelReactNativeHost
 import host.exp.exponent.factories.ReactHostFactory
-import host.exp.exponent.headless.InternalHeadlessAppLoader
 import host.exp.exponent.kernel.ExponentErrorMessage.Companion.developerErrorMessage
 import host.exp.exponent.kernel.ExponentUrls.toHttp
 import host.exp.exponent.kernel.KernelConstants.ExperienceOptions
@@ -241,11 +240,7 @@ class Kernel : KernelInterface() {
           if (!KernelConfig.FORCE_NO_KERNEL_DEBUG_MODE &&
             manifest.isDevelopmentMode()
           ) {
-            Exponent.enableDeveloperSupport(
-              manifest.getDebuggerHost(),
-              manifest.getMainModuleName(),
-              nativeHost
-            )
+            Exponent.enableDeveloperSupport(manifest.getMainModuleName(), nativeHost)
           }
 
           reactHost = ReactHostFactory.getDefaultReactHost(
@@ -253,7 +248,8 @@ class Kernel : KernelInterface() {
             packageList = nativeHost.packages,
             jsMainModulePath = nativeHost.jsMainModuleName,
             jsBundleFilePath = nativeHost.jsBundleFile,
-            useDevSupport = nativeHost.useDeveloperSupport
+            useDevSupport = nativeHost.useDeveloperSupport,
+            devServerBundleUrl = toHttp(manifest.getBundleURL())
           )
 
           reactNativeHost = nativeHost
@@ -946,50 +942,8 @@ class Kernel : KernelInterface() {
       }
     }
 
-    // Called from DevServerHelper via ReactNativeStaticHelpers
-    @JvmStatic
-    @DoNotStrip
-    fun getManifestUrlForActivityId(activityId: Int): String? {
+    private fun getManifestUrlForActivityId(activityId: Int): String? {
       return manifestUrlToExperienceActivityTask.values.find { it.activityId == activityId }?.manifestUrl
-    }
-
-    // Called from DevServerHelper via ReactNativeStaticHelpers
-    @JvmStatic
-    @DoNotStrip
-    fun getBundleUrlForActivityId(
-      activityId: Int,
-      host: String,
-      mainModuleId: String?,
-      bundleTypeId: String?,
-      devMode: Boolean,
-      jsMinify: Boolean
-    ): String? {
-      // NOTE: This current implementation doesn't look at the bundleTypeId (see RN's private
-      // BundleType enum for the possible values) but may need to
-      if (activityId == -1) {
-        // This is the kernel
-        return instance.bundleUrl
-      }
-      if (InternalHeadlessAppLoader.hasBundleUrlForActivityId(activityId)) {
-        return InternalHeadlessAppLoader.getBundleUrlForActivityId(activityId)
-      }
-      return manifestUrlToExperienceActivityTask.values.find { it.activityId == activityId }?.bundleUrl
-    }
-
-    // <= SDK 25
-    @DoNotStrip
-    fun getBundleUrlForActivityId(
-      activityId: Int,
-      host: String,
-      jsModulePath: String?,
-      devMode: Boolean,
-      jsMinify: Boolean
-    ): String? {
-      if (activityId == -1) {
-        // This is the kernel
-        return instance.bundleUrl
-      }
-      return manifestUrlToExperienceActivityTask.values.find { it.activityId == activityId }?.bundleUrl
     }
 
     /*

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
@@ -1,6 +1,8 @@
 package host.exp.exponent.modules.perfmonitor
 
 import android.content.Context
+import android.net.Uri
+import android.util.Log
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.SurfaceDelegateFactory
@@ -11,6 +13,7 @@ import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager
 import com.facebook.react.devsupport.interfaces.RedBoxHandler
 import com.facebook.react.packagerconnection.RequestHandler
+import host.exp.exponent.kernel.Kernel
 
 internal class ExpoBridgelessDevSupportManager(
   applicationContext: Context,
@@ -43,6 +46,32 @@ internal class ExpoBridgelessDevSupportManager(
     devSettings.isFpsDebugEnabled = false
   }
 
+  // Expo Go runs one Activity per open project. Reload and bundle URL lookups are scoped to it.
+  var exponentActivityId: Int = -1
+
+  /**
+   * Points React Native's dev server plumbing at this project's packager. React Native builds the
+   * bundle, source map, HMR and inspector URLs from the host and bundle name. The manifest's other
+   * query params carry the project's Metro configuration, such as the router root, and are
+   * forwarded as-is because the dev server otherwise falls back to its own defaults.
+   */
+  fun setDevServer(bundleUrl: String) {
+    val uri = Uri.parse(bundleUrl)
+    val host = uri.host ?: return
+    val port = if (uri.port != -1) uri.port else if (uri.scheme == "https") 443 else 80
+
+    val settings = devSettings.packagerConnectionSettings
+    settings.debugServerHost = "$host:$port"
+    jsAppBundleName = uri.path?.removePrefix("/")?.removeSuffix(".bundle")?.ifEmpty { null } ?: "index"
+
+    for (name in uri.queryParameterNames) {
+      if (name in REACT_NATIVE_QUERY_PARAMS) {
+        continue
+      }
+      uri.getQueryParameter(name)?.let { settings.setAdditionalOptionForPackager(name, it) }
+    }
+  }
+
   // Kept as "Bridgeless" because it keys persisted dev support state.
   override val uniqueTag: String
     get() = "Bridgeless"
@@ -50,7 +79,18 @@ internal class ExpoBridgelessDevSupportManager(
   override fun handleReloadJS() {
     UiThreadUtil.assertOnUiThread()
     hideRedboxDialog()
-    reactInstanceDevHelper.reload("ExpoBridgelessDevSupportManager.handleReloadJS()")
+
+    try {
+      // Reloading in Expo Go destroys the current Activity and creates a new one with a fresh React
+      // instance, so drop the packager connection first. Otherwise a repeated reload, such as holding
+      // "r" in the CLI, can re-enter this while the old instance is still tearing down.
+      devServerHelper.closePackagerConnection()
+
+      Kernel.reloadVisibleExperience(exponentActivityId)
+    } catch (e: Exception) {
+      Log.e(TAG, "Could not reload from the manifest, falling back to a JS reload", e)
+      reactInstanceDevHelper.reload("ExpoBridgelessDevSupportManager.handleReloadJS() fallback")
+    }
   }
 
   override fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean) {
@@ -72,5 +112,13 @@ internal class ExpoBridgelessDevSupportManager(
   override fun onReactInstanceDestroyed(reactContext: ReactContext) {
     super.onReactInstanceDestroyed(reactContext)
     perfController.onContextDestroyed(reactContext)
+  }
+
+  private companion object {
+    private val TAG = ExpoBridgelessDevSupportManager::class.java.simpleName
+
+    // React Native puts these on the bundle URL itself, in DevServerHelper.createBundleURL.
+    private val REACT_NATIVE_QUERY_PARAMS =
+      setOf("platform", "dev", "lazy", "minify", "app", "modulesOnly", "runModule")
   }
 }

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/expoview/Exponent.kt
@@ -5,7 +5,6 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Handler
 import android.os.Looper
 import android.os.StrictMode
@@ -15,7 +14,6 @@ import com.facebook.common.internal.ByteStreams
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.imagepipeline.backends.okhttp3.OkHttpImagePipelineConfigFactory
 import com.facebook.imagepipeline.producers.HttpUrlConnectionNetworkFetcher
-import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 import com.raizlabs.android.dbflow.config.DatabaseConfig
 import com.raizlabs.android.dbflow.config.FlowConfig
 import com.raizlabs.android.dbflow.config.FlowManager
@@ -342,55 +340,18 @@ class Exponent private constructor(val context: Context, val application: Applic
       return URLEncoder.encode("experience-$manifestId", "UTF-8")
     }
 
-    private fun getPort(urlArg: String): Int {
-      var url = urlArg
-      if (!url.contains("://")) {
-        url = "http://$url"
-      }
-      val uri = Uri.parse(url)
-      val port = uri.port
-      return if (port == -1) {
-        80
-      } else {
-        port
-      }
-    }
-
-    private fun getHostname(urlArg: String): String? {
-      var url = urlArg
-      if (!url.contains("://")) {
-        url = "http://$url"
-      }
-      val uri = Uri.parse(url)
-      return uri.host
-    }
-
+    // The dev server itself is set on the DevSupportManager once the React host exists, see
+    // ExpoBridgelessDevSupportManager.setDevServer.
     @JvmStatic fun enableDeveloperSupport(
-      debuggerHost: String,
       mainModuleName: String,
       host: ExpoNativeHost
     ) {
-      if (debuggerHost.isEmpty() || mainModuleName.isEmpty()) {
+      if (mainModuleName.isEmpty()) {
         return
       }
 
-      try {
-        val debuggerHostHostname = getHostname(debuggerHost)
-        val debuggerHostPort = getPort(debuggerHost)
-
-        AndroidInfoHelpers.DEVICE_LOCALHOST = debuggerHostHostname ?: ""
-        AndroidInfoHelpers.GENYMOTION_LOCALHOST = debuggerHostHostname ?: ""
-        AndroidInfoHelpers.EMULATOR_LOCALHOST = debuggerHostHostname ?: ""
-        AndroidInfoHelpers.setDevServerPort(debuggerHostPort)
-        AndroidInfoHelpers.setInspectorProxyPort(debuggerHostPort)
-
-        host.devSupportEnabled = true
-        host.mainModuleName = mainModuleName
-      } catch (e: IllegalAccessException) {
-        e.printStackTrace()
-      } catch (e: NoSuchFieldException) {
-        e.printStackTrace()
-      }
+      host.devSupportEnabled = true
+      host.mainModuleName = mainModuleName
     }
   }
 

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import com.facebook.common.logging.FLog
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.packagerconnection.NotificationOnlyHandler
 import com.facebook.react.packagerconnection.RequestHandler
@@ -28,21 +29,23 @@ object VersionedUtils {
     }
   }
 
-  fun reloadExpoApp() = synchronized(this) {
-    val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
-      FLog.e(
-        ReactConstants.TAG,
-        "Unable to reload the app because the current activity could not be found."
-      )
-    }
-    val devSupportManager = currentActivity.devSupportManager ?: return run {
-      FLog.e(
-        ReactConstants.TAG,
-        "Unable to get the DevSupportManager from current activity."
-      )
-    }
+  // The packager sends its reload command on a WebSocket thread and handleReloadJS has to run on the
+  // UI thread. Hopping threads here also serialises repeated reloads, such as holding "r" in the CLI.
+  fun reloadExpoApp() {
+    UiThreadUtil.runOnUiThread {
+      val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity
+        ?: return@runOnUiThread FLog.e(
+          ReactConstants.TAG,
+          "Unable to reload the app because the current activity could not be found."
+        )
+      val devSupportManager = currentActivity.devSupportManager
+        ?: return@runOnUiThread FLog.e(
+          ReactConstants.TAG,
+          "Unable to get the DevSupportManager from current activity."
+        )
 
-    devSupportManager.reloadExpoApp()
+      devSupportManager.handleReloadJS()
+    }
   }
 
   private fun toggleElementInspector() {


### PR DESCRIPTION
## Why

Three hooks the fork added to React Native's dev support: an activity id on `DeveloperSettings`, a `reloadExpoApp` entry point, and a `DevServerHelper` that reflected back into Expo Go to build the bundle URL.

## How

All three move onto Expo Go's own dev support manager. It overrides `handleReloadJS` and calls `Kernel.reloadVisibleExperience` directly, and it sets `debugServerHost` and `jsAppBundleName`, forwarding the manifest's remaining query params so the bundler still receives the project's Metro configuration.

That configuration happens in `ExpoGoDevSupportFactory` before dev support is enabled, because enabling it is what opens the packager connection.

Removed from the fork: the `reloadExpoApp` hook, the `DevServerHelper` bundle URL reflection, the activity id on `DeveloperSettings`, and the `AndroidInfoHelpers` global host and port overrides.

## Test Plan

Expo Go builds. Reload from the dev menu and packager commands (`r` in the CLI) verified working.
