### PR TITLE
[fingerprint] Hoist Minimatch build out of ExpoConfigLoader per-module filter

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- Hoisted the ignore-path Minimatch build out of the per-module filter in `ExpoConfigLoader`, avoiding O(modules × patterns) Minimatch constructions during config load. Byte-identical fingerprint hash. ([#48367](https://github.com/expo/expo/pull/48367) by [@alfonsocj](https://github.com/alfonsocj))
 - Reworked config-plugin module capture with a `Module.prototype._compile` hook. ([#47666](https://github.com/expo/expo/pull/47666) by [@kudo](https://github.com/kudo))
 - Derived config-plugin modules by diffing a plugins-skipped config load, which drops most config-loading framework modules automatically and shrinks the hand-maintained allowlist. ([#47678](https://github.com/expo/expo/pull/47678) by [@kudo](https://github.com/kudo))
 

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import resolveFrom from 'resolve-from';
 
 import { DEFAULT_IGNORE_PATHS } from './Options';
-import { isIgnoredPath, toPosixPath } from './utils/Path';
+import { buildPathMatchObjects, isIgnoredPathWithMatchObjects, toPosixPath } from './utils/Path';
 
 async function runAsync(programName: string, args: string[] = []) {
   if (args[0] == null) {
@@ -159,6 +159,7 @@ export async function resolveLoadedModuleSourcesAsync(
   ignoredPaths: string[]
 ): Promise<LoadedModuleSource[]> {
   const seen = new Set<string>();
+  const ignoredPathMatchObjects = buildPathMatchObjects(ignoredPaths);
   const candidates = capturedModules
     .map(({ filename, content }) => ({
       relativePath: toPosixPath(path.relative(projectRoot, filename)),
@@ -166,7 +167,10 @@ export async function resolveLoadedModuleSourcesAsync(
       content,
     }))
     .filter(({ relativePath }) => {
-      if (seen.has(relativePath) || isIgnoredPath(relativePath, ignoredPaths)) {
+      if (
+        seen.has(relativePath) ||
+        isIgnoredPathWithMatchObjects(relativePath, ignoredPathMatchObjects)
+      ) {
         return false;
       }
       seen.add(relativePath);

--- a/packages/@expo/fingerprint/src/__tests__/ExpoConfigLoader-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ExpoConfigLoader-test.ts
@@ -9,6 +9,18 @@ import {
   type CapturedModule,
 } from '../ExpoConfigLoader';
 
+const minimatchConstructorSpy = jest.fn();
+jest.mock('minimatch', () => {
+  const actual = jest.requireActual('minimatch');
+  class SpyMinimatch extends actual.Minimatch {
+    constructor(...args: ConstructorParameters<typeof actual.Minimatch>) {
+      minimatchConstructorSpy(...args);
+      super(...args);
+    }
+  }
+  return { ...actual, Minimatch: SpyMinimatch };
+});
+
 describe('installModuleCaptureHook', () => {
   let tmpDir: string;
   let hook: ReturnType<typeof installModuleCaptureHook> | null = null;
@@ -113,5 +125,19 @@ describe('resolveLoadedModuleSourcesAsync', () => {
     const sources = await resolveLoadedModuleSourcesAsync(captured, tmpDir, []);
 
     expect(sources).toEqual([{ type: 'file', path: 'plugin.ts' }]);
+  });
+
+  it('should build Minimatch objects once per call, not once per module', async () => {
+    const ignoredPaths = Array.from({ length: 8 }, (_, i) => `**/ignored-${i}/**/*`);
+    const captured: CapturedModule[] = Array.from({ length: 20 }, (_, i) => {
+      const filePath = path.join(tmpDir, `plugin-${i}.ts`);
+      fs.writeFileSync(filePath, 'export default {};');
+      return { id: filePath, filename: filePath, content: 'x' };
+    });
+
+    minimatchConstructorSpy.mockClear();
+    await resolveLoadedModuleSourcesAsync(captured, tmpDir, ignoredPaths);
+
+    expect(minimatchConstructorSpy).toHaveBeenCalledTimes(ignoredPaths.length);
   });
 });


### PR DESCRIPTION
# Why

`ExpoConfigLoader.resolveLoadedModuleSourcesAsync` calls `isIgnoredPath()` once per captured module. `isIgnoredPath()` rebuilds every `Minimatch` on each call, so the filter is O(modules × patterns) in Minimatch **constructions**, not just matches.

On a large monorepo (~600 modules × ~4200 ignore patterns) that is ~2.5M constructions — measured at ~37s of a ~79s `native-hash` run. The cost was previously invisible because `getExpoConfigAsync` is not wrapped in Expo's `profile()` helper.

# How

Hoist `buildPathMatchObjects()` out of the per-module filter and use `isIgnoredPathWithMatchObjects()` (already exported from `utils/Path`) per module. The matchers are built once per call instead of once per module.

Performance only — the resulting fingerprint hash is byte-identical, verified with an explicit A/B on a large project.

# Test Plan

- Added `should build Minimatch objects once per call, not once per module` to `ExpoConfigLoader-test.ts`. It spies on the `Minimatch` constructor via `jest.mock('minimatch')` and asserts it is called exactly `ignoredPaths.length` times for 20 modules × 8 patterns. Without the fix the spy records 160 constructions (20 × 8); with the fix it records 8.
- `pnpm -F @expo/fingerprint test` — 214 passed.
- `et check-packages @expo/fingerprint` — build, lint, format, typecheck all pass.
- End-to-end on a large monorepo: `native-hash` 1:19 → 0:41; hash unchanged.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)