### PR TITLE
[docs] Remove flags from the language switcher

### DIFF
--- a/docs/ui/components/Header/LanguageSwitcher.tsx
+++ b/docs/ui/components/Header/LanguageSwitcher.tsx
@@ -10,8 +10,8 @@ import {
 import { Select } from '~/ui/components/Select';
 
 const options = [
-  { id: 'en', label: '🇺🇸 English' },
-  { id: 'ja', label: '🇯🇵 日本語' },
+  { id: 'en', label: 'English' },
+  { id: 'ja', label: '日本語' },
 ];
 
 export function LanguageSwitcher() {
@@ -33,7 +33,7 @@ export function LanguageSwitcher() {
 
   return (
     <Select
-      className="min-w-35 whitespace-nowrap"
+      className="min-w-25 whitespace-nowrap"
       value={currentLocale}
       onValueChange={onLocaleSelect}
       options={options}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25556

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove flags from the language switcher and resize the switcher.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="310" height="290" alt="CleanShot 2026-07-30 at 13 25 01@2x" src="https://github.com/user-attachments/assets/4ff4b82b-716b-4281-8151-cc35380211d4" />

<img width="328" height="294" alt="CleanShot 2026-07-30 at 13 25 07@2x" src="https://github.com/user-attachments/assets/33231323-a7fb-4d1f-aff2-63d78bb9ac3a" />

<img width="802" height="130" alt="CleanShot 2026-07-30 at 13 25 12@2x" src="https://github.com/user-attachments/assets/d1ff4172-cb39-47f7-8c1d-e134a5fdf12b" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
