### PR TITLE
docs: document EAS Simulator events

### DIFF
--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: EAS Simulator CLI reference
 sidebar_title: CLI reference
-description: Reference for the experimental EAS CLI commands that create, inspect, control, list, and stop remote simulator sessions.
+description: Reference for the experimental EAS CLI commands that create, inspect, monitor, control, list, and stop remote simulator sessions.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -21,6 +21,7 @@ The `--help` flag displays the available options for `simulator:start`.
 | [`simulator:start`](#simulatorstart)               | Create a session and wait for its controller configuration               |
 | [`simulator`](#simulatorstart)                     | Alias for `simulator:start`                                              |
 | [`simulator:exec`](#simulatorexec)                 | Run another command with **.env.eas-simulator** loaded                   |
+| [`simulator:events`](#simulatorevents)             | Show recorded activity or follow activity from a running session         |
 | [`simulator:get`](#simulatorget)                   | Get status, connection details, dashboard URL, timestamps, and artifacts |
 | [`simulator:list`](#simulatorlist)                 | List and filter sessions for the current project                         |
 | [`simulator:stop`](#simulatorstop)                 | Stop a session                                                           |
@@ -113,6 +114,30 @@ Use the command pattern for the controller selected when the session started:
 </Tabs>
 
 `simulator:exec` does not implement device actions. It only supplies the active session's connection environment and runs the command that follows. The available actions and argument syntax come from [agent-device](/agents/agent-device/) or [Argent](/agents/argent/).
+
+## `simulator:events`
+
+Show a snapshot of the activity recorded for the session referenced by **.env.eas-simulator**:
+
+<Terminal cmd={['$ eas simulator:events']} />
+
+Pass a session ID to inspect another session:
+
+<Terminal cmd={['$ eas simulator:events --id <session-id>']} />
+
+The default text output condenses related operations into a readable timeline. It includes the timestamp, controller, summary, and duration when available. This command shows session and controller activity from agent-device or Argent, not application runtime logs.
+
+Follow new activity while a session is running:
+
+<Terminal cmd={['$ eas simulator:events --follow']} />
+
+The `-f` short flag is equivalent to `--follow`. The command stops following when the session ends. Press Ctrl+C to stop following earlier.
+
+For agents and automation, request the raw event records as JSON:
+
+<Terminal cmd={['$ eas simulator:events --json']} />
+
+The JSON object contains `deviceRunSessionId` and an `events` array. Common event fields include `eventId`, `ts`, `producer`, `type`, and `summary`, with operation ID, outcome, duration, and controller-specific data when available. `--json` cannot be combined with `--follow`.
 
 ## `simulator:get`
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -131,7 +131,7 @@ Follow new activity while a session is running:
 
 <Terminal cmd={['$ eas simulator:events --follow']} />
 
-The `-f` short flag is equivalent to `--follow`. The command stops following when the session ends. Press Ctrl+C to stop following earlier.
+The `-f` short flag is equivalent to `--follow`. The command stops following when the session ends. Press <kbd>Ctrl</kbd> + <kbd>C</kbd> to stop following earlier.
 
 For agents and automation, request the raw event records as JSON:
 

--- a/docs/pages/preview/eas-simulator/run-and-control.mdx
+++ b/docs/pages/preview/eas-simulator/run-and-control.mdx
@@ -241,6 +241,20 @@ Use these commands with a session started with `--type argent`. `simulator:exec`
 
 Argent uses its own tools and app installation commands. An Argent session does not also provision an agent-device daemon, so do not run agent-device commands against it.
 
+## Inspect session activity
+
+Sessions that use agent-device or Argent record controller activity. Show the activity recorded so far for the current session:
+
+<Terminal cmd={['$ eas simulator:events']} />
+
+In another terminal, follow new activity while you or an agent drives the device:
+
+<Terminal cmd={['$ eas simulator:events --follow']} />
+
+The follow command exits when the session ends. Use `--id <session-id>` to inspect another session, or `--json` to return raw event records for an agent or script. `--json` and `--follow` cannot be used together.
+
+Session activity describes controller operations and interactions. It does not replace application runtime logs.
+
 ## Use the iOS browser preview
 
 Supported iOS sessions return a `webPreviewUrl`. Open it in a desktop browser while the session is active.


### PR DESCRIPTION
# Why

The EAS Simulator preview docs do not yet cover the experimental `eas simulator:events` command released in EAS CLI 21.4. Documenting it helps developers and coding agents inspect controller activity during and after a remote simulator session.

# How

- Add `simulator:events` to the EAS Simulator CLI reference.
- Document one-time snapshots, explicit session IDs, `--follow`/`-f`, JSON output, and the JSON event fields.
- Add the practical activity-monitoring workflow to the run-and-control guide.
- Clarify that session activity is controller activity from agent-device or Argent, not application runtime logs.

# Test Plan

- `npx --yes eas-cli@latest simulator:events --help`
- `npx --yes oxfmt@latest --write docs/pages/preview/eas-simulator/cli-reference.mdx docs/pages/preview/eas-simulator/run-and-control.mdx`
- Vale on both modified files
- MDX compilation for both modified files
- `git diff --check`

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)