### PR TITLE
[ios][camera] Read capture orientation from the camera's own scene

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [iOS] Preserve the capture orientation as EXIF metadata instead of rotating captured pixels, so `takePictureAsync` and `savePictureAsync` return the real orientation tag and dimensions. ([#47824](https://github.com/expo/expo/pull/47824) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Return zeroed `bounds` and `cornerPoints` from the ZXing fallback scanner so scanning a `pdf417`, `code39`, or `codabar` code no longer crashes with `Cannot read property 'origin' of undefined`. ([#47854](https://github.com/expo/expo/pull/47854) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix `responsiveOrientationWhenOrientationLocked: false` being ignored — photos and videos captured while the app orientation is locked now follow the locked interface orientation instead of the physical device rotation. ([#47881](https://github.com/expo/expo/pull/47881) by [@jiunshinn](https://github.com/jiunshinn))
+- [iOS] Read the capture interface orientation from the scene the camera view is in rather than an arbitrary connected scene. ([#48315](https://github.com/expo/expo/pull/48315) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -157,9 +157,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   let onAvailableLensesChanged = EventDispatcher()
 
   internal var deviceOrientation: UIInterfaceOrientation {
-    UIApplication.shared.connectedScenes.compactMap {
-      $0 as? UIWindowScene
-    }.first?.interfaceOrientation ?? .unknown
+    SceneGeometry.interfaceOrientation(for: self)
   }
 
   required init(appContext: AppContext? = nil) {


### PR DESCRIPTION
# Why

Follow-up to the iOS 27 resizability stack (#48168 to #48175)

`CameraView.deviceOrientation` took the first window scene out of `connectedScenes` with no activation filter, so it read an arbitrary scene, and it used the `interfaceOrientation` property deprecated in iOS 26. That value decides how photos and video are oriented, so on a device with more than one scene the capture can be rotated against a window the camera isn't in.

# How

Read it from the scene the camera view belongs to, via `effectiveGeometry`.

The accelerometer path is untouched. `ExpoCameraUtils.captureOrientation` picks between physical and interface orientation based on `responsiveOrientationWhenOrientationLocked`, and resizability widens the gap between the two rather than closing it, since iPhone Mirroring always reports portrait and a resized window's interface orientation describes the window rather than the device.

# Test Plan

`ExpoCameraUtilsTests` covers the mapping either side of this value and passes unchanged, which is expected since only the source changed.