### PR TITLE
[location][Android] Fix leaking watches

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))
+- [Android] Fix leaking watches ([#48294](https://github.com/expo/expo/pull/48294) by [@Wenszel](https://github.com/Wenszel))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -38,7 +38,6 @@ import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.LocationSettingsRequest
 import com.google.android.gms.location.Priority
 import expo.modules.core.interfaces.ActivityEventListener
-import expo.modules.core.interfaces.LifecycleEventListener
 import expo.modules.core.interfaces.services.UIManager
 import expo.modules.interfaces.taskManager.TaskManagerInterface
 import expo.modules.kotlin.Promise
@@ -75,7 +74,7 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 import kotlin.math.abs
 
-class LocationModule : Module(), LifecycleEventListener, SensorEventListener, ActivityEventListener {
+class LocationModule : Module(), SensorEventListener, ActivityEventListener {
   private var mGeofield: GeomagneticField? = null
   private val mLocationCallbacks = HashMap<Int, LocationCallback>()
   private val mLocationRequests = HashMap<Int, LocationRequest>()
@@ -377,10 +376,16 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
 
     OnActivityEntersForeground {
       AppForegroundedSingleton.isForegrounded = true
+      onHostResume()
     }
 
     OnActivityEntersBackground {
       AppForegroundedSingleton.isForegrounded = false
+      onHostPause()
+    }
+
+    OnDestroy {
+      onHostDestroy()
     }
   }
 
@@ -1079,19 +1084,19 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
     const val TIME_DELTA = 50f // in milliseconds
   }
 
-  override fun onHostResume() {
+  fun onHostResume() {
     startWatching()
     startHeadingUpdate()
     resumeMotionActivityWatch()
   }
 
-  override fun onHostPause() {
+  fun onHostPause() {
     stopWatching()
     stopHeadingWatch()
     pauseMotionActivityWatch()
   }
 
-  override fun onHostDestroy() {
+  fun onHostDestroy() {
     stopWatching()
     stopHeadingWatch()
     stopMotionActivityWatch()

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -376,16 +376,23 @@ class LocationModule : Module(), SensorEventListener, ActivityEventListener {
 
     OnActivityEntersForeground {
       AppForegroundedSingleton.isForegrounded = true
-      onHostResume()
+      resumeGeocoder()
+      resumeLocationUpdates()
+      resumeHeadingWatch()
+      resumeMotionActivityWatch()
     }
 
     OnActivityEntersBackground {
       AppForegroundedSingleton.isForegrounded = false
-      onHostPause()
+      stopWatching()
+      stopHeadingWatch()
+      pauseMotionActivityWatch()
     }
 
     OnDestroy {
-      onHostDestroy()
+      stopWatching()
+      stopHeadingWatch()
+      stopMotionActivityWatch()
     }
   }
 
@@ -698,14 +705,18 @@ class LocationModule : Module(), SensorEventListener, ActivityEventListener {
     mAccuracy = 0
   }
 
-  private fun startWatching() {
+  private fun resumeGeocoder() {
     // if permissions not granted it won't work anyway, but this can be invoked when permission dialog disappears
     if (!isMissingForegroundPermissions()) {
       mGeocoderPaused = false
     }
+  }
 
-    // Resume paused location updates
-    resumeLocationUpdates()
+  private fun resumeHeadingWatch() {
+    if (mHeadingId == 0) {
+      return
+    }
+    startHeadingUpdate()
   }
 
   private fun stopWatching() {
@@ -1082,24 +1093,6 @@ class LocationModule : Module(), SensorEventListener, ActivityEventListener {
 
     const val DEGREE_DELTA = 0.0355 // in radians, about 2 degrees
     const val TIME_DELTA = 50f // in milliseconds
-  }
-
-  fun onHostResume() {
-    startWatching()
-    startHeadingUpdate()
-    resumeMotionActivityWatch()
-  }
-
-  fun onHostPause() {
-    stopWatching()
-    stopHeadingWatch()
-    pauseMotionActivityWatch()
-  }
-
-  fun onHostDestroy() {
-    stopWatching()
-    stopHeadingWatch()
-    stopMotionActivityWatch()
   }
 
   override fun onSensorChanged(event: SensorEvent?) {


### PR DESCRIPTION
# Why
Fixes an issue where resources weren't released. LocationModule used to implement `LifecycleEventListener` but never subscribed to its events, which caused resources to leak on module destroy or when switching between background and foreground.

# How

Used the `OnDestroy`, `OnActivityEntersForeground`, and `OnActivityEntersBackground` APIs to release resources, and removed the `LifecycleEventListener` implementation from the module.

# Test plan
NCL -> Location screen, with `subscription.remove()` disabled. Without this fix, the receiver persists after a reload, which can be observed with this command:

```
while true; do echo "$(date +%H:%M:%S) receivers: $(adb shell dumpsys activity broadcasts | sed -n '/Registered Receivers:/,/Receiver Resolver Table:/p' | grep -c MOTION_ACTIVITY_UPDATE)"; sleep 2; done
```