### PR TITLE
[autolinking][Android] Support linking published Gradle plugins

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
+- [Android] Support linking published Gradle plugins. ([#48334](https://github.com/expo/expo/pull/48334) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -146,7 +146,7 @@ data class GradlePlugin(
   val classpathCoordinate: String
     get() = when {
       sourceDir != null -> "$group:$id"
-      version != null -> "$group:$id:$version"
+      version != null -> "$id:$id.gradle.plugin:$version"
       else -> throw IllegalArgumentException(
         "The gradle plugin '$id' declares neither a 'sourceDir' nor a 'version'."
       )

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/main/kotlin/expo/modules/plugin/configuration/ExpoAutolinkingConfig.kt
@@ -130,15 +130,28 @@ data class ModuleInfo(
 )
 
 /**
- * Object representing a gradle plugin
+ * Object representing a gradle plugin.
+ *
+ * A plugin is either built from sources shipped with the module ([sourceDir] is set and the
+ * build is included into the project) or resolved from a published artifact ([version] is set).
  */
 @Serializable
 data class GradlePlugin(
   val id: String,
   val group: String,
-  val sourceDir: String,
+  val sourceDir: String? = null,
+  val version: String? = null,
   val applyToRootProject: Boolean = true
-)
+) {
+  val classpathCoordinate: String
+    get() = when {
+      sourceDir != null -> "$group:$id"
+      version != null -> "$group:$id:$version"
+      else -> throw IllegalArgumentException(
+        "The gradle plugin '$id' declares neither a 'sourceDir' nor a 'version'."
+      )
+    }
+}
 
 /**
  * Object representing a gradle project containing AAR file

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
@@ -68,8 +68,6 @@ class ExpoAutolinkingConfigTest {
 
     Truth.assertThat(expoModule.projects.firstOrNull()?.sourceDir)
       .isEqualTo("/Users/lukasz/work/expo/packages/expo/android")
-    Truth.assertThat(expoModule.modules.firstOrNull())
-      .isEqualTo("expo.modules.fetch.ExpoFetchModule")
 
     Truth.assertThat(expoNetworkAddonsModule.projects.firstOrNull()?.sourceDir)
       .isEqualTo("/Users/lukasz/work/expo/packages/expo-network-addons/android")
@@ -143,5 +141,37 @@ class ExpoAutolinkingConfigTest {
     val awsCredentials = repo3.credentials as AWSMavenCredentials
     Truth.assertThat(awsCredentials.accessKey).isEqualTo("accessKey")
     Truth.assertThat(awsCredentials.secretKey).isEqualTo("secretKey")
+  }
+
+  @Test
+  fun `can deserialize published gradle plugin`() {
+    // language=JSON
+    val mockedConfig = """
+{
+  "extraDependencies": [],
+  "modules": [
+    {
+      "packageName": "expo-third-party",
+      "packageVersion": "1.0.0",
+      "projects": [],
+      "plugins": [
+        {
+          "id": "some-plugin",
+          "group": "io.github.example",
+          "version": "1.0.0",
+          "applyToRootProject": true
+        }
+      ]
+    }
+  ]
+}
+    """.trimIndent()
+
+    val config = ExpoAutolinkingConfig.decodeFromString(mockedConfig)
+    val plugin = config.allPlugins.single()
+
+    Truth.assertThat(plugin.sourceDir).isNull()
+    Truth.assertThat(plugin.classpathCoordinate)
+      .isEqualTo("io.github.example:some-plugin:1.0.0")
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-plugin-shared/src/test/kotlin/com/modules/plugin/connfiguration/ExpoAutolinkingConfigTest.kt
@@ -156,7 +156,7 @@ class ExpoAutolinkingConfigTest {
       "projects": [],
       "plugins": [
         {
-          "id": "some-plugin",
+          "id": "io.github.example.some-plugin",
           "group": "io.github.example",
           "version": "1.0.0",
           "applyToRootProject": true
@@ -172,6 +172,8 @@ class ExpoAutolinkingConfigTest {
 
     Truth.assertThat(plugin.sourceDir).isNull()
     Truth.assertThat(plugin.classpathCoordinate)
-      .isEqualTo("io.github.example:some-plugin:1.0.0")
+      .isEqualTo(
+        "io.github.example.some-plugin:io.github.example.some-plugin.gradle.plugin:1.0.0"
+      )
   }
 }

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/ProjectExtension.kt
@@ -17,7 +17,7 @@ internal fun Project.applyAarProject(aarProject: GradleAarProject) {
 }
 
 internal fun Project.linkBuildDependence(plugin: GradlePlugin) {
-  buildscript.dependencies.add("classpath", "${plugin.group}:${plugin.id}")
+  buildscript.dependencies.add("classpath", plugin.classpathCoordinate)
 }
 
 internal fun Project.linkLocalMavenRepository(path: String, publications: List<Publication>) {

--- a/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/SettingsExtension.kt
+++ b/packages/expo-modules-autolinking/android/expo-gradle-plugin/expo-autolinking-settings-plugin/src/main/kotlin/expo/modules/plugin/gradle/SettingsExtension.kt
@@ -20,7 +20,9 @@ internal fun Settings.linkProject(project: GradleProject) {
 }
 
 internal fun Settings.linkPlugin(plugin: GradlePlugin) {
-  includeBuild(File(plugin.sourceDir))
+  // Published plugins are resolved from a maven repository instead of an included build.
+  val sourceDir = plugin.sourceDir ?: return
+  includeBuild(File(sourceDir))
 }
 
 internal fun Settings.linkAarProject(aarProject: GradleAarProject) {

--- a/packages/expo-modules-autolinking/src/platforms/android/android.ts
+++ b/packages/expo-modules-autolinking/src/platforms/android/android.ts
@@ -38,12 +38,19 @@ export async function resolveModuleAsync(
   }
 
   const plugins = (revision.config?.androidGradlePlugins() ?? []).map(
-    ({ id, group, sourceDir, applyToRootProject }) => ({
-      id,
-      group,
-      sourceDir: path.join(revision.path, sourceDir),
-      applyToRootProject: applyToRootProject ?? true,
-    })
+    ({ id, group, sourceDir, version, applyToRootProject }) =>
+      sourceDir
+        ? {
+            id,
+            group,
+            sourceDir: path.join(revision.path, sourceDir),
+            applyToRootProject,
+          }
+        : { id,
+            group,
+            version,
+            applyToRootProject,
+          }
   );
 
   const defaultProjectName = convertPackageToProjectName(packageName);

--- a/packages/expo-modules-autolinking/src/platforms/android/android.ts
+++ b/packages/expo-modules-autolinking/src/platforms/android/android.ts
@@ -46,11 +46,7 @@ export async function resolveModuleAsync(
             sourceDir: path.join(revision.path, sourceDir),
             applyToRootProject,
           }
-        : { id,
-            group,
-            version,
-            applyToRootProject,
-          }
+        : { id, group, version, applyToRootProject }
   );
 
   const defaultProjectName = convertPackageToProjectName(packageName);

--- a/packages/expo-modules-autolinking/src/types.ts
+++ b/packages/expo-modules-autolinking/src/types.ts
@@ -45,7 +45,10 @@ export interface ModuleAndroidModuleInfo {
 
 export interface ModuleAndroidPluginInfo {
   id: string;
-  sourceDir: string;
+  group: string;
+  sourceDir?: string;
+  version?: string;
+  applyToRootProject?: boolean;
 }
 
 export interface ModuleAndroidAarProjectInfo extends AndroidGradleAarProjectDescriptor {
@@ -127,7 +130,13 @@ export interface AndroidGradlePluginDescriptor {
   /**
    * Relative path to the gradle plugin directory
    */
-  sourceDir: string;
+  sourceDir?: string;
+
+  /**
+   * Version of a published gradle plugin.
+   * Ignored when `sourceDir` is declared.
+   */
+  version?: string;
 
   /**
    * Whether to apply the plugin to the root project


### PR DESCRIPTION
# Why

It should be possible to apply a published gradle plugin instead of manually creating a source wrapper for it.

# How

Support linking published Gradle plugins. A `gradlePlugins` entry in `expo-module.config.json` can now declare a `version` instead of `sourceDir` to resolve the plugin from a Maven repository. `sourceDir` takes precedence when both are declared.

Published plugins resolve through the Gradle plugin marker artifact (`<id>:<id>.gradle.plugin:<version>`) — the same lookup Gradle's own `plugins {}` DSL uses, so it works for any plugin published with `java-gradle-plugin` or the Plugin Portal.

Example:

```json
"gradlePlugins": [
  {
    "id": "io.github.jakex7.peek.glance-fork",
    "group": "io.github.jakex7.peek",
    "version": "0.2.0"
  }
]
```

# Test Plan

Tests should pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)