### PR TITLE
[router] Make js-tabs and js-top-tabs usable in RSC and add RSC tests

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
 - Redirect fully guarded navigators to parent ([#47984](https://github.com/expo/expo/pull/47984) by [@Ubax](https://github.com/Ubax))
 - Unset `nativeContainerStyle` in transparent presentations ([#48154](https://github.com/expo/expo/pull/48154) by [@Ubax](https://github.com/Ubax))
 - [android] Disable safe area insets in Native Tabs on Android when tab bar is hidden. ([#47611](https://github.com/expo/expo/pull/47611) by [@debitan](https://github.com/debitan))

--- a/packages/expo-router/src/layouts/Tabs.tsx
+++ b/packages/expo-router/src/layouts/Tabs.tsx
@@ -1,9 +1,32 @@
+import { Protected } from '../views/Protected';
 import { Screen } from '../views/Screen';
 import Tabs from './TabsClient';
 
-export * from '../react-navigation/bottom-tabs';
+export {
+  createBottomTabNavigator,
+  BottomTabBar,
+  BottomTabView,
+  BottomTabBarHeightCallbackContext,
+  BottomTabBarHeightContext,
+  useBottomTabBarHeight,
+} from './TabsClient';
+export * as SceneStyleInterpolators from '../react-navigation/bottom-tabs/TransitionConfigs/SceneStyleInterpolators';
+export * as TransitionPresets from '../react-navigation/bottom-tabs/TransitionConfigs/TransitionPresets';
+export * as TransitionSpecs from '../react-navigation/bottom-tabs/TransitionConfigs/TransitionSpecs';
+export type {
+  BottomTabBarButtonProps,
+  BottomTabBarProps,
+  BottomTabHeaderProps,
+  BottomTabNavigationEventMap,
+  BottomTabNavigationOptions,
+  BottomTabNavigationProp,
+  BottomTabNavigatorProps,
+  BottomTabOptionsArgs,
+  BottomTabScreenProps,
+} from '../react-navigation/bottom-tabs';
 
 Tabs.Screen = Screen;
+Tabs.Protected = Protected;
 
 export { Tabs };
 

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -14,6 +14,9 @@ import type { Href } from '../types';
 import { Protected } from '../views/Protected';
 import { withLayoutContext } from './withLayoutContext';
 
+// Keep React Navigation client-only so the entry evaluates in React Server Components.
+export * from '../react-navigation/bottom-tabs';
+
 // This is the only way to access the navigator.
 const BottomTabNavigator = createBottomTabNavigator().Navigator;
 

--- a/packages/expo-router/src/layouts/TopTabs.tsx
+++ b/packages/expo-router/src/layouts/TopTabs.tsx
@@ -1,10 +1,26 @@
+import { Protected } from '../views/Protected';
 import { Screen } from '../views/Screen';
 import TopTabs from './TopTabsClient';
 
 TopTabs.Screen = Screen;
+TopTabs.Protected = Protected;
 
 export { TopTabs };
 
-export * from '../react-navigation/material-top-tabs';
+export {
+  createMaterialTopTabNavigator,
+  MaterialTopTabBar,
+  MaterialTopTabView,
+  useTabAnimation,
+} from './TopTabsClient';
+export type {
+  MaterialTopTabBarProps,
+  MaterialTopTabNavigationEventMap,
+  MaterialTopTabNavigationOptions,
+  MaterialTopTabNavigationProp,
+  MaterialTopTabNavigatorProps,
+  MaterialTopTabOptionsArgs,
+  MaterialTopTabScreenProps,
+} from '../react-navigation/material-top-tabs';
 
 export default TopTabs;

--- a/packages/expo-router/src/layouts/TopTabsClient.tsx
+++ b/packages/expo-router/src/layouts/TopTabsClient.tsx
@@ -12,6 +12,9 @@ import { Protected } from '../views/Protected';
 import { Screen } from '../views/Screen';
 import { withLayoutContext } from './withLayoutContext';
 
+// Keep React Navigation client-only so the entry evaluates in React Server Components.
+export * from '../react-navigation/material-top-tabs';
+
 const MaterialTopTabNavigator = createMaterialTopTabNavigator().Navigator;
 
 const MaterialTopTabs = withLayoutContext<

--- a/packages/expo-router/src/layouts/__rsc_tests__/Tabs.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/Tabs.test.tsx
@@ -1,0 +1,52 @@
+/// <reference types="jest-expo/rsc/expect" />
+
+import Tabs, {
+  BottomTabBar,
+  BottomTabBarHeightCallbackContext,
+  BottomTabBarHeightContext,
+  BottomTabView,
+  SceneStyleInterpolators,
+  TransitionPresets,
+  TransitionSpecs,
+  createBottomTabNavigator,
+  useBottomTabBarHeight,
+} from '../Tabs';
+
+function expectClientReference(value: unknown) {
+  expect((value as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.client.reference'));
+}
+
+it('resolves React Navigation exports as client references', () => {
+  expectClientReference(createBottomTabNavigator);
+  expectClientReference(BottomTabBar);
+  expectClientReference(BottomTabView);
+  expectClientReference(BottomTabBarHeightCallbackContext);
+  expectClientReference(BottomTabBarHeightContext);
+  expectClientReference(useBottomTabBarHeight);
+});
+
+it('resolves transition namespaces on the server', () => {
+  expect(TransitionPresets.ShiftTransition).toBeDefined();
+  const fadeConfig = TransitionSpecs.FadeSpec.config as { easing?: unknown };
+  expect(fadeConfig).toMatchObject({ duration: 150 });
+  if (process.env.EXPO_OS === 'web') {
+    // react-native-web's `Easing` works on the server.
+    expect(fadeConfig.easing).toBeInstanceOf(Function);
+  } else {
+    // On native, `easing` still needs the client — `Easing` is only resolved when read.
+    expect(() => fadeConfig.easing).toThrow();
+  }
+  expect(SceneStyleInterpolators.forFade).toBeInstanceOf(Function);
+});
+
+it(`renders Tabs`, async () => {
+  await expect(<Tabs />).toMatchFlightSnapshot();
+});
+
+it(`renders Tabs.Screen`, async () => {
+  await expect(<Tabs.Screen options={{ title: '...' }} />).toMatchFlightSnapshot();
+});
+
+it(`renders Tabs.Protected`, async () => {
+  await expect(<Tabs.Protected guard={false} />).toMatchFlightSnapshot();
+});

--- a/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
@@ -1,0 +1,33 @@
+/// <reference types="jest-expo/rsc/expect" />
+
+import TopTabs, {
+  MaterialTopTabBar,
+  MaterialTopTabView,
+  createMaterialTopTabNavigator,
+  useTabAnimation,
+} from '../TopTabs';
+
+// The module proxy answers any property name, so `toBeDefined()` would pass even for a dropped
+// export. Assert the client-reference marker to pin that these crossed a client boundary.
+function expectClientReference(value: unknown) {
+  expect((value as { $$typeof?: symbol }).$$typeof).toBe(Symbol.for('react.client.reference'));
+}
+
+it('resolves React Navigation exports as client references', () => {
+  expectClientReference(createMaterialTopTabNavigator);
+  expectClientReference(MaterialTopTabBar);
+  expectClientReference(MaterialTopTabView);
+  expectClientReference(useTabAnimation);
+});
+
+it(`renders TopTabs`, async () => {
+  await expect(<TopTabs />).toMatchFlightSnapshot();
+});
+
+it(`renders TopTabs.Screen`, async () => {
+  await expect(<TopTabs.Screen options={{ title: '...' }} />).toMatchFlightSnapshot();
+});
+
+it(`renders TopTabs.Protected`, async () => {
+  await expect(<TopTabs.Protected guard={false} />).toMatchFlightSnapshot();
+});

--- a/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.android
+++ b/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.android
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders TopTabs 1`] = `
-"1:I["src/layouts/TopTabsClient.tsx",[],"",1]
+exports[`renders Tabs 1`] = `
+"1:I["src/layouts/TabsClient.tsx",[],"",1]
 0:["$","$L1",null,{},null]"
 `;
 
-exports[`renders TopTabs.Protected 1`] = `
+exports[`renders Tabs.Protected 1`] = `
 "1:I["src/primitives/navigation.tsx",[],"Group",1]
 0:["$","$L1",null,{"guard":false},null]"
 `;
 
-exports[`renders TopTabs.Screen 1`] = `
+exports[`renders Tabs.Screen 1`] = `
 "1:I["src/views/Screen.tsx",[],"Screen",1]
 0:["$","$L1",null,{"options":{"title":"..."}},null]"
 `;

--- a/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.ios
+++ b/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.ios
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders TopTabs 1`] = `
-"1:I["src/layouts/TopTabsClient.tsx",[],"",1]
+exports[`renders Tabs 1`] = `
+"1:I["src/layouts/TabsClient.tsx",[],"",1]
 0:["$","$L1",null,{},null]"
 `;
 
-exports[`renders TopTabs.Protected 1`] = `
+exports[`renders Tabs.Protected 1`] = `
 "1:I["src/primitives/navigation.tsx",[],"Group",1]
 0:["$","$L1",null,{"guard":false},null]"
 `;
 
-exports[`renders TopTabs.Screen 1`] = `
+exports[`renders Tabs.Screen 1`] = `
 "1:I["src/views/Screen.tsx",[],"Screen",1]
 0:["$","$L1",null,{"options":{"title":"..."}},null]"
 `;

--- a/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.web
+++ b/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/Tabs.test.tsx.snap.web
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders TopTabs 1`] = `
-"1:I["src/layouts/TopTabsClient.tsx",[],"",1]
+exports[`renders Tabs 1`] = `
+"1:I["src/layouts/TabsClient.tsx",[],"",1]
 0:["$","$L1",null,{},null]"
 `;
 
-exports[`renders TopTabs.Protected 1`] = `
+exports[`renders Tabs.Protected 1`] = `
 "1:I["src/primitives/navigation.tsx",[],"Group",1]
 0:["$","$L1",null,{"guard":false},null]"
 `;
 
-exports[`renders TopTabs.Screen 1`] = `
+exports[`renders Tabs.Screen 1`] = `
 "1:I["src/views/Screen.tsx",[],"Screen",1]
 0:["$","$L1",null,{"options":{"title":"..."}},null]"
 `;

--- a/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/TopTabs.test.tsx.snap.ios
+++ b/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/TopTabs.test.tsx.snap.ios
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders to RSC 1`] = `
+exports[`renders TopTabs 1`] = `
+"1:I["src/layouts/TopTabsClient.tsx",[],"",1]
+0:["$","$L1",null,{},null]"
+`;
+
+exports[`renders TopTabs.Protected 1`] = `
+"1:I["src/primitives/navigation.tsx",[],"Group",1]
+0:["$","$L1",null,{"guard":false},null]"
+`;
+
+exports[`renders TopTabs.Screen 1`] = `
 "1:I["src/views/Screen.tsx",[],"Screen",1]
 0:["$","$L1",null,{"options":{"title":"..."}},null]"
 `;

--- a/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/TopTabs.test.tsx.snap.web
+++ b/packages/expo-router/src/layouts/__rsc_tests__/__snapshots__/TopTabs.test.tsx.snap.web
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders to RSC 1`] = `
+exports[`renders TopTabs 1`] = `
+"1:I["src/layouts/TopTabsClient.tsx",[],"",1]
+0:["$","$L1",null,{},null]"
+`;
+
+exports[`renders TopTabs.Protected 1`] = `
+"1:I["src/primitives/navigation.tsx",[],"Group",1]
+0:["$","$L1",null,{"guard":false},null]"
+`;
+
+exports[`renders TopTabs.Screen 1`] = `
 "1:I["src/views/Screen.tsx",[],"Screen",1]
 0:["$","$L1",null,{"options":{"title":"..."}},null]"
 `;

--- a/packages/expo-router/src/layouts/__tests__/Tabs-exports.test.tsx
+++ b/packages/expo-router/src/layouts/__tests__/Tabs-exports.test.tsx
@@ -1,0 +1,27 @@
+import * as VendoredTabs from '../../react-navigation/bottom-tabs';
+import * as TabsEntry from '../Tabs';
+
+describe('expo-router/js-tabs re-exports', () => {
+  it('re-exports every value from ../react-navigation/bottom-tabs', () => {
+    const missing = Object.keys(VendoredTabs).filter((key) => !(key in TabsEntry));
+    expect(missing).toEqual([]);
+  });
+
+  it('exports the Tabs navigator with its static components', () => {
+    expect(TabsEntry.Tabs).toBeDefined();
+    expect(TabsEntry.default).toBe(TabsEntry.Tabs);
+    expect(TabsEntry.Tabs.Screen).toBeDefined();
+    expect(TabsEntry.Tabs.Protected).toBeDefined();
+  });
+
+  it('resolves transition easing lazily', () => {
+    expect(TabsEntry.TransitionSpecs.FadeSpec.config).toMatchObject({
+      duration: 150,
+      easing: expect.any(Function),
+    });
+    expect(TabsEntry.TransitionSpecs.ShiftSpec.config).toMatchObject({
+      duration: 150,
+      easing: expect.any(Function),
+    });
+  });
+});

--- a/packages/expo-router/src/layouts/__tests__/TopTabs-exports.test.tsx
+++ b/packages/expo-router/src/layouts/__tests__/TopTabs-exports.test.tsx
@@ -1,0 +1,16 @@
+import * as vendored from '../../react-navigation/material-top-tabs';
+import * as entry from '../TopTabs';
+
+describe('expo-router/js-top-tabs re-exports', () => {
+  it('re-exports every value from ../react-navigation/material-top-tabs', () => {
+    const missing = Object.keys(vendored).filter((key) => !(key in entry));
+    expect(missing).toEqual([]);
+  });
+
+  it('exports the TopTabs navigator with its static components', () => {
+    expect(entry.TopTabs).toBeDefined();
+    expect(entry.default).toBe(entry.TopTabs);
+    expect(entry.TopTabs.Screen).toBeDefined();
+    expect(entry.TopTabs.Protected).toBeDefined();
+  });
+});

--- a/packages/expo-router/src/react-navigation/bottom-tabs/TransitionConfigs/TransitionSpecs.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/TransitionConfigs/TransitionSpecs.tsx
@@ -6,7 +6,11 @@ export const FadeSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 150,
-    easing: Easing.in(Easing.linear),
+    // Resolve lazily so this module evaluates in React Server Components.
+    // Reading `easing` still needs the client on native — `Easing` throws on the server there.
+    get easing() {
+      return Easing.in(Easing.linear);
+    },
   },
 };
 
@@ -14,6 +18,10 @@ export const ShiftSpec: TransitionSpec = {
   animation: 'timing',
   config: {
     duration: 150,
-    easing: Easing.inOut(Easing.ease),
+    // Resolve lazily so this module evaluates in React Server Components.
+    // Reading `easing` still needs the client on native — `Easing` throws on the server there.
+    get easing() {
+      return Easing.inOut(Easing.ease);
+    },
   },
 };

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
@@ -9,6 +9,7 @@ jest.mock(
 );
 
 test('throws an error when react-native-tab-view is not installed', () => {
+  jest.resetModules();
   jest.doMock('react-native-tab-view', () => {
     throw new Error();
   });


### PR DESCRIPTION
# Why

JS Tabs and Top Tab are currently not usable in RSC

# How

1. Evaluate client side code for animation easing lazily
2. Fix exports
3. Update RSC tests

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)