### PR TITLE
[ios][dev-menu] Resolve remaining scene lookups through the shared helper

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Show the floating Tools button at its final position instead of animating in from the top-left corner. ([#46762](https://github.com/expo/expo/pull/46762) by [@alanjhughes](https://github.com/alanjhughes))
 - [macOS] Fix build failure from `RCTDevMenu.devMenuEnabled` / `keyboardShortcutsEnabled` access, which react-native-macos does not have. ([#47693](https://github.com/expo/expo/pull/47693) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Fixed the dev menu sizing itself from the main screen instead of the app's own window, and the FAB choosing its slide-in edge from the screen rather than its window. ([#48171](https://github.com/expo/expo/pull/48171) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed the dev menu and FAB resolving their scene by filtering all scene types before casting, which could miss a real window scene. ([#48317](https://github.com/expo/expo/pull/48317) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -439,9 +439,7 @@ open class DevMenuManager: NSObject {
         self.updateFABVisibility()
 
         if self.window?.windowScene == nil {
-          let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-          self.window?.windowScene = windowScene
+          self.window?.windowScene = SceneGeometry.foregroundActiveScene()
         }
         self.window?.makeKeyAndVisible()
 #endif
@@ -576,8 +574,7 @@ open class DevMenuManager: NSObject {
       guard let self else { return }
 
       if self.fabWindow == nil {
-        if let windowScene = UIApplication.shared.connectedScenes
-          .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+        if let windowScene = SceneGeometry.foregroundActiveScene() {
           self.setupFABWindowIfNeeded(for: windowScene)
         }
       }

--- a/packages/expo-dev-menu/ios/FAB/DevMenuFABView.swift
+++ b/packages/expo-dev-menu/ios/FAB/DevMenuFABView.swift
@@ -3,6 +3,7 @@
 #if !os(macOS) && !os(tvOS)
 
 import SwiftUI
+import ExpoModulesCore
 
 enum FABConstants {
   static let iconSize: CGFloat = 44
@@ -138,11 +139,7 @@ struct DevMenuFABView: View {
 
   // Get safe area from window since .ignoresSafeArea() may zero out geometry values
   private var windowSafeArea: UIEdgeInsets {
-    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-          let window = windowScene.windows.first else {
-      return .zero
-    }
-    return window.safeAreaInsets
+    return SceneGeometry.keyWindow()?.safeAreaInsets ?? .zero
   }
 
   private let dragSpring: Animation = .spring(


### PR DESCRIPTION
# Why

Same follow-up as #48315. #48171 migrated the dev menu's windows but left three lookups behind, all filtering across every scene type and casting afterwards, so a foreground-active non-window scene could shadow a real `UIWindowScene`. That is the defect review found in `SceneGeometry` itself on #48168.

The FAB's safe area also came from `windows.first` rather than the key window, so it could read insets from the wrong window in the scene.

# How

All three go through `SceneGeometry`. `connectedScenes` no longer appears in the package.

# Test Plan

Open the dev menu and check the FAB sits at the right inset from the screen edge, since that property feeds its positioning.
