### PR TITLE
[router] Stop decoding route params twice

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))
 - Remove `StackNavigationState.preloadedRoutes` property and append preloaded routes to `state.routes` ([#47961](https://github.com/expo/expo/pull/47961) by [@Ubax](https://github.com/Ubax))
 - Migrate the JS `Tabs` navigator to the `standard-navigation` integration. ([#48292](https://github.com/expo/expo/pull/48292) by [@Ubax](https://github.com/Ubax))
+- Stop decoding route params a second time in `useLocalSearchParams()` and `getRouteInfoFromState()`. Params are already decoded while the navigation state is built, so a value that must stay percent-encoded (for example `%2F` in an AWS SigV4 token) is no longer corrupted. Params that are passed in already encoded are now returned verbatim instead of being decoded. ([#48423](https://github.com/expo/expo/pull/48423) by [@kdelay](https://github.com/kdelay))
 
 ### 🎉 New features
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))
 - Remove `StackNavigationState.preloadedRoutes` property and append preloaded routes to `state.routes` ([#47961](https://github.com/expo/expo/pull/47961) by [@Ubax](https://github.com/Ubax))
 - Migrate the JS `Tabs` navigator to the `standard-navigation` integration. ([#48292](https://github.com/expo/expo/pull/48292) by [@Ubax](https://github.com/Ubax))
+- Stop decoding route params a second time in `useLocalSearchParams()` and `getRouteInfoFromState()`. Params are already decoded while the navigation state is built, so a value that must stay percent-encoded (for example `%2F` in an AWS SigV4 token) is no longer corrupted. Params that are passed in already encoded are now returned verbatim instead of being decoded. ([#48423](https://github.com/expo/expo/pull/48423) by [@kdelay](https://github.com/kdelay))
 
 ### 🎉 New features
 

--- a/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
@@ -224,7 +224,10 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/feed');
   });
 
-  it('decodes URI-encoded params', () => {
+  // Params reach the state already decoded: `getStateFromPath()` decodes path segments and reads
+  // search params through `URLSearchParams`. Anything still percent-encoded at this point is a
+  // literal value the caller passed in, so it is returned unchanged.
+  it('returns params without decoding them again', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
@@ -238,8 +241,8 @@ describe('getRouteInfoFromState', () => {
       index: 0,
     });
 
-    expect(result.params.name).toBe('hello world');
-    expect(result.pathname).toBe('/hello world');
+    expect(result.params.name).toBe('hello%20world');
+    expect(result.pathname).toBe('/hello%20world');
   });
 
   it('handles malformed URI component (returns as-is)', () => {
@@ -309,7 +312,7 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/dashboard');
   });
 
-  it('decodes array params in catch-all', () => {
+  it('returns array params in a catch-all without decoding them again', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
@@ -323,7 +326,7 @@ describe('getRouteInfoFromState', () => {
       index: 0,
     });
 
-    expect(result.params.path).toEqual(['hello world', 'foo/bar']);
+    expect(result.params.path).toEqual(['hello%20world', 'foo%2Fbar']);
   });
 
   it('uses index 0 when state has no index property', () => {

--- a/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
@@ -228,7 +228,10 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/feed');
   });
 
-  it('decodes URI-encoded params', () => {
+  // Params reach the state already decoded: `getStateFromPath()` decodes path segments and reads
+  // search params through `URLSearchParams`. Anything still percent-encoded at this point is a
+  // literal value the caller passed in, so it is returned unchanged.
+  it('returns params without decoding them again', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
@@ -242,8 +245,8 @@ describe('getRouteInfoFromState', () => {
       index: 0,
     });
 
-    expect(result.params.name).toBe('hello world');
-    expect(result.pathname).toBe('/hello world');
+    expect(result.params.name).toBe('hello%20world');
+    expect(result.pathname).toBe('/hello%20world');
   });
 
   it('handles malformed URI component (returns as-is)', () => {
@@ -385,7 +388,7 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/dashboard');
   });
 
-  it('decodes array params in catch-all', () => {
+  it('returns array params in a catch-all without decoding them again', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
@@ -399,7 +402,7 @@ describe('getRouteInfoFromState', () => {
       index: 0,
     });
 
-    expect(result.params.path).toEqual(['hello world', 'foo/bar']);
+    expect(result.params.path).toEqual(['hello%20world', 'foo%2Fbar']);
   });
 
   it('uses index 0 when state has no index property', () => {

--- a/packages/expo-router/src/global-state/getRouteInfoFromState.ts
+++ b/packages/expo-router/src/global-state/getRouteInfoFromState.ts
@@ -1,7 +1,6 @@
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../constants';
 import { appendBaseUrl } from '../fork/getPathFromState-forks';
 import type { NavigationState, PartialState } from '../react-navigation/native';
-import { safeDecodeURIComponent } from '../utils/url';
 import type { FocusedRouteState } from './types';
 
 export type UrlObject = {
@@ -70,7 +69,7 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
   state = route.state;
 
   const segments: string[] = [];
-  let params: UrlObject['params'] = Object.create(null);
+  const params: UrlObject['params'] = Object.create(null);
 
   while (state) {
     route = state.routes['index' in state && state.index ? state.index : 0]!;
@@ -85,18 +84,6 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
     segments.push(...routeName.split('/'));
     state = route.state;
   }
-
-  params = Object.fromEntries(
-    Object.entries(params).map(([key, value]) => {
-      if (typeof value === 'string') {
-        return [key, safeDecodeURIComponent(value)];
-      } else if (Array.isArray(value)) {
-        return [key, value.map((v) => safeDecodeURIComponent(v))];
-      } else {
-        return [key, value];
-      }
-    })
-  );
 
   /**
    * If React Navigation didn't render the entire tree (e.g it was interrupted in a layout)

--- a/packages/expo-router/src/global-state/getRouteInfoFromState.ts
+++ b/packages/expo-router/src/global-state/getRouteInfoFromState.ts
@@ -5,7 +5,6 @@ import { appendBaseUrl } from '../fork/getPathFromState-forks';
 import { warnIfNestedParams } from '../navigationParams';
 import { isArrayEqual } from '../react-navigation/core/isArrayEqual';
 import type { NavigationState, PartialState } from '../react-navigation/native';
-import { safeDecodeURIComponent } from '../utils/url';
 import type { FocusedRouteState } from './types';
 
 export type UrlObject = {
@@ -78,7 +77,7 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
   state = route.state;
 
   const segments: string[] = [];
-  let params: Record<string, unknown> = Object.create(null);
+  const params: Record<string, unknown> = Object.create(null);
 
   while (state) {
     route = state.routes['index' in state && state.index ? state.index : 0]!;
@@ -94,18 +93,6 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
     segments.push(...routeName.split('/'));
     state = route.state;
   }
-
-  params = Object.fromEntries(
-    Object.entries(params).map(([key, value]) => {
-      if (typeof value === 'string') {
-        return [key, safeDecodeURIComponent(value)];
-      } else if (Array.isArray(value)) {
-        return [key, value.map((v) => (typeof v === 'string' ? safeDecodeURIComponent(v) : v))];
-      } else {
-        return [key, value];
-      }
-    })
-  );
 
   if (segments[segments.length - 1] === 'index') {
     segments.pop();
@@ -193,7 +180,9 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
     pathname,
     // Navigation params can contain ordinary object values at runtime despite the public search-param type.
     // TODO: address this together with other params serialization issues
-    params: params as UrlObject['params'],
+    // Copied into an ordinary object: `params` is prototype-less, and `areUrlObjectsEqual()`
+    // compares it with `fast-deep-equal`, which calls `valueOf()` on the values it walks.
+    params: { ...params } as UrlObject['params'],
     unstable_globalHref: appendBaseUrl(pathnameWithParams),
     searchParams,
     pathnameWithParams,

--- a/packages/expo-router/src/hooks/__tests__/useGlobalSearchParams.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useGlobalSearchParams.test.ios.tsx
@@ -208,7 +208,7 @@ describe(useGlobalSearchParams, () => {
     act(() => router.setParams({ test: '%2Fhello%2Fworld%2Fagain' }));
 
     expect(result.current).toEqual({
-      test: '/hello/world/again',
+      test: '%2Fhello%2Fworld%2Fagain',
     });
 
     act(() =>
@@ -221,7 +221,30 @@ describe(useGlobalSearchParams, () => {
     );
 
     expect(result.current).toEqual({
-      test: '/foo/bar/',
+      test: '%2Ffoo%2Fbar%2F',
     });
+  });
+
+  it(`decodes an encoded path segment exactly once`, () => {
+    const { result } = renderHook(() => useGlobalSearchParams(), ['[name]'], {
+      initialUrl: '/hello%20world',
+    });
+
+    expect(result.current).toEqual({
+      name: 'hello world',
+    });
+  });
+
+  it(`returns a pushed param unchanged when it contains percent-encoded characters`, () => {
+    // A value that has to stay percent-encoded to remain valid, such as an AWS SigV4 token.
+    const token = 'IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts';
+
+    const { result } = renderHook(() => useGlobalSearchParams(), ['index'], {
+      initialUrl: '/',
+    });
+
+    act(() => router.push({ pathname: '/', params: { token } }));
+
+    expect(result.current).toEqual({ token });
   });
 });

--- a/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
@@ -110,7 +110,7 @@ describe(useLocalSearchParams, () => {
     act(() => router.setParams({ test: '%2Fhello%2Fworld%2Fagain' }));
 
     expect(result.current).toEqual({
-      test: '/hello/world/again',
+      test: '%2Fhello%2Fworld%2Fagain',
     });
 
     act(() =>
@@ -123,7 +123,40 @@ describe(useLocalSearchParams, () => {
     );
 
     expect(result.current).toEqual({
-      test: '/foo/bar/',
+      test: '%2Ffoo%2Fbar%2F',
     });
+  });
+
+  it(`decodes an encoded path segment exactly once`, () => {
+    const { result } = renderHook(() => useLocalSearchParams(), ['[name]'], {
+      initialUrl: '/hello%20world',
+    });
+
+    expect(result.current).toEqual({
+      name: 'hello world',
+    });
+  });
+
+  it(`returns a pushed param unchanged when it contains percent-encoded characters`, () => {
+    // A value that has to stay percent-encoded to remain valid, such as an AWS SigV4 token.
+    const token = 'IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts';
+
+    const { result } = renderHook(() => useLocalSearchParams(), ['index'], {
+      initialUrl: '/',
+    });
+
+    act(() => router.push({ pathname: '/', params: { token } }));
+
+    expect(result.current).toEqual({ token });
+  });
+
+  it(`returns a param from the URL unchanged when it contains percent-encoded characters`, () => {
+    const token = 'IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts';
+
+    const { result } = renderHook(() => useLocalSearchParams(), ['index'], {
+      initialUrl: `/?token=${encodeURIComponent(token)}`,
+    });
+
+    expect(result.current).toEqual({ token });
   });
 });

--- a/packages/expo-router/src/hooks/useLocalSearchParams.ts
+++ b/packages/expo-router/src/hooks/useLocalSearchParams.ts
@@ -48,33 +48,9 @@ export function useLocalSearchParams<
 export function useLocalSearchParams() {
   const params = React.use(LocalRouteParamsContext) ?? {};
   const { params: previewParams } = usePreviewInfo();
-  return Object.fromEntries(
-    Object.entries(previewParams ?? params).map(([key, value]) => {
-      // React Navigation doesn't remove `undefined` values from the params object, and you cannot remove them via
-      // `navigation.setParams()` as it shallow merges. Hence, we hide them here. We also pass `null` through unchanged
-      // for the same reason; running it through `decodeURIComponent()` would otherwise stringify it to `null`.
-      if (value == null) {
-        return [key, value];
-      }
-
-      if (Array.isArray(value)) {
-        return [
-          key,
-          value.map((v) => {
-            try {
-              return decodeURIComponent(v);
-            } catch {
-              return v;
-            }
-          }),
-        ];
-      } else {
-        try {
-          return [key, decodeURIComponent(value as string)];
-        } catch {
-          return [key, value];
-        }
-      }
-    })
-  ) as any;
+  // Params are already decoded once while the navigation state is built: path segments go through
+  // `safelyDecodeURIComponent()` in `getStateFromPath()`, and search params are read through
+  // `URLSearchParams`, which decodes on access. Decoding them a second time here would turn an
+  // encoded value such as `%2F` into `/` and corrupt values that have to stay percent-encoded.
+  return { ...(previewParams ?? params) } as any;
 }


### PR DESCRIPTION
# Why

Fixes #48421.

Route params are encoded once and decoded twice, so any value that has to stay percent-encoded comes back corrupted. `%2F` arrives as `/` and `%2B` as `+`. The report shows this breaking an AWS SigV4 presigned URL passed through `router.push()`: the token no longer matches its signature and S3 answers `InvalidToken`, with nothing pointing at the router as the cause.

The same root cause was reported in #35598 and #42075 (both closed by the stale bot) and is still open as #26664.

The extra decode is in two places, and it hits both hooks:

| Step | Location |
|---|---|
| encode ×1 | `link/href.ts` → `createQueryParams()` |
| decode ×1 | `fork/getStateFromPath-forks.ts` → `parseQueryParams()`, via `URLSearchParams` |
| decode ×1 | `hooks/useLocalSearchParams.ts` (`useLocalSearchParams`) |
| decode ×1 | `global-state/getRouteInfoFromState.ts` (`useGlobalSearchParams`, `routeInfo`) |

# How

Removed the second decode in `useLocalSearchParams()` and in `getRouteInfoFromState()`.

Params are already decoded exactly once by the time they are in the navigation state: `getStateFromPath()` runs path segments through `safelyDecodeURIComponent()`, and search params are read through `URLSearchParams`, which decodes on access. Params set programmatically (`navigation.setParams()`, `router.setParams()`) were never encoded, so decoding them was wrong in that direction too.

Behaviour change worth calling out: a param that a caller passes in **already percent-encoded** is now returned verbatim instead of being decoded. Two existing tests asserted the old behaviour and are updated here:

- `useLocalSearchParams › handles encoded params` and its `useGlobalSearchParams` twin — `router.setParams({ test: '%2Fhello%2Fworld%2Fagain' })` now reads back as `%2Fhello%2Fworld%2Fagain` rather than `/hello/world/again`.
- `getRouteInfoFromState › decodes URI-encoded params` / `decodes array params in catch-all` — these build a state object by hand with pre-encoded params. The router never produces such a state (verified below), so they now assert pass-through.

Decoding an encoded URL is unaffected: `/hello%20world` on `[name]` still yields `hello world`, because that decode happens in `getStateFromPath()`.

I flagged this as a breaking change in the changelog since it is observable for anyone who worked around the bug by pre-encoding. Happy to move it to bug fixes if you would rather ship it that way.

# Test Plan

`packages/expo-router`, all commands with `NODE_ENV` unset.

Full suite, on the branch:

```
CI=1 pnpm test
Test Suites: 1 skipped, 315 passed, 315 of 316 total
Tests:       6 skipped, 4455 passed, 4461 total
Snapshots:   258 passed, 258 total
```

`tsc -b tsconfig.all.json`, `oxlint`, and `expo-build cjs:src` are all clean.

New regression tests in `useLocalSearchParams.test.ios.tsx` and `useGlobalSearchParams.test.ios.tsx`:

- a pushed param containing `%2F` / `%2B` (the SigV4 token from the report) round-trips unchanged;
- the same value arriving through the URL round-trips unchanged;
- `/hello%20world` on `[name]` still decodes to `hello world` exactly once.

They fail on `main` and pass here.

Before the change (probe through the real router pipeline, value `IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts`):

```
LOCAL push  -> {"t":"IQoJb3JpZ2luX2Vj/PB94qm+x+4Ts"}
GLOBAL push -> {"t":"IQoJb3JpZ2luX2Vj/PB94qm+x+4Ts"}
LOCAL url   -> {"t":"IQoJb3JpZ2luX2Vj/PB94qm+x+4Ts"}
```

After:

```
LOCAL push  -> {"t":"IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts"}
GLOBAL push -> {"t":"IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts"}
LOCAL url   -> {"t":"IQoJb3JpZ2luX2Vj%2FPB94qm%2Bx%2B4Ts"}
```

Check that the state never holds pre-encoded params (which is what the two rewritten `getRouteInfoFromState` unit tests assumed), same probe harness, after the change:

```
/hello%20world on [name]            -> {"name":"hello world"}
/hello%20world/foo%2Fbar on [...path] -> {"path":["hello world","foo","bar"]}
router.push('/hello%20world')        -> {"name":"hello world"}
router.setParams({ q: 'a b/c' })     -> {"q":"a b/c"}
```

Not run: the simulator and E2E apps. The change is confined to how params are read out of the navigation state, and the unit suite covers both hooks on iOS, Android, and web.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
