### PR TITLE
[ios][app-metrics] Fix crash when GTMSessionFetcher inspects our URLSession delegate proxy

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
@@ -547,14 +547,10 @@ private final class ObservationContext: @unchecked Sendable {
 /// `NSObject` subclass that captures `didFinishCollectingMetrics` for our observation context while
 /// transparently forwarding every other selector to the caller's original delegate.
 ///
-/// **Why we don't declare `URLSessionTaskDelegate` conformance in Swift.** `URLSession` introspects
-/// its delegate via `conformsToProtocol:(URLSessionDataDelegate)`, `conformsToProtocol:(URLSessionDownloadDelegate)`,
-/// etc., to decide which optional callbacks it should emit. If we conformed to `URLSessionTaskDelegate`
-/// in Swift, the Obj-C runtime would advertise that conformance for the proxy unconditionally — even
-/// when the wrapped delegate is actually a `URLSessionDataDelegate`. That could change which callbacks
-/// fire and break the caller. We instead reflect the wrapped delegate's `responds(to:)` results, plus
-/// `true` for the metrics selector we intercept. This is the same pattern Bugsnag's
-/// `BSGURLSessionPerformanceProxy` uses.
+/// Every introspection method mirrors the wrapped delegate rather than declaring conformance, which
+/// would advertise callbacks it may not implement. `NSProxy` would forward all of it for free, but
+/// Swift can't subclass it usefully (no accessible initializer, no `NSInvocation`), so each method is
+/// enumerated by hand — and a missing one crashes someone else's library, as `isKind(of:)` describes.
 ///
 /// The metrics callback is implemented as an `@objc` method so the Obj-C runtime can dispatch it via
 /// `responds(to:)` without us declaring formal protocol conformance.
@@ -575,14 +571,33 @@ private final class DelegateProxy: NSObject {
     return wrapped?.responds(to: aSelector) ?? false
   }
 
+  /// GTMSessionFetcher detects its internal dispatcher with `![delegate isKindOfClass:[GTMSessionFetcher
+  /// class]]`; answering for the proxy made it send us a dispatcher-only selector and crash FirebaseAuth.
+  /// Obj-C senders only — Swift's `is`/`as?` compare class pointers and never reach this.
+  override func isKind(of aClass: AnyClass) -> Bool {
+    if let wrapped = wrapped as? NSObject, wrapped.isKind(of: aClass) {
+      return true
+    }
+    return super.isKind(of: aClass)
+  }
+
+  /// Same as `isKind(of:)` for protocol questions; unmirrored, the proxy conforms to nothing.
+  override func conforms(to aProtocol: Protocol) -> Bool {
+    if let wrapped = wrapped as? NSObject, wrapped.conforms(to: aProtocol) {
+      return true
+    }
+    return super.conforms(to: aProtocol)
+  }
+
+  /// Unimplemented selectors go to the wrapped delegate too, so the resulting `unrecognized selector`
+  /// names the caller's delegate and not `ExpoAppMetrics` — except for delegate-less sessions, where
+  /// there is nothing to forward to. Keep `wrapped` a `let` bound to an already-built object: a cycle
+  /// back here would tail-call forever instead of crashing.
   override func forwardingTarget(for aSelector: Selector!) -> Any? {
     if aSelector == Self.metricsSelector {
       return nil
     }
-    if let wrapped, wrapped.responds(to: aSelector) {
-      return wrapped
-    }
-    return nil
+    return wrapped
   }
 
   /// Canonical recording site. `didFinishCollectingMetrics:` is Apple's "task is fully done" signal

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -604,6 +604,56 @@ struct NetworkRequestTaskSwizzlingTests {
     #expect(recorded?.statusCode == 200)
   }
 
+  /// Regression test for the FirebaseAuth crash: GTMSessionFetcher reads the class and conformance of
+  /// `session.delegate` to decide what to send it.
+  @Test
+  func `mirrors the wrapped delegate for class and protocol checks`() {
+    let delegate = FakeSessionDelegate()
+    let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    let installed = session.delegate as? NSObject
+    // Without this the assertions below would pass for the wrong reason.
+    #expect(installed !== delegate)
+    #expect(installed?.isKind(of: FakeSessionDelegate.self) == true)
+    #expect(installed?.isKind(of: URLSession.self) == false)
+    #expect(installed?.conforms(to: URLSessionDataDelegate.self) == true)
+    #expect(installed?.conforms(to: URLSessionStreamDelegate.self) == false)
+  }
+
+  /// The other half of the crash: an unimplemented selector has to reach the wrapped delegate instead
+  /// of dying on the proxy.
+  @Test
+  func `forwards unimplemented selectors to the wrapped delegate`() {
+    let delegate = FakeSessionDelegate()
+    let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    let installed = session.delegate as? NSObject
+    #expect(installed !== delegate)
+    let unimplemented = NSSelectorFromString("setFetcher:forTask:")
+    #expect(delegate.responds(to: unimplemented) == false)
+    #expect(installed?.forwardingTarget(for: unimplemented) as? NSObject === delegate)
+    // A selector it does implement still forwards, as before.
+    #expect(
+      installed?.forwardingTarget(for: NSSelectorFromString("URLSession:didBecomeInvalidWithError:"))
+        as? NSObject === delegate
+    )
+  }
+
+  /// Delegate-less sessions are wrapped too, so the proxy exists with nothing behind it. Nothing to
+  /// forward to means the `unrecognized selector` lands on the proxy — pinned here so a refactor that
+  /// force-unwraps or substitutes a placeholder fails loudly.
+  @Test
+  func `forwards nowhere when it wraps a nil delegate`() {
+    let session = URLSession(configuration: .ephemeral, delegate: nil, delegateQueue: nil)
+    defer { session.invalidateAndCancel() }
+
+    let installed = session.delegate as? NSObject
+    #expect(installed != nil)
+    #expect(installed?.forwardingTarget(for: NSSelectorFromString("setFetcher:forTask:")) == nil)
+  }
+
   private func waitForRecorded(matching url: URL, attempts: Int = 50) async -> NetworkRequest? {
     for _ in 0..<attempts {
       let found = try? await AppMetricsActor.isolated {
@@ -843,6 +893,12 @@ private final class FilteringDelegate: NetworkRequestObserverDelegate, @unchecke
     }
     completed.append(request)
   }
+}
+
+/// Stands in for a third-party session delegate. Implements one callback so the forwarding test can
+/// tell a selector it handles apart from one it doesn't.
+private final class FakeSessionDelegate: NSObject, URLSessionDataDelegate {
+  func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {}
 }
 
 /// A trivial `URLProtocol` that pretends to be a server. Routes by URL path:


### PR DESCRIPTION
# Why

Reported on [Discord](https://discord.com/channels/695411232856997968/1532162191355281599) — crash on launch with `expo-observe` in an app that uses Firebase:

```
-[ExpoAppMetrics.DelegateProxy setFetcher:forTask:]: unrecognized selector

 5  App  -[GTMSessionFetcherService fetcherDidBeginFetching:]
15  App  FirebaseAuth.SecureTokenServiceInternal.fetchAccessToken(forcingRefresh:service:backend:)
```

It's our bug. We wrap the session delegate to capture `didFinishCollectingMetrics:`. GTMSessionFetcher
(FirebaseAuth's HTTP layer) makes the fetcher its own delegate, then checks
`![delegate isKindOfClass:[GTMSessionFetcher class]]` to decide whether the delegate is its internal
dispatcher ([GTMSessionFetcherService.m:436](https://github.com/google/gtm-session-fetcher/blob/main/Sources/Core/GTMSessionFetcherService.m)).
Our proxy answered that for itself, so GTM took it for a dispatcher and sent it `setFetcher:forTask:`,
which only the dispatcher implements. `forwardingTarget(for:)` returned nil for it, so the message died
on the proxy.

# How

`isKind(of:)` and `conforms(to:)` now answer for the wrapped delegate, so GTM takes its "the fetcher is
the delegate" branch. `forwardingTarget(for:)` hands over every non-metrics selector, including ones
the wrapped delegate doesn't implement, so an unrecognized selector blames the caller's delegate
instead of us. `responds(to:)` is unchanged, so callback delivery isn't affected.

Bugsnag's `BSGURLSessionTracingProxy` solves this by being an `NSProxy`, which forwards class and
protocol checks for free. We can't do that from Swift — `NSProxy` has no accessible initializer and
`NSInvocation` isn't exposed — so the proxy mirrors each method by hand.

# Test Plan

Two tests in the existing `NetworkRequestTaskSwizzling` suite, one per half of the fix.

`et native-unit-tests -p ios --packages expo-app-metrics` on an iPhone 17 Pro sim: 195 passed. With
`NetworkRequestTaskSwizzling.swift` reverted to main, those two fail and nothing else does.
