### PR TITLE
[expo-contacts][iOS] Fix `getAllDetails` dropping `thumbnail`, `birthday` and `nonGregorianBirthday`

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `Contact.getAllDetails` always returning `null` for `thumbnail`, `birthday` and `nonGregorianBirthday`. ([#48384](https://github.com/expo/expo/pull/48384) by [@martintreurnicht](https://github.com/martintreurnicht))
+
 ### 💡 Others
 
 ## 57.0.3 - 2026-07-29

--- a/packages/expo-contacts/ios/next/records/contact/GetContactDetailsRecord.swift
+++ b/packages/expo-contacts/ios/next/records/contact/GetContactDetailsRecord.swift
@@ -82,6 +82,9 @@ struct GetContactDetailsRecord: Record {
     self.phoneticCompanyName = phoneticCompanyName
     self.note = note
     self.image = image
+    self.thumbnail = thumbnail
+    self.birthday = birthday
+    self.nonGregorianBirthday = nonGregorianBirthday
     self.emails = emails
     self.dates = dates
     self.phones = phones


### PR DESCRIPTION
# Why

`GetContactDetailsRecord`'s initializer accepts `thumbnail`, `birthday` and `nonGregorianBirthday`, but never assigns them — the assignment block goes straight from `self.image = image` to `self.emails = emails`. The fields therefore stay `nil` and `Contact.getAllDetails` always resolves them to `null`, no matter which `ContactField`s the caller requests.

For thumbnails this is easy to miss, because the *argument expression* still runs: `GetContactDetailsMapper` calls `ThumbnailMapper.extract`, which writes `<identifier>-thumb.png` into the cache directory for every contact that has a photo — and then the returned path is discarded. So the side effect (a file per contact, per fetch) happens while JS still sees `thumbnail: null`.

Repro on a device with contacts that have photos:

```ts
const details = await Contact.getAllDetails([ContactField.FULL_NAME, ContactField.THUMBNAIL])
details.filter((c) => c.thumbnail != null).length // 0, and Library/Caches/Contacts is full of *-thumb.png
```

Measured on a 715-contact address book (256 with photos), before → after this change: `thumbnail != null` goes **0 → 256**. `Contact.getThumbnail()` on an individual contact was unaffected; only the bulk `getAllDetails` path is.

# How

Assign the three missing fields in the initializer.

# Test Plan

- Built an app against these sources on device (iOS 26.5) and called `Contact.getAllDetails([...ContactField.THUMBNAIL])`: every contact with a photo now returns a thumbnail path that renders, where previously all 256 were `null`.
- `birthday` / `nonGregorianBirthday` are fixed by the same block; they were dropped identically.

# Checklist

- [x] Documentation is up to date to reflect any changes (n/a — bug fix, no API change).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (added a CHANGELOG entry).