### PR TITLE
fix(cli): Ignore invalid port values

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -34,7 +34,7 @@
     "start:headless": "E2E_ROUTER_SRC=headless expo",
     "start:web-modal": "E2E_ROUTER_SRC=web-modal E2E_ROUTER_JS_ENGINE=hermes EXPO_WEB_DEV_HYDRATE=1 expo start",
     "export:web-modal": "E2E_ROUTER_SRC=web-modal E2E_ROUTER_JS_ENGINE=hermes expo export -p web",
-    "start:fast-refresh": "E2E_ROUTER_SRC=fast-refresh E2E_ROUTER_JS_ENGINE=hermes expo start -p web",
+    "start:fast-refresh": "E2E_ROUTER_SRC=fast-refresh E2E_ROUTER_JS_ENGINE=hermes expo start -w",
     "start:middleware-async": "E2E_ROUTER_SRC=server-middleware-async EXPO_USE_STATIC=server E2E_ROUTER_SERVER_MIDDLEWARE=true expo start",
     "export:middleware-async": "E2E_ROUTER_SRC=server-middleware-async EXPO_USE_STATIC=server E2E_ROUTER_SERVER_MIDDLEWARE=true expo export -p web",
     "start:static-loader": "E2E_ROUTER_SRC=server-loader E2E_ROUTER_SERVER_LOADERS=true expo start",

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,7 +38,7 @@
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fix opening web from the Terminal UI when the dev server was started without `--web` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
-- Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null`
+- Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null` ([#48300](https://github.com/expo/expo/pull/48300) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fix opening web from the Terminal UI when the dev server was started without `--web` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null`
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
+++ b/packages/@expo/cli/src/run/__tests__/resolveBundlerProps-test.ts
@@ -13,6 +13,18 @@ describe(resolveBundlerPropsAsync, () => {
       /mutually exclusive arguments/
     );
   });
+  it(`ignores an invalid port when the bundler is skipped`, async () => {
+    expect(await resolveBundlerPropsAsync('/', { bundler: false, port: NaN })).toEqual({
+      port: 8081,
+      shouldStartBundler: false,
+    });
+  });
+  it(`ignores an invalid port when the bundler is started`, async () => {
+    expect(await resolveBundlerPropsAsync('/', { port: NaN })).toEqual({
+      port: 8081,
+      shouldStartBundler: true,
+    });
+  });
   it(`skips bundling if the port is busy`, async () => {
     jest.mocked(resolveMetroPortAsync).mockResolvedValueOnce(null);
 

--- a/packages/@expo/cli/src/run/resolveBundlerProps.ts
+++ b/packages/@expo/cli/src/run/resolveBundlerProps.ts
@@ -1,6 +1,6 @@
 import { Log } from '../log';
 import { CommandError } from '../utils/errors';
-import { resolveMetroPortAsync } from '../utils/port';
+import { isValidPort, resolveMetroPortAsync } from '../utils/port';
 
 export interface BundlerProps {
   /** Port to start the dev server on. */
@@ -37,8 +37,8 @@ export async function resolveBundlerPropsAsync(
   // Skip bundling if the port is null -- meaning skip the bundler if the port is already running the app.
   options.bundler = !!port;
   if (!port) {
-    // Use explicit user-provided port, or the default port
-    port = options.port ?? 8081;
+    // Use a valid user-provided port, or the default port
+    port = isValidPort(options.port) ? options.port : 8081;
   }
   Log.debug(`Resolved port: ${port}, start dev server: ${options.bundler}`);
 

--- a/packages/@expo/cli/src/utils/__mocks__/port.ts
+++ b/packages/@expo/cli/src/utils/__mocks__/port.ts
@@ -1,7 +1,9 @@
-export const resolveMetroPortAsync = jest.fn(
-  async (root, { defaultPort, fallbackPort } = {}) => defaultPort ?? fallbackPort ?? 8081
+export const { isValidPort } = jest.requireActual('../port');
+
+export const resolveMetroPortAsync = jest.fn(async (root, { defaultPort, fallbackPort } = {}) =>
+  isValidPort(defaultPort) ? defaultPort : (fallbackPort ?? 8081)
 );
-export const _resolvePortAsync = jest.fn(
-  async (root, { defaultPort, preferredPort }) => defaultPort ?? preferredPort
+export const _resolvePortAsync = jest.fn(async (root, { defaultPort, preferredPort }) =>
+  isValidPort(defaultPort) ? defaultPort : preferredPort
 );
 export const ensurePortAvailabilityAsync = jest.fn(async () => true);

--- a/packages/@expo/cli/src/utils/__tests__/port.test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/port.test.ts
@@ -141,6 +141,14 @@ describe(choosePortAsync, () => {
 });
 
 describe(_resolvePortAsync, () => {
+  it.each([NaN, -1, 8081.5, Infinity, 65_536])(
+    `uses the preferred port when the requested port is invalid: %s`,
+    async (defaultPort) => {
+      const port = await _resolvePortAsync('/', { defaultPort, preferredPort: 8081 });
+      expect(port).toBe(8081);
+      expect(freePortAsync).toHaveBeenCalledWith(8081, [null]);
+    }
+  );
   it(`finds the first available port from the preferred port when port is 0`, async () => {
     jest.mocked(freePortAsync).mockResolvedValueOnce(8081);
     const port = await _resolvePortAsync('/', { defaultPort: 0, preferredPort: 8081 });
@@ -168,6 +176,13 @@ describe(_resolvePortAsync, () => {
     await expect(
       _resolvePortAsync('/', { defaultPort: 8081, preferredPort: 8081 })
     ).rejects.toThrow(/Port 8081 is unavailable/);
+    expect(confirmAsync).not.toHaveBeenCalled();
+  });
+  it(`rolls over instead of hard-failing when an invalid --port is busy in non-interactive mode`, async () => {
+    jest.mocked(isInteractive).mockReturnValueOnce(false);
+    jest.mocked(freePortAsync).mockResolvedValueOnce(8082);
+    const port = await _resolvePortAsync('/', { defaultPort: NaN, preferredPort: 8081 });
+    expect(port).toBe(8082);
     expect(confirmAsync).not.toHaveBeenCalled();
   });
   it(`hard-fails when an explicitly requested preferred port is busy in non-interactive mode`, async () => {
@@ -207,6 +222,17 @@ describe(resolveMetroPortAsync, () => {
     const port = await resolveMetroPortAsync('/', { defaultPort: 3000, fallbackPort: 8081 });
     expect(port).toBe(3000);
     expect(process.env.RCT_METRO_PORT).toBe('3000');
+  });
+  it(`uses and writes back the fallback when --port parsing returns NaN`, async () => {
+    const port = await resolveMetroPortAsync('/', { defaultPort: NaN, fallbackPort: 8081 });
+    expect(port).toBe(8081);
+    expect(process.env.RCT_METRO_PORT).toBe('8081');
+  });
+  it(`uses the fallback when RCT_METRO_PORT is out of range`, async () => {
+    process.env.RCT_METRO_PORT = '65536';
+    const port = await resolveMetroPortAsync('/', { fallbackPort: 8081 });
+    expect(port).toBe(8081);
+    expect(freePortAsync).toHaveBeenCalledWith(8081, [null]);
   });
   it(`falls back to 8081 when nothing requests a port`, async () => {
     const port = await resolveMetroPortAsync('/');

--- a/packages/@expo/cli/src/utils/port.ts
+++ b/packages/@expo/cli/src/utils/port.ts
@@ -6,6 +6,11 @@ import { CommandError } from './errors';
 import { testPortAsync, freePortAsync } from './freeport';
 import { isInteractive } from './interactive';
 
+/** Whether the port is in the usable range. Port 0 is valid and means "pick any available port". */
+export function isValidPort(port: number | undefined): port is number {
+  return port != null && Number.isInteger(port) && port >= 0 && port <= 65_535;
+}
+
 /** Get a free port or assert a CLI command error. */
 async function getFreePortAsync(rangeStart: number): Promise<number> {
   const port = await freePortAsync(rangeStart, [null, 'localhost']);
@@ -152,25 +157,19 @@ export async function _resolvePortAsync(
     reuseExistingPort,
     /** Requested port, e.g. from `--port`. */
     defaultPort,
-    /** Port to use when none is requested, and the port to scan from when `--port 0` is used. */
+    /** Port to use when no valid port is requested, and the port to scan from when `--port 0` is used. */
     preferredPort,
     /** Whether the preferred port was requested rather than defaulted, making it a hard requirement. */
     isPreferredPortExplicit,
   }: {
     reuseExistingPort?: boolean;
-    defaultPort?: string | number;
+    defaultPort?: number;
     preferredPort: number;
     isPreferredPortExplicit?: boolean;
   }
 ): Promise<number | null> {
-  let port: number;
-  if (typeof defaultPort === 'string') {
-    port = parseInt(defaultPort, 10);
-  } else if (typeof defaultPort === 'number') {
-    port = defaultPort;
-  } else {
-    port = preferredPort;
-  }
+  const isRequestedPortValid = isValidPort(defaultPort);
+  const port = isRequestedPortValid ? defaultPort : preferredPort;
 
   // Port 0 means "pick any available port"
   if (port === 0) {
@@ -181,7 +180,7 @@ export async function _resolvePortAsync(
   const resolvedPort = await choosePortAsync(projectRoot, {
     defaultPort: port,
     reuseExistingPort,
-    explicitPort: defaultPort != null || !!isPreferredPortExplicit,
+    explicitPort: isRequestedPortValid || !!isPreferredPortExplicit,
   });
   if (resolvedPort == null) {
     Log.log('\u203A Skipping dev server');
@@ -200,16 +199,18 @@ export async function resolveMetroPortAsync(
   {
     reuseExistingPort,
     defaultPort,
-    /** Backup port for when neither `--port` nor `RCT_METRO_PORT` is set. */
+    /** Backup port for when neither `--port` nor `RCT_METRO_PORT` gives a valid port. */
     fallbackPort,
   }: {
     reuseExistingPort?: boolean;
-    defaultPort?: string | number;
+    defaultPort?: number;
     fallbackPort?: number;
   } = {}
 ): Promise<number | null> {
   // NOTE(@kitten): We treat `--port` and `RCT_METRO_PORT` as the fixed preferred ports
-  const requestedMetroPort = env.RCT_METRO_PORT;
+  const metroPort = env.RCT_METRO_PORT;
+  // `env.RCT_METRO_PORT` returns 0 when unset, so invalid values use the same fallback path.
+  const requestedMetroPort = isValidPort(metroPort) ? metroPort : 0;
   const resolvedPort = await _resolvePortAsync(projectRoot, {
     reuseExistingPort,
     defaultPort,


### PR DESCRIPTION
# Why

The router E2E fast-refresh script was starting Expo with:

`expo start -p web`

On `expo start`, `-p` means `--port`, so `web` was parsed as a port and became `NaN`. The port resolver then prompted to use port `null` instead.

An invalid parsed port should be ignored so the CLI can continue with its preferred port.

# How

I added a shared check for whether a parsed port is an integer between `0` and `65535`.

If the parsed `--port` is invalid, we now ignore it and use the preferred port instead of adding another error. We also don’t count the ignored value as an explicit port, so a busy preferred port can roll over in a non-interactive shell.

I used the same check for numeric `RCT_METRO_PORT` values and for the fallback used by `run:ios` and `run:android`. I also updated the existing Jest mocks to follow the same behavior.

Malformed `RCT_METRO_PORT` strings are still handled by the existing environment parser. This only changes numeric values outside the valid port range.

The router E2E script now uses `expo start -w`.

# Test Plan

I added unit tests for:

- Invalid parsed ports falling back to the preferred port.
- A busy preferred port rolling over in a non-interactive shell.
- Out-of-range `RCT_METRO_PORT` values.
- Invalid ports with the bundler enabled and disabled.

I also checked these manually against the built CLI:

- `pnpm start:fast-refresh` starts the web project on port `8081`.
- `expo start -p web` starts on `8081` without the `NaN`/`null` prompt.
- `RCT_METRO_PORT=65536 expo start` starts on `8081`.
- `expo run:ios --no-bundler --port web` resolves `8081` and keeps the bundler disabled.

`et check-packages @expo/cli` passes all 44 tasks.

# Checklist

- [x] I added a `CHANGELOG.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
