### PR TITLE
[router] Improve withLayoutContext types

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- Improve withLayoutContext types ([#48356](https://github.com/expo/expo/pull/48356) by [@Ubax](https://github.com/Ubax))
 - Expose `unstable_nativeProps` props from Stack component ([#48152](https://github.com/expo/expo/pull/48152) by [@Ubax](https://github.com/Ubax))
 - Expose route provenance to custom navigators through descriptor `routeSource`. ([#47827](https://github.com/expo/expo/pull/47827) by [@Ubax](https://github.com/Ubax))
 - Re-export drawer content components and types (`DrawerContentScrollView`, `DrawerItem`, `DrawerItemList`, `DrawerContentComponentProps`, `DrawerNavigationProp`, and more) from `expo-router/drawer` ([#46635](https://github.com/expo/expo/pull/46635) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
@@ -2,9 +2,30 @@ import { screen } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
 import { Navigator, Slot } from '../index';
+import { withLayoutContext } from '../layouts/withLayoutContext';
 import type { TabRouterOptions } from '../react-navigation/native';
 import { TabRouter } from '../react-navigation/native';
+import { createStackNavigator } from '../react-navigation/stack';
 import { renderRouter } from '../testing-library';
+
+const StackNavigator = createStackNavigator().Navigator;
+
+function renderProcessedScreens(
+  processScreens: NonNullable<Parameters<typeof withLayoutContext>[1]>
+) {
+  const CustomNavigator = withLayoutContext(StackNavigator, processScreens);
+
+  return renderRouter({
+    _layout: () => (
+      <CustomNavigator>
+        <CustomNavigator.Screen name="index" />
+        <CustomNavigator.Screen name="two" />
+      </CustomNavigator>
+    ),
+    index: () => <Text testID="index" />,
+    two: () => <Text testID="two" />,
+  });
+}
 
 it('can render a custom navigator', () => {
   // The default <Stack /> doesn't have any routerOptions, so we use TabRouter
@@ -34,4 +55,44 @@ it('can render a custom navigator', () => {
     backBehavior: 'history',
     initialRouteName: undefined,
   });
+});
+
+it.each([
+  ['adds a screen', (screens) => [...screens, { ...screens[0]!, name: 'three' }]],
+  ['removes a screen', (screens) => screens.slice(1)],
+  ['renames a screen', (screens) => [{ ...screens[0]!, name: 'three' }, screens[1]!]],
+  ['duplicates and removes a screen', (screens) => [screens[0]!, screens[0]!]],
+  ['adds a duplicate screen', (screens) => [screens[0]!, screens[0]!, screens[1]!]],
+] satisfies [string, NonNullable<Parameters<typeof withLayoutContext>[1]>][])(
+  '%s',
+  (_, processScreens) => {
+    expect(() => renderProcessedScreens(processScreens)).toThrow(
+      '`processScreens` must not add, remove, rename, or duplicate screens.'
+    );
+  }
+);
+
+it('allows processScreens to update screen options', () => {
+  expect(() =>
+    renderProcessedScreens((screens) =>
+      screens.map((screen) => {
+        if (
+          typeof screen.options !== 'function' &&
+          screen.options &&
+          'customOption' in screen.options
+        ) {
+          return screen;
+        }
+        return { ...screen, options: { customOption: true } };
+      })
+    )
+  ).not.toThrow();
+});
+
+it('allows processScreens to reorder screens', () => {
+  expect(() => renderProcessedScreens((screens) => [...screens].reverse())).not.toThrow();
+});
+
+it('preserves the fallback for a nullish processScreens result', () => {
+  expect(() => renderProcessedScreens(() => undefined as never)).not.toThrow();
 });

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -39,7 +39,6 @@ const ExpoTabs = withLayoutContext<
         options: {
           ...options,
           tabBarItemStyle: href == null ? { display: 'none' } : options.tabBarItemStyle,
-          // @ts-expect-error: TODO(@kitten): This isn't properly typed
           tabBarButton: (props) => {
             if (href == null) {
               return null;

--- a/packages/expo-router/src/layouts/withLayoutContext.tsx
+++ b/packages/expo-router/src/layouts/withLayoutContext.tsx
@@ -19,7 +19,11 @@ import { isScreen, Screen } from '../views/Screen';
 import { GuardContextProvider, normalizeRouteName, type GuardedRedirects } from './GuardContext';
 import { IsWithinLayoutContext } from './IsWithinLayoutContext';
 
-export function useFilterScreenChildren(
+export function useFilterScreenChildren<
+  TOptions extends object = Record<string, any>,
+  TState extends NavigationState = NavigationState,
+  TEventMap extends EventMapBase = EventMapBase,
+>(
   children: ReactNode,
   {
     isCustomNavigator,
@@ -33,12 +37,12 @@ export function useFilterScreenChildren(
   return useMemo(() => {
     const customChildren: any[] = [];
 
-    const screens: (ScreenProps & { name: string })[] = [];
+    const screens: (ScreenProps<TOptions, TState, TEventMap> & { name: string })[] = [];
     const guardedRedirects: GuardedRedirects = new Map();
 
     function flattenChild(child: ReactNode, exclude = false, redirectTo?: Href) {
       if (isScreen(child, contextKey)) {
-        screens.push(child.props);
+        screens.push(child.props as ScreenProps<TOptions, TState, TEventMap> & { name: string });
         if (exclude) {
           guardedRedirects.set(child.props.name, redirectTo);
         }
@@ -50,7 +54,7 @@ export function useFilterScreenChildren(
         screens.push({
           ...child.props,
           options: exclude ? { ...options, hidden: true } : options,
-        } as ScreenProps & { name: string });
+        } as ScreenProps<TOptions, TState, TEventMap> & { name: string });
         if (exclude) {
           guardedRedirects.set(child.props.name, redirectTo);
         }
@@ -111,7 +115,9 @@ export function useFilterScreenChildren(
  * Enables use of other built-in React Navigation navigators and other navigators built with the React Navigation custom navigator API.
  *
  * @param Nav - The navigator component to wrap.
- * @param processor - A function that processes the screens before passing them to the navigator.
+ * @param processScreens - A function that processes the screens before passing them to the navigator.
+ * It must preserve every screen name exactly once because guards are associated with the original
+ * screen names.
  *
  *  @example
  * ```tsx app/_layout.tsx
@@ -138,21 +144,47 @@ export function useFilterScreenChildren(
  * ```
  */
 export function withLayoutContext<
-  TOptions extends object,
-  T extends ComponentType<any>,
-  TState extends NavigationState,
-  TEventMap extends EventMapBase,
->(Nav: T, processor?: (options: ScreenProps[]) => ScreenProps[]) {
+  TOptions extends object = Record<string, any>,
+  T extends ComponentType<any> = ComponentType<any>,
+  TState extends NavigationState = NavigationState,
+  TEventMap extends EventMapBase = EventMapBase,
+>(
+  Nav: T,
+  processScreens?: (
+    screens: (ScreenProps<TOptions, TState, TEventMap> & { name: string })[]
+  ) => (ScreenProps<TOptions, TState, TEventMap> & { name: string })[]
+) {
   return Object.assign(
     forwardRef(({ children: userDefinedChildren, ...props }: any, ref) => {
       const contextKey = useContextKey();
       const node = useRouteNode();
 
-      const { screens, guardedRedirects } = useFilterScreenChildren(userDefinedChildren, {
-        contextKey,
-      });
+      const { screens, guardedRedirects } = useFilterScreenChildren<TOptions, TState, TEventMap>(
+        userDefinedChildren,
+        { contextKey }
+      );
 
-      const processed = processor ? processor(screens ?? []) : screens;
+      const screenNames =
+        processScreens && process.env.NODE_ENV !== 'production'
+          ? new Set(screens.map(({ name }) => name))
+          : undefined;
+
+      const processed = processScreens ? processScreens(screens ?? []) : screens;
+
+      if (screenNames && processed) {
+        const processedNames = processed.map(({ name }) => name);
+        if (
+          processedNames.length !== screenNames.size ||
+          new Set(processedNames).size !== screenNames.size ||
+          !processedNames.every((name) => screenNames.has(name))
+        ) {
+          throw new Error(
+            '`processScreens` must not add, remove, rename, or duplicate screens. ' +
+              `Received: ${JSON.stringify(processedNames)}. ` +
+              `Expected: ${JSON.stringify([...screenNames])}.`
+          );
+        }
+      }
 
       const sorted = useSortedScreens(processed ?? [], guardedRedirects);
 

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -80,11 +80,19 @@ export type SingularOptions =
   | boolean
   | ((name: string, params: UnknownOutputParams) => string | undefined);
 
-function getSortedChildren(
+function getSortedChildren<
+  TOptions extends object,
+  TState extends NavigationState,
+  TEventMap extends EventMapBase,
+>(
   children: RouteNode[],
-  order: ScreenProps[] = [],
+  order: ScreenProps<TOptions, TState, TEventMap>[] = [],
   initialRouteName?: string
-): { route: RouteNode; props: Partial<ScreenProps>; routeSource: RouteSource }[] {
+): {
+  route: RouteNode;
+  props: Partial<ScreenProps<TOptions, TState, TEventMap>>;
+  routeSource: RouteSource;
+}[] {
   if (!order?.length) {
     return children
       .sort(sortRoutesWithInitial(initialRouteName))
@@ -161,7 +169,7 @@ function getSortedChildren(
     )
     .filter(Boolean) as {
     route: RouteNode;
-    props: Partial<ScreenProps>;
+    props: Partial<ScreenProps<TOptions, TState, TEventMap>>;
     routeSource: RouteSource;
   }[];
 
@@ -178,8 +186,12 @@ function getSortedChildren(
 /**
  * @returns React Navigation screens sorted by the `route` property.
  */
-export function useSortedScreens(
-  order: ScreenProps[],
+export function useSortedScreens<
+  TOptions extends object,
+  TState extends NavigationState,
+  TEventMap extends EventMapBase,
+>(
+  order: ScreenProps<TOptions, TState, TEventMap>[],
   guardedRedirects: GuardedRedirects = new Map()
 ): React.ReactNode[] {
   const node = useRouteNode();
@@ -534,9 +546,13 @@ export function screenOptionsFactory(
 }
 
 // TODO: Refactor to take a single named-args object instead of positional params.
-export function routeToScreen(
+export function routeToScreen<
+  TOptions extends object,
+  TState extends NavigationState,
+  TEventMap extends EventMapBase,
+>(
   route: RouteNode,
-  { options, getId, ...props }: Partial<ScreenProps> = {},
+  { options, getId, ...props }: Partial<ScreenProps<TOptions, TState, TEventMap>> = {},
   isGuarded?: boolean,
   routeSource?: RouteSource
 ) {


### PR DESCRIPTION
# Why

`withLayoutContext` lost navigator-specific screen option types inside `processScreens`, which required local type suppressions such as the one around `Tabs` `tabBarButton`.

# How

Thread navigator option, state, and event map types through screen processing and sorting. Preserve the default `Record<string, any>` options type for callers that omit generics.

Validate in development that `processScreens` preserves each original screen exactly once. Guard metadata is keyed by the original screen names, so adding, removing, renaming, or duplicating screens would desynchronize it. Reordering screens and changing their options remain supported.

# Test Plan

- `pnpm test src/__tests__/custom-navigators.test.ios.tsx --runInBand`
- `pnpm build`
- `pnpm lint`

Automated tests cover adding, removing, renaming, duplicating, reordering, updating options, omitted generic option access, and the legacy nullish processor fallback.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)