### PR TITLE
[android][expo-go] Keep the Hermes debugger in release without patching Hermes

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -102,6 +102,15 @@ reactAndroidProject.plugins.withId("com.android.library") {
   )
 }
 
+// Hermes itself also has to keep its debugger in release, which React Native turns off explicitly
+// rather than behind a guard. This runs after the hermes-engine build script so the value it sets can
+// be swapped, and before AGP reads the arguments to create variants.
+project(":packages:react-native:ReactAndroid:hermes-engine").afterEvaluate { hermesEngine ->
+  def releaseCmake = hermesEngine.android.buildTypes.release.externalNativeBuild.cmake
+  releaseCmake.arguments.removeAll { it == "-DHERMES_ENABLE_DEBUGGER=False" }
+  releaseCmake.arguments.add("-DHERMES_ENABLE_DEBUGGER=True")
+}
+
 // This var needs to be defined outside any "remove_from_here" comment blocks
 // because the "*/" in there could affect the resulted code by closing the comment to early.
 def ktlintTarget = '**/*.kt'


### PR DESCRIPTION
## Why

The Hermes engine build turns its debugger off for release explicitly rather than behind a guard, so the flag cannot simply be set from outside.

## How

Swap `HERMES_ENABLE_DEBUGGER` to `True` on the hermes-engine release build type when Expo Go configures the project. That runs after the hermes-engine build script, so the value it sets can be replaced, and before AGP reads the arguments to create variants.

Removed from the fork: the `hermes-engine/build.gradle.kts` patch. This was the last Android build patch in the fork.

## Test Plan

Release build, with React Native DevTools attaching. Confirmed the resolved arguments are `[-DCMAKE_BUILD_TYPE=MinSizeRel, -DHERMES_ENABLE_DEBUGGER=True]`.
