### PR TITLE
[ios][battery] Scope event observers to their own events

### DIFF
--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Scope each notification observer to its own event so subscribing to one battery event no longer starts observing the others. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@Ignigena](https://github.com/Ignigena))
+- [iOS] Scope each notification observer to its own event so subscribing to one battery event no longer starts observing the others. ([#48377](https://github.com/expo/expo/pull/48377) by [@Ignigena](https://github.com/Ignigena))
 
 ### 💡 Others
 

--- a/packages/expo-battery/CHANGELOG.md
+++ b/packages/expo-battery/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Scope each notification observer to its own event so subscribing to one battery event no longer starts observing the others. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@Ignigena](https://github.com/Ignigena))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-battery/ios/BatteryModule.swift
+++ b/packages/expo-battery/ios/BatteryModule.swift
@@ -41,21 +41,33 @@ public class BatteryModule: Module {
       UIDevice.current.isBatteryMonitoringEnabled = false
     }
 
-    OnStartObserving {
+    OnStartObserving(batteryLevelDidChange) {
       NotificationCenter.default.addObserver(
         self,
         selector: #selector(self.batteryLevelListener),
         name: UIDevice.batteryLevelDidChangeNotification,
         object: nil
       )
+    }
 
+    OnStopObserving(batteryLevelDidChange) {
+      NotificationCenter.default.removeObserver(self, name: UIDevice.batteryLevelDidChangeNotification, object: nil)
+    }
+
+    OnStartObserving(batteryStateDidChange) {
       NotificationCenter.default.addObserver(
         self,
         selector: #selector(self.batteryStateListener),
         name: UIDevice.batteryStateDidChangeNotification,
         object: nil
       )
+    }
 
+    OnStopObserving(batteryStateDidChange) {
+      NotificationCenter.default.removeObserver(self, name: UIDevice.batteryStateDidChangeNotification, object: nil)
+    }
+
+    OnStartObserving(powerModeDidChange) {
       NotificationCenter.default.addObserver(
         self,
         selector: #selector(self.powerModeListener),
@@ -64,9 +76,7 @@ public class BatteryModule: Module {
       )
     }
 
-    OnStopObserving {
-      NotificationCenter.default.removeObserver(self, name: UIDevice.batteryLevelDidChangeNotification, object: nil)
-      NotificationCenter.default.removeObserver(self, name: UIDevice.batteryStateDidChangeNotification, object: nil)
+    OnStopObserving(powerModeDidChange) {
       NotificationCenter.default.removeObserver(self, name: Notification.Name.NSProcessInfoPowerStateDidChange, object: nil)
     }
   }


### PR DESCRIPTION
# Why

On iOS, subscribing to a single `expo-battery` event silently starts observing all three. `Battery.addLowPowerModeListener(...)` — and nothing else — also registers `NotificationCenter` observers for `UIDevice.batteryLevelDidChangeNotification` and `UIDevice.batteryStateDidChangeNotification`.

`BatteryModule.swift` declared `OnStartObserving`/`OnStopObserving` **without an event name**. `expo-modules-core`'s `EventObservingDecorator` treats an unscoped definition as "call once for the module": it fires on the *first* `startObserving(eventName)` for any event, and only tears down after the *last* listener across *all* events is removed. So the level/state observers stay armed for the rest of the process lifetime.

Real battery level/state changes are then delivered routinely, including while backgrounded, and `sendEvent(...)` dispatches into the JS bridge for events the app never subscribed to and has no handler for. We saw this in our production app: it reached the main thread and crashed with `SIGSEGV` while the app was backgrounded (crash log minimally redacted):

```
Exception Type: SIGSEGV

Thread 0 (crashed):
0   MyApp           0x... + <offset>   (app binary; not related to expo-battery)
1   CoreFoundation  ...
2   CoreFoundation  ...
3   CoreFoundation  ...
4   CoreFoundation  ...
5   Foundation      ...
6   UIKitCore       -[UIDevice(UIDevicePrivate) _setBatteryLevel:]
7   UIKitCore       _updateBatteryStatusBasedOnProperties
8   UIKitCore       _3rdParty_batteryInformationChanged
9   libsystem_notify.dylib
10  libdispatch.dylib   _dispatch_block_async_invoke2
11  libdispatch.dylib   _dispatch_client_callout
12  libdispatch.dylib   _dispatch_main_queue_drain.cold.6
13  libdispatch.dylib   _dispatch_main_queue_drain
14  libdispatch.dylib   _dispatch_main_queue_callback_4CF
15  CoreFoundation  ...
16  CoreFoundation  ...
17  CoreFoundation  ...
18  GraphicsServices  GSEventRunModal
19  UIKitCore       -[UIApplication _run]
20  UIKitCore       UIApplicationMain
21  UIKitCore       ...
22  MyApp           <app entry>
```

Two separate background crashes from our TestFlight build on the same iOS version (26.5.2, on iPhone13,3 and iPhone15,4) produced this identical frame signature: battery level change delivery on the main thread, inside our app binary, which only ever asked for low power mode updates. We can't prove the unsolicited observer is the crashing frame — `expo-battery` is statically linked into the app binary, so its listeners show up as app frames — but an observer we never asked for, running in the background, is the only battery code we have on that stack.

Regardless of the crash, the observer scoping is wrong on its own terms: an app that subscribes to one event shouldn't be paying for notification observers and JS dispatch for the other two.

# How

The single unscoped `OnStartObserving`/`OnStopObserving` pair was split into three pairs, each scoped to its own event constant (`batteryLevelDidChange`, `batteryStateDidChange`, `powerModeDidChange`), so each `NotificationCenter` observer is registered only while that specific event has a JS listener and is removed as soon as it doesn't.

This uses the per-event overload `expo-modules-core` already provides (`OnStartObserving(_ event: String? = nil, ...)`), which is what most modules that emit more than one event already do (`expo-widgets`, `expo-contacts`, `expo-network`, `expo-updates`, and others). There are no JS-side or public API changes — the `startObserving` / `stopObserving` calls were already made per event name, and the JS `EventEmitter` only calls them on the first/last listener for a given event, so each observer is still added and removed exactly once.

# Test Plan

Reproduced with the snippet below, plus a temporary log added to each of the three `@objc` listener methods in `BatteryModule.swift`:

```ts
import * as Battery from 'expo-battery';

// The app never calls addBatteryLevelListener or addBatteryStateListener.
const subscription = Battery.addLowPowerModeListener(({ lowPowerMode }) => {
  console.log('low power mode changed', lowPowerMode);
});
```

- Change the battery level (device, or Simulator → Features → Battery).
  - **Before:** `batteryLevelListener()` / `batteryStateListener()` fire and `sendEvent(...)` is dispatched despite no JS subscription.
  - **After:** neither fires; only `NSProcessInfoPowerStateDidChange` is observed.
- Toggle Low Power Mode: `powerModeListener()` still fires and the JS listener receives the update, before and after.
- We also checked there's no regression when all three listeners are registered — each event is delivered, and removing one subscription stops only that event's observer while the others keep working.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

