### PR TITLE
[ci][ios] Break each argument onto its own line in swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,6 +1,9 @@
 {
   "indentation": { "spaces": 2 },
   "indentConditionalCompilationBlocks": false,
+  "lineBreakBeforeEachArgument": true,
+  "lineBreakBeforeEachGenericRequirement": true,
   "lineLength": 120,
+  "spacesBeforeEndOfLineComments": 1,
   "version": 1
 }

--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -35,7 +35,8 @@ public struct AppMetrics {
         // not the just-started `mainSession`, so this doesn't depend on the current session's row INSERT.
         do {
           _ = try database?.insert(
-            log: LogRow.from(log: pendingError.toLogRecord(), sessionId: pendingError.sessionId))
+            log: LogRow.from(log: pendingError.toLogRecord(), sessionId: pendingError.sessionId)
+          )
         } catch {
           logger.warn("[AppMetrics] Failed to ingest pending error: \(error.localizedDescription)")
         }
@@ -139,7 +140,8 @@ public struct AppMetrics {
     AppMetricsActor.isolated {
       if let foregroundSession = Self.foregroundSession {
         logger.warn(
-          "[AppMetrics] New foreground session started while one was already active. Stopping the old session.")
+          "[AppMetrics] New foreground session started while one was already active. Stopping the old session."
+        )
         foregroundSession.stop()
       }
       foregroundSession = ForegroundSession()

--- a/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
@@ -15,7 +15,8 @@ public class AppMetricsAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   }
 
   public func application(
-    _ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     AppMetrics.mainSession.appStartupMonitor.markDidFinishLaunching()
     return true

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -176,7 +176,8 @@ extension CrashReport: CustomStringConvertible {
 
     if let exceptionType {
       lines.append(
-        "  Exception: type=\(exceptionName(for: exceptionType)) code=\(exceptionCode.map(String.init) ?? "unknown")")
+        "  Exception: type=\(exceptionName(for: exceptionType)) code=\(exceptionCode.map(String.init) ?? "unknown")"
+      )
     }
     if let signal {
       lines.append("  Signal: \(signalName(for: signal)) (\(signal))")

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -14,7 +14,7 @@ final class MetricsDatabase: Sendable {
   static let currentSchemaVersion = 3
 
   /// How long a session (and its metrics, logs, crash report) is retained before `init` prunes it.
-  static let sessionRetention: TimeInterval = 7 * 24 * 60 * 60  // 7 days
+  static let sessionRetention: TimeInterval = 7 * 24 * 60 * 60 // 7 days
 
   let database: SQLiteDatabase
 
@@ -122,7 +122,8 @@ final class MetricsDatabase: Sendable {
         """
         [AppMetrics] Metrics database at \(fileUrl.path) is at schema v\(mismatchedVersion) but \
         this build expects v\(currentSchemaVersion); recreating to keep this build functional.
-        """)
+        """
+      )
       try removeDatabaseFile(at: fileUrl)
     }
     return try SQLiteDatabase(fileUrl: fileUrl)
@@ -135,7 +136,8 @@ final class MetricsDatabase: Sendable {
     let tableExists = try database.prepare(
       """
       SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'schema_version' LIMIT 1
-      """)
+      """
+    )
     var hasTable = false
     try tableExists.forEachRow { _ in
       hasTable = true
@@ -191,7 +193,8 @@ final class MetricsDatabase: Sendable {
         ?15, ?16, ?17, ?18,
         ?19, ?20, ?21, ?22
       )
-      """)
+      """
+    )
     try statement.bindAll([
       session.id, session.type, session.startTimestamp, session.endTimestamp, session.isActive, session.environment,
       session.appName, session.appIdentifier, session.appVersion, session.appBuildNumber,
@@ -218,7 +221,8 @@ final class MetricsDatabase: Sendable {
     let statement = try database.prepare(
       """
       UPDATE sessions SET isActive = ?1, endTimestamp = ?2 WHERE id = ?3
-      """)
+      """
+    )
     try statement.bindAll([isActive, endTimestamp, id])
     try statement.run()
   }
@@ -228,7 +232,8 @@ final class MetricsDatabase: Sendable {
     let statement = try database.prepare(
       """
       UPDATE sessions SET isActive = 0 WHERE isActive = 1 AND startTimestamp < ?1
-      """)
+      """
+    )
     try statement.bindAll([timestamp])
     try statement.run()
   }
@@ -261,7 +266,8 @@ final class MetricsDatabase: Sendable {
       UPDATE sessions
       SET appUpdateId = ?1, appUpdateRuntimeVersion = ?2, appUpdateRequestHeaders = ?3
       WHERE isActive = 1
-      """)
+      """
+    )
     try statement.bindAll([updateId, runtimeVersion, requestHeadersJSON])
     try statement.run()
   }
@@ -331,7 +337,8 @@ final class MetricsDatabase: Sendable {
       """
       SELECT id, sessionId, timestamp, category, name, value, routeName, updateId, params
       FROM metrics WHERE id > ?1 ORDER BY id ASC
-      """)
+      """
+    )
     try statement.bindAll([cursor])
     var rows: [MetricRow] = []
     try statement.forEachRow { row in
@@ -347,7 +354,8 @@ final class MetricsDatabase: Sendable {
       """
       SELECT id, sessionId, timestamp, severity, name, body, attributes, droppedAttributesCount
       FROM logs WHERE id > ?1 ORDER BY id ASC
-      """)
+      """
+    )
     try statement.bindAll([cursor])
     var rows: [LogRow] = []
     try statement.forEachRow { row in
@@ -367,7 +375,8 @@ final class MetricsDatabase: Sendable {
     let statement = try database.prepare(
       """
       SELECT \(sessionColumns) FROM sessions WHERE id IN (\(placeholders))
-      """)
+      """
+    )
     try statement.bindAll(ids.map { $0 as SQLiteBindable })
     var rows: [SessionRow] = []
     try statement.forEachRow { row in
@@ -381,7 +390,8 @@ final class MetricsDatabase: Sendable {
     return try collectSessions(
       sql: """
         SELECT \(sessionColumns) FROM sessions WHERE isActive = 1 ORDER BY startTimestamp DESC
-        """)
+        """
+    )
   }
 
   /// Deletes sessions whose start timestamp is older than `cutoff`, regardless of their `isActive`
@@ -395,7 +405,8 @@ final class MetricsDatabase: Sendable {
         """
         DELETE FROM crash_reports
         WHERE sessionId IN (SELECT id FROM sessions WHERE startTimestamp < ?1)
-        """)
+        """
+      )
       try dropCrashReports.bindAll([cutoff])
       try dropCrashReports.run()
 
@@ -415,7 +426,8 @@ final class MetricsDatabase: Sendable {
       """
       INSERT INTO metrics (sessionId, timestamp, category, name, value, routeName, updateId, params)
       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-      """)
+      """
+    )
     try statement.bindAll([
       metric.sessionId, metric.timestamp, metric.category, metric.name,
       metric.value, metric.routeName, metric.updateId, metric.params,
@@ -442,7 +454,8 @@ final class MetricsDatabase: Sendable {
       """
       SELECT id, sessionId, timestamp, category, name, value, routeName, updateId, params
       FROM metrics WHERE sessionId = ?1 ORDER BY id ASC
-      """)
+      """
+    )
     try statement.bindAll([sessionId])
     var rows: [MetricRow] = []
     try statement.forEachRow { row in
@@ -468,7 +481,8 @@ final class MetricsDatabase: Sendable {
       """
       INSERT INTO logs (sessionId, timestamp, severity, name, body, attributes, droppedAttributesCount)
       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
-      """)
+      """
+    )
     try statement.bindAll([
       log.sessionId, log.timestamp, log.severity, log.name,
       log.body, log.attributes, log.droppedAttributesCount,
@@ -495,7 +509,8 @@ final class MetricsDatabase: Sendable {
       """
       SELECT id, sessionId, timestamp, severity, name, body, attributes, droppedAttributesCount
       FROM logs WHERE sessionId = ?1 ORDER BY id ASC
-      """)
+      """
+    )
     try statement.bindAll([sessionId])
     var rows: [LogRow] = []
     try statement.forEachRow { row in
@@ -521,7 +536,8 @@ final class MetricsDatabase: Sendable {
     let statement = try database.prepare(
       """
       INSERT OR REPLACE INTO crash_reports (sessionId, payload) VALUES (?1, ?2)
-      """)
+      """
+    )
     try statement.bindAll([sessionId, payload])
     try statement.run()
   }
@@ -626,7 +642,8 @@ final class MetricsDatabase: Sendable {
         sessionId TEXT PRIMARY KEY NOT NULL,
         payload TEXT NOT NULL
       );
-      """)
+      """
+    )
   }
 
   private static func readSchemaVersion(database: borrowing SQLiteDatabase) throws -> Int? {

--- a/packages/expo-app-metrics/ios/LogEvents/PendingErrorStore.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/PendingErrorStore.swift
@@ -95,7 +95,11 @@ enum PendingErrorStore {
   /// The directory holding pending-error files, under the caches directory so they're not backed up.
   private static func directoryUrl() throws -> URL {
     let base = try FileManager.default.url(
-      for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+      for: .cachesDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    )
     let directory = base.appendingPathComponent("ExpoAppMetrics/pending-errors")
     try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
     return directory

--- a/packages/expo-app-metrics/ios/Memory/MemoryMonitoring.swift
+++ b/packages/expo-app-metrics/ios/Memory/MemoryMonitoring.swift
@@ -22,7 +22,8 @@ final class MemoryMonitoring: MetricReporter, Sendable {
       )
       reportMetrics(snapshot)
       AppMetrics.mainSession.receiveLog(
-        makeMemoryWarningLogRecord(snapshot: snapshot, warningsCount: data.warningsCount))
+        makeMemoryWarningLogRecord(snapshot: snapshot, warningsCount: data.warningsCount)
+      )
     }
   }
 }

--- a/packages/expo-app-metrics/ios/Memory/MemoryUsageSnapshot.swift
+++ b/packages/expo-app-metrics/ios/Memory/MemoryUsageSnapshot.swift
@@ -57,10 +57,12 @@ struct MemoryUsageSnapshot: Metrics, CustomStringConvertible, Sendable {
   private static func getMemoryFootprint() -> UInt {
     // swift-format-ignore: AlwaysUseLowerCamelCase
     let TASK_VM_INFO_COUNT = mach_msg_type_number_t(
-      MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+      MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size
+    )
     // swift-format-ignore: AlwaysUseLowerCamelCase
     let TASK_VM_INFO_REV1_COUNT = mach_msg_type_number_t(
-      MemoryLayout.offset(of: \task_vm_info_data_t.min_address)! / MemoryLayout<integer_t>.size)
+      MemoryLayout.offset(of: \task_vm_info_data_t.min_address)! / MemoryLayout<integer_t>.size
+    )
     var info = task_vm_info_data_t()
     var count = TASK_VM_INFO_COUNT
     let kerr = withUnsafeMutablePointer(to: &info) { infoPtr in

--- a/packages/expo-app-metrics/ios/Sessions/Session.swift
+++ b/packages/expo-app-metrics/ios/Sessions/Session.swift
@@ -155,7 +155,8 @@ public class Session: SharedObject, MetricsReceiver, @unchecked Sendable {
       try AppMetrics.database?.insert(log: LogRow.from(log: log, sessionId: self.id))
     } catch {
       logger.warn(
-        "[AppMetrics] Failed to insert log \"\(log.name)\" for session \(self.id): \(error.localizedDescription)")
+        "[AppMetrics] Failed to insert log \"\(log.name)\" for session \(self.id): \(error.localizedDescription)"
+      )
     }
   }
 }

--- a/packages/expo-app-metrics/ios/Tests/AppStartupMonitoringTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/AppStartupMonitoringTests.swift
@@ -36,7 +36,8 @@ struct AppStartupMonitoringTests {
         isConstrained: false,
         unsatisfiedReason: nil,
         timestamp: 0
-      ))
+      )
+    )
     return monitoring
   }
 

--- a/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
@@ -347,7 +347,8 @@ struct MetricsDatabaseTests {
           routeName: "/home",
           updateId: "update-1",
           params: "{\"k\":1}"
-        ))
+        )
+      )
 
       let row = try #require(try database.getMetrics(sessionId: "s").first)
       #expect(row.id != nil)
@@ -433,7 +434,8 @@ struct MetricsDatabaseTests {
           body: "something exploded",
           attributes: "{\"key\":\"value\"}",
           droppedAttributesCount: 3
-        ))
+        )
+      )
 
       let row = try #require(try database.getLogs(sessionId: "s").first)
       #expect(row.id != nil)

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -80,7 +80,11 @@ struct NetworkRequestMonitorTests {
       id: UUID(),
       request: URLRequest(url: URL(string: "https://expo.dev/x")!),
       response: HTTPURLResponse(
-        url: URL(string: "https://expo.dev/x")!, statusCode: 200, httpVersion: nil, headerFields: nil),
+        url: URL(string: "https://expo.dev/x")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+      ),
       taskBytesSent: nil,
       taskBytesReceived: nil,
       metrics: nil,
@@ -324,13 +328,37 @@ struct NetworkRequestSummaryTests {
     // typically follows but if one surfaces here it's still a successful response from the
     // origin's perspective. Only 4xx/5xx (and explicit errors) belong in the failed count.
     let cacheHit = makeRequest(
-      host: "expo.dev", duration: 0.05, status: 304, bytesSent: 0, bytesReceived: 0, fetchStart: Date())
+      host: "expo.dev",
+      duration: 0.05,
+      status: 304,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
     let redirect = makeRequest(
-      host: "expo.dev", duration: 0.1, status: 301, bytesSent: 0, bytesReceived: 0, fetchStart: Date())
+      host: "expo.dev",
+      duration: 0.1,
+      status: 301,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
     let clientError = makeRequest(
-      host: "expo.dev", duration: 0.1, status: 404, bytesSent: 0, bytesReceived: 0, fetchStart: Date())
+      host: "expo.dev",
+      duration: 0.1,
+      status: 404,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
     let serverError = makeRequest(
-      host: "expo.dev", duration: 0.1, status: 500, bytesSent: 0, bytesReceived: 0, fetchStart: Date())
+      host: "expo.dev",
+      duration: 0.1,
+      status: 500,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
 
     let summary = NetworkRequestSummary.from([cacheHit, redirect, clientError, serverError])
     #expect(summary.count == 4)

--- a/packages/expo-app-metrics/ios/Tests/PendingErrorStoreTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/PendingErrorStoreTests.swift
@@ -32,9 +32,13 @@ struct PendingErrorStoreTests {
   func `drains multiple errors oldest-first by timestamp`() throws {
     try withTemporaryDirectory { directory in
       PendingErrorStore.write(
-        makePendingError(message: "first", sessionId: "s", timestamp: "2026-01-01T00:00:01Z"), in: directory)
+        makePendingError(message: "first", sessionId: "s", timestamp: "2026-01-01T00:00:01Z"),
+        in: directory
+      )
       PendingErrorStore.write(
-        makePendingError(message: "second", sessionId: "s", timestamp: "2026-01-01T00:00:02Z"), in: directory)
+        makePendingError(message: "second", sessionId: "s", timestamp: "2026-01-01T00:00:02Z"),
+        in: directory
+      )
 
       let drained = PendingErrorStore.drain(in: directory)
       #expect(drained.map(\.message) == ["first", "second"])

--- a/packages/expo-app-metrics/ios/Updates/UpdatesMonitoring.swift
+++ b/packages/expo-app-metrics/ios/Updates/UpdatesMonitoring.swift
@@ -33,7 +33,8 @@ internal class UpdatesMonitoring: MetricReporter {
             )
           } catch {
             logger.warn(
-              "[AppMetrics] Failed to patch app updates info on active sessions: \(error.localizedDescription)")
+              "[AppMetrics] Failed to patch app updates info on active sessions: \(error.localizedDescription)"
+            )
           }
         }
       }

--- a/packages/expo-modules-jsi/apple/Package.swift
+++ b/packages/expo-modules-jsi/apple/Package.swift
@@ -156,9 +156,9 @@ func resolvePodsRoot() -> String {
   let repoRoot =
     env["EXPO_ROOT_DIR"]
     ?? URL(fileURLWithPath: packageDir)
-    .deletingLastPathComponent()  // expo-modules-jsi
-    .deletingLastPathComponent()  // packages
-    .deletingLastPathComponent()  // repo root
+    .deletingLastPathComponent() // expo-modules-jsi
+    .deletingLastPathComponent() // packages
+    .deletingLastPathComponent() // repo root
     .path
   return "\(repoRoot)/apps/bare-expo/ios/Pods"
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -19,7 +19,8 @@ internal final class UnownedThisHostFunctionContext: Sendable {
   let call: JavaScriptRuntime.UnownedThisSyncFunctionClosure
 
   init(
-    runtime: JavaScriptRuntime, name: String? = nil,
+    runtime: JavaScriptRuntime,
+    name: String? = nil,
     _ function: @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
   ) {
     self.runtime = runtime

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -193,7 +193,9 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     }
 
     func setter(
-      context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>, valuePointer: UnsafeMutableRawPointer
+      context: UnsafeMutableRawPointer,
+      propertyName: UnsafePointer<CChar>,
+      valuePointer: UnsafeMutableRawPointer
     ) {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
 
@@ -255,7 +257,12 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     // Pass a null setter to C++ when the Swift setter is nil so that JS assignment
     // raises a `jsi::JSError` directly, without crossing the Swift boundary.
     let callbacks = expo.HostObjectCallbacks(
-      context, getter, set == nil ? nil : setterPointer, propertyNamesGetter, deallocate)
+      context,
+      getter,
+      set == nil ? nil : setterPointer,
+      propertyNamesGetter,
+      deallocate
+    )
     let hostObject = expo.HostObject.makeObject(pointee, consume callbacks)
 
     return JavaScriptObject(self, hostObject)
@@ -300,7 +307,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   /// Creates a class with the given name and native constructor.
   @JavaScriptActor
   public func createClass(
-    name: String, inheriting baseClass: consuming JavaScriptFunction? = nil,
+    name: String,
+    inheriting baseClass: consuming JavaScriptFunction? = nil,
     _ constructor: @escaping SyncFunctionClosure
   ) throws -> JavaScriptFunction {
     // Host functions are not standard functions, thus cannot be used as class constructors.
@@ -314,7 +322,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
 
     let klassValue = try eval(
       label: "\(name).\(nativeConstructorKey)",
-      "(function \(name)(...args) { return this.\(nativeConstructorKey)(...args); })")
+      "(function \(name)(...args) { return this.\(nativeConstructorKey)(...args); })"
+    )
     let klassObject = klassValue.getObject()
 
     // Create a host function that is called by the constructor
@@ -384,7 +393,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   @_disfavoredOverload
   @JavaScriptActor
   public func createFunction(
-    _ name: String, _ function: sending @escaping UnownedThisSyncFunctionClosure
+    _ name: String,
+    _ function: sending @escaping UnownedThisSyncFunctionClosure
   ) -> JavaScriptFunction {
     let closure = createFunctionClosure(runtime: self, name: name, function)
     let hostFunction = expo.createHostFunction(pointee, name, closure)
@@ -757,13 +767,17 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
 }
 
 private func createFunctionClosure(
-  runtime: JavaScriptRuntime, name: String? = nil, _ closure: @escaping JavaScriptRuntime.SyncFunctionClosure
+  runtime: JavaScriptRuntime,
+  name: String? = nil,
+  _ closure: @escaping JavaScriptRuntime.SyncFunctionClosure
 ) -> expo.HostFunctionClosure {
   let context = Unmanaged.passRetained(HostFunctionContext(runtime: runtime, name: name, closure)).toOpaque()
 
   func call(
-    context: UnsafeMutableRawPointer, thisPtr: UnsafePointer<facebook.jsi.Value>,
-    argumentsPtr: UnsafePointer<facebook.jsi.Value>, argumentsCount: Int
+    context: UnsafeMutableRawPointer,
+    thisPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsCount: Int
   ) -> facebook.jsi.Value {
     let context = Unmanaged<HostFunctionContext>.fromOpaque(context).takeUnretainedValue()
 
@@ -801,14 +815,17 @@ private func createFunctionClosure(
 }
 
 private func createFunctionClosure(
-  runtime: JavaScriptRuntime, name: String? = nil,
+  runtime: JavaScriptRuntime,
+  name: String? = nil,
   _ closure: @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
 ) -> expo.HostFunctionClosure {
   let context = Unmanaged.passRetained(UnownedThisHostFunctionContext(runtime: runtime, name: name, closure)).toOpaque()
 
   func call(
-    context: UnsafeMutableRawPointer, thisPtr: UnsafePointer<facebook.jsi.Value>,
-    argumentsPtr: UnsafePointer<facebook.jsi.Value>, argumentsCount: Int
+    context: UnsafeMutableRawPointer,
+    thisPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsCount: Int
   ) -> facebook.jsi.Value {
     let context = Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context).takeUnretainedValue()
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -36,7 +36,8 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   internal init(
-    _ runtime: JavaScriptRuntime, buffer: consuming UnsafeMutableBufferPointer<facebook.jsi.Value>,
+    _ runtime: JavaScriptRuntime,
+    buffer: consuming UnsafeMutableBufferPointer<facebook.jsi.Value>,
     ownsMemory: Bool = false
   ) {
     self.runtime = runtime
@@ -47,8 +48,10 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
 
   internal init(_ runtime: JavaScriptRuntime, start: consuming UnsafePointer<facebook.jsi.Value>?, count: Int) {
     self.init(
-      runtime, buffer: UnsafeMutableBufferPointer(start: UnsafeMutablePointer(mutating: start), count: count),
-      ownsMemory: false)
+      runtime,
+      buffer: UnsafeMutableBufferPointer(start: UnsafeMutablePointer(mutating: start), count: count),
+      ownsMemory: false
+    )
   }
 
   internal init(_ runtime: JavaScriptRuntime, buffer: consuming UnsafeBufferPointer<facebook.jsi.Value>) {
@@ -122,13 +125,17 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   /// You must initialize all elements using `set(value:atIndex)` method.
   public static func allocate(in runtime: JavaScriptRuntime, capacity: Int) -> JavaScriptValuesBuffer {
     return JavaScriptValuesBuffer(
-      runtime, buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: capacity), ownsMemory: true)
+      runtime,
+      buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: capacity),
+      ownsMemory: true
+    )
   }
 
   /// Allocates new values buffer with the given JS representables.
   /// Note that parameter packs still do not support non-copyable types so they need to be passed as `JavaScriptRef`.
   public static func allocate<each T: JavaScriptRepresentable>(
-    in runtime: JavaScriptRuntime, with values: repeat each T
+    in runtime: JavaScriptRuntime,
+    with values: repeat each T
   ) -> JavaScriptValuesBuffer {
     // First we count parameters in a pack to find the proper buffer capacity. This is still the simplest way.
     var capacity = 0
@@ -170,7 +177,9 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     let buffer = UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: values.count)
     for (index, value) in values.enumerated() {
       assert(
-        value.runtime === runtime, "JavaScriptValue belongs to a different runtime than the buffer being initialized")
+        value.runtime === runtime,
+        "JavaScriptValue belongs to a different runtime than the buffer being initialized"
+      )
       buffer.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, value.pointee))
     }
     return JavaScriptValuesBuffer(runtime, buffer: buffer, ownsMemory: true)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
@@ -41,7 +41,9 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
     }
     return try capturingCppErrors {
       return JavaScriptValue(
-        runtime, expo.callFunction(runtime.pointee, pointee, arguments?.baseAddress, arguments?.count ?? 0))
+        runtime,
+        expo.callFunction(runtime.pointee, pointee, arguments?.baseAddress, arguments?.count ?? 0)
+      )
     }
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -278,7 +278,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
   @_disfavoredOverload
   @JavaScriptActor
   public func setProperty(
-    _ name: String, function: sending @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
+    _ name: String,
+    function: sending @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
   ) {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -330,7 +331,9 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
   }
 
   public func defineProperty<T: JavaScriptRepresentable & ~Copyable>(
-    _ name: String, value: borrowing T, options: PropertyOptions = []
+    _ name: String,
+    value: borrowing T,
+    options: PropertyOptions = []
   ) {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -359,7 +362,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
   @discardableResult
   @JavaScriptActor
   public func callFunction<each T: JavaScriptRepresentable>(
-    _ functionName: JavaScriptPropNameID, arguments: repeat each T
+    _ functionName: JavaScriptPropNameID,
+    arguments: repeat each T
   ) throws -> JavaScriptValue {
     return try getPropertyAsFunction(functionName).call(this: self, arguments: repeat each arguments)
   }
@@ -534,7 +538,10 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     /// - Note: When all parameters use their default values, this creates a non-configurable,
     ///   non-enumerable, non-writable property with no value (undefined in JavaScript).
     public init(
-      configurable: Bool = false, enumerable: Bool = false, writable: Bool = false, value: JavaScriptValue? = nil
+      configurable: Bool = false,
+      enumerable: Bool = false,
+      writable: Bool = false,
+      value: JavaScriptValue? = nil
     ) {
       self.configurable = configurable
       self.enumerable = enumerable

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -47,7 +47,8 @@ public struct JavaScriptUnownedValue: ~Copyable {
   public func copied(in runtime: JavaScriptRuntime) -> JavaScriptValue {
     assert(
       Unmanaged.passUnretained(runtime.pointee).toOpaque() == Unmanaged.passUnretained(self.runtime).toOpaque(),
-      "`copied(in:)` must be passed the runtime that owns the borrowed value")
+      "`copied(in:)` must be passed the runtime that owns the borrowed value"
+    )
     return JavaScriptValue(runtime, pointer.pointee)
   }
 
@@ -124,7 +125,8 @@ public struct JavaScriptUnownedValue: ~Copyable {
     assert(isObject(), "Value is not an object")
     assert(
       Unmanaged.passUnretained(runtime.pointee).toOpaque() == Unmanaged.passUnretained(self.runtime).toOpaque(),
-      "`getObject(in:)` must be passed the runtime that owns the borrowed value")
+      "`getObject(in:)` must be passed the runtime that owns the borrowed value"
+    )
     return JavaScriptObject(runtime, pointer.pointee.getObject(self.runtime))
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -32,7 +32,9 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
   public init(_ runtime: JavaScriptRuntime, _ string: String) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(
-      runtime.pointee, facebook.jsi.String.createFromUtf8(runtime.pointee, std.string(string)))
+      runtime.pointee,
+      facebook.jsi.String.createFromUtf8(runtime.pointee, std.string(string))
+    )
   }
 
   /// Creates a BigInt JS value from an Int64.

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
@@ -136,7 +136,7 @@ struct JavaScriptActorTests {
     // async outside, async inside
     try await runtime.execute {
       JavaScriptActor.assertIsolated()
-      try await Task.sleep(nanoseconds: 0)  // makes the closure async
+      try await Task.sleep(nanoseconds: 0) // makes the closure async
       JavaScriptActor.assertIsolated()
     }
   }
@@ -146,7 +146,7 @@ struct JavaScriptActorTests {
     // sync outside, async inside
     try runtime.execute {
       JavaScriptActor.assertIsolated()
-      try await Task.sleep(nanoseconds: 0)  // makes the closure async
+      try await Task.sleep(nanoseconds: 0) // makes the closure async
       JavaScriptActor.assertIsolated()
     }
   }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
@@ -139,7 +139,7 @@ struct JavaScriptArrayTests {
     #expect(try array.getValue(at: 1).getBool() == true)
     #expect(try array.getValue(at: 2).isNull() == true)
     #expect(try array.getValue(at: 3).isUndefined() == true)
-    #expect(try array.getValue(at: 4).getInt() == 5)  // Unchanged
+    #expect(try array.getValue(at: 4).getInt() == 5) // Unchanged
   }
 
   @Test

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptBigIntTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptBigIntTests.swift
@@ -137,7 +137,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `create from string beyond Int64 range`() throws {
-    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808")  // Int64.max + 1
+    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808") // Int64.max + 1
     #expect(bigInt.isInt64() == false)
     let str = try bigInt.toString()
     #expect(str == "9223372036854775808")
@@ -169,7 +169,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `asInt64 throws when beyond Int64 range`() throws {
-    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808")  // Int64.max + 1
+    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808") // Int64.max + 1
     #expect(throws: BigIntConversionError.self) {
       try bigInt.asInt64()
     }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableContainersTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableContainersTests.swift
@@ -90,7 +90,9 @@ struct JavaScriptCodableContainersTests {
     // An `undefined`-valued property is treated as absent rather than decoded (which would throw
     // for a non-optional value), matching the v1 dictionary converter.
     let decoded = try [String: Int].decode(
-      runtime.eval("({ a: 1, b: undefined })"), in: runtime)
+      runtime.eval("({ a: 1, b: undefined })"),
+      in: runtime
+    )
     #expect(decoded == ["a": 1])
   }
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableDateTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableDateTests.swift
@@ -96,7 +96,8 @@ struct JavaScriptCodableDateTests {
     // Compare at whole-millisecond granularity (JS `Date`'s resolution); the original is already an
     // exact number of milliseconds, so nothing is lost, but the comparison avoids float-equality ULP noise.
     #expect(
-      (roundTripped.timeIntervalSince1970 * 1000.0).rounded() == (original.timeIntervalSince1970 * 1000.0).rounded())
+      (roundTripped.timeIntervalSince1970 * 1000.0).rounded() == (original.timeIntervalSince1970 * 1000.0).rounded()
+    )
   }
 
   @Test

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableTaskTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptCodableTaskTests.swift
@@ -29,7 +29,7 @@ struct JavaScriptCodableTaskTests {
   @Test
   func `resolves with a value produced after suspension`() async throws {
     let task = Task<String, any Error> {
-      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+      try await Task.sleep(nanoseconds: 10_000_000) // 10ms
       return "done"
     }
     let result = try await Task.encode(task, in: runtime).getPromise().await()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
@@ -219,7 +219,8 @@ struct JavaScriptErrorTests {
       let innerResult = try runtime.eval(
         """
           try { inner(); 'no error' } catch (e) { e.message }
-        """)
+        """
+      )
       #expect(innerResult.getString() == "inner boom")
 
       throw CodedError(message: "outer boom", code: "ERR_OUTER")

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -278,7 +278,7 @@ struct JavaScriptObjectTests {
       object.defineProperty("test", descriptor: .init(value: JavaScriptValue(runtime, true)))
       #expect(object.hasProperty("test") == true)
       #expect(object.getProperty("test").getBool() == true)
-      #expect(object.getPropertyNames().contains("test") == false)  // non-enumerable by default
+      #expect(object.getPropertyNames().contains("test") == false) // non-enumerable by default
     }
 
     @Test
@@ -529,7 +529,11 @@ struct JavaScriptObjectTests {
     func `PropertyDescriptor with all properties`() {
       let value = JavaScriptValue(runtime, "test")
       let descriptor = JavaScriptObject.PropertyDescriptor(
-        configurable: true, enumerable: true, writable: true, value: value)
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: value
+      )
       let object = descriptor.toObject(runtime)
       #expect(object.hasProperty("configurable") == true)
       #expect(object.getProperty("configurable").getBool() == true)
@@ -544,7 +548,11 @@ struct JavaScriptObjectTests {
     @Test
     func `PropertyDescriptor to object conversion`() {
       let descriptor = JavaScriptObject.PropertyDescriptor(
-        configurable: false, enumerable: true, writable: false, value: JavaScriptValue(runtime, 42))
+        configurable: false,
+        enumerable: true,
+        writable: false,
+        value: JavaScriptValue(runtime, 42)
+      )
       let object = descriptor.toObject(runtime)
       #expect(object.getProperty("enumerable").getBool() == true)
       #expect(object.getProperty("value").getInt() == 42)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -150,7 +150,8 @@ struct JavaScriptPromiseTests {
       const promise = Promise.resolve(42);
       promise.then = undefined;
       promise;
-      """)
+      """
+    )
 
     #expect(throws: Error.self) {
       _ = try promiseValue.getPromise()
@@ -323,7 +324,7 @@ struct JavaScriptPromiseTests {
 
     // Resolve from a task
     Task.detached {
-      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+      try await Task.sleep(nanoseconds: 10_000_000) // 10ms
       promise.resolve(JavaScriptValue(runtime, 99))
     }
 
@@ -341,7 +342,7 @@ struct JavaScriptPromiseTests {
     // Reject after the await has already suspended on the pending promise. This must throw, not
     // resume the awaiting caller with the rejection value as if it were fulfilled.
     Task.detached {
-      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
+      try await Task.sleep(nanoseconds: 10_000_000) // 10ms
       promise.reject(TestError())
     }
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -321,7 +321,8 @@ struct JavaScriptRuntimeTests {
     let result = try runtime.eval(
       """
         try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
-      """)
+      """
+    )
 
     #expect(result.getString().contains("set failed"))
   }
@@ -365,7 +366,8 @@ struct JavaScriptRuntimeTests {
     let result = try runtime.eval(
       """
         try { globalThis.hostObj.foo; 'no error' } catch (e) { e.message }
-      """)
+      """
+    )
 
     #expect(result.getString().contains("get failed"))
   }
@@ -418,7 +420,8 @@ struct JavaScriptRuntimeTests {
     let firstAttempt = try runtime.eval(
       """
         try { globalThis.hostObj.value = 1; 'no error' } catch (e) { e.message }
-      """)
+      """
+    )
     #expect(firstAttempt.getString().contains("boom"))
 
     // Subsequent write must succeed — verifies the C++ thread-local error
@@ -427,7 +430,8 @@ struct JavaScriptRuntimeTests {
     let secondAttempt = try runtime.eval(
       """
         try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
-      """)
+      """
+    )
     #expect(secondAttempt.getInt() == 7)
   }
 
@@ -456,7 +460,8 @@ struct JavaScriptRuntimeTests {
       """
         try { globalThis.hostObj.value = 1 } catch (e) {}
         globalThis.hostObj.ok
-      """)
+      """
+    )
 
     #expect(result.getInt() == 123)
   }
@@ -474,7 +479,8 @@ struct JavaScriptRuntimeTests {
     let result = try runtime.eval(
       """
         try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
-      """)
+      """
+    )
     let message = result.getString()
 
     #expect(message.contains("read-only host object"))
@@ -495,7 +501,8 @@ struct JavaScriptRuntimeTests {
     let result = try runtime.eval(
       """
         try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
-      """)
+      """
+    )
 
     #expect(result.getInt() == 7)
   }
@@ -509,7 +516,8 @@ struct JavaScriptRuntimeTests {
           e.code = 'ERR_INNER';
           throw e;
         };
-      """)
+      """
+    )
     let throwTagged = try runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
@@ -541,7 +549,8 @@ struct JavaScriptRuntimeTests {
           e.code = 'ERR_SETTER';
           throw e;
         };
-      """)
+      """
+    )
     let throwTagged = try runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
@@ -579,7 +588,8 @@ struct JavaScriptRuntimeTests {
     let result = try runtime.eval(
       """
         try { failing(); 'no error' } catch (e) { e.message }
-      """)
+      """
+    )
 
     #expect(result.getString().contains("something went wrong"))
   }

--- a/packages/expo-observe/ios/CursorRepair.swift
+++ b/packages/expo-observe/ios/CursorRepair.swift
@@ -24,7 +24,8 @@ internal func repairCursorIfStale(
     maxId = try readMaxId()
   } catch {
     observeLogger.warn(
-      "[Observe] Failed to read max \(signalName) id while repairing cursor: \(error.localizedDescription)")
+      "[Observe] Failed to read max \(signalName) id while repairing cursor: \(error.localizedDescription)"
+    )
     return
   }
   if cursor > (maxId ?? -1) {

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -233,7 +233,9 @@ internal struct ObservabilityManager {
 
   // Static function extracted for testability
   internal nonisolated static func shouldDispatch(
-    config: PersistedConfig?, isDev: Bool, isInSample: Bool
+    config: PersistedConfig?,
+    isDev: Bool,
+    isInSample: Bool
   ) -> Bool {
     let dispatchingEnabled = config?.dispatchingEnabled ?? true
     let dispatchInDebug = config?.dispatchInDebug ?? false
@@ -244,7 +246,9 @@ internal struct ObservabilityManager {
     let isJsDev = ObserveUserDefaults.bundleDefaults?.isJsDev ?? false
     let isDev = EXAppDefines.APP_DEBUG || isJsDev
     return Self.shouldDispatch(
-      config: ObserveUserDefaults.config, isDev: isDev, isInSample: isInSample()
+      config: ObserveUserDefaults.config,
+      isDev: isDev,
+      isInSample: isInSample()
     )
   }
 

--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -59,7 +59,8 @@ enum OTAnyValue: Codable, Sendable {
       self = .kvlist(value.values)
     } else {
       throw DecodingError.dataCorruptedError(
-        forKey: .stringValue, in: container,
+        forKey: .stringValue,
+        in: container,
         debugDescription: "OTAnyValue has no recognized variant"
       )
     }

--- a/packages/expo-observe/ios/Tests/DispatchUtilsBackoffTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsBackoffTests.swift
@@ -31,20 +31,20 @@ struct DispatchUtilsBackoffTests {
       random: { 0.999 }
     )
     #expect(delay > base * 0.99)
-    #expect(delay < base)  // strict — `random(in: 0..<1)` excludes 1
+    #expect(delay < base) // strict — `random(in: 0..<1)` excludes 1
   }
 
   /// The exponential schedule doubles between attempts: attempt 2 reaches 2 × base, attempt
   /// 3 reaches 4 × base, …, all multiplied by the jitter draw.
   @Test
   func `attempts two through four double the unjittered ceiling`() {
-    let r: () -> Double = { 0.5 }  // pin jitter to exactly half
+    let r: () -> Double = { 0.5 } // pin jitter to exactly half
     let two = DispatchUtils.computeBackoffDelay(attempt: 2, base: base, cap: cap, random: r)
     let three = DispatchUtils.computeBackoffDelay(attempt: 3, base: base, cap: cap, random: r)
     let four = DispatchUtils.computeBackoffDelay(attempt: 4, base: base, cap: cap, random: r)
-    #expect(two == base * 2 * 0.5)  //  60
-    #expect(three == base * 4 * 0.5)  // 120
-    #expect(four == base * 8 * 0.5)  // 240
+    #expect(two == base * 2 * 0.5) //  60
+    #expect(three == base * 4 * 0.5) // 120
+    #expect(four == base * 8 * 0.5) // 240
   }
 
   /// Once `base * 2^(attempt-1)` would exceed `cap`, the unjittered ceiling clamps to `cap`.

--- a/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
@@ -29,7 +29,7 @@ struct DispatchUtilsRetryGateTests {
       backoff: stubbedBackoff
     )
     #expect(next.consecutiveRetryableFailures == 0)
-    #expect(next.dispatchAfterDate == state.dispatchAfterDate)  // untouched
+    #expect(next.dispatchAfterDate == state.dispatchAfterDate) // untouched
   }
 
   /// `.partialSuccess` is treated the same as success for gate purposes: the bytes landed on

--- a/packages/expo-observe/ios/Tests/OTAnyValueTests.swift
+++ b/packages/expo-observe/ios/Tests/OTAnyValueTests.swift
@@ -247,7 +247,8 @@ struct OTAnyValueCodableTests {
       .kvlist([
         OTKeyValue(key: "a", value: .int(1)),
         OTKeyValue(key: "b", value: .string("x")),
-      ]))
+      ])
+    )
     #expect(json.count == 1)
     let kvlistValue = try #require(json["kvlistValue"] as? [String: Any])
     let values = try #require(kvlistValue["values"] as? [[String: Any]])

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -245,8 +245,8 @@ struct ObservabilityParseRetryAfterTests {
     // Neither a Double nor an RFC 7231 HTTP-date — caller should fall through to backoff.
     let cases = [
       "tomorrow morning",
-      "Mon Jun 16",  // partial date, missing time + year + zone
-      "30 minutes",  // delta-seconds doesn't accept units
+      "Mon Jun 16", // partial date, missing time + year + zone
+      "30 minutes", // delta-seconds doesn't accept units
       "30s",
       "abc",
       "300/600",

--- a/packages/expo-observe/ios/Tests/OpenTelemetryTests.swift
+++ b/packages/expo-observe/ios/Tests/OpenTelemetryTests.swift
@@ -334,7 +334,8 @@ struct OpenTelemetryTests {
     )
     let otMetric = metric.toOTMetric()
     let attrs = Dictionary(
-      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) })
+      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) }
+    )
 
     #expect(attrs["expo.route_name"] == "/home")
   }
@@ -354,7 +355,8 @@ struct OpenTelemetryTests {
     )
     let otMetric = metric.toOTMetric()
     let attrs = Dictionary(
-      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) })
+      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) }
+    )
 
     #expect(otMetric.name == "expo.updates.download_time")
     #expect(attrs["expo.update_id"] == "abc123-def456")
@@ -394,7 +396,8 @@ struct OpenTelemetryTests {
     )
     let otMetric = metric.toOTMetric()
     let attrs = Dictionary(
-      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) })
+      uniqueKeysWithValues: otMetric.gauge.dataPoints[0].attributes.map { ($0.key, $0.value.stringValue) }
+    )
 
     let jsonString = try #require(attrs["expo.custom_params"] ?? nil)
     let parsed = try! JSONSerialization.jsonObject(with: jsonString.data(using: .utf8)!) as! [String: String]


### PR DESCRIPTION
# Why

A wrapped call currently packs its arguments onto continuation lines, which makes the argument list hard to scan and produces a noisy diff whenever one argument changes:

```swift
let response = try await AgeRangeService.shared.requestAgeRange(
  ageGates: opts.threshold1, opts.threshold2, opts.threshold3, in: currentVc)
```

# How

Three options added to `.swift-format`:

- `lineBreakBeforeEachArgument`: a wrapped call gets one argument per line and its closing paren on its own line. Calls that fit on one line are untouched.
- `lineBreakBeforeEachGenericRequirement`: the same for generic requirements. No diff today; it keeps the two consistent as generic code is added.
- `spacesBeforeEndOfLineComments: 1`. The default of 2 was rewriting trailing comments against the repo's own style, which is one space (127 occurrences vs 53).

The same call now reads:

```swift
let response = try await AgeRangeService.shared.requestAgeRange(
  ageGates: opts.threshold1,
  opts.threshold2,
  opts.threshold3,
  in: currentVc
)
```

The config is repo-wide, so the second commit reformats the three packages already enrolled: `expo-modules-jsi`, `expo-app-metrics` and `expo-observe`. Config and reformat are split into two commits.

# Test Plan

Ran the CI command locally with swift-format 6.3.0 (Xcode 26.2 bundle):

```
./scripts/swift-format.sh --lint packages/expo-modules-jsi packages/expo-app-metrics packages/expo-observe
```

Changes are formatting only, no behavior change, so no native tests were run.

