### PR TITLE
[expo-audio][android] Emit an `onAudioFocusChanged` event

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Support lockscreen controls with playlists. ([#46020](https://github.com/expo/expo/pull/46020) by [@alanjhughes](https://github.com/alanjhughes))
 - Added a `fileSize` field to `RecorderState` reporting the current size of the recording file in bytes. ([#46808](https://github.com/expo/expo/pull/46808) by [@behenate](https://github.com/behenate))
 - Added `startFileRecordingAsync` and `stopFileRecordingAsync` methods to `AudioStream` for continuous WAV and PCM file recording alongside buffer streaming. ([#46771](https://github.com/expo/expo/pull/46771) by [@behenate](https://github.com/behenate))
+- [Android] Added an `onAudioFocusChanged` event so apps can tell a transient audio focus loss apart from a permanent one, which cannot be inferred from playback stopping or obtained in userland. ([#48310](https://github.com/expo/expo/pull/48310) by [@michaellcraig80-stack](https://github.com/michaellcraig80-stack))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -123,19 +123,45 @@ class AudioModule : Module() {
         AudioManager.AUDIOFOCUS_GAIN -> {
           focusAcquired = true
 
-          if (!shouldPlayInSilentMode()) {
-            return@launch
-          }
-
-          allPlayables.forEach { playable ->
-            playable.setVolume(playable.previousVolume)
-            if (playable.isPaused) {
-              playable.isPaused = false
-              playable.play()
+          // NOTE: this was an early `return@launch`. It is a positive condition so
+          // that the event emitted below is not skipped on this path. Behaviour is
+          // unchanged.
+          if (shouldPlayInSilentMode()) {
+            allPlayables.forEach { playable ->
+              playable.setVolume(playable.previousVolume)
+              if (playable.isPaused) {
+                playable.isPaused = false
+                playable.play()
+              }
             }
           }
         }
       }
+
+      // Emitted AFTER the branches above have handled the change, deliberately.
+      //
+      // Emitting first would let a JS listener pause a player while `focusAcquired`
+      // is still true, and `AudioPlayer.onPlaybackStateChange` then reaches
+      // `releaseAudioFocus()` and abandons the request. Every loss branch above
+      // clears `focusAcquired` before pausing, which is what keeps a later
+      // AUDIOFOCUS_GAIN deliverable, so abandoning it here would mean the app never
+      // hears that focus came back.
+      sendEvent(
+        "onAudioFocusChanged",
+        mapOf(
+          "reason" to when (focusChange) {
+            AudioManager.AUDIOFOCUS_LOSS -> "loss"
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "lossTransient"
+            AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "lossTransientCanDuck"
+            AudioManager.AUDIOFOCUS_GAIN,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK,
+            AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE -> "gain"
+            else -> "unknown"
+          },
+          "interruptionMode" to interruptionMode?.value
+        )
+      )
     }
   }
 
@@ -225,6 +251,8 @@ class AudioModule : Module() {
   @OptIn(DelicateCoroutinesApi::class)
   override fun definition() = ModuleDefinition {
     Name("ExpoAudio")
+
+    Events("onAudioFocusChanged")
 
     OnCreate {
       audioManager = appContext.reactContext?.getSystemService(Context.AUDIO_SERVICE) as AudioManager

--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -20,9 +20,55 @@ import type { AudioLockScreenOptions } from './AudioConstants';
 import type { AudioStream } from './AudioStream.types';
 
 /**
+ * Why the system audio focus changed.
+ *
+ * - `'loss'`: focus was lost for the foreseeable future, for example another app
+ *   started playing music. Playback is not expected to resume on its own.
+ * - `'lossTransient'`: focus was lost briefly, for example an incoming call. The
+ *   system is expected to hand focus back with `'gain'`.
+ * - `'lossTransientCanDuck'`: another app wants focus but is happy for this app to
+ *   keep playing quietly. Whether the audio is ducked or paused depends on
+ *   `interruptionMode`.
+ * - `'gain'`: focus was regained after a loss.
+ * @platform android
+ */
+export type AudioFocusChangeReason =
+  | 'loss'
+  | 'lossTransient'
+  | 'lossTransientCanDuck'
+  | 'gain'
+  | 'unknown';
+
+/**
+ * @platform android
+ */
+export type AudioFocusChangeEvent = {
+  /** Why the focus changed. */
+  reason: AudioFocusChangeReason;
+  /** The interruption mode in effect when the change happened, which determines whether a duck request ducks or pauses. */
+  interruptionMode: AudioMode['interruptionMode'] | null;
+};
+
+/**
  * @hidden
  */
-export declare class NativeAudioModule extends NativeModule {
+export type AudioModuleEvents = {
+  /**
+   * Fires when the system audio focus changes.
+   *
+   * The module already handles focus changes internally (pausing, ducking and
+   * resuming). This event exists so an app can tell a brief interruption apart from
+   * a permanent one, which it cannot infer from playback simply stopping, and decide
+   * for itself whether resuming is appropriate.
+   * @platform android
+   */
+  onAudioFocusChanged(event: AudioFocusChangeEvent): void;
+};
+
+/**
+ * @hidden
+ */
+export declare class NativeAudioModule extends NativeModule<AudioModuleEvents> {
   setIsAudioActiveAsync(active: boolean): Promise<void>;
   setAudioModeAsync(category: Partial<AudioMode>): Promise<void>;
   requestRecordingPermissionsAsync(): Promise<PermissionResponse>;


### PR DESCRIPTION
# Why

`AudioModule` already receives every Android audio focus change and already acts on it:

| Focus change | Current behaviour |
|---|---|
| `AUDIOFOCUS_LOSS` | pauses all playables |
| `AUDIOFOCUS_LOSS_TRANSIENT` | pauses those that are playing |
| `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` | ducks, or pauses, depending on `interruptionMode` |
| `AUDIOFOCUS_GAIN` | restores volume and resumes whatever it paused |

None of it is surfaced to JS. So an app cannot tell a **brief** interruption from a **permanent** one: both arrive only as playback having stopped. An app that wants to resume by itself after a short interruption, but wait for an explicit user action after a phone call, has nothing to branch on.

It also cannot be obtained in userland. Android grants audio focus to a single listener per app, so a second `AudioFocusRequest` from app-level code **displaces this module's**, and this module's listener then pauses every player. The signal is not missing, only its surfacing.

# What this changes

- `Events("onAudioFocusChanged")` on the module.
- The listener emits `{ reason, interruptionMode }`.
- TS types for the event, following the `NativeModule<TEvents>` convention used elsewhere.

No `AudioFocusRequest` is added. No existing branch behaviour changes.

```ts
import { AudioModule } from 'expo-audio';

AudioModule.addListener('onAudioFocusChanged', ({ reason }) => {
  if (reason === 'lossTransient') {
    // brief: safe to resume when 'gain' arrives
  } else if (reason === 'loss') {
    // permanent: wait for the user
  }
});
```

# Two details worth reviewing

**The event is emitted after the `when` block, not before, and that is load-bearing rather than stylistic.** Emitting first lets a JS listener pause a player while `focusAcquired` is still `true`; `AudioPlayer.onPlaybackStateChange` then reaches `releaseAudioFocus()` and abandons the request, so no later `AUDIOFOCUS_GAIN` is delivered and the app never hears that focus came back. Every loss branch clears `focusAcquired` **before** pausing, which is exactly what keeps the request alive.

**The early `return@launch` in the gain branch became a positive condition** so the emit is not skipped on that path. Behaviour is unchanged.

**All gain-family values map to `'gain'`.** The request is made with `AUDIOFOCUS_GAIN_TRANSIENT` so the return is normally `AUDIOFOCUS_GAIN`, but matching only that constant would silently drop a transient variant and leave a listener waiting forever.

# Test plan

- `:expo-audio:compileDebugKotlin` passes, and the equivalent change compiles cleanly in an SDK 55 app with the emitted strings verified present in the resulting bytecode.
- Verified by hand in an app that discriminates interruption types: a transient loss followed by a gain resumes, a permanent loss does not.
- No behavioural change to existing consumers: the four branches are untouched and the gain restructure is a brace change.

# Scope

Android only. iOS already observes `interruptionNotification` and `routeChangeNotification` internally via `NotificationCenter`, so the same event could be added there. Happy to extend this PR if you would prefer it land cross-platform, or to rename `reason` if you would rather mirror the platform constants.

I will add the changelog entry once this has a PR number.