### PR TITLE
[ios][core] Add a foreground-scene helper and use it in store-review

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -78,6 +78,7 @@
 - [iOS][android] Resolve the worklet UI runtime from its `react-native-worklets` holder instead of the reanimated `_WORKLET_RUNTIME` global; `installOnUIRuntime` now takes the holder from `getUIRuntimeHolder()`. ([#46922](https://github.com/expo/expo/pull/46922), [#46935](https://github.com/expo/expo/pull/46935) by [@nishan](https://github.com/intergalacticspacehighway))
 - iOS Turn `getModule(implementing:)` into a public function ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - [iOS] Added `SceneGeometry` for reading bounds, safe area, display scale and interface orientation from the scene a view belongs to. ([#48168](https://github.com/expo/expo/pull/48168) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Added `SceneGeometry.foregroundScene()`, which returns nil when no scene is on screen so callers can avoid presenting UI into a background scene. ([#48318](https://github.com/expo/expo/pull/48318) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 56.0.13 — 2026-05-26
 

--- a/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
+++ b/packages/expo-modules-core/ios/Utilities/SceneGeometry.swift
@@ -14,15 +14,19 @@ public enum SceneGeometry {
     if let scene = view?.window?.windowScene {
       return scene
     }
-    let scenes = windowScenes()
-    return scenes.first { $0.activationState == .foregroundActive }
-      ?? scenes.first { $0.activationState == .foregroundInactive }
-      ?? scenes.first
+    return foregroundScene() ?? windowScenes().first
   }
 
   /// Deliberately strict, for callers deciding whether to attach a window to a scene at all.
   public static func foregroundActiveScene() -> UIWindowScene? {
     return windowScenes().first { $0.activationState == .foregroundActive }
+  }
+
+  /// Nil when no scene is on screen, so callers don't present UI into a background scene.
+  public static func foregroundScene() -> UIWindowScene? {
+    let scenes = windowScenes()
+    return scenes.first { $0.activationState == .foregroundActive }
+      ?? scenes.first { $0.activationState == .foregroundInactive }
   }
 
   private static func windowScenes() -> [UIWindowScene] {
@@ -74,17 +78,6 @@ public extension SceneGeometry {
   /// Reads `effectiveGeometry` because `UIWindowScene.interfaceOrientation` is deprecated as of iOS 26.
   static func interfaceOrientation(for view: UIView? = nil) -> UIInterfaceOrientation {
     return windowScene(for: view)?.effectiveGeometry.interfaceOrientation ?? .unknown
-  }
-
-  /// Returns `nil` when the system won't say. A requested lock is only a preference on iOS 27.
-  static func isInterfaceOrientationLocked(for view: UIView? = nil) -> Bool? {
-    guard let scene = windowScene(for: view) else {
-      return nil
-    }
-    if #available(iOS 26.0, *) {
-      return scene.effectiveGeometry.isInterfaceOrientationLocked
-    }
-    return nil
   }
 }
 #endif

--- a/packages/expo-store-review/CHANGELOG.md
+++ b/packages/expo-store-review/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Resolved the review prompt's scene through the shared scene geometry helper, which also fixes a foreground scene being missed when another scene type sorted ahead of it. ([#48318](https://github.com/expo/expo/pull/48318) by [@alanjhughes](https://github.com/alanjhughes))
+
 ## 56.0.3 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-store-review/ios/StoreReviewModule.swift
+++ b/packages/expo-store-review/ios/StoreReviewModule.swift
@@ -25,21 +25,7 @@ public class StoreReviewModule: Module {
 
   @MainActor
   private func getForegroundActiveScene() -> UIWindowScene? {
-    // First try to find a foreground active scene
-    if let activeScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
-      return activeScene
-    }
-
-    // If no foreground active scene is found (e.g., app is in App Switcher),
-    // try to find any foreground inactive scene
-    if let foregroundScene = UIApplication.shared.connectedScenes.first(where: {
-      $0.activationState == .foregroundInactive
-    }) as? UIWindowScene {
-      return foregroundScene
-    }
-
-    // If no valid foreground scene is found, return nil
-    return nil
+    return SceneGeometry.foregroundScene()
   }
 
   private func isRunningFromTestFlight() -> Bool {


### PR DESCRIPTION
# Why

Same follow-up as #48315.

`StoreReviewModule` hand-rolled a scene lookup that filtered across every scene type and cast afterwards, so a foreground scene could be missed when another scene type sorted ahead of it.

It could not use `windowScene(for:)`, which falls back to any connected scene. Store-review depends on nil to throw when nothing is on screen, because a review prompt requested into a background scene is never seen.

# How

There are three distinct scene contracts in the SDK and now each has a name:

| Helper | Contract | Callers |
| --- | --- | --- |
| `windowScene(for:)` | best available, something whenever any scene exists | layout and geometry |
| `foregroundActiveScene()` | strictly active or nothing | dev menu, updates: attach a window or don't |
| `foregroundScene()` | on screen or nil | store-review: present or throw |

`windowScene(for:)` is now expressed in terms of `foregroundScene()`, so the ordering lives in one place.

This also removes `SceneGeometry.isInterfaceOrientationLocked`, added in #48168 for a consumer that turned out not to work: `getOrientationLockAsync` returns a mask-derived enum while that property is a `Bool`, so it can only contradict the answer rather than supply it. Adding public API in the same PR that removes some is deliberate, not inconsistent. This one ships with a caller, that one never found one, and it is unreleased so removing it now is free.

# Test Plan

Trigger the review prompt. This package has no test target, so that is its only coverage.
