### PR TITLE
[docs][font] Fix ios and android config plugin property shapes

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -52,6 +52,9 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                 ]
               }
             ]
+          },
+          "ios": {
+            "fonts": ["./path/to/SourceSerif4-ExtraBold.ttf"]
           }
         }
       ]
@@ -73,14 +76,14 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
     {
       name: 'android',
       description:
-        'An array of font definitions to link to the native project on Android. Use the object syntax to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
-      default: '[]',
+        'An object with a `fonts` array of font definitions to link to the native project on Android. Use the object syntax within `fonts` to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
+      default: '{}',
     },
     {
       name: 'ios',
       description:
-        'An array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
-      default: '[]',
+        'An object with a `fonts` array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
+      default: '{}',
     },
   ]}
 />

--- a/docs/pages/versions/v54.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/font.mdx
@@ -52,6 +52,9 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                 ]
               }
             ]
+          },
+          "ios": {
+            "fonts": ["./path/to/SourceSerif4-ExtraBold.ttf"]
           }
         }
       ]
@@ -73,14 +76,14 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
     {
       name: 'android',
       description:
-        'An array of font definitions to link to the native project on Android. Use the object syntax to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
-      default: '[]',
+        'An object with a `fonts` array of font definitions to link to the native project on Android. Use the object syntax within `fonts` to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
+      default: '{}',
     },
     {
       name: 'ios',
       description:
-        'An array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
-      default: '[]',
+        'An object with a `fonts` array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
+      default: '{}',
     },
   ]}
 />

--- a/docs/pages/versions/v55.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/font.mdx
@@ -52,6 +52,9 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                 ]
               }
             ]
+          },
+          "ios": {
+            "fonts": ["./path/to/SourceSerif4-ExtraBold.ttf"]
           }
         }
       ]
@@ -73,14 +76,14 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
     {
       name: 'android',
       description:
-        'An array of font definitions to link to the native project on Android. Use the object syntax to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
-      default: '[]',
+        'An object with a `fonts` array of font definitions to link to the native project on Android. Use the object syntax within `fonts` to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
+      default: '{}',
     },
     {
       name: 'ios',
       description:
-        'An array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
-      default: '[]',
+        'An object with a `fonts` array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
+      default: '{}',
     },
   ]}
 />

--- a/docs/pages/versions/v56.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/font.mdx
@@ -52,6 +52,9 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                 ]
               }
             ]
+          },
+          "ios": {
+            "fonts": ["./path/to/SourceSerif4-ExtraBold.ttf"]
           }
         }
       ]
@@ -73,14 +76,14 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
     {
       name: 'android',
       description:
-        'An array of font definitions to link to the native project on Android. Use the object syntax to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
-      default: '[]',
+        'An object with a `fonts` array of font definitions to link to the native project on Android. Use the object syntax within `fonts` to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
+      default: '{}',
     },
     {
       name: 'ios',
       description:
-        'An array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
-      default: '[]',
+        'An object with a `fonts` array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
+      default: '{}',
     },
   ]}
 />

--- a/docs/pages/versions/v57.0.0/sdk/font.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/font.mdx
@@ -52,6 +52,9 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                 ]
               }
             ]
+          },
+          "ios": {
+            "fonts": ["./path/to/SourceSerif4-ExtraBold.ttf"]
           }
         }
       ]
@@ -73,14 +76,14 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
     {
       name: 'android',
       description:
-        'An array of font definitions to link to the native project on Android. Use the object syntax to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
-      default: '[]',
+        'An object with a `fonts` array of font definitions to link to the native project on Android. Use the object syntax within `fonts` to embed [xml fonts](https://developer.android.com/develop/ui/views/text-and-emoji/fonts-in-xml) with custom family name.',
+      default: '{}',
     },
     {
       name: 'ios',
       description:
-        'An array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
-      default: '[]',
+        'An object with a `fonts` array of font file paths to link to the native project on iOS. The font family name is taken directly from the font file.',
+      default: '{}',
     },
   ]}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25586

# How

<!--
How did you build this feature or fix this bug and why?
-->


- Correct the `ios` and `android` config plugin properties on the expo-font page, which are objects with a `fonts` array rather than bare arrays and add an `ios` block to the `app.json` example. 
- Applied to unversioned and backported v54 through v57.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
