### PR TITLE
[sdk-56][brownfield] Fix check-packages failures

### DIFF
--- a/packages/expo-brownfield/cli/jest.config.js
+++ b/packages/expo-brownfield/cli/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-  ...require('../e2e/cli/jest.config.js'),
-  // When expo-module-test runs "pnpm test cli" it passes --rootDir cli, so Jest's
-  // rootDir is cli/. Point roots at e2e/cli so the same cli tests run.
-  roots: ['../e2e/cli'],
-};

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -48,9 +48,6 @@
   "author": "650 Industries, Inc.",
   "license": "MIT",
   "homepage": "https://docs.expo.dev/versions/unversioned/sdk/brownfield/",
-  "jest": {
-    "preset": "expo-module-scripts"
-  },
   "dependencies": {
     "@expo/env": "workspace:~2.3.1",
     "@expo/spawn-async": "^1.8.0",

--- a/packages/expo-brownfield/plugin/build/android/plugins/withGradlePropertiesPlugin.js
+++ b/packages/expo-brownfield/plugin/build/android/plugins/withGradlePropertiesPlugin.js
@@ -31,7 +31,7 @@ const getFusedLibrarySupportConfiguration = (hasFusedOptIn, hasFusedPubFlag) => 
     if (!hasFusedOptIn) {
         items.push({
             type: 'comment',
-            value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+            value: 'Acknowledge AGP Fused Library Preview status (required to apply the plugin)',
         }, {
             type: 'property',
             key: 'android.experimental.fusedLibrarySupport',

--- a/packages/expo-brownfield/plugin/jest.config.js
+++ b/packages/expo-brownfield/plugin/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-  ...require('../e2e/plugin/jest.config.js'),
-  // When expo-module-test runs "pnpm test plugin" it passes --rootDir plugin, so Jest's
-  // rootDir is plugin/. Point roots at e2e/plugin so the same plugin tests run.
-  roots: ['../e2e/plugin'],
-};

--- a/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
@@ -18,8 +18,7 @@ const withGradlePropertiesPlugin: ConfigPlugin = (config) => {
     // `include(project(...))` resolve sibling subprojects directly (no mavenLocal
     // round-trip). No-op in non-fused mode.
     const hasFusedOptIn = config.modResults.some(
-      (item) =>
-        item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
+      (item) => item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
     );
     const hasFusedPubFlag = config.modResults.some(
       (item) =>
@@ -46,7 +45,7 @@ const getFusedLibrarySupportConfiguration = (
     items.push(
       {
         type: 'comment',
-        value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+        value: 'Acknowledge AGP Fused Library Preview status (required to apply the plugin)',
       },
       {
         type: 'property',

--- a/packages/expo-module-scripts/createCompositeJestPreset.cjs
+++ b/packages/expo-module-scripts/createCompositeJestPreset.cjs
@@ -1,0 +1,51 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const basePreset = require('./jest-preset.cjs');
+
+// Builds a single multi-project Jest config for a package that has build sub-targets
+// (e.g. `plugin`, `cli`, `utils`) with their own tests. The package's `src` tests run via
+// the multi-platform module preset, and each sub-folder runs as its own project rooted at
+// that folder — so a single `jest` invocation runs the whole package.
+//
+// Notes:
+// - Jest forbids nesting `projects`, so the module preset's per-platform projects are
+//   flattened in rather than added as one entry.
+// - `watchPlugins`/`prettierPath` are root-only in multi-project mode, so they're kept at the
+//   root (from the module preset) and stripped from each sub-project config.
+// - `rootDir` is forced to the sub-folder so the sub-configs don't need to be invoked with an
+//   external `--rootDir` (as `expo-module test <target>` does).
+// `opts.srcProjects` overrides the default `src` projects — used by packages whose `src`
+// tests are platform-specific (e.g. iOS-only) rather than the full multi-platform set.
+// `opts.rsc` appends the React Server Component per-platform projects (from
+// `jest-expo/rsc/jest-preset`) so a package's `__rsc_tests__` run as part of the single `jest`
+// invocation instead of a separate `test:rsc` script.
+module.exports = function createCompositeJestPreset(
+  rootDir,
+  subdirs = [],
+  { srcProjects, rsc = false } = {}
+) {
+  return {
+    ...basePreset,
+    projects: [
+      // `src` — flattened per-platform projects from the module preset (or a custom set).
+      ...(srcProjects ?? basePreset.projects),
+      // Each build sub-target as its own project, rooted at its folder. Mirrors
+      // `expo-module test <target>`: use the sub-folder's own `jest.config.js` if present,
+      // otherwise fall back to the default preset for that target (`jest-preset-<target>`).
+      ...subdirs.map((dir) => {
+        const localConfig = path.join(rootDir, dir, 'jest.config.js');
+        const { watchPlugins, prettierPath, ...config } = fs.existsSync(localConfig)
+          ? require(localConfig)
+          : require(`./jest-preset-${dir}.cjs`);
+        // Name the project after its folder so failures are attributable in multi-project output.
+        return { displayName: dir, ...config, rootDir: path.join(rootDir, dir) };
+      }),
+      // RSC `__rsc_tests__` as their own per-platform projects (named `rsc/<platform>`). These
+      // only match `**/__rsc_tests__/**`, so they're inert for packages without such tests.
+      ...(rsc ? require('jest-expo/rsc/jest-preset').projects : []),
+    ],
+  };
+};

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -21,6 +21,10 @@
     "./eslint.config.base": {
       "require": "./eslint.config.base.cjs"
     },
+    "./createCompositeJestPreset": {
+      "import": "./createCompositeJestPreset.cjs",
+      "require": "./createCompositeJestPreset.cjs"
+    },
     "./jest-preset-*": {
       "import": "./jest-preset-*.cjs",
       "require": "./jest-preset-*.cjs"


### PR DESCRIPTION
## Why?

Same as https://github.com/expo/expo/pull/48113

The cherry-picks of the Fused Library support (https://github.com/expo/expo/pull/47921) and the iOS packaging fixes (https://github.com/expo/expo/pull/48065) to sdk-56 broke the check-packages CI job for expo-brownfield

## How?
Same as https://github.com/expo/expo/pull/48113

## Test

CI should pass


