### PR TITLE
fix(sensors)[ios]: convert uncalibrated magnetometer update interval to seconds

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fixed the prebuilt `ExpoSensors.xcframework` always returning `denied` for the motion permission on iOS. The prebuild config unconditionally defined `EXPO_DISABLE_MOTION_PERMISSION`, which is only meant to be set when opting out via the `motionPermission: false` config plugin option. ([#46686](https://github.com/expo/expo/issues/46686) by [@zoontek](https://github.com/zoontek))
+- Fixed `MagnetometerUncalibrated.setUpdateInterval()` on iOS setting `magnetometerUpdateInterval` in milliseconds instead of seconds, so only the first reading was ever delivered. ([#48338](https://github.com/expo/expo/pull/48338) by [@Bram-dc](https://github.com/Bram-dc))
 
 ### 💡 Others
 

--- a/packages/expo-sensors/ios/MagnetometerUncalibratedModule.swift
+++ b/packages/expo-sensors/ios/MagnetometerUncalibratedModule.swift
@@ -19,7 +19,7 @@ public final class MagnetometerUncalibratedModule: Module {
     }
 
     AsyncFunction("setUpdateInterval") { (intervalMs: Double) in
-      motionManager.magnetometerUpdateInterval = intervalMs
+      motionManager.magnetometerUpdateInterval = intervalMs / 1000.0
     }
 
     OnStartObserving {


### PR DESCRIPTION
# Why

`MagnetometerUncalibratedModule` assigns `magnetometerUpdateInterval` straight from its millisecond argument:

```swift
AsyncFunction("setUpdateInterval") { (intervalMs: Double) in
  motionManager.magnetometerUpdateInterval = intervalMs
}
```

`CMMotionManager.magnetometerUpdateInterval` is expressed in **seconds**, and the JS layer (`DeviceSensor.setUpdateInterval`) passes milliseconds through unconverted. The three sibling modules all divide first:

| Module | Assignment |
| --- | --- |
| `AccelerometerModule` | `accelerometerUpdateInterval = intervalMs / 1000.0` |
| `GyroscopeModule` | `gyroUpdateInterval = intervalMs / 1000.0` |
| `MagnetometerModule` | `deviceMotionUpdateInterval = intervalMs / 1000.0` |
| `MagnetometerUncalibratedModule` | `magnetometerUpdateInterval = intervalMs` |

So `MagnetometerUncalibrated.setUpdateInterval(100)` asks CoreMotion for one reading every 100 seconds instead of every 100 ms.

The failure mode is confusing, because the sensor looks like it starts correctly. `isAvailableAsync()` resolves `true`, `addListener` fires once with a valid reading, and then nothing arrives. CoreMotion delivers the first sample promptly and schedules the next one at the (wrong) interval, so any consumer that needs a stream, or that gives up after a timeout shorter than the accidental interval, sees a single event followed by silence.

# How

Divide by 1000, matching the other three sensor modules. One line.

# Test Plan

On a physical iPhone 15 running iOS 26.5:

```js
import { MagnetometerUncalibrated } from 'expo-sensors';

MagnetometerUncalibrated.setUpdateInterval(100);
MagnetometerUncalibrated.addListener((reading) => console.log(reading));
```

- **Before:** exactly one reading is logged, then the stream goes silent.
- **After:** readings arrive at roughly 10 per second, as requested.

Also verified in a real app that samples the uncalibrated magnetometer over a 20 second window. Before the change it collected 1 sample and hit its timeout every time; after the change it collected the full stream and completed normally. The calibrated `Magnetometer` was unaffected in both cases, which is consistent with it already having the conversion.

# Checklist

- [x] Tested on iOS, on a physical device.
- [x] Added a `CHANGELOG.md` entry.
- [ ] Documentation does not need updating: the documented contract (`setUpdateInterval(intervalMs)`) is unchanged, this makes the implementation match it.
