### PR TITLE
[android][expo-go] Enable the debugger with React Native's own CMake flag

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -98,7 +98,15 @@ android {
       proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
       consumerProguardFiles 'proguard-rules.pro'
       if (!System.getenv("ANDROID_UNSIGNED")) {
-        signingConfig signingConfigs.release
+        // EAS and CI supply the release keystore. Local release builds fall back to the debug key so
+        // the release variant can be built and installed for testing.
+        def releaseKeystore = file(System.getenv("ANDROID_KEYSTORE_PATH") ?: "release-key.jks")
+        if (releaseKeystore.exists()) {
+          signingConfig signingConfigs.release
+        } else {
+          project.logger.lifecycle("Expo Go: no release keystore at ${releaseKeystore}, signing the release build with the debug key.")
+          signingConfig signingConfigs.debug
+        }
       }
       def shouldUploadCrashlytics = System.getenv("EAS_BUILD") != null
       firebaseCrashlytics {

--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -91,6 +91,17 @@ project(":packages:react-native:ReactAndroid").afterEvaluate { reactAndroid ->
   reactAndroid.tasks.named("buildCodegenCLI").configure { it.enabled = false }
 }
 
+// Expo Go ships a release build that keeps the JS debugger. React Native gates those native defines
+// behind REACT_NATIVE_DEBUG_OPTIMIZED, and its CMake guard only passes automatically when
+// CMAKE_BUILD_TYPE is Debug. Release maps to RelWithDebInfo, which does not match, so set the flag
+// for every variant. Debug builds already satisfy the guard, so this only changes release.
+def reactAndroidProject = project(":packages:react-native:ReactAndroid")
+reactAndroidProject.plugins.withId("com.android.library") {
+  reactAndroidProject.android.defaultConfig.externalNativeBuild.cmake.arguments.add(
+    "-DREACT_NATIVE_DEBUG_OPTIMIZED=True"
+  )
+}
+
 // This var needs to be defined outside any "remove_from_here" comment blocks
 // because the "*/" in there could affect the resulted code by closing the comment to early.
 def ktlintTarget = '**/*.kt'


### PR DESCRIPTION
## Why

Expo Go ships a release build that keeps the JS debugger. React Native gates those native defines behind `REACT_NATIVE_DEBUG_OPTIMIZED`, and its CMake guard only passes automatically when `CMAKE_BUILD_TYPE` is `Debug`. The release variant maps to `RelWithDebInfo`, which does not match.

## How

Set the flag for every ReactAndroid variant when Expo Go configures the project. Debug builds already satisfy the guard, so only release changes.

Removed from the fork: four hand-patched CMakeLists. Those covered 4 of the 12 places React Native honours the flag, so a release build now gets the debugger everywhere upstream intends rather than in a subset.

## Test Plan

Release build, with React Native DevTools attaching. The CMake cache confirms the flag is set, and the debugger defines went from 4 / 29 / 0 occurrences to 21 / 74 / 37.
