### PR TITLE
[expo-router] add processScreens option to standard-navigation integration

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add `pageHeaders` config plugin option for declaring per-path response headers ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Upgrade react-native-screens to 4.26.0 ([#47770](https://github.com/expo/expo/pull/47770) by [@Ubax](https://github.com/Ubax))
 - Improve standard-navigation types for `createProps`. ([#47825](https://github.com/expo/expo/pull/47825) by [@Ubax](https://github.com/Ubax))
+- Add a `processScreens` option to the `standard-navigation` integration. ([#48290](https://github.com/expo/expo/pull/48290) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -382,6 +382,178 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
   });
 });
 
+describe('processScreens', () => {
+  const optionsByName = () =>
+    Object.fromEntries(
+      lastArgs().state.routes.map(
+        (route) => [route.name, lastArgs().descriptors[route.key]!.options] as const
+      )
+    );
+
+  it('transforms declared screen options before they are rendered', () => {
+    const Prefixed = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) =>
+        screens.map((screen) => ({
+          ...screen,
+          options: { ...screen.options, title: `processed-${screen.name}` },
+        })),
+    });
+
+    renderRouter({
+      _layout: () => (
+        <Prefixed>
+          <Prefixed.Screen name="index" options={{ title: 'Home' }} />
+          <Prefixed.Screen name="second" />
+        </Prefixed>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
+
+    expect(optionsByName()).toMatchObject({
+      index: { title: 'processed-index' },
+      second: { title: 'processed-second' },
+    });
+  });
+
+  it('receives only the declared screens', () => {
+    const names: string[] = [];
+    const Recording = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) => {
+        names.length = 0;
+        names.push(...screens.map((screen) => screen.name));
+        return screens;
+      },
+    });
+
+    renderRouter({
+      _layout: () => (
+        <Recording>
+          <Recording.Screen name="index" />
+        </Recording>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
+
+    expect(names).toEqual(['index']);
+    // The undeclared route is still registered, it just never reaches the processor.
+    expect(lastArgs().state.routes.map((route) => route.name)).toContain('second');
+  });
+
+  it('rejects dropped screens', () => {
+    const Filtered = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) => screens.filter((screen) => screen.name !== 'second'),
+    });
+
+    expect(() =>
+      renderRouter({
+        _layout: () => (
+          <Filtered>
+            <Filtered.Screen name="index" options={{ title: 'Home' }} />
+            <Filtered.Screen name="second" options={{ title: 'Declared title' }} />
+          </Filtered>
+        ),
+        index: () => <View testID="index" />,
+        second: () => <View testID="second" />,
+      })
+    ).toThrow('`processScreens` must not add, remove, rename, or duplicate screens');
+  });
+
+  it('rejects renamed screens', () => {
+    const Renamed = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) =>
+        screens.map((screen) => ({ ...screen, name: `renamed-${screen.name}` })),
+    });
+
+    expect(() =>
+      renderRouter({
+        _layout: () => (
+          <Renamed>
+            <Renamed.Screen name="index" />
+          </Renamed>
+        ),
+        index: () => <View testID="index" />,
+      })
+    ).toThrow('`processScreens` must not add, remove, rename, or duplicate screens');
+  });
+
+  it('rejects screens renamed in place', () => {
+    const Renamed = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) => {
+        screens[0] = { ...screens[0]!, name: 'renamed-index' };
+        return screens;
+      },
+    });
+
+    expect(() =>
+      renderRouter({
+        _layout: () => (
+          <Renamed>
+            <Renamed.Screen name="index" />
+          </Renamed>
+        ),
+        index: () => <View testID="index" />,
+      })
+    ).toThrow('`processScreens` must not add, remove, rename, or duplicate screens');
+  });
+
+  it('rejects duplicate screens returned by the processor', () => {
+    const Duplicated = unstable_createStandardRouterNavigator<
+      TestOptions,
+      TabNavigationState<ParamListBase>,
+      TestEventMap,
+      object,
+      TabRouterOptions
+    >(NavigatorContent, TabRouter, {
+      processScreens: (screens) => [screens[0]!, { ...screens[0]! }],
+    });
+
+    expect(() =>
+      renderRouter({
+        _layout: () => (
+          <Duplicated>
+            <Duplicated.Screen name="index" />
+            <Duplicated.Screen name="second" />
+          </Duplicated>
+        ),
+        index: () => <View testID="index" />,
+        second: () => <View testID="second" />,
+      })
+    ).toThrow('`processScreens` must not add, remove, rename, or duplicate screens');
+  });
+});
+
 describe('preloaded routes projected through the integration (StackRouter)', () => {
   const StandardStack = unstable_createStandardRouterNavigator<
     TestOptions,

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -209,9 +209,46 @@ unstable_createStandardRouterNavigator(OptionalCreateContent, TabRouter, {
 createSplitNav(SplitContent, TabRouter);
 
 // @ts-expect-error `createProps` is required when `CreateProps` is non-empty.
-createSplitNav(SplitContent, TabRouter, { useOnlyUserDefinedScreens: true });
+createSplitNav(SplitContent, TabRouter, { processScreens: (screens) => screens });
 
 createPublicNav(PublicContent, TabRouter);
+
+// ---------------------------------------------------------------------------
+// processScreens is always optional and composes with createProps
+// ---------------------------------------------------------------------------
+
+type ProcessScreens = NonNullable<
+  IntegrateWithRouterOptions<TabState, object, Opts, EventMap>['processScreens']
+>;
+export type _ProcessedScreenNameIsRequired = Expect<
+  Equal<Parameters<ProcessScreens>[0][number]['name'], string>
+>;
+
+createPublicNav(PublicContent, TabRouter, { processScreens: (screens) => screens });
+
+createSplitNav(SplitContent, TabRouter, {
+  createProps: () => ({ routeNames: [], preload: () => {} }),
+  processScreens: (screens) => screens.map((screen) => ({ ...screen, redirect: false })),
+});
+
+// The screens carry the navigator's own options, so reading an undeclared one is rejected.
+createPublicNav(PublicContent, TabRouter, {
+  processScreens: (screens) =>
+    screens.map((screen) => {
+      if (typeof screen.options !== 'function') {
+        const title: string | undefined = screen.options?.title;
+        // @ts-expect-error `badge` is not an option of this navigator.
+        screen.options?.badge;
+        return { ...screen, options: { title } };
+      }
+      return screen;
+    }),
+});
+
+createPublicNav(PublicContent, TabRouter, {
+  // @ts-expect-error `processScreens` must preserve every screen's name.
+  processScreens: (screens) => screens.map(({ name, ...rest }) => rest),
+});
 
 // ---------------------------------------------------------------------------
 // createProps cannot declare props the content does not declare
@@ -226,10 +263,11 @@ unstable_createStandardRouterNavigator(PublicContent, TabRouter, {
 // @ts-expect-error Five explicit generics declare no injected props, so `createProps` is forbidden.
 createPublicNav(PublicContent, TabRouter, { createProps: () => ({ injected: true }) });
 
-const broadlyAnnotatedFactoryOptions: IntegrateWithRouterOptions = {
-  // @ts-expect-error Bare options do not declare injected props, so `createProps` is forbidden.
-  createProps: () => ({ injected: true }),
-};
+const broadlyAnnotatedFactoryOptions: IntegrateWithRouterOptions<TabState, object, Opts, EventMap> =
+  {
+    // @ts-expect-error Bare options do not declare injected props, so `createProps` is forbidden.
+    createProps: () => ({ injected: true }),
+  };
 unstable_createStandardRouterNavigator(PublicContent, TabRouter, broadlyAnnotatedFactoryOptions);
 
 type CarrierCreateProps = { x: string };

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -37,11 +37,14 @@ const STANDARD_NAVIGATOR_TYPE = 'standard';
 
 // A rest tuple is the only way to make the whole argument optional for empty `CreateProps` and
 // required otherwise; a normal optional parameter would accept `undefined` in both cases.
-type IntegrateWithRouterOptionsTuple<State extends NavigationState, CreateProps extends object> = [
-  keyof CreateProps,
-] extends [never]
-  ? [options?: IntegrateWithRouterOptions<State, CreateProps>]
-  : [options: IntegrateWithRouterOptions<State, CreateProps>];
+type IntegrateWithRouterOptionsTuple<
+  State extends NavigationState,
+  CreateProps extends object,
+  NavigatorOptions extends object,
+  EventMap extends StandardNavigatorEventMapBase,
+> = [keyof CreateProps] extends [never]
+  ? [options?: IntegrateWithRouterOptions<State, CreateProps, NavigatorOptions, EventMap>]
+  : [options: IntegrateWithRouterOptions<State, CreateProps, NavigatorOptions, EventMap>];
 
 type StandardRouterNavigatorComponent<
   NavigatorOptions extends object,
@@ -93,7 +96,12 @@ export function unstable_createStandardRouterNavigator<
     NavigatorContentProps<NavigatorOptions, EventMap, NavigatorProps, CreateProps>
   >,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  ...options: IntegrateWithRouterOptionsTuple<State, NoInfer<CreateProps>>
+  ...options: IntegrateWithRouterOptionsTuple<
+    State,
+    NoInfer<CreateProps>,
+    NavigatorOptions,
+    EventMap
+  >
 ): StandardRouterNavigatorComponent<
   NavigatorOptions,
   State,
@@ -146,7 +154,12 @@ export function unstable_integrateWithRouter<
 >(
   navigator: StandardNavigator<NavigatorOptions, EventMap, NavigatorProps & CreateProps>,
   router: RouterFactory<State, NavigationAction, RouterOptions>,
-  ...[options]: IntegrateWithRouterOptionsTuple<State, NoInfer<CreateProps>>
+  ...[options]: IntegrateWithRouterOptionsTuple<
+    State,
+    NoInfer<CreateProps>,
+    NavigatorOptions,
+    EventMap
+  >
 ) {
   assertStandardNavigator(navigator);
   const { NavigatorContent } = navigator;
@@ -209,7 +222,8 @@ export function unstable_integrateWithRouter<
   }
 
   return withLayoutContext<NavigatorOptions, typeof StandardRouterNavigator, State, EventMap>(
-    StandardRouterNavigator
+    StandardRouterNavigator,
+    options?.processScreens
   );
 }
 

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   DefaultNavigatorOptions,
   DefaultRouterOptions,
+  EventMapBase,
   NavigationAction,
   NavigationHelpers,
   NavigationState,
@@ -14,6 +15,7 @@ import type {
   RouteSource,
 } from '../react-navigation/native';
 import type { GoBackAction, NavigateAction } from '../react-navigation/routers/CommonActions';
+import type { ScreenProps } from '../useScreens';
 
 export type StandardNavigatorEventMapBase = Record<
   string,
@@ -83,7 +85,22 @@ type CreatePropsOption<State extends NavigationState, CreateProps extends object
 export type IntegrateWithRouterOptions<
   State extends NavigationState = NavigationState,
   CreateProps extends object = object,
-> = CreatePropsOption<State, CreateProps>;
+  NavigatorOptions extends object = Record<string, any>,
+  EventMap extends EventMapBase = EventMapBase,
+> = CreatePropsOption<State, CreateProps> & {
+  /**
+   * Transforms the screens declared as children of the navigator before they are rendered.
+   *
+   * @example
+   * ```tsx
+   * processScreens: (screens) =>
+   *   screens.map((screen) => ({ ...screen, options: { ...screen.options, title: screen.name } })),
+   * ```
+   */
+  processScreens?: (
+    screens: (ScreenProps<NavigatorOptions, State, EventMap> & { name: string })[]
+  ) => (ScreenProps<NavigatorOptions, State, EventMap> & { name: string })[];
+};
 
 /**
  * A standard-navigation descriptor extended with Expo Router route information.


### PR DESCRIPTION
# Why

Add `processScreens` option to standard navigation API to map expo-router descriptors to the standard-navigation ones.

# How

1. Expose `processScreens` from `unstable_integrateWithRouter` and `unstable_createStandardRouterNavigator`
2. Pass the function to `withLayoutContext`
3. Improve typings for `useFilterScreenChildren` and `processScreens` in `withLayoutContext`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
