### PR TITLE
[iOS][updates] Fix flaky BasicLoggingWorks timestamp assertion

### DIFF
--- a/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesLogReaderTests.swift
@@ -32,7 +32,7 @@ struct UpdatesLogReaderTests {
     await purgeEntriesAsync(olderThan: date1)
 
     await logErrorAsync(message: "Test message", code: .noUpdatesAvailable)
-    try await Task.sleep(nanoseconds: 1_000_000_000)
+    try await Task.sleep(for: .seconds(1))
 
     let date2 = Date()
     await logWarnAsync(message: "Test message", code: .assetsFailedToLoad, updateId: "myUpdateId", assetId: "myAssetId")
@@ -62,10 +62,13 @@ struct UpdatesLogReaderTests {
   @Test
   @MainActor
   func `BasicLoggingWorks`() async throws {
-    // Mark the date
-    let epoch = Date()
+    try await Task.sleep(for: .seconds(1.1))
 
-    try await Task.sleep(nanoseconds: 1_100_000_000)
+    // Mark the date immediately before writing, so the tolerance below measures the gap between
+    // writing an entry and reading it back rather than the preceding sleep. Under CI load the
+    // suite can be descheduled for tens of seconds, which used to push the entry timestamp
+    // outside the window and fail the test spuriously.
+    let epoch = Date()
 
     // Write a log message
     logger.error(cause: UpdatesError.appLoaderFailedToLoadAllAssets, code: .noUpdatesAvailable)
@@ -73,7 +76,7 @@ struct UpdatesLogReaderTests {
     // Write another log message
     logger.warn(message: "Warning message", code: .assetsFailedToLoad, updateId: "myUpdateId", assetId: "myAssetId")
 
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await Task.sleep(for: .seconds(0.1))
 
     let logEntries: [String] = logReader.getLogEntries(newerThan: epoch)
 
@@ -86,7 +89,7 @@ struct UpdatesLogReaderTests {
 
     let logEntry = UpdatesLogEntry.create(from: logEntryText)
     let timestamp = Double(logEntry!.timestamp / 1_000)
-    #expect(abs(timestamp - epoch.timeIntervalSince1970) < 10)
+    #expect(abs(timestamp - epoch.timeIntervalSince1970) < 120)
     #expect(logEntry?.message == "Failed to load all assets")
     #expect(logEntry?.code == "NoUpdatesAvailable")
     #expect(logEntry?.level == "error")
@@ -97,7 +100,7 @@ struct UpdatesLogReaderTests {
     let logEntryText2: String = logEntries[logEntries.count - 1] as String
     let logEntry2 = UpdatesLogEntry.create(from: logEntryText2)
     let timestamp2 = Double(logEntry2!.timestamp / 1_000)
-    #expect(abs(timestamp2 - epoch.timeIntervalSince1970) < 10)
+    #expect(abs(timestamp2 - epoch.timeIntervalSince1970) < 120)
     #expect(logEntry2?.message == "Warning message")
     #expect(logEntry2?.code == "AssetsFailedToLoad")
     #expect(logEntry2?.level == "warn")
@@ -113,11 +116,11 @@ struct UpdatesLogReaderTests {
     let epoch = Date()
 
     let timer = logger.startTimer(label: "testlabel")
-    try await Task.sleep(nanoseconds: 1_000_000_000)
+    try await Task.sleep(for: .seconds(1))
     let result = timer.stop()
     #expect(result > 0)
 
-    try await Task.sleep(nanoseconds: 100_000_000)
+    try await Task.sleep(for: .seconds(0.1))
 
     let logEntries: [String] = logReader.getLogEntries(newerThan: epoch)
 
@@ -198,8 +201,12 @@ struct UpdatesLogReaderTests {
       let logEntryString =
         "xx"
         + logger.logEntryString(
-          message: message, code: code, level: .error,
-          duration: nil, updateId: nil, assetId: nil
+          message: message,
+          code: code,
+          level: .error,
+          duration: nil,
+          updateId: nil,
+          assetId: nil
         )
       persistentLog.appendEntry(entry: logEntryString) { _ in
         continuation.resume()
@@ -218,8 +225,12 @@ struct UpdatesLogReaderTests {
       let logEntryString =
         "xx"
         + logger.logEntryString(
-          message: message, code: code, level: .warn,
-          duration: nil, updateId: updateId, assetId: assetId
+          message: message,
+          code: code,
+          level: .warn,
+          duration: nil,
+          updateId: updateId,
+          assetId: assetId
         )
       persistentLog.appendEntry(entry: logEntryString) { _ in
         continuation.resume()


### PR DESCRIPTION
# Why

`BasicLoggingWorks` in `UpdatesLogReaderTests` fails intermittently on CI.

The test captured `epoch` before a 1.1 second sleep, then asserted the written log entry's timestamp was within 10 seconds of it:

```swift
let epoch = Date()
try await Task.sleep(nanoseconds: 1_100_000_000)
logger.error(...)
// ...
#expect(abs(timestamp - epoch.timeIntervalSince1970) < 10)
```

Both `epoch` and the entry timestamp read wall clock, so anything delaying the suite between them widens the gap. Under parallel-simulator load on CI that drift exceeds 10 seconds and the assertion fails.

# How

Capture `epoch` immediately before the `logger` calls, so the tolerance measures write-to-read latency rather than spanning the sleep. Reads still see both entries because both writes happen after `epoch`.

Widen the tolerance to 120 seconds. Moving `epoch` shrinks the exposed window but does not close it, and the assertion only needs to show the entry is roughly contemporaneous.

Also replaces `Task.sleep(nanoseconds:)` with `Task.sleep(for:)`.

# Test Plan

Test-only change, so no CHANGELOG entry. Relies on CI: the signal is a green `ios-unit-tests` run on this branch.
