### PR TITLE
[expo-updates] Fix SSR memory leak (OOM crash) when imported by expo-router

### DIFF
--- a/packages/expo-updates/src/UpdatesEmitter.ts
+++ b/packages/expo-updates/src/UpdatesEmitter.ts
@@ -6,7 +6,17 @@ import type {
 
 export let latestContext = transformNativeStateMachineContext(ExpoUpdatesModule.initialContext);
 
-ExpoUpdatesModule.addListener('Expo.nativeUpdatesStateChangeEvent', _handleNativeStateChangeEvent);
+// Register the native state change listener only in browser/native environments.
+// In server/SSR rendering contexts, the module is re-evaluated per-request and
+// has no real native module backing it. Repeated addListener calls cause
+// listeners to accumulate, leading to a memory leak (OOM crash).
+// See https://github.com/expo/expo/issues/47938
+if (typeof window !== 'undefined') {
+  ExpoUpdatesModule.addListener(
+    'Expo.nativeUpdatesStateChangeEvent',
+    _handleNativeStateChangeEvent
+  );
+}
 
 interface UpdatesStateChangeSubscription {
   remove(): void;


### PR DESCRIPTION
## Why

When `expo-updates` is imported anywhere in an expo-router project with `output: server`, the dev server leaks memory and eventually crashes with OOM.

Root cause: `UpdatesEmitter.ts` registers a native event listener as a module-level side effect (`ExpoUpdatesModule.addListener(...)`). In server/SSR rendering contexts, this module is re-evaluated per request, and each evaluation adds another listener that is never removed. The listener set grows unbounded.

Fixes #47938.

## How

Guard the `addListener` call with `typeof window !== 'undefined'` so the listener is only registered in browser and native environments — where the module is evaluated once — and is skipped entirely on the server.

- `window` exists in both React Native (native) and browser (web) runtimes → listener registered, behavior unchanged
- `window` does not exist in Node.js (SSR) → listener skipped, no accumulation, no leak

## Test Plan

- Manual: Verified the logic with a test script (`typeof window` checks produce the expected results in Node vs browser vs RN environments)
- The change is a 1-line guard wrapping an existing side-effect; no functional change on native or web platforms