### PR TITLE
[ui][ios] Fix BottomSheet close callbacks firing before dismissal

### DIFF
--- a/apps/native-component-list/src/screens/UI/CommunityBottomSheetScreen.tsx
+++ b/apps/native-component-list/src/screens/UI/CommunityBottomSheetScreen.tsx
@@ -5,7 +5,7 @@ import BottomSheet, {
   useBottomSheet,
 } from '@expo/ui/community/bottom-sheet'; // can replace with `@gorhom/bottom-sheet` to check compatibility
 import { useRef, useState } from 'react';
-import { Button, Platform, StyleSheet, Text, View } from 'react-native';
+import { Button, Modal, Platform, StyleSheet, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { BodyText } from '../../components/BodyText';
@@ -31,7 +31,9 @@ export default function CommunityBottomSheetScreen() {
   const sheetRef = useRef<BottomSheet>(null);
   const modalRef = useRef<BottomSheetModal>(null);
   const fitRef = useRef<BottomSheetModal>(null);
+  const modalFromDismissRef = useRef<BottomSheetModal>(null);
 
+  const [isModalVisible, setIsModalVisible] = useState(false);
   const [log, setLog] = useState<string[]>([]);
   const addLog = (msg: string) =>
     setLog((prev) => [`${new Date().toLocaleTimeString()} ${msg}`, ...prev].slice(0, 15));
@@ -66,6 +68,15 @@ export default function CommunityBottomSheetScreen() {
                 setTimeout(() => fitRef.current?.close(), 2000);
               }}
             />
+          </View>
+
+          {/* 4. Present a React Native Modal from onDismiss */}
+          <BodyText style={styles.heading}>Modal from onDismiss</BodyText>
+          <BodyText style={styles.hint}>
+            Close the sheet — onDismiss presents a React Native Modal
+          </BodyText>
+          <View style={styles.buttonRow}>
+            <Button title="Open" onPress={() => modalFromDismissRef.current?.present()} />
           </View>
 
           {/* Event log */}
@@ -127,6 +138,30 @@ export default function CommunityBottomSheetScreen() {
               <SheetControls />
             </BottomSheetView>
           </BottomSheetModal>
+
+          {/* Sheet 4: presents a React Native Modal once fully dismissed */}
+          <BottomSheetModal
+            ref={modalFromDismissRef}
+            snapPoints={['50%']}
+            onDismiss={() => {
+              addLog('dismiss-then-modal onDismiss');
+              setIsModalVisible(true);
+            }}
+            enablePanDownToClose>
+            <BottomSheetView style={styles.sheetView}>
+              <Text style={styles.sheetTitle}>Modal from onDismiss</Text>
+              <SheetControls />
+            </BottomSheetView>
+          </BottomSheetModal>
+
+          <Modal visible={isModalVisible} transparent animationType="fade">
+            <View style={styles.modalBackdrop}>
+              <View style={styles.modalCard}>
+                <Text style={styles.sheetTitle}>Modal presented</Text>
+                <Button title="Close" onPress={() => setIsModalVisible(false)} />
+              </View>
+            </View>
+          </Modal>
         </View>
       </BottomSheetModalProvider>
     </GestureHandlerRootView>
@@ -190,5 +225,17 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'center',
     marginTop: 8,
+  },
+  modalBackdrop: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+  },
+  modalCard: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 24,
+    gap: 8,
   },
 });

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
+- [iOS] Fix `community/bottom-sheet` close callbacks firing before the sheet finished dismissing. ([#48389](https://github.com/expo/expo/issues/48389) by [@nicklamont](https://github.com/nicklamont)) ([#48436](https://github.com/expo/expo/pull/48436) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed viewport size measurement reading the main screen instead of the scene the view is in. ([#48170](https://github.com/expo/expo/pull/48170) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
@@ -132,7 +132,6 @@ export function BottomSheet(props: BottomSheetProps) {
   useEffect(() => {
     if (indexProp === -1) {
       setIsPresented(false);
-      fireCloseCallbacks();
     } else if (indexProp >= 0) {
       closedRef.current = false;
       setIsPresented(true);
@@ -140,17 +139,13 @@ export function BottomSheet(props: BottomSheetProps) {
       setCurrentIndex(clampedIndex);
       currentIndexRef.current = clampedIndex;
     }
-  }, [indexProp, detents.length, fireCloseCallbacks]);
+  }, [indexProp, detents.length]);
 
-  const handlePresentedChange = useCallback(
-    (presented: boolean) => {
-      if (!presented) {
-        setIsPresented(false);
-        fireCloseCallbacks();
-      }
-    },
-    [fireCloseCallbacks]
-  );
+  const handlePresentedChange = useCallback((presented: boolean) => {
+    if (!presented) {
+      setIsPresented(false);
+    }
+  }, []);
 
   const handleDetentChange = useCallback(
     (detent: PresentationDetent) => {
@@ -168,7 +163,6 @@ export function BottomSheet(props: BottomSheetProps) {
     const snapToIndex = (index: number) => {
       if (index === -1) {
         setIsPresented(false);
-        fireCloseCallbacks();
         return;
       }
       const clampedIndex = Math.min(Math.max(index, 0), detents.length - 1);
@@ -179,14 +173,11 @@ export function BottomSheet(props: BottomSheetProps) {
       onChangeRef.current?.(clampedIndex);
     };
 
-    // Fire close callbacks immediately: the native `onIsPresentedChange` event is
-    // suppressed when JS drives the state change (the Swift layer guards against
-    // the feedback loop), so we can't rely on handlePresentedChange here. The
-    // closedRef guard inside fireCloseCallbacks prevents double-firing if a
-    // native user-dismiss event also arrives during the animation.
+    // Close callbacks fire from the native `onDismiss` event, which SwiftUI sends after
+    // the dismissal transition finishes, so they can present another modal without UIKit
+    // rejecting it. Android awaits `hide()` for the same reason.
     const close = () => {
       setIsPresented(false);
-      fireCloseCallbacks();
     };
 
     return {
@@ -200,7 +191,7 @@ export function BottomSheet(props: BottomSheetProps) {
       present: () => snapToIndex(0),
       dismiss: close,
     };
-  }, [detents, fireCloseCallbacks]);
+  }, [detents]);
 
   useImperativeHandle(ref, () => methods, [methods]);
 
@@ -237,6 +228,7 @@ export function BottomSheet(props: BottomSheetProps) {
           <NativeBottomSheet
             isPresented={isPresented}
             onIsPresentedChange={handlePresentedChange}
+            onDismiss={fireCloseCallbacks}
             fitToContents={fitToContents}>
             <Group modifiers={modifiers}>
               <RNHostView matchContents={fitToContents}>


### PR DESCRIPTION
## Why

Fixes - https://github.com/expo/expo/issues/48389

Trigger `onDismiss` callback in the community sheet when the sheet actually dismisses (via `onDismiss` prop in SwiftUI native sheet).

## How

Pass `onDismiss` callback as prop to `onDismiss` native prop.

## Test Plan

Tested user shared repro and added an example for the same in NCL.

## Checklist

- [x] I added a description of my changes to the `CHANGELOG.md` file of the modified package.
- [x] I ensured that my changes build, type-check, lint, and test successfully.
