### PR TITLE
[docs][gh] Add SDK beta docs cutoff script and workflow

### DIFF
--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -1,0 +1,120 @@
+name: Docs SDK Beta
+
+defaults:
+  run:
+    shell: bash
+
+on:
+  workflow_call:
+    inputs:
+      sdkVersion:
+        description: 'Enter the SDK version'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      sdkVersion:
+        description: 'Enter the SDK version'
+        required: true
+      reactNative:
+        description: 'React Native version for the compatibility row, for example 0.87'
+        required: false
+        default: ''
+      dryRun:
+        description: 'Validate and print the plan without writing anything'
+        type: boolean
+        default: false
+  pull_request:
+    paths:
+      - '.github/workflows/docs-sdk-beta.yml'
+      - 'docs/scripts/sdk-release/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # JS-only job, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
+  SKIP_SKIA_DOWNLOAD: '1'
+  SDK_VERSION: ${{ inputs.sdkVersion || '99' }}
+  DRY_RUN: ${{ github.event_name != 'workflow_dispatch' || inputs.dryRun }}
+
+jobs:
+  beta:
+    if: github.repository == 'expo/expo'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: 🏗️ Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10
+      - name: ⬢ Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+      - name: ♻️ Restore caches
+        uses: ./.github/actions/expo-caches
+        id: expo-caches
+        with:
+          pnpm-docs: 'true'
+          docs-api-data: 'true'
+      - name: 📦 Install workspace deps
+        run: pnpm install --ignore-scripts --frozen-lockfile
+      - name: 📦 Install tools deps
+        working-directory: tools
+        run: pnpm install --ignore-scripts --frozen-lockfile
+      - name: 📦 Install docs deps
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+      - name: ➕ Add `bin` to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 🛠 Build expotools
+        run: pnpm turbo build --filter expotools...
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
+      - name: ✂️ Cut beta docs
+        id: beta
+        working-directory: docs
+        run: |
+          args=(--sdk "$SDK_VERSION")
+          if [[ "$DRY_RUN" == 'true' ]]; then
+            args+=(--dry-run)
+          fi
+          if [[ -n "${{ inputs.reactNative }}" ]]; then
+            args+=(--set "react-native=${{ inputs.reactNative }}")
+          fi
+          result="$(pnpm --silent sdk-beta "${args[@]}" | tail -n1)"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+      - name: 📝 Create Pull Request
+        if: ${{ !fromJSON(steps.beta.outputs.result).dryRun && fromJSON(steps.beta.outputs.result).hasChanged }}
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          branch: bot/docs-sdk-${{ fromJSON(steps.beta.outputs.result).sdkVersion }}-beta
+          base: main
+          commit-message: ${{ fromJSON(steps.beta.outputs.result).commitMessage }}
+          title: ${{ fromJSON(steps.beta.outputs.result).title }}
+          body: ${{ fromJSON(steps.beta.outputs.result).body }}
+          labels: |
+            docs
+            preview
+          assignees: amandeepmittal
+          delete-branch: true
+          committer: Expo Bot <expo-bot@users.noreply.github.com>
+          author: Expo Bot <expo-bot@users.noreply.github.com>
+      - name: 🚨 Surface step failures
+        if: ${{ fromJSON(steps.beta.outputs.result).failedCount != 0 }}
+        run: |
+          echo "::error::Some beta cutoff steps failed. Check the 'Cut beta docs' step log for details."
+          exit 1
+      - name: 🔔 Notify on Slack
+        if: failure() && github.event_name != 'pull_request'
+        uses: ./.github/actions/slack-notify
+        with:
+          webhook: ${{ secrets.slack_webhook_docs }}
+          channel: '#docs'
+          author_name: Docs SDK beta

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -129,9 +129,7 @@ jobs:
         with:
           token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           branch: bot/docs-sdk-${{ fromJSON(steps.beta.outputs.result).sdkVersion }}-beta
-          # TEMP(demo): revert to plain `base: main`. Targeting the feature branch
-          # keeps the demo PR limited to the demo commits.
-          base: ${{ github.head_ref || 'main' }}
+          base: main
           commit-message: ${{ fromJSON(steps.beta.outputs.result).commitMessage }}
           title: ${{ fromJSON(steps.beta.outputs.result).title }}
           body: ${{ fromJSON(steps.beta.outputs.result).body }}
@@ -149,7 +147,7 @@ jobs:
           echo "::error::Some beta cutoff steps failed. Check the 'Cut beta docs' step log for details."
           exit 1
       - name: 🔔 Notify on Slack
-        if: failure()
+        if: ${{ failure() && github.event_name != 'pull_request' }} # TEMP(demo): revert to plain failure()
         uses: ./.github/actions/slack-notify
         with:
           webhook: ${{ secrets.slack_webhook_docs }}

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -111,9 +111,9 @@ jobs:
         working-directory: docs
         run: |
           args=(--sdk "$SDK_VERSION" --commit-per-step)
-          # TEMP(demo): pull_request runs exercise the demo steps, not a real cut.
+          # TEMP(demo): pull_request runs dry-run the real steps as a self-test.
           if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
-            args+=(--demo)
+            args+=(--dry-run)
           fi
           if [[ "$DRY_RUN" == 'true' ]]; then
             args+=(--dry-run)

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -11,6 +11,15 @@ on:
         description: 'Enter the SDK version'
         required: true
         type: string
+      reactNative:
+        description: 'React Native version for the compatibility row, for example 0.87'
+        required: false
+        default: ''
+        type: string
+      dryRun:
+        description: 'Validate and print the plan without writing anything'
+        type: boolean
+        default: false
   workflow_dispatch:
     inputs:
       sdkVersion:
@@ -34,6 +43,7 @@ env:
   SKIP_SKIA_DOWNLOAD: '1'
   SDK_VERSION: ${{ inputs.sdkVersion }}
   DRY_RUN: ${{ inputs.dryRun }}
+  REACT_NATIVE: ${{ inputs.reactNative }}
 
 jobs:
   beta:
@@ -84,8 +94,8 @@ jobs:
           if [[ "$DRY_RUN" == 'true' ]]; then
             args+=(--dry-run)
           fi
-          if [[ -n "${{ inputs.reactNative }}" ]]; then
-            args+=(--set "react-native=${{ inputs.reactNative }}")
+          if [[ -n "$REACT_NATIVE" ]]; then
+            args+=(--set "react-native=$REACT_NATIVE")
           fi
           result="$(pnpm --silent sdk-beta "${args[@]}" | tail -n1)"
           echo "result=$result" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -36,12 +36,12 @@ concurrency:
 env:
   # JS-only job, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
   SKIP_SKIA_DOWNLOAD: '1'
-  SDK_VERSION: ${{ inputs.sdkVersion || '99' }}
-  DRY_RUN: ${{ github.event_name != 'workflow_dispatch' || inputs.dryRun }}
+  SDK_VERSION: ${{ inputs.sdkVersion || '58' }}
+  DRY_RUN: ${{ inputs.dryRun || false }}
 
 jobs:
   beta:
-    if: github.repository == 'expo/expo'
+    if: github.repository == 'expo/expo' && !startsWith(github.head_ref, 'bot/')
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
@@ -60,7 +60,6 @@ jobs:
         id: expo-caches
         with:
           pnpm-docs: 'true'
-          docs-api-data: 'true'
       - name: 📦 Install workspace deps
         run: pnpm install --ignore-scripts --frozen-lockfile
       - name: 📦 Install tools deps
@@ -73,6 +72,11 @@ jobs:
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🛠 Build expotools
         run: pnpm turbo build --filter expotools...
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
+      - name: 🛠 Build packages required by docs API data generation
+        run: pnpm turbo build --filter expo-task-manager
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -86,11 +86,15 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo
+      - name: ✍️ Set git identity for per-step commits
+        run: |
+          git config user.name 'Expo Bot'
+          git config user.email 'expo-bot@users.noreply.github.com'
       - name: ✂️ Cut beta docs
         id: beta
         working-directory: docs
         run: |
-          args=(--sdk "$SDK_VERSION")
+          args=(--sdk "$SDK_VERSION" --commit-per-step)
           if [[ "$DRY_RUN" == 'true' ]]; then
             args+=(--dry-run)
           fi

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -72,32 +72,26 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: ♻️ Restore caches
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
           pnpm-docs: 'true'
       - name: 📦 Install workspace deps
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm install --ignore-scripts --frozen-lockfile
       - name: 📦 Install tools deps
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         working-directory: tools
         run: pnpm install --ignore-scripts --frozen-lockfile
       - name: 📦 Install docs deps
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         working-directory: docs
         run: pnpm install --frozen-lockfile
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🛠 Build expotools
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm turbo build --filter expotools...
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo
       - name: 🛠 Build packages required by docs API data generation
-        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm turbo build --filter expo-task-manager
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -111,10 +105,6 @@ jobs:
         working-directory: docs
         run: |
           args=(--sdk "$SDK_VERSION" --commit-per-step)
-          # TEMP(demo): pull_request runs dry-run the real steps as a self-test.
-          if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
-            args+=(--dry-run)
-          fi
           if [[ "$DRY_RUN" == 'true' ]]; then
             args+=(--dry-run)
           fi

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -24,10 +24,6 @@ on:
         description: 'Validate and print the plan without writing anything'
         type: boolean
         default: false
-  pull_request:
-    paths:
-      - '.github/workflows/docs-sdk-beta.yml'
-      - 'docs/scripts/sdk-release/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -36,12 +32,12 @@ concurrency:
 env:
   # JS-only job, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
   SKIP_SKIA_DOWNLOAD: '1'
-  SDK_VERSION: ${{ inputs.sdkVersion || '58' }}
-  DRY_RUN: ${{ inputs.dryRun || false }}
+  SDK_VERSION: ${{ inputs.sdkVersion }}
+  DRY_RUN: ${{ inputs.dryRun }}
 
 jobs:
   beta:
-    if: github.repository == 'expo/expo' && !startsWith(github.head_ref, 'bot/')
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
@@ -117,7 +113,7 @@ jobs:
           echo "::error::Some beta cutoff steps failed. Check the 'Cut beta docs' step log for details."
           exit 1
       - name: 🔔 Notify on Slack
-        if: failure() && github.event_name != 'pull_request'
+        if: failure()
         uses: ./.github/actions/slack-notify
         with:
           webhook: ${{ secrets.slack_webhook_docs }}

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -107,6 +107,7 @@ jobs:
             docs
             preview
           assignees: amandeepmittal
+          reviewers: amandeepmittal
           delete-branch: true
           committer: Expo Bot <expo-bot@users.noreply.github.com>
           author: Expo Bot <expo-bot@users.noreply.github.com>

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -5,12 +5,6 @@ defaults:
     shell: bash
 
 on:
-  # TEMP(demo): self-test trigger so PR #48336 can open a per-step-commit demo
-  # PR before this workflow exists on main. Remove with the other TEMP(demo) lines.
-  pull_request:
-    paths:
-      - .github/workflows/docs-sdk-beta.yml
-      - docs/scripts/sdk-release/**
   workflow_call:
     inputs:
       sdkVersion:
@@ -47,7 +41,7 @@ concurrency:
 env:
   # JS-only job, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
   SKIP_SKIA_DOWNLOAD: '1'
-  SDK_VERSION: ${{ inputs.sdkVersion || '99' }} # TEMP(demo): drop the || '99' fallback
+  SDK_VERSION: ${{ inputs.sdkVersion }}
   DRY_RUN: ${{ inputs.dryRun }}
   REACT_NATIVE: ${{ inputs.reactNative }}
 
@@ -58,10 +52,6 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          # TEMP(demo): pull_request checks out a detached merge commit, but
-          # create-pull-request only picks up our commits from a branch checkout.
-          ref: ${{ github.head_ref || github.ref }}
       - name: 🏗️ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -137,7 +127,7 @@ jobs:
           echo "::error::Some beta cutoff steps failed. Check the 'Cut beta docs' step log for details."
           exit 1
       - name: 🔔 Notify on Slack
-        if: ${{ failure() && github.event_name != 'pull_request' }} # TEMP(demo): revert to plain failure()
+        if: failure()
         uses: ./.github/actions/slack-notify
         with:
           webhook: ${{ secrets.slack_webhook_docs }}

--- a/.github/workflows/docs-sdk-beta.yml
+++ b/.github/workflows/docs-sdk-beta.yml
@@ -5,6 +5,12 @@ defaults:
     shell: bash
 
 on:
+  # TEMP(demo): self-test trigger so PR #48336 can open a per-step-commit demo
+  # PR before this workflow exists on main. Remove with the other TEMP(demo) lines.
+  pull_request:
+    paths:
+      - .github/workflows/docs-sdk-beta.yml
+      - docs/scripts/sdk-release/**
   workflow_call:
     inputs:
       sdkVersion:
@@ -41,7 +47,7 @@ concurrency:
 env:
   # JS-only job, so skip the ~685 MB @shopify/react-native-skia prebuilt-binary download.
   SKIP_SKIA_DOWNLOAD: '1'
-  SDK_VERSION: ${{ inputs.sdkVersion }}
+  SDK_VERSION: ${{ inputs.sdkVersion || '99' }} # TEMP(demo): drop the || '99' fallback
   DRY_RUN: ${{ inputs.dryRun }}
   REACT_NATIVE: ${{ inputs.reactNative }}
 
@@ -52,6 +58,10 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # TEMP(demo): pull_request checks out a detached merge commit, but
+          # create-pull-request only picks up our commits from a branch checkout.
+          ref: ${{ github.head_ref || github.ref }}
       - name: 🏗️ Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
@@ -62,26 +72,32 @@ jobs:
           node-version: 24
           cache: 'pnpm'
       - name: ♻️ Restore caches
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         uses: ./.github/actions/expo-caches
         id: expo-caches
         with:
           pnpm-docs: 'true'
       - name: 📦 Install workspace deps
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm install --ignore-scripts --frozen-lockfile
       - name: 📦 Install tools deps
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         working-directory: tools
         run: pnpm install --ignore-scripts --frozen-lockfile
       - name: 📦 Install docs deps
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         working-directory: docs
         run: pnpm install --frozen-lockfile
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🛠 Build expotools
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm turbo build --filter expotools...
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
           TURBO_TEAM: expo
       - name: 🛠 Build packages required by docs API data generation
+        if: github.event_name != 'pull_request' # TEMP(demo): drop the condition
         run: pnpm turbo build --filter expo-task-manager
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -95,6 +111,10 @@ jobs:
         working-directory: docs
         run: |
           args=(--sdk "$SDK_VERSION" --commit-per-step)
+          # TEMP(demo): pull_request runs exercise the demo steps, not a real cut.
+          if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+            args+=(--demo)
+          fi
           if [[ "$DRY_RUN" == 'true' ]]; then
             args+=(--dry-run)
           fi
@@ -109,7 +129,9 @@ jobs:
         with:
           token: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           branch: bot/docs-sdk-${{ fromJSON(steps.beta.outputs.result).sdkVersion }}-beta
-          base: main
+          # TEMP(demo): revert to plain `base: main`. Targeting the feature branch
+          # keeps the demo PR limited to the demo commits.
+          base: ${{ github.head_ref || 'main' }}
           commit-message: ${{ fromJSON(steps.beta.outputs.result).commitMessage }}
           title: ${{ fromJSON(steps.beta.outputs.result).title }}
           body: ${{ fromJSON(steps.beta.outputs.result).body }}

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,6 +17,7 @@
     "watch": "tsc --noEmit -w",
     "test": "pnpm generate-static-resources && node --experimental-strip-types --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",
+    "sdk-beta": "node --experimental-strip-types ./scripts/sdk-release/beta.ts",
     "copy-latest": "node ./scripts/copy-latest.js",
     "generate-llms": "node --experimental-strip-types ./scripts/generate-llms/index.js",
     "generate-markdown-pages": "node --experimental-strip-types ./scripts/generate-markdown-pages.ts",

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -2,8 +2,8 @@
 // workflow uses to raise a PR. Run: pnpm sdk-beta --sdk 58 [--dry-run]
 
 import { execFileSync, execSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SDK_INPUT = /^(\d{2})(?:\.0\.0)?$/;
@@ -211,20 +211,32 @@ function generateVersionedDocs() {
 }
 
 function syncAppConfigSchema() {
-  execSync(`pnpm schema-sync ${major}`, { cwd: docsDir, stdio: 'pipe' });
+  const schemasDir = join(docsDir, 'public', 'static', 'schemas');
+  const schemaPath = join(schemasDir, versionDir, 'app-config-schema.json');
 
-  const schemaPath = join(
-    docsDir,
-    'public',
-    'static',
-    'schemas',
-    versionDir,
-    'app-config-schema.json'
-  );
+  let syncError = '';
+  try {
+    execSync(`pnpm schema-sync ${major}`, { cwd: docsDir, stdio: 'pipe' });
+  } catch (error) {
+    syncError = describeError(error).split('\n').at(-1) ?? '';
+  }
+
   if (!existsSync(schemaPath)) {
-    throw new Error(
-      `pnpm schema-sync ${major} did not write public/static/schemas/${versionDir}/app-config-schema.json. ` +
-        `The SDK ${version} schema may not be published to exp.host or staging yet.`
+    const unversionedSchema = join(schemasDir, 'unversioned', 'app-config-schema.json');
+
+    if (!existsSync(unversionedSchema)) {
+      throw new Error(
+        `SDK ${version} has no published schema and public/static/schemas/unversioned/app-config-schema.json ` +
+          `is missing, so there is nothing to fall back to. Run pnpm schema-sync unversioned first.`
+      );
+    }
+
+    mkdirSync(dirname(schemaPath), { recursive: true });
+    copyFileSync(unversionedSchema, schemaPath);
+    notes.push(
+      `SDK ${version} is not on exp.host or staging yet, so app-config-schema.json was copied from ` +
+        `\`unversioned\` and the import still points at ${versionDir}. Re-run \`pnpm schema-sync ${major}\` ` +
+        `once the ${version} schema is published (Release Workflow §0.2)${syncError ? `. Sync reported: ${syncError}` : '.'}`
     );
   }
 

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -1,0 +1,546 @@
+// Cuts beta docs for a new SDK version and prints a JSON summary the docs-sdk-beta
+// workflow uses to raise a PR. Run: pnpm sdk-beta --sdk 58 [--dry-run]
+
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SDK_INPUT = /^(\d{2})(?:\.0\.0)?$/;
+const LLMS_SOURCE_URL = 'https://docs.expo.dev/llms-sdk.txt';
+const LLMS_MIN_BYTES = 500_000;
+
+const docsDir = process.cwd();
+const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+  cwd: docsDir,
+  encoding: 'utf8',
+}).trim();
+const self = relative(root, fileURLToPath(import.meta.url));
+
+const git = (...args: string[]) =>
+  execFileSync('git', args, { cwd: root, encoding: 'utf8' }).replace(/\n+$/, '');
+
+const log = (message: string) => process.stderr.write(`${message}\n`);
+
+function fail(what: string, why: string, how: string): never {
+  log(`\n${what}\n${why}\n${how}\n`);
+  process.exit(1);
+}
+
+function describeError(error: unknown) {
+  const { stdout, stderr, message } = error as {
+    stdout?: Buffer;
+    stderr?: Buffer;
+    message?: string;
+  };
+  const streams = [stdout, stderr]
+    .map(stream => (stream ? String(stream).trim() : ''))
+    .filter(Boolean)
+    .join('\n');
+
+  return streams || (message ?? String(error));
+}
+
+function parseOptions() {
+  const argv = process.argv.slice(2);
+  const overrides: Record<string, string> = {};
+  let sdk = '';
+  let dryRun = false;
+  let skipLlms = false;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--sdk') {
+      sdk = argv[++index] ?? '';
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    } else if (arg === '--skip-llms') {
+      skipLlms = true;
+    } else if (arg === '--set') {
+      const pair = argv[++index] ?? '';
+      const splitAt = pair.indexOf('=');
+      if (splitAt < 1) {
+        fail(
+          `Could not read --set "${pair}".`,
+          'Each --set expects a key=value pair naming one field of the sdk-versions.json row.',
+          'For example: --set react-native=0.87 --set xcode=27.0+'
+        );
+      }
+      overrides[pair.slice(0, splitAt)] = pair.slice(splitAt + 1);
+    } else {
+      fail(
+        `Unknown argument "${arg}".`,
+        'Only --sdk, --dry-run, --skip-llms and --set are accepted.',
+        'For example: pnpm sdk-beta --sdk 58 --dry-run'
+      );
+    }
+  }
+
+  return { sdk, dryRun, skipLlms, overrides };
+}
+
+const options = parseOptions();
+
+const match = SDK_INPUT.exec(options.sdk);
+if (!match) {
+  fail(
+    options.sdk ? `"${options.sdk}" is not a valid SDK version.` : 'No SDK version was given.',
+    'The version selects the directories this script creates, so it is never inferred. A wrong value ' +
+      'would generate hundreds of files under the wrong path.',
+    'Pass a two-digit major, or its full form: pnpm sdk-beta --sdk 58'
+  );
+}
+
+const major = match[1];
+const version = `${major}.0.0`;
+const versionDir = `v${version}`;
+
+const packageJsonPath = join(docsDir, 'package.json');
+const packageJsonText = readFileSync(packageJsonPath, 'utf8');
+const packageJson = JSON.parse(packageJsonText) as { version: string; betaVersion?: string };
+const currentVersion = packageJson.version;
+const currentMajor = Number(currentVersion.split('.')[0]);
+
+if (Number(major) <= currentMajor) {
+  fail(
+    `SDK ${major} is not newer than the current released version, ${currentVersion}.`,
+    'The beta cut only ever creates a version above the one in docs/package.json, so this input would ' +
+      'overwrite released reference docs.',
+    `Pass a version above ${currentMajor}, or promote the current beta first if one is already open.`
+  );
+}
+
+if (packageJson.betaVersion) {
+  fail(
+    `A beta cut is already open for SDK ${packageJson.betaVersion}.`,
+    'docs/package.json still carries a betaVersion, so the previous beta was never promoted or reverted. ' +
+      'Cutting a second beta on top of it would leave two unreleased versions visible.',
+    'Promote or revert that beta first, then re-run this command.'
+  );
+}
+
+const pagesDir = join(docsDir, 'pages', 'versions', versionDir);
+if (existsSync(pagesDir)) {
+  fail(
+    `pages/versions/${versionDir} already exists.`,
+    'et generate-sdk-docs skips directories that already exist rather than failing, so continuing would ' +
+      'half-generate this release and leave the rest untouched.',
+    `Remove pages/versions/${versionDir} and its public/static counterparts, or pick a different version.`
+  );
+}
+
+const sdkVersionsPath = join(docsDir, 'ui', 'components', 'SDKTables', 'sdk-versions.json');
+const sdkVersionsFields = Object.keys(
+  (JSON.parse(readFileSync(sdkVersionsPath, 'utf8')) as { sdkVersions: Record<string, string>[] })
+    .sdkVersions[0] ?? {}
+);
+const unknownOverride = Object.keys(options.overrides).find(
+  key => !sdkVersionsFields.includes(key)
+);
+
+if (unknownOverride) {
+  fail(
+    `--set ${unknownOverride} does not match any field in the compatibility table.`,
+    'Each --set writes one field of the new sdk-versions.json row, so an unrecognized key would be ' +
+      'silently dropped instead of reaching the table.',
+    `Use one of: ${sdkVersionsFields.filter(field => field !== 'sdk').join(', ')}.`
+  );
+}
+
+if (!options.dryRun) {
+  const dirtyFiles = git('status', '--porcelain')
+    .split('\n')
+    .filter(Boolean)
+    .filter(line => line.slice(3) !== self);
+
+  if (dirtyFiles.length) {
+    fail(
+      `The working tree has ${dirtyFiles.length} uncommitted change(s).`,
+      'Every edit this script makes has to be attributable to the cut. A pnpm export run, for example, ' +
+        'rewrites modificationDate across roughly 1,489 MDX files, which would land in the release PR.',
+      'Commit, stash, or run git restore on the working tree, then re-run. To validate without writing, ' +
+        'add --dry-run, which tolerates a dirty tree.'
+    );
+  }
+}
+
+log(`Cutting beta docs for SDK ${version} (current released: ${currentVersion})`);
+if (options.dryRun) {
+  log('Dry run: validating and reporting the plan, writing nothing.\n');
+}
+
+function expotools(args: string[]) {
+  const hasEt = (() => {
+    try {
+      execFileSync('which', ['et'], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  })();
+
+  if (hasEt) {
+    execFileSync('et', args, { cwd: root, stdio: 'pipe' });
+    return;
+  }
+
+  const bin = join(root, 'tools', 'bin', 'expotools.js');
+  if (!existsSync(bin)) {
+    throw new Error(
+      `expotools is not on PATH and ${relative(root, bin)} is missing. Run direnv allow in the repo ` +
+        'root, or build expotools with pnpm turbo build --filter expotools...'
+    );
+  }
+  execFileSync(process.execPath, [bin, ...args], { cwd: root, stdio: 'pipe' });
+}
+
+const notes: string[] = [];
+
+function regenerateUnversionedApiData() {
+  expotools(['generate-docs-api-data']);
+}
+
+function generateVersionedDocs() {
+  expotools(['generate-sdk-docs', '--sdk', version]);
+
+  if (!existsSync(pagesDir)) {
+    throw new Error(
+      `et generate-sdk-docs reported success but pages/versions/${versionDir} was not created.`
+    );
+  }
+}
+
+function syncAppConfigSchema() {
+  execSync(`pnpm schema-sync ${major}`, { cwd: docsDir, stdio: 'pipe' });
+
+  const schemaPath = join(
+    docsDir,
+    'public',
+    'static',
+    'schemas',
+    versionDir,
+    'app-config-schema.json'
+  );
+  if (!existsSync(schemaPath)) {
+    throw new Error(
+      `pnpm schema-sync ${major} did not write public/static/schemas/${versionDir}/app-config-schema.json. ` +
+        `The SDK ${version} schema may not be published to exp.host or staging yet.`
+    );
+  }
+
+  const appConfigPath = join(pagesDir, 'config', 'app.mdx');
+  const appConfig = readFileSync(appConfigPath, 'utf8');
+  const repointed = appConfig.replace(
+    '~/public/static/schemas/unversioned/app-config-schema.json',
+    `~/public/static/schemas/${versionDir}/app-config-schema.json`
+  );
+
+  if (repointed === appConfig) {
+    throw new Error(
+      `Could not repoint the schema import in pages/versions/${versionDir}/config/app.mdx. ` +
+        'It no longer imports the unversioned schema, so the import path may have been restructured.'
+    );
+  }
+
+  writeFileSync(appConfigPath, repointed);
+}
+
+function createNativeModulesStub() {
+  const stubDir = join(docsDir, 'public', 'static', 'schemas', versionDir);
+  const stubPath = join(stubDir, 'native-modules.json');
+
+  if (existsSync(stubPath)) {
+    notes.push(`native-modules.json already existed for ${versionDir} and was left alone.`);
+    return;
+  }
+
+  mkdirSync(stubDir, { recursive: true });
+  writeFileSync(stubPath, '{"versions":[]}');
+  notes.push(
+    `native-modules.json written as an empty stub. pnpm versions-schema-sync fills it once the SDK ` +
+      `${version} packages are live; until then it keeps this snapshot.`
+  );
+}
+
+async function archivePreviousLlmsBundleAsync() {
+  const archiveName = `llms-sdk-v${currentVersion}.txt`;
+  const archivePath = join(docsDir, 'public', archiveName);
+
+  if (existsSync(archivePath)) {
+    notes.push(`${archiveName} already existed and was left alone.`);
+    return;
+  }
+
+  const response = await fetch(LLMS_SOURCE_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Could not download ${LLMS_SOURCE_URL} (HTTP ${response.status}). public/llms-sdk.txt is ` +
+        'gitignored and only exists after a build, so the published bundle is the snapshot source.'
+    );
+  }
+
+  const bundle = await response.text();
+  const bytes = Buffer.byteLength(bundle);
+
+  if (bytes < LLMS_MIN_BYTES) {
+    throw new Error(
+      `${LLMS_SOURCE_URL} returned only ${bytes} bytes, far below the expected size for an SDK bundle. ` +
+        'Production may be mid-deploy. Re-run this step, or pass --skip-llms and archive it by hand.'
+    );
+  }
+
+  if (!bundle.includes(`/versions/v${currentVersion}/`) && !bundle.includes('/versions/latest/')) {
+    throw new Error(
+      `${LLMS_SOURCE_URL} does not reference SDK ${currentVersion}, so it is not the snapshot this cut ` +
+        'should archive. Check what production is currently serving as latest.'
+    );
+  }
+
+  writeFileSync(archivePath, bundle);
+  git('add', '--force', relative(root, archivePath));
+
+  const llmsPagePath = join(docsDir, 'pages', 'llms.mdx');
+  const llmsPage = readFileSync(llmsPagePath, 'utf8');
+  const anchor = '<Collapsible summary="Looking for deprecated Expo SDK versions?">\n\n';
+
+  if (!llmsPage.includes(anchor)) {
+    throw new Error(
+      'Could not find the deprecated-versions Collapsible in pages/llms.mdx, so the archive link was ' +
+        `not added. Add a row for ${archiveName} by hand.`
+    );
+  }
+
+  const row = `- [/${archiveName}](/${archiveName}): Documentation for the Expo SDK v${currentVersion}\n\n`;
+  writeFileSync(llmsPagePath, llmsPage.replace(anchor, `${anchor}${row}`));
+  notes.push(
+    `${archiveName} archived from production (${(bytes / 1_000_000).toFixed(1)} MB) and force-added, ` +
+      'since `public/llms-sdk-*.txt` is gitignored and the existing archives are tracked only because ' +
+      'they were force-added too.'
+  );
+}
+
+const carriedFields: string[] = [];
+
+function planSdkVersionsRow() {
+  const tablePath = join(docsDir, 'ui', 'components', 'SDKTables', 'sdk-versions.json');
+  const table = JSON.parse(readFileSync(tablePath, 'utf8')) as {
+    sdkVersions: Record<string, string>[];
+  };
+
+  if (table.sdkVersions.some(row => row.sdk === version)) {
+    notes.push(`sdk-versions.json already had a row for ${version} and was left alone.`);
+    return null;
+  }
+
+  const previous = table.sdkVersions[0];
+  if (!previous) {
+    throw new Error('sdk-versions.json has no existing rows to model the new one on.');
+  }
+
+  const row: Record<string, string> = { ...previous, sdk: version };
+  for (const [key, value] of Object.entries(options.overrides)) {
+    if (!(key in row)) {
+      throw new Error(
+        `--set ${key} does not match any field in sdk-versions.json. Valid fields: ` +
+          `${Object.keys(previous).join(', ')}.`
+      );
+    }
+    row[key] = value;
+  }
+
+  carriedFields.length = 0;
+  for (const key of Object.keys(previous)) {
+    if (key !== 'sdk' && !(key in options.overrides) && row[key] === previous[key]) {
+      carriedFields.push(`${key}: \`${row[key]}\``);
+    }
+  }
+
+  return { tablePath, table, row };
+}
+
+function addSdkVersionsRow() {
+  const planned = planSdkVersionsRow();
+  if (!planned) {
+    return;
+  }
+
+  planned.table.sdkVersions.unshift(planned.row);
+  writeFileSync(planned.tablePath, `${JSON.stringify(planned.table, null, 2)}\n`);
+}
+
+function setBetaVersion() {
+  const updated = packageJsonText.replace(
+    /("version":\s*"[^"]+",\n)/,
+    `$1  "betaVersion": "${version}",\n`
+  );
+
+  if (updated === packageJsonText) {
+    throw new Error(
+      'Could not insert betaVersion after version in docs/package.json. The field order may have changed.'
+    );
+  }
+
+  writeFileSync(packageJsonPath, updated);
+}
+
+const steps: {
+  label: string;
+  run: () => void | Promise<void>;
+  preview?: () => void;
+  skip?: boolean;
+}[] = [
+  { label: 'Regenerate unversioned API data', run: regenerateUnversionedApiData },
+  { label: `Generate ${versionDir} reference docs`, run: generateVersionedDocs },
+  { label: 'Sync app config schema and repoint the import', run: syncAppConfigSchema },
+  { label: 'Create the native-modules.json stub', run: createNativeModulesStub },
+  {
+    label: `Archive the SDK ${currentVersion} llms bundle`,
+    run: archivePreviousLlmsBundleAsync,
+    skip: options.skipLlms,
+  },
+  {
+    label: `Add the ${version} compatibility row`,
+    run: addSdkVersionsRow,
+    preview: planSdkVersionsRow,
+  },
+  { label: `Set betaVersion to ${version}`, run: setBetaVersion },
+];
+
+const failures = new Map<string, string>();
+const completed: string[] = [];
+const skipped: string[] = [];
+
+for (const { label, run, preview, skip } of steps) {
+  if (skip) {
+    log(`- skipped: ${label}`);
+    skipped.push(label);
+    continue;
+  }
+
+  if (options.dryRun) {
+    log(`- would run: ${label}`);
+    try {
+      preview?.();
+    } catch (error) {
+      const output = describeError(error);
+      log(`  preview failed: ${output}`);
+      failures.set(label, output);
+    }
+    continue;
+  }
+
+  log(`- ${label}`);
+  try {
+    await run();
+    completed.push(label);
+  } catch (error) {
+    const output = describeError(error);
+    log(`  failed: ${output}`);
+    failures.set(label, output);
+  }
+}
+
+const changed = options.dryRun
+  ? []
+  : git('status', '--porcelain')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => line.slice(3))
+      .filter(file => file !== self);
+
+const HUMAN_TASKS = [
+  'Re-check [brownfield install instructions](https://docs.expo.dev/brownfield/installing-expo-modules/) against the new template diff',
+  'Backport any docs PRs merged to main since the branch point',
+  `Run \`pnpm versions-schema-sync\` once the SDK ${version} packages are live on exp.host`,
+];
+
+const title = `[docs] Cut off SDK ${major} beta docs`;
+
+const statusOf = (label: string) =>
+  failures.has(label)
+    ? '❌ Failed'
+    : skipped.includes(label)
+      ? '➖ Skipped'
+      : options.dryRun
+        ? '🔍 Planned'
+        : '✅ Done';
+
+const excerpt = (text: string) => text.split('\n').slice(-30).join('\n').slice(-2000);
+
+const summaryByDirectory = changed.reduce<Record<string, number>>((counts, file) => {
+  const key = file.split('/').slice(0, 4).join('/');
+  counts[key] = (counts[key] ?? 0) + 1;
+  return counts;
+}, {});
+
+const body = [
+  `Beta docs cut for SDK ${version}, generated by \`pnpm sdk-beta --sdk ${major}\`.`,
+  '',
+  `\`docs/package.json\` keeps \`version\` at ${currentVersion} and gains \`betaVersion: ${version}\`, so`,
+  'the new reference stays hidden in production until it is promoted.',
+  '',
+  '| Step | Status |',
+  '| --- | --- |',
+  ...steps.map(({ label }) => `| ${label} | ${statusOf(label)} |`),
+  ...(Object.keys(summaryByDirectory).length
+    ? [
+        '',
+        '## Files',
+        '',
+        '| Path | Files |',
+        '| --- | --- |',
+        ...Object.entries(summaryByDirectory)
+          .sort((a, b) => b[1] - a[1])
+          .map(([path, count]) => `| \`${path}\` | ${count} |`),
+      ]
+    : []),
+  ...(carriedFields.length
+    ? [
+        '',
+        '## Compatibility row needs review',
+        '',
+        `These fields were carried over unchanged from SDK ${currentVersion}. Confirm each one or push a fix:`,
+        '',
+        ...carriedFields.map(field => `- [ ] ${field}`),
+      ]
+    : []),
+  '',
+  '## Still to do by hand',
+  '',
+  ...HUMAN_TASKS.map(task => `- [ ] ${task}`),
+  ...(notes.length ? ['', '## Notes', '', ...notes.map(note => `- ${note}`)] : []),
+  ...(failures.size
+    ? [
+        '',
+        '## Failures',
+        ...[...failures].flatMap(([label, output]) => [
+          '',
+          '<details>',
+          `<summary>${label}</summary>`,
+          '',
+          '```',
+          excerpt(output),
+          '```',
+          '',
+          '</details>',
+        ]),
+      ]
+    : []),
+].join('\n');
+
+log(
+  `\n${options.dryRun ? 'Dry run complete' : `${completed.length}/${steps.length - skipped.length} steps done`}` +
+    `, ${changed.length} file(s) changed, ${failures.size} failure(s)`
+);
+
+process.stdout.write(
+  JSON.stringify({
+    hasChanged: changed.length > 0,
+    failedCount: failures.size,
+    dryRun: options.dryRun,
+    sdkVersion: version,
+    title,
+    commitMessage: title,
+    body,
+  })
+);

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -1,5 +1,5 @@
 // Cuts beta docs for a new SDK version and prints a JSON summary the docs-sdk-beta
-// workflow uses to raise a PR. Run: pnpm sdk-beta --sdk 58 [--dry-run]
+// workflow uses to raise a PR. Run: pnpm sdk-beta --sdk 58 [--dry-run].
 
 import { execFileSync, execSync } from 'node:child_process';
 import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -50,6 +50,7 @@ function parseOptions() {
   let sdk = '';
   let dryRun = false;
   let skipLlms = false;
+  let commitPerStep = false;
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
@@ -59,6 +60,8 @@ function parseOptions() {
       dryRun = true;
     } else if (arg === '--skip-llms') {
       skipLlms = true;
+    } else if (arg === '--commit-per-step') {
+      commitPerStep = true;
     } else if (arg === '--set') {
       const pair = argv[++index] ?? '';
       const splitAt = pair.indexOf('=');
@@ -73,13 +76,13 @@ function parseOptions() {
     } else {
       fail(
         `Unknown argument "${arg}".`,
-        'Only --sdk, --dry-run, --skip-llms and --set are accepted.',
+        'Only --sdk, --dry-run, --skip-llms, --commit-per-step and --set are accepted.',
         'For example: pnpm sdk-beta --sdk 58 --dry-run'
       );
     }
   }
 
-  return { sdk, dryRun, skipLlms, overrides };
+  return { sdk, dryRun, skipLlms, commitPerStep, overrides };
 }
 
 const options = parseOptions();
@@ -513,6 +516,27 @@ const failures = new Map<string, string>();
 const completed: string[] = [];
 const skipped: string[] = [];
 
+const startSha = git('rev-parse', 'HEAD');
+
+function commitStep(label: string) {
+  const dirty = git('status', '--porcelain', '--untracked-files=all')
+    .split('\n')
+    .filter(Boolean)
+    .some(line => line.slice(3) !== self);
+
+  if (!dirty) {
+    return;
+  }
+
+  git('add', '--all', '--', '.', `:!${self}`);
+  git(
+    'commit',
+    '-m',
+    `[docs] SDK ${major} beta: ${label}${failures.has(label) ? ' (failed)' : ''}`
+  );
+  log(`  committed as ${git('rev-parse', '--short', 'HEAD')}`);
+}
+
 for (const { label, run, preview, skip } of steps) {
   if (skip) {
     log(`- skipped: ${label}`);
@@ -541,15 +565,26 @@ for (const { label, run, preview, skip } of steps) {
     log(`  failed: ${output}`);
     failures.set(label, output);
   }
+
+  if (options.commitPerStep) {
+    commitStep(label);
+  }
 }
 
 const changed = options.dryRun
   ? []
-  : git('status', '--porcelain', '--untracked-files=all')
-      .split('\n')
-      .filter(Boolean)
-      .map(line => line.slice(3))
-      .filter(file => file !== self);
+  : [
+      ...new Set([
+        ...(options.commitPerStep
+          ? git('diff', '--name-only', startSha, 'HEAD').split('\n').filter(Boolean)
+          : []),
+        ...git('status', '--porcelain', '--untracked-files=all')
+          .split('\n')
+          .filter(Boolean)
+          .map(line => line.slice(3))
+          .filter(file => file !== self),
+      ]),
+    ];
 
 const HUMAN_TASKS = [
   'Re-check [brownfield install instructions](https://docs.expo.dev/brownfield/installing-expo-modules/) against the new template diff',

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -150,7 +150,7 @@ if (unknownOverride) {
 }
 
 if (!options.dryRun) {
-  const dirtyFiles = git('status', '--porcelain')
+  const dirtyFiles = git('status', '--porcelain', '--untracked-files=all')
     .split('\n')
     .filter(Boolean)
     .filter(line => line.slice(3) !== self);
@@ -540,7 +540,7 @@ for (const { label, run, preview, skip } of steps) {
 
 const changed = options.dryRun
   ? []
-  : git('status', '--porcelain')
+  : git('status', '--porcelain', '--untracked-files=all')
       .split('\n')
       .filter(Boolean)
       .map(line => line.slice(3))

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -9,8 +9,9 @@ import { fileURLToPath } from 'node:url';
 const SDK_INPUT = /^(\d{2})(?:\.0\.0)?$/;
 const LLMS_SOURCE_URL = 'https://docs.expo.dev/llms-sdk.txt';
 const LLMS_MIN_BYTES = 500_000;
-const EXPO_REGISTRY_URL = 'https://registry.npmjs.org/expo';
+const EXPO_DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/expo/dist-tags';
 const CANARY_EXAMPLE = /`\d+\.\d+\.\d+-canary-\d{8}-[\da-f]+`/;
+const EXPOTOOLS_MAX_BUFFER = 64 * 1024 * 1024;
 
 const docsDir = process.cwd();
 const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -182,7 +183,7 @@ function expotools(args: string[]) {
   })();
 
   if (hasEt) {
-    execFileSync('et', args, { cwd: root, stdio: 'pipe' });
+    execFileSync('et', args, { cwd: root, stdio: 'pipe', maxBuffer: EXPOTOOLS_MAX_BUFFER });
     return;
   }
 
@@ -193,7 +194,11 @@ function expotools(args: string[]) {
         'root, or build expotools with pnpm turbo build --filter expotools...'
     );
   }
-  execFileSync(process.execPath, [bin, ...args], { cwd: root, stdio: 'pipe' });
+  execFileSync(process.execPath, [bin, ...args], {
+    cwd: root,
+    stdio: 'pipe',
+    maxBuffer: EXPOTOOLS_MAX_BUFFER,
+  });
 }
 
 const notes: string[] = [];
@@ -210,20 +215,20 @@ async function updateCanaryExampleAsync() {
     );
   }
 
-  const response = await fetch(EXPO_REGISTRY_URL);
+  const response = await fetch(EXPO_DIST_TAGS_URL);
   if (!response.ok) {
     throw new Error(
-      `Could not read the expo package from ${EXPO_REGISTRY_URL} (HTTP ${response.status}), so the ` +
+      `Could not read the expo dist-tags from ${EXPO_DIST_TAGS_URL} (HTTP ${response.status}), so the ` +
         'canary example could not be refreshed.'
     );
   }
 
-  const registry = (await response.json()) as Record<string, Record<string, string> | undefined>;
-  const canary = registry['dist-tags']?.canary;
+  const distTags = (await response.json()) as Record<string, string | undefined>;
+  const canary = distTags.canary;
 
   if (!canary) {
     throw new Error(
-      `${EXPO_REGISTRY_URL} has no canary dist-tag, so there is no published version to copy.`
+      `${EXPO_DIST_TAGS_URL} has no canary dist-tag, so there is no published version to copy.`
     );
   }
 

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -7,8 +7,6 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const SDK_INPUT = /^(\d{2})(?:\.0\.0)?$/;
-const LLMS_SOURCE_URL = 'https://docs.expo.dev/llms-sdk.txt';
-const LLMS_MIN_BYTES = 500_000;
 const EXPO_DIST_TAGS_URL = 'https://registry.npmjs.org/-/package/expo/dist-tags';
 const CANARY_EXAMPLE = /`\d+\.\d+\.\d+-canary-\d{8}-[\da-f]+`/;
 const EXPOTOOLS_MAX_BUFFER = 64 * 1024 * 1024;
@@ -49,7 +47,6 @@ function parseOptions() {
   const overrides: Record<string, string> = {};
   let sdk = '';
   let dryRun = false;
-  let skipLlms = false;
   let commitPerStep = false;
 
   for (let index = 0; index < argv.length; index++) {
@@ -58,8 +55,6 @@ function parseOptions() {
       sdk = argv[++index] ?? '';
     } else if (arg === '--dry-run') {
       dryRun = true;
-    } else if (arg === '--skip-llms') {
-      skipLlms = true;
     } else if (arg === '--commit-per-step') {
       commitPerStep = true;
     } else if (arg === '--set') {
@@ -76,13 +71,13 @@ function parseOptions() {
     } else {
       fail(
         `Unknown argument "${arg}".`,
-        'Only --sdk, --dry-run, --skip-llms, --commit-per-step and --set are accepted.',
+        'Only --sdk, --dry-run, --commit-per-step and --set are accepted.',
         'For example: pnpm sdk-beta --sdk 58 --dry-run'
       );
     }
   }
 
-  return { sdk, dryRun, skipLlms, commitPerStep, overrides };
+  return { sdk, dryRun, commitPerStep, overrides };
 }
 
 const options = parseOptions();
@@ -366,63 +361,6 @@ function createNativeModulesStub() {
   );
 }
 
-async function archivePreviousLlmsBundleAsync() {
-  const archiveName = `llms-sdk-v${currentVersion}.txt`;
-  const archivePath = join(docsDir, 'public', archiveName);
-
-  if (existsSync(archivePath)) {
-    notes.push(`${archiveName} already existed and was left alone.`);
-    return;
-  }
-
-  const response = await fetch(LLMS_SOURCE_URL);
-  if (!response.ok) {
-    throw new Error(
-      `Could not download ${LLMS_SOURCE_URL} (HTTP ${response.status}). public/llms-sdk.txt is ` +
-        'gitignored and only exists after a build, so the published bundle is the snapshot source.'
-    );
-  }
-
-  const bundle = await response.text();
-  const bytes = Buffer.byteLength(bundle);
-
-  if (bytes < LLMS_MIN_BYTES) {
-    throw new Error(
-      `${LLMS_SOURCE_URL} returned only ${bytes} bytes, far below the expected size for an SDK bundle. ` +
-        'Production may be mid-deploy. Re-run this step, or pass --skip-llms and archive it by hand.'
-    );
-  }
-
-  if (!bundle.includes(`/versions/v${currentVersion}/`) && !bundle.includes('/versions/latest/')) {
-    throw new Error(
-      `${LLMS_SOURCE_URL} does not reference SDK ${currentVersion}, so it is not the snapshot this cut ` +
-        'should archive. Check what production is currently serving as latest.'
-    );
-  }
-
-  writeFileSync(archivePath, bundle);
-  git('add', '--force', relative(root, archivePath));
-
-  const llmsPagePath = join(docsDir, 'pages', 'llms.mdx');
-  const llmsPage = readFileSync(llmsPagePath, 'utf8');
-  const anchor = '<Collapsible summary="Looking for deprecated Expo SDK versions?">\n\n';
-
-  if (!llmsPage.includes(anchor)) {
-    throw new Error(
-      'Could not find the deprecated-versions Collapsible in pages/llms.mdx, so the archive link was ' +
-        `not added. Add a row for ${archiveName} by hand.`
-    );
-  }
-
-  const row = `- [/${archiveName}](/${archiveName}): Documentation for the Expo SDK v${currentVersion}\n\n`;
-  writeFileSync(llmsPagePath, llmsPage.replace(anchor, `${anchor}${row}`));
-  notes.push(
-    `${archiveName} archived from production (${(bytes / 1_000_000).toFixed(1)} MB) and force-added, ` +
-      'since `public/llms-sdk-*.txt` is gitignored and the existing archives are tracked only because ' +
-      'they were force-added too.'
-  );
-}
-
 const carriedFields: string[] = [];
 
 function planSdkVersionsRow() {
@@ -491,7 +429,6 @@ const steps: {
   label: string;
   run: () => void | Promise<void>;
   preview?: () => void;
-  skip?: boolean;
 }[] = [
   { label: 'Refresh the canary example on the Reference index', run: updateCanaryExampleAsync },
   { label: 'Regenerate unversioned API data', run: regenerateUnversionedApiData },
@@ -499,11 +436,6 @@ const steps: {
   { label: `Clone hardcoded type links into ${versionDir}`, run: addStaticDataTypeLinks },
   { label: 'Sync app config schema and repoint the import', run: syncAppConfigSchema },
   { label: 'Create the native-modules.json stub', run: createNativeModulesStub },
-  {
-    label: `Archive the SDK ${currentVersion} llms bundle`,
-    run: archivePreviousLlmsBundleAsync,
-    skip: options.skipLlms,
-  },
   {
     label: `Add the ${version} compatibility row`,
     run: addSdkVersionsRow,
@@ -514,7 +446,6 @@ const steps: {
 
 const failures = new Map<string, string>();
 const completed: string[] = [];
-const skipped: string[] = [];
 
 const startSha = git('rev-parse', 'HEAD');
 
@@ -537,13 +468,7 @@ function commitStep(label: string) {
   log(`  committed as ${git('rev-parse', '--short', 'HEAD')}`);
 }
 
-for (const { label, run, preview, skip } of steps) {
-  if (skip) {
-    log(`- skipped: ${label}`);
-    skipped.push(label);
-    continue;
-  }
-
+for (const { label, run, preview } of steps) {
   if (options.dryRun) {
     log(`- would run: ${label}`);
     try {
@@ -595,13 +520,7 @@ const HUMAN_TASKS = [
 const title = `[docs] Cut off SDK ${major} beta docs`;
 
 const statusOf = (label: string) =>
-  failures.has(label)
-    ? '❌ Failed'
-    : skipped.includes(label)
-      ? '➖ Skipped'
-      : options.dryRun
-        ? '🔍 Planned'
-        : '✅ Done';
+  failures.has(label) ? '❌ Failed' : options.dryRun ? '🔍 Planned' : '✅ Done';
 
 const excerpt = (text: string) => text.split('\n').slice(-30).join('\n').slice(-2000);
 
@@ -667,7 +586,7 @@ const body = [
 ].join('\n');
 
 log(
-  `\n${options.dryRun ? 'Dry run complete' : `${completed.length}/${steps.length - skipped.length} steps done`}` +
+  `\n${options.dryRun ? 'Dry run complete' : `${completed.length}/${steps.length} steps done`}` +
     `, ${changed.length} file(s) changed, ${failures.size} failure(s)`
 );
 

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -51,6 +51,7 @@ function parseOptions() {
   let dryRun = false;
   let skipLlms = false;
   let commitPerStep = false;
+  let demo = false; // TEMP(demo)
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
@@ -62,6 +63,8 @@ function parseOptions() {
       skipLlms = true;
     } else if (arg === '--commit-per-step') {
       commitPerStep = true;
+    } else if (arg === '--demo') {
+      demo = true; // TEMP(demo)
     } else if (arg === '--set') {
       const pair = argv[++index] ?? '';
       const splitAt = pair.indexOf('=');
@@ -82,7 +85,7 @@ function parseOptions() {
     }
   }
 
-  return { sdk, dryRun, skipLlms, commitPerStep, overrides };
+  return { sdk, dryRun, skipLlms, commitPerStep, demo, overrides };
 }
 
 const options = parseOptions();
@@ -512,6 +515,32 @@ const steps: {
   { label: `Set betaVersion to ${version}`, run: setBetaVersion },
 ];
 
+// NOTE(@amandeepmittal): TEMP(demo) scaffolding so PR #48336 can verify the
+// per-step commit PR end to end in CI. Delete this block, the --demo flag,
+// and every line marked TEMP(demo) here and in docs-sdk-beta.yml once the
+// demo PR has been reviewed and closed.
+if (options.demo) {
+  const demoDir = join(docsDir, '.sdk-beta-demo');
+  steps.splice(
+    0,
+    steps.length,
+    {
+      label: 'Demo: write the first file',
+      run: () => {
+        mkdirSync(demoDir, { recursive: true });
+        writeFileSync(join(demoDir, 'one.txt'), 'demo step one\n');
+      },
+    },
+    {
+      label: 'Demo: write the second file',
+      run: () => {
+        writeFileSync(join(demoDir, 'two.txt'), 'demo step two\n');
+      },
+    },
+    { label: 'Demo: change nothing, expect no commit', run: () => {} }
+  );
+}
+
 const failures = new Map<string, string>();
 const completed: string[] = [];
 const skipped: string[] = [];
@@ -592,7 +621,10 @@ const HUMAN_TASKS = [
   `Run \`pnpm versions-schema-sync\` once the SDK ${version} packages are live on exp.host`,
 ];
 
-const title = `[docs] Cut off SDK ${major} beta docs`;
+// TEMP(demo): revert to the plain template literal with the scaffolding.
+const title = options.demo
+  ? '[docs] Demo: sdk-beta per-step commits (do not merge)'
+  : `[docs] Cut off SDK ${major} beta docs`;
 
 const statusOf = (label: string) =>
   failures.has(label)

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -256,6 +256,44 @@ function generateVersionedDocs() {
   }
 }
 
+function addStaticDataTypeLinks() {
+  const staticDataPath = join(docsDir, 'components', 'plugins', 'api', 'APIStaticData.ts');
+  const source = readFileSync(staticDataPath, 'utf8');
+
+  if (source.includes(`'${versionDir}': {`)) {
+    notes.push(`APIStaticData.ts already had a ${versionDir} block and was left alone.`);
+    return;
+  }
+
+  const unversioned = /^ {2}unversioned: {\n([\S\s]*?)^ {2}},\n/m.exec(source);
+  if (!unversioned?.[1]) {
+    throw new Error(
+      'Could not find the unversioned block in components/plugins/api/APIStaticData.ts, so the ' +
+        `${versionDir} type links were not added. The sdkVersionHardcodedTypeLinks shape may have changed.`
+    );
+  }
+
+  const anchor = /^ {2}latest: {$/m;
+  if (!anchor.test(source)) {
+    throw new Error(
+      'Could not find the latest block in components/plugins/api/APIStaticData.ts, so there was no ' +
+        `place to insert ${versionDir} ahead of it.`
+    );
+  }
+
+  const body = unversioned[1].replaceAll('/versions/unversioned/', `/versions/${versionDir}/`);
+  const block = `  '${versionDir}': {\n${body}  },\n`;
+
+  writeFileSync(staticDataPath, source.replace(anchor, `${block}  latest: {`));
+  execSync(`pnpm exec oxfmt --write ${relative(docsDir, staticDataPath)}`, {
+    cwd: docsDir,
+    stdio: 'pipe',
+  });
+
+  const linkCount = body.split(`/versions/${versionDir}/`).length - 1;
+  notes.push(`Cloned ${linkCount} hardcoded type links from \`unversioned\` into ${versionDir}.`);
+}
+
 function syncAppConfigSchema() {
   const schemasDir = join(docsDir, 'public', 'static', 'schemas');
   const schemaPath = join(schemasDir, versionDir, 'app-config-schema.json');
@@ -450,6 +488,7 @@ const steps: {
   { label: 'Refresh the canary example on the Reference index', run: updateCanaryExampleAsync },
   { label: 'Regenerate unversioned API data', run: regenerateUnversionedApiData },
   { label: `Generate ${versionDir} reference docs`, run: generateVersionedDocs },
+  { label: `Clone hardcoded type links into ${versionDir}`, run: addStaticDataTypeLinks },
   { label: 'Sync app config schema and repoint the import', run: syncAppConfigSchema },
   { label: 'Create the native-modules.json stub', run: createNativeModulesStub },
   {

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -51,7 +51,6 @@ function parseOptions() {
   let dryRun = false;
   let skipLlms = false;
   let commitPerStep = false;
-  let demo = false; // TEMP(demo)
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
@@ -63,8 +62,6 @@ function parseOptions() {
       skipLlms = true;
     } else if (arg === '--commit-per-step') {
       commitPerStep = true;
-    } else if (arg === '--demo') {
-      demo = true; // TEMP(demo)
     } else if (arg === '--set') {
       const pair = argv[++index] ?? '';
       const splitAt = pair.indexOf('=');
@@ -85,7 +82,7 @@ function parseOptions() {
     }
   }
 
-  return { sdk, dryRun, skipLlms, commitPerStep, demo, overrides };
+  return { sdk, dryRun, skipLlms, commitPerStep, overrides };
 }
 
 const options = parseOptions();
@@ -515,32 +512,6 @@ const steps: {
   { label: `Set betaVersion to ${version}`, run: setBetaVersion },
 ];
 
-// NOTE(@amandeepmittal): TEMP(demo) scaffolding so PR #48336 can verify the
-// per-step commit PR end to end in CI. Delete this block, the --demo flag,
-// and every line marked TEMP(demo) here and in docs-sdk-beta.yml once the
-// demo PR has been reviewed and closed.
-if (options.demo) {
-  const demoDir = join(docsDir, '.sdk-beta-demo');
-  steps.splice(
-    0,
-    steps.length,
-    {
-      label: 'Demo: write the first file',
-      run: () => {
-        mkdirSync(demoDir, { recursive: true });
-        writeFileSync(join(demoDir, 'one.txt'), 'demo step one\n');
-      },
-    },
-    {
-      label: 'Demo: write the second file',
-      run: () => {
-        writeFileSync(join(demoDir, 'two.txt'), 'demo step two\n');
-      },
-    },
-    { label: 'Demo: change nothing, expect no commit', run: () => {} }
-  );
-}
-
 const failures = new Map<string, string>();
 const completed: string[] = [];
 const skipped: string[] = [];
@@ -621,10 +592,7 @@ const HUMAN_TASKS = [
   `Run \`pnpm versions-schema-sync\` once the SDK ${version} packages are live on exp.host`,
 ];
 
-// TEMP(demo): revert to the plain template literal with the scaffolding.
-const title = options.demo
-  ? '[docs] Demo: sdk-beta per-step commits (do not merge)'
-  : `[docs] Cut off SDK ${major} beta docs`;
+const title = `[docs] Cut off SDK ${major} beta docs`;
 
 const statusOf = (label: string) =>
   failures.has(label)

--- a/docs/scripts/sdk-release/beta.ts
+++ b/docs/scripts/sdk-release/beta.ts
@@ -9,6 +9,8 @@ import { fileURLToPath } from 'node:url';
 const SDK_INPUT = /^(\d{2})(?:\.0\.0)?$/;
 const LLMS_SOURCE_URL = 'https://docs.expo.dev/llms-sdk.txt';
 const LLMS_MIN_BYTES = 500_000;
+const EXPO_REGISTRY_URL = 'https://registry.npmjs.org/expo';
+const CANARY_EXAMPLE = /`\d+\.\d+\.\d+-canary-\d{8}-[\da-f]+`/;
 
 const docsDir = process.cwd();
 const root = execFileSync('git', ['rev-parse', '--show-toplevel'], {
@@ -195,6 +197,50 @@ function expotools(args: string[]) {
 }
 
 const notes: string[] = [];
+
+async function updateCanaryExampleAsync() {
+  const indexPath = join(docsDir, 'pages', 'versions', 'unversioned', 'index.mdx');
+  const page = readFileSync(indexPath, 'utf8');
+  const current = CANARY_EXAMPLE.exec(page);
+
+  if (!current) {
+    throw new Error(
+      'Could not find a canary version example in pages/versions/unversioned/index.mdx. The Canary ' +
+        'releases wording may have changed, so the example was left alone.'
+    );
+  }
+
+  const response = await fetch(EXPO_REGISTRY_URL);
+  if (!response.ok) {
+    throw new Error(
+      `Could not read the expo package from ${EXPO_REGISTRY_URL} (HTTP ${response.status}), so the ` +
+        'canary example could not be refreshed.'
+    );
+  }
+
+  const registry = (await response.json()) as Record<string, Record<string, string> | undefined>;
+  const canary = registry['dist-tags']?.canary;
+
+  if (!canary) {
+    throw new Error(
+      `${EXPO_REGISTRY_URL} has no canary dist-tag, so there is no published version to copy.`
+    );
+  }
+
+  if (canary === current[0].replaceAll('`', '')) {
+    notes.push(`Canary example was already \`${canary}\`.`);
+    return;
+  }
+
+  writeFileSync(indexPath, page.replace(CANARY_EXAMPLE, `\`${canary}\``));
+
+  notes.push(
+    canary.startsWith(`${major}.`)
+      ? `Canary example updated to \`${canary}\` (was ${current[0]}).`
+      : `Canary example updated to \`${canary}\` (was ${current[0]}), but that is not an SDK ${major} ` +
+          `build. Re-run this once main publishes a ${version} canary.`
+  );
+}
 
 function regenerateUnversionedApiData() {
   expotools(['generate-docs-api-data']);
@@ -401,6 +447,7 @@ const steps: {
   preview?: () => void;
   skip?: boolean;
 }[] = [
+  { label: 'Refresh the canary example on the Reference index', run: updateCanaryExampleAsync },
   { label: 'Regenerate unversioned API data', run: regenerateUnversionedApiData },
   { label: `Generate ${versionDir} reference docs`, run: generateVersionedDocs },
   { label: 'Sync app config schema and repoint the import', run: syncAppConfigSchema },

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -107,15 +107,21 @@ We use our fork of React Native for building Expo Go, but it is not used otherwi
 
 **Why:** We store separate versions of API reference docs for each SDK version. We need to version the docs as soon as we cut the release branch so that docs changes that land on main between cutting the release branch and the release date get applied to the new SDK version or not, as appropriate.
 
-**How:**
+**How:** Run the **Docs SDK Beta** workflow (`.github/workflows/docs-sdk-beta.yml`) from the Actions tab, passing the major version to cut as `sdkVersion`, for example `58`. Do this immediately before cutting the release branch.
 
-- Do this step immediately before cutting the release branch.
-- Run `et generate-docs-api-data` to regenerate `unversioned` API data files before cutting new documentation version.
-- Run `et generate-sdk-docs --sdk XX.X.X` to generate versioned docs for the new SDK.
-- Run `pnpm schema-sync XX` (`XX` being the major version number) in `docs` directory and then change the schema import in `pages/versions/<version>/config/app.mdx` from `unversioned` to the new versioned schema file.
-- Run `pnpm versions-schema-sync` in the `docs` directory to fetch the new version's `native-modules.json`, which the package-version header on each SDK page requires. This fetches from `exp.host`, so the new SDK's packages must already be published and synced to the versions endpoint (see [0.6. Publish `next` packages](#06-publish-next-packages)). If the packages are not live yet, the fetch returns nothing, so run this step once they are but you should create the `native-modules.json` file for the new SDK version before cutting the release branch.
-- Ensure that the `version` in package.json has NOT been updated to the new SDK version. SDK versions greater than the `version` in package.json will be hidden in production docs, and we do not want the new version to show up until the SDK has been released.
-- Commit and push changes to main.
+The run takes care of:
+
+- Refreshing the canary example on the Reference index.
+- Regenerating the `unversioned` API data (`et generate-docs-api-data`).
+- Generating the versioned reference docs for the new SDK (`et generate-sdk-docs`).
+- Cloning hardcoded type links into the new version directory.
+- Syncing the app config schema and repointing the import in `pages/versions/<version>/config/app.mdx` from `unversioned` to the new versioned schema file.
+- Creating the `native-modules.json` stub, so the cut is not blocked on the new SDK's packages being live on `exp.host`. Run `pnpm versions-schema-sync` in `docs` to replace it once they are.
+- Archiving the previous SDK's `llms-sdk.txt` bundle and linking it from `pages/llms.mdx`.
+- Adding the new SDK's row to the compatibility table.
+- Setting `betaVersion` in `docs/package.json`, leaving `version` at the released SDK.
+
+The run never pushes to `main`. It opens a PR labelled `docs` and `preview` whose body carries a per-step status table, the files changed per directory, and a checklist of what is still manual. `docs/package.json` keeps `version` at the released SDK and gains `betaVersion`, so the new reference stays hidden in production until it is promoted.
 
 # Stage 1 - Quality Assurance
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25565

# How

Adds **Docs SDK Beta** workflow (`.github/workflows/docs-sdk-beta.yml`) which runs the namesake script from the GitHub Actions tab, passing the major version to cut as `sdkVersion`, for example `58`:

- Refreshing the canary example on the Reference index.
- Regenerating the `unversioned` API data (`et generate-docs-api-data`).
- Generating the versioned reference docs for the new SDK (`et generate-sdk-docs`).
- Cloning hardcoded type links into the new version directory.
- Syncing the app config schema and repointing the import in `pages/versions/<version>/config/app.mdx` from `unversioned` to the new versioned schema file.
- Creating the `native-modules.json` stub, so the cut is not blocked on the new SDK's packages being live on `exp.host`. Run `pnpm versions-schema-sync` in `docs` to replace it once they are.
- ~~Archiving the previous SDK's `llms-sdk.txt` bundle and linking it from `pages/llms.mdx`.~~
- Adding the new SDK's row to the compatibility table.
- Setting `betaVersion` in `docs/package.json`, leaving `version` at the released SDK.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See test PR opened after running this workflow:
- Test PR: https://github.com/expo/expo/pull/48339

The following screenshots were taken from the PR's preview deployment:

<img width="4068" height="2550" alt="CleanShot 2026-07-30 at 21 47 08@2x" src="https://github.com/user-attachments/assets/ffcab0a5-56fd-46ed-92ce-3f877e2a5d0c" />

<img width="4068" height="2550" alt="CleanShot 2026-07-30 at 22 23 34@2x" src="https://github.com/user-attachments/assets/1807152f-831d-4258-a3a6-773e871626ae" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
