### PR TITLE
[android][task-manager] Fix crash scheduling task jobs on Android 9

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Fix a crash when a task execution request is evaluated re-entrantly, by making its completion callback fire exactly once. ([#47594](https://github.com/expo/expo/pull/47594) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix `TaskService` leaking a `TaskExecutionCallback` (and the `JobService` it retains) for every executed background task. ([#47844](https://github.com/expo/expo/pull/47844) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -206,12 +206,13 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
         .setRequiresDeviceIdle(false);
 
     if (Build.VERSION.SDK_INT < 28) {
-      // For Android versions below 28 (Android 9 and below)
+      // For Android versions below 28 (Android 8.1 and below)
       jobBuilder.setMinimumLatency(0)
           .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
     } else if (Build.VERSION.SDK_INT < 31) {
       // For Android 9 (API 28) to Android 11 (API 30)
-      jobBuilder.setImportantWhileForeground(true);
+      jobBuilder.setImportantWhileForeground(true)
+          .setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE);
     } else {
       // For Android 12 (API 31) and above
       jobBuilder.setExpedited(true);

--- a/packages/expo-task-manager/android/src/test/java/expo/modules/taskManager/TaskManagerUtilsTest.kt
+++ b/packages/expo-task-manager/android/src/test/java/expo/modules/taskManager/TaskManagerUtilsTest.kt
@@ -1,0 +1,42 @@
+package expo.modules.taskManager
+
+import android.app.job.JobScheduler
+import android.content.Context
+import android.os.Bundle
+import android.os.PersistableBundle
+import expo.modules.interfaces.taskManager.TaskConsumerInterface
+import expo.modules.interfaces.taskManager.TaskExecutionCallback
+import expo.modules.interfaces.taskManager.TaskInterface
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+// API 28 is the last level where JobInfo.Builder.build() rejects a job with no constraint
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class TaskManagerUtilsTest {
+  private fun stubTask() = object : TaskInterface {
+    override fun getName() = "testTask"
+    override fun getAppScopeKey() = "testAppScopeKey"
+    override fun getAppUrl() = "appUrl"
+    override fun getConsumer(): TaskConsumerInterface? = null
+    override fun getOptions(): Map<String, Any>? = null
+    override fun getOptionsBundle(): Bundle? = null
+    override fun execute(data: Bundle?, error: Error?) = Unit
+    override fun execute(data: Bundle?, error: Error?, callback: TaskExecutionCallback?) = Unit
+    override fun setOptions(options: Map<String, Any>?) = Unit
+  }
+
+  @Test
+  fun `scheduleJob schedules a job that the system accepts`() {
+    val context = RuntimeEnvironment.getApplication()
+
+    TaskManagerUtils().scheduleJob(context, stubTask(), listOf(PersistableBundle()))
+
+    val jobScheduler = context.getSystemService(Context.JOB_SCHEDULER_SERVICE) as JobScheduler
+    assertEquals(1, jobScheduler.allPendingJobs.size)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #47571. On Android 9, every task event delivered through `JobScheduler` —
geofencing and background location from `expo-location` — kills the app:

    IllegalArgumentException: You're trying to build a job with no constraints, this is not allowed.

`createJobInfo`'s API 28–30 branch (a regression from #41688) only calls
`setImportantWhileForeground(true)`, which is a scheduling hint, not a
constraint, so `JobInfo.Builder.build()` throws on API 28. Nothing on the path
from `TaskBroadcastReceiver.onReceive` catches it (`updateOrScheduleJob` guards
only `IllegalStateException`), so the process dies instead of dropping one event.

The issue says API 28–30, but AOSP dropped this validation in API 29 — only
Android 9 crashes.

# How

Add the same `setOverrideDeadline(DEFAULT_OVERRIDE_DEADLINE)` the pre-28 branch
uses — a late constraint that satisfies `build()` and bounds scheduling delay
the same way. A minimum latency wouldn't work: `build()` rejects an
important-while-foreground job that carries an early constraint.

# Test Plan

New Robolectric test (`@Config(sdk = [28])`) drives the real `scheduleJob`
path — red before the fix with the exact trace from the issue, green after; it
also fails if the deadline is swapped for a minimum latency.
`et check-packages expo-task-manager` and
`et native-unit-tests -p android --packages expo-task-manager` pass.
