### PR TITLE
[tools] Rename the publish canaries workflow to publish packages

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,4 +1,4 @@
-name: Publish Canaries
+name: Publish Packages
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         default: false
   pull_request:
     paths:
-      - .github/workflows/publish-canaries.yml
+      - .github/workflows/publish-packages.yml
   schedule:
     - cron: 0 1 * * * # Nightly at 1:00 AM UTC
 
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish-canaries:
+  publish-packages:
     if: github.repository == 'expo/expo'
     runs-on: macos-26
     timeout-minutes: 120
@@ -60,5 +60,5 @@ jobs:
         if: failure() && github.event_name == 'schedule'
         with:
           webhook: ${{ secrets.slack_webhook_api }}
-          author_name: Publish Canaries
+          author_name: Publish Packages
           fields: job,message,author,took

--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -265,7 +265,7 @@ function tasksForOptions(options: CommandOptions): Task<TaskArgs>[] {
   if (options.canary) {
     if (!process.env.CI) {
       logger.info(
-        `🛠️ You can also use the CI action instead: https://github.com/expo/expo/actions/workflows/publish-canaries.yml`
+        `🛠️ You can also use the CI action instead: https://github.com/expo/expo/actions/workflows/publish-packages.yml`
       );
     }
     if (options.packageNames.length > 0) {

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -16,7 +16,7 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
  * Xcode version that prebuilds must be built with. Each Xcode bundles a specific Swift
  * compiler, and `.swiftinterface` files emitted by a newer Swift cannot be parsed by an
  * older one, which breaks consumers who haven't yet upgraded. Keep in sync with the CI
- * workflows that publish artifacts (see .github/workflows/publish-canaries.yml).
+ * workflows that publish artifacts (see .github/workflows/publish-packages.yml).
  */
 export const SUPPORTED_XCODE_VERSION = '26.4.1';
 


### PR DESCRIPTION
# Why

Preparation for npm trusted publishing. A trusted publisher is registered per package with `npm trust github`, which takes the repository and the workflow **filename**. Only one publisher is allowed per package, so the filename has to be final before registration: renaming afterwards would require revoking and re-registering every package.

The workflow is also meant to publish non-canary versions, which the current name does not describe.

# How

Renamed `publish-canaries.yml` to `publish-packages.yml` and updated every reference to the old name: `name:`, the job id, the Slack `author_name`, the `pull_request.paths` self-reference, and two lines in `tools/`.

Unchanged: the publish step still runs `et publish-packages --canary`, so it keeps its current name. No input, trigger, or authentication changes.

# Test Plan

- Parsed the YAML and confirmed the job key, `pull_request.paths`, and Slack `author_name` read back with the new name.
- `git grep publish-canaries` returns nothing.
- `tsc --noEmit` and `eslint` pass on the two touched files in `tools/`.

`pull_request.paths` matches the new filename, so this PR runs the workflow against itself in `--dry` mode.

<!-- disable:changelog-checks -->