### PR TITLE
[ios][expo-go] Set the Hermes source build flag from the Podfile

### DIFF
--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -5,6 +5,9 @@ require File.join(File.dirname(`node --print "require.resolve('expo/package.json
 ENV['RCT_NEW_ARCH_ENABLED'] = '1'
 ENV['RCT_HERMES_V1_ENABLED'] = '1'
 
+# Expo Go needs a customized Hermes, so build it from source rather than using a released artifact.
+ENV['RCT_BUILD_HERMES_FROM_SOURCE'] = 'true'
+
 # Build Expo Go from Expo's fork of React Native
 ENV['RCT_USE_RN_DEP']  = '0'
 ENV['RCT_USE_PREBUILT_RNCORE'] = '0'

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -165,6 +165,10 @@ PODS:
   - ExpoImageManipulator (56.0.15):
     - ExpoModulesCore
     - SDWebImageWebPCoder
+  - ExpoImageManipulator/Tests (56.0.15):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+    - SDWebImageWebPCoder
   - ExpoImagePicker (56.0.14):
     - ExpoModulesCore
   - ExpoImagePicker/Tests (56.0.14):
@@ -4185,6 +4189,7 @@ DEPENDENCIES:
   - ExpoImage (from `../../../packages/expo-image/ios`)
   - ExpoImage/Tests (from `../../../packages/expo-image/ios`)
   - ExpoImageManipulator (from `../../../packages/expo-image-manipulator/ios`)
+  - ExpoImageManipulator/Tests (from `../../../packages/expo-image-manipulator/ios`)
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
   - ExpoImagePicker/Tests (from `../../../packages/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
@@ -4769,7 +4774,7 @@ SPEC CHECKSUMS:
   ExpoGlassEffect: 7d4233dc0727ee2b28dd757eda70e1b6abf662fd
   ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
-  ExpoImageManipulator: 441ca8a28fe700c5948863772578bab2ffd79e77
+  ExpoImageManipulator: 00e382cd32da78b9162cff710953f6e35bd6460c
   ExpoImagePicker: 25027f16965fca672abf93c2a79d22e71527b53f
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
@@ -4947,6 +4952,6 @@ SPEC CHECKSUMS:
   Yoga: 18b7c3b4ad4df70f7c1f90871213fd001e6c3528
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: ee248c28ee15fdbe22127df8a6fb1be3dfa3516f
+PODFILE CHECKSUM: 3a791729857914d683ccc497dc6a526dc0c3263a
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
## Why

Expo Go needs a customized Hermes, so it has to be built from source rather than pulled from a released artifact. React Native already reads `RCT_BUILD_HERMES_FROM_SOURCE` for this and documents it in `hermes-utils.rb`.

## How

Set it alongside the other `RCT_` variables in Expo Go's Podfile.

Removed from the fork: the `hermes-engine.podspec` patch that hardcoded the same variable. Setting it from the Podfile also applies earlier, before CocoaPods evaluates any podspec.

## Test Plan

iOS builds and runs. `Podfile.lock` shows a `:tag:` checkout for hermes-engine with no prebuilt tarball, and `Pods/hermes-engine` contains the Hermes source tree including `build_host_hermesc`.
