### PR TITLE
[ios][video] Resolve fullscreen rotation from the player's own scene

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -22,6 +22,7 @@
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
 - [iOS] Fixed a thread-safety crash caused by mutating the internal player registries while they were being iterated on another thread (e.g. during audio session and now playing updates). ([#46930](https://github.com/expo/expo/pull/46930) by [@jiunshinn](https://github.com/jiunshinn))
 - Fix VideoView holding a strong reference to VideoPlayer even after the player has been detached. ([#46453](https://github.com/expo/expo/pull/46453) by [@behenate](https://github.com/behenate))
+- [iOS] Fixed fullscreen rotation requesting geometry from an arbitrary scene rather than the one the player is in. ([#48316](https://github.com/expo/expo/pull/48316) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/OrientationAVPlayerViewController.swift
+++ b/packages/expo-video/ios/OrientationAVPlayerViewController.swift
@@ -237,12 +237,8 @@ internal class OrientationAVPlayerViewController: AVPlayerViewController, AVPlay
 
   #if !os(tvOS)
   private func forceRotationUpdate() {
-    if #available(iOS 16.0, *) {
-      let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
-      windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: fullscreenOrientation))
-    } else {
-      UIViewController.attemptRotationToDeviceOrientation()
-    }
+    let windowScene = SceneGeometry.windowScene(for: view)
+    windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: fullscreenOrientation))
   }
   #endif
 }


### PR DESCRIPTION
# Why

Same follow-up as #48315.

`forceRotationUpdate` requested geometry from `connectedScenes.first` with no activation filter, so it could target a scene the player isn't in.

# How

Resolve the scene from the player's own view.

The `#available(iOS 16.0, *)` guard is dead at our 16.4 deployment target, so this also drops its unreachable `attemptRotationToDeviceOrientation()` branch, itself deprecated.

# Test Plan

Enter and leave fullscreen. `forceRotationUpdate` has one caller, the transition coordinator completion after presenting, so that is the whole surface.