### PR TITLE
[docs] Explain localizing iOS permission messages

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -193,6 +193,7 @@ The keys provided to `locales` should be the [language identifier](https://devel
   "ios": {
     "CFBundleDisplayName": "こんにちは",
     "NSContactsUsageDescription": "日本語のこれらの言葉",
+    "NSUserTrackingUsageDescription": "より関連性の高い広告を表示するために、このアプリによるアクティビティの追跡を許可します。",
     "Localizable.strings": {
       "HELLO_NOTIFICATION_KEY": "こんにちは世界"
     }
@@ -206,17 +207,7 @@ The keys provided to `locales` should be the [language identifier](https://devel
 
 Now, the display name of your app is set to `こんにちは` whenever it's installed on a device with the language set to Japanese.
 
-Config plugins set the default value for iOS usage descriptions in **Info.plist**. To show a translated system permission message, add the matching usage-description key to the `ios` object in each locale file. During prebuild, Expo writes those values to `InfoPlist.strings` for the corresponding locale.
-
-For example, `expo-tracking-transparency` uses `NSUserTrackingUsageDescription`. Keep `userTrackingPermission` in the config plugin as the default message, then provide a localized value in every locale file:
-
-```json japanese.json
-{
-  "ios": {
-    "NSUserTrackingUsageDescription": "Allow this app to track your activity to show more relevant ads."
-  }
-}
-```
+Config plugins set the default value for iOS usage descriptions in **Info.plist**. To show a translated system permission message, add the matching usage-description key to the `ios` object in each locale file. During prebuild, Expo writes those values to **InfoPlist.strings** for the corresponding locale.
 
 In SDK 55 and later, there is an iOS-only option to specify a `Localizable.strings` object whose entries are used to create native localization files. The entries can be used in [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages).
 

--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -206,6 +206,18 @@ The keys provided to `locales` should be the [language identifier](https://devel
 
 Now, the display name of your app is set to `こんにちは` whenever it's installed on a device with the language set to Japanese.
 
+Config plugins set the default value for iOS usage descriptions in **Info.plist**. To show a translated system permission message, add the matching usage-description key to the `ios` object in each locale file. During prebuild, Expo writes those values to `InfoPlist.strings` for the corresponding locale.
+
+For example, `expo-tracking-transparency` uses `NSUserTrackingUsageDescription`. Keep `userTrackingPermission` in the config plugin as the default message, then provide a localized value in every locale file:
+
+```json japanese.json
+{
+  "ios": {
+    "NSUserTrackingUsageDescription": "Allow this app to track your activity to show more relevant ads."
+  }
+}
+```
+
 In SDK 55 and later, there is an iOS-only option to specify a `Localizable.strings` object whose entries are used to create native localization files. The entries can be used in [iOS localized notifications](https://developer.apple.com/documentation/usernotifications/generating-a-remote-notification#Localize-your-alert-messages).
 
 ## RTL support

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -79,6 +79,8 @@ You can configure `expo-calendar` using its built-in [config plugin](/config-plu
   ]}
 />
 
+To localize an iOS calendar or reminders permission message, keep the matching config-plugin property as the default value and add its `NS*UsageDescription` key to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **ios** project manually), then you need to configure following permissions in your native project:

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -79,7 +79,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/config-plu
   ]}
 />
 
-To localize an iOS calendar or reminders permission message, keep the matching config-plugin property as the default value and add its `NS*UsageDescription` key to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize an iOS calendar or reminders permission message, add the matching usage description keys to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). The `calendarPermission` property sets both `NSCalendarsUsageDescription` and `NSCalendarsFullAccessUsageDescription`, and `remindersPermission` sets both `NSRemindersUsageDescription` and `NSRemindersFullAccessUsageDescription`. Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -83,7 +83,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
   ]}
 />
 
-To localize the iOS camera or microphone permission message, keep the matching config-plugin property as the default value and add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize the iOS camera or microphone permission message, add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Keep `cameraPermission` and `microphonePermission` as the default values. Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -83,6 +83,8 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
   ]}
 />
 
+To localize the iOS camera or microphone permission message, keep the matching config-plugin property as the default value and add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **android** and **ios** projects manually), then you need to configure following permissions in your native projects:

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -60,7 +60,7 @@ You can configure `expo-tracking-transparency` using its built-in [config plugin
   ]}
 />
 
-To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/unversioned/sdk/tracking-transparency.mdx
@@ -60,6 +60,8 @@ You can configure `expo-tracking-transparency` using its built-in [config plugin
   ]}
 />
 
+To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **android** and **ios** projects manually), then you need to configure following permissions in your native projects:

--- a/docs/pages/versions/v57.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/calendar.mdx
@@ -79,6 +79,8 @@ You can configure `expo-calendar` using its built-in [config plugin](/config-plu
   ]}
 />
 
+To localize an iOS calendar or reminders permission message, keep the matching config-plugin property as the default value and add its `NS*UsageDescription` key to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **ios** project manually), then you need to configure following permissions in your native project:

--- a/docs/pages/versions/v57.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/calendar.mdx
@@ -79,7 +79,7 @@ You can configure `expo-calendar` using its built-in [config plugin](/config-plu
   ]}
 />
 
-To localize an iOS calendar or reminders permission message, keep the matching config-plugin property as the default value and add its `NS*UsageDescription` key to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize an iOS calendar or reminders permission message, add the matching usage description keys to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). The `calendarPermission` property sets both `NSCalendarsUsageDescription` and `NSCalendarsFullAccessUsageDescription`, and `remindersPermission` sets both `NSRemindersUsageDescription` and `NSRemindersFullAccessUsageDescription`. Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v57.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/camera.mdx
@@ -83,7 +83,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
   ]}
 />
 
-To localize the iOS camera or microphone permission message, keep the matching config-plugin property as the default value and add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize the iOS camera or microphone permission message, add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Keep `cameraPermission` and `microphonePermission` as the default values. Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v57.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/camera.mdx
@@ -83,6 +83,8 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
   ]}
 />
 
+To localize the iOS camera or microphone permission message, keep the matching config-plugin property as the default value and add `NSCameraUsageDescription` or `NSMicrophoneUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **android** and **ios** projects manually), then you need to configure following permissions in your native projects:

--- a/docs/pages/versions/v57.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/tracking-transparency.mdx
@@ -60,7 +60,7 @@ You can configure `expo-tracking-transparency` using its built-in [config plugin
   ]}
 />
 
-To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to **InfoPlist.strings** during prebuild.
 
 <ConfigReactNative>
 

--- a/docs/pages/versions/v57.0.0/sdk/tracking-transparency.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/tracking-transparency.mdx
@@ -60,6 +60,8 @@ You can configure `expo-tracking-transparency` using its built-in [config plugin
   ]}
 />
 
+To localize this iOS permission message, keep `userTrackingPermission` as the default value and add `NSUserTrackingUsageDescription` to the `ios` object in each [locale file](/guides/localization/#translating-app-metadata). Expo writes the localized values to `InfoPlist.strings` during prebuild.
+
 <ConfigReactNative>
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) (you're using native **android** and **ios** projects manually), then you need to configure following permissions in your native projects:


### PR DESCRIPTION
# Why

The localization guide explains that system-dialog strings can be translated, but it did not make the relationship to config-plugin permission messages explicit. This led to uncertainty about where values such as `NSUserTrackingUsageDescription` belong. This addresses https://github.com/expo/expo/issues/16003.

# How

Document the default `Info.plist` value versus localized `InfoPlist.strings` values, with a tracking-transparency example. Add direct guidance from the tracking transparency, camera, and calendar config-plugin references, keeping the current SDK and unversioned pages aligned.

# Test Plan

- Ran `pnpm --dir docs lint-links` with Node v24.14.0.
- Ran Vale against all seven edited MDX files with zero errors, warnings, or suggestions.

# Checklist

- [x] Conforms with the Documentation Writing Style Guide