### PR TITLE
[android][core] Restore hosted Compose layout after lifecycle changes

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))
 - [iOS] Concurrent functions build on the new two-phase `createAsyncFunction` from `expo-modules-jsi` again, instead of wiring the promise themselves. This also restores rejecting the returned promise (rather than throwing synchronously) when the app context is lost or argument decoding fails. ([#47755](https://github.com/expo/expo/pull/47755) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Support `android.graphics.Color` arguments and props on Android below API 26 by adding a `ColorCompat` wrapper, since the class-based `Color` API (`Color.valueOf` and the float accessors) only exists on API 26 and above. `PlatformColor` values now resolve below API 26 too, via React Native's ARGB-int color path. ([#47546](https://github.com/expo/expo/issues/47546) by [@anasvemmully](https://github.com/anasvemmully)) ([#47575](https://github.com/expo/expo/pull/47575) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.views
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
@@ -113,6 +114,15 @@ abstract class ExpoComposeView<T : ComposeProps>(
     }
   }
 
+  override fun dispatchConfigurationChanged(newConfig: Configuration) {
+    super.dispatchConfigurationChanged(newConfig)
+    // React Native owns this view's bounds and may not schedule another Android layout pass
+    // when a configuration change leaves its Yoga layout unchanged.
+    if (withHostingView && isAttachedToWindow && isLaidOut) {
+      requestLayout()
+    }
+  }
+
   /**
    * Validates that this non-hosting Compose view has a valid Compose parent.
    *
@@ -193,6 +203,15 @@ abstract class ExpoComposeView<T : ComposeProps>(
     if (withHostingView) {
       clipChildren = false
       clipToPadding = false
+      addOnAttachStateChangeListener(
+        OnAttachAfterDetachmentListener(
+          onAttachAfterDetachment = {
+            // Restore the Android layout pass after a real detach. The listener deliberately
+            // ignores the first attach and React Native's same-loop reparenting.
+            requestLayout()
+          }
+        )
+      )
       addComposeView()
     } else {
       this.visibility = GONE


### PR DESCRIPTION
# Why

Fixes #48370.

After a retained hosted `ExpoComposeView` is reattached or receives an in-place Android configuration change, newly inserted Compose content may not receive the Android layout pass required to determine its coordinates.

A `MenuView` popup makes this visible because the popup window is created and consumes input, but its content remains invisible while valid anchor coordinates are unavailable. The affected layer is the Android Compose hosting lifecycle in `expo-modules-core`, rather than the menu implementation itself.

# How

- Request the existing asynchronous Android layout path after a real detach and reattach of a hosted `ExpoComposeView`.
- Reuse `OnAttachAfterDetachmentListener`, preserving its behavior of ignoring the initial attach and same-loop React Native reparenting.
- After dispatching an Android configuration change, request layout only when the hosted view is attached and already laid out.
- Keep the change scoped to views that own a hosting `ComposeView`, without remounting the composition or modifying the generic `ExpoView` layout bridge.

# Test Plan

- Ran `et check-packages expo-modules-core`.
- Ran `et native-unit-tests -p android --packages expo-modules-core`.
- Ran `cd apps/bare-expo/android && ./gradlew :expo-modules-core:spotlessCheck --build-cache`.
- Built the minimal reproduction against matching Expo sources from the latest `main`.
- Verified on a Pixel 9 Pro Android emulator:
  - the menu opens after the initial mount;
  - the menu remains visible and correctly anchored after navigating to another screen and returning;
  - the menu remains visible after an in-place system `uiMode` change;
  - the menu remains visible when the configuration changes while its screen is detached, followed by navigation back.
- Confirmed the process was not recreated, popup bounds remained stable, and logcat contained no fatal or Compose layout exceptions.

Minimal reproduction: https://github.com/lujjjh/expo-ui-menu-android-popup-repro

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)