### PR TITLE
[ui][ios] Use SwiftUI default spacing when spacing prop is unset

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - [iOS] Fix `<Host>` centering its content instead of top-aligning it, so a `flex: 1` host matches Android's top-leading layout. ([#47561](https://github.com/expo/expo/pull/47561) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix `HStack`, `VStack` and `GlassEffectContainer` collapsing an unset `spacing` to `0` instead of forwarding `nil` to SwiftUI, so they now use the system default spacing like `Grid`, `LazyHStack` and `LazyVStack` already do. Pass `spacing={0}` explicitly to keep the previous layout. (by [@Den1Marshall](https://github.com/Den1Marshall))
 
 ### 🎉 New features
 

--- a/packages/expo-ui/ios/GlassEffectContainerView.swift
+++ b/packages/expo-ui/ios/GlassEffectContainerView.swift
@@ -17,7 +17,7 @@ public struct GlassEffectContainerView: ExpoSwiftUI.View {
   public var body: some View {
     if #available(iOS 26.0, macOS 26.0, tvOS 26.0, *) {
 #if compiler(>=6.2) // Xcode 26
-      GlassEffectContainer(spacing: CGFloat(props.spacing ?? 0.0)) {
+      GlassEffectContainer(spacing: props.spacing.map { CGFloat($0) }) {
         Children()
       }
 #else

--- a/packages/expo-ui/ios/HStackView.swift
+++ b/packages/expo-ui/ios/HStackView.swift
@@ -41,7 +41,7 @@ public struct HStackView: ExpoSwiftUI.View {
   public var body: some View {
     HStack(
       alignment: props.alignment?.toVerticalAlignment() ?? .center,
-      spacing: CGFloat(props.spacing ?? 0)) {
+      spacing: props.spacing.map { CGFloat($0) }) {
         Children()
     }
   }

--- a/packages/expo-ui/ios/VStackView.swift
+++ b/packages/expo-ui/ios/VStackView.swift
@@ -35,7 +35,7 @@ public struct VStackView: ExpoSwiftUI.View {
   public var body: some View {
     VStack(
       alignment: props.alignment?.toHorizontalAlignment() ?? .center,
-      spacing: CGFloat(props.spacing ?? 0)) {
+      spacing: props.spacing.map { CGFloat($0) }) {
         Children()
     }
   }


### PR DESCRIPTION
# Why

`HStack`, `VStack` and `GlassEffectContainer` declare `spacing` as an optional `Double?`, but collapse an unset value to `0` before handing it to SwiftUI:

```swift
// HStackView.swift, VStackView.swift
HStack(alignment: ..., spacing: CGFloat(props.spacing ?? 0))
// GlassEffectContainerView.swift
GlassEffectContainer(spacing: CGFloat(props.spacing ?? 0.0))
```

The corresponding SwiftUI initializers take an optional, where `nil` means "use the platform default":

```swift
public init(spacing: CGFloat? = nil, @ViewBuilder content: () -> Content)
```

As a result every `HStack` and `VStack` renders with zero spacing unless the app passes an explicit number, and there is no way to ask for the system default. Apps end up re-implementing the platform's spacing with manual `padding` modifiers.

Other views in this package already forward the optional unchanged:

- `LazyHStackView.swift` and `LazyVStackView.swift` — `spacing: props.spacing.map { CGFloat($0) }`
- `GridView.swift` — passes `props.horizontalSpacing` / `props.verticalSpacing` straight through
- the `listRowSpacing` modifier — `.map { CGFloat($0) }`

So these three views are the outliers rather than the rule.

# How

Forward the optional instead of substituting `0`, matching the lazy stacks:

```swift
spacing: props.spacing.map { CGFloat($0) }
```

# Test Plan

Verified in an Expo SDK 57 app on iOS 26 built against the patched package:

- `HStack` / `VStack` without a `spacing` prop now lay out with SwiftUI's default spacing; previously their children were flush. Manual `padding` modifiers that existed only to emulate that spacing could be deleted.
- Passing `spacing={N}` explicitly behaves exactly as before.
- `GlassEffectContainer` without `spacing` showed no visible change in my app — the SDK default appears to be a very small merge radius. It is included here for consistency: the prop is optional, so the default should come from SwiftUI rather than from a hardcoded `0`.

No unit tests were added — the change is native-only and has no JS surface.

# Note on the changelog category

I put the entry under **🛠 Breaking changes**: apps that (knowingly or not) relied on the implicit `0` will see default spacing appear and need `spacing={0}` to keep their current layout. If you consider a major bump too strong for this, I am happy to move it to **⚠️ Notices**.
