### PR TITLE
[ncl] Fix the search screen

### DIFF
--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -16,6 +16,7 @@ import {
   Platform,
   Pressable,
   useWindowDimensions,
+  type ScrollViewProps,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
@@ -58,6 +59,11 @@ interface Props {
   apis: ListElement[];
   renderItemRight?: (props: ListElement) => React.ReactNode;
   sort?: boolean;
+  /**
+   * Set to `automatic` on screens whose header grows at runtime, such as one with a native
+   * search bar, so iOS insets the list instead of letting the header cover the first rows.
+   */
+  contentInsetAdjustmentBehavior?: ScrollViewProps['contentInsetAdjustmentBehavior'];
 }
 
 function LinkButton({
@@ -166,6 +172,7 @@ export default function ComponentListScreen(props: Props) {
     <FlatList<ListElement>
       initialNumToRender={25}
       removeClippedSubviews={false}
+      contentInsetAdjustmentBehavior={props.contentInsetAdjustmentBehavior}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       style={{ backgroundColor: theme.background.screen }}

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -16,7 +16,6 @@ import {
   Platform,
   Pressable,
   useWindowDimensions,
-  type ScrollViewProps,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
@@ -59,11 +58,6 @@ interface Props {
   apis: ListElement[];
   renderItemRight?: (props: ListElement) => React.ReactNode;
   sort?: boolean;
-  /**
-   * Set to `automatic` on screens whose header grows at runtime, such as one with a native
-   * search bar, so iOS insets the list instead of letting the header cover the first rows.
-   */
-  contentInsetAdjustmentBehavior?: ScrollViewProps['contentInsetAdjustmentBehavior'];
 }
 
 function LinkButton({
@@ -172,7 +166,9 @@ export default function ComponentListScreen(props: Props) {
     <FlatList<ListElement>
       initialNumToRender={25}
       removeClippedSubviews={false}
-      contentInsetAdjustmentBehavior={props.contentInsetAdjustmentBehavior}
+      // Screens with a native search bar or large title grow their header at runtime, so let iOS
+      // inset the list instead of letting the header cover the first rows.
+      contentInsetAdjustmentBehavior="automatic"
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       style={{ backgroundColor: theme.background.screen }}

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -78,5 +78,12 @@ export default function SearchScreen() {
     []
   );
 
-  return <ComponentListScreen renderItemRight={renderItemRight} apis={apis} sort={false} />;
+  return (
+    <ComponentListScreen
+      contentInsetAdjustmentBehavior="automatic"
+      renderItemRight={renderItemRight}
+      apis={apis}
+      sort={false}
+    />
+  );
 }

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -84,14 +84,7 @@ export default function SearchScreen() {
     []
   );
 
-  const list = (
-    <ComponentListScreen
-      contentInsetAdjustmentBehavior="automatic"
-      renderItemRight={renderItemRight}
-      apis={apis}
-      sort={false}
-    />
-  );
+  const list = <ComponentListScreen renderItemRight={renderItemRight} apis={apis} sort={false} />;
 
   if (Platform.OS !== 'web') {
     return list;

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,6 +1,12 @@
-import { type NativeStackNavigationOptions, useNavigation } from 'expo-router';
+import {
+  type NativeStackNavigationOptions,
+  type NativeStackNavigationProp,
+  useNavigation,
+} from 'expo-router';
 import Fuse from 'fuse.js';
 import React from 'react';
+import { Platform } from 'react-native';
+import type { SearchBarCommands } from 'react-native-screens';
 
 import { ThemeType, useTheme } from '../../../common/ThemeProvider';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
@@ -23,15 +29,20 @@ export function getSearchScreenOptions(theme: ThemeType): NativeStackNavigationO
 }
 
 export default function SearchScreen() {
-  const navigation = useNavigation();
+  const navigation = useNavigation<NativeStackNavigationProp<Record<string, object | undefined>>>();
   const { theme } = useTheme();
   const [query, setQuery] = React.useState('');
+  const searchBarRef = React.useRef<SearchBarCommands>(null);
 
   React.useLayoutEffect(() => {
     navigation.setOptions({
       headerSearchBarOptions: {
+        ref: searchBarRef,
         placeholder: 'Search',
         autoFocus: true,
+        // Without this iOS hides the navigation bar while searching, which slides the results
+        // under the search field and swallows taps on the first row.
+        hideNavigationBar: false,
         textColor: theme.text.default,
         tintColor: theme.icon.info,
         headerIconColor: theme.icon.secondary,
@@ -42,6 +53,18 @@ export default function SearchScreen() {
       },
     });
   }, [navigation, theme]);
+
+  // `autoFocus` is Android-only, so focus the iOS search bar once the screen finishes opening.
+  React.useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+    return navigation.addListener('transitionEnd', ({ data }) => {
+      if (!data.closing) {
+        searchBarRef.current?.focus();
+      }
+    });
+  }, [navigation]);
 
   const apis = React.useMemo(() => {
     if (!query) return [];

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  Stack,
   type NativeStackNavigationOptions,
   type NativeStackNavigationProp,
   useNavigation,
@@ -16,8 +17,8 @@ import ComponentListScreen from './ComponentListScreen';
 
 const fuse = new Fuse(ApiScreenApiItems.concat(ComponentScreenApiItems), { keys: ['name'] });
 
-// The header (with the native search bar) comes from the stack that renders this screen,
-// so hosts must apply `getSearchScreenOptions` to that stack screen.
+// The header comes from the stack that renders this screen, so hosts must apply
+// `getSearchScreenOptions` to that stack screen.
 export function getSearchScreenOptions(theme: ThemeType): NativeStackNavigationOptions {
   return {
     title: 'Search',
@@ -34,31 +35,6 @@ export default function SearchScreen() {
   const { theme } = useTheme();
   const [query, setQuery] = React.useState('');
   const searchBarRef = React.useRef<SearchBarCommands>(null);
-
-  React.useLayoutEffect(() => {
-    // The web header turns these options into a button that expands its own search field.
-    // Web renders a plain input below instead, so setting them would show both.
-    if (Platform.OS === 'web') {
-      return;
-    }
-    navigation.setOptions({
-      headerSearchBarOptions: {
-        ref: searchBarRef,
-        placeholder: 'Search',
-        autoFocus: true,
-        // Without this iOS hides the navigation bar while searching, which slides the results
-        // under the search field and swallows taps on the first row.
-        hideNavigationBar: false,
-        textColor: theme.text.default,
-        tintColor: theme.icon.info,
-        headerIconColor: theme.icon.secondary,
-        hintTextColor: theme.text.quaternary,
-        onChangeText: (event: { nativeEvent: { text: string } }) =>
-          setQuery(event.nativeEvent.text),
-        onCancelButtonPress: () => navigation.goBack(),
-      },
-    });
-  }, [navigation, theme]);
 
   // `autoFocus` is Android-only, so focus the iOS search bar once the screen finishes opening.
   React.useEffect(() => {
@@ -87,10 +63,29 @@ export default function SearchScreen() {
   const list = <ComponentListScreen renderItemRight={renderItemRight} apis={apis} sort={false} />;
 
   if (Platform.OS !== 'web') {
-    return list;
+    return (
+      <>
+        <Stack.SearchBar
+          ref={searchBarRef}
+          autoFocus
+          placeholder="Search"
+          // Without this iOS hides the navigation bar while searching, which slides the results
+          // under the search field and swallows taps on the first row.
+          hideNavigationBar={false}
+          textColor={theme.text.default}
+          tintColor={theme.icon.info}
+          headerIconColor={theme.icon.secondary}
+          hintTextColor={theme.text.quaternary}
+          onChangeText={(event) => setQuery(event.nativeEvent.text)}
+          onCancelButtonPress={() => navigation.goBack()}
+        />
+        {list}
+      </>
+    );
   }
 
-  // The web header only renders a button that expands the search field, so web gets its own input.
+  // On web the search bar turns into a header button that expands its own field, so web gets a
+  // plain input above the results instead.
   return (
     <View style={[styles.webContainer, { backgroundColor: theme.background.default }]}>
       <TextInput

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -5,7 +5,7 @@ import {
 } from 'expo-router';
 import Fuse from 'fuse.js';
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, StyleSheet, TextInput, View } from 'react-native';
 import type { SearchBarCommands } from 'react-native-screens';
 
 import { ThemeType, useTheme } from '../../../common/ThemeProvider';
@@ -36,6 +36,9 @@ export default function SearchScreen() {
   const searchBarRef = React.useRef<SearchBarCommands>(null);
 
   React.useLayoutEffect(() => {
+    if (Platform.OS === 'web') {
+      return;
+    }
     navigation.setOptions({
       headerSearchBarOptions: {
         ref: searchBarRef,
@@ -79,7 +82,7 @@ export default function SearchScreen() {
     []
   );
 
-  return (
+  const list = (
     <ComponentListScreen
       contentInsetAdjustmentBehavior="automatic"
       renderItemRight={renderItemRight}
@@ -87,4 +90,37 @@ export default function SearchScreen() {
       sort={false}
     />
   );
+
+  if (Platform.OS !== 'web') {
+    return list;
+  }
+
+  // The web header only renders a button that expands the search field, so web gets its own input.
+  return (
+    <View style={[styles.webContainer, { backgroundColor: theme.background.default }]}>
+      <TextInput
+        autoFocus
+        placeholder="Search"
+        placeholderTextColor={theme.text.quaternary}
+        value={query}
+        onChangeText={setQuery}
+        style={[
+          styles.webInput,
+          { borderBottomColor: theme.border.default, color: theme.text.default },
+        ]}
+      />
+      {list}
+    </View>
+  );
 }
+
+const styles = StyleSheet.create({
+  webContainer: {
+    flex: 1,
+  },
+  webInput: {
+    borderBottomWidth: 1,
+    fontSize: 16,
+    padding: 12,
+  },
+});

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -22,6 +22,7 @@ export function getSearchScreenOptions(theme: ThemeType): NativeStackNavigationO
   return {
     title: 'Search',
     headerShown: true,
+    headerBackButtonDisplayMode: 'minimal',
     headerStyle: { backgroundColor: theme.background.default },
     headerTintColor: theme.icon.info,
     headerTitleStyle: { color: theme.text.default },

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -36,6 +36,8 @@ export default function SearchScreen() {
   const searchBarRef = React.useRef<SearchBarCommands>(null);
 
   React.useLayoutEffect(() => {
+    // The web header turns these options into a button that expands its own search field.
+    // Web renders a plain input below instead, so setting them would show both.
     if (Platform.OS === 'web') {
       return;
     }


### PR DESCRIPTION
# Why

fix broken NCL search screen which might come from expo-router migration

# How

- auto focus the search text input
- fix top search item rendered under the navigation bar
- fix text input not showing on web

# Test Plan

test search on NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
