### PR TITLE
[bare-expo][macOS] Update react-native-screens patch

### DIFF
--- a/apps/bare-expo/scripts/fixtures/macos/patches/react-native-screens.patch
+++ b/apps/bare-expo/scripts/fixtures/macos/patches/react-native-screens.patch
@@ -1,11 +1,11 @@
 diff --git a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
-index 945a75bebe089b8b6798e659031fbd91060d52eb..549fca693645bd3e61b11dfbff22b21f9e2e5f9f 100644
+index 06b8e7fbedb213fdb1bf15458ccbf025f5c77503..228cbef99e5eeaad756f0d8cd77c3cbcc6a5e319 100644
 --- a/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
 +++ b/src/fabric/gamma/stack/StackHeaderConfigAndroidNativeComponent.ts
-@@ -81,7 +81,7 @@ export type StackHeaderToolbarMenuItemOptionsAndroid = Partial<
+@@ -123,7 +123,7 @@ export type StackHeaderToolbarMenuElementOptionsAndroid = Partial<
  
  export interface NativeCommands {
-   setToolbarMenuItemOptions: (
+   setToolbarMenuElementOptions: (
 -    viewRef: React.ComponentRef<ComponentType>,
 +    viewRef: React.ElementRef<ComponentType>,
      id: string,


### PR DESCRIPTION
# Why

Fixes the `react-native-screens` patch which is failing on `pod install` with `[Codegen] Error: The first argument of method setToolbarMenuElementOptions must be of type React.ElementRef<>`

# How

- Changes `setToolbarMenuItemOptions` to `setToolbarMenuElementOptions` to match the renamed command in `4.26.0`.

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
