### PR TITLE
[ios][expo-go] Attach the loading window to a scene

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/Onboarding/OnboardingTopicsView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Onboarding/OnboardingTopicsView.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import SwiftUI
+import ExpoModulesCore
 
 struct OnboardingTopicsView: View {
   @ObservedObject var viewModel: OnboardingViewModel
@@ -10,7 +11,7 @@ struct OnboardingTopicsView: View {
       Spacer()
       
       Text("What do you want to learn?")
-        .frame(width: UIScreen.main.bounds.width * 0.65)
+        .frame(width: SceneGeometry.bounds().width * 0.65)
         .font(.system(size: 32, weight: .bold))
         .multilineTextAlignment(.center)
         .padding(.bottom, 20)

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -3,6 +3,7 @@
 import Foundation
 import AuthenticationServices
 import Combine
+import ExpoModulesCore
 
 @MainActor
 class AuthenticationService: ObservableObject {
@@ -184,10 +185,6 @@ class AuthenticationService: ObservableObject {
 
 private class AuthPresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
   func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-    let window = UIApplication.shared.connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .flatMap { $0.windows }
-      .first { $0.isKeyWindow }
-    return window ?? ASPresentationAnchor()
+    return SceneGeometry.keyWindow() ?? ASPresentationAnchor()
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/SettingsManager.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import UIKit
+import ExpoModulesCore
 
 @MainActor
 class SettingsManager: ObservableObject {
@@ -106,10 +107,7 @@ class SettingsManager: ObservableObject {
   }
 
   private func applyThemeChange(_ themeIndex: Int) {
-    guard let window = UIApplication.shared.connectedScenes
-      .compactMap({ $0 as? UIWindowScene })
-      .flatMap({ $0.windows })
-      .first(where: { $0.isKeyWindow }) else {
+    guard let window = SceneGeometry.keyWindow() else {
       return
     }
 

--- a/apps/expo-go/ios/Client/SwiftUI/Services/UserReviewManager.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/UserReviewManager.swift
@@ -3,6 +3,7 @@
 import Foundation
 import StoreKit
 import UIKit
+import ExpoModulesCore
 
 @MainActor
 final class UserReviewManager: ObservableObject {
@@ -82,9 +83,7 @@ final class UserReviewManager: ObservableObject {
   }
 
   private func requestStoreReview() {
-    if let scene = UIApplication.shared.connectedScenes
-      .compactMap({ $0 as? UIWindowScene })
-      .first(where: { $0.activationState == .foregroundActive }) {
+    if let scene = SceneGeometry.foregroundActiveScene() {
       SKStoreReviewController.requestReview(in: scene)
     } else {
       SKStoreReviewController.requestReview()

--- a/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/SettingsTabView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 import AuthenticationServices
 import AppTrackingTransparency
 import EXApplication
+import ExpoModulesCore
 
 struct SettingsTabView: View {
   @Binding var selectedTab: HomeTab
@@ -299,10 +300,6 @@ struct SettingsTabView: View {
 
 private class AuthPresentationContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
   func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-    let window = UIApplication.shared.connectedScenes
-      .compactMap { $0 as? UIWindowScene }
-      .flatMap { $0.windows }
-      .first { $0.isKeyWindow }
-    return window ?? ASPresentationAnchor()
+    return SceneGeometry.keyWindow() ?? ASPresentationAnchor()
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/Views/ProjectDetailsView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/ProjectDetailsView.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2025 650 Industries. All rights reserved.
 
 import SwiftUI
+import ExpoModulesCore
 
 struct ProjectDetailsView: View {
   let projectId: String
@@ -125,8 +126,7 @@ struct ProjectDetailsView: View {
     let host = APIClient.shared.apiOrigin.replacingOccurrences(of: "https://", with: "")
     let expUrl = "exp://\(host)/\(project.fullName)"
     let activityView = UIActivityViewController(activityItems: [expUrl], applicationActivities: nil)
-    if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-       let root = scene.windows.first?.rootViewController {
+    if let root = SceneGeometry.keyWindow()?.rootViewController {
       root.present(activityView, animated: true)
     }
   }

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuManager.swift
@@ -109,9 +109,7 @@ public class DevMenuManager: NSObject {
         self.updateFABVisibility()
 
         if self.window?.windowScene == nil {
-          let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-          self.window?.windowScene = windowScene
+          self.window?.windowScene = SceneGeometry.foregroundActiveScene()
         }
         self.window?.makeKeyAndVisible()
       }
@@ -206,8 +204,7 @@ public class DevMenuManager: NSObject {
       guard let self else { return }
 
       if self.fabWindow == nil {
-        if let windowScene = UIApplication.shared.connectedScenes
-          .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+        if let windowScene = SceneGeometry.foregroundActiveScene() {
           self.setupFABWindowIfNeeded(for: windowScene)
         }
       }

--- a/apps/expo-go/ios/Exponent/DevMenu/DevMenuWindow.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/DevMenuWindow.swift
@@ -1,5 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
+import ExpoModulesCore
+
 @MainActor
 class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
   private let manager: DevMenuManager
@@ -11,7 +13,11 @@ class DevMenuWindow: UIWindow, UISheetPresentationControllerDelegate {
     self.manager = manager
     self.devMenuViewController = DevMenuViewController(manager: manager)
 
-    super.init(frame: UIScreen.main.bounds)
+    if let windowScene = SceneGeometry.foregroundActiveScene() {
+      super.init(windowScene: windowScene)
+    } else {
+      super.init(frame: .zero)
+    }
 
     self.rootViewController = UIViewController()
     self.backgroundColor = UIColor(white: 0, alpha: 0.4)

--- a/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABView.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABView.swift
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 import SwiftUI
+import ExpoModulesCore
 
 enum SnappedEdge {
   case left, right
@@ -231,11 +232,7 @@ struct DevMenuFABView: View {
 
   // Get safe area from window since .ignoresSafeArea() or initial render may zero out geometry values
   private var windowSafeArea: UIEdgeInsets {
-    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-          let window = windowScene.windows.first else {
-      return .zero
-    }
-    return window.safeAreaInsets
+    return SceneGeometry.keyWindow()?.safeAreaInsets ?? .zero
   }
 
   var body: some View {

--- a/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABWindow.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/FAB/DevMenuFABWindow.swift
@@ -2,6 +2,7 @@
 
 import UIKit
 import SwiftUI
+import ExpoModulesCore
 
 /// A passthrough window that hosts the floating action button.
 class DevMenuFABWindow: UIWindow {
@@ -50,8 +51,8 @@ class DevMenuFABWindow: UIWindow {
   }
 
   private var edgeTranslation: CGAffineTransform {
-    let screenWidth = windowScene?.screen.bounds.width ?? UIScreen.main.bounds.width
-    let isOnRight = fabFrame == .zero || fabFrame.midX > (screenWidth / 2)
+    let availableWidth = SceneGeometry.bounds(for: self).width
+    let isOnRight = fabFrame == .zero || fabFrame.midX > (availableWidth / 2)
     let dx: CGFloat = isOnRight ? 60 : -60
     return CGAffineTransform(translationX: dx, y: 0)
   }

--- a/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Views/Loading/EXAppLoadingProgressWindowController.m
@@ -15,6 +15,17 @@
 
 @end
 
+// `SceneGeometry` in ExpoModulesCore is a Swift enum, so it isn't reachable from Objective-C.
+static UIWindowScene *EXForegroundActiveWindowScene(void)
+{
+  for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+    if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+      return (UIWindowScene *)scene;
+    }
+  }
+  return nil;
+}
+
 @implementation EXAppLoadingProgressWindowController
 
 - (instancetype)initWithEnabled:(BOOL)enabled
@@ -36,13 +47,17 @@
   dispatch_async(dispatch_get_main_queue(), ^{
     EX_ENSURE_STRONGIFY(self);
     if (!self.window) {
-      CGSize screenSize = [UIScreen mainScreen].bounds.size;
+      UIWindowScene *windowScene = EXForegroundActiveWindowScene();
+      UIWindow *hostWindow = windowScene.keyWindow ?: windowScene.windows.firstObject;
+      CGSize windowSize = hostWindow.bounds.size;
+      CGFloat bottomInsets = hostWindow.safeAreaInsets.bottom;
 
-      int bottomInsets = RCTSharedApplication().keyWindow.safeAreaInsets.bottom;
-      self.window = [[UIWindow alloc] initWithFrame:CGRectMake(0,
-                                                               screenSize.height - 36 - bottomInsets,
-                                                               screenSize.width,
-                                                               36 + bottomInsets)];
+      self.window = windowScene ? [[UIWindow alloc] initWithWindowScene:windowScene]
+                                : [[UIWindow alloc] initWithFrame:CGRectZero];
+      self.window.frame = CGRectMake(0,
+                                     windowSize.height - 36 - bottomInsets,
+                                     windowSize.width,
+                                     36 + bottomInsets);
       self.window.windowLevel = UIWindowLevelStatusBar + 1;
       self.window.rootViewController = [EXAppLoadingProgressWindowViewController new];
       self.window.backgroundColor = [EXUtil colorWithRGB:0xfafafa];
@@ -51,12 +66,12 @@
       [self.window addSubview:containerView];
 
       CALayer *topBorderLayer = [CALayer layer];
-      topBorderLayer.frame = CGRectMake(0, 0, screenSize.width, 1);
+      topBorderLayer.frame = CGRectMake(0, 0, windowSize.width, 1);
       topBorderLayer.backgroundColor = [EXUtil colorWithRGB:0xe3e3e3].CGColor;
       [containerView.layer addSublayer:topBorderLayer];
 
       self.textLabel = [UILabel new];
-      self.textLabel.frame = CGRectMake(10, 0, screenSize.width - 20, 36);
+      self.textLabel.frame = CGRectMake(10, 0, windowSize.width - 20, 36);
       self.textLabel.font = [UIFont monospacedDigitSystemFontOfSize:12 weight:(UIFontWeightRegular)];
       self.textLabel.textAlignment = NSTextAlignmentLeft;
       self.textLabel.textColor = [EXUtil colorWithRGB:0xa7a7a7];

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/PerfMonitor/PerfMonitorModels.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/PerfMonitor/PerfMonitorModels.swift
@@ -3,6 +3,7 @@
 import Foundation
 import SwiftUI
 import UIKit
+import ExpoModulesCore
 
 enum PerfMonitorConstants {
   static let maxWidth: CGFloat = 360
@@ -139,7 +140,7 @@ final class PerfMonitorPresenter: NSObject {
     }
 
     let targetWidth = min(
-      UIScreen.main.bounds.width * PerfMonitorConstants.screenWidthRatio,
+      SceneGeometry.bounds(for: hostingController.view).width * PerfMonitorConstants.screenWidthRatio,
       PerfMonitorConstants.maxWidth
     )
     return NSValue(cgSize: CGSize(width: targetWidth, height: 176))

--- a/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/PerfMonitor/PerfMonitorView.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/PerfMonitor/PerfMonitorView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import UIKit
+import ExpoModulesCore
 
 struct PerfMonitorView: View {
   @ObservedObject var viewModel: PerfMonitorViewModel
@@ -13,7 +14,7 @@ struct PerfMonitorView: View {
   private static let borderColor = Color.white.opacity(0.08)
 
   private var cardWidth: CGFloat {
-    min(UIScreen.main.bounds.width * PerfMonitorConstants.screenWidthRatio, PerfMonitorConstants.maxWidth)
+    min(SceneGeometry.bounds().width * PerfMonitorConstants.screenWidthRatio, PerfMonitorConstants.maxWidth)
   }
 
   var body: some View {

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -165,6 +165,10 @@ PODS:
   - ExpoImageManipulator (56.0.15):
     - ExpoModulesCore
     - SDWebImageWebPCoder
+  - ExpoImageManipulator/Tests (56.0.15):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
+    - SDWebImageWebPCoder
   - ExpoImagePicker (56.0.14):
     - ExpoModulesCore
   - ExpoImagePicker/Tests (56.0.14):
@@ -4185,6 +4189,7 @@ DEPENDENCIES:
   - ExpoImage (from `../../../packages/expo-image/ios`)
   - ExpoImage/Tests (from `../../../packages/expo-image/ios`)
   - ExpoImageManipulator (from `../../../packages/expo-image-manipulator/ios`)
+  - ExpoImageManipulator/Tests (from `../../../packages/expo-image-manipulator/ios`)
   - ExpoImagePicker (from `../../../packages/expo-image-picker/ios`)
   - ExpoImagePicker/Tests (from `../../../packages/expo-image-picker/ios`)
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
@@ -4248,7 +4253,7 @@ DEPENDENCIES:
   - GoogleDataTransport
   - GoogleUtilities
   - hermes-engine (from `../../../react-native-lab/react-native/packages/react-native/sdks/hermes-engine/hermes-engine.podspec`)
-  - "lottie-react-native (from `../../../node_modules/.pnpm/lottie-react-native@7.3.8_@lottiefiles+dotlottie-react@0.13.5_react@19.2.3__react-nativ_c9fb061a55ccecab613bf2c96d8bd167/node_modules/lottie-react-native`)"
+  - "lottie-react-native (from `../../../node_modules/.pnpm/lottie-react-native@7.3.8_@lottiefiles+dotlottie-react@0.13.5_react@19.2.3__react-nativ_f470db34fe3f166dc7629c782c7d8437/node_modules/lottie-react-native`)"
   - MBProgressHUD (~> 1.2.0)
   - nanopb
   - RCT-Folly (from `../../../react-native-lab/react-native/packages/react-native/third-party-podspecs/RCT-Folly.podspec`)
@@ -4289,13 +4294,13 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon/react/nativemodule/microtasks`)
   - React-mutationobservernativemodule (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon/react/nativemodule/mutationobserver`)
-  - "react-native-keyboard-controller (from `../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.9_react-native-reanimated@4.5.1_patch_hash=f1adeb_51273a963e17690db8ba13cb8a40af98/node_modules/react-native-keyboard-controller`)"
-  - "react-native-maps/Maps (from `../../../node_modules/.pnpm/react-native-maps@1.27.2_react-native-web@0.21.2_encoding@0.1.13_react-dom@19.2.3_react_54eb92b05a5766976b391f39b48ecd24/node_modules/react-native-maps`)"
-  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_c62e1b8b8d4564a9c83ae42991bba29e/node_modules/@react-native-community/netinfo`)"
-  - "react-native-pager-view (from `../../../node_modules/.pnpm/react-native-pager-view@8.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest_47e3e27a9adf512837c99f978cef9022/node_modules/react-native-pager-view`)"
-  - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.0_@react-nati_5fbb277e95644896606144d0e4eeaf29/node_modules/react-native-safe-area-context`)"
-  - "react-native-segmented-control (from `../../../node_modules/.pnpm/@react-native-segmented-control+segmented-control@2.5.7_react-native@0.86.0_@babel+core_4424b9aab5547b4c569a512a06608564/node_modules/@react-native-segmented-control/segmented-control`)"
-  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_4e680bb5cec2f31eeb963af0cc5df7dd/node_modules/@shopify/react-native-skia`)"
+  - "react-native-keyboard-controller (from `../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.9_react-native-reanimated@4.5.1_patch_hash=f1adeb_9a349fcb8493a723edbedfbafcf73f19/node_modules/react-native-keyboard-controller`)"
+  - "react-native-maps/Maps (from `../../../node_modules/.pnpm/react-native-maps@1.27.2_react-native-web@0.21.2_encoding@0.1.13_react-dom@19.2.3_react_07670b4144253b002775c6adf1c85a39/node_modules/react-native-maps`)"
+  - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_66433ebdfb3ea787f7fc42b0ed8ee206/node_modules/@react-native-community/netinfo`)"
+  - "react-native-pager-view (from `../../../node_modules/.pnpm/react-native-pager-view@8.0.2_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest_050fee3d9ae7682571a8180ab6e58f1e/node_modules/react-native-pager-view`)"
+  - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.7_@react-nati_c28ea83fe184def3347ae322f545fd20/node_modules/react-native-safe-area-context`)"
+  - "react-native-segmented-control (from `../../../node_modules/.pnpm/@react-native-segmented-control+segmented-control@2.5.7_react-native@0.86.0_@babel+core_c6ef13c08c75131e283db5a3c9a036c4/node_modules/@react-native-segmented-control/segmented-control`)"
+  - "react-native-skia (from `../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_63e1a34e6ea8f3c3b971a952aacc46a1/node_modules/@shopify/react-native-skia`)"
   - "react-native-slider (from `../../../node_modules/.pnpm/@react-native-community+slider@5.2.0/node_modules/@react-native-community/slider`)"
   - react-native-view-shot (from `../modules/react-native-view-shot`)
   - react-native-webview (from `../modules/react-native-webview`)
@@ -4334,16 +4339,16 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios/ReactCodegen`)
   - ReactCommon/turbomodule/core (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../modules/@react-native-async-storage/async-storage`)"
-  - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view`)"
-  - "RNCPicker (from `../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.0_@react-native_df9b5bdf4983a534926d94e4f6b171c1/node_modules/@react-native-picker/picker`)"
-  - "RNDateTimePicker (from `../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_3410ef6ce3d9f843a98f5e317302287f/node_modules/@react-native-community/datetimepicker`)"
-  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_@babel+core@7.29.0_@react-native_f0957e3912a3002fa439f41439d8e38a/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated`)"
-  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.26.0_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-p_0de600cb780b6b45bea3c60febec69c4/node_modules/react-native-screens`)"
-  - "RNSVG (from `../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-pres_7db2513d16ccc60642452ad7fe65813d/node_modules/react-native-svg`)"
-  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_e98144a6c5d6242836167e9069761b53/node_modules/react-native-worklets`)"
+  - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.7_@rea_0b1cb48f64769e8cdee0e87c7385a41f/node_modules/@react-native-masked-view/masked-view`)"
+  - "RNCPicker (from `../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.7_@react-native_8f11d1ea8f0fd35d12338e84fc5ebe73/node_modules/@react-native-picker/picker`)"
+  - "RNDateTimePicker (from `../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_5988bfa80b1bbd47ddf5007ef6d2eedf/node_modules/@react-native-community/datetimepicker`)"
+  - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_@babel+core@7.29.7_@react-native_4aa76a0e73afa3150b371a7bceafc5bf/node_modules/react-native-gesture-handler`)"
+  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b6ef5a1d7ea42cde643b3b398d3f65d1/node_modules/react-native-reanimated`)"
+  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.26.0_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest-p_095d8f27a4d7296418051aaa10e4a8e3/node_modules/react-native-screens`)"
+  - "RNSVG (from `../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest-pres_100382bcc91f7310e67ae9af27ee7676/node_modules/react-native-svg`)"
+  - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_3c2da4b685ce12ff0e10894541b0a9fd/node_modules/react-native-worklets`)"
   - SocketRocket (~> 0.7.1)
-  - "stripe-react-native (from `../../../node_modules/.pnpm/@stripe+stripe-react-native@0.64.0_expo@packages+expo_react-native-webview@13.16.1_reac_1b651f5d850a77c7df154fb0380a03b9/node_modules/@stripe/stripe-react-native`)"
+  - "stripe-react-native (from `../../../node_modules/.pnpm/@stripe+stripe-react-native@0.64.0_expo@packages+expo_react-native-webview@13.16.1_reac_3c13e5735b9afe0361b2f46dc53f20d1/node_modules/@stripe/stripe-react-native`)"
   - UMAppLoader (from `../../../packages/unimodules-app-loader/ios`)
   - UMAppLoader/Tests (from `../../../packages/unimodules-app-loader/ios`)
   - Yoga (from `../../../react-native-lab/react-native/packages/react-native/ReactCommon/yoga`)
@@ -4547,7 +4552,7 @@ EXTERNAL SOURCES:
     :podspec: "../../../react-native-lab/react-native/packages/react-native/sdks/hermes-engine/hermes-engine.podspec"
     :tag: hermes-v250829098.0.14
   lottie-react-native:
-    :path: "../../../node_modules/.pnpm/lottie-react-native@7.3.8_@lottiefiles+dotlottie-react@0.13.5_react@19.2.3__react-nativ_c9fb061a55ccecab613bf2c96d8bd167/node_modules/lottie-react-native"
+    :path: "../../../node_modules/.pnpm/lottie-react-native@7.3.8_@lottiefiles+dotlottie-react@0.13.5_react@19.2.3__react-nativ_f470db34fe3f166dc7629c782c7d8437/node_modules/lottie-react-native"
   RCT-Folly:
     :podspec: "../../../react-native-lab/react-native/packages/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -4623,19 +4628,19 @@ EXTERNAL SOURCES:
   React-mutationobservernativemodule:
     :path: "../../../react-native-lab/react-native/packages/react-native/ReactCommon/react/nativemodule/mutationobserver"
   react-native-keyboard-controller:
-    :path: "../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.9_react-native-reanimated@4.5.1_patch_hash=f1adeb_51273a963e17690db8ba13cb8a40af98/node_modules/react-native-keyboard-controller"
+    :path: "../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.9_react-native-reanimated@4.5.1_patch_hash=f1adeb_9a349fcb8493a723edbedfbafcf73f19/node_modules/react-native-keyboard-controller"
   react-native-maps:
-    :path: "../../../node_modules/.pnpm/react-native-maps@1.27.2_react-native-web@0.21.2_encoding@0.1.13_react-dom@19.2.3_react_54eb92b05a5766976b391f39b48ecd24/node_modules/react-native-maps"
+    :path: "../../../node_modules/.pnpm/react-native-maps@1.27.2_react-native-web@0.21.2_encoding@0.1.13_react-dom@19.2.3_react_07670b4144253b002775c6adf1c85a39/node_modules/react-native-maps"
   react-native-netinfo:
-    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_c62e1b8b8d4564a9c83ae42991bba29e/node_modules/@react-native-community/netinfo"
+    :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@12.0.1_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_66433ebdfb3ea787f7fc42b0ed8ee206/node_modules/@react-native-community/netinfo"
   react-native-pager-view:
-    :path: "../../../node_modules/.pnpm/react-native-pager-view@8.0.2_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest_47e3e27a9adf512837c99f978cef9022/node_modules/react-native-pager-view"
+    :path: "../../../node_modules/.pnpm/react-native-pager-view@8.0.2_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest_050fee3d9ae7682571a8180ab6e58f1e/node_modules/react-native-pager-view"
   react-native-safe-area-context:
-    :path: "../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.0_@react-nati_5fbb277e95644896606144d0e4eeaf29/node_modules/react-native-safe-area-context"
+    :path: "../../../node_modules/.pnpm/react-native-safe-area-context@5.7.0_react-native@0.86.0_@babel+core@7.29.7_@react-nati_c28ea83fe184def3347ae322f545fd20/node_modules/react-native-safe-area-context"
   react-native-segmented-control:
-    :path: "../../../node_modules/.pnpm/@react-native-segmented-control+segmented-control@2.5.7_react-native@0.86.0_@babel+core_4424b9aab5547b4c569a512a06608564/node_modules/@react-native-segmented-control/segmented-control"
+    :path: "../../../node_modules/.pnpm/@react-native-segmented-control+segmented-control@2.5.7_react-native@0.86.0_@babel+core_c6ef13c08c75131e283db5a3c9a036c4/node_modules/@react-native-segmented-control/segmented-control"
   react-native-skia:
-    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_4e680bb5cec2f31eeb963af0cc5df7dd/node_modules/@shopify/react-native-skia"
+    :path: "../../../node_modules/.pnpm/@shopify+react-native-skia@2.6.2_patch_hash=ba884424a75156115606f768b005e5af9a39e9836f1_63e1a34e6ea8f3c3b971a952aacc46a1/node_modules/@shopify/react-native-skia"
   react-native-slider:
     :path: "../../../node_modules/.pnpm/@react-native-community+slider@5.2.0/node_modules/@react-native-community/slider"
   react-native-view-shot:
@@ -4713,23 +4718,23 @@ EXTERNAL SOURCES:
   RNCAsyncStorage:
     :path: "../modules/@react-native-async-storage/async-storage"
   RNCMaskedView:
-    :path: "../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.0_@rea_cf519709f40b69ef0ba3b80a98db0b39/node_modules/@react-native-masked-view/masked-view"
+    :path: "../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.86.0_@babel+core@7.29.7_@rea_0b1cb48f64769e8cdee0e87c7385a41f/node_modules/@react-native-masked-view/masked-view"
   RNCPicker:
-    :path: "../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.0_@react-native_df9b5bdf4983a534926d94e4f6b171c1/node_modules/@react-native-picker/picker"
+    :path: "../../../node_modules/.pnpm/@react-native-picker+picker@2.11.4_react-native@0.86.0_@babel+core@7.29.7_@react-native_8f11d1ea8f0fd35d12338e84fc5ebe73/node_modules/@react-native-picker/picker"
   RNDateTimePicker:
-    :path: "../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_3410ef6ce3d9f843a98f5e317302287f/node_modules/@react-native-community/datetimepicker"
+    :path: "../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.86.0_@ba_5988bfa80b1bbd47ddf5007ef6d2eedf/node_modules/@react-native-community/datetimepicker"
   RNGestureHandler:
-    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_@babel+core@7.29.0_@react-native_f0957e3912a3002fa439f41439d8e38a/node_modules/react-native-gesture-handler"
+    :path: "../../../node_modules/.pnpm/react-native-gesture-handler@3.1.0_react-native@0.86.0_@babel+core@7.29.7_@react-native_4aa76a0e73afa3150b371a7bceafc5bf/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_bcfe01e02589bb9be0f75e9d7d147503/node_modules/react-native-reanimated"
+    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.5.1_patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d_b6ef5a1d7ea42cde643b3b398d3f65d1/node_modules/react-native-reanimated"
   RNScreens:
-    :path: "../../../node_modules/.pnpm/react-native-screens@4.26.0_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-p_0de600cb780b6b45bea3c60febec69c4/node_modules/react-native-screens"
+    :path: "../../../node_modules/.pnpm/react-native-screens@4.26.0_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest-p_095d8f27a4d7296418051aaa10e4a8e3/node_modules/react-native-screens"
   RNSVG:
-    :path: "../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.0_@react-native+jest-pres_7db2513d16ccc60642452ad7fe65813d/node_modules/react-native-svg"
+    :path: "../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.86.0_@babel+core@7.29.7_@react-native+jest-pres_100382bcc91f7310e67ae9af27ee7676/node_modules/react-native-svg"
   RNWorklets:
-    :path: "../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_e98144a6c5d6242836167e9069761b53/node_modules/react-native-worklets"
+    :path: "../../../node_modules/.pnpm/react-native-worklets@0.10.1_patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501_3c2da4b685ce12ff0e10894541b0a9fd/node_modules/react-native-worklets"
   stripe-react-native:
-    :path: "../../../node_modules/.pnpm/@stripe+stripe-react-native@0.64.0_expo@packages+expo_react-native-webview@13.16.1_reac_1b651f5d850a77c7df154fb0380a03b9/node_modules/@stripe/stripe-react-native"
+    :path: "../../../node_modules/.pnpm/@stripe+stripe-react-native@0.64.0_expo@packages+expo_react-native-webview@13.16.1_reac_3c13e5735b9afe0361b2f46dc53f20d1/node_modules/@stripe/stripe-react-native"
   UMAppLoader:
     :path: "../../../packages/unimodules-app-loader/ios"
   Yoga:
@@ -4769,7 +4774,7 @@ SPEC CHECKSUMS:
   ExpoGlassEffect: 7d4233dc0727ee2b28dd757eda70e1b6abf662fd
   ExpoHaptics: 89364cf3c3ca2cfd54cafed42f3be3169bab6d42
   ExpoImage: 3f44073bf450afdb87333f9671ffe7b9bfa5f70e
-  ExpoImageManipulator: 441ca8a28fe700c5948863772578bab2ffd79e77
+  ExpoImageManipulator: 00e382cd32da78b9162cff710953f6e35bd6460c
   ExpoImagePicker: 25027f16965fca672abf93c2a79d22e71527b53f
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
@@ -4784,7 +4789,7 @@ SPEC CHECKSUMS:
   ExpoModulesJSI: f25a013ea9a79904bdd535e4bea0872e155cde09
   ExpoModulesTestCore: 768a9a2b0401e87090bc7280cdb0607ab4cad382
   ExpoModulesWorklets: 874ceeb92a8da1dfa32adf197aa65f926e74b9c5
-  ExpoModulesWorkletsAdapter: 15d9ad3876be51248caa6241d629a8892a945b7c
+  ExpoModulesWorkletsAdapter: fad365939baece1af888494a70a5784da1e0f13e
   ExpoNetwork: d244aa406eb0aba7e36e5f009a061b2744ab11d7
   ExpoNotifications: 4f6324955cea640a65f40c67a8e42505a6a514b7
   ExpoPrint: 6b5bcac4492908b7e28144c2e7265c1c5ee4ade0
@@ -4923,10 +4928,10 @@ SPEC CHECKSUMS:
   RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
   RNGestureHandler: d9aaa02b8cdfc140cc27bd79cb76936e827f6a17
-  RNReanimated: f06a7e844a5ca4178837f6663e151620eac9f513
+  RNReanimated: f48581c623af353394b1ec1cc5d9f7e6c0646693
   RNScreens: abcfa9ad7536fcd68ad6c14c8e7d4b5af8ac3f33
   RNSVG: c6acd5c597d26625214295105756c5e488f5ae4c
-  RNWorklets: a872cc4564ec764b121a1c88c1c7bae69c508311
+  RNWorklets: c081a75b6c836c87ed3546b6b68313bc8286a0df
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c


### PR DESCRIPTION
# Why

The loading progress window was created with `initWithFrame:`, so it was never attached to a scene, and it sized itself from `[UIScreen mainScreen].bounds`. Under iOS 27 resizing it lands off the bottom of a resized window and at the wrong width. It also read the deprecated `UIApplication.keyWindow` for its safe area inset.

# How

Attach it to the foreground-active scene and size it from that scene's key window.

`SceneGeometry` is a Swift enum, so it is not reachable from Objective-C. Hence the local scene lookup rather than reusing it, which is what the comment on the helper is there to explain.

`bottomInsets` also changes from `int` to `CGFloat`, so the inset is no longer truncated. In practice it is a whole number on every device that has one.

# Test Plan

Load a project in Expo Go and watch the progress bar along the bottom. It should sit flush with the bottom of the app's window and span its full width.
