### PR TITLE
[cli] Resolve username for partner provisioned actors

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fix opening web from the Terminal UI when the dev server was started without `--web` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null` ([#48300](https://github.com/expo/expo/pull/48300) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Resolve the signed-in username for partner provisioned actors so Expo Go can verify the account match ([#48354](https://github.com/expo/expo/pull/48354) by [@davidko604](https://github.com/davidko604))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/graphql/queries/UserQuery.ts
+++ b/packages/@expo/cli/src/api/graphql/queries/UserQuery.ts
@@ -5,7 +5,7 @@ export type Permission = 'ADMIN' | 'OWN' | 'PUBLISH' | 'VIEW';
 type CurrentUserDataUser = {
   permissions: Permission[];
   actor: {
-    __typename: 'Robot' | 'SSOUser' | 'User';
+    __typename: 'PartnerActor' | 'Robot' | 'SSOUser' | 'User';
     id: string;
   };
 };
@@ -31,6 +31,12 @@ export type Actor =
         id: string;
       };
       accounts: CurrentUserDataAccount[];
+    }
+  | {
+      __typename: 'PartnerActor';
+      id: string;
+      username: string;
+      accounts: CurrentUserDataAccount[];
     };
 
 type CurrentUserData = {
@@ -50,6 +56,9 @@ const CurrentUserDocument = graphql<CurrentUserData>(`
       }
       ... on Robot {
         firstName
+      }
+      ... on PartnerActor {
+        username
       }
       accounts {
         id

--- a/packages/@expo/cli/src/api/user/__tests__/user-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/user-test.ts
@@ -58,6 +58,13 @@ const robotStub: Actor = {
   accounts: [],
 };
 
+const partnerActorStub: Actor = {
+  __typename: 'PartnerActor',
+  id: 'userId',
+  username: 'partner-username',
+  accounts: [],
+};
+
 function mockLoginRequest() {
   nock(getExpoApiBaseUrl())
     .post('/v2/auth/loginAsync')
@@ -235,5 +242,9 @@ describe(getActorDisplayName, () => {
 
   it('returns robot prefix only for robot actors without firstName', () => {
     expect(getActorDisplayName({ ...robotStub, firstName: undefined })).toBe('robot');
+  });
+
+  it('returns username for partner provisioned actors', () => {
+    expect(getActorDisplayName(partnerActorStub)).toBe('partner-username');
   });
 });

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -27,6 +27,8 @@ export function getActorDisplayName(user?: Actor): string {
       return user.username;
     case 'Robot':
       return user.firstName ? `${user.firstName} (robot)` : 'robot';
+    case 'PartnerActor':
+      return user.username;
     default:
       return ANONYMOUS_USERNAME;
   }


### PR DESCRIPTION
# Why

The Expo Go iOS client requires the dev server manifest username to match the account signed into Expo Go. The CLI can't resolve a username for partner provisioned accounts so those users cannot connect to a dev server.

`getActorDisplayName` had no `PartnerActor` case so it returned `anonymous`. The manifest drops the username when it sees that.

# How

Added the `PartnerActor` to `getActorDisplayName` and fragment + type to `UserQuery` so the username actually comes back from the API.

# Test Plan

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test src/api/user`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
