### PR TITLE
[docs] Show only llms.txt link in page footer

### DIFF
--- a/docs/messages/en.json
+++ b/docs/messages/en.json
@@ -31,7 +31,7 @@
   "footerShareFeedback": "Share your feedback",
   "footerAskOnForums": "Ask a question on the forums",
   "footerEditPage": "Edit this page",
-  "footerLlmsView": "View <llmsLink>llms.txt</llmsLink> and <fullLink>{fullName}</fullLink>",
+  "footerLlmsView": "View <llmsLink>llms.txt</llmsLink>",
   "footerNewsletterTitle": "Sign up for the Expo Newsletter",
   "footerSignUp": "Sign up",
   "footerThankYouSignUp": "Thank you for the sign up! 💙",

--- a/docs/messages/ja.json
+++ b/docs/messages/ja.json
@@ -31,7 +31,7 @@
   "footerShareFeedback": "フィードバックを共有する",
   "footerAskOnForums": "フォーラムで質問する",
   "footerEditPage": "このページを編集する",
-  "footerLlmsView": "<llmsLink>llms.txt</llmsLink> と <fullLink>{fullName}</fullLink> を表示",
+  "footerLlmsView": "<llmsLink>llms.txt</llmsLink> を表示",
   "footerNewsletterTitle": "Expo ニュースレターに登録する",
   "footerSignUp": "登録",
   "footerThankYouSignUp": "ご登録ありがとうございます！💙",

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -5,8 +5,6 @@ import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
 import { useRouter } from 'next/compat/router';
 import { useIntl } from 'react-intl';
 
-import { isEasPath } from '~/common/routes';
-import { usePageApiVersion } from '~/providers/page-api-version';
 import { NavigationRouteWithSection } from '~/types/common';
 import { NewsletterSignUp } from '~/ui/components/Footer/NewsletterSignUp';
 import { P, FOOTNOTE, UL, LI } from '~/ui/components/Text';
@@ -24,8 +22,6 @@ type Props = {
 };
 
 const isDev = process.env.NODE_ENV === 'development';
-const LLMS_SDK_VERSIONS = ['v55.0.0', 'v54.0.0'];
-const LLMS_SDK_LATEST_VERSION = LLMS_SDK_VERSIONS[0];
 
 export const Footer = ({
   title,
@@ -35,23 +31,11 @@ export const Footer = ({
   nextPage,
   modificationDate,
 }: Props) => {
-  const { hasVersion, version } = usePageApiVersion();
   const router = useRouter();
   const intl = useIntl();
   const isAPIPage = router?.pathname.includes('/sdk/') ?? false;
   const isTutorial = router?.pathname.includes('/tutorial/') ?? false;
   const isExpoPackage = packageName ? packageName.startsWith('expo-') : isAPIPage;
-  const llmsSdkVersion = version === 'latest' ? LLMS_SDK_LATEST_VERSION : version;
-  const shouldUseLlmsSdkFile = hasVersion && LLMS_SDK_VERSIONS.includes(llmsSdkVersion);
-  const isEasPage = router?.pathname ? isEasPath(router.pathname) : false;
-  const llmsFullFilename = isEasPage
-    ? 'llms-eas.txt'
-    : shouldUseLlmsSdkFile
-      ? `llms-sdk-${llmsSdkVersion}.txt`
-      : 'llms-full.txt';
-  const llmsFullHref = `/${llmsFullFilename}`;
-  const llmsFullLabel = 'llms-full.txt';
-
   const shouldShowModifiedDate = !isExpoPackage && !isTutorial && title;
 
   return (
@@ -120,7 +104,7 @@ export const Footer = ({
               <IssuesLink title={title} repositoryUrl={isExpoPackage ? undefined : sourceCodeUrl} />
             )}
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
-            <LlmsTxtLink fullVersionHref={llmsFullHref} fullVersionLabel={llmsFullLabel} />
+            <LlmsTxtLink />
             {!isDev && shouldShowModifiedDate && modificationDate && (
               <LI className="mt-4! text-xs! text-quaternary!">
                 Last updated on <time dateTime={modificationDate}>{modificationDate}</time>

--- a/docs/ui/components/Footer/Links.tsx
+++ b/docs/ui/components/Footer/Links.tsx
@@ -65,12 +65,7 @@ export const EditPageLink = ({ pathname }: { pathname: string }) => {
   );
 };
 
-type LlmsTxtLinkProps = {
-  fullVersionHref: string;
-  fullVersionLabel: string;
-};
-
-export const LlmsTxtLink = ({ fullVersionHref, fullVersionLabel }: LlmsTxtLinkProps) => (
+export const LlmsTxtLink = () => (
   <LI className="flex items-center">
     <File02Icon aria-hidden="true" className={ICON_CLASSES} />
     <CALLOUT theme="secondary" tag="span">
@@ -82,12 +77,6 @@ export const LlmsTxtLink = ({ fullVersionHref, fullVersionLabel }: LlmsTxtLinkPr
               {chunks}
             </A>
           ),
-          fullLink: (chunks: ReactNode) => (
-            <A openInNewTab href={fullVersionHref} className="focus-visible:outline-offset-4">
-              {chunks}
-            </A>
-          ),
-          fullName: fullVersionLabel,
         }}
       />
     </CALLOUT>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The llms-full.txt and llms-sdk.txt bundles are big enough (1.9 MB and 2.8 MB) that linking them from every page footer does more harm than good, since llms.txt and per-page .md are the entry points we actually want agents using.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Dropped the SDK and EAS filename branching in `Footer.tsx` along with the full-bundle link in `LlmsTxtLink`, so the footer renders just the llms.txt link, and updated the `footerLlmsView` string in `en.json` and `ja.json` to match.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="852" height="492" alt="CleanShot 2026-08-01 at 23 24 02@2x" src="https://github.com/user-attachments/assets/6d60fea5-2aad-4529-8790-991d36fc7b2e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
