### PR TITLE
[create-expo] Fix npm pack JSON parsing on npm 12

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix template downloads failing on `npm@>=12`, which returns `npm pack --json` results as an object keyed by package name instead of an array. ([#48392](https://github.com/expo/expo/pull/48392) by [@00vortexlabsoneuzb00-wq](https://github.com/00vortexlabsoneuzb00-wq))
+
 ### 💡 Others
 
 ## 5.0.0 - 2026-06-25

--- a/packages/create-expo/src/utils/__tests__/npmPack.test.ts
+++ b/packages/create-expo/src/utils/__tests__/npmPack.test.ts
@@ -1,0 +1,60 @@
+import spawnAsync from '@expo/spawn-async';
+
+import { npmPackAsync } from '../npm';
+
+jest.mock('@expo/spawn-async');
+
+const mockSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
+
+function mockNpmStdout(stdout: string) {
+  mockSpawnAsync.mockResolvedValue({ stdout } as any);
+}
+
+const packageInfo = {
+  id: 'expo-template-blank@57.0.11',
+  name: 'expo-template-blank',
+  version: '57.0.11',
+  size: 509443,
+  unpackedSize: 516067,
+  shasum: '5b4d5304d629b42cbbc35aeb59a8ac223412c1a1',
+  integrity:
+    'sha512-A9SuNKCRIkjKYaj39KG0h898wLXosWL2s/bF1AQLHhcJjDk+S7wTEpCXTjB59ocYRxhd4DRXEZ09Qq7VK99IQg==',
+  filename: 'expo-template-blank-57.0.11.tgz',
+  files: [],
+  entryCount: 0,
+  bundled: [],
+};
+
+describe(npmPackAsync, () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('parses the array response from npm@<12', async () => {
+    mockNpmStdout(JSON.stringify([packageInfo]));
+    await expect(npmPackAsync('expo-template-blank')).resolves.toEqual([packageInfo]);
+  });
+
+  it('parses the keyed object response from npm@>=12', async () => {
+    mockNpmStdout(JSON.stringify({ 'expo-template-blank': packageInfo }));
+    await expect(npmPackAsync('expo-template-blank')).resolves.toEqual([packageInfo]);
+  });
+
+  it('parses a single package info object', async () => {
+    mockNpmStdout(JSON.stringify(packageInfo));
+    await expect(npmPackAsync('expo-template-blank')).resolves.toEqual([packageInfo]);
+  });
+
+  it('ignores non-json noise surrounding the response', async () => {
+    mockNpmStdout(`npm warn using --force\n${JSON.stringify([packageInfo])}\nnpm notice done`);
+    await expect(npmPackAsync('expo-template-blank')).resolves.toEqual([packageInfo]);
+  });
+
+  it('returns null without output', async () => {
+    mockNpmStdout('');
+    await expect(npmPackAsync('expo-template-blank')).resolves.toBeNull();
+  });
+
+  it('throws on an unexpected response', async () => {
+    mockNpmStdout('{"error":{"code":"E404"}}');
+    await expect(npmPackAsync('expo-template-blank')).rejects.toThrow(/Invalid response from npm/);
+  });
+});

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -148,7 +148,7 @@ async function npmPackAsync(
   try {
     results = (await spawnAsync(npm, [...cmd, '--json'], { cwd })).stdout?.trim();
   } catch (error: any) {
-    if (error?.stderr.match(/npm ERR! code E404/)) {
+    if (error?.stderr?.match(/npm ERR! code E404/)) {
       const pkg =
         error.stderr.match(/npm ERR! 404\s+'(.*)' is not in this registry\./)?.[1] ?? error.stderr;
       throw new Error(`NPM package not found: ` + pkg);
@@ -160,12 +160,46 @@ async function npmPackAsync(
     return null;
   }
 
+  // =========================================================================
+  // 🛠️ BUG FIX: NPM OUTPUT NOISE & OBJECT-TO-ARRAY NORMALIZATION
+  // 1. Terminalga chiqadigan "npm WARN" va keraksiz matnlarni tozalash uchun
+  //    JSON boshlanishi ('{' yoki '[') va tugashini ('}' yoki ']') ajratib olamiz.
+  // 2. npm 10+ versiyalari --json berilganda javobni Massiv emas, Obyekt
+  //    ({ "expo-template-default": {...} }) shaklida qaytargani uchun uni
+  //    Object.values() yordamida qayta Massivga o'giramiz.
+  // =========================================================================
+
+  const firstCurly = results.indexOf('{');
+  const firstSquare = results.indexOf('[');
+
+  let jsonStart = -1;
+  if (firstCurly !== -1 && firstSquare !== -1) {
+    jsonStart = Math.min(firstCurly, firstSquare);
+  } else {
+    jsonStart = firstCurly !== -1 ? firstCurly : firstSquare;
+  }
+
+  const lastCurly = results.lastIndexOf('}');
+  const lastSquare = results.lastIndexOf(']');
+  const jsonEnd = Math.max(lastCurly, lastSquare);
+
+  const cleanJson =
+    jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart
+      ? results.slice(jsonStart, jsonEnd + 1)
+      : results;
+
   try {
-    const json = JSON.parse(results);
+    let json = JSON.parse(cleanJson);
+
+    // Agar npm javobni Obyekt ko'rinishida qaytarsa, uni Expo kutayotgan Massivga o'giramiz
+    if (json && typeof json === 'object' && !Array.isArray(json)) {
+      json = Object.values(json);
+    }
+
     if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
       return json.map(sanitizeNpmPackageFilename);
     } else {
-      throw new Error(`Invalid response from npm: ${results}`);
+      throw new Error(`Invalid response from npm: ${cleanJson}`);
     }
   } catch (error: any) {
     throw new Error(

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -128,7 +128,7 @@ export async function extractLocalNpmTarballAsync(
   );
 }
 
-async function npmPackAsync(
+export async function npmPackAsync(
   packageName: string,
   cwd: string | undefined = undefined,
   ...props: string[]
@@ -160,52 +160,54 @@ async function npmPackAsync(
     return null;
   }
 
-  // =========================================================================
-  // 🛠️ BUG FIX: NPM OUTPUT NOISE & OBJECT-TO-ARRAY NORMALIZATION
-  // 1. Terminalga chiqadigan "npm WARN" va keraksiz matnlarni tozalash uchun
-  //    JSON boshlanishi ('{' yoki '[') va tugashini ('}' yoki ']') ajratib olamiz.
-  // 2. npm 10+ versiyalari --json berilganda javobni Massiv emas, Obyekt
-  //    ({ "expo-template-default": {...} }) shaklida qaytargani uchun uni
-  //    Object.values() yordamida qayta Massivga o'giramiz.
-  // =========================================================================
+  const json = extractJson(results);
 
-  const firstCurly = results.indexOf('{');
-  const firstSquare = results.indexOf('[');
-
-  let jsonStart = -1;
-  if (firstCurly !== -1 && firstSquare !== -1) {
-    jsonStart = Math.min(firstCurly, firstSquare);
-  } else {
-    jsonStart = firstCurly !== -1 ? firstCurly : firstSquare;
-  }
-
-  const lastCurly = results.lastIndexOf('}');
-  const lastSquare = results.lastIndexOf(']');
-  const jsonEnd = Math.max(lastCurly, lastSquare);
-
-  const cleanJson =
-    jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart
-      ? results.slice(jsonStart, jsonEnd + 1)
-      : results;
-
-  try {
-    let json = JSON.parse(cleanJson);
-
-    // Agar npm javobni Obyekt ko'rinishida qaytarsa, uni Expo kutayotgan Massivga o'giramiz
-    if (json && typeof json === 'object' && !Array.isArray(json)) {
-      json = Object.values(json);
-    }
-
-    if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
-      return json.map(sanitizeNpmPackageFilename);
-    } else {
-      throw new Error(`Invalid response from npm: ${cleanJson}`);
-    }
-  } catch (error: any) {
+  if (json === null) {
     throw new Error(
-      `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
+      `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: no JSON found in the npm output`
     );
   }
+
+  const infos = normalizeNpmPackInfos(json);
+
+  if (!infos) {
+    throw new Error(`Invalid response from npm: ${results}`);
+  }
+
+  return infos.map(sanitizeNpmPackageFilename);
+}
+
+/** Parse the JSON payload from npm output, dropping any log lines printed around it. */
+function extractJson(output: string): unknown | null {
+  const candidates = [output.indexOf('{'), output.indexOf('[')].filter((index) => index !== -1);
+  const start = candidates.length ? Math.min(...candidates) : -1;
+  const end = Math.max(output.lastIndexOf('}'), output.lastIndexOf(']'));
+
+  try {
+    return JSON.parse(start !== -1 && end > start ? output.slice(start, end + 1) : output);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalize the shape of `npm pack --json`, which differs per npm version.
+ * - `npm@<12` returns an array of package infos.
+ * - `npm@>=12` returns an object keyed by package name, e.g. `{ "expo-template-blank": { ... } }`.
+ */
+function normalizeNpmPackInfos(json: unknown): NpmPackageInfo[] | null {
+  // A single package info is an object too, so it must not be unwrapped below.
+  if (isNpmPackageInfo(json)) {
+    return [json];
+  }
+
+  const list = Array.isArray(json)
+    ? json
+    : json && typeof json === 'object'
+      ? Object.values(json)
+      : null;
+
+  return list?.every(isNpmPackageInfo) ? list : null;
 }
 
 export type NpmPackageInfo = {


### PR DESCRIPTION
# Why

`create-expo` fails to download any template on `npm@>=12`.

`npmPackAsync` in `packages/create-expo/src/utils/npm.ts` runs `npm pack --json` and expects an array of package infos back. Starting with `npm@12`, `npm pack --json` returns an **object keyed by package name** instead:

```console
$ npm --version
12.0.2

$ npm pack expo-template-blank --dry-run --json
{
  "expo-template-blank": {
    "id": "expo-template-blank@57.0.11",
    "name": "expo-template-blank",
    "version": "57.0.11",
    "filename": "expo-template-blank-57.0.11.tgz",
    ...
  }
}
```

The `Array.isArray(json)` check therefore fails and the command aborts with `Invalid response from npm: ...`, so no project can be created. Because that error is thrown inside the `try` block that wraps `JSON.parse`, it is then caught and re-thrown as `Could not parse JSON returned from "npm pack ..."`, which points the user at JSON parsing rather than at the real cause.

A second, smaller problem: the raw stdout is passed straight to `JSON.parse`, so any log line npm prints next to the payload breaks parsing.

# How

All changes are in `packages/create-expo/src/utils/npm.ts`.

- **Normalize the response shape.** A new `normalizeNpmPackInfos` helper accepts all three shapes `npm pack --json` can produce and returns `NpmPackageInfo[]`:
  - an array of package infos (`npm@<12`),
  - an object keyed by package name, unwrapped with `Object.values` (`npm@>=12`),
  - a single bare package info, wrapped into a list.

  The bare-object case is checked **first**, because a package info is an object too. Running `Object.values` on it would return its field values (`"expo-template-blank@57.0.11"`, `509443`, …) and fail validation with the same `Invalid response` error the fix is meant to remove.

- **Tolerate non-JSON output.** A new `extractJson` helper slices from the first `{` or `[` to the last `}` or `]` before parsing, so warnings or notices printed next to the payload no longer break it. If nothing parseable is found it returns `null` and the caller throws the existing "Could not parse JSON" error with the full npm output attached, so the diagnostic detail is preserved.

- **Stop masking the real error.** `Invalid response from npm` is now thrown outside the JSON parse `try`, so an unexpected response is no longer re-labelled as a JSON parse failure. The two failure modes now report distinctly.

- **Exported `npmPackAsync`** so the behaviour above can be unit tested with a mocked `@expo/spawn-async`. It is not exported from the package entry point and remains internal to `create-expo`.

Existing behaviour is unchanged for `npm@<12`: the array path is still the first branch, and the `E404` handling and `sanitizeNpmPackageFilename` call are untouched.

# Test Plan

**New unit tests** — `packages/create-expo/src/utils/__tests__/npmPack.test.ts` mocks `@expo/spawn-async` and covers the array response, the keyed object response, a single package info, output with surrounding noise, empty output, and an unexpected response. Three of them — the keyed object, the single package info, and the noisy output — fail against `main` and pass with this change.

```console
$ pnpm test
Test Suites: 17 passed, 17 total
Tests:       136 passed, 136 total
Snapshots:   1 passed, 1 total
```

**Full package check:**

```console
$ et check-packages create-expo
create-expo:lint: Found 0 warnings and 0 errors.
create-expo:format: All matched files use the correct format.
🏁 All checks passed.
```

**End-to-end against a real registry with `npm@12.0.2`** — built the bundle and generated a project:

```console
$ npm --version
12.0.2

$ pnpm build
$ EXPO_NO_CACHE=1 node build/index.js my-app --template blank --no-install
Creating my-app using the blank template.
✔ Downloaded and extracted project files.
✅ Your project is ready!

$ ls my-app
AGENTS.md  App.js  app.json  assets  CLAUDE.md  index.js  LICENSE  package.json
```

**To reproduce the bug**, run the same command on `main` with `npm@>=12` installed, or run the new test file against `main`, where those three cases fail.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — not applicable, this does not touch a config plugin or native code
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
