### PR TITLE
[server] Add temporary fallback to allow SDK 55 server exports to keep working

### DIFF
--- a/packages/expo-server/CHANGELOG.md
+++ b/packages/expo-server/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Use favicon from app config when SSR is enabled ([#46570](https://github.com/expo/expo/pull/46570) by [@hassankhan](https://github.com/hassankhan))
 - Ensure external CSS imports are added to the server manifest so they reach the streaming renderer ([#46984](https://github.com/expo/expo/pull/46984) by [@hassankhan](https://github.com/hassankhan))
+- Support web apps exported using SDK 55 ([#48351](https://github.com/expo/expo/pull/48351) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-server/src/rendering.ts
+++ b/packages/expo-server/src/rendering.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { type ImmutableRequest } from './ImmutableRequest';
-import type { AssetInfo, GetStreamingContentOptions } from './manifest';
+import type { AssetInfo, GetStaticContentOptions, GetStreamingContentOptions } from './manifest';
 import type { Metadata } from './metadata';
 
 export interface MatchedRouteMetadata {
@@ -21,6 +21,16 @@ export interface ResolveMetadataOptions {
 }
 
 /**
+ * The legacy SSR render module exported from `_expo/server/render.js`.
+ *
+ * {@link import('@expo/router-server/src/static/renderStaticContent')}
+ */
+export interface LegacyServerRenderModule {
+  /** {@type import('@expo/router-server/src/static/renderStaticContent').getStaticContent} */
+  getStaticContent(location: URL, options?: GetStaticContentOptions): Promise<string>;
+}
+
+/**
  * The SSR render module exported from `_expo/server/render.js`.
  *
  * {@link import('@expo/router-server/src/static/renderStreamingContent')}
@@ -34,6 +44,8 @@ export interface ServerRenderModule {
   ): Promise<ReadableStream<Uint8Array>>;
 }
 
+export type MaybeLegacyServerRenderModule = LegacyServerRenderModule | ServerRenderModule;
+
 export interface RenderOptions {
   loader?: { data: unknown; key: string };
   metadata?: ResolvedMetadata | null;
@@ -43,7 +55,7 @@ export interface RenderOptions {
 export type SsrRenderFn = (
   request: Request,
   options?: RenderOptions
-) => Promise<ReadableStream<Uint8Array>>;
+) => Promise<string | ReadableStream<Uint8Array>>;
 
 /** Module exported from loader bundle, typically `_expo/loaders/[ROUTE].js` */
 export interface LoaderModule {
@@ -51,4 +63,10 @@ export interface LoaderModule {
     request: ImmutableRequest | undefined,
     params: Record<string, string>
   ): Promise<unknown> | unknown;
+}
+
+export function isStreamingRenderer(
+  module: LegacyServerRenderModule | ServerRenderModule
+): module is ServerRenderModule {
+  return 'getStreamingContent' in module;
 }

--- a/packages/expo-server/src/vendor/environment/__tests__/common.test.ts
+++ b/packages/expo-server/src/vendor/environment/__tests__/common.test.ts
@@ -6,7 +6,7 @@ import type {
   RenderingConfiguration,
   RouteInfo,
 } from '../../../manifest';
-import type { ServerRenderModule } from '../../../rendering';
+import type { LegacyServerRenderModule, ServerRenderModule } from '../../../rendering';
 import { createEnvironment } from '../common';
 
 describe('getRoutesManifest', () => {
@@ -293,6 +293,48 @@ describe('getHtml', () => {
     );
 
     expect(input.loadModule).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the legacy SSR renderer for SDK 55 exports', async () => {
+    const mockLegacySSRModule = createMockLegacySSRModule();
+    const input = createMockInput({
+      manifest: {
+        rendering: { mode: 'ssr', file: '_expo/server/render.js' },
+        assets: { css: ['/style.css'], js: ['/app.js'] },
+      },
+      modules: { '_expo/server/render.js': mockLegacySSRModule },
+    });
+    const env = createEnvironment(input);
+    const request = new Request('http://localhost/path?query=1');
+
+    const result = await env.getHtml(
+      request,
+      createMockRoute({
+        file: './path.tsx',
+        page: '/path',
+        namedRegex: new RegExp('^/path(?:/)?$'),
+      })
+    );
+    expect(result).toEqual('<html>Legacy SSR content</html>');
+
+    expect(mockLegacySSRModule.getStaticContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/path',
+        search: '?query=1',
+      }),
+      expect.objectContaining({
+        request,
+        assets: { css: ['/style.css'], externalCss: [], js: ['/app.js'] },
+      })
+    );
+    expect(mockLegacySSRModule.getStaticContent).toHaveBeenCalledWith(
+      expect.any(URL),
+      expect.objectContaining({
+        request: expect.objectContaining({
+          signal: request.signal,
+        }),
+      })
+    );
   });
 
   it('passes location, request, and assets to `getStreamingContent()`', async () => {
@@ -876,6 +918,15 @@ function createMockRoute<T extends string | RegExp = string>(
     page: '',
     namedRegex: '' as T,
     routeKeys: {},
+    ...overrides,
+  };
+}
+
+function createMockLegacySSRModule(
+  overrides: Partial<LegacyServerRenderModule> = {}
+): LegacyServerRenderModule {
+  return {
+    getStaticContent: jest.fn().mockResolvedValue('<html>Legacy SSR content</html>'),
     ...overrides,
   };
 }

--- a/packages/expo-server/src/vendor/environment/common.ts
+++ b/packages/expo-server/src/vendor/environment/common.ts
@@ -1,6 +1,12 @@
 import { ImmutableRequest } from '../../ImmutableRequest';
 import type { AssetInfo, Manifest, MiddlewareInfo, RawManifest, Route } from '../../manifest';
-import type { LoaderModule, RenderOptions, ServerRenderModule, SsrRenderFn } from '../../rendering';
+import {
+  isStreamingRenderer,
+  type LoaderModule,
+  type MaybeLegacyServerRenderModule,
+  type RenderOptions,
+  type SsrRenderFn,
+} from '../../rendering';
 import { isResponse, parseParams, resolveLoaderContextKey } from '../../utils/matchers';
 
 function initManifestRegExp(manifest: RawManifest): Manifest {
@@ -34,7 +40,7 @@ function initManifestRegExp(manifest: RawManifest): Manifest {
     pageHeaders: manifest.pageHeaders?.map((rule) => ({
       ...rule,
       namedRegex: new RegExp(rule.namedRegex),
-    }))
+    })),
   };
 }
 
@@ -57,7 +63,7 @@ export interface CommonEnvironment {
 export function createEnvironment(input: EnvironmentInput): CommonEnvironment {
   // Cached manifest and SSR renderer, initialized on first request
   let cachedManifest: Manifest | null | undefined;
-  let cachedSsrModule: ServerRenderModule | null = null;
+  let cachedSsrModule: MaybeLegacyServerRenderModule | null = null;
   let ssrRenderer: SsrRenderFn | null = null;
 
   async function getRoutesManifest(): Promise<Manifest | null> {
@@ -70,7 +76,7 @@ export function createEnvironment(input: EnvironmentInput): CommonEnvironment {
 
   async function getServerRenderer(): Promise<{
     renderer: SsrRenderFn | null;
-    module: ServerRenderModule | null;
+    module: MaybeLegacyServerRenderModule | null;
   }> {
     if (ssrRenderer && !input.isDevelopment) {
       return {
@@ -91,7 +97,7 @@ export function createEnvironment(input: EnvironmentInput): CommonEnvironment {
     // available
     const ssrModule = (await input.loadModule(
       manifest.rendering.file
-    )) as ServerRenderModule | null;
+    )) as MaybeLegacyServerRenderModule | null;
 
     if (!ssrModule) {
       throw new Error(`SSR module not found at: ${manifest.rendering.file}`);
@@ -103,6 +109,16 @@ export function createEnvironment(input: EnvironmentInput): CommonEnvironment {
       const url = new URL(request.url);
       const location = new URL(url.pathname + url.search, url.origin);
       const assets = mergeAssets(topLevelAssets, options?.assets);
+
+      // NOTE(@hassankhan): We still need to support SDK 55 deployments which
+      // use the "legacy" server export
+      if (!isStreamingRenderer(ssrModule)) {
+        return ssrModule.getStaticContent(location, {
+          loader: options?.loader,
+          request,
+          assets,
+        });
+      }
 
       return ssrModule.getStreamingContent(location, {
         loader: options?.loader,
@@ -145,7 +161,7 @@ export function createEnvironment(input: EnvironmentInput): CommonEnvironment {
         const params = parseParams(request, route);
 
         try {
-          if (ssrModule?.resolveMetadata) {
+          if (ssrModule && isStreamingRenderer(ssrModule) && ssrModule.resolveMetadata) {
             renderOptions.metadata = await ssrModule.resolveMetadata({
               route: {
                 file: route.file,


### PR DESCRIPTION
# Why

When using `web.output: 'server'` with `unstable_useServerRendering: true` in SDK 55, the SSR bundle exports `getStaticContent()` which is used to render HTML. In #43963 (released in SDK 56), we changed server output to use streaming, which means the SSR bundle now exports `getStreamingContent()` in addition to `getStaticContent()`.

As part of #43963, `expo-server` was modified to only look for `getStreamingContent()`, and so when it attempts to run an SDK 55 export, the render call fails with `getStreamingContent is not a function`.

# How

- Added a `LegacyServerRenderModule` type for SDK 55-shaped modules, and a typeguard that can be used to differentiate legacy vs current
- Use the typeguard in `expo-server` to fall back to SDK 55 behavior when the runtime check detects a `getStaticContent()` export

# Test Plan

- CI
- Manual testing locally against an SDK 55 and 56 project

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
