### PR TITLE
[ui][android] Fix hosted Pressable firing `onLongPress` during an ancestor scroll

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix a `Pressable` hosted in `RNHostView` firing `onLongPress` while the user pans to scroll a surrounding `ScrollView`. ([#48355](https://github.com/expo/expo/pull/48355) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix a `TextField` selection crash when JavaScript replaces the text while the user types, by using the clamped selection binding on all OS versions and clearing the selection on external writes. ([#48274](https://github.com/expo/expo/issues/48274) by [@realZachi](https://github.com/realZachi)) ([#48277](https://github.com/expo/expo/pull/48277) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix `Pressable` (and other responder-based touchables) hosted in `RNHostView` dropping presses on any finger movement. ([#48131](https://github.com/expo/expo/issues/48131) by [@BrianUribe6](https://github.com/BrianUribe6)) ([#48217](https://github.com/expo/expo/pull/48217) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix `community/masked-view` content being clipped after rotation because of window safe area insets. ([#48243](https://github.com/expo/expo/pull/48243) by [@Elehiggle](https://github.com/Elehiggle))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -182,6 +182,10 @@ private class TouchDispatchingRootViewGroup(
   private val currentLocation = IntArray(2)
   private var trackingGestureOffset = false
 
+  // Timestamp which is sent to JSTouchDispatcher to propogae a custom ACTION_CANCEL event
+  // JSTouchDispatcher uses timestamp as id to recognize the event
+  private var gestureKeyTime = -1L
+
   // True if the sheet consumed scroll on the most recent drag frame; drives the settle decision.
   private var sheetMovingOnLastDragFrame = false
 
@@ -226,6 +230,7 @@ private class TouchDispatchingRootViewGroup(
       trackingGestureOffset = true
       sheetMovingOnLastDragFrame = false
       flingHandledThisGesture = false
+      gestureKeyTime = ev.eventTime
     }
 
     // While a nested scroll is in flight the sheet may be sliding this whole view up/down. Re-express
@@ -247,6 +252,7 @@ private class TouchDispatchingRootViewGroup(
 
     if (ev.actionMasked == MotionEvent.ACTION_UP || ev.actionMasked == MotionEvent.ACTION_CANCEL) {
       trackingGestureOffset = false
+      gestureKeyTime = -1L
       notifyAncestorRootViews { it.onChildEndedNativeGesture(this, ev) }
     }
     return handled
@@ -261,21 +267,44 @@ private class TouchDispatchingRootViewGroup(
   }
 
   override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
-    eventDispatcher?.let { dispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
-      jsPointerDispatcher?.handleMotionEvent(event, dispatcher, true)
-    }
+    dispatchTouchEventToJS(event, isCapture = true)
     return super.onInterceptTouchEvent(event)
   }
 
   @SuppressLint("ClickableViewAccessibility")
   override fun onTouchEvent(event: MotionEvent): Boolean {
-    eventDispatcher?.let { dispatcher ->
-      jsTouchDispatcher.handleTouchEvent(event, dispatcher, reactContext)
-      jsPointerDispatcher?.handleMotionEvent(event, dispatcher, false)
-    }
+    dispatchTouchEventToJS(event, isCapture = false)
     super.onTouchEvent(event)
     return true
+  }
+
+  private fun dispatchTouchEventToJS(event: MotionEvent, isCapture: Boolean) {
+    val dispatcher = eventDispatcher ?: return
+    val reissued = if (event.actionMasked == MotionEvent.ACTION_CANCEL) reissueCancel(event) else null
+    val outgoing = reissued ?: event
+
+    jsTouchDispatcher.handleTouchEvent(outgoing, dispatcher, reactContext)
+    jsPointerDispatcher?.handleMotionEvent(outgoing, dispatcher, isCapture)
+    reissued?.recycle()
+  }
+
+  /**
+   * We recreate a custom ACTION_CANCEL event by passing the same gestureKeyTime which was set on ACTION_DOWN
+   * This is sent to JSTouchDispatcher so it can cancel the touch event as some other parent view handled it
+   * TODO(@nishan): This probably will not be needed when RN enables pointer events feature flag. So revisit it
+   */
+  private fun reissueCancel(event: MotionEvent): MotionEvent? {
+    if (gestureKeyTime < 0 || event.downTime == gestureKeyTime) {
+      return null
+    }
+    return MotionEvent.obtain(
+      gestureKeyTime,
+      event.eventTime,
+      MotionEvent.ACTION_CANCEL,
+      event.x,
+      event.y,
+      event.metaState
+    )
   }
 
   override fun onInterceptHoverEvent(event: MotionEvent): Boolean {


### PR DESCRIPTION
# Why

Reported on discord - https://discord.com/channels/695411232856997968/1504711019199467550/1532337488910221445

Regression caused by https://github.com/expo/expo/pull/48217

`Pressable` inside an `RNHostView` which itself is in a `ScrollView` fires `onLongPress` when user does a Pan action on a `ScrollView`.

As demonstrated below, user is trying to perform a scroll on a ScrollView while keeping the finger on a Menu. It opens the `Menu` which is unexpected, the `Menu`'s onLongPress trigger should've been cancelled as soon as user starts scrolling.

https://github.com/user-attachments/assets/06b1419a-6af0-4078-88aa-bb0bf26df06d



<details>
<summary>Repro code.</summary>

```jsx

  <ScrollView>
    <Host matchContents>
      <RNHostView matchContents>
        <Pressable onLongPress={() => console.log('LONG PRESS')} style={{ height: 64, width: 240 }}>
          <Text>Pan across me</Text>
        </Pressable>
      </RNHostView>
    </Host>
    {/* filler rows */}
  </ScrollView>
```
</details>



# How

We dispatch `ACTION_CANCEL` to `JSTouchDispatcher` using the same timestamp Android provided for `ACTION_DOWN`. This feels a bit hacky. We reuse the React Native `Modal` mechanism for `RNHostView`, but the situations are different. A `Modal` is mounted in a separate window hierarchy, so it cannot have a parent `ScrollView`. `RNHostView`, however, can be inside a `ScrollView`, so we need to handle touch cancellation ourselves. The good news is that once React Native enables the pointer events feature flag, we should be able to remove some of these workarounds.


# Test Plan

Tested the user mentioned repro. Tested the existing behavior for any regressions, tested will multiple touches.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
