### PR TITLE
[bare-expo][ncl] Unify app and navigation theming

### DIFF
--- a/apps/bare-expo/app/(tabs)/_layout.tsx
+++ b/apps/bare-expo/app/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { getWebNativeTabsTheme, useTheme } from 'ThemeProvider';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import * as React from 'react';
 
@@ -10,8 +11,9 @@ const hasNativeComponentList = !!optionalRequire(() =>
 );
 
 export default function TabsLayout() {
+  const { theme } = useTheme();
   return (
-    <NativeTabs>
+    <NativeTabs {...(process.env.EXPO_OS === 'web' && getWebNativeTabsTheme(theme))}>
       <NativeTabs.Trigger name="test-suite">
         <NativeTabs.Trigger.Icon sf="checklist" md="checklist" />
         <NativeTabs.Trigger.Label>Tests</NativeTabs.Trigger.Label>

--- a/apps/bare-expo/app/_layout.tsx
+++ b/apps/bare-expo/app/_layout.tsx
@@ -2,12 +2,7 @@ import { ThemeProvider, useTheme } from 'ThemeProvider';
 import BenchmarkHelper from 'benchmark-helper';
 import * as DevMenu from 'expo-dev-menu';
 import { AppMetrics, Observe, ObserveRoot } from 'expo-observe';
-import {
-  DarkTheme,
-  DefaultTheme,
-  Stack,
-  ThemeProvider as NavigationThemeProvider,
-} from 'expo-router';
+import { Stack } from 'expo-router';
 import * as Splashscreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import React from 'react';
@@ -100,15 +95,12 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      {/* TODO(kudo,20260802): Unify these navigation themes with `ThemeProvider` so there's a single source of truth. */}
-      <NavigationThemeProvider value={themeName === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="(tabs)" />
-          <Stack.Screen name="redirect" />
-          <Stack.Screen name="search" options={getSearchScreenOptions?.(theme)} />
-        </Stack>
-        <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
-      </NavigationThemeProvider>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" />
+        <Stack.Screen name="redirect" />
+        <Stack.Screen name="search" options={getSearchScreenOptions?.(theme)} />
+      </Stack>
+      <StatusBar style={themeName === 'light' ? 'dark' : 'light'} />
     </GestureHandlerRootView>
   );
 }

--- a/apps/common/ThemeProvider.tsx
+++ b/apps/common/ThemeProvider.tsx
@@ -1,8 +1,15 @@
 import { darkTheme, lightTheme } from '@expo/styleguide-base';
+import {
+  DarkTheme,
+  DefaultTheme,
+  ThemeProvider as NavigationThemeProvider,
+  type Theme as NavigationTheme,
+} from 'expo-router';
 import React, {
   createContext,
   useCallback,
   useContext,
+  useMemo,
   useState,
   type PropsWithChildren,
 } from 'react';
@@ -23,6 +30,22 @@ export const ThemeContext = createContext<ThemeContextType>({
   setTheme: () => undefined,
 });
 
+// The navigation theme is derived from the styleguide theme, so headers, tab bars and screen
+// backgrounds stay in sync with the rest of the app.
+function createNavigationTheme(themeName: ThemeName, theme: ThemeType): NavigationTheme {
+  return {
+    ...(themeName === 'dark' ? DarkTheme : DefaultTheme),
+    colors: {
+      primary: theme.icon.info,
+      background: theme.background.default,
+      card: theme.background.default,
+      text: theme.text.default,
+      border: theme.border.default,
+      notification: theme.icon.danger,
+    },
+  };
+}
+
 export function ThemeProvider({ children }: PropsWithChildren) {
   const systemColorScheme = useColorScheme();
   // react-native-web's Appearance has no setColorScheme, so keep an override in state.
@@ -30,6 +53,10 @@ export function ThemeProvider({ children }: PropsWithChildren) {
   const currentThemeName =
     themeOverride ?? (systemColorScheme !== 'unspecified' ? systemColorScheme : 'light');
   const currentTheme = currentThemeName === 'dark' ? darkTheme : lightTheme;
+  const navigationTheme = useMemo(
+    () => createNavigationTheme(currentThemeName, currentTheme),
+    [currentThemeName, currentTheme]
+  );
 
   const setTheme = useCallback((themeName: ThemeName) => {
     if (typeof Appearance.setColorScheme === 'function') {
@@ -46,7 +73,7 @@ export function ThemeProvider({ children }: PropsWithChildren) {
         theme: currentTheme,
         setTheme,
       }}>
-      {children}
+      <NavigationThemeProvider value={navigationTheme}>{children}</NavigationThemeProvider>
     </ThemeContext.Provider>
   );
 }

--- a/apps/common/ThemeProvider.tsx
+++ b/apps/common/ThemeProvider.tsx
@@ -46,6 +46,19 @@ function createNavigationTheme(themeName: ThemeName, theme: ThemeType): Navigati
   };
 }
 
+// `NativeTabs` styles its web tab bar from CSS variables that fall back to a dark palette, and it
+// never reads the navigation theme, so web has to be given the colors.
+export function getWebNativeTabsTheme(theme: ThemeType) {
+  return {
+    backgroundColor: theme.background.element,
+    indicatorColor: theme.background.selected,
+    labelStyle: {
+      default: { color: theme.text.secondary },
+      selected: { color: theme.text.default },
+    },
+  };
+}
+
 export function ThemeProvider({ children }: PropsWithChildren) {
   const systemColorScheme = useColorScheme();
   // react-native-web's Appearance has no setColorScheme, so keep an override in state.

--- a/apps/common/package.json
+++ b/apps/common/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@expo/styleguide-base": "^1.0.1",
     "@expo/vector-icons": "^15.0.2",
+    "expo-router": "workspace:*",
     "react-native": "0.86.0",
     "react": "19.2.3"
   },

--- a/apps/native-component-list/src/app/(main)/_layout.tsx
+++ b/apps/native-component-list/src/app/(main)/_layout.tsx
@@ -1,3 +1,4 @@
+import { getWebNativeTabsTheme, useTheme } from 'ThemeProvider';
 import { Drawer } from 'expo-router/drawer';
 import { NativeTabs } from 'expo-router/unstable-native-tabs';
 import * as React from 'react';
@@ -5,6 +6,7 @@ import { Platform, useWindowDimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function MainLayout() {
+  const { theme } = useTheme();
   const { width } = useWindowDimensions();
   const { left } = useSafeAreaInsets();
   const isMobile = width <= 640;
@@ -18,7 +20,7 @@ export default function MainLayout() {
   // of its children will be reset.
   if (Platform.OS !== 'web' || isMobile) {
     return (
-      <NativeTabs>
+      <NativeTabs {...(Platform.OS === 'web' && getWebNativeTabsTheme(theme))}>
         <NativeTabs.Trigger name="apis">
           <NativeTabs.Trigger.Icon sf="chevron.left.forwardslash.chevron.right" md="code" />
           <NativeTabs.Trigger.Label>APIs</NativeTabs.Trigger.Label>

--- a/apps/native-component-list/src/app/_layout.tsx
+++ b/apps/native-component-list/src/app/_layout.tsx
@@ -1,10 +1,5 @@
 import { ThemeProvider, useTheme } from 'ThemeProvider';
-import {
-  DarkTheme,
-  DefaultTheme,
-  Stack,
-  ThemeProvider as NavigationThemeProvider,
-} from 'expo-router';
+import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import { Platform, StatusBar } from 'react-native';
@@ -56,13 +51,11 @@ function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <NavigationThemeProvider value={themeName === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack screenOptions={{ presentation: 'modal', headerShown: false }}>
-          <Stack.Screen name="(main)" />
-          <Stack.Screen name="redirect" />
-          <Stack.Screen name="search" options={getSearchScreenOptions(theme)} />
-        </Stack>
-      </NavigationThemeProvider>
+      <Stack screenOptions={{ presentation: 'modal', headerShown: false }}>
+        <Stack.Screen name="(main)" />
+        <Stack.Screen name="redirect" />
+        <Stack.Screen name="search" options={getSearchScreenOptions(theme)} />
+      </Stack>
     </GestureHandlerRootView>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,6 +420,9 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.1.1(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      expo-router:
+        specifier: workspace:*
+        version: link:../../packages/expo-router
       react:
         specifier: 19.2.3
         version: 19.2.3


### PR DESCRIPTION
# Why

follow up TODO in https://github.com/expo/expo/pull/47510#discussion_r3657722383

# How

- unify to use `apps/common/ThemeProvider`
- workaround NativeTabs always showing dark (my system theme) background even the app uses light theme

# Test Plan

test NCL and switch theme

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
