### PR TITLE
[router] Remove Stack `redirect` property

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Remove the `redirect` prop from layout `<Screen>` components.
+- Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))
 - Remove `StackNavigationState.preloadedRoutes` property and append preloaded routes to `state.routes` ([#47961](https://github.com/expo/expo/pull/47961) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the `redirect` prop from layout `<Screen>` components.
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))
 - Remove `StackNavigationState.preloadedRoutes` property and append preloaded routes to `state.routes` ([#47961](https://github.com/expo/expo/pull/47961) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -8,6 +8,7 @@ import Stack from '../layouts/Stack';
 import Tabs from '../layouts/Tabs';
 import type { StackScreenProps } from '../layouts/stack-utils';
 import { renderRouter, testRouter } from '../testing-library';
+import type { ScreenProps } from '../useScreens';
 
 jest.mock('react-native-screens', () => {
   const actualScreens = jest.requireActual(
@@ -720,7 +721,8 @@ describe('singular', () => {
 
 describe('Stack.Screen types', () => {
   it('accepts layout navigation props', () => {
-    expectTypeOf({ name: 'home', redirect: true }).toExtend<StackScreenProps>();
+    expectTypeOf<ScreenProps>().not.toHaveProperty('redirect');
+    expectTypeOf<StackScreenProps>().not.toHaveProperty('redirect');
     expectTypeOf({ name: 'profile', initialParams: { id: '123' } }).toExtend<StackScreenProps>();
     expectTypeOf({ name: 'settings', dangerouslySingular: true }).toExtend<StackScreenProps>();
     expectTypeOf({
@@ -752,6 +754,23 @@ describe('Stack.Screen types', () => {
       }),
     } satisfies StackScreenProps).toExtend<StackScreenProps>();
   });
+});
+
+it('does not deregister screens when passed the removed redirect prop', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Stack>
+          <Stack.Screen name="a" {...({ redirect: true } as Record<string, unknown>)} />
+        </Stack>
+      ),
+      a: () => <Text testID="a">A</Text>,
+      b: () => <Text>B</Text>,
+    },
+    { initialUrl: '/a' }
+  );
+
+  expect(screen.getByTestId('a')).toBeVisible();
 });
 
 describe('function-form options', () => {

--- a/packages/expo-router/src/layouts/stack-utils/StackScreen.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/StackScreen.tsx
@@ -34,14 +34,6 @@ export interface StackScreenProps extends PropsWithChildren {
   options?: StackBaseScreenProps['options'];
 
   /**
-   * Redirect to the nearest sibling route.
-   * If all children are `redirect={true}`, the layout will render `null` as there are no children to render.
-   *
-   * Only supported when used inside a Layout component.
-   */
-  redirect?: StackBaseScreenProps['redirect'];
-
-  /**
    * Initial params to pass to the route.
    *
    * Only supported when used inside a Layout component.

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -96,63 +96,50 @@ function getSortedChildren<
   const entries = [...children];
 
   const ordered = order
-    .map(
-      ({
-        name,
-        initialParams,
-        listeners,
-        options,
-        getId,
-        dangerouslySingular: singular,
-      }) => {
-        if (!entries.length) {
-          console.warn(
-            `[Layout children]: Too many screens defined. Route "${name}" is extraneous.`
-          );
-          return null;
-        }
-        const matchIndex = entries.findIndex(
-          (child) => child.route === name || child.route === `${name}/index`
-        );
-        if (matchIndex === -1) {
-          console.warn(
-            `[Layout children]: No route named "${name}" exists in nested children:`,
-            children.map(({ route }) => route)
-          );
-          return null;
-        } else {
-          // Get match and remove from entries
-          const match = entries[matchIndex];
-          entries.splice(matchIndex, 1);
-
-          if (getId) {
-            console.warn(
-              `Deprecated: prop 'getId' on screen ${name} is deprecated. Please rename the prop to 'dangerouslySingular'`
-            );
-            if (singular) {
-              console.warn(
-                `Screen ${name} cannot use both getId and dangerouslySingular together.`
-              );
-            }
-          } else if (singular) {
-            // If singular is set, use it as the getId function.
-            if (typeof singular === 'string') {
-              getId = () => singular;
-            } else if (typeof singular === 'function' && name) {
-              getId = (options) => singular(name, options.params || {});
-            } else if (singular === true && name) {
-              getId = (options) => getSingularId(name, options);
-            }
-          }
-
-          return {
-            route: match,
-            props: { initialParams, listeners, options, getId },
-            routeSource: 'layout' as const,
-          };
-        }
+    .map(({ name, initialParams, listeners, options, getId, dangerouslySingular: singular }) => {
+      if (!entries.length) {
+        console.warn(`[Layout children]: Too many screens defined. Route "${name}" is extraneous.`);
+        return null;
       }
-    )
+      const matchIndex = entries.findIndex(
+        (child) => child.route === name || child.route === `${name}/index`
+      );
+      if (matchIndex === -1) {
+        console.warn(
+          `[Layout children]: No route named "${name}" exists in nested children:`,
+          children.map(({ route }) => route)
+        );
+        return null;
+      } else {
+        // Get match and remove from entries
+        const match = entries[matchIndex];
+        entries.splice(matchIndex, 1);
+
+        if (getId) {
+          console.warn(
+            `Deprecated: prop 'getId' on screen ${name} is deprecated. Please rename the prop to 'dangerouslySingular'`
+          );
+          if (singular) {
+            console.warn(`Screen ${name} cannot use both getId and dangerouslySingular together.`);
+          }
+        } else if (singular) {
+          // If singular is set, use it as the getId function.
+          if (typeof singular === 'string') {
+            getId = () => singular;
+          } else if (typeof singular === 'function' && name) {
+            getId = (options) => singular(name, options.params || {});
+          } else if (singular === true && name) {
+            getId = (options) => getSingularId(name, options);
+          }
+        }
+
+        return {
+          route: match,
+          props: { initialParams, listeners, options, getId },
+          routeSource: 'layout' as const,
+        };
+      }
+    })
     .filter(Boolean) as {
     route: RouteNode;
     props: Partial<ScreenProps<TOptions, TState, TEventMap>>;

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -54,11 +54,6 @@ export type ScreenProps<
 > = {
   /** Name is required when used inside a Layout component. */
   name?: string;
-  /**
-   * Redirect to the nearest sibling route.
-   * If all children are `redirect={true}`, the layout will render `null` as there are no children to render.
-   */
-  redirect?: boolean;
   initialParams?: Record<string, any>;
   options?:
     | TOptions
@@ -104,7 +99,6 @@ function getSortedChildren<
     .map(
       ({
         name,
-        redirect,
         initialParams,
         listeners,
         options,
@@ -130,14 +124,6 @@ function getSortedChildren<
           // Get match and remove from entries
           const match = entries[matchIndex];
           entries.splice(matchIndex, 1);
-
-          // Ensure to return null after removing from entries.
-          if (redirect) {
-            if (typeof redirect === 'string') {
-              throw new Error(`Redirecting to a specific route is not supported yet.`);
-            }
-            return null;
-          }
 
           if (getId) {
             console.warn(


### PR DESCRIPTION
# Why

The prop was `deprecated` and removed in https://github.com/expo/expo/pull/24219, but left in `ScreenProps` in `useScreens`

Note for review: first commit is the change. Second is formatting change

# How

Remove the prop

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
