### PR TITLE
[ios][autolinking] Persist ReactCodegen phase for transitive modules

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Persist the ReactCodegen autolinking build phase so transitive native components remain registered. ([#44314](https://github.com/expo/expo/issues/44314) by [@vivekjm](https://github.com/vivekjm))
+
 ### 💡 Others
 
 ## 3.0.26 — 2026-05-28

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Persist the ReactCodegen autolinking build phase so transitive native components remain registered. ([#44314](https://github.com/expo/expo/issues/44314) by [@vivekjm](https://github.com/vivekjm))
+- [iOS] Persist the ReactCodegen autolinking build phase so transitive native components remain registered. ([#48383](https://github.com/expo/expo/pull/48383) by [@vivekjm](https://github.com/vivekjm))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -33,6 +33,17 @@ module Pod
       # Call original implementation first
       _original_perform_post_install_actions.bind(self).()
 
+      # CocoaPods has already assigned deterministic UUIDs and saved the Pods project by this
+      # point. Use collision-safe UUIDs for objects added below, then explicitly save them.
+      project = self.pods_project
+      existing_uuids = project.objects_by_uuid.keys.to_set
+      project.define_singleton_method(:generate_available_uuid_list) do |count = 100|
+        new_uuids = (0..count).map { SecureRandom.hex(12).upcase }
+        uniques = new_uuids.reject { |uuid| existing_uuids.include?(uuid) || @generated_uuids.include?(uuid) }
+        @generated_uuids += uniques
+        @available_uuids += uniques
+      end
+
       # Next we'll perform an Expo workaround for Codegen in React Native where it uses the wrong output path for
       # the generated files. This can be remove when the following PR is merged and released upstream:
       # https://github.com/facebook/react-native/pull/54066
@@ -102,6 +113,8 @@ module Pod
           else
             Pod::UI.puts "[Expo] ".yellow + "Could not find 'Compile Sources' phase, build phase added at default position"
           end
+
+          self.pods_project.save
         end
       else
         Pod::UI.puts "[Expo] ".yellow + "ReactCodegen target not found in pods project"


### PR DESCRIPTION
## Why

Fixes #44314.

React Native 0.81 runs codegen again from an Xcode build phase, where its temporary output directory prevents it from reading the `autolinking.json` generated during `pod install`. Expo already adds a corrective ReactCodegen phase for SDK 54, but after that phase was moved to `perform_post_install_actions`, it was added after CocoaPods had saved `Pods.xcodeproj` and was never persisted. Direct app dependencies mask the problem because React Native can rediscover them; native dependencies reachable only through a workspace package leave `RCTThirdPartyComponentsProvider.mm` empty.

## How

- Save `Pods.xcodeproj` after adding the existing Expo autolinking codegen phase.
- Generate collision-safe UUIDs for post-save Xcode objects so persisting the phase does not reintroduce the UUID collision fixed by #40572.

## Impact

SDK 54 pnpm monorepos using iOS static frameworks can keep native dependencies in a workspace package without duplicating them in the app package solely for Fabric registration.

## Test plan

- `ruby -c packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb`
- Used the reproduction from #44314 with pnpm, `ios.useFrameworks: static`, and native dependencies declared only in `packages/shared`.
- Ran `pod install` with the patched `expo-modules-autolinking`; verified the saved ReactCodegen target contains `[CP-User] Generate Specs`, then `[Expo Autolinking] Run Codegen with autolinking`, then Compile Sources.
- Ran `plutil -lint Pods/Pods.xcodeproj/project.pbxproj` successfully.
- Ran a full unsigned iOS Simulator build with `xcodebuild`; build succeeded and the final provider contained 23 `NSClassFromString` registrations, including Screens, Safe Area Context, and Gesture Handler.
- `et check-packages expo-modules-autolinking` was attempted but did not start package checks because the local Corepack installation selected pnpm 11.10 and exited with `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`.