### PR TITLE
[create-expo] Add tests for the GitHub template resolver

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### 💡 Others
 
+- Add test coverage for the GitHub template resolver ([#48415](https://github.com/expo/expo/pull/48415) by [@00vortexlabsoneuzb00-wq](https://github.com/00vortexlabsoneuzb00-wq))
+
 ## 5.0.0 - 2026-06-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/create-expo/src/utils/__tests__/github.test.ts
+++ b/packages/create-expo/src/utils/__tests__/github.test.ts
@@ -1,0 +1,180 @@
+import nock from 'nock';
+
+import { downloadAndExtractGitHubRepositoryAsync } from '../github';
+import { extractNpmTarballAsync } from '../npm';
+
+jest.mock('../npm', () => ({
+  ...jest.requireActual('../npm'),
+  extractNpmTarballAsync: jest.fn(async () => '/output'),
+}));
+
+const mockExtractNpmTarballAsync = extractNpmTarballAsync as jest.MockedFunction<
+  typeof extractNpmTarballAsync
+>;
+
+/** Reply to the "does this repository contain a package.json" check. */
+function mockContentsRequest(path: string, status = 200) {
+  return nock('https://api.github.com').get(path).reply(status);
+}
+
+/** Reply to the tarball download from codeload. */
+function mockTarballRequest(path: string, status = 200) {
+  return nock('https://codeload.github.com').get(path).reply(status, 'tarball');
+}
+
+describe(downloadAndExtractGitHubRepositoryAsync, () => {
+  afterEach(() => {
+    nock.cleanAll();
+    jest.clearAllMocks();
+  });
+
+  it('resolves the default branch when the url has no branch', async () => {
+    const repo = nock('https://api.github.com')
+      .get('/repos/expo/examples')
+      .reply(200, { default_branch: 'main' });
+    const contents = mockContentsRequest('/repos/expo/examples/contents/package.json?ref=main');
+    const tarball = mockTarballRequest('/expo/examples/tar.gz/main');
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(new URL('https://github.com/expo/examples'), '/out', {
+        expName: 'my-app',
+      })
+    ).resolves.toBe('/output');
+
+    repo.done();
+    contents.done();
+    tarball.done();
+    // Only the root folder added by GitHub is stripped.
+    expect(mockExtractNpmTarballAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      '/out',
+      expect.objectContaining({ expName: 'my-app', strip: 1 })
+    );
+  });
+
+  it('uses the branch from the url without querying the api', async () => {
+    const contents = mockContentsRequest('/repos/expo/examples/contents/package.json?ref=beta');
+    const tarball = mockTarballRequest('/expo/examples/tar.gz/beta');
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/tree/beta'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).resolves.toBe('/output');
+
+    contents.done();
+    tarball.done();
+  });
+
+  it('strips the sub directory from the url', async () => {
+    const contents = mockContentsRequest(
+      '/repos/expo/examples/contents/with-router/package.json?ref=main'
+    );
+    const tarball = mockTarballRequest('/expo/examples/tar.gz/main');
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/tree/main/with-router'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).resolves.toBe('/output');
+
+    contents.done();
+    tarball.done();
+    // Both the root folder added by GitHub and the sub directory are stripped.
+    expect(mockExtractNpmTarballAsync).toHaveBeenCalledWith(
+      expect.anything(),
+      '/out',
+      expect.objectContaining({ strip: 2 })
+    );
+  });
+
+  it('throws when the repository does not exist', async () => {
+    const repo = nock('https://api.github.com').get('/repos/expo/private').reply(404);
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(new URL('https://github.com/expo/private'), '/out', {
+        expName: 'my-app',
+      })
+    ).rejects.toThrow('GitHub repository not found for url: https://github.com/expo/private');
+
+    repo.done();
+  });
+
+  it('throws on an unexpected api response', async () => {
+    const repo = nock('https://api.github.com').get('/repos/expo/examples').reply(500);
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(new URL('https://github.com/expo/examples'), '/out', {
+        expName: 'my-app',
+      })
+    ).rejects.toThrow('[500] Failed to fetch GitHub repository information');
+
+    repo.done();
+  });
+
+  it('throws for a url that is not a tree', async () => {
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/blob/main/package.json'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).rejects.toThrow('Malformed GitHub repository response for URL');
+  });
+
+  it('throws when the repository has no package.json', async () => {
+    const contents = mockContentsRequest(
+      '/repos/expo/examples/contents/package.json?ref=main',
+      404
+    );
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/tree/main'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).rejects.toThrow('Could not locate repository');
+
+    contents.done();
+    expect(mockExtractNpmTarballAsync).not.toHaveBeenCalled();
+  });
+
+  it('throws when the tarball response has no body', async () => {
+    const contents = mockContentsRequest('/repos/expo/examples/contents/package.json?ref=main');
+    const tarball = nock('https://codeload.github.com')
+      .get('/expo/examples/tar.gz/main')
+      .reply(204);
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/tree/main'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).rejects.toThrow('Unexpected response: no response body');
+
+    contents.done();
+    tarball.done();
+  });
+
+  it('throws when the tarball can not be downloaded', async () => {
+    const contents = mockContentsRequest('/repos/expo/examples/contents/package.json?ref=main');
+    const tarball = mockTarballRequest('/expo/examples/tar.gz/main', 500);
+
+    await expect(
+      downloadAndExtractGitHubRepositoryAsync(
+        new URL('https://github.com/expo/examples/tree/main'),
+        '/out',
+        { expName: 'my-app' }
+      )
+    ).rejects.toThrow('Unexpected response');
+
+    contents.done();
+    tarball.done();
+  });
+});


### PR DESCRIPTION
# Why

`packages/create-expo/src/utils/github.ts` resolves and downloads templates and examples passed as a GitHub URL, and it had almost no test coverage — **11.9% of statements**, one of the lowest in the package.

Nothing currently guards its branching logic: reading the default branch from the API versus taking it from a `/tree/<branch>` URL, computing how many path segments to strip for a sub directory, and five distinct error paths. A regression in any of them surfaces to the user as a failed `create-expo --template <github url>` run.

# How

Adds `packages/create-expo/src/utils/__tests__/github.test.ts`. **No source files are changed.**

The tests drive the exported `downloadAndExtractGitHubRepositoryAsync`, so the unexported helpers (`getGitHubRepoAsync`, `isValidGitHubRepoAsync`, `extractRemoteGitHubTarballAsync`) are covered without widening the module's public surface. HTTP is intercepted with `nock`, matching the existing approach in `src/__tests__/Examples.test.ts`, and `extractNpmTarballAsync` is mocked so no tarball is written to disk.

Cases covered:

| Case | Asserts |
| - | - |
| URL without a branch | The default branch is read from `GET /repos/:owner/:name` and `strip: 1` is used |
| `/tree/beta` | The branch comes from the URL and the API is never called |
| `/tree/main/with-router` | The sub directory reaches the contents check and `strip: 2` is used |
| Repository missing | `GitHub repository not found for url: ...` |
| Unexpected API status | `[500] Failed to fetch GitHub repository information ...` |
| URL that is not a tree | `Malformed GitHub repository response for URL: ...` |
| No `package.json` in the repository | `Could not locate repository ...`, and no extraction is attempted |
| Tarball response has no body | `Unexpected response: no response body ...` |
| Tarball request fails | `Unexpected response: ...` |

# Test Plan

Coverage for `src/utils/github.ts`:

| | Before | After |
| - | - | - |
| Statements | 11.9% | 100% |
| Branches | 0% | 90% |
| Functions | 0% | 100% |
| Lines | 12.5% | 100% |

```console
$ pnpm test
Test Suites: 17 passed, 17 total
Tests:       139 passed, 139 total

$ et check-packages create-expo
create-expo:lint: Found 0 warnings and 0 errors.
create-expo:format: All matched files use the correct format.
🏁 All checks passed.
```

To confirm the tests fail when the behaviour they describe changes, three mutations were applied to `github.ts` and reverted:

| Mutation | Result |
| - | - |
| `const strip = directory.length` (dropping the `+ 1`) | 2 tests fail |
| `t === 'blob'` instead of `t === 'tree'` | 6 tests fail |
| `response.status === 410` instead of `404` | 1 test fails |

The one uncovered branch is the `owner = ''` / `name = ''` destructuring default on line 20, which is unreachable through a valid `URL`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — not applicable, tests only
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
