### PR TITLE
[ios][app-metrics] Fix crash when GTMSessionFetcher inspects our URLSession delegate proxy

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class checks for the delegate it wraps. ([#48359](https://github.com/expo/expo/pull/48359) by [@tsapeta](https://github.com/tsapeta))
 - Fix integer metric and log attributes equal to `0` or `1` serializing as booleans on iOS. ([#47108](https://github.com/expo/expo/pull/47108) by [@tsapeta](https://github.com/tsapeta))
 - fix race condition between db inserts ([#46702](https://github.com/expo/expo/pull/46702) by [@Ubax](https://github.com/Ubax))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
@@ -575,14 +575,40 @@ private final class DelegateProxy: NSObject {
     return wrapped?.responds(to: aSelector) ?? false
   }
 
+  /// Class checks have to answer for the wrapped delegate, not for the proxy. Libraries branch on
+  /// the class of `session.delegate` and a proxy that answers for itself sends them down the wrong
+  /// branch.
+  ///
+  /// GTMSessionFetcher (FirebaseAuth's HTTP layer) is the case that forced this: it makes the fetcher
+  /// its own session delegate for sessions it can't share, then decides whether the delegate is its
+  /// internal dispatcher with `delegate != nil && ![delegate isKindOfClass:[GTMSessionFetcher class]]`.
+  /// Answering that check for the proxy made GTM treat us as a dispatcher and send us
+  /// `setFetcher:forTask:`, a selector only the dispatcher implements — crashing the app on
+  /// FirebaseAuth's first token refresh.
+  override func isKind(of aClass: AnyClass) -> Bool {
+    if let wrapped = wrapped as? NSObject, wrapped.isKind(of: aClass) {
+      return true
+    }
+    return super.isKind(of: aClass)
+  }
+
+  override func isMember(of aClass: AnyClass) -> Bool {
+    if let wrapped = wrapped as? NSObject, wrapped.isMember(of: aClass) {
+      return true
+    }
+    return super.isMember(of: aClass)
+  }
+
+  /// Everything except the metrics callback goes to the wrapped delegate — including selectors it
+  /// doesn't implement. Returning `nil` for those would raise `unrecognized selector` on the proxy,
+  /// naming `ExpoAppMetrics` in a crash the app would have hit on its own delegate anyway. Forwarding
+  /// unconditionally keeps the failure where it belongs and keeps the crash report pointing at the
+  /// real culprit.
   override func forwardingTarget(for aSelector: Selector!) -> Any? {
     if aSelector == Self.metricsSelector {
       return nil
     }
-    if let wrapped, wrapped.responds(to: aSelector) {
-      return wrapped
-    }
-    return nil
+    return wrapped
   }
 
   /// Canonical recording site. `didFinishCollectingMetrics:` is Apple's "task is fully done" signal

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -604,6 +604,55 @@ struct NetworkRequestTaskSwizzlingTests {
     #expect(recorded?.statusCode == 200)
   }
 
+  /// Regression test for the FirebaseAuth crash reported in SDK 54
+  /// (`-[ExpoAppMetrics.DelegateProxy setFetcher:forTask:]: unrecognized selector`).
+  ///
+  /// GTMSessionFetcher — the HTTP layer under FirebaseAuth — makes itself the delegate of sessions
+  /// it can't share, then later asks whether that delegate is its own dispatcher with
+  /// `delegate != nil && ![delegate isKindOfClass:[GTMSessionFetcher class]]`. An opaque proxy
+  /// answers that check for itself, so GTM mistakes it for a dispatcher and sends it
+  /// `setFetcher:forTask:` — a selector only the dispatcher implements. `isKind(of:)` therefore has
+  /// to answer for the wrapped delegate, which makes GTM take its "the fetcher is the delegate"
+  /// branch and never send the selector.
+  @Test
+  func `answers isKindOfClass for the wrapped delegate`() {
+    let delegate = FakeSessionDelegate()
+    let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    let installed = session.delegate as? NSObject
+    // Guard the premise: if the proxy stopped being installed the assertions below would pass for
+    // the wrong reason.
+    #expect(installed !== delegate)
+    #expect(installed?.isKind(of: FakeSessionDelegate.self) == true)
+    #expect(installed?.isMember(of: FakeSessionDelegate.self) == true)
+    #expect(installed?.isKind(of: URLSession.self) == false)
+  }
+
+  /// Second half of the same crash: even when something does send an unimplemented selector, the
+  /// proxy must hand the message to the wrapped delegate instead of letting it die on the proxy.
+  /// The wrapped delegate then raises the same `unrecognized selector` the app would have raised
+  /// without instrumentation — a proxy that returns `nil` here turns a caller's mistake into a
+  /// crash inside `ExpoAppMetrics`.
+  @Test
+  func `forwards unimplemented selectors to the wrapped delegate`() {
+    let delegate = FakeSessionDelegate()
+    let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    let installed = session.delegate as? NSObject
+    #expect(installed !== delegate)
+    // `setFetcher:forTask:` stands in for any selector the wrapped delegate doesn't implement.
+    let unimplemented = NSSelectorFromString("setFetcher:forTask:")
+    #expect(delegate.responds(to: unimplemented) == false)
+    #expect(installed?.forwardingTarget(for: unimplemented) as? NSObject === delegate)
+    // Selectors the wrapped delegate does implement keep forwarding to it as before.
+    #expect(
+      installed?.forwardingTarget(for: NSSelectorFromString("URLSession:didBecomeInvalidWithError:"))
+        as? NSObject === delegate
+    )
+  }
+
   private func waitForRecorded(matching url: URL, attempts: Int = 50) async -> NetworkRequest? {
     for _ in 0..<attempts {
       let found = try? await AppMetricsActor.isolated {
@@ -843,6 +892,13 @@ private final class FilteringDelegate: NetworkRequestObserverDelegate, @unchecke
     }
     completed.append(request)
   }
+}
+
+/// Stands in for a third-party session delegate — GTMSessionFetcher's fetcher object in the crash
+/// this file regression-tests. It implements one delegate callback so the forwarding test can tell a
+/// selector the delegate handles apart from one it doesn't.
+private final class FakeSessionDelegate: NSObject, URLSessionDataDelegate {
+  func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {}
 }
 
 /// A trivial `URLProtocol` that pretends to be a server. Routes by URL path:


### PR DESCRIPTION
# Why

Reported on Discord: an app that uses `expo-observe` together with Firebase crashes on launch in the
iOS Simulator, on FirebaseAuth's first token refresh.

```
NSInvalidArgumentException
-[ExpoAppMetrics.DelegateProxy setFetcher:forTask:]: unrecognized selector sent to instance 0x60000007bdf0

 5  App   -[GTMSessionFetcherService fetcherDidBeginFetching:] + 408
 6  App   -[GTMSessionFetcher beginFetchMayDelay:mayAuthorize:mayDecorate:] + 9648
 8  App   closure #1 in FirebaseAuth.AuthBackendRPCIssuer.asyncCallToURL<A>(with:body:contentType:)
15  App   FirebaseAuth.SecureTokenServiceInternal.fetchAccessToken(forcingRefresh:service:backend:)
18  App   FirebaseAuth.TokenRefreshCoalescer.coalescedRefresh(currentToken:refreshFunction:)
```

The crash is ours, not Firebase's:

1. `NetworkRequestTaskSwizzling` swizzles `+[NSURLSession sessionWithConfiguration:delegate:delegateQueue:]`
   and wraps the caller's delegate in `DelegateProxy` to capture `didFinishCollectingMetrics:`.
2. GTMSessionFetcher — FirebaseAuth's HTTP layer — makes the fetcher its own session delegate for
   sessions it can't share ([`GTMSessionFetcher.m:1094-1100`](https://github.com/google/gtm-session-fetcher/blob/main/Sources/Core/GTMSessionFetcher.m)).
3. `GTMSessionFetcherService` later decides whether that delegate is its internal dispatcher
   ([`GTMSessionFetcherService.m:436`](https://github.com/google/gtm-session-fetcher/blob/main/Sources/Core/GTMSessionFetcherService.m)):

   ```objc
   BOOL hasDispatcher = (fetcherDelegate != nil && ![fetcherDelegate isKindOfClass:[GTMSessionFetcher class]]);
   ```

   `DelegateProxy` is an `NSObject` subclass, so `isKindOfClass:` answered for the proxy and the check
   passed. GTM concluded there was a dispatcher and sent the proxy `setFetcher:forTask:`, a selector
   only `GTMSessionFetcherSessionDelegateDispatcher` implements.
4. `forwardingTarget(for:)` only forwarded selectors the wrapped delegate responds to. The fetcher
   doesn't implement `setFetcher:forTask:`, so it returned `nil` and the message died on the proxy.

GTM's comment on that check says it deliberately tolerates proxies ("some third-party frameworks are
known to swizzle NSURLSession to proxy its delegate") — but its tolerance depends on `isKindOfClass:`
passing through to the wrapped object, which an `NSObject` subclass does not do on its own.

# How

Two changes to `DelegateProxy`:

- `isKind(of:)` and `isMember(of:)` now answer for the wrapped delegate first, falling back to the
  proxy's own class. GTM therefore takes its "the fetcher is the delegate" branch and never sends
  `setFetcher:forTask:`. This is the general fix — any library that branches on the class of
  `session.delegate` was equally exposed.
- `forwardingTarget(for:)` hands over every selector except the metrics callback, including ones the
  wrapped delegate doesn't implement. Returning `nil` there raised `unrecognized selector` on the
  proxy, putting `ExpoAppMetrics` in the middle of a crash the app would have hit on its own delegate
  anyway. Now the failure lands where it belongs.

`responds(to:)` is unchanged, so which optional `URLSession` callbacks fire is unaffected.

An alternative was swizzling `-[NSURLSession delegate]` to unwrap the proxy, which would make it
invisible to every caller instead of just to class checks. I didn't take it: if `URLSession` reads its
own delegate through that getter internally, unwrapping would route callbacks past the proxy and we'd
silently lose all per-request metrics. The narrow fix has predictable behavior.

# Test Plan

Two regression tests in `NetworkRequestTests.swift`, under the existing `NetworkRequestTaskSwizzling`
suite:

- `answers isKindOfClass for the wrapped delegate` — mirrors GTM's exact predicate against a session
  created with a plain `NSObject` delegate, and asserts the proxy is in fact installed so the test
  can't pass for the wrong reason.
- `forwards unimplemented selectors to the wrapped delegate` — asserts `forwardingTarget(for:)`
  returns the wrapped delegate for `setFetcher:forTask:` (which it does not implement) as well as for
  a selector it does.

`et native-unit-tests -p ios --packages expo-app-metrics`, iPhone 17 Pro simulator:

```
** TEST SUCCEEDED **
✅ All unit tests passed for the following packages: expo-app-metrics
```

195 test cases passed, nothing failed.

Both tests were confirmed red first. Reverting only
`NetworkRequestTaskSwizzling.swift` to `origin/main` and re-running the same suite fails exactly the
two new tests and nothing else:

```
Failing tests:
	NetworkRequestTaskSwizzlingTests.`answers isKindOfClass for the wrapped delegate`()
	NetworkRequestTaskSwizzlingTests.`forwards unimplemented selectors to the wrapped delegate`()
** TEST FAILED **
```

Not yet done: end-to-end reproduction on a device or simulator with a real Firebase app. Build an app
with `expo-observe` and `@react-native-firebase/auth`, sign in, and let FirebaseAuth refresh its token
— before this change it crashes with the trace above.

# Checklist

- [x] I added a `CHANGELOG.md` entry
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
