### PR TITLE
[expo-contacts][iOS] Return image and thumbnail URIs instead of file paths

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fix `Contact.getAllDetails` always returning `null` for `thumbnail`, `birthday` and `nonGregorianBirthday`. ([#48384](https://github.com/expo/expo/pull/48384) by [@martintreurnicht](https://github.com/martintreurnicht))
 - [iOS] Fix `Contact.getAll` and `Contact.getAllDetails` returning contacts linked across accounts once per account record, and honour the `rawContacts` query option. ([#48387](https://github.com/expo/expo/pull/48387) by [@martintreurnicht](https://github.com/martintreurnicht))
+- [iOS] Return contact image and thumbnail URIs instead of bare file paths, matching the documented contract and Android. ([#48385](https://github.com/expo/expo/pull/48385) by [@martintreurnicht](https://github.com/martintreurnicht))
 
 ### 💡 Others
 

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -353,7 +353,6 @@ private func writeDataToUri(userId: String, data: Data?, imageKey: String, inclu
 
   try data.write(to: newPath, options: .atomic)
   var response: [String: Any?] = [
-    // Matches the class API and Android: the contract for this field is a URI, not a path.
     "uri": newPath.absoluteString,
     "width": image?.cgImage?.width,
     "height": image?.cgImage?.height

--- a/packages/expo-contacts/ios/Serialization.swift
+++ b/packages/expo-contacts/ios/Serialization.swift
@@ -353,7 +353,8 @@ private func writeDataToUri(userId: String, data: Data?, imageKey: String, inclu
 
   try data.write(to: newPath, options: .atomic)
   var response: [String: Any?] = [
-    "uri": newPath.path,
+    // Matches the class API and Android: the contract for this field is a URI, not a path.
+    "uri": newPath.absoluteString,
     "width": image?.cgImage?.width,
     "height": image?.cgImage?.height
   ]

--- a/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
+++ b/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
@@ -14,8 +14,6 @@ class ImageService {
   func url(from imageData: Data, filename: String) throws -> String {
     let imageFileURL = try prepareCacheFileURL(filename: filename)
     try imageData.write(to: imageFileURL, options: .atomic)
-    // The API contract is a URI (see the `file:///path/to/image.jpg` examples in the types, and
-    // Android returning `content://` URIs), so return one instead of a bare filesystem path.
     return imageFileURL.absoluteString
   }
 

--- a/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
+++ b/packages/expo-contacts/ios/next/objects/contact/services/ImageService.swift
@@ -14,7 +14,9 @@ class ImageService {
   func url(from imageData: Data, filename: String) throws -> String {
     let imageFileURL = try prepareCacheFileURL(filename: filename)
     try imageData.write(to: imageFileURL, options: .atomic)
-    return imageFileURL.path
+    // The API contract is a URI (see the `file:///path/to/image.jpg` examples in the types, and
+    // Android returning `content://` URIs), so return one instead of a bare filesystem path.
+    return imageFileURL.absoluteString
   }
 
   func imageData(from url: String) throws -> Data? {


### PR DESCRIPTION
# Why

`ImageService.url(from:filename:)` (class API) and `writeDataToUri` (legacy) returned `URL.path`, so iOS handed back **bare filesystem paths** while the documented contract — and Android — use URIs:

- `Contact.types.ts` documents `image`/`thumbnail` as `@example "file:///path/to/image.jpg"` (4 places), and `setImage` is documented as `setImage('file:///path/to/new/image.jpg')`
- Android already returns `content://…` URIs (`PhotoUri` / `PhotoThumbnailUri`)
- the legacy response field is literally named `uri`

Two user-visible consequences follow from the mismatch, which returning a URI fixes:

**1. Photos with a `:` in the identifier never render.** AddressBook-backed contacts have identifiers like `<uuid>:ABPerson`, so the file is `<uuid>:ABPerson-image.png`. A *path* containing `:` cannot be reopened by consumers that convert the string to a URL — React Native's image loader fails with:

```
The file "DBFB258B-6102-44A9-8B95-B856479686A8:ABPerson-image.png" couldn't be opened.
```

On a real 715-contact address book that was **146 of the 256 contacts with photos** (57%): 99 distinct failing files, all 99 containing `:`, zero colon-free failures. Returning `file://…` fixes it without special-casing the character.

**2. The value can't be round-tripped.** `ImageService.imageData(from:)` and the legacy image setter both require `URL(string: value)?.isFileURL`, which a bare path fails — so an image path the module returned was rejected when passed back into `setImage`.

# How

Return `URL.absoluteString` from both write paths. The `/` sanitization from #48201 stays, since `appendingPathComponent` would still treat it as a nested directory.

Note this changes what iOS returns for these fields (path → URI). That's the documented behaviour and matches Android, so I've filed it under bug fixes — happy to move the CHANGELOG entry if you'd rather flag it as breaking.

# Test Plan

Built an app against these sources on device (iOS 26.5) with an address book mixing AddressBook-backed (`<uuid>:ABPerson`) and plain-UUID identifiers:

- before: 106 `Image` load failures, all colon-containing; 57% of contacts with photos showed no avatar
- after: every contact photo renders, 0 load failures

Applied to both the class API and the legacy module, as requested.

# Checklist

- [x] Documentation is up to date to reflect any changes (n/a — this makes the code match the existing documented contract).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (added a CHANGELOG entry).