### PR TITLE
[expo-router] prepare bottom tabs views for standard navigation

### DIFF
--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
@@ -1,5 +1,6 @@
 import { afterEach, expect, jest, test } from '@jest/globals';
-import { act, fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render, userEvent } from '@testing-library/react-native';
+import * as React from 'react';
 import {
   type EmitterSubscription,
   Keyboard,
@@ -12,6 +13,7 @@ import {
 import { NavigationContainer } from '../../../fork/NavigationContainer';
 import { Text } from '../../elements';
 import { createNavigationContainerRef } from '../../native';
+import { createStackNavigator } from '../../stack';
 import { type BottomTabScreenProps, createBottomTabNavigator } from '../index';
 
 type BottomTabParamList = {
@@ -133,6 +135,81 @@ test('tab bar cannot be tapped when hidden', async () => {
   expect(queryByText('Screen B')).not.toBeNull();
 
   spy.mockRestore();
+});
+
+test('keeps the params and does not remount the tab on re-press with getId', async () => {
+  type ParamList = {
+    A: undefined;
+    B: { user: string } | undefined;
+  };
+
+  const Tab = createBottomTabNavigator<ParamList>();
+  const navigation = createNavigationContainerRef<ParamList>();
+  const onMountB = jest.fn();
+
+  const B = ({ route }: BottomTabScreenProps<ParamList, 'B'>) => {
+    React.useEffect(() => {
+      onMountB();
+    }, []);
+    return <Text>B user: {route.params?.user ?? 'none'}</Text>;
+  };
+
+  const { queryByText, getByRole } = render(
+    <NavigationContainer ref={navigation}>
+      <Tab.Navigator>
+        <Tab.Screen name="A">{() => <Text>Screen A</Text>}</Tab.Screen>
+        <Tab.Screen name="B" component={B} getId={({ params }) => params?.user} />
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('B', { user: 'jane' }));
+
+  expect(queryByText('B user: jane')).not.toBeNull();
+  expect(onMountB).toHaveBeenCalledTimes(1);
+
+  await userEvent.press(getByRole('button', { name: 'A, tab, 1 of 2' }));
+  await userEvent.press(getByRole('button', { name: 'B, tab, 2 of 2' }));
+
+  expect(queryByText('B user: jane')).not.toBeNull();
+  expect(onMountB).toHaveBeenCalledTimes(1);
+});
+
+test('resets a nested stack when its tab loses focus with popToTopOnBlur', async () => {
+  const Tab = createBottomTabNavigator<BottomTabParamList>();
+  const Stack = createStackNavigator<{ Home: undefined; Details: undefined }>();
+  const navigation = createNavigationContainerRef<BottomTabParamList>();
+
+  const StackA = () => (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="Home">{() => <Text>Home</Text>}</Stack.Screen>
+      <Stack.Screen name="Details">{() => <Text>Details</Text>}</Stack.Screen>
+    </Stack.Navigator>
+  );
+
+  const { queryByText, getByRole } = render(
+    <NavigationContainer ref={navigation}>
+      <Tab.Navigator>
+        <Tab.Screen name="A" component={StackA} options={{ popToTopOnBlur: true }} />
+        <Tab.Screen name="B">{() => <Text>Screen B</Text>}</Tab.Screen>
+      </Tab.Navigator>
+    </NavigationContainer>
+  );
+
+  act(() => navigation.navigate('A', { screen: 'Details' } as never));
+  act(() => jest.runAllTimers());
+
+  expect(queryByText('Details')).not.toBeNull();
+
+  await userEvent.press(getByRole('button', { name: 'B, tab, 2 of 2' }));
+  act(() => jest.runAllTimers());
+
+  await userEvent.press(getByRole('button', { name: 'A, tab, 1 of 2' }));
+  act(() => jest.runAllTimers());
+
+  // Without `popToTopOnBlur`, the details screen would still be active.
+  expect(queryByText('Home')).not.toBeNull();
+  expect(queryByText('Details')).toBeNull();
 });
 
 test('tab bars render appropriate hrefs on web', () => {

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -1,8 +1,13 @@
 'use client';
+import { useCallback } from 'react';
+
+import { useStandardEmitter } from '../../../standard-navigation/useStandardEmitter';
 import {
+  CommonActions,
   createNavigatorFactory,
   type NavigatorTypeBagBase,
   type ParamListBase,
+  StackActions,
   type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
@@ -48,9 +53,52 @@ function BottomTabNavigator({
     UNSTABLE_router,
   });
 
+  const emitter = useStandardEmitter(navigation);
+
+  const navigateToTab = useCallback(
+    (routeKey: string) => {
+      const route = state.routes.find((route) => route.key === routeKey);
+
+      if (route) {
+        navigation.dispatch({
+          ...CommonActions.navigate(route),
+          target: state.key,
+        });
+      } else if (__DEV__) {
+        console.warn(
+          `Bottom tabs could not switch to the tab "${routeKey}" because no tab with that key exists. ` +
+            `'navigateToTab' takes a route key, not a route name — pass 'route.key' from the tab bar props.`
+        );
+      }
+    },
+    [navigation, state.key, state.routes]
+  );
+
+  const popNestedStackToTop = useCallback(
+    (routeKey: string) => {
+      const prevRoute = state.routes.find((route) => route.key === routeKey);
+
+      if (prevRoute?.state?.type === 'stack' && prevRoute.state.key) {
+        navigation.dispatch({
+          ...StackActions.popToTop(),
+          target: prevRoute.state.key,
+        });
+      }
+    },
+    [navigation, state.routes]
+  );
+
   return (
     <NavigationContent>
-      <BottomTabView {...rest} state={state} navigation={navigation} descriptors={descriptors} />
+      <BottomTabView
+        {...rest}
+        state={state}
+        descriptors={descriptors}
+        emitter={emitter}
+        navigateToTab={navigateToTab}
+        preloadedRouteKeys={state.preloadedRouteKeys}
+        popNestedStackToTop={popNestedStackToTop}
+      />
     </NavigationContent>
   );
 }

--- a/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
@@ -8,12 +8,12 @@ import type {
   ViewStyle,
 } from 'react-native';
 import type { EdgeInsets } from 'react-native-safe-area-context';
+import type { NavigatorArgs } from 'standard-navigation';
 
 import type { HeaderOptions, PlatformPressable } from '../elements';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
-  NavigationHelpers,
   NavigationProp,
   ParamListBase,
   RouteProp,
@@ -35,24 +35,37 @@ export type BottomTabNavigationEventMap = {
   /**
    * Event which fires on long press on the tab in the tab bar.
    */
-  tabLongPress: { data: undefined };
+  tabLongPress: { data: undefined; canPreventDefault: false };
   /**
    * Event which fires when a transition animation starts.
    */
-  transitionStart: { data: undefined };
+  transitionStart: { data: undefined; canPreventDefault: false };
   /**
    * Event which fires when a transition animation ends.
    */
-  transitionEnd: { data: undefined };
+  transitionEnd: { data: undefined; canPreventDefault: false };
 };
 
 export type LabelPosition = 'beside-icon' | 'below-icon';
 
-export type BottomTabNavigationHelpers = NavigationHelpers<
-  ParamListBase,
+export type BottomTabViewRoute = {
+  key: string;
+  name: string;
+  params?: object;
+};
+
+/**
+ * The navigator state consumed by `BottomTabView` and the tab bar.
+ */
+export type BottomTabViewState = {
+  index: number;
+  routes: BottomTabViewRoute[];
+};
+
+export type BottomTabEmitter = NavigatorArgs<
+  Record<string, never>,
   BottomTabNavigationEventMap
-> &
-  TabActionHelpers<ParamListBase>;
+>['emitter'];
 
 export type BottomTabNavigationProp<
   ParamList extends ParamListBase,
@@ -408,10 +421,12 @@ export type BottomTabHeaderProps = {
   navigation: BottomTabNavigationProp<ParamListBase>;
 };
 
+// TODO(@ubax): update docs — https://linear.app/expo/issue/ENG-25579/update-documentation-after-the-refactor
 export type BottomTabBarProps = {
-  state: TabNavigationState<ParamListBase>;
+  state: BottomTabViewState;
   descriptors: BottomTabDescriptorMap;
-  navigation: NavigationHelpers<ParamListBase, BottomTabNavigationEventMap>;
+  emitter: BottomTabEmitter;
+  navigateToTab: (routeKey: string) => void;
   insets: EdgeInsets;
 };
 

--- a/packages/expo-router/src/react-navigation/bottom-tabs/utils/useAnimatedHashMap.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/utils/useAnimatedHashMap.tsx
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import { Animated } from 'react-native';
 
-import type { NavigationState } from '../../routers';
+import type { BottomTabViewState } from '../types';
 
-export function useAnimatedHashMap({ routes, index }: NavigationState) {
+export function useAnimatedHashMap({ routes, index }: BottomTabViewState) {
   const refs = React.useRef<Record<string, Animated.Value>>({});
   const previous = refs.current;
   const routeKeys = Object.keys(previous);

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
@@ -12,16 +12,8 @@ import {
 import type { EdgeInsets } from 'react-native-safe-area-context';
 
 import { getDefaultSidebarWidth, getLabel, MissingIcon, useFrameSize } from '../../elements';
-import {
-  CommonActions,
-  NavigationProvider,
-  type ParamListBase,
-  type TabNavigationState,
-  useLinkBuilder,
-  useLocale,
-  useTheme,
-} from '../../native';
-import type { BottomTabBarProps, BottomTabDescriptorMap } from '../types';
+import { NavigationProvider, useLinkBuilder, useLocale, useTheme } from '../../native';
+import type { BottomTabBarProps, BottomTabDescriptorMap, BottomTabViewState } from '../types';
 import { BottomTabBarHeightCallbackContext } from '../utils/BottomTabBarHeightCallbackContext';
 import { useIsKeyboardShown } from '../utils/useIsKeyboardShown';
 import { BottomTabItem } from './BottomTabItem';
@@ -39,7 +31,7 @@ const DEFAULT_MAX_TAB_ITEM_WIDTH = 125;
 const useNativeDriver = process.env.EXPO_OS !== 'web';
 
 type Options = {
-  state: TabNavigationState<ParamListBase>;
+  state: BottomTabViewState;
   descriptors: BottomTabDescriptorMap;
   dimensions: { height: number; width: number };
 };
@@ -129,7 +121,7 @@ export const getTabBarHeight = ({
   return TABBAR_HEIGHT_UIKIT + inset;
 };
 
-export function BottomTabBar({ state, navigation, descriptors, insets, style }: Props) {
+export function BottomTabBar({ state, descriptors, emitter, navigateToTab, insets, style }: Props) {
   const { colors } = useTheme();
   const { direction } = useLocale();
   const { buildHref } = useLinkBuilder();
@@ -344,22 +336,19 @@ export function BottomTabBar({ state, navigation, descriptors, insets, style }: 
           const { options } = descriptors[route.key]!;
 
           const onPress = () => {
-            const event = navigation.emit({
+            const event = emitter.emit({
               type: 'tabPress',
               target: route.key,
               canPreventDefault: true,
             });
 
             if (!focused && !event.defaultPrevented) {
-              navigation.dispatch({
-                ...CommonActions.navigate(route),
-                target: state.key,
-              });
+              navigateToTab(route.key);
             }
           };
 
           const onLongPress = () => {
-            navigation.emit({
+            emitter.emit({
               type: 'tabLongPress',
               target: route.key,
             });

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -4,21 +4,17 @@ import { Animated, Platform, StyleSheet } from 'react-native';
 import { SafeAreaInsetsContext } from 'react-native-safe-area-context';
 
 import { getHeaderTitle, Header, SafeAreaProviderCompat, Screen } from '../../elements';
-import {
-  type NavigationAction,
-  type ParamListBase,
-  StackActions,
-  type TabNavigationState,
-} from '../../native';
+import { type ParamListBase } from '../../native';
 import { FadeTransition, ShiftTransition } from '../TransitionConfigs/TransitionPresets';
 import type {
   BottomTabBarProps,
   BottomTabDescriptorMap,
+  BottomTabEmitter,
   BottomTabHeaderProps,
   BottomTabNavigationConfig,
-  BottomTabNavigationHelpers,
   BottomTabNavigationOptions,
   BottomTabNavigationProp,
+  BottomTabViewState,
 } from '../types';
 import { BottomTabBarHeightCallbackContext } from '../utils/BottomTabBarHeightCallbackContext';
 import { BottomTabBarHeightContext } from '../utils/BottomTabBarHeightContext';
@@ -27,9 +23,12 @@ import { BottomTabBar, getTabBarHeight } from './BottomTabBar';
 import { MaybeScreen, MaybeScreenContainer } from './ScreenFallback';
 
 type Props = BottomTabNavigationConfig & {
-  state: TabNavigationState<ParamListBase>;
-  navigation: BottomTabNavigationHelpers;
+  state: BottomTabViewState;
   descriptors: BottomTabDescriptorMap;
+  emitter: BottomTabEmitter;
+  navigateToTab: (routeKey: string) => void;
+  preloadedRouteKeys: string[];
+  popNestedStackToTop: (routeKey: string) => void;
 };
 
 const EPSILON = 1e-5;
@@ -67,8 +66,11 @@ export function BottomTabView(props: Props) {
   const {
     tabBar = renderTabBarDefault,
     state,
-    navigation,
     descriptors,
+    emitter,
+    navigateToTab,
+    preloadedRouteKeys,
+    popNestedStackToTop,
     safeAreaInsets,
     detachInactiveScreens = Platform.OS === 'web' ||
       Platform.OS === 'android' ||
@@ -93,25 +95,13 @@ export function BottomTabView(props: Props) {
   React.useEffect(() => {
     const previousRouteKey = previousRouteKeyRef.current;
 
-    let popToTopAction: NavigationAction | undefined;
-
-    if (
+    const shouldPopPreviousToTop =
       previousRouteKey !== focusedRouteKey &&
-      descriptors[previousRouteKey]?.options.popToTopOnBlur
-    ) {
-      const prevRoute = state.routes.find((route) => route.key === previousRouteKey);
-
-      if (prevRoute?.state?.type === 'stack' && prevRoute.state.key) {
-        popToTopAction = {
-          ...StackActions.popToTop(),
-          target: prevRoute.state.key,
-        };
-      }
-    }
+      !!descriptors[previousRouteKey]?.options.popToTopOnBlur;
 
     const animateToIndex = () => {
       if (previousRouteKey !== focusedRouteKey) {
-        navigation.emit({
+        emitter.emit({
           type: 'transitionStart',
           target: focusedRouteKey,
         });
@@ -146,12 +136,12 @@ export function BottomTabView(props: Props) {
           })
           .filter(Boolean) as Animated.CompositeAnimation[]
       ).start(({ finished }) => {
-        if (finished && popToTopAction) {
-          navigation.dispatch(popToTopAction);
+        if (finished && shouldPopPreviousToTop) {
+          popNestedStackToTop(previousRouteKey);
         }
 
         if (previousRouteKey !== focusedRouteKey) {
-          navigation.emit({
+          emitter.emit({
             type: 'transitionEnd',
             target: focusedRouteKey,
           });
@@ -162,7 +152,15 @@ export function BottomTabView(props: Props) {
     animateToIndex();
 
     previousRouteKeyRef.current = focusedRouteKey;
-  }, [descriptors, focusedRouteKey, navigation, state.index, state.routes, tabAnims]);
+  }, [
+    descriptors,
+    focusedRouteKey,
+    emitter,
+    popNestedStackToTop,
+    state.index,
+    state.routes,
+    tabAnims,
+  ]);
 
   const dimensions = SafeAreaProviderCompat.initialMetrics.frame;
   const [tabBarHeight, setTabBarHeight] = React.useState(() =>
@@ -185,7 +183,8 @@ export function BottomTabView(props: Props) {
           tabBar({
             state,
             descriptors,
-            navigation,
+            emitter,
+            navigateToTab,
             insets: {
               top: safeAreaInsets?.top ?? insets?.top ?? 0,
               right: safeAreaInsets?.right ?? insets?.right ?? 0,
@@ -230,7 +229,7 @@ export function BottomTabView(props: Props) {
             sceneStyleInterpolator = NAMED_TRANSITIONS_PRESETS[animation]!.sceneStyleInterpolator,
           } = descriptor.options;
           const isFocused = state.index === index;
-          const isPreloaded = state.preloadedRouteKeys.includes(route.key);
+          const isPreloaded = preloadedRouteKeys.includes(route.key);
 
           if (lazy && !loaded.includes(route.key) && !isFocused && !isPreloaded) {
             // Don't render a lazy screen if we've never navigated to it or it wasn't preloaded


### PR DESCRIPTION
# Why

Refactor `BottomTabs` before migrating to `standard-navigation` to minimize the diff

# How

1. Remove `navigation` prop from `BottomTabView` and replace it with direct APIs for:
   - dispatching navigate action - `navigateToTab`
   - emitting events - `emitter`
   - popping the nested stack to top - `popNestedStackToTop`
2. Replace the state used by `BottomTabView` with a simple standard-navigation compliant one
   - pass additional prop - `preloadedRouteKeys`
3. Add missing types

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
