### PR TITLE
[router] Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 💡 Others
 
+- Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))
 - Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))
 - Refactor native-stack for compliance with standard-navigation integration ([#46592](https://github.com/expo/expo/pull/46592) by [@Ubax](https://github.com/Ubax))
 - Remove the deprecated static-navigation API from `expo-router/react-navigation`. ([#48071](https://github.com/expo/expo/pull/48071) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -11,9 +11,11 @@ import { useGuardRedirect } from '../layouts/GuardContext';
 import { Stack } from '../layouts/Stack';
 import { Tabs as JSTabs } from '../layouts/Tabs';
 import { Link, Redirect } from '../link/Link';
+import { useIsFocused } from '../react-navigation/native';
 import { type RenderRouterOptions, renderRouter, waitFor } from '../testing-library';
 import { TabList, TabSlot, TabTrigger, Tabs, useTabTrigger } from '../ui';
 import { useNavigation } from '../useNavigation';
+import { useNavigatorContext } from '../views/Navigator';
 import type { PressableProps } from '../views/Pressable';
 import { Pressable } from '../views/Pressable';
 
@@ -31,6 +33,7 @@ const renderFruitApp = (options: RenderRouterOptions = {}) =>
                 <TabTrigger name="apple" testID="goto-apple" href="/apple">
                   <Text>Apple</Text>
                 </TabTrigger>
+                {/* TODO(@ubax): Remove nested trigger href once headless tabs require direct-child hrefs (unify with NativeTabs). */}
                 <TabTrigger name="banana" testID="goto-banana" href="/banana/taste">
                   <Text>Banana</Text>
                 </TabTrigger>
@@ -246,6 +249,428 @@ it('can dynamically add and remove tabs', () => {
   expect(screen).toHaveSegments(['apple']);
 });
 
+it('can dynamically remove the active tab', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showAll, setShowAll] = useState(true);
+
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showAll && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowAll(false)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+    },
+    {
+      initialUrl: '/orange',
+    }
+  );
+
+  expect(screen).toHaveSegments(['orange']);
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+
+  expect(screen).toHaveSegments(['apple']);
+});
+
+it('preserves surviving tab content when the trigger set changes', () => {
+  let appleMounts = 0;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showOrange && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(appleMounts).toBe(1);
+});
+
+it('does not reset tab content when only a trigger href changes', () => {
+  let appleMounts = 0;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [withQuery, setWithQuery] = useState(false);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href={withQuery ? '/apple?updated=true' : '/apple'} />
+            </TabList>
+            <TabSlot />
+            <Button testID="change-href" title="Change href" onPress={() => setWithQuery(true)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('change-href'));
+  expect(appleMounts).toBe(1);
+});
+
+it('does not reset tab content when triggers are reordered', () => {
+  let appleMounts = 0;
+  let tabState: { routeNames: string[]; routes: string[] } | undefined;
+
+  function Apple() {
+    useState(() => appleMounts++);
+    return null;
+  }
+
+  function StateProbe() {
+    const { state } = useNavigatorContext();
+    tabState = {
+      routeNames: state.routeNames,
+      routes: state.routes.map((route) => route.name),
+    };
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reversed, setReversed] = useState(false);
+        const triggers = [
+          <TabTrigger key="apple" name="apple" href="/apple" />,
+          <TabTrigger key="orange" name="orange" href="/orange" />,
+        ];
+        return (
+          <Tabs>
+            <TabList>{reversed ? triggers.reverse() : triggers}</TabList>
+            <TabSlot />
+            <StateProbe />
+            <Button testID="reorder" title="Reorder" onPress={() => setReversed(true)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(appleMounts).toBe(1);
+  fireEvent.press(screen.getByTestId('reorder'));
+  expect(appleMounts).toBe(1);
+  expect(tabState).toEqual({
+    routeNames: ['orange', 'apple'],
+    routes: ['apple', 'orange'],
+  });
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('uses the new trigger order for order back behavior', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = reordered
+          ? [
+              <TabTrigger key="orange" name="orange" href="/orange" />,
+              <TabTrigger key="apple" name="apple" href="/apple" />,
+              <TabTrigger key="pear" name="pear" href="/pear" />,
+            ]
+          : [
+              <TabTrigger key="apple" name="apple" href="/apple" />,
+              <TabTrigger key="orange" name="orange" href="/orange" />,
+              <TabTrigger key="pear" name="pear" href="/pear" />,
+            ];
+
+        return (
+          <Tabs options={{ backBehavior: 'order' }}>
+            <TabList>{triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/pear' }
+  );
+
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['apple']);
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('returns to the initial route after triggers are reordered', () => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName: 'orange' },
+        default: function TabLayout() {
+          const [reordered, setReordered] = useState(false);
+          const triggers = [
+            <TabTrigger key="apple" name="apple" href="/apple" />,
+            <TabTrigger key="orange" name="orange" href="/orange" />,
+            <TabTrigger key="pear" name="pear" href="/pear" />,
+          ];
+
+          return (
+            <Tabs>
+              <TabList>{reordered ? triggers.reverse() : triggers}</TabList>
+              <TabSlot />
+              <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+            </Tabs>
+          );
+        },
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/pear' }
+  );
+
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('preserves visit history when triggers are reordered', () => {
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = [
+          <TabTrigger key="apple" name="apple" href="/apple" />,
+          <TabTrigger key="orange" name="orange" testID="goto-orange" href="/orange" />,
+          <TabTrigger key="pear" name="pear" testID="goto-pear" href="/pear" />,
+        ];
+
+        return (
+          <Tabs options={{ backBehavior: 'history' }}>
+            <TabList>{reordered ? triggers.reverse() : triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      apple: () => null,
+      orange: () => null,
+      pear: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  fireEvent.press(screen.getByTestId('goto-orange'));
+  fireEvent.press(screen.getByTestId('goto-pear'));
+  fireEvent.press(screen.getByTestId('reorder'));
+  act(() => router.back());
+  expect(screen).toHaveSegments(['orange']);
+});
+
+it('scopes trigger reordering to a nested tab navigator', () => {
+  let parentState: string | undefined;
+
+  function ParentStateProbe() {
+    const { state } = useNavigatorContext();
+    parentState = JSON.stringify({
+      routeNames: state.routeNames,
+      routeKeys: state.routes.map((route) => route.key),
+      index: state.index,
+      history: state.history,
+    });
+    return null;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs options={{ backBehavior: 'history' }}>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+          <ParentStateProbe />
+        </Tabs>
+      ),
+      index: () => null,
+      'fruit/_layout': function FruitTabs() {
+        const [reordered, setReordered] = useState(false);
+        const triggers = reordered
+          ? [
+              <TabTrigger key="orange" name="orange" href="/fruit/orange" />,
+              <TabTrigger key="apple" name="apple" href="/fruit/apple" />,
+              <TabTrigger key="pear" name="pear" href="/fruit/pear" />,
+            ]
+          : [
+              <TabTrigger key="apple" name="apple" href="/fruit/apple" />,
+              <TabTrigger key="orange" name="orange" href="/fruit/orange" />,
+              <TabTrigger key="pear" name="pear" href="/fruit/pear" />,
+            ];
+
+        return (
+          <Tabs options={{ backBehavior: 'order' }}>
+            <TabList>{triggers}</TabList>
+            <TabSlot />
+            <Button testID="reorder-child" title="Reorder" onPress={() => setReordered(true)} />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+      'fruit/pear': () => null,
+    },
+    { initialUrl: '/fruit/pear' }
+  );
+
+  const stateBeforeReorder = parentState;
+  fireEvent.press(screen.getByTestId('reorder-child'));
+  expect(parentState).toBe(stateBeforeReorder);
+  act(() => router.back());
+  expect(screen).toHaveSegments(['fruit', 'apple']);
+});
+
+it('keeps focus hooks correct after removing the active trigger', () => {
+  function Apple() {
+    return <Text testID="apple-focus">{useIsFocused() ? 'focused' : 'not focused'}</Text>;
+  }
+
+  renderRouter(
+    {
+      _layout: function TabLayout() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/apple" />
+              {showOrange && <TabTrigger name="orange" href="/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      apple: Apple,
+      orange: () => null,
+    },
+    { initialUrl: '/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(screen.getByTestId('apple-focus')).toHaveTextContent('focused');
+});
+
+it('removes the active trigger from a nested dynamic tab navigator', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/_layout': function FruitTabs() {
+        const [showOrange, setShowOrange] = useState(true);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/fruit/apple" />
+              {showOrange && <TabTrigger name="orange" href="/fruit/orange" />}
+            </TabList>
+            <TabSlot />
+            <Button testID="hide-orange" title="Hide orange" onPress={() => setShowOrange(false)} />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+    },
+    { initialUrl: '/fruit/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('hide-orange'));
+  expect(screen).toHaveSegments(['fruit', 'apple']);
+});
+
+it('does not redirect from an inactive nested tab navigator', () => {
+  let hideOrange!: () => void;
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" testID="goto-index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => null,
+      'fruit/_layout': function FruitTabs() {
+        const [showOrange, setShowOrange] = useState(true);
+        hideOrange = () => setShowOrange(false);
+        return (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="apple" href="/fruit/apple" />
+              {showOrange && <TabTrigger name="orange" href="/fruit/orange" />}
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        );
+      },
+      'fruit/apple': () => null,
+      'fruit/orange': () => null,
+    },
+    { initialUrl: '/fruit/orange' }
+  );
+
+  fireEvent.press(screen.getByTestId('goto-index'));
+  act(hideOrange);
+  expect(screen).toHavePathname('/');
+});
+
 it('does works with shared groups', () => {
   renderRouter(
     {
@@ -311,6 +736,176 @@ it('works with nested layouts', () => {
   fireEvent.press(screen.getByTestId('goto-page'));
   expect(screen.getByTestId('page')).toBeVisible();
   expect(screen).toHaveSegments(['page']);
+});
+
+it('registers declared routes in trigger order', () => {
+  function StateProbe() {
+    const { state } = useNavigatorContext();
+    return (
+      <Text testID="tab-state">
+        {state.routes.map((route) => route.name).join(',')}:{state.routes[state.index]!.name}
+      </Text>
+    );
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="orange" href="/orange" />
+            <TabTrigger name="apple" href="/apple" />
+          </TabList>
+          <TabSlot />
+          <StateProbe />
+        </Tabs>
+      ),
+      apple: () => null,
+      orange: () => null,
+    },
+    { initialUrl: '/apple' }
+  );
+
+  expect(screen.getByTestId('tab-state')).toHaveTextContent('orange,apple:apple');
+});
+
+it('redirects router.push from a filesystem route without a trigger', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" testID="goto-index" href="/" />
+          <TabTrigger name="visible" testID="goto-visible" href="/visible" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => <Text testID="index">Index</Text>,
+    visible: () => <Text testID="visible">Visible</Text>,
+    hidden: () => <Text testID="hidden">Hidden</Text>,
+  });
+
+  act(() => router.push('/hidden'));
+  expect(screen).toHavePathname('/');
+  expect(screen.queryByTestId('hidden')).toBeNull();
+  expect(screen.getByTestId('goto-index')).toHaveProp('isFocused', true);
+});
+
+it('removes a redirected filesystem route from tab history', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs options={{ backBehavior: 'history' }}>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="visible" testID="goto-visible" href="/visible" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    visible: () => null,
+    hidden: () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-visible'));
+  act(() => router.push('/hidden'));
+  expect(screen).toHavePathname('/');
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/visible');
+});
+
+it('redirects a Link from a filesystem route without a trigger', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => <Link testID="hidden-link" href="/hidden" />,
+    hidden: () => <Text testID="hidden">Hidden</Text>,
+  });
+
+  fireEvent.press(screen.getByTestId('hidden-link'));
+  expect(screen).toHavePathname('/');
+  expect(screen.queryByTestId('hidden')).toBeNull();
+});
+
+it('redirects a deep link from a filesystem route without a trigger', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('hidden')).toBeNull();
+});
+
+it.each(['second', 'second/index'])('redirects to initial route %s', (initialRouteName) => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName },
+        default: () => (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="index" href="/" />
+              <TabTrigger name="second" href="/second" />
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        ),
+      },
+      index: () => <Text testID="index">Index</Text>,
+      [initialRouteName]: () => <Text testID="second">Second</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/second');
+  expect(screen.getByTestId('second')).toBeVisible();
+});
+
+it('falls back to the first trigger when the initial route has no trigger', () => {
+  renderRouter(
+    {
+      _layout: {
+        unstable_settings: { initialRouteName: 'hidden' },
+        default: () => (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="index" href="/" />
+              <TabTrigger name="visible" href="/visible" />
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        ),
+      },
+      index: () => <Text testID="index">Index</Text>,
+      visible: () => <Text testID="visible">Visible</Text>,
+      hidden: () => <Text testID="hidden">Hidden</Text>,
+    },
+    { initialUrl: '/hidden' }
+  );
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
 });
 
 describe('warnings/errors', () => {
@@ -388,9 +983,33 @@ describe('warnings/errors', () => {
       'Trigger {"name":"duplicate","href":"http://expo.dev"} has the same name as parent trigger {"name":"duplicate","href":"/two"}. Triggers must have unique names.'
     );
   });
+
+  it('does not allow trigger hrefs outside a nested tabs layout', () => {
+    expect(() =>
+      renderRouter(
+        {
+          _layout: () => <Stack />,
+          'fruit/_layout': () => (
+            <Tabs>
+              <TabList>
+                <TabTrigger name="apple" href="/other/apple" />
+              </TabList>
+              <TabSlot />
+            </Tabs>
+          ),
+          'fruit/apple': () => null,
+          'other/_layout': () => <Stack />,
+          'other/apple': () => null,
+        },
+        { initialUrl: '/fruit/apple' }
+      )
+    ).toThrow(
+      `Tab trigger 'apple' with href '/other/apple' must point to a route within the tabs layout.`
+    );
+  });
 });
 
-it('can update href dynamically', () => {
+it('can update a tab trigger href', () => {
   const MockContext = React.createContext({ href: '/a', setHref: (href: string) => {} });
   renderRouter({
     _layout: function TabLayout() {
@@ -400,11 +1019,11 @@ it('can update href dynamically', () => {
           <Tabs>
             <TabSlot />
             <TabList>
-              <TabTrigger name="index" href="/">
-                <Text>Index</Text>
-              </TabTrigger>
               <TabTrigger name="[p]" href={href}>
                 <Text>{href}</Text>
+              </TabTrigger>
+              <TabTrigger name="index" href="/">
+                <Text>Index</Text>
               </TabTrigger>
             </TabList>
           </Tabs>
@@ -418,38 +1037,127 @@ it('can update href dynamically', () => {
           <Button
             testID="toggle"
             title="Toggle"
-            onPress={() => setHref(href === '/a' ? '/b' : '/a')}
+            onPress={() => setHref(href === '/a' ? '/b?updated=true' : '/a')}
           />
         </View>
       );
     },
     '[p]': function P() {
-      const { p } = useLocalSearchParams();
-      return <Text testID="page">{p}</Text>;
+      const { p, updated } = useLocalSearchParams();
+      return <Text testID="page">{`${p}:${updated}`}</Text>;
     },
   });
   expect(screen.getByTestId('index')).toBeVisible();
-  expect(screen.queryByTestId('page')).toBeNull();
-  expect(screen.getByText('/a')).toBeVisible();
-  expect(screen.getByText('Index')).toBeVisible();
-
   fireEvent.press(screen.getByText('/a'));
-  expect(screen.queryByTestId('index')).toBeNull();
-  expect(screen.getByTestId('page')).toBeVisible();
-  expect(screen.getByTestId('page')).toHaveTextContent('a');
-  expect(screen.getByText('Index')).toBeVisible();
-
+  expect(screen.getByTestId('page')).toHaveTextContent('a:undefined');
   fireEvent.press(screen.getByText('Index'));
-  expect(screen.getByTestId('index')).toBeVisible();
-  expect(screen.queryByTestId('page')).toBeNull();
-
   fireEvent.press(screen.getByTestId('toggle'));
-  expect(screen.getByText('/b')).toBeVisible();
-  expect(screen.queryByText('/a')).toBeNull();
+  fireEvent.press(screen.getByText('/b?updated=true'));
+  expect(screen.getByTestId('page')).toHaveTextContent('b:true');
+});
 
-  fireEvent.press(screen.getByText('/b'));
-  expect(screen.getByTestId('page')).toBeVisible();
-  expect(screen.getByTestId('page')).toHaveTextContent('b');
+it('passes query params to a direct child navigator', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" testID="goto-index" href="/" />
+          <TabTrigger name="movies" testID="goto-movies" href="/movies?filter=recent" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    'movies/_layout': function MoviesLayout() {
+      const { filter } = useLocalSearchParams();
+      return (
+        <>
+          <Text testID="filter">{filter}</Text>
+          <Stack />
+        </>
+      );
+    },
+    'movies/index': () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-movies'));
+  expect(screen.getByTestId('filter')).toHaveTextContent('recent');
+});
+
+it('can reference a parent trigger from nested tabs', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      'fruit/_layout': () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="apple" href="/fruit/apple" />
+          </TabList>
+          <TabTrigger name="fruit" testID="current-parent" />
+          <TabTrigger name="index" testID="goto-parent" />
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/apple': () => <Text testID="apple">Apple</Text>,
+    },
+    { initialUrl: '/fruit/apple' }
+  );
+
+  expect(screen.getByTestId('current-parent')).toHaveProp('isFocused', true);
+  expect(screen.getByTestId('goto-parent')).toHaveProp('isFocused', false);
+  fireEvent.press(screen.getByTestId('goto-parent'));
+  expect(screen.getByTestId('index')).toBeVisible();
+});
+
+it('can reference a parent trigger from tabs nested three navigators deep', () => {
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="fruit" href="/fruit" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      'fruit/_layout': () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="apple" href="/fruit/apple" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/apple/_layout': () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="red" href="/fruit/apple/red" />
+          </TabList>
+          <TabTrigger name="fruit" testID="current-root" />
+          <TabTrigger name="index" testID="goto-root" />
+          <TabSlot />
+        </Tabs>
+      ),
+      'fruit/apple/red': () => <Text testID="red">Red Apple</Text>,
+    },
+    { initialUrl: '/fruit/apple/red' }
+  );
+
+  expect(screen.getByTestId('current-root')).toHaveProp('isFocused', true);
+  expect(screen.getByTestId('goto-root')).toHaveProp('isFocused', false);
+  fireEvent.press(screen.getByTestId('goto-root'));
+  expect(screen.getByTestId('index')).toBeVisible();
 });
 
 it('does not reset on focus when resetOnFocus is false', () => {
@@ -788,6 +1496,33 @@ it('router.replace works in headless tabs', async () => {
 
   expect(screen.getByTestId('second')).toBeVisible();
   expect(router.canGoBack()).toBe(false);
+});
+
+it('router.replace only removes the latest visit with full history', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs options={{ backBehavior: 'fullHistory' }}>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="second" testID="goto-second" href="/second" />
+          <TabTrigger name="third" href="/third" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('goto-second'));
+  act(() => router.push('/'));
+  act(() => router.replace('/third'));
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+  act(() => router.back());
+  expect(screen).toHavePathname('/');
 });
 
 it('Link with replace works in headless tabs', async () => {

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -45,6 +45,7 @@ const Tabs = unstable_integrateWithRouter<
   BottomTabNavigatorCreateProps
 >(createStandardBottomTabNavigator, TabRouter, {
   createProps: ({ state, dispatch }) => ({
+    routeNames: state.routeNames,
     preloadedRouteKeys: state.preloadedRouteKeys,
     popNestedStackToTop: (routeKey) => {
       const nestedState = state.routes.find((route) => route.key === routeKey)?.state;

--- a/packages/expo-router/src/layouts/TopTabsClient.tsx
+++ b/packages/expo-router/src/layouts/TopTabsClient.tsx
@@ -30,7 +30,10 @@ const TopTabs = unstable_integrateWithRouter<
   TabRouterOptions,
   MaterialTopTabNavigatorCreateProps
 >(createStandardMaterialTopTabNavigator, TabRouter, {
-  createProps: ({ state }) => ({ preloadedRouteKeys: state.preloadedRouteKeys }),
+  createProps: ({ state }) => ({
+    routeNames: state.routeNames,
+    preloadedRouteKeys: state.preloadedRouteKeys,
+  }),
 });
 
 export type JSTopTabsProps = ComponentProps<typeof TopTabs>;

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -32,6 +32,7 @@ export const NativeTabsContext = React.createContext<boolean>(false);
 
 function NativeTabsContent({
   state,
+  routeNames,
   descriptors,
   actions,
   emitter,
@@ -53,7 +54,7 @@ function NativeTabsContent({
   NativeTabOptions,
   NativeTabNavigationEventMap,
   Omit<InternalNativeTabsProps, 'screenListeners'>
->) {
+> & { routeNames: string[] }) {
   if (use(NativeTabsContext)) {
     throw new Error(
       'Nesting Native Tabs inside each other is not supported natively. Use JS tabs for nesting instead.'
@@ -64,6 +65,7 @@ function NativeTabsContent({
 
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes,
+    routeNames,
     focusedRouteKey: routes[state.index]!.key,
     descriptors,
   });
@@ -166,8 +168,11 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
   TabNavigationState<ParamListBase>,
   NativeTabNavigationEventMap,
   Omit<InternalNativeTabsProps, 'screenListeners'>,
-  TabRouterOptions
->(NativeTabsContent, NativeBottomTabsRouter);
+  TabRouterOptions,
+  { routeNames: string[] }
+>(NativeTabsContent, NativeBottomTabsRouter, {
+  createProps: ({ state }) => ({ routeNames: state.routeNames }),
+});
 
 export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
   const routeNode = useRouteNode();

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
@@ -53,6 +53,39 @@ test('renders a bottom tab navigator and navigates between screens on tab press'
   expect(screen).toHavePathname('/second');
 });
 
+test('renders tabs in route names order while preserving focus', () => {
+  let reverse!: () => void;
+
+  function Layout() {
+    const [reversed, setReversed] = useState(false);
+    reverse = () => setReversed(true);
+    const screens = [
+      <Tabs.Screen key="index" name="index" />,
+      <Tabs.Screen key="second" name="second" />,
+    ];
+    return <Tabs>{reversed ? screens.reverse() : screens}</Tabs>;
+  }
+
+  renderRouter({
+    _layout: Layout,
+    index: () => <Text>Screen index</Text>,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  act(() => router.navigate('/second'));
+  act(reverse);
+
+  expect(
+    screen.getByRole('button', { name: 'second, tab, 1 of 2' }).props.accessibilityState
+  ).toEqual({ selected: true });
+  expect(
+    screen.getByRole('button', { name: 'index, tab, 2 of 2' }).props.accessibilityState
+  ).toEqual({
+    selected: false,
+  });
+  expect(screen.queryByText('Screen second')).not.toBeNull();
+});
+
 test('handles screens preloading', () => {
   renderRouter({
     _layout: () => (

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
@@ -12,6 +12,9 @@ type TabsProps = ComponentProps<typeof Tabs>;
 export type _PublicPropsMatchTabs = Expect<Equal<JSTabsProps, TabsProps>>;
 
 // The props injected by `createProps` reach the content component but never the element.
+export type _RouteNamesIsNotPublic = Expect<
+  Equal<'routeNames' extends keyof TabsProps ? true : false, false>
+>;
 export type _PreloadedRouteKeysIsNotPublic = Expect<
   Equal<'preloadedRouteKeys' extends keyof TabsProps ? true : false, false>
 >;
@@ -20,6 +23,9 @@ export type _PopNestedStackToTopIsNotPublic = Expect<
 >;
 export type _ContentRequiresPreloadedRouteKeys = Expect<
   Equal<BottomTabNavigatorContentProps['preloadedRouteKeys'], string[]>
+>;
+export type _ContentRequiresRouteNames = Expect<
+  Equal<BottomTabNavigatorContentProps['routeNames'], string[]>
 >;
 export type _ContentRequiresPopNestedStackToTop = Expect<
   Equal<BottomTabNavigatorContentProps['popNestedStackToTop'], (routeKey: string) => void>

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -13,6 +13,7 @@ import type {
 import { BottomTabView } from '../views/BottomTabView';
 
 export interface BottomTabNavigatorCreateProps {
+  routeNames: string[];
   preloadedRouteKeys: string[];
   popNestedStackToTop: (routeKey: string) => void;
 }
@@ -32,12 +33,14 @@ function BottomTabNavigatorContent({
   descriptors,
   actions,
   emitter,
+  routeNames,
   preloadedRouteKeys,
   popNestedStackToTop,
   ...rest
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
+    routeNames,
     focusedRouteKey: state.routes[state.index]!.key,
     descriptors,
   });

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/index.test.ios.tsx
@@ -1,6 +1,6 @@
 import 'react-native-gesture-handler/jestSetup';
 import { userEvent } from '@testing-library/react-native';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Text, View } from 'react-native';
 import { Drawer as DrawerLayout } from 'react-native-drawer-layout';
 
@@ -95,6 +95,38 @@ test('renders no drawer UI when no screens are declared in the layout', () => {
   expect(screen.queryByTestId('Drawer')).toBeNull();
   expect(screen.queryByTestId('index')).toBeNull();
   expect(warnSpy.mock.calls).toMatchSnapshot();
+});
+
+test('renders drawer items in route names order while preserving focus', () => {
+  let reverse!: () => void;
+
+  function Layout() {
+    const [reversed, setReversed] = useState(false);
+    reverse = () => setReversed(true);
+    const screens = [
+      <Drawer.Screen key="index" name="index" options={{ drawerLabel: 'Index item' }} />,
+      <Drawer.Screen key="second" name="second" options={{ drawerLabel: 'Second item' }} />,
+    ];
+    return <Drawer>{reversed ? screens.reverse() : screens}</Drawer>;
+  }
+
+  renderRouter(
+    {
+      _layout: Layout,
+      index: () => null,
+      second: () => <View testID="second" />,
+    },
+    { initialUrl: '/second' }
+  );
+
+  act(reverse);
+
+  const items = screen.getAllByRole('button', { name: /item/ });
+  expect(items[0]!.props.accessibilityState).toEqual({ selected: true });
+  expect(items[0]).toHaveTextContent('Second item');
+  expect(items[1]!.props.accessibilityState).toEqual({ selected: false });
+  expect(items[1]).toHaveTextContent('Index item');
+  expect(screen.getByTestId('second')).toBeVisible();
 });
 
 test('handles drawer actions and preventable item presses', async () => {

--- a/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
@@ -47,6 +47,7 @@ function DrawerNavigatorContent({
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: drawerState.routes,
+    routeNames: drawerState.routeNames,
     focusedRouteKey: drawerState.routes[drawerState.index]!.key,
     descriptors,
   });

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
@@ -1,5 +1,5 @@
 import { userEvent } from '@testing-library/react-native';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import type { PagerViewProps } from 'react-native-pager-view';
 import { TabView, type TabBarProps, type TabViewProps } from 'react-native-tab-view';
@@ -368,4 +368,44 @@ test('emits swipeStart and swipeEnd events', async () => {
 
   expect(onSwipeStart).toHaveBeenCalledTimes(1);
   expect(onSwipeEnd).toHaveBeenCalledTimes(1);
+});
+
+test('renders tabs in route names order while preserving focus', async () => {
+  let reverse!: () => void;
+
+  function Layout() {
+    const [reversed, setReversed] = useState(false);
+    reverse = () => setReversed(true);
+    const screens = [
+      <TopTabs.Screen key="index" name="index" />,
+      <TopTabs.Screen key="second" name="second" />,
+    ];
+    return (
+      <TopTabs
+        tabBar={({ state }: MaterialTopTabBarProps) => (
+          <View>
+            {state.routes.map((route: MaterialTopTabViewRoute, index: number) => (
+              <Text key={route.key} testID={`tab-${index}`}>
+                {route.name}:{route.key === state.routes[state.index]!.key ? 'focused' : 'blurred'}
+              </Text>
+            ))}
+          </View>
+        )}>
+        {reversed ? screens.reverse() : screens}
+      </TopTabs>
+    );
+  }
+
+  renderRouter({
+    _layout: Layout,
+    index: () => <Text>Screen index</Text>,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  act(() => router.navigate('/second'));
+  act(() => reverse());
+
+  expect(screen.getByTestId('tab-0')).toHaveTextContent('second:focused');
+  expect(screen.getByTestId('tab-1')).toHaveTextContent('index:blurred');
+  expect(screen.getByText('Screen second')).toBeVisible();
 });

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
@@ -32,6 +32,9 @@ export type _IndicatorUsesTopTabViewState = Expect<
 export type _ContentRequiresPreloadedRouteKeys = Expect<
   Equal<MaterialTopTabNavigatorContentProps['preloadedRouteKeys'], string[]>
 >;
+export type _ContentRequiresRouteNames = Expect<
+  Equal<MaterialTopTabNavigatorContentProps['routeNames'], string[]>
+>;
 
 describe('material top tabs types', () => {
   it('type-checks', () => {

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -13,6 +13,7 @@ import type {
 import { MaterialTopTabView } from '../views/MaterialTopTabView';
 
 export interface MaterialTopTabNavigatorCreateProps {
+  routeNames: string[];
   preloadedRouteKeys: string[];
 }
 
@@ -31,11 +32,13 @@ function MaterialTopTabNavigatorContent({
   descriptors,
   actions,
   emitter,
+  routeNames,
   preloadedRouteKeys,
   ...rest
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
+    routeNames,
     focusedRouteKey: state.routes[state.index]!.key,
     descriptors,
   });

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid/non-secure';
 
+import { orderRoutesByRouteNames } from '../../utils/orderRoutesByRouteNames';
 import { BaseRouter } from './BaseRouter';
 import { createParamsFromAction } from './createParamsFromAction';
 import type {
@@ -198,7 +199,9 @@ const changeIndex = (
       params: backBehavior === 'fullHistory' ? currentRoute.params : undefined,
     });
   } else {
-    history = getRouteHistory(state.routes, index, backBehavior, initialRouteName);
+    const routes = orderRoutesByRouteNames(state.routes, state.routeNames);
+    const orderedIndex = routes.findIndex((route) => route.key === state.routes[index]!.key);
+    history = getRouteHistory(routes, orderedIndex, backBehavior, initialRouteName);
   }
 
   return {
@@ -308,24 +311,57 @@ export function TabRouter({
     },
 
     getStateForRouteNamesChange(state, { routeNames, routeParamList, routeKeyChanges }) {
-      const routes = routeNames.map(
-        (name) =>
-          state.routes.find((r) => r.name === name && !routeKeyChanges.includes(r.name)) || {
+      const routes = state.routes
+        .filter((route) => routeNames.includes(route.name))
+        .map((route) =>
+          routeKeyChanges.includes(route.name)
+            ? {
+                name: route.name,
+                key: `${route.name}-${nanoid()}`,
+                params: routeParamList[route.name],
+              }
+            : route
+        );
+
+      for (const name of routeNames) {
+        if (!routes.some((route) => route.name === name)) {
+          routes.push({
             name,
             key: `${name}-${nanoid()}`,
             params: routeParamList[name],
-          }
-      );
+          });
+        }
+      }
 
-      const index = Math.max(0, routeNames.indexOf(state.routes[state.index]!.name));
+      const focusedName = state.routes[state.index]!.name;
+      const index = Math.max(
+        0,
+        routes.findIndex((route) => route.name === focusedName)
+      );
 
       let history = state.history.filter(
         // Type will always be 'route' for tabs, but could be different in a router extending this (e.g. drawer)
         (it) => it.type !== 'route' || routes.find((r) => r.key === it.key)
       );
 
-      if (!history.length) {
-        history = getRouteHistory(routes, index, backBehavior, initialRouteName);
+      // Static back behaviors follow display order, while history behaviors retain valid visits.
+      // Preserve non-route entries added by extending routers such as `DrawerRouter`.
+      if (
+        backBehavior === 'firstRoute' ||
+        backBehavior === 'initialRoute' ||
+        backBehavior === 'order'
+      ) {
+        const orderedRoutes = orderRoutesByRouteNames(routes, routeNames);
+        const orderedIndex = orderedRoutes.findIndex((route) => route.key === routes[index]!.key);
+        history = [
+          ...getRouteHistory(orderedRoutes, orderedIndex, backBehavior, initialRouteName),
+          ...history.filter((item) => item.type !== 'route'),
+        ];
+      } else if (!history.some((item) => item.type === 'route')) {
+        history = [
+          ...getRouteHistory(routes, index, backBehavior, initialRouteName),
+          ...history.filter((item) => item.type !== 'route'),
+        ];
       }
 
       return {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -72,6 +72,55 @@ test('gets initial state from route names and params without initialRouteName', 
   });
 });
 
+test('preserves drawer status when route names change', () => {
+  const router = DrawerRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const initialState = router.getInitialState(options) as DrawerNavigationState<ParamListBase>;
+  const openState = router.getStateForAction(
+    initialState,
+    DrawerActions.openDrawer(),
+    options
+  ) as DrawerNavigationState<ParamListBase>;
+
+  const state = router.getStateForRouteNamesChange(openState, {
+    ...options,
+    routeNames: ['baz', 'bar'],
+    routeKeyChanges: [],
+  });
+
+  expect(state.history).toContainEqual({ type: 'drawer', status: 'open' });
+});
+
+test('restores route history without dropping drawer status when the active route is removed', () => {
+  const router = DrawerRouter({ backBehavior: 'history' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const initialState = router.getInitialState(options) as DrawerNavigationState<ParamListBase>;
+  const openState = router.getStateForAction(
+    initialState,
+    DrawerActions.openDrawer(),
+    options
+  ) as DrawerNavigationState<ParamListBase>;
+
+  const state = router.getStateForRouteNamesChange(openState, {
+    ...options,
+    routeNames: ['baz'],
+    routeKeyChanges: [],
+  });
+
+  expect(state.history).toEqual([
+    { type: 'route', key: 'baz-test' },
+    { type: 'drawer', status: 'open' },
+  ]);
+});
+
 test('gets rehydrated state from partial state', () => {
   const router = DrawerRouter({});
 

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,5 +1,6 @@
 import { expect, jest, test } from '@jest/globals';
 import { expectTypeOf } from 'expect-type';
+import { nanoid } from 'nanoid/non-secure';
 
 import {
   CommonActions,
@@ -11,7 +12,9 @@ import {
   TabRouter,
 } from '../index';
 
-jest.mock('nanoid/non-secure', () => ({ nanoid: () => 'test' }));
+jest.mock('nanoid/non-secure', () => ({ nanoid: jest.fn(() => 'test') }));
+
+const mockNanoid = jest.mocked(nanoid);
 
 test('types replace action helper params', () => {
   type Params = {
@@ -572,12 +575,15 @@ test('gets state on route names change', () => {
     key: 'tab-test',
     routeNames: ['qux', 'baz', 'foo', 'fiz'],
     routes: [
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
       { key: 'foo-test', name: 'foo' },
       { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
     ],
-    history: [{ type: 'route', key: 'qux-test' }],
+    history: [
+      { type: 'route', key: 'qux-test' },
+      { type: 'route', key: 'baz-test' },
+    ],
     stale: false,
     type: 'tab',
     preloadedRouteKeys: [],
@@ -610,7 +616,7 @@ test('gets state on route names change', () => {
     key: 'tab-test',
     routeNames: ['foo', 'fiz'],
     routes: [
-      { key: 'foo-test', name: 'foo' },
+      { key: 'foo-test', name: 'foo', params: undefined },
       { key: 'fiz-test', name: 'fiz' },
     ],
     history: [{ type: 'route', key: 'foo-test' }],
@@ -650,19 +656,56 @@ test('preserves focused route on route names change', () => {
       }
     )
   ).toEqual({
-    index: 3,
+    index: 0,
     key: 'tab-test',
     routeNames: ['qux', 'foo', 'fiz', 'baz'],
     routes: [
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-      { key: 'foo-test', name: 'foo' },
-      { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
       { key: 'baz-test', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
+      { key: 'foo-test', name: 'foo', params: undefined },
+      { key: 'fiz-test', name: 'fiz', params: { fruit: 'apple' } },
     ],
-    history: [{ type: 'route', key: 'baz-test' }],
+    history: [
+      { type: 'route', key: 'qux-test' },
+      { type: 'route', key: 'baz-test' },
+    ],
     stale: false,
     type: 'tab',
     preloadedRouteKeys: [],
+  });
+});
+
+test('preserves focused route when its key changes', () => {
+  const router = TabRouter({});
+  mockNanoid.mockReturnValueOnce('changed');
+
+  const state = router.getStateForRouteNamesChange(
+    {
+      index: 1,
+      key: 'tab-test',
+      routeNames: ['bar', 'baz', 'qux'],
+      routes: [
+        { key: 'bar-test', name: 'bar' },
+        { key: 'baz-test', name: 'baz' },
+        { key: 'qux-test', name: 'qux' },
+      ],
+      history: [{ type: 'route', key: 'baz-test' }],
+      stale: false,
+      type: 'tab',
+      preloadedRouteKeys: [],
+    },
+    {
+      routeNames: ['bar', 'baz', 'qux'],
+      routeParamList: {},
+      routeGetIdList: {},
+      routeKeyChanges: ['baz'],
+    }
+  );
+
+  expect(state.routes[state.index]).toEqual({
+    key: 'baz-changed',
+    name: 'baz',
+    params: undefined,
   });
 });
 
@@ -1213,7 +1256,10 @@ test('replaces the focused route with backBehavior: order', () => {
 });
 
 test('replaces the focused route with backBehavior: initialRoute', () => {
-  const router = TabRouter({ backBehavior: 'initialRoute', initialRouteName: 'baz' });
+  const router = TabRouter({
+    backBehavior: 'initialRoute',
+    initialRouteName: 'baz',
+  });
   const options: RouterConfigOptions = {
     routeNames: ['bar', 'baz', 'qux'],
     routeParamList: {},

--- a/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
@@ -34,6 +34,8 @@ const descriptors = {
   'hidden-key': { routeSource: 'layout' as const, options: { hidden: true } },
   'filesystem-key': { routeSource: 'filesystem' as const },
 };
+const routeNames = routes.map((route) => route.name);
+
 let replaceSpy: jest.SpyInstance;
 let warnSpy: jest.SpyInstance;
 let buildHref: jest.Mock;
@@ -58,6 +60,7 @@ describe('useVisibleTabsWithRedirect', () => {
     const { result } = renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
+        routeNames,
         focusedRouteKey: 'settings-key',
         descriptors,
       })
@@ -71,7 +74,12 @@ describe('useVisibleTabsWithRedirect', () => {
 
   it('returns zero when the focused route is not visible', () => {
     const { result } = renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors })
+      useVisibleTabsWithRedirect({
+        routes,
+        routeNames,
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+      })
     );
 
     expect(result.current.focusedIndex).toBe(0);
@@ -84,6 +92,7 @@ describe('useVisibleTabsWithRedirect', () => {
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
+        routeNames,
         focusedRouteKey: 'hidden-key',
         descriptors,
       })
@@ -100,6 +109,7 @@ describe('useVisibleTabsWithRedirect', () => {
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
+        routeNames,
         focusedRouteKey: 'hidden-key',
         descriptors,
       })
@@ -115,6 +125,7 @@ describe('useVisibleTabsWithRedirect', () => {
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
+        routeNames,
         focusedRouteKey: 'hidden-key',
         descriptors,
       })
@@ -128,7 +139,12 @@ describe('useVisibleTabsWithRedirect', () => {
     mockedUseIsFocused.mockReturnValue(false);
 
     renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors })
+      useVisibleTabsWithRedirect({
+        routes,
+        routeNames,
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+      })
     );
 
     expect(replaceSpy).not.toHaveBeenCalled();
@@ -136,7 +152,12 @@ describe('useVisibleTabsWithRedirect', () => {
 
   it('does not redirect when the focused route is visible', () => {
     renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'home-key', descriptors })
+      useVisibleTabsWithRedirect({
+        routes,
+        routeNames,
+        focusedRouteKey: 'home-key',
+        descriptors,
+      })
     );
 
     expect(buildHref).toHaveBeenCalledWith(routes[0]);
@@ -150,6 +171,7 @@ describe('useVisibleTabsWithRedirect', () => {
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes: [routes[3]!],
+        routeNames: ['filesystem'],
         focusedRouteKey: 'filesystem-key',
         descriptors,
       })
@@ -157,5 +179,19 @@ describe('useVisibleTabsWithRedirect', () => {
 
     expect(replaceSpy).not.toHaveBeenCalled();
     expect(warnSpy.mock.calls).toMatchSnapshot();
+  });
+
+  it('orders visible routes and redirect fallback by route names', () => {
+    const { result } = renderHook(() =>
+      useVisibleTabsWithRedirect({
+        routes,
+        routeNames: ['settings/index', 'home', 'hidden', 'filesystem'],
+        focusedRouteKey: 'hidden-key',
+        descriptors,
+      })
+    );
+
+    expect(result.current.visibleRoutes).toEqual([routes[1], routes[0]]);
+    expect(replaceSpy).toHaveBeenCalledWith('/href/settings/index');
   });
 });

--- a/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
+++ b/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
@@ -9,6 +9,7 @@ import {
   type RouteSource,
   useIsFocused,
 } from '../react-navigation/native';
+import { orderRoutesByRouteNames } from '../utils/orderRoutesByRouteNames';
 import { useBuildHref } from './useBuildHref';
 
 type TabRoute = NavigationRoute<ParamListBase, string>;
@@ -27,10 +28,12 @@ export function useVisibleTabsWithRedirect<
   Options extends { hidden?: boolean },
 >({
   routes,
+  routeNames,
   focusedRouteKey,
   descriptors,
 }: {
   routes: Route[];
+  routeNames: string[];
   focusedRouteKey: string;
   descriptors: Record<string, TabDescriptor<Options>>;
 }) {
@@ -42,13 +45,13 @@ export function useVisibleTabsWithRedirect<
 
   const visibleRoutes = useMemo(
     () =>
-      routes.filter((route) => {
+      orderRoutesByRouteNames(routes, routeNames).filter((route) => {
         // Every filesystem route is registered in state; only routes declared by a non-hidden
         // trigger become tab items.
         const descriptor = descriptors[route.key];
         return isDeclaredInLayout(descriptor) && descriptor?.options?.hidden !== true;
       }),
-    [routes, descriptors]
+    [routes, routeNames, descriptors]
   );
   const visibleFocusedIndex = useMemo(
     () => visibleRoutes.findIndex((route) => route.key === focusedRouteKey),

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -35,9 +35,9 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
     ExpoTabActionType | CommonNavigationAction
   > = {
     ...rnTabRouter,
-    getStateForAction(state, action, options) {
+    getStateForAction(state, action, routerConfigOptions) {
       if (action.type !== 'JUMP_TO') {
-        return rnTabRouter.getStateForAction(state, action, options);
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
       }
 
       const route = state.routes.find((route) => route.name === action.payload.name);
@@ -55,8 +55,8 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
       }
 
       if (shouldReset) {
-        options.routeParamList[route.name] = {
-          ...options.routeParamList[route.name],
+        routerConfigOptions.routeParamList[route.name] = {
+          ...routerConfigOptions.routeParamList[route.name],
         };
         state = {
           ...state,
@@ -67,9 +67,14 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
             return { ...r, state: undefined };
           }),
         };
-        return rnTabRouter.getStateForAction(state, action, options);
-      } else {
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
+      } else if (route.state !== undefined) {
+        // TODO(@ubax): Remove this branch together with nested trigger href support. Refocusing
+        // a tab that hosts a navigator must not re-apply the trigger's nested payload
+        // (`params.screen`), which would reset the preserved child state.
         return rnTabRouter.getStateForRouteFocus(state, route.key);
+      } else {
+        return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
       }
     },
   };

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -125,7 +125,7 @@ export type Trigger = TriggerMap[string] & {
   hidden: boolean;
   isFocused: boolean;
   resolvedHref: string;
-  route: TabNavigationState<any>['routes'][number];
+  route?: TabNavigationState<any>['routes'][number];
 };
 
 export type UseTabTriggerResult = {
@@ -145,7 +145,7 @@ export type TriggerProps = {
  * Utility hook creating custom `TabTrigger`.
  */
 export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
-  const { state, navigation, descriptors } = useNavigatorContext();
+  const { state, navigation, contextKey, descriptors } = useNavigatorContext();
   const { name, resetOnFocus, onPress, onLongPress } = options;
   const triggerMap = use(TabTriggerMapContext);
 
@@ -165,15 +165,25 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
       const hidden =
         routeOptions != null && 'hidden' in routeOptions && routeOptions.hidden === true;
 
+      // Parent triggers are inherited, so read the state of the navigator that registered them.
+      const owningState =
+        config.type === 'internal' && config.contextKey !== contextKey
+          ? navigation?.getParent(config.contextKey)?.getState()
+          : state;
+      const routeIndex =
+        config.type === 'internal'
+          ? (owningState?.routes.findIndex((route) => route.name === config.routeNode.route) ?? -1)
+          : -1;
+
       return {
         hidden,
-        isFocused: state.index === config.index,
-        route: state.routes[config.index]!,
+        isFocused: owningState?.index === routeIndex,
+        route: owningState?.routes[routeIndex],
         resolvedHref: stripGroupSegmentsFromPath(appendBaseUrl(config.href)),
         ...config,
       };
     },
-    [descriptors, state, triggerMap]
+    [contextKey, descriptors, navigation, state, triggerMap]
   );
 
   const trigger = name !== undefined ? getTrigger(name) : undefined;
@@ -215,7 +225,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
 
       navigation?.emit({
         type: 'tabPress',
-        target: trigger.type === 'internal' ? trigger.route.key : trigger?.href,
+        target: trigger.route?.key ?? trigger.href,
         canPreventDefault: true,
       });
 
@@ -236,7 +246,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
 
       navigation?.emit({
         type: 'tabLongPress',
-        target: trigger.type === 'internal' ? trigger.route.key : trigger?.href,
+        target: trigger.route?.key ?? trigger.href,
       });
 
       if (!shouldHandleMouseEvent(event)) return;

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -28,7 +28,7 @@ import { ExpoTabRouter } from './TabRouter';
 import { isTabSlot } from './TabSlot';
 import { isTabTrigger } from './TabTrigger';
 import type { ScreenTrigger } from './common';
-import { ViewSlot, triggersToScreens } from './common';
+import { ViewSlot, useTriggersToScreens } from './common';
 import { useComponent } from './useComponent';
 
 export * from './TabContext';
@@ -158,11 +158,10 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
 
   const initialRouteName = routeNode.initialRouteName;
 
-  const { children, triggerMap } = triggersToScreens(
+  const { children, triggerMap } = useTriggersToScreens(
     triggers,
     routeNode,
     linking,
-    initialRouteName,
     parentTriggerMap,
     routeInfo,
     contextKey
@@ -180,6 +179,7 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     triggerMap,
     id: contextKey,
     initialRouteName,
+    backBehavior: rest.backBehavior ?? (initialRouteName ? 'initialRoute' : undefined),
   });
 
   const {
@@ -222,6 +222,7 @@ function TabVisibilityRedirect({
 }) {
   useVisibleTabsWithRedirect({
     routes: state.routes,
+    routeNames: state.routeNames,
     focusedRouteKey: state.routes[state.index]!.key,
     descriptors,
   });

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -8,9 +8,8 @@ import type {
   PartialRoute,
   Route,
 } from '../react-navigation/native';
-import { sortRoutesWithInitial } from '../sortRoutes';
 import type { Href } from '../types';
-import { routeToScreen } from '../useScreens';
+import { type ScreenProps, useSortedScreens } from '../useScreens';
 import { Slot } from './Slot';
 import type { ExpoTabActionType } from './TabRouter';
 
@@ -35,17 +34,18 @@ type TriggerConfig =
       name: string;
       href: string;
       routeNode: RouteNode;
+      contextKey: string;
+      initialParams?: Record<string, any>;
       action: JumpToNavigationAction;
     }
   | { type: 'external'; name: string; href: string };
 
-export type TriggerMap = Record<string, TriggerConfig & { index: number }>;
+export type TriggerMap = Record<string, TriggerConfig>;
 
-export function triggersToScreens(
+export function useTriggersToScreens(
   triggers: ScreenTrigger[],
   layoutRouteNode: RouteNode,
   linking: LinkingOptions<ParamListBase>,
-  initialRouteName: undefined | string,
   parentTriggerMap: TriggerMap,
   routeInfo: UrlObject,
   contextKey: string
@@ -119,10 +119,17 @@ export function triggersToScreens(
       if (state.name === targetStateName) break;
       state = state.state.routes[state.state.index ?? state.state.routes.length - 1]!;
     }
+    const isWithinLayout = state?.name === targetStateName;
     routeState =
       state!.state?.routes[state!.state.index ?? state!.state.routes.length - 1] || state;
 
     const routeNode = layoutRouteNode.children.find((child) => child.route === routeState?.name);
+
+    if (!isWithinLayout) {
+      throw new Error(
+        `Tab trigger '${trigger.name}' with href '${resolvedHref}' must point to a route within the tabs layout.`
+      );
+    }
 
     if (!routeNode) {
       console.warn(
@@ -144,51 +151,56 @@ export function triggersToScreens(
     if (duplicateTrigger) {
       const duplicateTriggerText = `${JSON.stringify({ name: duplicateTrigger.name, href: duplicateTrigger.href })} and ${JSON.stringify({ name: trigger.name, href: trigger.href })}`;
 
+      // TODO(@ubax): Support multiple triggers for one dynamic route with different params.
       throw new Error(
         `A navigator cannot contain multiple trigger components that map to the same sub-segment. Consider adding a shared group and assigning a group to each trigger. Conflicting triggers:\n\t${duplicateTriggerText}.\nBoth triggers map to route ${routeNode.route}.`
       );
     }
 
+    const params = { ...routeState.params };
+    let nestedState = routeState.state;
+    while (nestedState) {
+      const nestedRoute = nestedState.routes[nestedState.index ?? nestedState.routes.length - 1]!;
+      Object.assign(params, nestedRoute.params);
+      nestedState = nestedRoute.state;
+    }
+
+    // TODO(@ubax): Remove nested trigger href support to unify with other tab navigators.
+    const action = stateToAction(state, layoutRouteNode.route);
+    action.payload.params = { ...params, ...action.payload.params };
     configs.push({
       ...trigger,
       href: resolvedHref,
       routeNode,
-      action: stateToAction(state, layoutRouteNode.route),
+      contextKey,
+      initialParams: params,
+      action,
     });
   }
 
-  const sortFn = sortRoutesWithInitial(initialRouteName);
-
-  const sortedConfigs = configs.sort((a, b) => {
-    // External routes should be last. They will eventually be dropped
-    if (a.type === 'external' && b.type === 'external') {
-      return 0;
-    } else if (a.type === 'external') {
-      return 1;
-    } else if (b.type === 'external') {
-      return -1;
-    }
-
-    return sortFn(a.routeNode, b.routeNode);
-  });
-
-  const children: React.JSX.Element[] = [];
+  const screenProps: ScreenProps[] = [];
   const triggerMap: TriggerMap = { ...parentTriggerMap };
 
-  for (const [index, config] of sortedConfigs.entries()) {
-    triggerMap[config.name] = { ...config, index };
+  for (const config of configs) {
+    triggerMap[config.name] = config;
 
     if (config.type === 'internal') {
-      // Trigger-declared screens are layout-declared, same as `<Screen>` children.
-      children.push(routeToScreen(config.routeNode, undefined, undefined, 'layout'));
+      screenProps.push({
+        name: config.routeNode.route,
+        initialParams: config.initialParams,
+      });
     }
   }
+
+  const children = useSortedScreens(screenProps);
+
   return {
     children,
     triggerMap,
   };
 }
 
+// TODO(@ubax): Remove stateToAction together with nested trigger href support.
 export function stateToAction(
   state: PartialRoute<Route<string, object | undefined>> | undefined,
   startAtRoute?: string

--- a/packages/expo-router/src/utils/__tests__/orderRoutesByRouteNames.test.ios.ts
+++ b/packages/expo-router/src/utils/__tests__/orderRoutesByRouteNames.test.ios.ts
@@ -1,0 +1,31 @@
+import { orderRoutesByRouteNames } from '../orderRoutesByRouteNames';
+
+const routes = [
+  { key: 'apple-key', name: 'apple' },
+  { key: 'orange-key', name: 'orange' },
+  { key: 'pear-key', name: 'pear' },
+];
+
+test('orders routes by route names', () => {
+  expect(orderRoutesByRouteNames(routes, ['pear', 'apple', 'orange'])).toEqual([
+    routes[2],
+    routes[0],
+    routes[1],
+  ]);
+});
+
+test('skips missing route names and routes absent from route names', () => {
+  expect(orderRoutesByRouteNames(routes, ['missing', 'pear', 'apple'])).toEqual([
+    routes[2],
+    routes[0],
+  ]);
+});
+
+test('returns the input when routes are already ordered', () => {
+  expect(
+    orderRoutesByRouteNames(
+      routes,
+      routes.map((route) => route.name)
+    )
+  ).toBe(routes);
+});

--- a/packages/expo-router/src/utils/orderRoutesByRouteNames.ts
+++ b/packages/expo-router/src/utils/orderRoutesByRouteNames.ts
@@ -1,0 +1,17 @@
+/**
+ * Drops routes absent from `routeNames` and returns `routes` unchanged when already ordered.
+ */
+export function orderRoutesByRouteNames<Route extends { name: string }>(
+  routes: Route[],
+  routeNames: string[]
+): Route[] {
+  const orderedRoutes = routeNames.flatMap((name) => {
+    const route = routes.find((route) => route.name === name);
+    return route ? [route] : [];
+  });
+
+  return orderedRoutes.length === routes.length &&
+    orderedRoutes.every((route, index) => route === routes[index])
+    ? routes
+    : orderedRoutes;
+}


### PR DESCRIPTION
# Why

In order to remove the dependency of tabs on `state.routes` order, we can order them by `routeNames` order - the order of triggers. This way we don't need to adjust the `state.routes` on purely order change in `routeNames`

# How

1. Order tabs by routeNames in `useVisibleTabsWithRedirect` - hook used by all router tab navigators
2. Refactor headless tabs not to relay on routeNames changes

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
