### PR TITLE
experiment(cli,metro-config): Add experimental `noxcturnal` transform worker mode

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -77,6 +77,7 @@
       }
     },
     "experiments": {
+      "noxcturnalTransformWorker": true,
       "inlineModules": {
         "watchedDirectories": ["src/screens/inlineModules/inlineModulesExamples/"]
       }

--- a/apps/native-component-list/metro.config.js
+++ b/apps/native-component-list/metro.config.js
@@ -27,5 +27,9 @@ config.resolver.assetExts.push(
 
 // Disable Babel's RC lookup, reducing the config loading in Babel - resulting in faster bootup for transformations
 config.transformer.enableBabelRCLookup = false;
+if (process.env.E2E_FORCE_BABEL === '1') {
+  config.transformer.babelTransformerPath =
+    require.resolve('../router-e2e/forced-babel-transformer');
+}
 
 module.exports = config;

--- a/apps/router-e2e/app.config.js
+++ b/apps/router-e2e/app.config.js
@@ -29,6 +29,7 @@ module.exports = {
   jsEngine: process.env.E2E_ROUTER_JS_ENGINE ?? (process.env.E2E_ROUTER_SRC ? 'jsc' : 'hermes'),
   newArchEnabled: true,
   experiments: {
+    noxcturnalTransformWorker: true,
     autolinkingModuleResolution: true,
     baseUrl: process.env.EXPO_E2E_BASE_PATH || undefined,
     tsconfigPaths: process.env.EXPO_USE_PATH_ALIASES,

--- a/apps/router-e2e/forced-babel-transformer.js
+++ b/apps/router-e2e/forced-babel-transformer.js
@@ -1,0 +1,11 @@
+const defaultTransformer = require('../../packages/@expo/metro-config/build/babel-transformer');
+
+// Keep this wrapper observably distinct from Expo's default transformer so the
+// transform worker exercises its pristine-source custom-transformer/Babel path.
+// It is selected only by the router-e2e performance switch in metro.config.js.
+module.exports = {
+  ...defaultTransformer,
+  transform(...args) {
+    return defaultTransformer.transform(...args);
+  },
+};

--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -41,5 +41,8 @@ const config = getDefaultConfig(
 
 // Disable Babel's RC lookup, reducing the config loading in Babel - resulting in faster bootup for transformations
 config.transformer.enableBabelRCLookup = false;
+if (process.env.E2E_FORCE_BABEL === '1') {
+  config.transformer.babelTransformerPath = require.resolve('./forced-babel-transformer');
+}
 
 module.exports = config;

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Use default loader `Cache-Control` header value of `no-store` for loader responses in development ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
 - Use default `Cache-Control` header value of `public, max-age=0, must-revalidate` for SSG loader files and their pages ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
 - Use default `Cache-Control` header value of `no-store` for SSR loader responses ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
+- Add `experiments.noxcturnalTransformWorker` with native transformer experiment ([#48443](https://github.com/expo/expo/pull/48443) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/export-server-magic-import.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/export-server-magic-import.test.ts
@@ -27,7 +27,7 @@ describe('export server with magic import comments', () => {
   it('has expected syntax', async () => {
     expect(
       fs.readFileSync(path.resolve(outputDir, 'server/_expo/functions/methods+api.js'), 'utf8')
-    ).toMatch(/=await import\('path'\);/);
+    ).toMatch(/=await import\(["']path["']\);/);
   });
 
   describe('server', () => {

--- a/packages/@expo/cli/e2e/playwright/dev/react-compiler.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/react-compiler.test.ts
@@ -62,7 +62,7 @@ test.describe(baseDir, () => {
 
       // The useBananas code which otherwise causes the app to crash uses live bindings.
       expect(bundleContent).toMatch(
-        /Object\.defineProperty\(e,"useBananas",\{enumerable:!0,get:function\(\)\{return\s+(\w+)\.useBananas\}\}\)/
+        /Object\.defineProperty\(\w+,"useBananas",\{enumerable:!0,get:function\(\)\{return\s+(\w+)\.useBananas\}\}\)/
       );
     });
 
@@ -129,9 +129,9 @@ test.describe(baseDir, () => {
 
       // The useBananas code which causes the application to crash uses static bindings.
       expect(bundleContent).not.toMatch(
-        /Object\.defineProperty\(e,"useBananas",\{enumerable:!0,get:function\(\)\{return\s+(\w+)\.useBananas\}\}\)/
+        /Object\.defineProperty\(\w+,"useBananas",\{enumerable:!0,get:function\(\)\{return\s+(\w+)\.useBananas\}\}\)/
       );
-      expect(bundleContent).toContain('e.useBananas=function()');
+      expect(bundleContent).toMatch(/\w+\.useBananas=function\(\)/);
     });
 
     // This test generally ensures no errors are thrown during an export loading.

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -258,6 +258,12 @@ export async function loadMetroConfigAsync(
     },
   };
 
+  // TODO(@kitten): Add type once we stabilise this
+  const enableNativeTransformWorker: boolean = !!(exp.experiments as any)
+    ?.noxcturnalTransformWorker;
+  asWritable(config.transformer as any).unstable_noxcturnalTransformWorker =
+    enableNativeTransformWorker;
+
   // On-Demand Filesystem is enabled by default
   // TODO(@kitten): Add to config-types JSON schema
   const onDemandFilesystem = exp.experiments?.onDemandFilesystem ?? true;

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `experiments.noxcturnalTransformWorker` with native transformer experiment ([#48443](https://github.com/expo/expo/pull/48443) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -93,11 +93,15 @@
     "hermes-parser": "^0.36.0",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "^1.30.1",
+    "noxcturnal": "0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.23",
     "resolve-from": "^5.0.0"
   },
   "devDependencies": {
+    "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+    "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+    "@babel/plugin-transform-sticky-regex": "^7.27.1",
     "@jridgewell/trace-mapping": "^0.3.31",
     "@types/babel__code-frame": "^7.0.1",
     "@types/babel__core": "^7.20.5",

--- a/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
@@ -1,5 +1,5 @@
 import generate from '@babel/generator';
-import type { BabelTransformer } from '@expo/metro/metro-babel-transformer';
+import type { BabelTransformer, BabelTransformerArgs } from '@expo/metro/metro-babel-transformer';
 import { vol } from 'memfs';
 
 import * as babel from '../babel-core';
@@ -232,5 +232,64 @@ describe('getCacheKey', () => {
     const { transformer: t } = setupTransformerForCacheKey(files, 'babel.config.js');
     t.getCacheKey!({ projectRoot: '/' });
     expect(mockGetFileCacheKey).toHaveBeenCalledWith(['/.babelrc', '/babel.config.js']);
+  });
+});
+
+describe('isDefaultConfig', () => {
+  const args: BabelTransformerArgs = {
+    filename: '/app/node_modules/example/index.jsx',
+    src: 'module.exports = <View />;',
+    plugins: [],
+    options: {
+      dev: true,
+      enableBabelRCLookup: true,
+      enableBabelRuntime: '7.29.2',
+      extendsBabelConfigPath: 'babel.config.js',
+      globalPrefix: '',
+      inlineRequires: false as any,
+      minify: false,
+      platform: 'ios',
+      projectRoot: '/app',
+      publicPath: '/',
+      customTransformOptions: { engine: 'hermes' },
+    },
+  };
+
+  function setupConfigComparison(equivalent: boolean) {
+    jest.resetModules();
+    const configuredPreset = {};
+    const baselinePreset = equivalent ? configuredPreset : {};
+    const loadPartialConfigSync = jest.fn((options: { extends?: string }) => ({
+      files: new Set(['/app/babel.config.js']),
+      options: {
+        assumptions: {},
+        plugins: [],
+        presets: [
+          {
+            value: options.extends ? configuredPreset : baselinePreset,
+            options: undefined,
+          },
+        ],
+      },
+    }));
+    jest.doMock('../babel-core', () => ({
+      ...jest.requireActual('../babel-core'),
+      loadPartialConfigSync,
+    }));
+    const resolved = require('../babel-transformer') as BabelTransformer & {
+      isDefaultConfig(args: BabelTransformerArgs): boolean;
+    };
+    return { resolved, loadPartialConfigSync };
+  }
+
+  it('accepts a resolved config equivalent to the default Expo preset', () => {
+    const { resolved, loadPartialConfigSync } = setupConfigComparison(true);
+    expect(resolved.isDefaultConfig(args)).toBe(true);
+    expect(loadPartialConfigSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects a resolved config with a different preset descriptor', () => {
+    const { resolved } = setupConfigComparison(false);
+    expect(resolved.isDefaultConfig(args)).toBe(false);
   });
 });

--- a/packages/@expo/metro-config/src/babel-transformer.ts
+++ b/packages/@expo/metro-config/src/babel-transformer.ts
@@ -16,7 +16,7 @@ import { getCacheKey as getFileCacheKey } from '@expo/metro/metro-cache-key';
 import assert from 'node:assert';
 import path from 'node:path';
 
-import type { TransformOptions } from './babel-core';
+import type { PluginItem, TransformOptions } from './babel-core';
 import { loadPartialConfigSync } from './babel-core';
 import { loadBabelConfig, resolveBabelrcName } from './loadBabelConfig';
 import { debugEvent } from './transform-worker/events';
@@ -165,6 +165,130 @@ function stringOrUndefined(value: unknown): string | undefined {
   return typeof value === 'string' ? value : undefined;
 }
 
+function getDefaultExpoPreset(): PluginItem {
+  try {
+    return require('expo/internal/babel-preset');
+  } catch {
+    return require('babel-preset-expo');
+  }
+}
+
+function comparablePartialOptions(options: TransformOptions): unknown {
+  const {
+    babelrc: _babelrc,
+    caller: _caller,
+    configFile: _configFile,
+    cwd: _cwd,
+    envName: _envName,
+    filename: _filename,
+    plugins: _plugins,
+    presets: _presets,
+    root: _root,
+    ...comparable
+  } = options;
+  return comparable;
+}
+
+interface ResolvedConfigItem {
+  value: unknown;
+  options?: unknown;
+}
+
+interface ConfigComparison {
+  plugins: ResolvedConfigItem[];
+  presets: ResolvedConfigItem[];
+  options: string;
+}
+
+const defaultConfigComparisonCache = new Map<string, ConfigComparison>();
+
+function toConfigComparison(options: TransformOptions): ConfigComparison {
+  return {
+    plugins: (options.plugins ?? []) as ResolvedConfigItem[],
+    presets: (options.presets ?? []) as ResolvedConfigItem[],
+    options: JSON.stringify(comparablePartialOptions(options)),
+  };
+}
+
+/**
+ * Resolves the project config through Babel and compares its effective top-level
+ * configuration with Expo's default preset. This deliberately compares resolved
+ * descriptors rather than config filenames or source text.
+ */
+function isDefaultConfig({ filename, options, plugins = [] }: BabelTransformerArgs): boolean {
+  if (options.enableBabelRCLookup === false) return true;
+  const configName = options.extendsBabelConfigPath ?? resolveBabelrcName(options.projectRoot);
+  if (!configName) return true;
+
+  const shared: TransformOptions = {
+    sourceType: 'unambiguous',
+    cwd: options.projectRoot,
+    root: options.projectRoot,
+    filename,
+    babelrc: false,
+    configFile: false,
+    cloneInputAst: false,
+    caller: getBabelCaller({ filename, options }),
+    plugins,
+  };
+  try {
+    const configured = loadPartialConfigSync({
+      ...shared,
+      extends: path.resolve(options.projectRoot, configName),
+    });
+    if (!configured) return false;
+    const baselineKey = JSON.stringify({
+      caller: shared.caller,
+      cwd: shared.cwd,
+      root: shared.root,
+      sourceType: shared.sourceType,
+    });
+    let baseline = defaultConfigComparisonCache.get(baselineKey);
+    if (!baseline) {
+      const partial = loadPartialConfigSync({
+        ...shared,
+        // The default descriptor does not expand the preset, so it does not vary
+        // by filename. Cache it by the caller and resolution roots, while still
+        // resolving the project config for every filename so Babel overrides
+        // remain authoritative.
+        presets: [getDefaultExpoPreset()],
+      });
+      if (!partial) return false;
+      baseline = toConfigComparison(partial.options);
+      defaultConfigComparisonCache.set(baselineKey, baseline);
+    }
+    const comparison = toConfigComparison(configured.options);
+    const configuredPlugins = comparison.plugins;
+    const baselinePlugins = baseline.plugins;
+    if (
+      configuredPlugins.length !== baselinePlugins.length ||
+      configuredPlugins.some(
+        (descriptor, index) =>
+          descriptor.value !== baselinePlugins[index]?.value ||
+          JSON.stringify(descriptor.options) !== JSON.stringify(baselinePlugins[index]?.options)
+      )
+    ) {
+      return false;
+    }
+    const configuredPresets = comparison.presets;
+    const baselinePresets = baseline.presets;
+    if (
+      configuredPresets.length !== baselinePresets.length ||
+      configuredPresets.some(
+        (descriptor, index) =>
+          descriptor.value !== baselinePresets[index]?.value ||
+          JSON.stringify(descriptor.options) !== JSON.stringify(baselinePresets[index]?.options)
+      )
+    ) {
+      return false;
+    }
+    return comparison.options === baseline.options;
+  } catch {
+    // Babel remains the source of truth when config resolution is ambiguous.
+    return false;
+  }
+}
+
 const transform: BabelTransformer['transform'] = ({
   filename,
   src,
@@ -287,9 +411,13 @@ function getCacheKey(options?: BabelTransformerCacheKeyOptions): string {
   return getFileCacheKey([...files].sort());
 }
 
-const babelTransformer: BabelTransformer = {
+const babelTransformer: BabelTransformer & {
+  isDefaultConfig: typeof isDefaultConfig;
+} = {
   transform,
   getCacheKey,
+  // This is an Expo extension consumed by the matching Metro worker.
+  isDefaultConfig,
 };
 
 module.exports = babelTransformer;

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/metro-transform-worker.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/__snapshots__/metro-transform-worker.test.ts.snap
@@ -2,13 +2,26 @@
 
 exports[`allows the constantFoldingPlugin to not remove used helpers when \`dev: false\` 1`] = `
 "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  var _interopRequireWildcard = _$$_REQUIRE(_dependencyMap[0]).default;
-  Object.defineProperty(exports, "__esModule", {
-    value: true
+Object.defineProperty(exports, '__esModule', { value: true });
+function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () { return e[k]; }
+    });
   });
-  exports.test = void 0;
-  var test = _interopRequireWildcard(_$$_REQUIRE(_dependencyMap[1]));
-  exports.test = test;
+  n.default = e;
+  return n;
+}
+Object.defineProperty(exports, "test", { enumerable: true, get: function () { return test; } });
+var _testModule = _$$_REQUIRE(_dependencyMap[0], "test-module");
+var test = _interopNamespace(_testModule);
+
+
+
 });"
 `;
 
@@ -43,19 +56,22 @@ exports[`transforms a simple script 1`] = `
 
 exports[`transforms an es module with asyncToGenerator 1`] = `
 "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
-  exports.test = test;
-  var _asyncToGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], "@babel/runtime/helpers/asyncToGenerator"));
-  function test() {
-    return _test.apply(this, arguments);
-  }
-  function _test() {
-    _test = (0, _asyncToGenerator2.default)(function* () {});
-    return _test.apply(this, arguments);
-  }
+Object.defineProperty(exports, '__esModule', { value: true });
+function _interopDefault(e) {
+  return e && e.__esModule ? e : { default: e };
+}
+exports.test = test;
+var _babelRuntimeHelpersAsyncToGenerator = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/asyncToGenerator");
+var _asyncToGenerator = _interopDefault(_babelRuntimeHelpersAsyncToGenerator);
+
+function test() {
+	return _test.apply(this, arguments);
+}
+function _test() {
+	_test = (0, _asyncToGenerator.default)(function* () {});
+	return _test.apply(this, arguments);
+}
+
 });"
 `;
 
@@ -71,22 +87,24 @@ exports[`transforms an es module with asyncToGenerator 2`] = `
 
 exports[`transforms async generators 1`] = `
 "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
-  exports.test = test;
-  var _awaitAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], "@babel/runtime/helpers/awaitAsyncGenerator"));
-  var _wrapAsyncGenerator2 = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[2], "@babel/runtime/helpers/wrapAsyncGenerator"));
-  function test() {
-    return _test.apply(this, arguments);
-  }
-  function _test() {
-    _test = (0, _wrapAsyncGenerator2.default)(function* () {
-      yield "ok";
-    });
-    return _test.apply(this, arguments);
-  }
+Object.defineProperty(exports, '__esModule', { value: true });
+function _interopDefault(e) {
+  return e && e.__esModule ? e : { default: e };
+}
+exports.test = test;
+var _babelRuntimeHelpersWrapAsyncGenerator = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/wrapAsyncGenerator");
+var _wrapAsyncGenerator = _interopDefault(_babelRuntimeHelpersWrapAsyncGenerator);
+
+function test() {
+	return _test.apply(this, arguments);
+}
+function _test() {
+	_test = (0, _wrapAsyncGenerator.default)(function* () {
+		yield "ok";
+	});
+	return _test.apply(this, arguments);
+}
+
 });"
 `;
 

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/metro-transform-worker.test.ts
@@ -87,7 +87,7 @@ const HEADER_PROD = '__d(function (g, r, i, a, m, e, d) {';
 // let fs: typeof import('fs');
 let Transformer: typeof import('../metro-transform-worker');
 
-const baseConfig: JsTransformerConfig = {
+const baseConfig = {
   allowOptionalDependencies: false,
   assetPlugins: [],
   assetRegistryPath: '',
@@ -107,7 +107,8 @@ const baseConfig: JsTransformerConfig = {
   unstable_disableModuleWrapping: false,
   unstable_disableNormalizePseudoGlobals: false,
   unstable_allowRequireContext: false,
-};
+  unstable_noxcturnalTransformWorker: true,
+} as JsTransformerConfig & { unstable_noxcturnalTransformWorker: boolean };
 
 const baseTransformOptions: JsTransformOptions = {
   dev: true,
@@ -139,6 +140,97 @@ beforeEach(() => {
   fs.writeFileSync(babelTransformerPath, transformerContents);
 });
 
+it('keeps the Noxcturnal transform worker disabled by default', async () => {
+  const noxcturnal = require('noxcturnal') as typeof import('noxcturnal');
+  const transform = jest.spyOn(noxcturnal, 'transform');
+  const config = { ...baseConfig, unstable_noxcturnalTransformWorker: undefined };
+
+  try {
+    await Transformer.transform(
+      config,
+      '/root',
+      'local/file.js',
+      Buffer.from('module.exports = 1;', 'utf8'),
+      baseTransformOptions
+    );
+    expect(transform).not.toHaveBeenCalled();
+  } finally {
+    transform.mockRestore();
+  }
+});
+
+it('runs native React Compiler and Refresh through the full Metro path', async () => {
+  const contents = `type Props = { value: number };
+export function Component(props: Props) {
+  return <View>{props.value}</View>;
+}`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/Component.tsx',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      experimentalImportSupport: false,
+      customTransformOptions: {
+        __proto__: null,
+        engine: 'hermes',
+        reactCompiler: 'true',
+      },
+    }
+  );
+  const output = result.output[0]!;
+
+  expect(output.data.code).toContain('react/compiler-runtime');
+  expect(output.data.code).toMatch(/reactcompilerruntime\.c\)\(2\)/i);
+  expect(output.data.code).toContain('$RefreshReg$');
+  expect(output.data.code).not.toContain('type Props');
+  expect(output.data.code).not.toContain('<View>');
+
+  const generatedOffset = output.data.code.indexOf('function Component');
+  const generatedPrefix = output.data.code.slice(0, generatedOffset);
+  const generatedLines = generatedPrefix.split('\n');
+  const original = originalPositionFor(toTraceMap(output, contents), {
+    line: generatedLines.length,
+    column: generatedLines.at(-1)!.length,
+  });
+  expect(original.line).toBe(2);
+});
+
+it('maps errors inside JSX callbacks to the throwing expression', async () => {
+  const contents = `export default function App() {
+  return <BigButton
+    title="throw new Error()"
+    onPress={() => {
+      throw new Error('unhandled-throw');
+    }}
+  />;
+}`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    'local/App.tsx',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      platform: 'web',
+      customTransformOptions: { __proto__: null, engine: 'hermes' },
+    }
+  );
+  const output = result.output[0]!;
+  const messageOffset = output.data.code.indexOf('unhandled-throw');
+  const generatedOffset = output.data.code.lastIndexOf('new Error', messageOffset);
+  expect(generatedOffset).not.toBe(-1);
+  const generatedPrefix = output.data.code.slice(0, generatedOffset);
+  const generatedLines = generatedPrefix.split('\n');
+  expect(
+    originalPositionFor(toTraceMap(output, contents), {
+      line: generatedLines.length,
+      column: generatedLines.at(-1)!.length,
+    })
+  ).toMatchObject({ line: 5, column: 12 });
+});
+
 it('transforms a simple script', async () => {
   const contents = 'someReallyArbitrary(code)';
 
@@ -154,7 +246,7 @@ it('transforms a simple script', async () => {
   expect(result.output[0]!.data.code).toBe(
     [
       '(function (global) {',
-      '  someReallyArbitrary(code);',
+      'someReallyArbitrary(code);',
       "})(typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : this);",
     ].join('\n')
   );
@@ -163,31 +255,19 @@ it('transforms a simple script', async () => {
 
   expect(generatedPositionFor(trace, { source: '', line: 1, column: 0 })).toMatchObject({
     line: 2,
-    column: 2,
+    column: 0,
   });
 
   expect(originalPositionFor(trace, { line: 2, column: 2 })).toMatchObject({
     line: 1,
     column: 0,
-    name: 'someReallyArbitrary',
+    name: null,
   });
 
-  // NOTE: If downgraded below @babel/generator@7.21.0, names will be missing here
-  expect(originalPositionFor(trace, { line: 3, column: 10 })).toMatchObject({
-    line: 1,
-    column: 25,
-    name: 'globalThis',
-  });
-  expect(originalPositionFor(trace, { line: 3, column: 59 })).toMatchObject({
-    line: 1,
-    column: 25,
-    name: 'global',
-  });
-  expect(originalPositionFor(trace, { line: 3, column: 100 })).toMatchObject({
-    line: 1,
-    column: 25,
-    name: 'window',
-  });
+  // The generated polyfill wrapper is deliberately sourceless.
+  expect(originalPositionFor(trace, { line: 3, column: 10 }).line).toBeNull();
+  expect(originalPositionFor(trace, { line: 3, column: 59 }).line).toBeNull();
+  expect(originalPositionFor(trace, { line: 3, column: 100 }).line).toBeNull();
 
   expect(result.output[0]!.data.functionMap).toMatchSnapshot();
   expect(result.dependencies).toEqual([]);
@@ -208,28 +288,682 @@ it('transforms a simple module', async () => {
 
   expect(generatedPositionFor(trace, { source: '', line: 1, column: 0 })).toMatchObject({
     line: 2,
-    column: 2,
+    column: 0,
   });
-  expect(generatedPositionFor(trace, { source: '', line: 1, column: 10 })).toMatchObject({
-    line: 2,
-    column: 12,
-  });
-
-  expect(originalPositionFor(trace, { line: 2, column: 2 })).toMatchObject({
+  expect(originalPositionFor(trace, { line: 2, column: 0 })).toMatchObject({
     line: 1,
     column: 0,
-    name: 'arbitrary',
+    name: null,
   });
-  expect(originalPositionFor(trace, { line: 2, column: 12 })).toMatchObject({
-    line: 1,
-    column: 10,
-    name: 'code',
-  });
-
   expect(result.output[0]!.type).toBe('js/module');
-  expect(result.output[0]!.data.code).toBe([HEADER_DEV, '  arbitrary(code);', '});'].join('\n'));
+  expect(result.output[0]!.data.code).toBe([HEADER_DEV, 'arbitrary(code);', '', '});'].join('\n'));
   expect(result.output[0]!.data.functionMap).toMatchSnapshot();
   expect(result.dependencies).toEqual([]);
+});
+
+it('uses Noxcturnal instead of the Babel preset for eligible node_modules', async () => {
+  const contents = `module.exports = [process.env.EXPO_OS, process.env.NODE_ENV, __DEV__, require('dep')];`;
+
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).toMatch(
+    /module\.exports = \[\s*"ios",\s*"production",\s*false,\s*_\$\$_REQUIRE\(_dependencyMap\[0\]\)\s*\]/
+  );
+  expect(result.output[0]!.data.hasCjsExports).toBe(true);
+  expect(result.output[0]!.data.functionMap).toEqual({
+    mappings: 'AAA',
+    names: ['<global>'],
+  });
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(['dep']);
+
+  const trace = toTraceMap(result.output[0]!, contents);
+  expect(originalPositionFor(trace, { line: 6, column: 2 })).toMatchObject({
+    line: 1,
+    column: 70,
+  });
+});
+
+it.each([
+  '\0polyfill:environment-variables',
+  '/root/router-e2e?ctx=1122149ada429c11a789cd9dfdcaefb64b6dd8f5',
+])('uses the full native path for extensionless virtual module %s', async (filename) => {
+  const contents = `module.exports= require('dep');`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      experimentalImportSupport: true,
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).toMatch(
+    /module\.exports\s*=\s*_\$\$_REQUIRE\(_dependencyMap\[0\], "dep"\);/
+  );
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(['dep']);
+});
+
+it.each(['/repo/packages/expo/virtual/streams.js', '\0polyfill:environment-variables'])(
+  'uses the full native path to wrap script polyfill %s',
+  async (filename) => {
+    const contents = `globalThis.ReadableStream ||= require('stream/web').ReadableStream;`;
+    const result = await Transformer.transform(
+      baseConfig,
+      '/root',
+      filename,
+      Buffer.from(contents, 'utf8'),
+      {
+        ...baseTransformOptions,
+        type: 'script',
+        experimentalImportSupport: true,
+        customTransformOptions: { engine: 'hermes' },
+      }
+    );
+
+    expect(result.output[0]!.type).toBe('js/script');
+    expect(result.output[0]!.data.code).toMatch(/^\(function \(global\) \{/);
+    expect(result.output[0]!.data.code).toContain('globalThis.ReadableStream');
+    expect(result.output[0]!.data.code).not.toContain('__d(function');
+    expect(result.dependencies).toEqual([]);
+  }
+);
+
+it('uses the full native path and configured minifier for production application TSX', async () => {
+  const contents = `type Props = { code: unknown };
+export function App({ code }: Props) {
+  return <View testID="value">{arbitrary(code)}</View>;
+}`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/local/App.tsx',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      minify: true,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toMatch(/\btype Props\b|<View/);
+  expect(result.output[0]!.data.code).toContain('minified(code)');
+  expect(result.dependencies.map((dependency) => dependency.name)).toContain('react/jsx-runtime');
+  const trace = toTraceMap(result.output[0]!, contents);
+  const marker = result.output[0]!.data.code.indexOf('function App');
+  const prefix = result.output[0]!.data.code.slice(0, marker).split('\n');
+  expect(
+    originalPositionFor(trace, {
+      line: prefix.length,
+      column: prefix.at(-1)!.length,
+    }).line
+  ).toBe(2);
+});
+
+it('uses the full native path for plain production application JavaScript', async () => {
+  const contents = `export { value } from './value';`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/src/config.js',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).toContain('__d(function');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(['./value']);
+});
+
+it('uses the full native path for production Node application TSX', async () => {
+  const contents = `import value from './value';
+export default function Route(): JSX.Element {
+  return <main>{typeof window}:{value}</main>;
+}`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/routes/render.tsx',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes', environment: 'node' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toMatch(/JSX\.Element|<main>|typeof window/);
+  expect(result.output[0]!.data.code).toContain('"undefined"');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(
+    expect.arrayContaining(['./value', 'react/jsx-runtime'])
+  );
+});
+
+it('uses the full native path for ordinary production web TSX', async () => {
+  const contents = `import value from './value';
+export default function Route(): JSX.Element {
+  return <main>{value}</main>;
+}`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/web/route.tsx',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      platform: 'web',
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'default',
+      customTransformOptions: {},
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toMatch(/JSX\.Element|<main>/);
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(
+    expect.arrayContaining(['./value', 'react/jsx-runtime'])
+  );
+});
+
+it('rewrites React Native imports through the complete native web path', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/web/route.tsx',
+    Buffer.from(
+      `import { View, Text as Label } from 'react-native';
+export default function Route() {
+  return <View><Label>native web</Label></View>;
+}`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      platform: 'web',
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'default',
+      customTransformOptions: {},
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toMatch(/<View>|from ['"]react-native['"]/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(
+    expect.arrayContaining([
+      'react-native-web/dist/exports/View',
+      'react-native-web/dist/exports/Text',
+      'react/jsx-runtime',
+    ])
+  );
+});
+
+it('inlines APP_MANIFEST through the complete native web path', async () => {
+  const previousManifest = process.env.APP_MANIFEST;
+  process.env.APP_MANIFEST = '{"name":"worker-native"}';
+  try {
+    const result = await Transformer.transform(
+      baseConfig,
+      '/root',
+      '/root/web/constants.js',
+      Buffer.from('const manifest = process.env.APP_MANIFEST; module.exports = manifest;', 'utf8'),
+      {
+        ...baseTransformOptions,
+        dev: false,
+        platform: 'web',
+        experimentalImportSupport: true,
+        unstable_transformProfile: 'default',
+        customTransformOptions: {},
+      }
+    );
+
+    expect(result.output[0]!.data.code).toContain(String.raw`{\"name\":\"worker-native\"}`);
+    expect(result.output[0]!.data.code).not.toContain('process.env.APP_MANIFEST');
+  } finally {
+    if (previousManifest === undefined) delete process.env.APP_MANIFEST;
+    else process.env.APP_MANIFEST = previousManifest;
+  }
+});
+
+it('tree-shakes @expo/ui Icon.select through the complete native path', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/app/icon.js',
+    Buffer.from(
+      `import { Icon } from '@expo/ui';
+export const icon = Icon.select({ ios: 'heart.fill', android: import('./heart.xml') });`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      platform: 'ios',
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).toContain('heart.fill');
+  expect(result.output[0]!.data.code).not.toMatch(/Icon\.select|heart\.xml/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['@expo/ui']);
+});
+
+it('serializes widget functions through the complete native path', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/app/widget.tsx',
+    Buffer.from(
+      `export function Greeting({ name }: { name: string }) {
+  'widget';
+  return <Text>{name}</Text>;
+}`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      platform: 'ios',
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toContain("'widget'");
+  expect(result.output[0]!.data.code).toContain('var Greeting = `function');
+  expect(result.output[0]!.data.code).toContain('jsx');
+});
+
+it('preserves Babel diagnostics for precise restricted imports', async () => {
+  await expect(
+    Transformer.transform(
+      baseConfig,
+      '/root',
+      '/root/app/client.js',
+      Buffer.from(`import value from 'server-only';`, 'utf8'),
+      {
+        ...baseTransformOptions,
+        dev: false,
+        platform: 'ios',
+        experimentalImportSupport: true,
+        unstable_transformProfile: 'hermes-stable',
+        customTransformOptions: { engine: 'hermes' },
+      }
+    )
+  ).rejects.toThrow("Importing 'server-only' module is not allowed in a client component.");
+});
+
+it('creates and propagates native React Server client references', async () => {
+  const filename = '/root/app/client.tsx';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from(
+      `"use client";
+export const value: number = 1;
+export default function Component() { return <View />; }`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: false,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: {
+        engine: 'hermes',
+        environment: 'react-server',
+      },
+    }
+  );
+  const output = result.output[0]!;
+
+  expect(output.data.code).toContain('createClientModuleProxy');
+  expect(output.data.code).toContain('registerClientReference');
+  expect(output.data.code).not.toContain('<View');
+  expect(output.data.reactClientReference).toBe('file:///root/app/client.tsx');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual([
+    'react-server-dom-webpack/server',
+  ]);
+});
+
+it('creates and propagates native DOM component references', async () => {
+  const filename = '/root/app/Card.tsx';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from(
+      `"use dom";
+export default function Card({ title }: { title: string }) {
+  return <main>{title}</main>;
+}`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: true,
+      experimentalImportSupport: false,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+  const output = result.output[0]!;
+
+  expect(output.data.code).toContain('expo/dom/internal');
+  expect(output.data.code).toContain('DOM(Card)');
+  expect(output.data.code).not.toContain('<main');
+  expect(output.data.expoDomComponentReference).toBe('file:///root/app/Card.tsx');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual([
+    'react',
+    'expo/dom/internal',
+  ]);
+});
+
+it('creates and propagates native client-side server references', async () => {
+  const filename = '/root/app/actions.ts';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from(
+      `"use server";
+export async function save() { return 1; }
+export default async function reset() { return 2; }`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: false,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+  const output = result.output[0]!;
+
+  expect(output.data.code).toContain('createServerReference');
+  expect(output.data.code).toContain('./app/actions.ts#save');
+  expect(output.data.code).not.toContain('return 1');
+  expect(output.data.reactServerReference).toBe('file:///root/app/actions.ts');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual([
+    'react-server-dom-webpack/client',
+    'expo-router/rsc/internal',
+  ]);
+});
+
+it('registers and propagates native module-level React Server actions', async () => {
+  const filename = '/root/app/server-actions.ts';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from(
+      `"use server";
+export async function save() { return 1; }
+export const remove = async () => 2;`,
+      'utf8'
+    ),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: false,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: {
+        engine: 'hermes',
+        environment: 'react-server',
+      },
+    }
+  );
+  const output = result.output[0]!;
+
+  expect(output.data.code).toContain('registerServerReference');
+  expect(output.data.code).toContain('./app/server-actions.ts');
+  expect(output.data.code).not.toContain('"use server"');
+  expect(output.data.reactServerReference).toBe('file:///root/app/server-actions.ts');
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual([
+    'react-server-dom-webpack/server',
+  ]);
+});
+
+it('uses native source transforms and preserves graph-optimization reconciliation metadata', async () => {
+  const contents = `import primary, { alpha } from 'pkg';
+export { beta } from 'reexport';
+export const output = [primary, alpha];`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes', optimize: true },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toContain('__d(function');
+  expect(result.output[0]!.data.code).toMatch(/from ["']pkg["']/);
+  expect(result.output[0]!.data.ast).toBeDefined();
+  expect(result.output[0]!.data.reconcile).toBeDefined();
+  expect(() => JSON.stringify(result.output[0]!.data.ast)).not.toThrow();
+  expect(
+    result.dependencies.map((dependency) => [dependency.name, dependency.data.exportNames])
+  ).toEqual([
+    ['pkg', ['default', 'alpha']],
+    ['reexport', ['beta']],
+  ]);
+});
+
+it('finalizes native dependency export metadata without exposing its mutable sets', async () => {
+  const contents = `import 'side-effect';
+import primary from 'default-import';
+import * as namespace from 'namespace-import';
+import { alpha as a, duplicate as d1 } from 'pkg';
+import { beta as b, duplicate as d2 } from 'pkg';
+import { gamma as g, alpha as a2 } from 'pkg';
+export { first as publicFirst } from 'reexports';
+export { second as publicSecond, first as alternateFirst } from 'reexports';
+const commonOne = require('commonjs');
+const commonTwo = require('commonjs');
+export default [primary, namespace, a, d1, b, d2, g, a2, commonOne, commonTwo];`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes', optimize: true },
+    }
+  );
+
+  const dependencies = new Map(
+    result.dependencies.map((dependency) => [dependency.name, dependency] as const)
+  );
+  expect([...dependencies.keys()]).toEqual([
+    'side-effect',
+    'default-import',
+    'namespace-import',
+    'pkg',
+    'reexports',
+    'commonjs',
+  ]);
+  expect(dependencies.get('commonjs')).toMatchObject({
+    data: { exportNames: ['*'], imports: 2, isESMImport: false },
+  });
+  expect(dependencies.get('side-effect')).toMatchObject({
+    data: { exportNames: [], imports: 1, isESMImport: true },
+  });
+  expect(dependencies.get('default-import')).toMatchObject({
+    data: { exportNames: ['default'], imports: 1, isESMImport: true },
+  });
+  expect(dependencies.get('namespace-import')).toMatchObject({
+    data: { exportNames: ['*'], imports: 1, isESMImport: true },
+  });
+  expect(dependencies.get('pkg')).toMatchObject({
+    data: {
+      exportNames: ['alpha', 'duplicate', 'beta', 'gamma'],
+      imports: 3,
+      isESMImport: true,
+    },
+  });
+  expect(dependencies.get('reexports')).toMatchObject({
+    data: { exportNames: ['first', 'second'], imports: 2, isESMImport: true },
+  });
+  for (const dependency of result.dependencies) {
+    expect(Object.keys(dependency)).not.toContain('exportNameSet');
+  }
+  expect(JSON.stringify(result.dependencies)).not.toContain('exportNameSet');
+});
+
+it('uses Noxcturnal for the complete Metro transform of eligible dependencies', async () => {
+  const contents = `var oddly_spaced= require('dep');\nmodule.exports=oddly_spaced;`;
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from(contents, 'utf8'),
+    {
+      ...baseTransformOptions,
+      experimentalImportSupport: true,
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).toBe(
+    [
+      HEADER_DEV,
+      `var oddly_spaced= _$$_REQUIRE(_dependencyMap[0], "dep");`,
+      'module.exports=oddly_spaced;',
+      '});',
+    ].join('\n')
+  );
+  expect(result.output[0]!.data.hasCjsExports).toBe(true);
+  expect(result.dependencies).toEqual([
+    {
+      name: 'dep',
+      data: expect.objectContaining({
+        asyncType: null,
+        imports: 1,
+        isESMImport: false,
+      }),
+    },
+  ]);
+
+  const trace = toTraceMap(result.output[0]!, contents);
+  expect(generatedPositionFor(trace, { source: '', line: 1, column: 0 })).toMatchObject({
+    line: 2,
+    column: 0,
+  });
+});
+
+it('propagates native Expo Router loader metadata through the worker result', async () => {
+  const filename = '/root/app/route.js';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from('export async function loader() { return null; } export const value = 1;', 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toContain('loader');
+  expect(result.output[0]!.data.code).toContain('value');
+  expect(result.output[0]!.data.loaderReference).toBe(filename);
+});
+
+it('propagates native Expo Router loader metadata for optimized non-Hermes web bundles', async () => {
+  const filename = '/root/routes/route.js';
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    filename,
+    Buffer.from('export async function loader() { return null; } export const value = 1;', 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      platform: 'web',
+      experimentalImportSupport: true,
+      customTransformOptions: { routerRoot: 'routes', optimize: true },
+    }
+  );
+
+  expect(result.output[0]!.data.code).not.toContain('loader');
+  expect(result.output[0]!.data.code).toContain('value');
+  expect(result.output[0]!.data.loaderReference).toBe(filename);
+});
+
+it('runs the configured minifier after a complete native dependency transform', async () => {
+  const result = await Transformer.transform(
+    baseConfig,
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from('module.exports = arbitrary(code);', 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      minify: true,
+      experimentalImportSupport: true,
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+  expect(result.output[0]!.data.code).toContain('minified(code)');
+});
+
+it('collects optional dependencies through the complete native path', async () => {
+  const result = await Transformer.transform(
+    { ...baseConfig, allowOptionalDependencies: true },
+    '/root',
+    '/root/node_modules/example/index.js',
+    Buffer.from(`try { module.exports = require('optional-package'); } catch {}`, 'utf8'),
+    {
+      ...baseTransformOptions,
+      dev: false,
+      experimentalImportSupport: true,
+      customTransformOptions: { engine: 'hermes' },
+    }
+  );
+  expect(result.dependencies).toHaveLength(1);
+  expect(result.dependencies[0]!.name).toBe('optional-package');
+  expect(result.dependencies[0]!.data.isOptional).toBe(true);
+  expect(result.output[0]!.data.code).toContain('"optional-package"');
 });
 
 it('transforms a module with dependencies', async () => {
@@ -253,13 +987,13 @@ it('transforms a module with dependencies', async () => {
   expect(result.output[0]!.data.code).toBe(
     [
       HEADER_DEV,
-      '  "use strict";',
+      '"use strict";',
+      '_$$_REQUIRE(_dependencyMap[2], "./c");',
+      '_$$_REQUIRE(_dependencyMap[0], "./a");',
+      'arbitrary(code);',
+      'var b = _$$_REQUIRE(_dependencyMap[1], "b");',
       '',
-      '  var _interopRequireDefault = _$$_REQUIRE(_dependencyMap[0], "@babel/runtime/helpers/interopRequireDefault").default;',
-      '  var _c = _interopRequireDefault(_$$_REQUIRE(_dependencyMap[1], "./c"));',
-      '  _$$_REQUIRE(_dependencyMap[2], "./a");',
-      '  arbitrary(code);',
-      '  var b = _$$_REQUIRE(_dependencyMap[3], "b");',
+      '',
       '});',
     ].join('\n')
   );
@@ -268,56 +1002,25 @@ it('transforms a module with dependencies', async () => {
 
   expect(
     generatedPositionFor(trace, { source: '', line: 2, column: 0 } /* require("./a") */)
-  ).toMatchObject({ line: 6, column: 2 });
+  ).toMatchObject({ line: 4, column: 0 });
 
-  expect(originalPositionFor(trace, { line: 7, column: 2 })).toMatchObject({
+  expect(originalPositionFor(trace, { line: 5, column: 0 })).toMatchObject({
     line: 3,
     column: 0,
-    name: 'arbitrary',
+    name: null,
   });
-  expect(originalPositionFor(trace, { line: 8, column: 6 })).toMatchObject({
+  expect(originalPositionFor(trace, { line: 6, column: 6 })).toMatchObject({
     line: 4,
     column: 6,
-    name: 'b',
-  });
-  expect(originalPositionFor(trace, { line: 8, column: 6 })).toMatchObject({
-    line: 4,
-    column: 6,
-    name: 'b',
-  });
-
-  // NOTE: If downgraded below @babel/generator@7.21.0, names will be missing here
-  expect(originalPositionFor(trace, { line: 5, column: 6 })).toMatchObject({
-    line: 5,
-    column: 0,
-    name: '_c',
-  });
-  expect(originalPositionFor(trace, { line: 4, column: 6 })).toMatchObject({
-    line: 1,
-    column: 13,
-    name: '_interopRequireDefault',
-  });
-  expect(originalPositionFor(trace, { line: 4, column: 31 })).toMatchObject({
-    line: 1,
-    column: 13,
-    name: '_$$_REQUIRE',
-  });
-  expect(originalPositionFor(trace, { line: 4, column: 43 })).toMatchObject({
-    line: 1,
-    column: 13,
-    name: '_dependencyMap',
+    name: null,
   });
 
   expect(result.output[0]!.data.functionMap).toMatchSnapshot();
 
   expect(result.dependencies).toEqual([
-    {
-      data: expect.objectContaining({ asyncType: null }),
-      name: '@babel/runtime/helpers/interopRequireDefault',
-    },
-    { data: expect.objectContaining({ asyncType: null }), name: './c' },
     { data: expect.objectContaining({ asyncType: null }), name: './a' },
     { data: expect.objectContaining({ asyncType: null }), name: 'b' },
+    { data: expect.objectContaining({ asyncType: null }), name: './c' },
   ]);
 });
 
@@ -338,23 +1041,19 @@ it('transforms an es module with asyncToGenerator', async () => {
   const trace = toTraceMap(result.output[0]!, contents);
 
   expect(generatedPositionFor(trace, { source: '', line: 1, column: 12 })).toMatchObject({
-    line: 12,
-    column: 44,
+    line: 10,
+    column: 0,
   });
 
-  expect(originalPositionFor(trace, { line: 8, column: 11 })).toMatchObject({
+  expect(originalPositionFor(trace, { line: 10, column: 9 })).toMatchObject({
     line: 1,
     column: 22,
-    name: 'test',
+    name: null,
   });
 
   expect(result.output[0]!.data.functionMap).toMatchSnapshot();
 
   expect(result.dependencies).toEqual([
-    {
-      data: expect.objectContaining({ asyncType: null }),
-      name: '@babel/runtime/helpers/interopRequireDefault',
-    },
     {
       data: expect.objectContaining({ asyncType: null }),
       name: '@babel/runtime/helpers/asyncToGenerator',
@@ -373,14 +1072,6 @@ it('transforms async generators', async () => {
 
   expect(result.output[0]!.data.code).toMatchSnapshot();
   expect(result.dependencies).toEqual([
-    {
-      data: expect.objectContaining({ asyncType: null }),
-      name: '@babel/runtime/helpers/interopRequireDefault',
-    },
-    {
-      data: expect.objectContaining({ asyncType: null }),
-      name: '@babel/runtime/helpers/awaitAsyncGenerator',
-    },
     {
       data: expect.objectContaining({ asyncType: null }),
       name: '@babel/runtime/helpers/wrapAsyncGenerator',
@@ -404,37 +1095,24 @@ it('transforms import/export syntax when experimental flag is on', async () => {
   expect(result.output[0]!.data.code).toBe(
     [
       HEADER_DEV,
-      '  "use strict";',
+      'function _interopDefault(e) {',
+      '  return e && e.__esModule ? e : { default: e };',
+      '}',
+      'var _c = _$$_REQUIRE(_dependencyMap[0], "./c");',
+      'var c = _interopDefault(_c);',
       '',
-      '  function _interopDefault(e) {',
-      '    return e && e.__esModule ? e : {',
-      '      default: e',
-      '    };',
-      '  }',
-      '  var _c = _$$_REQUIRE(_dependencyMap[0], "./c");',
-      '  var c = _interopDefault(_c);',
-      '  test(c.default);',
+      'test(c.default);',
+      '',
       '});',
     ].join('\n')
   );
 
   const trace = toTraceMap(result.output[0]!, contents);
 
-  expect(generatedPositionFor(trace, { source: '', line: 1, column: 7 })).toMatchObject({
-    line: 10,
-    column: 28,
-  });
-
-  expect(originalPositionFor(trace, { line: 11, column: 7 })).toMatchObject({
+  expect(originalPositionFor(trace, { line: 8, column: 5 })).toMatchObject({
     line: 1,
     column: 26,
-    name: 'c',
-  });
-
-  expect(originalPositionFor(trace, { line: 9, column: 30 })).toMatchObject({
-    line: 1,
-    column: 0,
-    name: '_dependencyMap',
+    name: null,
   });
 
   expect(result.output[0]!.data.functionMap).toMatchSnapshot();
@@ -459,9 +1137,7 @@ it('does not add "use strict" on non-modules', async () => {
   );
 
   expect(result.output[0]!.type).toBe('js/module');
-  expect(result.output[0]!.data.code).toBe(
-    [HEADER_DEV, '  module.exports = {};', '});'].join('\n')
-  );
+  expect(result.output[0]!.data.code).toBe([HEADER_DEV, 'module.exports = {};', '});'].join('\n'));
 });
 
 it('preserves require() calls when module wrapping is disabled', async () => {
@@ -479,7 +1155,7 @@ it('preserves require() calls when module wrapping is disabled', async () => {
   );
 
   expect(result.output[0]!.type).toBe('js/module');
-  expect(result.output[0]!.data.code).toBe('require("./c");');
+  expect(result.output[0]!.data.code).toBe('require("./c");\n');
 });
 
 it('reports filename when encountering unsupported dynamic dependency', async () => {
@@ -537,7 +1213,7 @@ it('minifies the code correctly', async () => {
         { ...baseTransformOptions, minify: true }
       )
     ).output[0]!.data.code
-  ).toBe([HEADER_PROD, '  minified(code);', '});'].join('\n'));
+  ).toBe([HEADER_PROD, 'minified(code);', '', '});'].join('\n'));
 });
 
 it('minifies a JSON file', async () => {
@@ -587,7 +1263,8 @@ it('uses a reserved dependency map name and prevents it from being minified', as
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (g, r, i, a, m, e, THE_DEP_MAP) {
-      minified(code);
+    minified(code);
+
     });"
   `);
 });
@@ -619,7 +1296,8 @@ it('allows disabling the normalizePseudoGlobals pass when minifying', async () =
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-      minified(code);
+    minified(code);
+
     });"
   `);
 });
@@ -633,7 +1311,7 @@ it('allows emitting compact code when not minifying', async () => {
     { ...baseTransformOptions, dev: false, minify: false }
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(
-    `"__d(function(global,_$$_REQUIRE,_$$_IMPORT_DEFAULT,_$$_IMPORT_ALL,module,exports,_dependencyMap){arbitrary(code);});"`
+    `"__d(function(global,_$$_REQUIRE,_$$_IMPORT_DEFAULT,_$$_IMPORT_ALL,module,exports,_dependencyMap){arbitrary(code)});"`
   );
 });
 
@@ -653,7 +1331,8 @@ it('skips minification in Hermes stable transform profile', async () => {
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-      arbitrary(code);
+    arbitrary(code);
+
     });"
   `);
 });
@@ -674,7 +1353,8 @@ it('skips minification in Hermes canary transform profile', async () => {
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-      arbitrary(code);
+    arbitrary(code);
+
     });"
   `);
 });
@@ -694,7 +1374,8 @@ it('minifies with Hermes transform profile if bytecode is disabled', async () =>
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (g, r, i, a, m, e, d) {
-      minified(code);
+    minified(code);
+
     });"
   `);
 });
@@ -726,7 +1407,7 @@ it('outputs comments when `minify: false`', async () => {
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
-      /*#__PURE__*/arbitrary(code);
+    /*#__PURE__*/arbitrary(code);
     });"
   `);
 });
@@ -741,7 +1422,8 @@ it('omits comments when `minify: true`', async () => {
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (g, r, i, a, m, e, d) {
-      minified(code);
+     minified(code);
+
     });"
   `);
 });
@@ -756,7 +1438,7 @@ it('allows outputting comments when `minify: true`', async () => {
   );
   expect(result.output[0]!.data.code).toMatchInlineSnapshot(`
     "__d(function (g, r, i, a, m, e, d) {
-      /*#__PURE__*/minified(code);
+    /*#__PURE__*/minified(code);
     });"
   `);
 });

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/adapters.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/adapters.test.ts
@@ -1,0 +1,518 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+it('does not bypass typed child contracts through NativeNodePath', () => {
+  const fs = jest.requireActual<typeof import('node:fs')>('node:fs');
+  const transformerRoot = path.join(__dirname, '../../noxcturnal');
+  const transformerSource = [
+    path.join(transformerRoot, 'noxcturnal-transformer.ts'),
+    ...fs
+      .readdirSync(path.join(transformerRoot, 'plugins'))
+      .map((filename) => path.join(transformerRoot, 'plugins', filename)),
+  ]
+    .map((filename) => fs.readFileSync(filename, 'utf8'))
+    .join('\n');
+  expect(transformerSource).not.toContain('as unknown as NativeNodePath');
+  expect(transformerSource).not.toMatch(/route:\s*'\*'\s*,\s*children:/);
+  expect(transformerSource).not.toMatch(/children:\s*\{\s*'\*'/);
+  expect(transformerSource).not.toMatch(/params:\s*\{\s*route:\s*'FormalParameters'/);
+});
+
+it.each([
+  new TransformSyntaxError('syntax failure', '/app/file.js', { line: 1, column: 0 }, ''),
+  new NativeTransformError('native failure', []),
+  new Error('unknown transform failure'),
+  'non-error thrown value',
+])(
+  'propagates %s unchanged through full-Metro and node-module sync and async adapters',
+  async (thrown) => {
+    const nox = require('noxcturnal') as typeof import('noxcturnal');
+    const transform = jest.spyOn(nox, 'transform').mockImplementation(() => {
+      throw thrown;
+    });
+    const base = {
+      projectRoot: '/app',
+      source: 'const value = 1;',
+      options: options(),
+      isDefaultExpoTransformer: true,
+    } as const;
+    const nodeInput = { ...base, filename: '/app/node_modules/pkg/index.js' };
+    const fullInput = {
+      ...base,
+      filename: '/app/Component.js',
+      config: fullConfig(),
+    };
+
+    try {
+      let nodeThrown: unknown;
+      try {
+        transformNodeModuleWithNoxcturnalSync(nodeInput);
+      } catch (error) {
+        nodeThrown = error;
+      }
+      expect(nodeThrown).toBe(thrown);
+      await expect(transformNodeModuleWithNoxcturnal(nodeInput)).rejects.toBe(thrown);
+      let fullThrown: unknown;
+      try {
+        transformFileFullyWithNoxcturnalSync(fullInput);
+      } catch (error) {
+        fullThrown = error;
+      }
+      expect(fullThrown).toBe(thrown);
+      await expect(transformFileFullyWithNoxcturnal(fullInput)).rejects.toBe(thrown);
+    } finally {
+      transform.mockRestore();
+    }
+  }
+);
+
+it('converts only an explicit Noxcturnal bailout to fallback in sync and async adapters', async () => {
+  const nox = require('noxcturnal') as typeof import('noxcturnal');
+  const transform = jest.spyOn(nox, 'transform').mockReturnValue({
+    status: 'bailout',
+    reason: 'expo-language:parse-error',
+    source: 'const original = 1;',
+    diagnostics: [],
+  });
+  const base = {
+    projectRoot: '/app',
+    source: 'const original = 1;',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  } as const;
+  const nodeInput = { ...base, filename: '/app/node_modules/pkg/index.js' };
+  const fullInput = {
+    ...base,
+    filename: '/app/Component.js',
+    config: fullConfig(),
+  };
+
+  try {
+    expect(transformNodeModuleWithNoxcturnalSync(nodeInput)).toEqual({
+      status: 'fallback',
+      reason: 'expo-language:parse-error',
+    });
+    await expect(transformNodeModuleWithNoxcturnal(nodeInput)).resolves.toEqual({
+      status: 'fallback',
+      reason: 'expo-language:parse-error',
+    });
+    expect(transformFileFullyWithNoxcturnalSync(fullInput)).toEqual({
+      status: 'fallback',
+      reason: 'expo-language:parse-error',
+    });
+    await expect(transformFileFullyWithNoxcturnal(fullInput)).resolves.toEqual({
+      status: 'fallback',
+      reason: 'expo-language:parse-error',
+    });
+  } finally {
+    transform.mockRestore();
+  }
+});
+
+it('throws stable fatal error for invalid full-Metro metadata', () => {
+  const nox = require('noxcturnal') as typeof import('noxcturnal');
+  const transform = jest.spyOn(nox, 'transform').mockReturnValue({
+    status: 'complete',
+    code: '',
+    map: { mappings: '', names: [] },
+    functionMap: null,
+    metadata: {},
+    diagnostics: [],
+  });
+
+  try {
+    expect(() =>
+      transformFileFullyWithNoxcturnalSync({
+        projectRoot: '/app',
+        filename: '/app/Component.js',
+        source: 'const value = 1;',
+        options: options(),
+        isDefaultExpoTransformer: true,
+        config: fullConfig(),
+      })
+    ).toThrow(
+      expect.objectContaining({
+        code: 'NOXCTURNAL_TRANSFORM_ERROR',
+        reason: 'invalid-metro-metadata',
+      })
+    );
+  } finally {
+    transform.mockRestore();
+  }
+});
+
+it('preserves fatal error identity through every Noxcturnal adapter entry point', async () => {
+  const fatal = Object.assign(new SyntaxError('fatal'), {
+    code: 'TRANSFORM_SYNTAX_ERROR',
+  });
+  const nox = require('noxcturnal') as typeof import('noxcturnal');
+  const transform = jest.spyOn(nox, 'transform').mockImplementation(() => {
+    throw fatal;
+  });
+  const base = {
+    projectRoot: '/app',
+    source: 'const value = 1;',
+    options: options({
+      customTransformOptions: { engine: 'hermes', reactCompiler: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+  } as const;
+
+  try {
+    await expect(
+      transformNodeModuleWithNoxcturnal({
+        ...base,
+        filename: '/app/node_modules/pkg/index.js',
+      })
+    ).rejects.toBe(fatal);
+    await expect(
+      transformFileFullyWithNoxcturnal({
+        ...base,
+        filename: '/app/Component.js',
+        config: fullConfig(),
+      })
+    ).rejects.toBe(fatal);
+  } finally {
+    transform.mockRestore();
+  }
+});

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
@@ -1,0 +1,1576 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+it.each([
+  ['an import', `import value from "value"; global.value = value;`],
+  ['an export', `export const value = 1;`],
+])('falls back from the full native script path for %s', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '\0polyfill:test',
+    projectRoot: '/repo/apps/example',
+    source,
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result).toEqual({
+    status: 'fallback',
+    reason: expect.stringMatching(/script-(?:import|export)$/),
+  });
+});
+
+it('completes eligible production application source through the full native Metro path', async () => {
+  const appFilename = '/app/src/App.tsx';
+  const source = `
+type Props = { name: string };
+const React = require('react');
+function App({ name }: Props) {
+  return <View accessibilityLabel={name}>{name}</View>;
+}
+module.exports = App;`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: appFilename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map((dependency) => dependency.name)).toEqual(
+    expect.arrayContaining(['react', 'react/jsx-runtime'])
+  );
+  expect(result.result.code).not.toMatch(/\btype Props\b|<View/);
+  const mappedExport = originalPositionFor(
+    new TraceMap({
+      version: 3,
+      sources: [appFilename],
+      ...result.result.map,
+    } as any),
+    generatedPositionOf(result.result.code, 'module.exports')
+  );
+  expect(mappedExport.line).toBe(7);
+});
+
+it('completes plain production application JavaScript through the native path', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/config.js',
+    projectRoot: '/app',
+    source: `export { value } from './value';`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['./value']);
+  expect(result.result.code).toContain('__d(function');
+});
+
+it('removes loader and metadata exports from a native client route', async () => {
+  const route = '/app/app/route.js';
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: route,
+    projectRoot: '/app',
+    source: `export async function loader() { return null; }
+      export const generateMetadata = () => ({}), keep = 1;`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/\bloader\b|generateMetadata/);
+  expect(result.result.code).toContain('keep');
+  expect(result.result.metadata).toMatchObject({
+    loaderReference: route,
+    performConstantFolding: true,
+  });
+});
+
+it.each(['/app/app/..admin.tsx', '/app/app/..internal/route.ts'])(
+  'treats the dot-dot-prefixed descendant %s as a native client route',
+  async (route) => {
+    const source = `export async function loader() { return null; }
+      export const generateMetadata = () => ({}), keep = 1;`;
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: route,
+      projectRoot: '/app',
+      source,
+      options: options({ dev: false }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).not.toMatch(/\bloader\b|generateMetadata/);
+    expect(result.result.code).toContain('keep');
+    expect(result.result.metadata.loaderReference).toBe(route);
+
+    const babelResult = transformWithBabelPreset(source, route);
+    expect(babelResult.code).not.toMatch(/\bloader\b|generateMetadata/);
+    expect(babelResult.code).toContain('keep');
+    expect(babelResult.metadata).toMatchObject({
+      loaderReference: route,
+      performConstantFolding: true,
+    });
+  }
+);
+
+it.each([
+  ['node_modules', '/app/node_modules/example/index.js', undefined],
+  ['Node server source', '/app/src/server.js', 'node'],
+  ['React Server source', '/app/src/server.js', 'react-server'],
+] as const)(
+  'matches Babel preset Expo by keeping React Compiler off %s',
+  async (_name, candidate, environment) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: candidate,
+      projectRoot: '/app',
+      source: 'module.exports = function Component() { return null; };',
+      options: options({
+        unstable_transformProfile: 'default',
+        customTransformOptions: { engine: 'hermes', reactCompiler: 'true', environment },
+      }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).not.toContain('react/compiler-runtime');
+  }
+);
+
+it('keeps only loader exports in a native loader bundle', async () => {
+  const route = '/app/app/route.js';
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: route,
+    projectRoot: '/app',
+    source: `export default function Route() {}
+      export async function loader() { return null; }
+      export function helper() {}`,
+    options: options({
+      dev: false,
+      customTransformOptions: { engine: 'hermes', isLoaderBundle: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result).toMatchObject({ status: 'complete' });
+  expect(result.result.code).toContain('loader');
+  expect(result.result.code).not.toMatch(/\bRoute\b|\bother\b|\bhelper\b/);
+  expect(result.result.metadata.loaderReference).toBe(route);
+});
+
+it('does not classify identifiers nested in exported destructuring as Router server exports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/app/route.js',
+    projectRoot: '/app',
+    source: `const source = { loader: 1 };
+      export const { /* binding */ loader: nestedLoader } = source;`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('nestedLoader');
+  expect(result.result.metadata.loaderReference).toBeUndefined();
+});
+
+it('retains generateMetadata in a native Node route', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/app/route.js',
+    projectRoot: '/app',
+    source: `export function generateMetadata() { return {}; }
+      export const value = 1;`,
+    options: options({
+      dev: false,
+      customTransformOptions: { engine: 'hermes', environment: 'node' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('generateMetadata');
+  expect(result.result.code).toContain('value');
+});
+
+it.each(['ios', 'web'] as const)(
+  'inlines the Expo manifest on the native %s path',
+  async (platform) => {
+    const previousManifest = process.env.APP_MANIFEST;
+    process.env.APP_MANIFEST = '{"name":"native"}';
+    try {
+      const result = await transformFileFullyWithNoxcturnal({
+        filename: '/app/src/constants.js',
+        projectRoot: '/app',
+        source: `export const manifest = process.env.APP_MANIFEST;
+        process.env.APP_MANIFEST = "preserved";
+        process.env.APP_MANIFEST++;
+        delete (process.env.APP_MANIFEST);
+        ({ value: process.env.APP_MANIFEST } = input);
+        for (process.env.APP_MANIFEST in input) {}
+        for (process.env.APP_MANIFEST of input) {}`,
+        options: options({ dev: false, platform }),
+        isDefaultExpoTransformer: true,
+        config: fullConfig(),
+      });
+
+      expect(result.status).toBe('complete');
+      if (result.status !== 'complete') return;
+      expect(result.result.code).toContain(String.raw`{\"name\":\"native\"}`);
+      expect(result.result.code).toContain('process.env.APP_MANIFEST = "preserved"');
+      expect(result.result.code).toContain('process.env.APP_MANIFEST++');
+      expect(result.result.code).toMatch(/delete\s+\(?process\.env\.APP_MANIFEST\)?/);
+      expect(result.result.code).toMatch(/value:\s*process\.env\.APP_MANIFEST/);
+      expect(result.result.code).toContain('for (process.env.APP_MANIFEST in input)');
+      expect(result.result.code).toContain('for (process.env.APP_MANIFEST of input)');
+    } finally {
+      if (previousManifest === undefined) delete process.env.APP_MANIFEST;
+      else process.env.APP_MANIFEST = previousManifest;
+    }
+  }
+);
+
+it('uses the Babel WebView preflight for DOM components', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/dom-component.js',
+    projectRoot: '/app',
+    source: `function decorate(value) { return value; }
+      @decorate class Example {
+        field = 1;
+        static { this.ready = true; }
+        method(value = this?.field ?? 0) {
+          let output;
+          output ||= value;
+          for (const item of [value]) output += item;
+          return output;
+        }
+      }
+      module.exports = Example;`,
+    options: options({
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes', dom: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/@decorate|\?\.|\?\?|\|\|=|\bclass Example\b/);
+  expect(result.result.code).toContain('decorate');
+});
+
+it('matches Babel by lowering object spread for a modern non-Hermes target', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/web.js',
+    projectRoot: '/app',
+    source: 'module.exports = { ...source, value: 1 };',
+    options: options({ platform: 'web', customTransformOptions: { engine: undefined } }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('...source');
+});
+
+it('matches Babel by preserving async generators on modern web targets', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/web.js',
+    projectRoot: '/app',
+    source: 'module.exports = async function* values() { yield 1; };',
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('async function*');
+});
+
+it('matches Babel by preserving for-of outside the WebView profile', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/native.js',
+    projectRoot: '/app',
+    source: 'for (const value of values) consume(value);',
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(' of ');
+});
+
+it('preserves comments while applying Hermes v1 block scoping', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/native.js',
+    projectRoot: '/app',
+    source: '/* keep */ const value = 1; module.exports = value;',
+    options: options({ minify: false, unstable_transformProfile: 'hermes-stable' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('/* keep */');
+});
+
+it('matches Babel by leaving legacy React display names off modern web targets', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/web.js',
+    projectRoot: '/app',
+    source: 'const Component = createReactClass({ render() {} }); module.exports = Component;',
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('displayName');
+});
+
+it('matches Babel by skipping React Native Codegen on modern web targets', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/NativeValue.tsx',
+    projectRoot: '/app',
+    source: `import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
+      export default codegenNativeComponent<{ value: string }>("NativeValue");`,
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+});
+
+it('selects the native iOS @expo/ui icon without collecting the Android asset', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/icon.js',
+    projectRoot: '/app',
+    source: `import { Icon as ExpoIcon } from '@expo/ui';
+      export const icon = ExpoIcon.select({
+        ios: 'heart.fill',
+        android: import('./heart.xml'),
+      });`,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('heart.fill');
+  expect(result.result.code).not.toMatch(/Icon\.select|heart\.xml/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['@expo/ui']);
+});
+
+it('selects and statically collects the native Android @expo/ui icon asset', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/icon.js',
+    projectRoot: '/app',
+    source: `import * as ExpoUI from '@expo/ui';
+      export const icon = ExpoUI.Icon.select({
+        ios: 'heart.fill',
+        android: import('./heart.xml'),
+      });`,
+    options: options({ dev: false, platform: 'android' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/Icon\.select|heart\.fill|import\(/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['@expo/ui', './heart.xml']);
+});
+
+it('preserves unsupported @expo/ui Icon.select object shapes', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/icon.js',
+    projectRoot: '/app',
+    source: `import { Icon } from '@expo/ui';
+      const shared = { android: 1 };
+      export const icon = Icon.select({ ios: 'heart.fill', ...shared });`,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('select');
+  expect(result.result.code).toContain('heart.fill');
+});
+
+it('does not impose a blanket Babel boundary on compiled @expo/ui modules', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/node_modules/@expo/ui/build/runtime.js',
+    projectRoot: '/app',
+    source: `export const value = require('./value');`,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['./value']);
+});
+
+it('stringifies widget functions after native JSX lowering', async () => {
+  const source = `export function Greeting({ name }: { name: string }) {
+    'widget';
+    return <Text>{name + \` hello\`}</Text>;
+  }`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/widget.tsx',
+    projectRoot: '/app',
+    source,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain("'widget'");
+  expect(result.result.code).toContain('var Greeting = `function');
+  expect(result.result.code).toContain('jsx');
+  const babelResult = transformWithBabelPreset(source, '/app/src/widget.tsx');
+  const nativeTemplate = /`((?:\\.|[^`])*)`/.exec(result.result.code)?.[1];
+  const babelTemplate = /`((?:\\.|[^`])*)`/.exec(babelResult.code!)?.[1];
+  expect(nativeTemplate).toBe(babelTemplate);
+});
+
+it('stringifies widget arrows, object methods, and default exports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/widgets.js',
+    projectRoot: '/app',
+    source: `export const Arrow = (value) => {
+      'widget';
+      return value;
+    };
+    export const registry = {
+      Method(value) {
+        'widget';
+        return value;
+      }
+    };
+    export default function DefaultWidget(value) {
+      'widget';
+      return value;
+    }`,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain("'widget'");
+  expect(result.result.code.match(/`function/g)).toHaveLength(3);
+});
+
+it.each([
+  ['import', `import value from "server-only";`],
+  ['re-export', `export { value } from "server-only";`],
+  ['export all', `export * from "server-only";`],
+  ['require', `require("server-only");`],
+  ['resolve weak', `require.resolveWeak("server-only");`],
+  ['dynamic import', `import("server-only");`],
+])('precisely rejects a restricted client %s', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/client.js',
+    projectRoot: '/app',
+    source,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result).toEqual({
+    status: 'fallback',
+    reason:
+      'expo-environment-restricted-imports-server-only:environment-restricted-import:server-only',
+  });
+});
+
+it('does not bail out for an ordinary server-only string', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/client.js',
+    projectRoot: '/app',
+    source: `module.exports = "server-only";`,
+    options: options({ dev: false, platform: 'ios' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('"server-only"');
+});
+
+it.each([
+  ['import', `import value from "client-only";`],
+  ['re-export', `export { value } from "client-only";`],
+  ['export all', `export * from "client-only";`],
+  ['require', `require("client-only");`],
+  ['dynamic import', `import("client-only");`],
+])('precisely rejects a restricted React server %s', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('fallback');
+  if (result.status !== 'fallback') return;
+  expect(result.reason).toContain(
+    'expo-environment-restricted-imports-client-only:environment-restricted-import:client-only'
+  );
+});
+
+it.each([
+  [
+    'named class import',
+    `import { Component } from "react"; export class App extends Component {}`,
+    'react-server-client-api-import:react:Component',
+  ],
+  [
+    'named hook use',
+    `import { useState } from "react"; const state = useState(0);`,
+    'react-server-client-api-use:useState',
+  ],
+  [
+    'namespace hook use',
+    `import * as React from "react"; const state = React.useState(0);`,
+    'react-server-client-api-use:react:useState',
+  ],
+  [
+    'default react-dom API use',
+    `import ReactDOM from "react-dom"; ReactDOM.flushSync(() => {});`,
+    'react-server-client-api-use:react-dom:flushSync',
+  ],
+])("matches Babel's restricted React API boundary for %s", async (_name, source, reason) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source,
+    options: options({
+      customTransformOptions: {
+        engine: 'hermes',
+        environment: 'react-server',
+      },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('fallback');
+  if (result.status !== 'fallback') return;
+  expect(result.reason).toContain(reason);
+});
+
+it('completes an ordinary React server module and permits unused hook imports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.tsx',
+    projectRoot: '/app',
+    source: `import { useState } from "react";
+      import "server-only";
+      export default function Page(): JSX.Element { return <main>server</main>; }`,
+    options: options({
+      experimentalImportSupport: false,
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('<main>');
+  expect(result.result.code).toContain('Object.defineProperty(exports, "default"');
+});
+
+it('extracts no-capture inline arrow server actions natively', async () => {
+  const candidate = '/app/src/server.js';
+  const source = `export const action = async () => { "use server"; return 1; };`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  const babelResult = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    comments: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      projectRoot: '/app',
+      isDev: false,
+      isServer: true,
+      isReactServer: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  const babelMetadata = babelResult?.metadata as
+    | { reactServerActions?: { id: string; names: string[] } }
+    | undefined;
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('registerServerReference');
+  expect(result.result.code).toMatch(/_\$\$INLINE_ACTION/);
+  expect(result.result.code).not.toContain('"use server"');
+  expect(result.result.metadata.reactServerActions).toEqual(babelMetadata?.reactServerActions);
+});
+
+it('extracts no-capture inline function-expression server actions natively', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source: `export const action = async function named(value) { "use server"; return value; };`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('async function named(value)');
+  expect(result.result.code).toMatch(/_\$\$INLINE_ACTION/);
+  expect(result.result.code).not.toContain('"use server"');
+});
+
+it('extracts top-level inline function-declaration server actions natively', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source: `export async function action(value) { "use server"; return value; }`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('async function action(value)');
+  expect(result.result.code).toMatch(/_\$\$INLINE_ACTION/);
+  expect(result.result.code).not.toContain('"use server"');
+});
+
+it('extracts captured inline server actions with lazy bound arguments', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source: `export function factory(value) {
+      return async () => { "use server"; return value; };
+    }`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('.bind(null,');
+  expect(result.result.code).toContain('get value()');
+  expect(result.result.code).toMatch(/var \[value\] = .+\.value/);
+  expect(result.result.code).not.toContain('"use server"');
+});
+
+it.each([
+  {
+    name: 'arrow',
+    action: 'async () => { "use server"; return block + local + local + program; }',
+  },
+  {
+    name: 'function expression',
+    action: 'async function action() { "use server"; return block + local + local + program; }',
+  },
+])('captures non-Program bindings once for inline $name server actions', async ({ action }) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source: `const program = 1;
+      { const block = 2;
+        module.exports = function factory(local) { return ${action}; };
+      }`,
+    options: options({
+      customTransformOptions: {
+        engine: 'hermes',
+        environment: 'react-server',
+      },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/var \[block, local\] = .+\.value/);
+  expect(result.result.code).toMatch(/\(\) => \[block, local\]/);
+  expect(result.result.code).not.toMatch(/var \[[^\]]*program[^\]]*\] =/);
+});
+
+it('captures a lexical binding that shadows a same-named Program binding', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/server.js',
+    projectRoot: '/app',
+    source: `const value = 'program';
+      module.exports = function factory() {
+        const value = 'lexical';
+        return async () => { "use server"; return value + value; };
+      };`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/var \[value\] = .+\.value/);
+  expect(result.result.code).toMatch(/\(\) => \[_?value\]/);
+});
+
+it("matches Babel's module-level React Server action registrations", async () => {
+  const candidate = '/app/actions/server.ts';
+  const source = `"use server";
+    export async function save() { return 1; }
+    export const remove = async () => 2;
+    export default async function reset() { return 3; }`;
+  const native = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      experimentalImportSupport: false,
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  const babelResult = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    comments: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      projectRoot: '/app',
+      isDev: false,
+      isServer: true,
+      isReactServer: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  const babelMetadata = babelResult?.metadata as
+    | {
+        reactServerActions?: { id: string; names: string[] };
+        reactServerReference?: string;
+      }
+    | undefined;
+
+  expect(native.status).toBe('complete');
+  if (native.status !== 'complete') return;
+  expect(native.result.metadata.reactServerActions).toEqual(babelMetadata?.reactServerActions);
+  expect(native.result.metadata.reactServerReference).toBe(babelMetadata?.reactServerReference);
+  expect(native.result.code).toContain('registerServerReference');
+  expect(native.result.code).toContain('./actions/server.ts');
+  expect(native.result.code).not.toContain('"use server"');
+});
+
+it('retains unsupported module-level React Server action forms for Babel', async () => {
+  for (const source of [
+    `"use server"; export function syncAction() { return 1; }`,
+    `"use server"; export default function syncAction() { return 1; }`,
+  ]) {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: '/app/actions/server.ts',
+      projectRoot: '/app',
+      source,
+      options: options({
+        customTransformOptions: {
+          engine: 'hermes',
+          environment: 'react-server',
+        },
+      }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('fallback');
+    if (result.status !== 'fallback') continue;
+    expect(result.reason).toContain('server-action-non-async-function');
+  }
+});
+
+it.each([
+  ['anonymous function', `"use server"; export default async function(value) { return value; }`],
+  [
+    'anonymous function with whitespace',
+    `"use server"; export default async function (value) { return value; }`,
+  ],
+  [
+    'anonymous function with an anchor comment',
+    `"use server"; export default async function/* anchor */(value) { return value; }`,
+  ],
+  [
+    'anonymous function with a multiline anchor comment',
+    `"use server"; export default async function\n/* anchor */\n(value) { return value; }`,
+  ],
+  ['anonymous arrow', `"use server"; export default async (value) => value;`],
+  ['bound identifier', `"use server"; const action = async () => 1; export default action;`],
+])('supports module-level React Server %s defaults', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/actions/default.ts',
+    projectRoot: '/app',
+    source,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('registerServerReference');
+  expect(result.result.metadata.reactServerActions).toEqual({
+    id: './actions/default.ts',
+    names: ['default'],
+  });
+});
+
+it('registers the same anonymous server action that it exports by default', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/actions/default.ts',
+    projectRoot: '/app',
+    source: `"use server"; export default async function(value) { return value; }`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+
+  let factory: Function | undefined;
+  new Function('__d', result.result.code)((value: Function) => {
+    factory = value;
+  });
+  let registered: Function | undefined;
+  const registerServerReference = (value: Function) => {
+    registered = value;
+    return value;
+  };
+  const moduleExports: { default?: Function } = {};
+  factory?.(
+    globalThis,
+    () => ({ registerServerReference }),
+    (value: unknown) => value,
+    (value: unknown) => value,
+    { exports: moduleExports },
+    moduleExports,
+    []
+  );
+  expect(registered).toBe(moduleExports.default);
+  await expect(moduleExports.default?.('value')).resolves.toBe('value');
+});
+
+it('completes eligible production Node application source through the native Metro path', async () => {
+  const candidate = '/app/routes/render.tsx';
+  const source = `import value from './value';
+    export default function Render(): JSX.Element {
+      return <main>{typeof window}:{value}</main>;
+    }`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      dev: false,
+      customTransformOptions: { engine: 'hermes', environment: 'node' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name, data }) => [name, data.isESMImport])).toEqual(
+    expect.arrayContaining([
+      ['react/jsx-runtime', true],
+      ['./value', true],
+    ])
+  );
+  expect(result.dependencies).toHaveLength(2);
+  expect(result.result.code).toContain(`"undefined"`);
+  expect(result.result.code).not.toContain('JSX.Element');
+
+  const babelResult = transformWithBabelPreset(source, candidate, false, true);
+  expect(babelResult.code).toContain(`"undefined"`);
+  expect(babelResult.code).not.toContain('JSX.Element');
+  expect(babelResult.code).toContain('react/jsx-runtime');
+
+  let factory: Function | undefined;
+  Function(
+    '__d',
+    result.result.code
+  )((value: Function) => {
+    factory = value;
+  });
+  const modules: Record<string, unknown> = {
+    './value': 7,
+    'react/jsx-runtime': {
+      jsx(type: string, props: Record<string, unknown>) {
+        return { type, props };
+      },
+      jsxs(type: string, props: Record<string, unknown>) {
+        return { type, props };
+      },
+    },
+  };
+  const module = { exports: {} as Record<string, unknown> };
+  const dependencyMap = result.dependencies.map(({ name }) => name);
+  factory!(
+    globalThis,
+    (_id: string, name?: string) => modules[name ?? _id],
+    (id: string, name?: string) => {
+      const value = modules[name ?? id] as {
+        __esModule?: boolean;
+        default?: unknown;
+      };
+      return value?.__esModule ? value.default : value;
+    },
+    (id: string, name?: string) => modules[name ?? id],
+    module,
+    module.exports,
+    dependencyMap
+  );
+  const rendered = (module.exports.default as () => unknown)();
+  expect(rendered).toEqual({
+    type: 'main',
+    props: { children: ['undefined', ':', 7] },
+  });
+});
+
+it('completes ordinary production web TSX without invoking React Native Web', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/web/route.tsx',
+    projectRoot: '/app',
+    source: `import value from './value';
+      export default function Route(): JSX.Element {
+        return <main>{value}</main>;
+      }`,
+    options: options({
+      dev: false,
+      platform: 'web',
+      unstable_transformProfile: 'default',
+      customTransformOptions: { environment: undefined },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/JSX\.Element|<main>/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(
+    expect.arrayContaining(['./value', 'react/jsx-runtime'])
+  );
+});
+
+it('lowers modern-web private features without lowering unrelated classes', async () => {
+  const source = `class Unrelated { field = 1 }
+    export default class Secret {
+      #value = 2;
+      #read(input) { return this.#value + input; }
+      read(input) { return [this.#read(3), #value in input]; }
+    }`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/Secret.js',
+    projectRoot: '/app',
+    source,
+    options: options({
+      dev: false,
+      platform: 'web',
+      unstable_transformProfile: 'default',
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('class Unrelated');
+  expect(result.result.code).not.toMatch(/#(?:value|read)/);
+  expect(result.result.code).toContain('Object.defineProperty');
+});
+
+it('rewrites React Native named imports on the native web path', async () => {
+  const source = `import ReactNative, {
+    View as WebView,
+    unstable_createElement as createElement,
+    Unknown as UnknownExport
+  } from 'react-native';
+  import * as ReactNativeWeb from 'react-native-web';
+  export { Text as Label, Unknown as Other } from 'react-native';
+  export default [ReactNative, WebView, createElement, UnknownExport, ReactNativeWeb];`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual([
+    'react-native-web/dist/index',
+    'react-native-web/dist/exports/View',
+    'react-native-web/dist/exports/createElement',
+    'react-native-web/dist/exports/Text',
+  ]);
+  const babel = transformWithBabelPlugin(source, 'babel-plugin-react-native-web');
+  for (const moduleName of result.dependencies.map(({ name }) => name)) {
+    expect(babel).toContain(moduleName);
+  }
+});
+
+it('rewrites React Native CommonJS bindings on the native web path', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const { View: WebView, Unknown: UnknownAlias, Text } = require('react-native');
+      let { AnotherUnknown } = require('react-native-web');
+      const ReactNative = require('react-native-web');
+      module.exports = [WebView, UnknownAlias, Text, AnotherUnknown, ReactNative];`,
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/const WebView = [^;]+\.default;/);
+  expect(result.result.code).toMatch(/const Text = [^;]+\.default;/);
+  expect(result.result.code).toMatch(/const \{ Unknown: UnknownAlias \} = [^;]+;/);
+  expect(result.result.code).toMatch(/let \{ AnotherUnknown \} = [^;]+;/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual([
+    'react-native-web/dist/exports/View',
+    'react-native-web/dist/exports/Text',
+    'react-native-web/dist/index',
+  ]);
+});
+
+it('leaves unsupported React Native CommonJS destructuring unchanged', async () => {
+  const source = `
+    const { View = fallback } = require('react-native');
+    const { ...rest } = require('react-native-web');
+    const { ['View']: computed } = require('react-native');
+    const { View: { nested } } = require('react-native-web');
+  `;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['react-native', 'react-native-web']);
+  expect(result.result.code).toContain('{ View = fallback }');
+  expect(result.result.code).toContain('{ ...rest }');
+  expect(result.result.code).toContain('{ ["View"]: computed }');
+  expect(result.result.code).toContain('{ View: { nested } }');
+});
+
+it('preserves React Native subpaths that the RNW Babel plugin does not rewrite', async () => {
+  const source = 'react-native/Libraries/Utilities/Platform';
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = require(${JSON.stringify(source)});`,
+    options: options({ platform: 'web' }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual([source]);
+});
+
+it('instruments development application source with native React Refresh', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/App.js',
+    projectRoot: '/app',
+    source: `export default function App() { return null; }`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('$RefreshReg$');
+  expect(result.result.code).toContain('"App"');
+});
+
+it('preserves development deep React Native import warnings', async () => {
+  const candidate = '/app/src/deep-imports.js';
+  const source = `import View from "react-native/Libraries/Components/View/View";
+    export { default as Text } from "react-native/Libraries/Text/Text";
+    const Image = require("react-native/Libraries/Image/Image");
+    require("react-native/Libraries/Core/InitializeCore");
+    export default [View, Text, Image];`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      dev: true,
+      customTransformOptions: { engine: 'hermes' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(
+    result.result.code.match(/Deep imports from the 'react-native' package are deprecated/g)
+  ).toHaveLength(3);
+  expect(result.result.code).toContain(`Source: ${candidate} 1:0`);
+  expect(result.result.code).not.toContain(
+    "deprecated ('react-native/Libraries/Core/InitializeCore')"
+  );
+});
+
+it.each([
+  ['Hermes stable', 'ios', 'hermes', 'hermes-stable'],
+  ['Hermes canary', 'ios', 'hermes', 'hermes-canary'],
+  ['Hermes legacy', 'ios', 'hermes', 'default'],
+  ['web', 'web', 'hermes', 'default'],
+  ['non-Hermes', 'ios', undefined, 'default'],
+] as const)(
+  'completes React Compiler application source through the native Metro path for %s',
+  async (_name, platform, engine, unstable_transformProfile) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: '/app/src/App.tsx',
+      projectRoot: '/app',
+      source: `type Props = { value: string };
+      export function App({ value }: Props) { return <View>{value}</View>; }`,
+      options: options({
+        experimentalImportSupport: false,
+        platform,
+        unstable_transformProfile,
+        customTransformOptions: { engine, reactCompiler: 'true' },
+      }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain('react/compiler-runtime');
+    expect(result.result.code).toContain('exports.App = App');
+    expect(result.result.code).not.toContain('type Props');
+    expect(result.result.code).not.toContain('<View');
+  }
+);

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/language-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/language-plugins.test.ts
@@ -1,0 +1,1766 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+it('lowers JSX in a .js file through the consumer-owned JSX capability', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'module.exports = <View />;',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toContain('<View');
+  expect(result.result.code).toContain('react/jsx-runtime');
+});
+
+it.each([
+  [
+    '/app/node_modules/example/index.ts',
+    'const value: number = process.env.EXPO_OS; module.exports = value;',
+  ],
+  [
+    '/app/node_modules/example/index.tsx',
+    'const view: React.Node = <View title={process.env.EXPO_OS} />; module.exports = view;',
+  ],
+])('strips typed syntax for %s', async (typedFilename, source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: typedFilename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toMatch(/:\s*(?:number|React\.Node)|<View/);
+  expect(result.result.code).toContain('"ios"');
+});
+
+it("keeps Babel's .ts JSX rejection instead of widening TypeScript syntax", async () => {
+  const typedFilename = '/app/node_modules/example/index.ts';
+  const source = 'module.exports = <View />;';
+  expect(() => transformWithBabelPreset(source, typedFilename)).toThrow();
+
+  const native = await transformNodeModuleWithNoxcturnal({
+    filename: typedFilename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  expect(native.status).toBe('fallback');
+  if (native.status !== 'fallback') return;
+  expect(native.reason).toContain('parse-error');
+});
+
+it('matches Babel preset Expo runtime behavior and source positions for TypeScript', async () => {
+  const typedFilename = '/app/node_modules/example/differential.ts';
+  const source = `enum Direction { Up, Down = 4 }
+class Box {
+  constructor(public value: number) {}
+}
+module.exports = [Direction.Up, Direction.Down, new Box(3).value];`;
+  const native = await transformNodeModuleWithNoxcturnal({
+    filename: typedFilename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+  const babelResult = transformWithBabelPreset(source, typedFilename);
+
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function('module', 'exports', code)(module, module.exports);
+    return module.exports;
+  };
+  expect(evaluate(native.result.code)).toEqual(evaluate(babelResult.code!));
+  expect(evaluate(native.result.code)).toEqual([0, 4, 3]);
+
+  const nativeOriginal = originalPositionFor(
+    new TraceMap({
+      version: 3,
+      sources: [typedFilename],
+      ...native.result.map,
+    } as any),
+    generatedPositionOf(native.result.code, 'module.exports')
+  );
+  const babelOriginal = originalPositionFor(
+    new TraceMap(babelResult.map! as any),
+    generatedPositionOf(babelResult.code!, 'module.exports')
+  );
+  expect(nativeOriginal.line).toBe(5);
+  expect(babelOriginal.line).toBe(5);
+});
+
+it('matches Babel preset Expo runtime behavior for TypeScript namespaces', async () => {
+  const typedFilename = '/app/node_modules/example/namespace.ts';
+  const source =
+    'namespace Values { export const answer: number = 4 } module.exports = Values.answer;';
+  const native = await transformNodeModuleWithNoxcturnal({
+    filename: typedFilename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+  const babelResult = transformWithBabelPreset(source, typedFilename);
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function('module', 'exports', code)(module, module.exports);
+    return module.exports;
+  };
+  expect(evaluate(native.result.code)).toBe(evaluate(babelResult.code!));
+  expect(evaluate(native.result.code)).toBe(4);
+});
+
+it("matches Babel preset Expo's surviving TypeScript dependency edges", async () => {
+  const typedFilename = '/app/node_modules/example/dependencies.tsx';
+  const source = `import type { Removed } from "types-only";
+import { type AlsoRemoved, kept } from "runtime-edge";
+const value: Removed | AlsoRemoved = kept;
+module.exports = <View value={value} />;`;
+  const native = await transformFileFullyWithNoxcturnal({
+    filename: typedFilename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: true }),
+    config: fullConfig(),
+    isDefaultExpoTransformer: true,
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+  const babelResult = transformWithBabelPreset(source, typedFilename, true);
+
+  const babelEdges = staticModuleSpecifiers(babelResult.code!).sort();
+  const nativeEdges = native.dependencies.map((dependency) => dependency.name).sort();
+  expect(nativeEdges).toEqual(babelEdges);
+  expect(nativeEdges).toEqual(['react/jsx-runtime', 'runtime-edge']);
+  expect(native.result.code).not.toContain('types-only');
+  expect(native.result.code).not.toContain('AlsoRemoved');
+});
+
+it.each(
+  (['classic', 'automatic'] as const).flatMap((runtime) =>
+    [false, true].flatMap((dev) =>
+      ['js', 'jsx', 'tsx'].map((extension) => ({
+        runtime,
+        dev,
+        extension,
+      }))
+    )
+  )
+)('matches Babel JSX behavior for $runtime dev=$dev .$extension', ({ runtime, dev, extension }) => {
+  const filename = `/app/node_modules/example/component.${extension}`;
+  const typedPrefix = extension === 'tsx' ? 'const typed: number = 2;' : 'const typed = 2;';
+  const source = `${typedPrefix}
+const props = { label: "ok" };
+module.exports = <section {...props}>{typed}</section>;`;
+  const jsxMode = `${runtime}${dev ? '-development' : ''}` as
+    | 'classic'
+    | 'classic-development'
+    | 'automatic'
+    | 'automatic-development';
+  const nativeCode = transformWithNativePlan(source, filename, {
+    ...(extension === 'tsx' ? { typescript: 'strip' as const } : null),
+    jsx: jsxMode,
+  });
+  const jsxPlugin = dev
+    ? '@babel/plugin-transform-react-jsx-development'
+    : '@babel/plugin-transform-react-jsx';
+  const babelPlugins: [string, Record<string, unknown> | undefined][] = [];
+  if (extension === 'tsx') {
+    babelPlugins.push([
+      '@babel/plugin-transform-typescript',
+      { isTSX: true, allowExtensions: true },
+    ]);
+  }
+  babelPlugins.push([jsxPlugin, { runtime }]);
+  babelPlugins.push(['@babel/plugin-transform-modules-commonjs', undefined]);
+  const babelCode = transformWithBabelPlugins(source, babelPlugins, filename);
+  const nativeExecutable = transformWithBabelPlugins(
+    nativeCode,
+    [['@babel/plugin-transform-modules-commonjs', undefined]],
+    filename
+  );
+
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    const jsx = (type: unknown, props: Record<string, unknown>) => ({
+      type,
+      props,
+    });
+    const React = {
+      createElement(type: unknown, props: Record<string, unknown> | null, ...children: unknown[]) {
+        return {
+          type,
+          props: {
+            ...props,
+            ...(children.length === 0
+              ? null
+              : { children: children.length === 1 ? children[0] : children }),
+          },
+        };
+      },
+    };
+    const runtimeModule = {
+      jsx,
+      jsxs: jsx,
+      jsxDEV: jsx,
+      Fragment: Symbol.for('Fragment'),
+    };
+    Function(
+      'module',
+      'exports',
+      'require',
+      'React',
+      code
+    )(
+      module,
+      module.exports,
+      (specifier: string) => {
+        if (/^react\/jsx(?:-dev)?-runtime$/.test(specifier)) return runtimeModule;
+        throw new Error(`unexpected JSX dependency ${specifier}`);
+      },
+      React
+    );
+    const value = module.exports as {
+      type: unknown;
+      props: Record<string, unknown>;
+    };
+    const { __self: _self, __source: _source, ...props } = value.props;
+    return { type: value.type, props };
+  };
+
+  expect(evaluate(nativeExecutable)).toEqual(evaluate(babelCode));
+  expect(evaluate(nativeExecutable)).toEqual({
+    type: 'section',
+    props: { label: 'ok', children: 2 },
+  });
+  if (dev) {
+    expect(nativeCode).toMatch(runtime === 'automatic' ? /jsxDEV/ : /__source/);
+    expect(babelCode).toMatch(runtime === 'automatic' ? /jsxDEV/ : /__source/);
+  }
+});
+
+it.each([
+  {
+    name: 'class static blocks',
+    source: 'class Value { static { this.answer = 42 } } module.exports = Value.answer;',
+    transforms: { classStaticBlock: true },
+    plugin: '@babel/plugin-transform-class-static-block',
+  },
+  {
+    name: 'logical assignment evaluation order',
+    source:
+      'let gets = 0, sets = 0; const value = { get item() { gets++; return 0 }, set item(next) { sets += next } }; value.item ||= 3; module.exports = [gets, sets];',
+    transforms: { logicalAssignmentOperators: true },
+    plugin: '@babel/plugin-transform-logical-assignment-operators',
+  },
+  {
+    name: 'optional chaining evaluation order',
+    source:
+      'let calls = 0; const read = () => (++calls, { value: 7 }); module.exports = [read()?.value, calls];',
+    transforms: { optionalChaining: { loose: false } },
+    plugin: '@babel/plugin-transform-optional-chaining',
+    pluginOptions: { loose: false },
+  },
+  {
+    name: 'loose optional chaining evaluation order',
+    source:
+      'let calls = 0; const read = () => (++calls, { value: 7 }); module.exports = [read()?.value, calls];',
+    transforms: { optionalChaining: { loose: true } },
+    plugin: '@babel/plugin-transform-optional-chaining',
+    pluginOptions: { loose: true },
+  },
+  {
+    name: 'nullish coalescing evaluation order',
+    source:
+      'let calls = 0; const read = () => (++calls, null); module.exports = [read() ?? 7, calls];',
+    transforms: { nullishCoalescingOperator: { loose: false } },
+    plugin: '@babel/plugin-transform-nullish-coalescing-operator',
+    pluginOptions: { loose: false },
+  },
+  {
+    name: 'loose nullish coalescing evaluation order',
+    source:
+      'let calls = 0; const read = () => (++calls, null); module.exports = [read() ?? 7, calls];',
+    transforms: { nullishCoalescingOperator: { loose: true } },
+    plugin: '@babel/plugin-transform-nullish-coalescing-operator',
+    pluginOptions: { loose: true },
+  },
+  {
+    name: 'optional catch binding',
+    source: 'let caught = false; try { throw 1 } catch { caught = true } module.exports = caught;',
+    transforms: { optionalCatchBinding: true },
+    plugin: '@babel/plugin-transform-optional-catch-binding',
+  },
+  {
+    name: 'exponentiation assignment evaluation order',
+    source:
+      "let calls = 0; const key = () => (++calls, 'value'); const object = { value: 3 }; object[key()] **= 2; module.exports = [object.value, calls];",
+    transforms: { exponentiationOperator: true },
+    plugin: '@babel/plugin-transform-exponentiation-operator',
+  },
+  {
+    name: 'sticky regexp construction',
+    source: 'module.exports = /a/y;',
+    transforms: { regexpSticky: true },
+    plugin: '@babel/plugin-transform-sticky-regex',
+  },
+  {
+    name: 'dotAll regexp matching',
+    source: "const expression = /a.b/s; module.exports = expression.test('a\\nb');",
+    transforms: { regexpDotAll: true },
+    plugin: '@babel/plugin-transform-dotall-regex',
+  },
+  {
+    name: 'Unicode regexp astral literals code points and dot',
+    source:
+      "module.exports = [/😀+/u.test('😀😀'), /\\u{1F600}/u.test('😀'), /^.$/u.test('😀'), /^.$/u.test('\\n')];",
+    transforms: { regexpUnicode: true },
+    plugin: '@babel/plugin-transform-unicode-regex',
+  },
+  {
+    name: 'Unicode property regexp ASCII scripts letters and complements',
+    source:
+      "module.exports = [/\\p{ASCII}/u.test('A'), /\\p{Script=Greek}/u.test('λ'), /\\p{Letter}/u.test('𐐀'), /\\P{ASCII}/u.test('λ')];",
+    transforms: {
+      regexpUnicode: true,
+      regexpUnicodePropertyEscapes: true,
+    },
+    plugin: '@babel/plugin-transform-unicode-property-regex',
+  },
+  {
+    name: 'named capture groups exec replacement and backreferences',
+    source:
+      "const expression = /(?<word>a).\\k<word>/s; const match = expression.exec('a\\na'); module.exports = [match[0], match.groups.word, 'a\\na'.replace(expression, '$<word>!'), /😀+/u.test('😀😀'), /^.$/u.test('😀'), /\\p{Script=Greek}/u.test('λ')];",
+    transforms: {
+      regexpDotAll: true,
+      regexpNamedCaptureGroups: true,
+    },
+    plugin: '@babel/plugin-transform-named-capturing-groups-regex',
+  },
+  {
+    name: 'parameters defaults rest lexical state and body scope',
+    source:
+      'var fallback = 7; function make(input) { return (first = fallback, ...rest) => { var fallback = 2; return [first, rest, this.value, arguments[0]]; }; } const read = make.call({ value: 3 }, 4); module.exports = [read(undefined, 5), read.length];',
+    transforms: { parameters: true },
+    plugin: '@babel/plugin-transform-parameters',
+  },
+  {
+    name: 'destructuring iterators computed keys defaults rest assignment and catch',
+    source:
+      "let closed = false, reads = 0; const key = 'value'; const input = { get value() { reads++; return { nested: 3 } }, extra: 4 }; const { [key]: { nested = 2 }, ...rest } = input; function* values() { try { yield 5; yield 6; yield 7 } finally { closed = true } } let first, tail; const result = ([first, ...tail] = values()); let caught; try { throw { message: 'ok' } } catch ({ message }) { caught = message } module.exports = [nested, rest.extra, first, tail, result === result, reads, closed, caught];",
+    transforms: { destructuring: true },
+    plugin: '@babel/plugin-transform-destructuring',
+    pluginOptions: { useBuiltIns: true },
+  },
+  {
+    name: 'for-of iterator closing nested loops and labeled continue',
+    source:
+      'let closed = 0, output = []; function* values() { try { yield 1; yield 2 } finally { closed++ } } outer: for (const value of values()) { for (const nested of [value]) { if (nested === 1) continue outer; output.push(nested); break outer; } } module.exports = [output, closed];',
+    transforms: { forOf: true },
+    plugin: '@babel/plugin-transform-for-of',
+  },
+  {
+    name: 'classes methods accessors computed keys expressions and default inheritance',
+    source:
+      "const key = 'double'; class Base { constructor(value) { this.value = value } get current() { return this.value } set current(value) { this.value = value } [key]() { return this.value * 2 } static create(value) { return new this(value) } } class Derived extends Base {} const Expression = class Named { method() { return Named.name } }; const value = Derived.create(3); value.current = 4; module.exports = [value.current, value.double(), value instanceof Base, Expression.name, new Expression().method()];",
+    transforms: { classes: true },
+    plugin: '@babel/plugin-transform-classes',
+  },
+  {
+    // Noxcturnal selects a fixed private-state representation. Babel's loose
+    // mode is used here only as an independent semantic comparison.
+    name: 'private methods fields calls and access',
+    source:
+      'class Secret { #value = 2; #double(input) { return this.#value * input } read() { return this.#double(3) } } module.exports = new Secret().read();',
+    transforms: {
+      privateMethods: true,
+    },
+    plugin: '@babel/plugin-transform-private-methods',
+    pluginOptions: { loose: true },
+  },
+  {
+    name: 'private-in brand checks',
+    source:
+      'class Secret { #value = 2; has(input) { return #value in input } } const value = new Secret(); module.exports = [value.has(value), value.has({})];',
+    transforms: {
+      privatePropertyInObject: true,
+    },
+    plugin: '@babel/plugin-transform-private-property-in-object',
+    pluginOptions: { loose: true },
+  },
+] satisfies {
+  name: string;
+  source: string;
+  transforms: PreflightTransforms;
+  plugin: string;
+  pluginOptions?: Record<string, unknown>;
+}[])(
+  "matches Babel's independent $name behavior",
+  ({ source, transforms, plugin, pluginOptions }) => {
+    const evaluate = (code: string) => {
+      const module = { exports: undefined as unknown };
+      Function(
+        'module',
+        'exports',
+        'require',
+        code
+      )(module, module.exports, requireFromBabelPresetExpo);
+      return module.exports;
+    };
+    const nativeCode = transformWithNativeToggle(source, transforms);
+    const babelCode = transformWithBabelPlugin(source, plugin, pluginOptions);
+
+    expect(evaluate(nativeCode)).toEqual(evaluate(babelCode));
+  }
+);
+
+it.each([false, true])('matches Babel class-properties behavior with loose=%s', (loose) => {
+  const source =
+    'let calls = 0; class Base { set field(value) { calls += value } } class Derived extends Base { field = 2 } const value = new Derived(); module.exports = [calls, value.field];';
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, module.exports, requireFromBabelPresetExpo);
+    return module.exports;
+  };
+  const nativeCode = transformWithNativeToggle(source, {
+    classProperties: { loose },
+  });
+  const babelCode = transformWithBabelPlugin(source, '@babel/plugin-transform-class-properties', {
+    loose,
+  });
+
+  expect(evaluate(nativeCode)).toEqual(evaluate(babelCode));
+});
+
+it('matches Babel spec object-rest/spread symbols and getter order', () => {
+  const source = `const key = Symbol("key");
+let gets = 0;
+const source = { a: 1, get b() { gets++; return 2; }, [key]: 3 };
+const copy = { ...source };
+const { a, ...rest } = copy;
+module.exports = [copy.b, gets, rest[key], a];`;
+  const nativeCode = transformWithNativeToggle(source, {
+    objectRestSpread: { loose: false, useBuiltIns: false },
+  });
+  const babelCode = transformWithBabelPlugin(source, '@babel/plugin-transform-object-rest-spread', {
+    loose: false,
+    useBuiltIns: false,
+  });
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, module.exports, requireFromBabelPresetExpo);
+    return module.exports;
+  };
+
+  expect(evaluate(nativeCode)).toEqual(evaluate(babelCode));
+  expect(evaluate(nativeCode)).toEqual([2, 1, 3, 1]);
+});
+
+it('matches Babel export-namespace-from module behavior', () => {
+  const source = 'export * as values from "pkg";';
+  const nativeCode = transformWithNativeToggle(source, {
+    exportNamespaceFrom: true,
+  });
+  const nativeExecutable = transformWithBabelPlugins(nativeCode, [
+    ['@babel/plugin-transform-modules-commonjs', undefined],
+  ]);
+  const babelCode = transformWithBabelPlugins(source, [
+    ['@babel/plugin-transform-export-namespace-from', undefined],
+    ['@babel/plugin-transform-modules-commonjs', undefined],
+  ]);
+  const evaluate = (code: string) => {
+    const exports: Record<string, unknown> = {};
+    const module = { exports };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, exports, (specifier: string) => {
+      if (specifier === 'pkg') return { answer: 42 };
+      throw new Error(`unexpected namespace dependency ${specifier}`);
+    });
+    return module.exports;
+  };
+
+  expect(evaluate(nativeExecutable)).toEqual(evaluate(babelCode));
+  expect(evaluate(nativeExecutable)).toMatchObject({
+    values: { answer: 42 },
+  });
+});
+
+it('matches Babel async-to-generator runtime behavior', async () => {
+  const source =
+    'module.exports = async function read(value) { const first = await Promise.resolve(value); return first + await 2; };';
+  const nativeCode = transformWithNativeToggle(source, {
+    asyncFunctions: true,
+  });
+  const babelCode = transformWithBabelPlugin(source, '@babel/plugin-transform-async-to-generator');
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, module.exports, requireFromBabelPresetExpo);
+    return module.exports as (value: number) => Promise<number>;
+  };
+
+  expect(await evaluate(nativeCode)(4)).toBe(await evaluate(babelCode)(4));
+});
+
+it('matches Babel async-generator delegation and for-await behavior', async () => {
+  const source = `module.exports = async function* values(input) {
+  yield await 1;
+  yield* input;
+  for await (const value of input) yield value + 1;
+};`;
+  const nativeCode = transformWithNativeToggle(source, {
+    asyncGeneratorFunctions: true,
+  });
+  const babelCode = transformWithBabelPlugin(
+    source,
+    '@babel/plugin-transform-async-generator-functions'
+  );
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, module.exports, requireFromBabelPresetExpo);
+    return module.exports as (input: number[]) => AsyncIterable<number>;
+  };
+  const collect = async (iterable: AsyncIterable<number>) => {
+    const values: number[] = [];
+    for await (const value of iterable) values.push(value);
+    return values;
+  };
+
+  expect(await collect(evaluate(nativeCode)([2, 3]))).toEqual(
+    await collect(evaluate(babelCode)([2, 3]))
+  );
+});
+
+it.each([
+  {
+    name: 'reverse disposal order',
+    source: `const events = [];
+const first = { [Symbol.dispose || Symbol.for("Symbol.dispose")]() { events.push("first"); } };
+const second = { [Symbol.dispose || Symbol.for("Symbol.dispose")]() { events.push("second"); } };
+{
+  using a = first;
+  using b = second;
+  events.push("body");
+}
+module.exports = events;`,
+  },
+  {
+    name: 'suppressed disposal errors',
+    source: `module.exports = function run() {
+  try {
+    using value = { [Symbol.dispose || Symbol.for("Symbol.dispose")]() { throw new Error("dispose"); } };
+    throw new Error("body");
+  } catch (error) {
+    return [error.name, error.error.message, error.suppressed.message];
+  }
+};`,
+  },
+  {
+    name: 'async disposal',
+    source: `module.exports = async function run() {
+  const events = [];
+  await using value = {
+    [Symbol.asyncDispose || Symbol.for("Symbol.asyncDispose")]() {
+      return Promise.resolve().then(() => events.push("dispose"));
+    }
+  };
+  events.push("body");
+  return events;
+};`,
+  },
+])('matches Babel explicit-resource-management $name', async ({ source }) => {
+  const nativeCode = transformWithNativeToggle(source, {
+    explicitResourceManagement: true,
+  });
+  const babelCode = transformWithBabelPlugin(
+    source,
+    '@babel/plugin-transform-explicit-resource-management'
+  );
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function(
+      'module',
+      'exports',
+      'require',
+      code
+    )(module, module.exports, requireFromBabelPresetExpo);
+    return typeof module.exports === 'function'
+      ? (module.exports as () => unknown)()
+      : module.exports;
+  };
+
+  expect(await evaluate(nativeCode)).toEqual(await evaluate(babelCode));
+});
+
+it.each([
+  ['compiled', '', true],
+  ['default opt-out', '"use no memo";', false],
+  ['Expo widget opt-out', '"widget";', false],
+])(
+  "matches Babel preset Expo's React Compiler boundary for %s",
+  (_name, directive, shouldCompile) => {
+    const candidate = '/app/Component.tsx';
+    const source = `type Props = { text: string };
+function Component(props: Props) {
+  ${directive}
+  return <View>{props.text}</View>;
+}`;
+    const native = transformWithNoxcturnal(
+      source,
+      candidate,
+      defineNativePipeline({
+        phases: [
+          {
+            name: 'react-compiler',
+            native: {
+              reactCompiler: {
+                compilationMode: 'infer',
+                panicThreshold: 'none',
+                target: '19',
+                enableResetCacheOnSourceFileChanges: true,
+                customOptOutDirectives: ['widget'],
+              },
+              typescript: 'strip',
+              jsx: 'automatic',
+            },
+          },
+        ],
+      })
+    );
+    if (native.status !== 'complete') throw new Error(native.reason);
+    const babelResult = transformWithReactCompilerPreset(source, candidate);
+
+    for (const code of [native.code, babelResult.code!]) {
+      expect(code.includes('react/compiler-runtime')).toBe(shouldCompile);
+      expect(/\b_c\(/.test(code)).toBe(shouldCompile);
+      expect(code).not.toContain('type Props');
+      expect(code).not.toContain('<View');
+      expect(code).toContain('react/jsx-runtime');
+    }
+  }
+);
+
+it("matches React Refresh's component registrations and hook signatures", () => {
+  const source = `
+    import { memo, useState } from "react";
+    export const Wrapped = memo(function Inner() {
+      const [value] = useState(0);
+      return <View>{value}</View>;
+    });
+    export default function App() {
+      return <Wrapped />;
+    }
+  `;
+  const nativeCode = transformWithNativePlan(source, '/app/App.jsx', {
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+    reactRefresh: {},
+  });
+  const babelCode = transformWithBabelPlugins(
+    source,
+    [
+      ['react-refresh/babel', { skipEnvCheck: true }],
+      ['@babel/plugin-transform-react-jsx', { runtime: 'automatic' }],
+    ],
+    '/app/App.jsx'
+  );
+  const registrations = (code: string) =>
+    [...code.matchAll(/\$RefreshReg\$\([^,]+,\s*"([^"]+)"\)/g)].map((match) => match[1]).sort();
+  const signatures = (code: string) => [...code.matchAll(/\$RefreshSig\$\(\)/g)].length;
+
+  expect(registrations(nativeCode)).toEqual(registrations(babelCode));
+  expect(registrations(nativeCode)).toEqual(['App', 'Wrapped', 'Wrapped$memo']);
+  expect(signatures(nativeCode)).toBe(signatures(babelCode));
+  expect(signatures(nativeCode)).toBe(1);
+});
+
+it.each([
+  [false, 'react/jsx-runtime', /\b_?jsx\(/],
+  [true, 'react/jsx-runtime', /\b_?jsx\(/],
+])("matches Babel preset Expo's JSX runtime selection in dev=%s", async (dev, runtime, call) => {
+  const jsxFilename = '/app/node_modules/example/differential.jsx';
+  const source = 'module.exports = <View title="hello">text</View>;';
+  const native = await transformNodeModuleWithNoxcturnal({
+    filename: jsxFilename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev }),
+    isDefaultExpoTransformer: true,
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+  const babelResult = transformWithBabelPreset(source, jsxFilename, dev);
+
+  expect(native.result.code).toContain(runtime);
+  expect(babelResult.code).toContain(runtime);
+  expect(native.result.code).toMatch(call);
+  expect(babelResult.code).toMatch(call);
+  expect(native.result.code).not.toContain('<View');
+  expect(babelResult.code).not.toContain('<View');
+});
+
+it.each(
+  [false, true].flatMap((server) =>
+    [false, true].flatMap((dev) =>
+      ['js', 'jsx', 'tsx'].map((extension) => ({ server, dev, extension }))
+    )
+  )
+)(
+  'matches the real Expo preset language boundary for server=$server dev=$dev .$extension',
+  ({ server, dev, extension }) => {
+    const candidate = `/app/node_modules/example/preset-boundary.${extension}`;
+    const source =
+      extension === 'tsx'
+        ? 'const value: number = 2; module.exports = <View value={value} />;'
+        : 'const value = 2; module.exports = <View value={value} />;';
+    const nativeCode = transformWithNativePlan(source, candidate, {
+      ...(extension === 'tsx' ? { typescript: 'strip' as const } : null),
+      // This is the consumer recipe selected by Metro for both dev and prod.
+      jsx: 'automatic',
+    });
+    const babelResult = transformWithBabelPreset(source, candidate, dev, server);
+
+    for (const code of [nativeCode, babelResult.code!]) {
+      expect(code).toContain('react/jsx-runtime');
+      expect(code).toMatch(/\b_?jsx\(/);
+      expect(code).not.toContain('<View');
+      expect(code).not.toMatch(/value\s*:\s*number/);
+    }
+  }
+);
+
+it('lowers class static blocks without selecting unrelated class transforms', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'class Value { field = 1; static { this.answer = 42 } } module.exports = Value;',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toContain('static {');
+  expect(result.result.code).toContain('field = 1');
+});
+
+it('preserves per-iteration bindings captured by loop closures', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      'const callbacks = []; for (let value of [1, 2, 3]) callbacks.push(() => value); module.exports = callbacks.map(callback => callback());',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  expect(module.exports).toEqual([1, 2, 3]);
+});
+
+it.each([
+  [
+    'continue',
+    'const callbacks=[]; for(let i=0;i<4;i++){ if(i===1) continue; callbacks.push(()=>i); } module.exports=callbacks.map(fn=>fn());',
+    [0, 2, 3],
+  ],
+  [
+    'break',
+    'const callbacks=[]; for(let i=0;i<4;i++){ if(i===2) break; callbacks.push(()=>i); } module.exports=callbacks.map(fn=>fn());',
+    [0, 1],
+  ],
+  [
+    'return',
+    'function run(){ const callbacks=[]; for(let i=0;i<4;i++){ callbacks.push(()=>i); if(i===2) return [i,callbacks.map(fn=>fn())]; } } module.exports=run();',
+    [2, [0, 1, 2]],
+  ],
+  [
+    'labeled continue',
+    'const callbacks=[]; outer: for(let i=0;i<3;i++){ for(var j=0;j<2;j++){ if(j===1) continue outer; callbacks.push(()=>i); } } module.exports=callbacks.map(fn=>fn());',
+    [0, 1, 2],
+  ],
+  [
+    'captured mutation',
+    'const callbacks=[]; for(let i=0;i<4;i++){ callbacks.push(()=>i); i+=1; } module.exports=callbacks.map(fn=>fn());',
+    [1, 3],
+  ],
+  [
+    'multiple captured bindings',
+    'const callbacks=[]; for(let i=0,j=10;i<3;i++,j++){ callbacks.push(()=>i+j); } module.exports=callbacks.map(fn=>fn());',
+    [10, 12, 14],
+  ],
+])('preserves captured-loop %s control flow', async (_name, source, expected) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  const babelModule = { exports: undefined as unknown };
+  Function(
+    'module',
+    'exports',
+    transformWithBabelPlugin(source, '@babel/plugin-transform-block-scoping')
+  )(babelModule, babelModule.exports);
+  expect(module.exports).toEqual(babelModule.exports);
+  expect(module.exports).toEqual(expected);
+  expect(result.result.map.mappings.length).toBeGreaterThan(0);
+});
+
+it.each([
+  [
+    'for body',
+    'const callbacks=[]; for(var i=0;i<3;i++){ let value=i; callbacks.push(()=>value); } module.exports=callbacks.map(fn=>fn());',
+  ],
+  [
+    'while body',
+    'const callbacks=[]; var i=0; while(i<3){ let value=i++; callbacks.push(()=>value); } module.exports=callbacks.map(fn=>fn());',
+  ],
+  [
+    'do-while body',
+    'const callbacks=[]; var i=0; do { let value=i++; callbacks.push(()=>value); } while(i<3); module.exports=callbacks.map(fn=>fn());',
+  ],
+])('preserves per-iteration bindings declared in a %s', async (_name, source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  const babelModule = { exports: undefined as unknown };
+  Function(
+    'module',
+    'exports',
+    transformWithBabelPlugin(source, '@babel/plugin-transform-block-scoping')
+  )(babelModule, babelModule.exports);
+  expect(module.exports).toEqual(babelModule.exports);
+  expect(module.exports).toEqual([0, 1, 2]);
+});
+
+it('preserves this and arguments through captured-loop helpers', async () => {
+  const source =
+    'function run(offset){ const values=[]; for(let i=0;i<2;i++){ values.push(()=>this.base+arguments[0]+i); } return values.map(fn=>fn()); } module.exports=run.call({base:10},2);';
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  expect(module.exports).toEqual([12, 13]);
+});
+
+it('preserves await and yield through captured-loop helpers', async () => {
+  const cases = [
+    {
+      source:
+        'module.exports=(async()=>{ const callbacks=[]; for(let i=0;i<2;i++){ await Promise.resolve(); callbacks.push(()=>i); } return callbacks.map(fn=>fn()); })();',
+      read: async (value: unknown) => await value,
+      expected: [0, 1],
+    },
+    {
+      source:
+        'const callbacks=[]; function* run(){ for(let i=0;i<2;i++){ callbacks.push(()=>i); yield i; } } module.exports={values:[...run()],captured:callbacks.map(fn=>fn())};',
+      read: async (value: unknown) => value,
+      expected: { values: [0, 1], captured: [0, 1] },
+    },
+  ];
+
+  for (const { source, read, expected } of cases) {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    });
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') continue;
+    const module = { exports: undefined as unknown };
+    Function('module', 'exports', result.result.code)(module, module.exports);
+    expect(await read(module.exports)).toEqual(expected);
+  }
+});
+
+it.each([
+  [
+    'object destructure',
+    'module.exports = async ({ b }) => 42',
+    /async\s+\(_p\)\s*=>\s*\{\s*var\s+\{\s*b\s*\}\s*=\s*_p;\s*return 42;/,
+  ],
+  [
+    'renamed destructure with default',
+    'module.exports = async ({ a: x = 7 }) => x',
+    /var\s+\{\s*a:\s*x\s*=\s*7\s*\}\s*=\s*_p;/,
+  ],
+  [
+    'array destructure',
+    'module.exports = async ([a, ...rest]) => rest',
+    /var\s+\[a,\s*\.\.\.rest\]\s*=\s*_p;/,
+  ],
+  [
+    'default value',
+    'module.exports = async (x = compute()) => x',
+    /var x = _p === undefined \? compute\(\) : _p;/,
+  ],
+  [
+    'commented nested default',
+    'module.exports = async (value /* left */ = /* right */ choose(inner = 2)) => value',
+    /var value = _p === undefined \? choose\(inner = 2\) : _p;/,
+  ],
+  [
+    'Unicode binding default',
+    'module.exports = async (π = compute()) => π',
+    /var π = _p === undefined \? compute\(\) : _p;/,
+  ],
+  [
+    'rest parameter',
+    'module.exports = async (...rest) => rest.length',
+    /\(\.\.\.rest\)\s*=>\s*\(async\s*\(\)\s*=>\s*\{\s*return rest\.length;/,
+  ],
+])('applies the maintained async-arrow workaround for %s', async (_name, source, expected) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toMatch(expected);
+});
+
+it.each([
+  'module.exports = async (a, b) => a + b',
+  'module.exports = async () => 42',
+  'module.exports = ({ b }) => b',
+  'module.exports = async function ({ b }) { return b }',
+  'class C { async method({ b }) { return b } }',
+  'module.exports = { async method({ b }) { return b } }',
+])('does not over-apply the maintained async-arrow workaround to %s', async (source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toMatch(/\bvar _?\w+ = _p/);
+});
+
+it('preserves runtime behavior across maintained async-arrow rewrites', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `let calls = 0;
+      const destructured = async ({ value = ++calls }) => value;
+      const rest = async (...values) => values.join(':');
+      module.exports = async () => [
+        await destructured({}),
+        await destructured({ value: 7 }),
+        await rest('a', 'b'),
+        calls,
+      ];`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  await expect((module.exports as () => Promise<unknown>)()).resolves.toEqual([1, 7, 'a:b', 1]);
+});
+
+it.each([
+  [
+    'declaration',
+    'try {} finally { class C { static value = 42 } use(C) }',
+    /var C = \(\(\) => \{\s*class C[\s\S]*return C;\s*\}\)\(\);/,
+  ],
+  [
+    'expression',
+    'try {} finally { use(class { method() {} }) }',
+    /use\(\(\(\) => class \{ method\(\) \{\} \}\)\(\)\)/,
+  ],
+  [
+    'nested block',
+    'try {} finally { if (ok) { class C {} use(C) } }',
+    /if \(ok\) \{\s*var C = \(\(\) => \{/,
+  ],
+])(
+  'applies the maintained class-in-finally workaround for a %s',
+  async (_name, source, expected) => {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    });
+    if (result.status === 'fallback') throw new Error(result.reason);
+    expect(result.result.code).toMatch(expected);
+  }
+);
+
+it.each([
+  'class C {}',
+  'try { class C {} } catch (error) {}',
+  'try {} catch (error) { class C {} }',
+  'try {} finally { (() => { class C {} return C })() }',
+  'try {} finally { class Outer { method() { class Inner {} return Inner } } }',
+])('does not over-apply the maintained class-in-finally workaround to %s', async (source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  const wrappers = result.result.code.match(/var \w+ = \(\(\) =>/g) ?? [];
+  expect(wrappers).toHaveLength(source.includes('class Outer') ? 1 : 0);
+});
+
+it('preserves class identity and heritage through the maintained finally rewrite', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `class Base { static base = 1 }
+      try {} finally {
+        class Value extends Base { static own = 2 }
+        module.exports = [Value.name, Value.base, Value.own, new Value() instanceof Base]
+      }`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  const module = { exports: undefined as unknown };
+  Function('module', 'exports', result.result.code)(module, module.exports);
+  expect(module.exports).toEqual(['Value', 1, 2, true]);
+});
+
+it.each([
+  ['getter', 'module.exports = { get value() { return super.value } }', 'get ["value"]()'],
+  ['setter', 'module.exports = { set value(v) { super.value = v } }', 'set ["value"](v)'],
+  [
+    'string key',
+    'module.exports = { get "weird key"() { return super.value } }',
+    'get ["weird key"]()',
+  ],
+  [
+    'nested arrow',
+    'module.exports = { get value() { return (() => super.value)() } }',
+    'get ["value"]()',
+  ],
+])('applies the maintained Hermes super workaround for a %s', async (_name, source, expected) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain(expected);
+});
+
+it.each([
+  'module.exports = { get value() { return 1 } }',
+  'module.exports = { value() { return super.value } }',
+  'class Value extends Base { get value() { return super.value } }',
+  'module.exports = { get value() { class C extends B { static { super.value } } return C } }',
+  'module.exports = { get value() { class C extends B { field = super.value } return C } }',
+])('does not over-apply the maintained Hermes super workaround to %s', async (source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toMatch(/\b(?:get|set)\s+\[/);
+});
+
+it('preserves an already-computed object accessor in the maintained Hermes workaround', async () => {
+  const source = 'module.exports = { get ["value"]() { return super.value } }';
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain('get ["value"]()');
+});
+
+it('passes Expo’s exact babelRuntimeVersion to native helper selection', async () => {
+  const transform = (enableBabelRuntime: boolean | string) =>
+    transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: 'async function* value() { yield 1 }',
+      options: options(),
+      enableBabelRuntime,
+      isDefaultExpoTransformer: true,
+    });
+
+  const oldRuntime = await transform('6.0.0');
+  expect(oldRuntime.status).toBe('complete');
+  if (oldRuntime.status === 'complete') {
+    expect(oldRuntime.result.code).toContain('babelHelpersFallback.wrapAsyncGenerator');
+    expect(oldRuntime.result.code).not.toContain(
+      'require("@babel/runtime/helpers/wrapAsyncGenerator")'
+    );
+  }
+
+  const runtime = await transform('7.24.0');
+  expect(runtime.status).toBe('complete');
+  if (runtime.status === 'complete') {
+    expect(runtime.result.code).toContain('require("@babel/runtime/helpers/wrapAsyncGenerator")');
+    expect(runtime.result.code).not.toMatch(/\basync\s+function\s*\*/);
+  }
+
+  const inline = await transform(false);
+  expect(inline.status).toBe('complete');
+  if (inline.status === 'complete') {
+    expect(inline.result.code).not.toContain('require(');
+    expect(inline.result.code).not.toMatch(/\basync\s+function\s*\*|regeneratorRuntime/);
+  }
+});
+
+it('preserves modern syntax supported by Hermes V1', async () => {
+  const source =
+    'class Value { field = 1 } async function load({ value = 1, ...rest }) { return [value, rest] }';
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status === 'complete') expect(result.result.code).toBe(source);
+});
+
+it('does not mistake generated SignedSource markers for JSX', async () => {
+  const source =
+    '/* @generated SignedSource<<e7f6759bcc8955193867c6ab42bd07ad>> */\nmodule.exports=1;';
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain('module.exports = 1');
+  expect(result.result.code).not.toContain('jsx-runtime');
+});
+
+it('lowers legacy-profile parameters through the native syntax phase', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      'module.exports = function read(value = 2, ...rest) { return [value, rest, read.length]; };',
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  const read = module.exports as (value?: number, ...rest: number[]) => unknown;
+  expect(read(undefined, 3, 4)).toEqual([2, [3, 4], 0]);
+});
+
+it('lowers legacy-profile standalone destructuring through the native syntax phase', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      "const input = { value: 2, extra: 3 }; const { value, ...rest } = input; let first, tail; ([first, ...tail] = [4, 5, 6]); try { throw { message: 'ok' } } catch ({ message }) { module.exports = [value, rest.extra, first, tail, message]; }",
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toEqual([2, 3, 4, [5, 6], 'ok']);
+});
+
+it('lowers WebView-profile for-of through the native syntax phase', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      'let closed = false; function* values() { try { yield 1; yield 2 } finally { closed = true } } const output = []; for (const value of values()) { output.push(value); break } module.exports = [output, closed];',
+    options: options({
+      unstable_transformProfile: 'hermes-stable',
+      customTransformOptions: { engine: 'hermes', dom: '1' },
+    }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toEqual([[1], true]);
+});
+
+it('lowers legacy-profile classes through the native syntax phase', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      'class Value { constructor(value) { this.value = value } read() { return this.value } static create(value) { return new this(value) } } module.exports = Value.create(3).read();',
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toBe(3);
+});
+
+it('lowers legacy-profile private class features through the native syntax phase', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      'class Secret { #value = 2; #double(input) { return this.#value * input } read() { return this.#double(3) } has(input) { return #value in input } } const value = new Secret(); module.exports = [value.read(), value.has(value), value.has({})];',
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toEqual([6, true, false]);
+});
+
+it('lowers Flow private references captured by class-field arrows', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */
+      class Registry {
+        #value: number = 2;
+        #read = (): number => this.#value;
+        #callback = (): number => this.#read();
+        result(): number { return this.#callback(); }
+      }
+      module.exports = new Registry().result();`,
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/#[A-Za-z_$]/);
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toBe(2);
+});
+
+it('retains value-less Flow private fields as runtime brands', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */
+      class Registry {
+        #value: ?number;
+        read(): ?number { return this.#value; }
+      }
+      module.exports = new Registry().read();`,
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const module = { exports: null as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toBeUndefined();
+});
+
+it('preserves dotAll while lowering the regexp features selected by the legacy Babel profile', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source:
+      "const expression = /(?<word>a).\\k<word>/s; const match = expression.exec('a\\na'); module.exports = [match[0], match.groups.word, 'a\\na'.replace(expression, '$<word>!'), /\\p{ASCII}+/u.test('abc'), /\\p{Script=Greek}+/u.test('Ω'), /\\p{Letter}/u.test('𐐀')];",
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('/s');
+  const module = { exports: undefined as unknown };
+  Function('module', 'require', result.result.code)(module, requireFromMetroConfig);
+  expect(module.exports).toEqual(['a\na', 'a', 'a!', true, true, true]);
+});
+
+it('emits Metro-compatible function maps without Babel traversal', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'var x=1; function named(a){ return a } var inferred = function(){ return x };',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  // Differential value from Metro's functionMapBabelPlugin for this fixture.
+  expect(result.result.functionMap).toEqual({
+    names: ['<global>', 'named', 'inferred'],
+    mappings: 'AAA,SC,6BD,gBE,sBF',
+  });
+});
+
+it('lowers function-scope let and const declarations', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'const outer = 1; function value() { let inner = outer; return inner; }',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  expect(result.status).toBe('complete');
+  if (result.status === 'complete') {
+    expect(result.result.code).toMatch(
+      /var outer = 1;\s*function value\(\) \{\s*var inner = outer;\s*return inner;\s*\}/
+    );
+  }
+});
+
+it('renames and lowers nested block bindings without leaking collisions', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'var value = 0; if (condition) { const value = 1; consume(value); } consume(value);',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  expect(result.status).toBe('complete');
+  if (result.status === 'complete') {
+    expect(result.result.code).toMatch(
+      /var value = 0;\s*if \(condition\) \{\s*var (_value\d*) = 1;\s*consume\(\1\);\s*\}\s*consume\(value\);/
+    );
+  }
+});
+
+it('lowers loop bindings when per-iteration bindings are not captured', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'for (let value of values) consume(value);',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status === 'complete') {
+    expect(result.result.code).toMatch(/for \(var value of values\) consume\(value\);/);
+  }
+});

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
@@ -1,0 +1,2648 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+const nativeCorpus = [
+  {
+    name: 'production TypeScript and constant folding',
+    filename: '/app/node_modules/corpus/math.ts',
+    source:
+      'const answer: number = 20 + 22; module.exports = { answer, dead: false ? sideEffect() : 0 };',
+    options: options({ dev: false }),
+    anchor: 'answer',
+    dependencies: [] as string[],
+    runtime: { answer: 42, dead: 0 },
+  },
+  {
+    name: 'development automatic JSX and Refresh',
+    filename: '/app/components/Widget.tsx',
+    source:
+      'import React from "react"; export function Widget({value}: {value: number}) { return <span>{value}</span>; }',
+    options: { ...options({ dev: true }), hot: true } as JsTransformOptions,
+    anchor: 'Widget',
+    dependencies: ['react', 'react/jsx-runtime'],
+  },
+  {
+    name: 'production ESM live imports and exports',
+    filename: '/app/node_modules/corpus/reexport.js',
+    source:
+      'import { value } from "source"; export const doubled = value * 2; export { other } from "target";',
+    options: options({ dev: false }),
+    anchor: 'doubled',
+    dependencies: ['source', 'target'],
+  },
+  {
+    name: 'development native Flow erasure and side-effect dependency',
+    filename: '/app/node_modules/corpus/flow.js',
+    source:
+      '/* @flow */ import "setup"; type Value = number; const value: Value = 1; module.exports = value;',
+    options: options({ dev: true }),
+    anchor: 'value',
+    dependencies: ['setup'],
+  },
+  {
+    name: 'production dynamic import graph',
+    filename: '/app/node_modules/corpus/lazy.js',
+    source: 'export async function load() { return import("lazy"); }',
+    options: options({ dev: false }),
+    anchor: 'load',
+    dependencies: ['lazy', 'metro-runtime'],
+  },
+] as const;
+
+it.each(nativeCorpus)(
+  'keeps corpus trace, graph, and completion stable for $name',
+  async (fixture) => {
+    const input = {
+      filename: fixture.filename,
+      projectRoot: '/app',
+      source: fixture.source,
+      options: fixture.options,
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    };
+    const [first, repeated] = await Promise.all([
+      transformFileFullyWithNoxcturnal(input),
+      transformFileFullyWithNoxcturnal(input),
+    ]);
+
+    expect(first.status).toBe('complete');
+    expect(repeated.status).toBe('complete');
+    if (first.status !== 'complete' || repeated.status !== 'complete') return;
+
+    expect(repeated.result.code).toBe(first.result.code);
+    expect(repeated.result.map).toEqual(first.result.map);
+    expect(repeated.dependencies).toEqual(first.dependencies);
+    expect(first.dependencies.map(({ name }) => name)).toEqual(fixture.dependencies);
+    expect(first.result.functionMap).toBeDefined();
+    expect(first.result.map.mappings.length).toBeGreaterThan(0);
+
+    const trace = new TraceMap({
+      version: 3,
+      sources: [fixture.filename],
+      ...first.result.map,
+    } as any);
+    const mappedAnchor = generatedPositionsOf(first.result.code, fixture.anchor)
+      .map((generated) => originalPositionFor(trace, generated))
+      .find((original) => original.source === fixture.filename && original.line != null);
+    expect(mappedAnchor).toBeDefined();
+
+    if ('runtime' in fixture) {
+      const stage = await transformNodeModuleWithNoxcturnal(input);
+      expect(stage.status).toBe('complete');
+      if (stage.status !== 'complete') return;
+      const module = { exports: undefined as unknown };
+      Function(
+        'module',
+        'exports',
+        'sideEffect',
+        stage.result.code
+      )(module, module.exports, () => {
+        throw new Error('dead branch executed');
+      });
+      expect(module.exports).toEqual(fixture.runtime);
+    }
+  }
+);
+
+it('preserves JSX callback mappings through Metro module wrapping', async () => {
+  const source = [
+    'export function App() {',
+    '  return <BigButton',
+    '    title="throw"',
+    '    onPress={() => {',
+    "      throw new Error('failure');",
+    '    }}',
+    '  />;',
+    '}',
+  ].join('\n');
+  const filename = '/app/src/App.tsx';
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: { ...options({ dev: true, platform: 'web' }), hot: true } as JsTransformOptions,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const original = originalPositionFor(
+    new TraceMap({ version: 3, sources: [filename], ...result.result.map } as any),
+    generatedPositionOf(result.result.code, 'new Error')
+  );
+  expect(original).toMatchObject({ source: filename, line: 5, column: 12 });
+  expect(result.result.functionMap?.names).toEqual(
+    expect.arrayContaining(['BigButton.props.onPress'])
+  );
+});
+
+it.each([
+  ['variable', 'const Widget = createReactClass({ render() {} });', '"Widget"'],
+  ['assignment member', 'exports.Widget = React.createClass({});', '"Widget"'],
+  ['object property', 'const values = { Widget: createReactClass({}) };', '"Widget"'],
+  ['nested declarator', 'const Widget = memo(createReactClass({}));', '"Widget"'],
+  ['default export filename', 'export default createReactClass({});', '"example"'],
+])('adds legacy React display names inferred from a %s', async (_name, source, name) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain(`displayName: ${name}`);
+});
+
+it('preserves explicit display names and leaves Hermes V1 display names untouched', async () => {
+  const legacy = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'const Widget = createReactClass({ ["displayName"]: "Explicit" });',
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+  const modern = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: 'const Widget = createReactClass({});',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (legacy.status === 'fallback') throw new Error(legacy.reason);
+  if (modern.status === 'fallback') throw new Error(modern.reason);
+  expect(legacy.result.code.match(/displayName/g)).toHaveLength(1);
+  expect(legacy.result.code).toContain('"Explicit"');
+  expect(modern.result.code).not.toContain('displayName');
+});
+
+it('strips Flow with native erasure without running a Babel transform', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */\nimport type { Value } from './types';\nconst value: Value = process.env.EXPO_OS;\nmodule.exports = value;`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toContain('import type');
+  expect(result.result.code).not.toContain(': Value');
+  expect(result.result.code).toContain(`var value = "ios"`);
+  expect(result.result.map.mappings.length).toBeGreaterThan(0);
+});
+
+it('accepts a Flow module that legitimately strips to empty output', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: '/** @flow */\nexport type Value = { answer: number };',
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code.replace('/** @flow */', '').trim()).toBe('');
+});
+
+it.each([
+  [
+    'enum',
+    'enum Direction { Up, Down }\nmodule.exports = Direction.Up;',
+    /Mirrored\(\["Up",\s*"Down"\]\)/,
+  ],
+  [
+    'component',
+    "import * as React from 'react';\ncomponent Greeting(name: string) { return <div>{name}</div>; }\nmodule.exports = Greeting;",
+    /function Greeting\(\{\s*name\s*\}\)/,
+  ],
+  [
+    'hook',
+    "import * as React from 'react';\nhook useThing(value: number): number { return value; }\nmodule.exports = useThing;",
+    /function useThing\(value\)/,
+  ],
+])('lowers Flow %s syntax selected from the parsed Flow AST', async (_name, body, expected) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */\n${body}\n`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toMatch(expected);
+});
+
+it('does not treat proposal keywords in prose as proposal syntax', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    // `enum`, `match`, `component`, `hook`, and `record` all appear here as
+    // ordinary words. Proposal transforms are selected from parsed syntax, so
+    // none of them may run — and none may alter the stripped output.
+    source: `/** @flow */
+// This component does not enumerate or match any record, and hooks nothing.
+export function describe(value: number): string {
+  return \`component \${value} enum match record hook\`;
+}
+`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toMatch(/component \$\{value\} enum match record hook/);
+});
+
+it('preserves typed Flow parameter defaults through focused stripping', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */
+function collect(value: unknown, nodes: Array<number> = [], depth: number = 0): Array<number> {
+  nodes.push(depth);
+  return nodes;
+}
+module.exports = collect("value");`,
+    options: options({ unstable_transformProfile: 'default' }),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain(
+    `nodes = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : []`
+  );
+  expect(result.result.code).toContain(
+    `depth = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : 0`
+  );
+});
+
+it('removes value-less Flow class fields before class lowering', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */
+class Event {
+  static +NONE: 0;
+  +NONE: 0;
+}
+Object.defineProperty(Event, 'NONE', { value: 0 });
+Object.defineProperty(Event.prototype, 'NONE', { value: 0 });
+module.exports = new Event();`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toContain('this.NONE = void 0');
+  expect(result.result.code).not.toContain('Event.NONE = void 0');
+});
+
+it('preserves a value-bearing side-effect import through focused Flow stripping', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: "/** @flow */\nimport '../Core/InitializeCore';",
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).toContain("import '../Core/InitializeCore'");
+});
+
+it('collects a Flow side-effect import in the complete Metro dependency graph', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: "/** @flow */\nimport '../Core/InitializeCore';",
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['../Core/InitializeCore']);
+  expect(result.result.code).toContain('_$$_REQUIRE(_dependencyMap[0], "../Core/InitializeCore")');
+});
+
+it('continues Flow JSX through the consumer-owned native JSX capability', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `/** @flow */\nconst view: React.Node = <View title="hello" />;\nmodule.exports = view;`,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.result.code).not.toMatch(/React\.Node|<View/);
+  expect(result.result.code).toContain('react/jsx-runtime');
+  expect(result.result.code).toContain('jsx(View');
+});
+
+it('collects native lowering helpers in the complete Metro path', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = async function* values() { yield 1 };`,
+    options: options({ dev: true }),
+    enableBabelRuntime: '7.24.0',
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/\basync\s+function\s*\*/);
+  expect(result.dependencies.map(({ name }) => name)).toEqual([
+    '@babel/runtime/helpers/wrapAsyncGenerator',
+  ]);
+  expect(result.result.code).toContain(
+    '_$$_IMPORT_DEFAULT(_dependencyMap[0], "@babel/runtime/helpers/wrapAsyncGenerator")'
+  );
+});
+
+it('collects static CommonJS dependencies and wraps a module without Babel', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const first = require('one');\nmodule.exports = [first, require("one"), require('two')];`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result).toMatchObject({ status: 'complete' });
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(
+    /__d\(function \(global,[\s\S]*var first = _\$\$_REQUIRE\(_dependencyMap\[0\], "one"\);[\s\S]*module\.exports = \[\s*first,\s*_\$\$_REQUIRE\(_dependencyMap\[0\], "one"\),\s*_\$\$_REQUIRE\(_dependencyMap\[1\], "two"\)\s*\];[\s\S]*\}\);/
+  );
+  expect(result.dependencies.map(({ name, data }) => [name, (data as any).imports])).toEqual([
+    ['one', 2],
+    ['two', 1],
+  ]);
+  expect(result.result.metadata.hasCjsExports).toBe(true);
+  expect(result.result.map.mappings.length).toBeGreaterThan(0);
+});
+
+it('inlines stable top-level require aliases before native dependency collection', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const one = require("one"), kept = 2; module.exports = [one, one, kept];`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result).toMatchObject({ status: 'complete' });
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/\bone\s*=/);
+  expect(result.result.code).toContain('var kept = 2;');
+  expect(result.result.code.match(/_\$\$_REQUIRE\(_dependencyMap\[0\], "one"\)/g)).toHaveLength(2);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
+});
+
+it('inlines require member aliases and respects nonInlinedRequires', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const member = require("one").value; const ignored = require("two"); module.exports = [member, ignored];`,
+    options: options({
+      dev: true,
+      inlineRequires: true,
+      nonInlinedRequires: ['two'],
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/\bmember\s*=/);
+  expect(result.result.code).toContain(`_$$_REQUIRE(_dependencyMap[1], "one").value`);
+  expect(result.result.code).toContain(`var ignored = _$$_REQUIRE`);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['two', 'one']);
+});
+
+it('does not share nonInlinedRequires between transforms', async () => {
+  const source = `const one = require("one"); const two = require("two"); module.exports = [one, two];`;
+  const transform = (nonInlinedRequires: string[]) =>
+    transformFileFullyWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source,
+      options: options({ dev: true, inlineRequires: true, nonInlinedRequires }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+  const first = await transform(['one']);
+  const second = await transform(['two']);
+
+  if (first.status === 'fallback') throw new Error(first.reason);
+  if (second.status === 'fallback') throw new Error(second.reason);
+  expect(first.result.code).toMatch(/var one =/);
+  expect(first.result.code).not.toMatch(/var two =/);
+  expect(second.result.code).not.toMatch(/var one =/);
+  expect(second.result.code).toMatch(/var two =/);
+});
+
+it('does not inline reassigned aliases or shadowed require calls', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const stable = require("one"); let reassigned = require("two"); reassigned = 3; function local(require) { const value = require("local"); return value; } module.exports = [stable, reassigned, local];`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toMatch(/\bstable\s*=/);
+  expect(result.result.code).toContain('var reassigned =');
+  expect(result.result.code).toContain(`require("local")`);
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['two', 'one']);
+});
+
+it.each([
+  ['assignment', 'binding.value = next;'],
+  ['nested postfix update', 'binding.value.nested++;'],
+  ['prefix update', '++binding.value;'],
+  ['postfix update', 'binding.value++;'],
+  ['compound assignment', 'binding.value += next;'],
+  ['logical assignment', 'binding.value ||= next;'],
+  ['delete', 'delete binding.value;'],
+  ['optional delete', 'delete binding?.optional;'],
+  ['parenthesized chain', 'delete (binding).value;'],
+  ['destructuring target', '({ value: binding.value } = source);'],
+  ['for-in target', 'for (binding.value in source) break;'],
+  ['for-of target', 'for (binding.value of source) break;'],
+] as const)('does not inline an alias used by a %s', async (_name, mutation) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const binding = require("one"); ${mutation} module.exports = binding;`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('var binding = _$$_REQUIRE');
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
+});
+
+it('retains a mutated root while inlining an alias used only as its computed key', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const binding = require("one"); const key = require("key"); binding[key].nested++; module.exports = binding;`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('var binding = _$$_REQUIRE');
+  expect(result.result.code).not.toMatch(/\bkey\s*=/);
+  expect(result.result.code).toContain('binding[_$$_REQUIRE');
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one', 'key']);
+});
+
+it('handles repeated inline-require candidate names without repeating binding queries', async () => {
+  const declarations = Array.from(
+    { length: 200 },
+    (_, index) => `var binding = require("dependency-${index}");`
+  );
+  const references = Array.from({ length: 200 }, () => 'binding').join(', ');
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `${declarations.join('\n')} module.exports = [${references}];`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('module.exports');
+});
+
+it('inlines large require sets without follow-up inspection batches', async () => {
+  const aliases = Array.from(
+    { length: 200 },
+    (_, index) => `const dependency${index} = require("dependency-${index}");`
+  );
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `${aliases.join('\n')}\nmodule.exports = dependency199;`,
+    options: options({ dev: true, inlineRequires: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['dependency-199']);
+});
+
+it('compacts the complete Metro output without falling back to Babel', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const value = require("one");\nmodule.exports = value;`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: { ...fullConfig(), unstable_compactOutput: true },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('\n');
+  expect(result.result.code).toContain('_$$_REQUIRE(_dependencyMap[0])');
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
+});
+
+it('completes production constant folding and DCE in native code', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = [process.env.EXPO_OS, process.env.NODE_ENV, __DEV__, require("one")];`,
+    options: options({ dev: false, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    enableBabelRuntime: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+      unstable_dependencyMapReservedName: null,
+      unstable_disableModuleWrapping: false,
+      unstable_allowRequireContext: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('"production"');
+  expect(result.result.code).toContain('_$$_REQUIRE(_dependencyMap[0])');
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
+});
+
+it.each([
+  ['nested arithmetic', `const value = 1 + 2 * 3; module.exports = value;`],
+  [
+    'logical and conditional selection',
+    `const value = (false || true) ? "kept" : sideEffect(); module.exports = value;`,
+  ],
+  [
+    'fixed-point function removal',
+    `function leaf() { return 7; } function dead() { return leaf(); } module.exports = 3;`,
+  ],
+  [
+    'live function dependency',
+    `function leaf() { return 7; } function live() { return leaf(); } module.exports = live();`,
+  ],
+  ['unsafe call preservation', `const value = (sideEffect(), 1 + 2); module.exports = value;`],
+  ['string comparison', `module.exports = ["b" < "c", "10" < "2", "1" === 1, "1" == 1];`],
+])("matches Metro's Babel optimization for %s", (_name, source) => {
+  const metroOptimization = requireFromMetroConfig(
+    '@expo/metro/metro-transform-plugins'
+  ).constantFoldingPlugin;
+  const babelResult = babel.transformSync(source, {
+    babelrc: false,
+    configFile: false,
+    plugins: [metroOptimization],
+  });
+  const nativeResult = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'metro-optimization',
+          native: {
+            optimize: {
+              constantFolding: true,
+              deadCodeElimination: true,
+            },
+          },
+        },
+      ],
+    })
+  );
+
+  expect(nativeResult.status).toBe('complete');
+  if (nativeResult.status !== 'complete' || babelResult?.code == null) return;
+  const evaluate = (code: string) => {
+    const module = { exports: undefined as unknown };
+    const sideEffects: string[] = [];
+    Function(
+      'module',
+      'sideEffect',
+      code
+    )(module, () => {
+      sideEffects.push('called');
+      return 9;
+    });
+    return { exports: module.exports, sideEffects };
+  };
+  expect(evaluate(nativeResult.code)).toEqual(evaluate(babelResult.code));
+  expect(nativeResult.code.includes('function dead')).toBe(
+    babelResult.code.includes('function dead')
+  );
+  expect(nativeResult.code.includes('function leaf')).toBe(
+    babelResult.code.includes('function leaf')
+  );
+});
+
+it('collects optional dependencies and lets required uses dominate duplicates', async () => {
+  const base = {
+    filename,
+    projectRoot: '/app',
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  } as const;
+
+  await expect(
+    transformFileFullyWithNoxcturnal({
+      ...base,
+      source: `module.exports = require('one')`,
+    })
+  ).resolves.toMatchObject({ status: 'complete' });
+  const optional = await transformFileFullyWithNoxcturnal({
+    ...base,
+    source: `try { module.exports = require('one') } catch {}`,
+  });
+  expect(optional.status).toBe('complete');
+  if (optional.status !== 'complete') return;
+  expect(optional.dependencies[0]?.data.isOptional).toBe(true);
+  expect(optional.result.code).toContain('"one"');
+
+  const requiredDuplicate = await transformFileFullyWithNoxcturnal({
+    ...base,
+    source: `try { require('one') } catch {} module.exports = require('one')`,
+  });
+  expect(requiredDuplicate.status).toBe('complete');
+  if (requiredDuplicate.status !== 'complete') return;
+  expect(requiredDuplicate.dependencies).toHaveLength(1);
+  expect(requiredDuplicate.dependencies[0]?.data.isOptional).toBe(false);
+
+  const excluded = await transformFileFullyWithNoxcturnal({
+    ...base,
+    source: `try { module.exports = require('one') } catch {}`,
+    config: {
+      ...base.config,
+      allowOptionalDependencies: { exclude: ['one'] },
+    },
+  });
+  expect(excluded.status).toBe('complete');
+  if (excluded.status !== 'complete') return;
+  expect(excluded.dependencies[0]?.data.isOptional).toBeUndefined();
+});
+
+it('collects and rewrites weak dependencies without conflating them with sync requires', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = [require.resolveWeak('one'), require('one'), require.resolveWeak('one')];`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(
+    `module.exports = [_dependencyMap[0], _$$_REQUIRE(_dependencyMap[1], "one"), _dependencyMap[0]];`
+  );
+  expect(
+    result.dependencies.map(({ name, data }) => [name, data.asyncType, (data as any).imports])
+  ).toEqual([
+    ['one', 'weak', 2],
+    ['one', null, 1],
+  ]);
+});
+
+it('does not treat a shadowed require.resolveWeak call as a dependency', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `function read(require) { return require.resolveWeak('one'); } module.exports = read;`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies).toEqual([]);
+  expect(result.result.code).toContain(`require.resolveWeak('one')`);
+});
+
+it('collects and rewrites worker resolution through the Metro async runtime', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = require.unstable_resolveWorker('worker-entry');`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(
+    `module.exports = _$$_REQUIRE(_dependencyMap[1], "metro-runtime").unstable_resolve(_dependencyMap[0], _dependencyMap.paths);`
+  );
+  expect(
+    result.dependencies.map(({ name, data }) => [name, data.asyncType, data.isESMImport])
+  ).toEqual([
+    ['worker-entry', 'worker', false],
+    ['metro-runtime', null, false],
+  ]);
+});
+
+it('collects and rewrites Worker URL constructors through the Metro async runtime', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const worker = new Worker(new URL('./worker', window.location.href));`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('.unstable_createWorker)');
+  expect(result.result.code).toContain(
+    '.unstable_resolve(_dependencyMap[0], _dependencyMap.paths)'
+  );
+  expect(result.dependencies.map(({ name, data }) => [name, data.asyncType])).toEqual([
+    ['./worker', 'worker'],
+    ['metro-runtime', null],
+  ]);
+});
+
+it('collects require.context parameters and keeps distinct contexts separate', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = [require.context('./views'), require.context('./views', false, /a\\/b/gi, 'lazy')];`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_allowRequireContext: true,
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(
+    `module.exports = [_$$_REQUIRE(_dependencyMap[0], "./views"), _$$_REQUIRE(_dependencyMap[1], "./views")];`
+  );
+  expect(result.dependencies.map(({ name, data }) => [name, data.contextParams])).toEqual([
+    ['./views', { recursive: true, filter: { pattern: '.*', flags: '' }, mode: 'sync' }],
+    [
+      './views',
+      {
+        recursive: false,
+        filter: { pattern: 'a\\/b', flags: 'gi' },
+        mode: 'lazy',
+      },
+    ],
+  ]);
+});
+
+it('leaves require.context untouched when the Metro feature is disabled', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = require.context('./views');`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_allowRequireContext: false,
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies).toEqual([]);
+  expect(result.result.code).toContain(`require.context('./views')`);
+});
+
+it.each([
+  ['dynamic import', `import('one')`, 'async', ''],
+  ['prefetch import', `__prefetchImport('one')`, 'prefetch', '.prefetch'],
+  [
+    'maybe-sync import',
+    `require.unstable_importMaybeSync('one')`,
+    'maybeSync',
+    '.unstable_importMaybeSync',
+  ],
+])(
+  'collects and rewrites %s through the Metro async runtime',
+  async (_label, source, type, method) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `module.exports = ${source};`,
+      options: options({ dev: true }),
+      isDefaultExpoTransformer: true,
+      config: {
+        allowOptionalDependencies: false,
+        asyncRequireModulePath: 'metro-runtime',
+        globalPrefix: '',
+        unstable_compactOutput: false,
+      },
+    });
+
+    if (result.status === 'fallback') throw new Error(result.reason);
+    expect(result.result.code).toContain(
+      `module.exports = _$$_REQUIRE(_dependencyMap[1], "metro-runtime")${method}(_dependencyMap[0], _dependencyMap.paths, "one");`
+    );
+    expect(
+      result.dependencies.map(({ name, data }) => [name, data.asyncType, data.isESMImport])
+    ).toEqual([
+      ['one', type, true],
+      ['metro-runtime', null, false],
+    ]);
+  }
+);
+
+it('deduplicates the generated async runtime dependency across import kinds', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = [import('one'), __prefetchImport('two')];`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(
+    result.dependencies.map(({ name, data }) => [name, data.asyncType, (data as any).imports])
+  ).toEqual([
+    ['one', 'async', 1],
+    ['metro-runtime', null, 2],
+    ['two', 'prefetch', 1],
+  ]);
+});
+
+it('collects optional dynamic imports and lets a required duplicate dominate', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = [import('one').catch(onReject), import('one')];`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies).toHaveLength(2);
+  expect(result.dependencies[0]).toMatchObject({
+    name: 'one',
+    data: { asyncType: 'async', isOptional: false },
+  });
+  expect(result.dependencies[1]).toMatchObject({
+    name: 'metro-runtime',
+    data: { asyncType: null },
+  });
+  expect(result.dependencies[1]!.data.isOptional).toBeUndefined();
+});
+
+it.each([
+  [`import('one').catch(onReject)`, true],
+  [`import('one').then(onResolve).catch(onReject)`, true],
+  [`import('one').then(onResolve, onReject)`, true],
+  [`consume(import('one')).catch(onReject)`, false],
+  [`import('one') + value.catch(onReject)`, false],
+  [`import('one').catch(undefined)`, false],
+  [`import('one').then(onResolve, null)`, false],
+  [`import('one')["catch"](onReject)`, false],
+  [`import('one').catch?.(onReject)`, false],
+  [`import('one')?.catch(onReject)`, true],
+  [`try { import('one'); } catch {}`, true],
+  [`try /* comment */\n { import('one'); } catch {}`, true],
+  [`try { { import('one'); } } catch {}`, false],
+  [`try { if (condition) import('one'); } catch {}`, true],
+  [`try { label: if (condition) import('one'); } catch {}`, false],
+  [`try { label: if (condition) var value = import('one'); } catch {}`, false],
+  [`try {} catch { import('one'); }`, false],
+  [`try {} finally { import('one'); }`, false],
+])('matches Metro optional dynamic-import semantics in %s', async (source, optional) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies[0]).toMatchObject({
+    name: 'one',
+    data: { asyncType: 'async' },
+  });
+  expect(result.dependencies[0]!.data.isOptional).toBe(optional || undefined);
+  expect(result.dependencies[1]!.data.isOptional).toBeUndefined();
+});
+
+it('collects optional worker dependencies without making the runtime optional', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `try { require.unstable_resolveWorker('worker-entry'); } catch {}`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies[0]).toMatchObject({
+    name: 'worker-entry',
+    data: { asyncType: 'worker', isOptional: true },
+  });
+  expect(result.dependencies[1]).toMatchObject({
+    name: 'metro-runtime',
+    data: { asyncType: null },
+  });
+  expect(result.dependencies[1]!.data.isOptional).toBeUndefined();
+});
+
+it('honors optional dependency exclusions for dynamic imports and workers', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `try {
+      import('excluded');
+      require.unstable_resolveWorker('excluded-worker');
+    } catch {}`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: { exclude: ['excluded', 'excluded-worker'] },
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name, data }) => [name, data.isOptional])).toEqual([
+    ['excluded', undefined],
+    ['metro-runtime', undefined],
+    ['excluded-worker', undefined],
+  ]);
+});
+
+it('collects optional weak and context dependencies', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `try {
+      require.resolveWeak('weak-entry');
+      require.context('./routes');
+    } catch {}`,
+    options: options({ dev: false }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+      unstable_allowRequireContext: true,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(
+    result.dependencies.map(({ name, data }) => [name, data.asyncType, data.isOptional])
+  ).toEqual([
+    ['weak-entry', 'weak', true],
+    ['./routes', null, true],
+  ]);
+  expect(result.result.code).toContain(`_$$_REQUIRE(_dependencyMap[1], "./routes")`);
+});
+
+it.each([`import(/* @metro-ignore */ 'one')`, `import(/* webpackIgnore: true */ 'one')`])(
+  'leaves ignored dynamic imports uncollected in %s',
+  async (source) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `module.exports = ${source};`,
+      options: options({ dev: true }),
+      isDefaultExpoTransformer: true,
+      config: {
+        allowOptionalDependencies: true,
+        asyncRequireModulePath: 'metro-runtime',
+        globalPrefix: '',
+        unstable_compactOutput: false,
+      },
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.dependencies).toEqual([]);
+    expect(result.result.code).toContain(source);
+  }
+);
+
+it.each([
+  `/* @metro-ignore */ import('one')`,
+  `import('one') /* webpackIgnore: true */`,
+  `const annotation = '@metro-ignore'; import('one')`,
+  "const annotation = `webpackIgnore: true`; import('one')",
+  `/* unrelated @metro-ignore */ const value = 1; import('one')`,
+])('does not treat non-inner annotation text as a dynamic-import ignore in %s', async (source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `module.exports = (() => { ${source} })();`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: true,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one', 'metro-runtime']);
+});
+
+it('does not infer optional dynamic-import semantics from unrelated source text', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `const text = ".catch("; module.exports = import("one");`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: { ...fullConfig(), allowOptionalDependencies: true },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one', 'metro-runtime']);
+});
+
+it('mirrors Expo define and import-meta transforms for eligible dependencies', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `
+      var values = [process.env.EXPO_OS, process['env']['EXPO_OS'], process.env.EXPO_SERVER, process.env.NODE_ENV, __DEV__, Platform.OS];
+      var registry = import.meta.url;
+      var router = [process.env.EXPO_PROJECT_ROOT, process.env.EXPO_ROUTER_APP_ROOT, process.env.EXPO_ROUTER_IMPORT_MODE];
+      var selected = Platform.select({ web: 'web', native: 'native', ios: 'ios' });
+      function shadow(process, Platform, __DEV__) {
+        return [process.env.EXPO_OS, Platform.OS, __DEV__];
+      }
+      process.env.NODE_ENV = 'test';
+      process.env.NODE_ENV += suffix;
+      process.env.NODE_ENV ||= fallback;
+      process.env.NODE_ENV++;
+      ++process.env.NODE_ENV;
+      delete (process.env.NODE_ENV);
+      ({ value: process.env.NODE_ENV } = values);
+      for (process.env.NODE_ENV in values) {}
+      for (process.env.NODE_ENV of values) {}
+      module.exports = values;
+    `,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(
+    `var values = ["ios", "ios", false, "production", false, "ios"]`
+  );
+  expect(result.result.code).toContain('globalThis.__ExpoImportMetaRegistry.url');
+  expect(result.result.code).toContain(`var router = ["/app", "../../app", "sync"]`);
+  expect(result.result.code).toContain(`var selected = 'ios'`);
+  expect(result.result.code).toContain('return [process.env.EXPO_OS, Platform.OS, __DEV__]');
+  expect(result.result.code).toContain(`process.env.NODE_ENV = 'test'`);
+  expect(result.result.code).toContain(`process.env.NODE_ENV += suffix`);
+  expect(result.result.code).toContain(`process.env.NODE_ENV ||= fallback`);
+  expect(result.result.code).toContain(`process.env.NODE_ENV++`);
+  expect(result.result.code).toContain(`++process.env.NODE_ENV`);
+  expect(result.result.code).toMatch(/delete\s+\(?process\.env\.NODE_ENV\)?/);
+  expect(result.result.code).toMatch(/value:\s*process\.env\.NODE_ENV/);
+  expect(result.result.code).toContain(`for (process.env.NODE_ENV in values)`);
+  expect(result.result.code).toContain(`for (process.env.NODE_ENV of values)`);
+  expect(result.result.metadata.hasCjsExports).toBe(true);
+  expect(result.result.functionMap).toMatchObject({
+    names: ['<global>', 'shadow'],
+  });
+});
+
+it('uses the last duplicate Platform.select entry while preserving fallback precedence', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `
+      var platform = Platform.select({ ios: 'first-ios', ios: 'last-ios' });
+      var native = Platform.select({ native: 'first-native', native: 'last-native' });
+      var fallback = Platform.select({ default: 'first-default', default: 'last-default' });
+      var platformPrecedence = Platform.select({
+        ios: 'first-ios', native: 'first-native', default: 'first-default',
+        ios: 'last-ios', native: 'last-native', default: 'last-default'
+      });
+      var nativePrecedence = Platform.select({
+        native: 'first-native', default: 'first-default',
+        native: 'last-native', default: 'last-default'
+      });
+      var computed = Platform.select({ ['ios']: 'computed', ios: 'static' });
+      var spread = Platform.select({ ...values, ios: 'static' });
+    `,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(`var platform = 'last-ios'`);
+  expect(result.result.code).toContain(`var native = 'last-native'`);
+  expect(result.result.code).toContain(`var fallback = 'last-default'`);
+  expect(result.result.code).toContain(`var platformPrecedence = 'last-ios'`);
+  expect(result.result.code).toContain(`var nativePrecedence = 'last-native'`);
+  expect(result.result.code).toContain(`var computed = Platform.select`);
+  expect(result.result.code).toContain(`var spread = Platform.select`);
+});
+
+it('inlines EXPO_PUBLIC environment variables in production and preserves assignments', async () => {
+  const previous = process.env.EXPO_PUBLIC_NOXCTURNAL_TEST;
+  process.env.EXPO_PUBLIC_NOXCTURNAL_TEST = 'native-value';
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename: workspaceFilename,
+      projectRoot: '/app',
+      source: `var value = process.env.EXPO_PUBLIC_NOXCTURNAL_TEST; process.env.EXPO_PUBLIC_NOXCTURNAL_TEST = 'next';`,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status === 'complete') {
+      expect(result.result.code).toBe(
+        `var value = "native-value"; process.env.EXPO_PUBLIC_NOXCTURNAL_TEST = 'next';`
+      );
+    }
+  } finally {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_NOXCTURNAL_TEST;
+    else process.env.EXPO_PUBLIC_NOXCTURNAL_TEST = previous;
+  }
+});
+
+it('resolves only encountered public and Router environment properties', async () => {
+  const previous = process.env.EXPO_PUBLIC_NOXCTURNAL_I19;
+  process.env.EXPO_PUBLIC_NOXCTURNAL_I19 = 'native-value';
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename: workspaceFilename,
+      projectRoot: '/app',
+      source: `
+        var key = 'EXPO_PUBLIC_NOXCTURNAL_I19';
+        module.exports = [
+          process.env.EXPO_PUBLIC_NOXCTURNAL_I19,
+          process['env']['EXPO_PUBLIC_NOXCTURNAL_I19'],
+          process.env?.EXPO_PUBLIC_NOXCTURNAL_I19,
+          process.env?.['EXPO_PUBLIC_NOXCTURNAL_I19'],
+          process.env.EXPO_PUBLIC_NOXCTURNAL_I19_UNSET,
+          process.env[key],
+          (() => { const process = { env: { EXPO_PUBLIC_NOXCTURNAL_I19: 'shadow' } }; return process.env.EXPO_PUBLIC_NOXCTURNAL_I19; })(),
+          process.env.EXPO_ROUTER_APP_ROOT,
+          process['env'].EXPO_ROUTER_ABS_APP_ROOT
+        ];
+      `,
+      options: options({
+        customTransformOptions: { engine: 'hermes', routerRoot: 'routes' },
+      }),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain('"native-value"');
+    expect(result.result.code.match(/"native-value"/g)).toHaveLength(4);
+    expect(result.result.code).toContain('undefined');
+    expect(result.result.code).toContain('process.env[key]');
+    expect(result.result.code).toContain('EXPO_PUBLIC_NOXCTURNAL_I19: "shadow"');
+    expect(result.result.code).toContain('"../../../routes"');
+    expect(result.result.code).toContain('"/app/routes"');
+  } finally {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_NOXCTURNAL_I19;
+    else process.env.EXPO_PUBLIC_NOXCTURNAL_I19 = previous;
+  }
+});
+
+it('does not enumerate public environment variables while building a transform', async () => {
+  const entries = jest.spyOn(Object, 'entries');
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `module.exports = process.env.EXPO_PUBLIC_NOXCTURNAL_UNSET;`,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    expect(entries.mock.calls.some(([value]) => value === process.env)).toBe(false);
+  } finally {
+    entries.mockRestore();
+  }
+});
+
+it.each([false, true])(
+  'leaves ordinary public environment variables untouched in node modules with dev=%s',
+  async (dev) => {
+    const previous = process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY;
+    process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY = 'private-app-value';
+    try {
+      const result = await transformNodeModuleWithNoxcturnal({
+        filename,
+        projectRoot: '/app',
+        source: `module.exports = process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY;`,
+        options: options({ dev }),
+        isDefaultExpoTransformer: true,
+      });
+
+      expect(result.status).toBe('complete');
+      if (result.status !== 'complete') return;
+      expect(result.result.code).toContain('process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY');
+      expect(result.result.code).not.toContain('private-app-value');
+      expect(result.result.code).not.toContain('expo/virtual/env');
+    } finally {
+      if (previous === undefined) delete process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY;
+      else process.env.EXPO_PUBLIC_NOXCTURNAL_DEPENDENCY = previous;
+    }
+  }
+);
+
+it.each([
+  [false, 'node'],
+  [true, 'node'],
+  [false, 'react-server'],
+  [true, 'react-server'],
+] as const)(
+  'leaves public environment variables for the runtime in dev=%s %s bundles',
+  async (dev, environment) => {
+    const previous = process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER;
+    process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER = 'build-time-value';
+    try {
+      const result = await transformNodeModuleWithNoxcturnal({
+        filename: workspaceFilename,
+        projectRoot: '/app',
+        source: `module.exports = process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER;`,
+        options: options({
+          dev,
+          customTransformOptions: { engine: 'hermes', environment },
+        }),
+        isDefaultExpoTransformer: true,
+      });
+
+      expect(result.status).toBe('complete');
+      if (result.status !== 'complete') return;
+      expect(result.result.code).toContain('process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER');
+      expect(result.result.code).not.toContain('build-time-value');
+      expect(result.result.code).not.toContain('expo/virtual/env');
+    } finally {
+      if (previous === undefined) delete process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER;
+      else process.env.EXPO_PUBLIC_NOXCTURNAL_SERVER = previous;
+    }
+  }
+);
+
+it('preserves the configured RN fetch exception for node modules', async () => {
+  const previous = process.env.EXPO_PUBLIC_USE_RN_FETCH;
+  process.env.EXPO_PUBLIC_USE_RN_FETCH = '1';
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `module.exports = process.env.EXPO_PUBLIC_USE_RN_FETCH;`,
+      options: options({ dev: true }),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toBe(`module.exports = "1";`);
+    expect(result.result.code).not.toContain('expo/virtual/env');
+  } finally {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_USE_RN_FETCH;
+    else process.env.EXPO_PUBLIC_USE_RN_FETCH = previous;
+  }
+});
+
+it('leaves the RN fetch exception untouched in node modules when unset', async () => {
+  const previous = process.env.EXPO_PUBLIC_USE_RN_FETCH;
+  delete process.env.EXPO_PUBLIC_USE_RN_FETCH;
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `module.exports = process.env.EXPO_PUBLIC_USE_RN_FETCH;`,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain('process.env.EXPO_PUBLIC_USE_RN_FETCH');
+  } finally {
+    if (previous !== undefined) process.env.EXPO_PUBLIC_USE_RN_FETCH = previous;
+  }
+});
+
+it('references configured RN fetch through the virtual environment in development source', async () => {
+  const previous = process.env.EXPO_PUBLIC_USE_RN_FETCH;
+  process.env.EXPO_PUBLIC_USE_RN_FETCH = '1';
+  try {
+    const result = await transformNodeModuleWithNoxcturnal({
+      filename: workspaceFilename,
+      projectRoot: '/app',
+      source: `module.exports = process.env.EXPO_PUBLIC_USE_RN_FETCH;`,
+      options: options({ dev: true }),
+      isDefaultExpoTransformer: true,
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain('require("expo/virtual/env")');
+    expect(result.result.code).not.toContain('module.exports = "1"');
+    expect(result.result.metadata.publicEnvVars).toEqual(['EXPO_PUBLIC_USE_RN_FETCH']);
+  } finally {
+    if (previous === undefined) delete process.env.EXPO_PUBLIC_USE_RN_FETCH;
+    else process.env.EXPO_PUBLIC_USE_RN_FETCH = previous;
+  }
+});
+
+it('references EXPO_PUBLIC environment variables through the virtual module in development', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: workspaceFilename,
+    projectRoot: '/app',
+    source: `var _env; function mutate(input) { process.env.EXPO_PUBLIC_API_URL++; process.env['EXPO_PUBLIC_API_URL']++; delete (process.env.EXPO_PUBLIC_API_URL); ({ value: process.env.EXPO_PUBLIC_API_URL } = input); for (process.env.EXPO_PUBLIC_API_URL in input) {} for (process.env.EXPO_PUBLIC_API_URL of input) {} } module.exports = [process.env.EXPO_PUBLIC_API_URL, process.env['EXPO_PUBLIC_OTHER'], process.env.EXPO_PUBLIC_API_URL = 'next', (() => { const process = { env: { EXPO_PUBLIC_API_URL: 'shadow' } }; return process.env.EXPO_PUBLIC_API_URL; })(), process.env.EXPO_ROUTER_IMPORT_MODE];`,
+    options: options({
+      dev: true,
+      customTransformOptions: { engine: 'hermes', asyncRoutes: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('require("expo/virtual/env")');
+  expect(result.result.metadata.publicEnvVars).toEqual([
+    'EXPO_PUBLIC_API_URL',
+    'EXPO_PUBLIC_OTHER',
+  ]);
+  expect(result.result.code).toContain('process.env.EXPO_PUBLIC_API_URL++');
+  expect(result.result.code).toMatch(/process\.env\[['"]EXPO_PUBLIC_API_URL['"]\]\+\+/);
+  expect(result.result.code).toMatch(/delete\s+\(?process\.env\.EXPO_PUBLIC_API_URL\)?/);
+  expect(result.result.code).toMatch(/value:\s*process\.env\.EXPO_PUBLIC_API_URL/);
+  expect(result.result.code).toContain('for (process.env.EXPO_PUBLIC_API_URL in input)');
+  expect(result.result.code).toContain('for (process.env.EXPO_PUBLIC_API_URL of input)');
+  const mappedPublicEnv = originalPositionFor(
+    new TraceMap({
+      version: 3,
+      sources: [filename],
+      ...result.result.map,
+    } as any),
+    generatedPositionOf(result.result.code, '.env.EXPO_PUBLIC_API_URL')
+  );
+  expect(mappedPublicEnv.line).toBe(1);
+  const module = { exports: undefined as unknown };
+  const processObject = { env: { EXPO_PUBLIC_API_URL: 'original' } };
+  Function(
+    'module',
+    'require',
+    'process',
+    result.result.code
+  )(
+    module,
+    (name: string) => {
+      expect(name).toBe('expo/virtual/env');
+      return {
+        env: { EXPO_PUBLIC_API_URL: 'api', EXPO_PUBLIC_OTHER: 'other' },
+      };
+    },
+    processObject
+  );
+  expect(module.exports).toEqual(['api', 'other', 'next', 'shadow', 'lazy']);
+  expect(processObject.env.EXPO_PUBLIC_API_URL).toBe('next');
+
+  const full = await transformFileFullyWithNoxcturnal({
+    filename: workspaceFilename,
+    projectRoot: '/app',
+    source: `module.exports = process.env.EXPO_PUBLIC_API_URL;`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(full.status).toBe('complete');
+  if (full.status !== 'complete') return;
+  expect(full.dependencies.map((dependency) => dependency.name)).toContain('expo/virtual/env');
+});
+
+it('preserves lazy Expo Router imports in production web bundles', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: workspaceFilename,
+    projectRoot: '/app',
+    source: `module.exports = process.env.EXPO_ROUTER_IMPORT_MODE;`,
+    options: options({
+      dev: false,
+      platform: 'web',
+      customTransformOptions: { engine: 'hermes', asyncRoutes: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('module.exports = "lazy"');
+});
+
+it('matches the non-Hermes dependency recipe without Babel', async () => {
+  const source = `
+const input = { kept: 2, extra: 3 };
+const { kept, ...rest } = input;
+async function run(value = 1) {
+  class Box {
+    field = value;
+    read() { return { ...rest, kept, value: this.field }; }
+  }
+  return new Box().read();
+}
+module.exports = run;`;
+  const native = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({
+      unstable_transformProfile: 'default',
+      customTransformOptions: { engine: undefined },
+    }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+  });
+  expect(native.status).toBe('complete');
+  if (native.status !== 'complete') return;
+  const babelResult = transformWithNonHermesBabelPreset(source, filename);
+  const evaluate = async (code: string) => {
+    const module = { exports: undefined as unknown };
+    Function('module', 'exports', code)(module, module.exports);
+    return (module.exports as (value?: number) => Promise<unknown>)();
+  };
+  await expect(evaluate(native.result.code)).resolves.toEqual(await evaluate(babelResult.code!));
+  await expect(evaluate(native.result.code)).resolves.toEqual({
+    extra: 3,
+    kept: 2,
+    value: 1,
+  });
+  expect(native.result.code).not.toContain('class Box');
+  expect(native.result.code).not.toContain('async function run');
+  expect(native.result.code).not.toContain('const input');
+
+  const full = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({
+      unstable_transformProfile: 'default',
+      customTransformOptions: { engine: undefined },
+    }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(full.status).toBe('complete');
+});
+
+it('falls back for ESM when Metro import support is disabled', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import value from 'pkg'; export default value;`,
+    options: options({ experimentalImportSupport: false }),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result).toEqual({
+    status: 'fallback',
+    reason: 'expo-metro-eligibility:esm-requires-babel-module-transform',
+  });
+});
+
+it.each([
+  [
+    'imports',
+    `import v from 'foo'; import * as w from 'bar'; import { x } from 'baz'; import { y as z } from 'qux'; import 'side-effect'; v; w; x; z;`,
+  ],
+  [
+    'deduplicated imports',
+    `import a, * as b from 'second'; import c, { d as e, f } from 'third'; import { g, h } from 'third'; a; b; c; e; f; g; h;`,
+  ],
+  ['hoisting', `foo(); import { foo } from 'bar';`],
+  ['default re-export', `export { default as foo } from 'bar';`],
+  ['named re-exports', `export { foo as default, baz } from 'bar';`],
+  [
+    'local exports',
+    `export const foo = 'foo'; export function fn() {} export class Box {} export { foo as renamed };`,
+  ],
+  ['destructured exports', `export const { foo, bar: [baz] } = value;`],
+  ['default declarations', `export default class {};`],
+  ['export all', `export * from 'bar';`],
+  ['namespace re-export', `export * as namespace from 'bar';`],
+  ['locally exported namespace import', `import * as namespace from 'bar'; export { namespace };`],
+  [
+    'default import specifier',
+    `import { Platform, default as ReactNative } from 'react-native'; Platform; ReactNative;`,
+  ],
+  [
+    'calls and constructors',
+    `import value, { call, Constructor } from 'pkg'; call(); new Constructor(); new value.Member();`,
+  ],
+  ['forward local export', `export { value }; import { value } from 'pkg';`],
+  ['unused development import', `import unused from 'pkg'; run();`],
+  [
+    'deferred export ordering',
+    `export const local = 1; export default local; export { value } from 'pkg';`,
+  ],
+  ['mixed CommonJS exports', `export const value = 1; exports.other = 2; module.exports.x = 3;`],
+  ['empty source export', `export {} from 'pkg'; run();`],
+  ['duplicate export all', `export * from 'pkg'; export * from 'pkg';`],
+  ['anonymous default function', `export default function () {}`],
+  ['anonymous default function without keyword whitespace', `export default function() {}`],
+  [
+    'anonymous default async function without keyword whitespace',
+    `export default async function() {}`,
+  ],
+  [
+    'anonymous default generator function without keyword whitespace',
+    `export default function*() {}`,
+  ],
+  ['anonymous default class', `export default class {}`],
+  ['anonymous default derived class', `export default class extends Base {}`],
+  [
+    'd3 pointRadial named default function',
+    `export default function (x, y) { return [(y = +y) * Math.cos((x -= Math.PI / 2)), y * Math.sin(x)]; }`,
+  ],
+  ['computed imported name', `import { "x-y" as value } from 'pkg'; value;`],
+  ['renamed pseudo globals', `const exports = 1; export { exports as value };`],
+])('matches importExportLiveBindings syntax for %s', async (_name, source) => {
+  const native = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+
+  const expected = babel.transformSync(source, {
+    ast: false,
+    babelrc: false,
+    comments: false,
+    compact: false,
+    configFile: false,
+    filename,
+    plugins: [[importExportLiveBindingsPlugin, { performConstantFolding: false, resolve: false }]],
+  });
+  if (!expected?.code) throw new Error('Babel live-bindings transform produced no output');
+
+  expect(canonicalModuleBody(native.result.code, true)).toBe(canonicalModuleBody(expected.code));
+});
+
+it.each([
+  ['unused import', `import unused from 'pkg'; run();`],
+  ['used import', `import value from 'pkg'; run(value);`],
+  ['binding collision', `const _pkg = 1; import { value } from 'pkg'; run(_pkg, value);`],
+  ['directive prologue', `"use strict"; import { value } from 'pkg'; run(value);`],
+  ['duplicate export all', `export * from 'pkg'; export * from 'pkg';`],
+])('matches folded importExportLiveBindings syntax for %s', async (_name, source) => {
+  const native = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: false, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  if (native.status === 'fallback') throw new Error(native.reason);
+  const expected = babel.transformSync(source, {
+    babelrc: false,
+    comments: false,
+    configFile: false,
+    filename,
+    plugins: [[importExportLiveBindingsPlugin, { performConstantFolding: true, resolve: false }]],
+  });
+  if (!expected?.code) throw new Error('Babel live-bindings transform produced no output');
+  expect(canonicalModuleBody(native.result.code, true)).toBe(canonicalModuleBody(expected.code));
+});
+
+it('uses static import and export values when live bindings are disabled', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import { value, other as importedOther } from './source';
+      export function read() { return value; }
+      export { importedOther };
+      export { other } from './other';`,
+    options: options({
+      dev: false,
+      experimentalImportSupport: true,
+      customTransformOptions: { liveBindings: 'false' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/var value = .*\.value/);
+  expect(result.result.code).toMatch(/var importedOther = .*\.other/);
+  expect(result.result.code).toContain('exports.importedOther = importedOther');
+  expect(result.result.code).toContain('exports.read = read');
+  expect(result.result.code).toMatch(/var \w+ = .*\.other/);
+  expect(result.result.code).not.toContain('Object.defineProperty(exports, "read"');
+});
+
+it('keeps browser globals unreachable in static server modules', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/node_modules/react-native-web/dist/modules/canUseDom/index.js',
+    projectRoot: '/app',
+    source: `var canUseDOM = !!(typeof window !== 'undefined' && window.document); export default canUseDOM;`,
+    options: options({
+      dev: false,
+      experimentalImportSupport: true,
+      customTransformOptions: { environment: 'node', liveBindings: 'false' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('var canUseDOM = false');
+  expect(result.result.code).toContain("Object.defineProperty(exports, '__esModule'");
+  expect(result.result.code).toContain('exports.default = _default');
+});
+
+it('lowers static ESM imports and exports through the full native path', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import value from 'pkg'; export default value;`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(`var _pkg = _$$_REQUIRE(_dependencyMap[0], "pkg");`);
+  expect(result.result.code).toContain(`var value = _interopDefault(_pkg);`);
+  expect(result.result.code).toContain(`return _default;`);
+  expect(result.dependencies).toMatchObject([
+    { name: 'pkg', data: { isESMImport: true, asyncType: null } },
+  ]);
+});
+
+it.each([
+  ['class declaration', 'export default class Value {}', 'Value'],
+  ['function declaration', 'export default function value() {}', 'value'],
+  ['expression', 'export default { value: 1 }', '_default'],
+])(
+  'separates an EOF default-export %s from generated export assignments',
+  async (_name, source, binding) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source,
+      options: options({ dev: true, experimentalImportSupport: true }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+    if (result.status === 'fallback') throw new Error(result.reason);
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain(`return ${binding};`);
+    expect(() => babel.parseSync(result.result.code)).not.toThrow();
+  }
+);
+
+it.each([
+  ['class', `export default class DOMException {}; DOMException.code = 1;`],
+  ['function', `export default function createValue() {}; createValue.code = 1;`],
+])('preserves a named default %s declaration binding', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+
+  let factory: Function | undefined;
+  new Function('__d', result.result.code)((value: Function) => {
+    factory = value;
+  });
+  const moduleExports: { default?: { code?: number } } = {};
+  factory?.(
+    globalThis,
+    () => undefined,
+    () => undefined,
+    () => undefined,
+    { exports: moduleExports },
+    moduleExports,
+    []
+  );
+  expect(moduleExports.default?.code).toBe(1);
+});
+
+it.each([
+  ['function', `export default function(value) { return value; }`],
+  ['class', `export default class { constructor(value) { this.value = value; } }`],
+])('preserves anonymous default %s identity and behavior', async (kind, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+
+  let factory: Function | undefined;
+  new Function('__d', result.result.code)((value: Function) => {
+    factory = value;
+  });
+  const moduleExports: { default?: Function } = {};
+  factory?.(
+    globalThis,
+    () => undefined,
+    () => undefined,
+    () => undefined,
+    { exports: moduleExports },
+    moduleExports,
+    []
+  );
+  const exported = moduleExports.default;
+  expect(typeof exported).toBe('function');
+  if (kind === 'function') expect(exported?.('value')).toBe('value');
+  else
+    expect(new (exported as new (value: string) => { value: string })('value').value).toBe('value');
+});
+
+it('writes ESM exports through the normalized Metro exports parameter', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `export const ctx = require.context('./routes');`,
+    options: options({ dev: false, minify: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: { ...fullConfig(), unstable_allowRequireContext: true },
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+
+  let factory: Function | undefined;
+  new Function('__d', result.result.code)((value: Function) => {
+    factory = value;
+  });
+  const context = Object.assign(() => undefined, { keys: () => ['./route.tsx'] });
+  const moduleExports: { ctx?: typeof context } = {};
+  factory?.(
+    globalThis,
+    () => context,
+    () => undefined,
+    () => undefined,
+    {},
+    moduleExports,
+    []
+  );
+
+  expect(moduleExports.ctx).toBe(context);
+  expect(moduleExports.ctx?.keys()).toEqual(['./route.tsx']);
+});
+
+it('collects graph-optimization metadata without rewriting or wrapping modules', async () => {
+  const source = `import 'side-effect';
+import primary, { alpha as local } from 'pkg';
+import { alpha as duplicateLocal } from 'pkg';
+import * as namespace from 'all';
+export { beta as renamed } from 'reexport';
+export { gamma as another } from 'reexport';
+export * from 'star';
+const cjs = require('cjs');
+export const output = [primary, local, duplicateLocal, namespace, cjs];`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options({
+      dev: false,
+      customTransformOptions: { engine: 'hermes', optimize: true },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('__d(function');
+  expect(result.result.map.mappings.length).toBeGreaterThan(0);
+  expect(result.result.code).toMatch(/from ["']pkg["']/);
+  expect(result.result.code).toMatch(/require\(["']cjs["']\)/);
+  expect(result.result.code).toMatch(/export (?:const|var) output/);
+  expect(
+    result.dependencies.map(({ name, data }) => [name, data.isESMImport, data.exportNames])
+  ).toEqual([
+    ['side-effect', true, []],
+    ['pkg', true, ['default', 'alpha']],
+    ['all', true, ['*']],
+    ['reexport', true, ['beta', 'gamma']],
+    ['star', true, ['*']],
+    ['cjs', false, ['*']],
+  ]);
+  for (const dependency of result.dependencies) {
+    expect(Object.isFrozen(dependency)).toBe(true);
+    expect(Object.isFrozen(dependency.data)).toBe(true);
+    expect(Object.keys(dependency)).not.toContain('exportNameSet');
+  }
+  expect(JSON.stringify(result.result.metadata)).not.toContain('exportNameSet');
+});
+
+it('selects ESM lowering from parsed syntax after comments and a shebang', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `#!/usr/bin/env node\n/* retained lead */\nimport value from "one";\nexport default value;`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
+  expect(result.result.code).toContain(`Object.defineProperty(exports, "default"`);
+  expect(result.result.code).not.toContain('import value');
+});
+
+it('preserves live imported references, direct-call semantics, and live local exports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import * as ns from 'pkg'; import { value, call } from 'pkg'; export let local = value; export { local as renamed }; module.exports = { value, call: call(), ns }; local++;`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('var _pkg = _$$_REQUIRE(_dependencyMap[0], "pkg")');
+  expect(result.result.code).not.toContain('var _pkg2 =');
+  expect(result.result.code).toContain('var ns = _interopNamespace(_pkg)');
+  expect(result.result.code).toContain('var local = _pkg.value');
+  expect(result.result.code).toContain('value: _pkg.value');
+  expect(result.result.code).toContain('call: (0, _pkg.call)()');
+  expect(result.result.code).toContain('get: function () { return local; }');
+  expect(result.dependencies).toHaveLength(1);
+});
+
+it('preserves live imported bindings that are exported locally', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import { URL, URLSearchParams as Params } from 'whatwg-url-minimum'; export { URL, Params as URLSearchParams };`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('return _whatwgUrlMinimum.URL;');
+  expect(result.result.code).toContain('return _whatwgUrlMinimum.URLSearchParams;');
+  expect(result.result.code).not.toContain('return URL;');
+  expect(result.result.code).not.toContain('return Params;');
+});
+
+it('keeps ordinary named imports from helper directories as named imports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import { usePrevious } from './helpers/usePrevious'; module.exports = usePrevious(1);`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(`(0, _helpersUsePrevious.usePrevious)(1)`);
+  expect(result.result.code).not.toContain(
+    `_$$_IMPORT_DEFAULT(_dependencyMap[0], "./helpers/usePrevious")`
+  );
+});
+
+it('preserves constructor semantics for a default import', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import EventEmitter from 'events'; export default new EventEmitter();`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(`var EventEmitter = _interopDefault(_events);`);
+  expect(result.result.code).toContain(`new EventEmitter.default()`);
+});
+
+it('preserves constructor semantics for a member of a default import', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import Animated from './Animated'; export default new Animated.Value(1);`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain(`var Animated = _interopDefault(_Animated);`);
+  expect(result.result.code).toContain(`new Animated.default.Value(1)`);
+});
+
+it("loads Babel runtime helpers through Metro's default-import ABI", async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import Base from './Base'; class Derived extends Base {} module.exports = new Derived();`,
+    options: options({
+      dev: true,
+      experimentalImportSupport: true,
+      unstable_transformProfile: 'default',
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('var Base = _interopDefault(_Base)');
+  expect(result.result.code).toMatch(
+    /construct: _\$\$_IMPORT_DEFAULT\(_dependencyMap\[\d+\], "@babel\/runtime\/helpers\/construct"\)/
+  );
+});
+
+it('lowers named, namespace, and export-all re-exports with live getters', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `export { value as renamed } from 'pkg'; export * as namespace from 'other'; export * from 'all';`,
+    options: options({ dev: true, experimentalImportSupport: true }),
+    isDefaultExpoTransformer: true,
+    config: {
+      allowOptionalDependencies: false,
+      asyncRequireModulePath: 'metro-runtime',
+      globalPrefix: '',
+      unstable_compactOutput: false,
+    },
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('return _pkg.value;');
+  expect(result.result.code).toContain('return _other2;');
+  expect(result.result.code).toContain("if (k !== 'default'");
+  expect(result.dependencies.map(({ name }) => name)).toEqual(['pkg', 'other', 'all']);
+});
+
+it.each([
+  ['custom transformer', filename, 'const value = 1;', false, 'custom-babel-transformer'],
+  [
+    'React Native Codegen',
+    filename,
+    'codegenNativeComponent("View")',
+    true,
+    'react-native-codegen',
+  ],
+])('falls back for %s', async (_name, candidate, source, isDefaultExpoTransformer, reason) => {
+  await expect(
+    transformNodeModuleWithNoxcturnal({
+      filename: candidate,
+      projectRoot: '/app',
+      source,
+      options: options(),
+      isDefaultExpoTransformer,
+    })
+  ).resolves.toEqual({ status: 'fallback', reason });
+});
+
+it.each([
+  ['Metro null-prefixed polyfill', '\0polyfill:environment-variables'],
+  ['Expo Router require context', '/app/router-e2e?ctx=1122149ada429c11a789cd9dfdcaefb64b6dd8f5'],
+])('completes extensionless %s through the full native Metro path', async (_name, candidate) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source: 'module.exports = process.env.NODE_ENV;',
+    options: options(),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result).toEqual(expect.objectContaining({ status: 'complete' }));
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('__d(function');
+  expect(result.dependencies).toEqual([]);
+});
+
+it.each([
+  ['Expo virtual', '/repo/packages/expo/virtual/streams.js'],
+  ['Metro null-prefixed', '\0polyfill:environment-variables'],
+])('uses the native source stage for %s script polyfills', async (_name, candidate) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/repo/apps/example',
+    source: "globalThis.ReadableStream ||= require('stream/web').ReadableStream;",
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('globalThis.ReadableStream');
+});
+
+it.each([
+  ['Expo virtual', '/repo/packages/expo/virtual/streams.js'],
+  ['Metro null-prefixed', '\0polyfill:environment-variables'],
+])('completes %s through the full native script path', async (_name, candidate) => {
+  const source = `"use strict";
+global.__scriptModeValue = (global.__scriptModeValue ?? 0) + 1;`;
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/repo/apps/example',
+    source,
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result).toEqual(expect.objectContaining({ status: 'complete' }));
+  if (result.status !== 'complete') return;
+  expect(result.dependencies).toEqual([]);
+  expect(result.dependencyMapName).toBe('');
+  expect(result.result.code).toContain('(function (global) {');
+  expect(result.result.code).toContain(
+    "typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : this"
+  );
+  expect(result.result.code).not.toContain('__d(function');
+
+  const runtimeGlobal: { __scriptModeValue?: number } = {};
+  new Function('globalThis', result.result.code)(runtimeGlobal);
+  expect(runtimeGlobal.__scriptModeValue).toBe(1);
+});
+
+it.each([
+  ['empty input', ''],
+  ['single-line input', 'global.value = 1;'],
+  ['trailing-newline input', 'global.value = 1;\n'],
+  ['multiline input', 'global.first = 1;\nglobal.second = 2;'],
+] as const)('wraps %s without changing the script body', async (_name, source) => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '\0polyfill:test',
+    projectRoot: '/app',
+    source,
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const prefix = '(function (global) {\n';
+  const suffix =
+    "})(typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : this);";
+  expect(result.result.code).toBe(
+    `${prefix}${source}${source.endsWith('\n') ? '' : '\n'}${suffix}`
+  );
+  expect(result.dependencies).toEqual([]);
+});
+
+it('keeps native script mappings at column zero and the generated wrapper sourceless', async () => {
+  const source = 'global.first = 1;\nglobal.second = 2;';
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '\0polyfill:test',
+    projectRoot: '/app',
+    source,
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  const trace = new TraceMap({
+    version: 3,
+    sources: ['\0polyfill:test'],
+    ...result.result.map,
+  } as any);
+  expect(originalPositionFor(trace, { line: 2, column: 0 })).toMatchObject({
+    line: 1,
+    column: 0,
+  });
+  expect(originalPositionFor(trace, { line: 3, column: 0 })).toMatchObject({
+    line: 2,
+    column: 0,
+  });
+  expect(originalPositionFor(trace, { line: 1, column: 0 }).line).toBeNull();
+  expect(originalPositionFor(trace, { line: 4, column: 0 }).line).toBeNull();
+});
+
+it('preserves native script function maps and compact output behavior', async () => {
+  const source = 'function scriptFunction() { return 1; }\nglobal.value = scriptFunction();';
+  const input = {
+    filename: '\0polyfill:test',
+    projectRoot: '/app',
+    source,
+    options: options({ type: 'script' }),
+    enableBabelRuntime: false,
+    isDefaultExpoTransformer: true,
+  };
+  const regular = await transformFileFullyWithNoxcturnal({
+    ...input,
+    config: fullConfig(),
+  });
+  const compact = await transformFileFullyWithNoxcturnal({
+    ...input,
+    config: { ...fullConfig(), unstable_compactOutput: true },
+  });
+
+  expect(regular.status).toBe('complete');
+  expect(compact.status).toBe('complete');
+  if (regular.status !== 'complete' || compact.status !== 'complete') return;
+  expect(regular.result.functionMap?.names).toEqual(
+    expect.arrayContaining(['<global>', 'scriptFunction'])
+  );
+  expect(compact.result.code).not.toContain('\n');
+  const runtimeGlobal: { value?: number } = {};
+  new Function('globalThis', compact.result.code)(runtimeGlobal);
+  expect(runtimeGlobal.value).toBe(1);
+});

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-transform-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-transform-worker.test.ts
@@ -1,0 +1,45 @@
+import type { JsTransformerConfig, JsTransformOptions } from '@expo/metro/metro-transform-worker';
+
+import { tryTransformJSWithNoxcturnal } from '../../noxcturnal/metro-transform-worker';
+import { transformFileFullyWithNoxcturnalSync } from '../../noxcturnal/noxcturnal-transformer';
+
+jest.mock('../../noxcturnal/noxcturnal-transformer', () => ({
+  transformFileFullyWithNoxcturnalSync: jest.fn(() => ({
+    status: 'fallback',
+    reason: 'worklets',
+  })),
+}));
+
+it('falls back after one full native attempt without producing an intermediate transform', async () => {
+  const file = {
+    code: "function worklet() { 'worklet'; }",
+    filename: '/app/worklet.js',
+    inputFileSize: 33,
+    type: 'js/module' as const,
+    functionMap: null,
+  };
+  const context = {
+    config: {} as JsTransformerConfig,
+    projectRoot: '/app',
+    options: {
+      type: 'module',
+      customTransformOptions: { engine: 'hermes' },
+    } as JsTransformOptions,
+  };
+  const completeFullTransform = jest.fn();
+
+  await expect(
+    tryTransformJSWithNoxcturnal(
+      file,
+      context,
+      {
+        hasNonDefaultBabelConfig: false,
+        isDefaultExpoTransformer: true,
+      },
+      { completeFullTransform }
+    )
+  ).resolves.toEqual({ status: 'fallback' });
+
+  expect(transformFileFullyWithNoxcturnalSync).toHaveBeenCalledTimes(1);
+  expect(completeFullTransform).not.toHaveBeenCalled();
+});

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/react-server-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/react-server-plugins.test.ts
@@ -1,0 +1,720 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+it.each([
+  ['a comment', `// codegenNativeComponent("View")\nmodule.exports = "ordinary";`],
+  ['a string', `module.exports = "codegenNativeCommands should not trigger Codegen";`],
+  [
+    'a shadowed call',
+    `function codegenNativeComponent(value) { return value; }
+module.exports = codegenNativeComponent("ordinary");`,
+  ],
+])('does not classify Codegen-like text in %s as React Native Codegen', async (_name, source) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+});
+
+it.each([
+  [
+    'Flow TurboModule',
+    `// @flow
+import type { TurboModule } from "react-native/Libraries/TurboModule/RCTExport";
+export interface Spec extends TurboModule { getValue(): string; }`,
+  ],
+  [
+    'TypeScript Native Component',
+    `import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
+export default codegenNativeComponent<{ value: string }>("NativeValue");`,
+  ],
+  [
+    'TypeScript Native Commands',
+    `import codegenNativeCommands from "react-native/Libraries/Utilities/codegenNativeCommands";
+interface NativeCommands { focus(viewRef: unknown): void; }
+export default codegenNativeCommands<NativeCommands>({ supportedCommands: ["focus"] });`,
+  ],
+  [
+    'React Native named-export Native Component',
+    `import { codegenNativeComponent } from "react-native";
+export default codegenNativeComponent<{ value: string }>("NativeValue");`,
+  ],
+  [
+    'React Native named-export Native Commands',
+    `import { codegenNativeCommands } from "react-native";
+interface NativeCommands { focus(viewRef: unknown): void; }
+export default codegenNativeCommands<NativeCommands>({ supportedCommands: ["focus"] });`,
+  ],
+])('keeps a %s candidate on pristine Babel input', async (_name, source) => {
+  await expect(
+    transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source,
+      options: options(),
+      isDefaultExpoTransformer: true,
+    })
+  ).resolves.toEqual({ status: 'fallback', reason: 'react-native-codegen' });
+});
+
+it('keeps React Native Codegen candidates out of the full native Metro path', async () => {
+  await expect(
+    transformFileFullyWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: `import codegenNativeComponent from "react-native/Libraries/Utilities/codegenNativeComponent";
+export default codegenNativeComponent("NativeValue");`,
+      options: options(),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    })
+  ).resolves.toEqual({ status: 'fallback', reason: 'react-native-codegen' });
+});
+
+it('falls back when the default transformer is extended by a project Babel config', async () => {
+  await expect(
+    transformNodeModuleWithNoxcturnal({
+      filename,
+      projectRoot: '/app',
+      source: 'module.exports = <View />;',
+      options: options(),
+      isDefaultExpoTransformer: true,
+      hasNonDefaultBabelConfig: true,
+    })
+  ).resolves.toEqual({
+    status: 'fallback',
+    reason: 'non-default-babel-config',
+  });
+});
+
+it.each([
+  ['web', { platform: 'web' as const, unstable_transformProfile: 'default' as const }],
+  ['Hermes v1', { platform: 'ios' as const, unstable_transformProfile: 'hermes-stable' as const }],
+])('does not compile %s node_modules', async (_name, target) => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: '/app/node_modules/example/index.js',
+    projectRoot: '/app',
+    source: 'module.exports = function Component() { return null; };',
+    options: options({
+      ...target,
+      customTransformOptions: { engine: 'hermes', reactCompiler: 'true' },
+    }),
+    isDefaultExpoTransformer: true,
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('react/compiler-runtime');
+});
+
+it('keeps compiled Expo workspace client directives on the Babel path', async () => {
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename: '/repo/packages/expo-router/build/value.js',
+    projectRoot: '/repo/apps/example',
+    source: `'use client'; module.exports = 1;`,
+    options: options({ dev: true }),
+    isDefaultExpoTransformer: true,
+  });
+  expect(result).toEqual({ status: 'fallback', reason: 'expo-directive' });
+});
+
+it('creates React Server client proxies natively', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/repo/packages/expo-router/build/value.js',
+    projectRoot: '/repo/apps/example',
+    source: `'use client';
+      export const value = 1;
+      export default function Component() { return null; }`,
+    options: options({
+      minify: true,
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toContain('createClientModuleProxy');
+  expect(result.result.code).toContain('registerClientReference');
+  expect(result.result.code).toContain('m.exports = proxy');
+  expect(result.result.code).not.toContain('module.exports = proxy');
+  expect(result.result.code).not.toContain('require("react-server-dom-webpack/server")');
+  expect(result.dependencies.map((dependency) => dependency.name)).toContain(
+    'react-server-dom-webpack/server'
+  );
+  expect(result.result.code).not.toContain('function Component');
+  expect(result.result.metadata.proxyExports).toEqual(['value', 'default']);
+  expect(result.result.metadata.reactClientReference).toBe(
+    'file:///repo/packages/expo-router/build/value.js'
+  );
+});
+
+it('mocks the React Native console polyfill in unwrapped React Server bundles', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/node_modules/@react-native/js-polyfills/console.js',
+    projectRoot: '/app',
+    source: `'use client'; throw new Error('must not execute');`,
+    options: options({
+      minify: true,
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: { ...fullConfig(), unstable_disableModuleWrapping: true },
+  });
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toBe('');
+  expect(result.dependencies).toEqual([]);
+});
+
+it.each(['use client', 'use dom'])(
+  "matches Babel's React Server proxy metadata for %s",
+  async (directive) => {
+    const candidate = '/app/src/client.tsx';
+    const source = `"${directive}";
+      export const value: number = 1;
+      export class View {}
+      export { value as alias };
+      export default function Component() { return null; }`;
+    const native = await transformFileFullyWithNoxcturnal({
+      filename: candidate,
+      projectRoot: '/app',
+      source,
+      options: options({
+        customTransformOptions: {
+          engine: 'hermes',
+          environment: 'react-server',
+        },
+      }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+    const babelResult = babel.transformSync(source, {
+      filename: candidate,
+      babelrc: false,
+      configFile: false,
+      comments: false,
+      presets: [[babelPresetExpo, { reanimated: false }]],
+      caller: {
+        name: 'metro',
+        engine: 'hermes',
+        platform: 'ios',
+        projectRoot: '/app',
+        isDev: false,
+        isServer: true,
+        isReactServer: true,
+        supportsStaticESM: true,
+      } as babel.TransformCaller,
+    });
+
+    expect(native.status).toBe('complete');
+    if (native.status !== 'complete') return;
+    const babelMetadata = babelResult?.metadata as
+      | {
+          proxyExports?: string[];
+          reactClientReference?: string;
+        }
+      | undefined;
+    expect(native.result.metadata.proxyExports).toEqual(babelMetadata?.proxyExports);
+    expect(native.result.metadata.reactClientReference).toBe(babelMetadata?.reactClientReference);
+    expect(native.result.code).toContain('createClientModuleProxy("./src/client.tsx")');
+    expect(native.result.code).not.toContain('value: number');
+  }
+);
+
+it("keeps conflicting React Server directives on Babel's diagnostic path", async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/conflict.js',
+    projectRoot: '/app',
+    source: `"use client"; "use server"; export const value = 1;`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('fallback');
+  if (result.status !== 'fallback') return;
+  expect(result.reason).toContain('conflicting-client-server-directives');
+});
+
+it("matches Babel's client-side server reference proxy", async () => {
+  const candidate = '/app/actions/save.ts';
+  const source = `"use server";
+    export async function save() { return 1; }
+    export const remove = async () => 2;
+    export default async function reset() { return 3; }`;
+  const native = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      experimentalImportSupport: false,
+      customTransformOptions: { engine: 'hermes' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  const babelResult = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    comments: false,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      projectRoot: '/app',
+      isDev: false,
+      isServer: false,
+      isReactServer: false,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  const babelMetadata = babelResult?.metadata as
+    | { proxyExports?: string[]; reactServerReference?: string }
+    | undefined;
+
+  expect(native.status).toBe('complete');
+  if (native.status !== 'complete') return;
+  expect(native.result.metadata.proxyExports).toEqual(babelMetadata?.proxyExports);
+  expect(native.result.metadata.reactServerReference).toBe(babelMetadata?.reactServerReference);
+  expect(native.result.code).toContain('createServerReference');
+  expect(native.result.code).toContain('./actions/save.ts#save');
+  expect(native.result.code).not.toContain('return 1');
+});
+
+it('retains inline client-bundle server actions for Babel', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/actions/inline.ts',
+    projectRoot: '/app',
+    source: `export const save = async () => { "use server"; return 1; };`,
+    options: options({ customTransformOptions: { engine: 'hermes' } }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('fallback');
+  if (result.status !== 'fallback') return;
+  expect(result.reason).toContain('expo-client-server-directive-boundary:expo-directive');
+});
+
+it.each([false, true])("matches Babel's native DOM component proxy in dev=%s", async (dev) => {
+  const candidate = '/app/components/Card.tsx';
+  const source = `"use dom";
+      export type Props = { title: string };
+      export default function Card(props: Props) { return <main>{props.title}</main>; }`;
+  const native = await transformFileFullyWithNoxcturnal({
+    filename: candidate,
+    projectRoot: '/app',
+    source,
+    options: options({
+      dev,
+      experimentalImportSupport: false,
+      customTransformOptions: { engine: 'hermes' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+  const babelResult = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    comments: false,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      projectRoot: '/app',
+      isDev: dev,
+      isServer: false,
+      isReactServer: false,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  const babelMetadata = babelResult?.metadata as { expoDomComponentReference?: string } | undefined;
+
+  expect(native.status).toBe('complete');
+  if (native.status !== 'complete') return;
+  expect(native.result.metadata.expoDomComponentReference).toBe(
+    babelMetadata?.expoDomComponentReference
+  );
+  expect(native.result.code).toContain('expo/dom/internal');
+  if (dev) expect(native.result.code).toContain('DOM(Card)');
+  expect(native.result.code).toContain(dev ? 'Card.tsx?file=' : '.html');
+  expect(native.result.code).not.toContain('<main>');
+});
+
+it.each([
+  ['named export', `"use dom"; export const value = 1; export default null;`, undefined],
+  ['missing default', `"use dom"; const value = 1;`, undefined],
+  [
+    'layout route',
+    `"use dom"; export default function Layout() { return null; }`,
+    '/app/_layout.tsx',
+  ],
+])(
+  "keeps invalid DOM component %s on Babel's diagnostic path",
+  async (_name, source, filenameOverride) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: filenameOverride ?? '/app/components/Card.tsx',
+      projectRoot: '/app',
+      source,
+      options: options({ customTransformOptions: { engine: 'hermes' } }),
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('fallback');
+    if (result.status !== 'fallback') return;
+    expect(result.reason).toContain('dom-component-');
+  }
+);

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/source-facts.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/source-facts.test.ts
@@ -1,0 +1,381 @@
+import * as babel from '@babel/core';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import {
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transform as transformWithNoxcturnal,
+} from 'noxcturnal';
+import type { PreflightPlan, PreflightTransforms } from 'noxcturnal';
+
+import { importExportLiveBindingsPlugin } from '../../../transform-plugins/importExportLiveBindings';
+import {
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+} from '../../noxcturnal/noxcturnal-transformer';
+
+function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
+  return {
+    dev: false,
+    experimentalImportSupport: true,
+    hot: false,
+    inlineRequires: false,
+    minify: false,
+    platform: 'ios',
+    type: 'module',
+    unstable_transformProfile: 'hermes-stable',
+    customTransformOptions: { engine: 'hermes' },
+    ...overrides,
+  } as JsTransformOptions;
+}
+
+function fullConfig() {
+  return {
+    allowOptionalDependencies: false,
+    asyncRequireModulePath: 'metro-runtime',
+    globalPrefix: '',
+    unstable_compactOutput: false,
+  };
+}
+
+const filename = '/app/node_modules/example/index.js';
+const workspaceFilename = '/app/packages/expo/build/value.js';
+function canonicalModuleBody(code: string, unwrapMetroFactory = false): string {
+  const file = babel.parseSync(code, { sourceType: 'script' });
+  if (!file) throw new Error('Failed to parse transformed module');
+  if (unwrapMetroFactory) {
+    const statement = file.program.body[0];
+    if (
+      !babel.types.isExpressionStatement(statement) ||
+      !babel.types.isCallExpression(statement.expression) ||
+      !babel.types.isFunctionExpression(statement.expression.arguments[0])
+    ) {
+      throw new Error('Expected a Metro module factory');
+    }
+    const factoryBody = statement.expression.arguments[0].body;
+    file.program.body = factoryBody.body;
+    file.program.directives = factoryBody.directives;
+    babel.traverse(file, {
+      CallExpression(path) {
+        if (
+          babel.types.isIdentifier(path.node.callee) &&
+          /REQUIRE$/.test(path.node.callee.name) &&
+          babel.types.isStringLiteral(path.node.arguments[1])
+        ) {
+          path.replaceWith(
+            babel.types.callExpression(babel.types.identifier('require'), [
+              babel.types.cloneNode(path.node.arguments[1]),
+            ])
+          );
+        }
+      },
+    });
+  }
+  babel.traverse(file, {
+    StringLiteral(path) {
+      path.node.extra = undefined;
+    },
+    VariableDeclaration(path) {
+      // Block-scoping is owned by a different native phase. Normalize it here so
+      // this comparison isolates only the import/export plugin's syntax.
+      path.node.kind = 'var';
+    },
+  });
+  return (
+    babel.transformFromAstSync(file, undefined, {
+      ast: false,
+      babelrc: false,
+      comments: false,
+      compact: true,
+      configFile: false,
+    })?.code ?? ''
+  );
+}
+
+const loadedBabelPresetExpo = require(
+  path.join(__dirname, '../../../../../../babel-preset-expo/src')
+);
+const babelPresetExpo = loadedBabelPresetExpo.default ?? loadedBabelPresetExpo;
+const requireFromBabelPresetExpo = createRequire(
+  path.join(__dirname, '../../../../../../babel-preset-expo/package.json')
+);
+const requireFromMetroConfig = createRequire(path.join(__dirname, '../../../../package.json'));
+
+function transformWithBabelPlugin(
+  source: string,
+  plugin: string,
+  options?: Record<string, unknown>
+): string {
+  return transformWithBabelPlugins(source, [[plugin, options]]);
+}
+
+function transformWithBabelPlugins(
+  source: string,
+  plugins: readonly [string, Record<string, unknown> | undefined][],
+  filename = '/app/node_modules/example/lowering.js'
+): string {
+  const result = babel.transformSync(source, {
+    filename,
+    babelrc: false,
+    configFile: false,
+    compact: false,
+    comments: false,
+    plugins: plugins.map(([plugin, options]) => {
+      let loadedPlugin: any;
+      try {
+        loadedPlugin = requireFromBabelPresetExpo(plugin);
+      } catch {
+        loadedPlugin = requireFromMetroConfig(plugin);
+      }
+      return [loadedPlugin.default ?? loadedPlugin, options];
+    }),
+  });
+  if (!result?.code) throw new Error('Babel plugins produced no output');
+  return result.code;
+}
+
+function transformWithNativeToggle(source: string, transforms: PreflightTransforms): string {
+  const result = transformWithNoxcturnal(
+    source,
+    '/app/node_modules/example/lowering.js',
+    defineNativePipeline({
+      phases: [
+        {
+          name: 'lowering',
+          native: {
+            transforms,
+            helpers: {
+              mode: 'runtime',
+              moduleName: '@babel/runtime',
+              version: '7.29.2',
+            },
+          },
+        },
+      ],
+    })
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithNativePlan(source: string, filename: string, plan: PreflightPlan): string {
+  const result = transformWithNoxcturnal(
+    source,
+    filename,
+    defineNativePipeline({
+      phases: [{ name: 'language', native: plan }],
+    }),
+    {
+      parser: filename.endsWith('.tsx') ? 'tsx' : 'jsx',
+    }
+  );
+  if (result.status !== 'complete') throw new Error(result.reason);
+  return result.code;
+}
+
+function transformWithBabelPreset(
+  source: string,
+  candidate: string,
+  dev = false,
+  server = false
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          unstable_transformProfile: 'hermes-stable',
+          enableBabelRuntime: '7.29.2',
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: dev,
+      isServer: server,
+      supportsStaticESM: true,
+      babelRuntimeVersion: '7.29.2',
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithNonHermesBabelPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    compact: false,
+    comments: false,
+    presets: [
+      [
+        babelPresetExpo,
+        {
+          enableBabelRuntime: false,
+          reanimated: false,
+          expoUi: false,
+          decorators: false,
+        },
+      ],
+    ],
+    caller: {
+      name: 'metro',
+      engine: undefined,
+      platform: 'ios',
+      isDev: false,
+      isNodeModule: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Babel preset produced no output');
+  return result;
+}
+
+function transformWithReactCompilerPreset(
+  source: string,
+  candidate: string
+): babel.BabelFileResult {
+  const result = babel.transformSync(source, {
+    filename: candidate,
+    babelrc: false,
+    configFile: false,
+    sourceMaps: true,
+    presets: [[babelPresetExpo, { reanimated: false }]],
+    caller: {
+      name: 'metro',
+      engine: 'hermes',
+      platform: 'ios',
+      isDev: true,
+      isNodeModule: false,
+      supportsReactCompiler: true,
+      supportsStaticESM: true,
+    } as babel.TransformCaller,
+  });
+  if (!result?.code || !result.map) throw new Error('Compiler preset produced no output');
+  return result;
+}
+
+function generatedPositionOf(
+  code: string,
+  needle: string,
+  last = false
+): { line: number; column: number } {
+  const offset = last ? code.lastIndexOf(needle) : code.indexOf(needle);
+  if (offset < 0) throw new Error(`Missing generated marker: ${needle}`);
+  const prefix = code.slice(0, offset);
+  const lines = prefix.split('\n');
+  return { line: lines.length, column: lines.at(-1)!.length };
+}
+
+function generatedPositionsOf(code: string, needle: string): { line: number; column: number }[] {
+  const positions: { line: number; column: number }[] = [];
+  for (
+    let offset = code.indexOf(needle);
+    offset !== -1;
+    offset = code.indexOf(needle, offset + 1)
+  ) {
+    const lines = code.slice(0, offset).split('\n');
+    positions.push({ line: lines.length, column: lines.at(-1)!.length });
+  }
+  if (positions.length === 0) throw new Error(`Missing generated marker: ${needle}`);
+  return positions.reverse();
+}
+
+function staticModuleSpecifiers(code: string): string[] {
+  return [...code.matchAll(/\b(?:from\s*|import\s*|require\s*\(\s*)["']([^"']+)["']/g)].map(
+    (match) => match[1]!
+  );
+}
+
+void [
+  babel,
+  originalPositionFor,
+  TraceMap,
+  createRequire,
+  path,
+  defineNativePipeline,
+  NativeTransformError,
+  TransformSyntaxError,
+  transformWithNoxcturnal,
+  importExportLiveBindingsPlugin,
+  createNoxcturnalSourceFacts,
+  isPathInsideRoot,
+  transformFileFullyWithNoxcturnal,
+  transformFileFullyWithNoxcturnalSync,
+  transformNodeModuleWithNoxcturnal,
+  transformNodeModuleWithNoxcturnalSync,
+  options,
+  fullConfig,
+  filename,
+  workspaceFilename,
+  canonicalModuleBody,
+  transformWithBabelPlugin,
+  transformWithBabelPlugins,
+  transformWithNativeToggle,
+  transformWithNativePlan,
+  transformWithBabelPreset,
+  transformWithNonHermesBabelPreset,
+  transformWithReactCompilerPreset,
+  generatedPositionOf,
+  generatedPositionsOf,
+  staticModuleSpecifiers,
+];
+
+it.each([
+  ['async ({ value }) => value', 'hasAsyncArrowNonSimpleParamsCandidate'],
+  ['async (value = 1) => value', 'hasAsyncArrowNonSimpleParamsCandidate'],
+  ['async (...values) => values', 'hasAsyncArrowNonSimpleParamsCandidate'],
+  ['try {} finally { class Value {} }', 'hasClassInFinallyCandidate'],
+  ['({ get value() { return (() => super.value)() } })', 'hasSuperInObjectAccessorCandidate'],
+] as const)('classifies the focused workaround shape in %s', (source, fact) => {
+  expect(createNoxcturnalSourceFacts(source)[fact]).toBe(true);
+});
+
+it.each([
+  ['async (a, b) => a + b', 'hasAsyncArrowNonSimpleParamsCandidate'],
+  ['class Value {}; try {} finally {}', 'hasClassInFinallyCandidate'],
+] as const)('excludes a broad false-positive workaround shape in %s', (source, fact) => {
+  expect(createNoxcturnalSourceFacts(source)[fact]).toBe(false);
+});
+
+it.each([
+  ['ordinary descendant', '/app/routes', '/app/routes/index.tsx', true],
+  ['root itself', '/app/routes', '/app/routes', false],
+  ['parent', '/app/routes', '/app', false],
+  ['sibling', '/app/routes', '/app/other/route.tsx', false],
+  ['dot-dot-prefixed file', '/app/routes', '/app/routes/..admin.tsx', true],
+  ['dot-dot-prefixed directory', '/app/routes', '/app/routes/..internal/route.ts', true],
+] as const)('classifies %s for POSIX router containment', (_name, root, candidate, expected) => {
+  expect(isPathInsideRoot(root, candidate, path.posix)).toBe(expected);
+});
+
+it.each([
+  ['ordinary descendant', 'C:\\app\\routes', 'C:\\app\\routes\\index.tsx', true],
+  ['root itself', 'C:\\app\\routes', 'C:\\app\\routes', false],
+  ['parent', 'C:\\app\\routes', 'C:\\app', false],
+  ['sibling', 'C:\\app\\routes', 'C:\\app\\other\\route.tsx', false],
+  ['dot-dot-prefixed file', 'C:\\app\\routes', 'C:\\app\\routes\\..admin.tsx', true],
+  ['cross-volume path', 'C:\\app\\routes', 'D:\\app\\routes\\index.tsx', false],
+] as const)('classifies %s for Windows router containment', (_name, root, candidate, expected) => {
+  expect(isPathInsideRoot(root, candidate, path.win32)).toBe(expected);
+});

--- a/packages/@expo/metro-config/src/transform-worker/events.ts
+++ b/packages/@expo/metro-config/src/transform-worker/events.ts
@@ -5,7 +5,10 @@ declare module '2g' {
   interface EventRegistry {
     'transform:failed': { file: string; error: SerializedError };
     'transform:custom_transformer:loaded': { path: string };
-    'transform:custom_transformer:failed': { path: string; error: SerializedError };
+    'transform:custom_transformer:failed': {
+      path: string;
+      error: SerializedError;
+    };
 
     'transform:file': {
       file: string;
@@ -18,7 +21,16 @@ declare module '2g' {
 
     // per-file sub-phase spans (nested under transform:file)
     'transform:babel': { file: string };
-    'transform:asset_data': { file: string; platform: string | null; files: string[] };
+    'transform:noxcturnal': { file: string };
+    'transform:noxcturnal:full': {
+      file: string;
+      status: 'complete' | 'fallback';
+    };
+    'transform:asset_data': {
+      file: string;
+      platform: string | null;
+      files: string[];
+    };
     'transform:asset_hashes': { file: string; files: string[] };
     'transform:asset_hash_file': { file: string };
     'transform:import_support': { file: string };
@@ -29,18 +41,28 @@ declare module '2g' {
 
     // debug keys
     'transform:browserslist:targets': { targets: Record<string, unknown> };
-    'transform:collect_deps:magic_comment_ignored': { line: number | string; code: string };
+    'transform:collect_deps:magic_comment_ignored': {
+      line: number | string;
+      code: string;
+    };
     'transform:client_boundaries:parsed': { boundaries: string[] };
     'transform:postcss:config_loaded': { path: string };
     'transform:postcss:plugin_loaded': { plugin: string };
-    'transform:module_mapper:request_redirected': { request: string; resolved: string };
-    'transform:module_mapper:redirect_failed': { request: string; error: SerializedError };
+    'transform:module_mapper:request_redirected': {
+      request: string;
+      resolved: string;
+    };
+    'transform:module_mapper:redirect_failed': {
+      request: string;
+      error: SerializedError;
+    };
     'transform:import_export:unexpected_object_pattern': { node: string };
     'transform:import_export:unexpected_array_pattern': { node: string };
     'transform:import_export:unexpected_identifier': { node: string };
     'transform:import_export:unexpected_declaration': { node: string };
     'transform:import_export:unexpected_specifier': { node: string };
     'transform:babel:missing_router_root': { message: string };
+    'transform:noxcturnal:fallback': { file: string; reason: string };
   }
 }
 

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -28,7 +28,9 @@ import {
   importLocationsPlugin,
   locToKey,
 } from '@expo/metro/metro/ModuleGraph/worker/importLocationsPlugin';
+import fs from 'fs';
 import assert from 'node:assert';
+import path from 'path';
 
 import type { ExpoJsOutput, ReconcileTransformSettings } from '../serializer/jsOutput';
 import {
@@ -38,7 +40,12 @@ import {
   packRawMappings,
   type SerializableSourceMap,
 } from '../serializer/packedMap';
-import { rawMappingsToEncodedMap, type BabelSourceMapSegment } from '../serializer/sourceMap';
+import {
+  composeSourceMaps,
+  rawMappingsToEncodedMap,
+  type BabelSourceMapSegment,
+  type EncodedTransformerSourceMap,
+} from '../serializer/sourceMap';
 import { importExportPlugin, importExportLiveBindingsPlugin } from '../transform-plugins';
 import * as assetTransformer from './asset-transformer';
 import type {
@@ -53,6 +60,11 @@ import collectDependencies, {
   InvalidRequireCallError as InternalInvalidRequireCallError,
 } from './collect-dependencies';
 import { debugEvent } from './events';
+import {
+  isNoxcturnalTransformWorkerEnabled,
+  tryTransformJSWithNoxcturnal,
+} from './noxcturnal/metro-transform-worker';
+import { type NoxcturnalMetroTransformAttempt } from './noxcturnal/noxcturnal-transformer';
 import { shouldMinify } from './resolveOptions';
 import { getMinifier, resolveMinifier } from './utils/getMinifier';
 
@@ -81,6 +93,11 @@ interface JSFile extends BaseFile {
   readonly loaderReference?: string;
   readonly hasCjsExports?: boolean;
   readonly performConstantFolding?: boolean;
+  readonly inputSourceMap?: {
+    readonly mappings: string;
+    readonly names: string[];
+    readonly originalCode: string;
+  };
 }
 
 interface JSONFile extends BaseFile {
@@ -118,6 +135,30 @@ function nullthrows<T extends object>(x: T | null | undefined, message?: string)
   return x;
 }
 
+function isDefaultExpoBabelTransformer(
+  transformerPath: string,
+  transformer: BabelTransformer
+): boolean {
+  const defaultTransformer: BabelTransformer = require('../babel-transformer');
+  if (transformer.transform === defaultTransformer.transform) return true;
+  // Jest resolves the package export to build/ while this source-relative import resolves src/.
+  // Both are canonical @expo/metro-config entry points; arbitrary transformer paths stay excluded.
+  return /[/\\]@expo[/\\]metro-config[/\\](?:build|src)[/\\]babel-transformer\.[cm]?js$/.test(
+    transformerPath
+  );
+}
+
+type ExpoBabelTransformer = BabelTransformer & {
+  isDefaultConfig?: (args: BabelTransformerArgs) => boolean;
+};
+
+function hasNonDefaultProjectBabelConfig(
+  transformer: ExpoBabelTransformer,
+  args: BabelTransformerArgs
+): boolean {
+  return transformer.isDefaultConfig?.(args) === false;
+}
+
 function getDynamicDepsBehavior(
   inPackages: DynamicRequiresBehavior,
   filename: string
@@ -138,12 +179,13 @@ export const minifyCode = async (
   code: string,
   source: string,
   rawMappings: readonly BabelSourceMapSegment[],
-  reserved: string[] = []
+  reserved: string[] = [],
+  inputSourceMap?: EncodedTransformerSourceMap
 ): Promise<{
   code: string;
   sourceMap: SerializableSourceMap;
 }> => {
-  const sourceMap = rawMappingsToEncodedMap({ filename, source, rawMappings });
+  const sourceMap = inputSourceMap ?? rawMappingsToEncodedMap({ filename, source, rawMappings });
 
   const minify = getMinifier(config.minifierPath);
 
@@ -161,7 +203,10 @@ export const minifyCode = async (
     return {
       code: minified.code,
       sourceMap: minified.map
-        ? packDecodedMappings({ mappings: minified.map.mappings, names: minified.map.names })
+        ? packDecodedMappings({
+            mappings: minified.map.mappings,
+            names: minified.map.names,
+          })
         : emptySourceMap(),
     };
   } catch (error: any) {
@@ -525,6 +570,22 @@ async function transformJS(
   // `GeneratorResult`, but Babel emits it whenever `sourceMaps: true`.
   const rawMappings =
     (result as { rawMappings?: BabelSourceMapSegment[] } | null)?.rawMappings ?? [];
+  const generatedSourceMap = file.inputSourceMap
+    ? composeSourceMaps([
+        {
+          version: 3,
+          mappings: file.inputSourceMap.mappings,
+          names: file.inputSourceMap.names,
+          sources: [file.filename],
+          sourcesContent: [file.inputSourceMap.originalCode],
+        },
+        rawMappingsToEncodedMap({
+          filename: file.filename,
+          source: file.code,
+          rawMappings,
+        }),
+      ])
+    : null;
   let code = result.code;
   let sourceMap: SerializableSourceMap;
 
@@ -536,10 +597,22 @@ async function transformJS(
       result.code,
       file.code,
       rawMappings,
-      reserved
+      reserved,
+      generatedSourceMap
+        ? {
+            ...generatedSourceMap,
+            version: 3,
+            sources: generatedSourceMap.sources.map((source) => source ?? file.filename),
+          }
+        : undefined
     ));
   } else {
-    sourceMap = packRawMappings(rawMappings);
+    sourceMap = generatedSourceMap
+      ? packDecodedMappings({
+          mappings: generatedSourceMap.mappings,
+          names: generatedSourceMap.names,
+        })
+      : packRawMappings(rawMappings);
   }
 
   const possibleReconcile: ReconcileTransformSettings | undefined =
@@ -660,8 +733,46 @@ async function transformJSWithBabel(
   context: TransformationContext
 ): Promise<TransformResponse> {
   const { babelTransformerPath } = context.config;
-  const transformer: BabelTransformer = require(babelTransformerPath);
+  const transformer: ExpoBabelTransformer = require(babelTransformerPath);
+  const sourceDefaultTransformer: ExpoBabelTransformer = require('../babel-transformer');
+  const babelConfigArgs = getBabelTransformArgs(file, context);
+  const isDefaultExpoTransformer = isDefaultExpoBabelTransformer(babelTransformerPath, transformer);
+  const hasNonDefaultBabelConfig =
+    isDefaultExpoTransformer &&
+    hasNonDefaultProjectBabelConfig(
+      transformer.isDefaultConfig ? transformer : sourceDefaultTransformer,
+      babelConfigArgs
+    );
 
+  if (!isNoxcturnalTransformWorkerEnabled(context.config)) {
+    enableExperimentalImportSupportForReactCompiler(context);
+    return transformJSWithBabelFallback(file, context, transformer);
+  }
+
+  const noxcturnal = await tryTransformJSWithNoxcturnal<
+    JSFile,
+    TransformationContext,
+    TransformResponse
+  >(
+    file,
+    context,
+    {
+      hasNonDefaultBabelConfig,
+      isDefaultExpoTransformer,
+    },
+    {
+      completeFullTransform: completeFullNoxcturnalTransform,
+    }
+  );
+  if (noxcturnal.status === 'complete') {
+    return noxcturnal.response;
+  }
+
+  enableExperimentalImportSupportForReactCompiler(context);
+  return transformJSWithBabelFallback(file, context, transformer);
+}
+
+function enableExperimentalImportSupportForReactCompiler(context: TransformationContext): void {
   // HACK: React Compiler injects import statements and exits the Babel process which leaves the code in
   // a malformed state. For now, we'll enable the experimental import support which compiles import statements
   // outside of the standard Babel process.
@@ -675,7 +786,121 @@ async function transformJSWithBabel(
       asWritable(context.options).experimentalImportSupport = true;
     }
   }
+}
 
+async function completeFullNoxcturnalTransform(
+  file: JSFile,
+  context: TransformationContext,
+  fullNoxcturnal: Extract<NoxcturnalMetroTransformAttempt, { status: 'complete' }>
+): Promise<TransformResponse> {
+  if (String(context.options.customTransformOptions?.optimize) === 'true') {
+    return transformJS(
+      {
+        ...file,
+        code: fullNoxcturnal.result.code,
+        ast: null,
+        inputSourceMap: {
+          ...fullNoxcturnal.result.map,
+          originalCode: file.code,
+        },
+        hasCjsExports:
+          typeof fullNoxcturnal.result.metadata.hasCjsExports === 'boolean'
+            ? fullNoxcturnal.result.metadata.hasCjsExports
+            : file.hasCjsExports,
+        reactServerReference:
+          typeof fullNoxcturnal.result.metadata.reactServerReference === 'string'
+            ? fullNoxcturnal.result.metadata.reactServerReference
+            : file.reactServerReference,
+        reactClientReference:
+          typeof fullNoxcturnal.result.metadata.reactClientReference === 'string'
+            ? fullNoxcturnal.result.metadata.reactClientReference
+            : file.reactClientReference,
+        expoDomComponentReference:
+          typeof fullNoxcturnal.result.metadata.expoDomComponentReference === 'string'
+            ? fullNoxcturnal.result.metadata.expoDomComponentReference
+            : file.expoDomComponentReference,
+        loaderReference:
+          typeof fullNoxcturnal.result.metadata.loaderReference === 'string'
+            ? fullNoxcturnal.result.metadata.loaderReference
+            : file.loaderReference,
+        functionMap: fullNoxcturnal.result.functionMap ?? file.functionMap,
+      },
+      context
+    );
+  }
+
+  let code = fullNoxcturnal.result.code;
+  let sourceMap: SerializableSourceMap;
+  if (shouldMinify(context.options)) {
+    const reserved =
+      context.config.unstable_dependencyMapReservedName == null
+        ? []
+        : [context.config.unstable_dependencyMapReservedName];
+    ({ code, sourceMap } = await minifyCode(
+      context.config,
+      file.filename,
+      code,
+      file.code,
+      [],
+      reserved,
+      {
+        version: 3,
+        sources: [file.filename],
+        sourcesContent: [file.code],
+        names: fullNoxcturnal.result.map.names,
+        mappings: fullNoxcturnal.result.map.mappings,
+      }
+    ));
+  } else {
+    sourceMap = packDecodedMappings({
+      mappings: fullNoxcturnal.result.map.mappings,
+      names: fullNoxcturnal.result.map.names,
+    });
+  }
+  let lineCount: number;
+  ({ lineCount, sourceMap } = countLinesAndTerminateSourceMap(code, sourceMap));
+
+  return {
+    dependencies: fullNoxcturnal.dependencies,
+    output: [
+      {
+        type: file.type,
+        data: {
+          code,
+          lineCount,
+          map: sourceMap,
+          functionMap: fullNoxcturnal.result.functionMap ?? file.functionMap,
+          hasCjsExports:
+            typeof fullNoxcturnal.result.metadata.hasCjsExports === 'boolean'
+              ? fullNoxcturnal.result.metadata.hasCjsExports
+              : file.hasCjsExports,
+          reactServerReference:
+            typeof fullNoxcturnal.result.metadata.reactServerReference === 'string'
+              ? fullNoxcturnal.result.metadata.reactServerReference
+              : file.reactServerReference,
+          reactClientReference:
+            typeof fullNoxcturnal.result.metadata.reactClientReference === 'string'
+              ? fullNoxcturnal.result.metadata.reactClientReference
+              : file.reactClientReference,
+          expoDomComponentReference:
+            typeof fullNoxcturnal.result.metadata.expoDomComponentReference === 'string'
+              ? fullNoxcturnal.result.metadata.expoDomComponentReference
+              : file.expoDomComponentReference,
+          loaderReference:
+            typeof fullNoxcturnal.result.metadata.loaderReference === 'string'
+              ? fullNoxcturnal.result.metadata.loaderReference
+              : file.loaderReference,
+        },
+      },
+    ],
+  };
+}
+
+async function transformJSWithBabelFallback(
+  file: JSFile,
+  context: TransformationContext,
+  transformer: ExpoBabelTransformer
+): Promise<TransformResponse> {
   // TODO: Add a babel plugin which returns if the module has commonjs, and if so, disable all tree shaking optimizations early.
   const transformResult = await transformer.transform(
     getBabelTransformArgs(file, context, [
@@ -839,7 +1064,18 @@ export async function transform(
 
 // NOTE: Increment if cache becomes incompatible (original value would be '')
 // 1. Added new packed source map format
-const CACHE_VERSION = '1';
+const CACHE_VERSION = '2';
+
+function getNoxcturnalPluginCacheKeyFiles(): string[] {
+  const directory = path.join(__dirname, 'noxcturnal/plugins');
+  return fs
+    .readdirSync(directory, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isFile() && /\.(?:[cm]?js|ts)$/.test(entry.name) && !entry.name.endsWith('.d.ts')
+    )
+    .map((entry) => path.join(directory, entry.name));
+}
 
 export function getCacheKey(
   config: JsTransformerConfig,
@@ -859,6 +1095,10 @@ export function getCacheKey(
     resolveMinifier(minifierPath),
     require.resolve('@expo/metro/metro-transform-worker/utils/getMinifier'),
     require.resolve('./collect-dependencies'),
+    require.resolve('./noxcturnal/metro-transform-worker'),
+    require.resolve('./noxcturnal/noxcturnal-transformer'),
+    ...getNoxcturnalPluginCacheKeyFiles(),
+    require.resolve('noxcturnal'),
     require.resolve('./asset-transformer'),
     require.resolve('./resolveOptions'),
     require.resolve('@expo/metro/metro/ModuleGraph/worker/generateImportNames'),

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -28,9 +28,7 @@ import {
   importLocationsPlugin,
   locToKey,
 } from '@expo/metro/metro/ModuleGraph/worker/importLocationsPlugin';
-import fs from 'fs';
 import assert from 'node:assert';
-import path from 'path';
 
 import type { ExpoJsOutput, ReconcileTransformSettings } from '../serializer/jsOutput';
 import {
@@ -61,6 +59,7 @@ import collectDependencies, {
 } from './collect-dependencies';
 import { debugEvent } from './events';
 import {
+  getNoxcturnalCacheKeyFiles,
   isNoxcturnalTransformWorkerEnabled,
   tryTransformJSWithNoxcturnal,
 } from './noxcturnal/metro-transform-worker';
@@ -1066,17 +1065,6 @@ export async function transform(
 // 1. Added new packed source map format
 const CACHE_VERSION = '2';
 
-function getNoxcturnalPluginCacheKeyFiles(): string[] {
-  const directory = path.join(__dirname, 'noxcturnal/plugins');
-  return fs
-    .readdirSync(directory, { withFileTypes: true })
-    .filter(
-      (entry) =>
-        entry.isFile() && /\.(?:[cm]?js|ts)$/.test(entry.name) && !entry.name.endsWith('.d.ts')
-    )
-    .map((entry) => path.join(directory, entry.name));
-}
-
 export function getCacheKey(
   config: JsTransformerConfig,
   opts?: Readonly<{ projectRoot: string }>
@@ -1095,15 +1083,12 @@ export function getCacheKey(
     resolveMinifier(minifierPath),
     require.resolve('@expo/metro/metro-transform-worker/utils/getMinifier'),
     require.resolve('./collect-dependencies'),
-    require.resolve('./noxcturnal/metro-transform-worker'),
-    require.resolve('./noxcturnal/noxcturnal-transformer'),
-    ...getNoxcturnalPluginCacheKeyFiles(),
-    require.resolve('noxcturnal'),
     require.resolve('./asset-transformer'),
     require.resolve('./resolveOptions'),
     require.resolve('@expo/metro/metro/ModuleGraph/worker/generateImportNames'),
     require.resolve('@expo/metro/metro/ModuleGraph/worker/JsFileWrapping'),
     ...metroTransformPlugins.getTransformPluginCacheKeyFiles(),
+    ...getNoxcturnalCacheKeyFiles(),
   ]);
 
   let babelTransformer: BabelTransformer = require(babelTransformerPath);

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/codegen.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/codegen.ts
@@ -1,0 +1,9 @@
+const CODEGEN_NAME = /\b(?:codegenNativeComponent|codegenNativeCommands|TurboModule)\b/;
+
+export const TURBO_MODULE_SPEC =
+  /^[\t ]*(?:export[\t ]+)?interface[\t ]+[A-Za-z_$][\w$]*[\t \n]+extends[\t \n]+TurboModule\b/m;
+
+/** Cheap prerequisite for installing the authoritative native Codegen eligibility plugin. */
+export function mayContainReactNativeCodegen(source: string): boolean {
+  return CODEGEN_NAME.test(source);
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v0.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v0.ts
@@ -1,0 +1,18 @@
+import type { ProfilePreflightConfig, ProfilePreflightFacts } from './types';
+
+export function getHermesV0PreflightConfig(facts: ProfilePreflightFacts): ProfilePreflightConfig {
+  return {
+    blockScoping: facts.hasBlockScopedDeclaration,
+    classProperties: facts.hasClass ? { loose: true } : undefined,
+    classStaticBlock: facts.hasStaticBlock,
+    privateMethods: facts.hasClass,
+    privatePropertyInObject: facts.hasClass,
+    regexpUnicode: facts.hasRegexpLiteral,
+    classes: facts.hasClass,
+    regexpNamedCaptureGroups: facts.hasRegexpLiteral,
+    destructuring: true,
+    asyncGeneratorFunctions: facts.hasAsyncGenerator,
+    asyncFunctions: facts.hasAsync,
+    parameters: true,
+  };
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v1.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v1.ts
@@ -1,0 +1,9 @@
+import type { ProfilePreflightConfig, ProfilePreflightFacts } from './types';
+
+export function getHermesV1PreflightConfig(facts: ProfilePreflightFacts): ProfilePreflightConfig {
+  return {
+    blockScoping: facts.hasBlockScopedDeclaration,
+    classStaticBlock: facts.hasStaticBlock,
+    asyncGeneratorFunctions: facts.hasAsyncGenerator,
+  };
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/types.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/types.ts
@@ -1,0 +1,14 @@
+import type { PreflightTransforms } from 'noxcturnal';
+
+export interface ProfilePreflightFacts {
+  hasAsync: boolean;
+  hasAsyncGenerator: boolean;
+  hasBlockScopedDeclaration: boolean;
+  hasClass: boolean;
+  hasForOf: boolean;
+  hasPrivateSyntax: boolean;
+  hasRegexpLiteral: boolean;
+  hasStaticBlock: boolean;
+}
+
+export type ProfilePreflightConfig = PreflightTransforms;

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/web.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/web.ts
@@ -1,0 +1,9 @@
+import type { ProfilePreflightConfig, ProfilePreflightFacts } from './types';
+
+export function getWebPreflightConfig(facts: ProfilePreflightFacts): ProfilePreflightConfig {
+  return {
+    classStaticBlock: facts.hasStaticBlock,
+    privateMethods: facts.hasPrivateSyntax,
+    privatePropertyInObject: facts.hasPrivateSyntax,
+  };
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/webview.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/webview.ts
@@ -1,0 +1,23 @@
+import type { ProfilePreflightConfig, ProfilePreflightFacts } from './types';
+
+export function getWebViewPreflightConfig(facts: ProfilePreflightFacts): ProfilePreflightConfig {
+  return {
+    blockScoping: facts.hasBlockScopedDeclaration,
+    classProperties: facts.hasClass ? { loose: true } : undefined,
+    classStaticBlock: facts.hasStaticBlock,
+    classes: facts.hasClass,
+    privateMethods: facts.hasClass,
+    privatePropertyInObject: facts.hasClass,
+    regexpUnicode: facts.hasRegexpLiteral,
+    regexpNamedCaptureGroups: facts.hasRegexpLiteral,
+    destructuring: true,
+    asyncGeneratorFunctions: facts.hasAsyncGenerator,
+    asyncFunctions: facts.hasAsync,
+    forOf: facts.hasForOf,
+    parameters: true,
+    optionalCatchBinding: true,
+    optionalChaining: { loose: true },
+    nullishCoalescingOperator: { loose: true },
+    logicalAssignmentOperators: true,
+  };
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/metro-transform-worker.ts
@@ -1,0 +1,98 @@
+import type { JsTransformerConfig, JsTransformOptions } from '@expo/metro/metro-transform-worker';
+
+import { debugEvent } from '../events';
+import {
+  transformFileFullyWithNoxcturnalSync,
+  type NoxcturnalMetroTransformAttempt,
+} from './noxcturnal-transformer';
+
+interface NoxcturnalFile {
+  code: string;
+  filename: string;
+  inputFileSize: number;
+  type: 'js/script' | 'js/module' | 'js/module/asset';
+  ast?: unknown;
+  functionMap: unknown;
+  inputSourceMap?: {
+    mappings: string;
+    names: string[];
+    originalCode: string;
+  };
+  hasCjsExports?: boolean;
+}
+
+interface NoxcturnalContext {
+  config: JsTransformerConfig;
+  projectRoot: string;
+  options: JsTransformOptions;
+}
+
+export interface NoxcturnalBabelState {
+  hasNonDefaultBabelConfig: boolean;
+  isDefaultExpoTransformer: boolean;
+}
+
+interface NoxcturnalWorkerHooks<
+  File extends NoxcturnalFile,
+  Context extends NoxcturnalContext,
+  Response,
+> {
+  completeFullTransform(
+    file: File,
+    context: Context,
+    attempt: Extract<NoxcturnalMetroTransformAttempt, { status: 'complete' }>
+  ): Promise<Response>;
+}
+
+export type NoxcturnalWorkerAttempt<Response> =
+  | { status: 'complete'; response: Response }
+  | { status: 'fallback' };
+
+export function isNoxcturnalTransformWorkerEnabled(config: JsTransformerConfig): boolean {
+  return (
+    (
+      config as JsTransformerConfig & {
+        unstable_noxcturnalTransformWorker?: boolean;
+      }
+    ).unstable_noxcturnalTransformWorker === true
+  );
+}
+
+export async function tryTransformJSWithNoxcturnal<
+  File extends NoxcturnalFile,
+  Context extends NoxcturnalContext,
+  Response,
+>(
+  file: File,
+  context: Context,
+  state: NoxcturnalBabelState,
+  hooks: NoxcturnalWorkerHooks<File, Context, Response>
+): Promise<NoxcturnalWorkerAttempt<Response>> {
+  const doneFullNoxcturnal = debugEvent.span();
+  const fullNoxcturnal = transformFileFullyWithNoxcturnalSync({
+    filename: file.filename,
+    source: file.code,
+    projectRoot: context.projectRoot,
+    options: context.options,
+    config: context.config,
+    enableBabelRuntime:
+      context.options.type === 'script' ? false : context.config.enableBabelRuntime,
+    hasNonDefaultBabelConfig: state.hasNonDefaultBabelConfig,
+    isDefaultExpoTransformer: state.isDefaultExpoTransformer,
+  });
+  doneFullNoxcturnal('noxcturnal:full', {
+    file: debugEvent.path(file.filename),
+    status: fullNoxcturnal.status,
+  });
+  if (fullNoxcturnal.status === 'complete') {
+    return {
+      status: 'complete',
+      response: await hooks.completeFullTransform(file, context, fullNoxcturnal),
+    };
+  }
+  debugEvent('noxcturnal:fallback', {
+    file: debugEvent.path(file.filename),
+    reason: `full-metro:${fullNoxcturnal.reason}`,
+  });
+  return { status: 'fallback' };
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/metro-transform-worker.ts
@@ -96,3 +96,42 @@ export async function tryTransformJSWithNoxcturnal<
   });
   return { status: 'fallback' };
 }
+
+export function getNoxcturnalCacheKeyFiles(): readonly string[] {
+  return [
+    require.resolve('noxcturnal/package.json'),
+    require.resolve('./metro-transform-worker'),
+    require.resolve('./noxcturnal-transformer'),
+    require.resolve('./plugins/cjs-detection'),
+    require.resolve('./plugins/client-server-directive-boundary'),
+    require.resolve('./plugins/client-server-reference-proxy'),
+    require.resolve('./plugins/deep-react-native-import-warnings'),
+    require.resolve('./plugins/define'),
+    require.resolve('./plugins/development-public-env'),
+    require.resolve('./plugins/environment-restricted-imports'),
+    require.resolve('./plugins/environment-restricted-react-apis'),
+    require.resolve('./plugins/expo-dom-component'),
+    require.resolve('./plugins/expo-inline-manifest'),
+    require.resolve('./plugins/expo-router-server-exports'),
+    require.resolve('./plugins/expo-ui'),
+    require.resolve('./plugins/expo-widgets'),
+    require.resolve('./plugins/fix-hermes-v1-async-arrow-non-simple-params'),
+    require.resolve('./plugins/fix-hermes-v1-class-in-finally'),
+    require.resolve('./plugins/fix-hermes-v1-super-in-object-accessor'),
+    require.resolve('./plugins/import-meta'),
+    require.resolve('./plugins/inline-requires'),
+    require.resolve('./plugins/metro-dependency'),
+    require.resolve('./plugins/metro-esm-globals'),
+    require.resolve('./plugins/metro-live-bindings'),
+    require.resolve('./plugins/module-eligibility'),
+    require.resolve('./plugins/native-esm-eligibility'),
+    require.resolve('./plugins/platform-select'),
+    require.resolve('./plugins/process-env'),
+    require.resolve('./plugins/react-display-name'),
+    require.resolve('./plugins/react-native-codegen'),
+    require.resolve('./plugins/react-native-web'),
+    require.resolve('./plugins/react-server-client-proxy'),
+    require.resolve('./plugins/react-server-directive-boundary'),
+    require.resolve('./plugins/react-server-module-actions'),
+  ];
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
@@ -1,0 +1,1236 @@
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import path from 'node:path';
+import type {
+  DefinedNativePlugin,
+  NodeView,
+  NativePipeline,
+  NativeTransformResult,
+  PipelinePhase,
+  PreflightPlan,
+  PreflightTransforms,
+  PluginContext,
+  TransformResult,
+} from 'noxcturnal';
+
+import type { Dependency } from '../collect-dependencies';
+import { mayContainReactNativeCodegen } from './codegen';
+import { getHermesV0PreflightConfig } from './configs/hermes-v0';
+import { getHermesV1PreflightConfig } from './configs/hermes-v1';
+import type { ProfilePreflightFacts } from './configs/types';
+import { getWebPreflightConfig } from './configs/web';
+import { getWebViewPreflightConfig } from './configs/webview';
+import { createCjsDetectionPlugin } from './plugins/cjs-detection';
+import { createClientServerDirectiveBoundaryPlugin } from './plugins/client-server-directive-boundary';
+import { createClientServerReferenceProxyPlugin } from './plugins/client-server-reference-proxy';
+import { createDeepReactNativeImportWarningsPlugin } from './plugins/deep-react-native-import-warnings';
+import { createDefinePlugin } from './plugins/define';
+import { createDevelopmentPublicEnvPlugin } from './plugins/development-public-env';
+import { createEnvironmentRestrictedImportsPlugin } from './plugins/environment-restricted-imports';
+import { createEnvironmentRestrictedReactApisPlugin } from './plugins/environment-restricted-react-apis';
+import { createExpoDomComponentPlugin } from './plugins/expo-dom-component';
+import { createExpoInlineManifestPlugin } from './plugins/expo-inline-manifest';
+import { createExpoRouterServerExportsPlugin } from './plugins/expo-router-server-exports';
+import { createExpoUiPlugin } from './plugins/expo-ui';
+import { createExpoWidgetsPlugin, hasExpoWidgets } from './plugins/expo-widgets';
+import { createFixHermesV1AsyncArrowNonSimpleParamsPlugin } from './plugins/fix-hermes-v1-async-arrow-non-simple-params';
+import { createFixHermesV1ClassInFinallyPlugin } from './plugins/fix-hermes-v1-class-in-finally';
+import { createFixHermesV1SuperInObjectAccessorPlugin } from './plugins/fix-hermes-v1-super-in-object-accessor';
+import { createImportMetaPlugin } from './plugins/import-meta';
+import { createInlineRequiresPlugin } from './plugins/inline-requires';
+import { createMetroDependencyPlugin } from './plugins/metro-dependency';
+import type { MetroDependencyState } from './plugins/metro-dependency';
+import { createMetroEsmGlobalsPlugin } from './plugins/metro-esm-globals';
+import { createMetroLiveBindingsPlugin } from './plugins/metro-live-bindings';
+import { createModuleEligibilityPlugin } from './plugins/module-eligibility';
+import { createNativeEsmEligibilityPlugin } from './plugins/native-esm-eligibility';
+import { createPlatformSelectPlugin } from './plugins/platform-select';
+import { createProcessEnvPlugin } from './plugins/process-env';
+import { createReactDisplayNamePlugin } from './plugins/react-display-name';
+import { createReactNativeCodegenEligibilityPlugin } from './plugins/react-native-codegen';
+import { createReactNativeWebPlugin } from './plugins/react-native-web';
+import { createReactServerClientProxyPlugin } from './plugins/react-server-client-proxy';
+import { createReactServerDirectiveBoundaryPlugin } from './plugins/react-server-directive-boundary';
+import { createReactServerModuleActionsPlugin } from './plugins/react-server-module-actions';
+
+export type Noxcturnal = typeof import('noxcturnal');
+
+export interface MetroDependencyShared {
+  state?: MetroDependencyState;
+  sawImportSyntax?: boolean;
+  importedBindings?: Map<string, string>;
+}
+
+/** Boundary facts the server/client directive plugins share for one file.
+ *
+ * These plugins observe each other: the directive-boundary plugins must know
+ * whether a proxy or module-level action was already emitted. Keeping that on
+ * per-file plugin data rather than in a closure lets every plugin be defined once
+ * and interned, so its plan and routes compile once for the process. */
+export interface ServerBoundaryShared {
+  clientProxy: boolean;
+  moduleServerActions: boolean;
+  serverProxy: boolean;
+  handledDirectives: Set<number>;
+}
+
+export interface ExpoTransformPluginData {
+  input: NoxcturnalTransformInput;
+  sourceFacts: NoxcturnalSourceFacts;
+  serverBoundary: ServerBoundaryShared;
+}
+
+export function sortedUniqueCaptureNames(captures: readonly NodeView[]): string[] {
+  return [...new Set(captures.map((capture) => String(capture.name)))].sort();
+}
+
+export interface MetroTransformPluginData extends ExpoTransformPluginData {
+  input: NoxcturnalMetroTransformInput;
+  shared: MetroDependencyShared;
+  collectOnly: boolean;
+  normalizePseudoGlobals: boolean;
+}
+
+export function expoPluginInput(context: { pluginData: unknown }): NoxcturnalTransformInput {
+  return (context.pluginData as ExpoTransformPluginData).input;
+}
+
+export function serverBoundary(context: { pluginData: unknown }): ServerBoundaryShared {
+  return (context.pluginData as ExpoTransformPluginData).serverBoundary;
+}
+
+export function expoPluginData(context: { pluginData: unknown }): ExpoTransformPluginData {
+  return context.pluginData as ExpoTransformPluginData;
+}
+
+function createExpoTransformPluginData(
+  input: NoxcturnalTransformInput,
+  sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source)
+): ExpoTransformPluginData {
+  return {
+    input,
+    sourceFacts,
+    serverBoundary: {
+      clientProxy: false,
+      moduleServerActions: false,
+      serverProxy: false,
+      handledDirectives: new Set(),
+    },
+  };
+}
+
+export function metroPluginData(context: { pluginData: unknown }): MetroTransformPluginData {
+  return context.pluginData as MetroTransformPluginData;
+}
+
+function createMetroTransformPluginData(
+  input: NoxcturnalMetroTransformInput,
+  sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source)
+): MetroTransformPluginData {
+  const hermesBytecode =
+    getBaseProfile(input) === 'hermes-v1' && input.options.customTransformOptions?.bytecode === '1';
+  return {
+    ...createExpoTransformPluginData(input, sourceFacts),
+    input,
+    shared: {},
+    collectOnly: String(input.options.customTransformOptions?.optimize) === 'true',
+    normalizePseudoGlobals:
+      input.options.minify &&
+      !hermesBytecode &&
+      input.config.unstable_disableNormalizePseudoGlobals !== true &&
+      input.config.unstable_disableModuleWrapping !== true &&
+      input.source.length <= (input.config.optimizationSizeLimit ?? Number.POSITIVE_INFINITY) &&
+      !sourceFacts.hasPseudoGlobals,
+  };
+}
+
+function needsServerExportsPhase(
+  input: NoxcturnalTransformInput,
+  sourceFacts: NoxcturnalSourceFacts
+): boolean {
+  // `"use client"` is metadata only in an ordinary client graph. React Server
+  // graphs remain unconditional below, where the directive creates a proxy.
+  // Client-side `"use server"`/`"use dom"` references still require this phase.
+  const hasActionableClientDirective = sourceFacts.hasActionableClientDirective;
+  const isLoaderBundle = String(input.options.customTransformOptions?.isLoaderBundle) === 'true';
+  const hasRouterServerExport =
+    isInExpoRouterAppDirectory(input) &&
+    sourceFacts.hasExport &&
+    (isLoaderBundle || sourceFacts.hasRouterServerExport);
+  // React Server transforms also enforce restricted-import and restricted-API
+  // boundaries for ordinary modules, even when no directive is present.
+  return (
+    input.options.customTransformOptions?.environment === 'react-server' ||
+    hasActionableClientDirective ||
+    hasRouterServerExport
+  );
+}
+
+export interface MetroLiveModule {
+  source: string;
+  requiredLocal: string;
+  requireCall: string;
+  defaultLocal?: string;
+  namespaceLocal?: string;
+  afterImport: (
+    | { kind: 'statement'; code: string }
+    | { kind: 'default-interop'; code: string }
+    | { kind: 'namespace-interop'; code: string }
+  )[];
+  exportAll: boolean;
+  referenced: boolean;
+  defaultReferenced: boolean;
+  namespaceReferenced: boolean;
+  sideEffect: boolean;
+}
+
+export interface MetroLiveBindingsState {
+  sawEsm: boolean;
+  modules: Map<string, MetroLiveModule>;
+  moduleOrder: MetroLiveModule[];
+  importedBindings: Map<string, string>;
+  exportStatements: string[];
+  deferredExports: (
+    | { kind: 'specifier'; local: string; exported: string }
+    | { kind: 'declaration'; name: string; assign: boolean }
+  )[];
+}
+
+export type NoxcturnalTransformAttempt =
+  | { status: 'complete'; result: NativeTransformResult }
+  | { status: 'fallback'; reason: string };
+
+export type NoxcturnalMetroTransformAttempt =
+  | {
+      status: 'complete';
+      result: NativeTransformResult;
+      dependencies: readonly Dependency[];
+      dependencyMapName: string;
+    }
+  | { status: 'fallback'; reason: string };
+
+export interface NoxcturnalTransformInput {
+  filename: string;
+  source: string;
+  projectRoot: string;
+  options: JsTransformOptions;
+  /** False when Metro is invoking a custom Babel transformer. */
+  isDefaultExpoTransformer: boolean;
+  /**
+   * True when Babel's resolved project configuration differs from Expo's default
+   * preset recipe. Config filenames and source text are deliberately irrelevant.
+   */
+  hasNonDefaultBabelConfig?: boolean;
+  /** Exact semver exposed to Babel as its caller's `babelRuntimeVersion`. */
+  enableBabelRuntime?: boolean | string;
+  /** Optional precomputed source classification. */
+  sourceFacts?: NoxcturnalSourceFacts;
+}
+
+export interface NoxcturnalSourceFacts {
+  directive?: 'client' | 'server' | 'dom';
+  hasActionableClientDirective: boolean;
+  hasFlowPragma: boolean;
+  hasExport: boolean;
+  hasRouterServerExport: boolean;
+  hasPseudoGlobals: boolean;
+  hasDefineCandidate: boolean;
+  hasPublicEnv: boolean;
+  hasProcess: boolean;
+  hasPlatform: boolean;
+  hasSelect: boolean;
+  hasClass: boolean;
+  hasFinally: boolean;
+  hasSuper: boolean;
+  hasAsync: boolean;
+  hasArrow: boolean;
+  hasAsyncArrowNonSimpleParamsCandidate: boolean;
+  hasClassInFinallyCandidate: boolean;
+  hasSuperInObjectAccessorCandidate: boolean;
+  hasLetOrConst: boolean;
+  hasStaticBlock: boolean;
+  hasAsyncGenerator: boolean;
+  hasPrivateSyntax: boolean;
+  hasFor: boolean;
+  hasOf: boolean;
+  hasSpread: boolean;
+  hasSlash: boolean;
+  hasJsxCandidate: boolean;
+  hasComments: boolean;
+}
+
+const SOURCE_SIGNAL =
+  /["']use (?:server|dom)["']|@flow\b|\bexport\b|\b(?:loader|generateMetadata)\b|\b(?:global|module|exports)\b|\b(?:process|Platform|__DEV__)\b|\btypeof\s+window\b|EXPO_PUBLIC_|select|\bclass\b|\bfinally\b|\bsuper\b|\basync(?:\s+function)?\s*\*|\basync\b|\bstatic\s*\{|#[A-Za-z_$][\w$]*/g;
+
+export function createNoxcturnalSourceFacts(source: string): NoxcturnalSourceFacts {
+  const facts: NoxcturnalSourceFacts = {
+    directive: source.match(/^[\t ]*["']use (client|server|dom)["']/m)?.[1] as
+      | NoxcturnalSourceFacts['directive']
+      | undefined,
+    hasActionableClientDirective: false,
+    hasFlowPragma: false,
+    hasExport: false,
+    hasRouterServerExport: false,
+    hasPseudoGlobals: false,
+    hasDefineCandidate: false,
+    hasPublicEnv: false,
+    hasProcess: false,
+    hasPlatform: false,
+    hasSelect: false,
+    hasClass: false,
+    hasFinally: false,
+    hasSuper: false,
+    hasAsync: false,
+    hasArrow: source.includes('=>'),
+    hasAsyncArrowNonSimpleParamsCandidate: hasAsyncArrowNonSimpleParamsCandidate(source),
+    hasClassInFinallyCandidate: hasOrderedSignals(source, /\bfinally\b/g, /\bclass\b/g),
+    hasSuperInObjectAccessorCandidate: hasOrderedSignals(
+      source,
+      /\b(?:get|set)\b/g,
+      /\bsuper\s*(?:\.|\[)/g
+    ),
+    hasLetOrConst: /\b(?:let|const)\b/.test(source),
+    hasStaticBlock: false,
+    hasAsyncGenerator: false,
+    hasPrivateSyntax: false,
+    hasFor: source.includes('for'),
+    hasOf: source.includes('of'),
+    hasSpread: source.includes('...'),
+    hasSlash: source.includes('/'),
+    hasJsxCandidate: source.includes('<'),
+    hasComments: source.includes('/*') || source.includes('//'),
+  };
+  for (const match of source.matchAll(SOURCE_SIGNAL)) {
+    const signal = match[0];
+    if (signal.includes('use server') || signal.includes('use dom'))
+      facts.hasActionableClientDirective = true;
+    else if (signal === '@flow') facts.hasFlowPragma = true;
+    else if (signal === 'export') facts.hasExport = true;
+    else if (signal === 'loader' || signal === 'generateMetadata')
+      facts.hasRouterServerExport = true;
+    else if (signal === 'global' || signal === 'module' || signal === 'exports')
+      facts.hasPseudoGlobals = true;
+    else if (signal === 'process') {
+      facts.hasProcess = true;
+      facts.hasDefineCandidate = true;
+    } else if (signal === 'Platform') {
+      facts.hasPlatform = true;
+      facts.hasDefineCandidate = true;
+    } else if (signal === '__DEV__' || signal.startsWith('typeof')) facts.hasDefineCandidate = true;
+    else if (signal === 'EXPO_PUBLIC_') facts.hasPublicEnv = true;
+    else if (signal === 'select') facts.hasSelect = true;
+    else if (signal === 'class') facts.hasClass = true;
+    else if (signal === 'finally') facts.hasFinally = true;
+    else if (signal === 'super') facts.hasSuper = true;
+    else if (signal.startsWith('async')) {
+      facts.hasAsync = true;
+      if (signal.includes('*')) facts.hasAsyncGenerator = true;
+    } else if (signal.startsWith('static')) facts.hasStaticBlock = true;
+    else if (signal.startsWith('#')) facts.hasPrivateSyntax = true;
+  }
+  return facts;
+}
+
+/**
+ * Whether a left-hand signal occurs before a right-hand signal.
+ *
+ * Expressing this as `left[\s\S]*right` makes V8 retry the greedy middle from
+ * every left-hand match when the right-hand signal is absent or near EOF. Large
+ * generated bundles contain thousands of words such as `get`, so that shape is
+ * quadratic. Two forward searches preserve the deliberately broad prerequisite
+ * while making its worst case linear.
+ */
+function hasOrderedSignals(source: string, left: RegExp, right: RegExp): boolean {
+  const leftMatch = left.exec(source);
+  if (leftMatch == null) return false;
+  right.lastIndex = leftMatch.index + leftMatch[0].length;
+  return right.test(source);
+}
+
+function hasAsyncArrowNonSimpleParamsCandidate(source: string): boolean {
+  let arrow = source.indexOf('=>');
+  let asyncSearchFrom = 0;
+  let asyncStart = -1;
+  while (arrow !== -1) {
+    for (let next = source.indexOf('async', asyncSearchFrom); next !== -1 && next < arrow; ) {
+      asyncStart = next;
+      asyncSearchFrom = next + 5;
+      next = source.indexOf('async', asyncSearchFrom);
+    }
+    if (
+      asyncStart !== -1 &&
+      !/[$\w]/.test(source[asyncStart - 1] ?? '') &&
+      !/[$\w]/.test(source[asyncStart + 5] ?? '')
+    ) {
+      const parameters = source.slice(asyncStart + 5, arrow).trim();
+      if (
+        !/^[$A-Z_a-z][$\w]*$/.test(parameters) &&
+        !/^\(\s*(?:[$A-Z_a-z][$\w]*\s*(?:,\s*[$A-Z_a-z][$\w]*\s*)*)?\)$/.test(parameters)
+      ) {
+        return true;
+      }
+    }
+    arrow = source.indexOf('=>', arrow + 2);
+  }
+  return false;
+}
+
+export interface NoxcturnalMetroTransformInput extends NoxcturnalTransformInput {
+  config: {
+    allowOptionalDependencies: boolean | { exclude: string[] };
+    asyncRequireModulePath: string;
+    globalPrefix: string;
+    unstable_compactOutput: boolean;
+    unstable_dependencyMapReservedName?: string | null;
+    unstable_disableNormalizePseudoGlobals?: boolean;
+    optimizationSizeLimit?: number;
+    minifierConfig?: { output?: { comments?: boolean } };
+    unstable_disableModuleWrapping?: boolean;
+    unstable_allowRequireContext?: boolean;
+    unstable_renameRequire?: boolean;
+  };
+}
+
+let noxcturnal: Noxcturnal | undefined;
+
+function loadNoxcturnal(): Noxcturnal {
+  // Keep native initialization off the legacy and early-fallback paths.
+  if (!noxcturnal) {
+    const loaded = require('noxcturnal') as Noxcturnal;
+    noxcturnal = loaded;
+  }
+  return noxcturnal;
+}
+
+function literal(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  const result = JSON.stringify(value);
+  return result === undefined ? 'undefined' : result;
+}
+
+export function mappedLiteral(context: PluginContext, value: unknown) {
+  if (value === undefined) return context.code.parseExpression('undefined');
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    return {
+      ...context.code.literal(value),
+      mapping: 'anchor-boundaries' as const,
+    };
+  }
+  return context.code.parseExpression(literal(value));
+}
+
+export function isNodeModule(filename: string): boolean {
+  return filename.includes('node_modules');
+}
+
+type BaseProfile = 'hermes-v0' | 'hermes-v1' | 'web' | 'webview';
+
+function getBaseProfile(input: NoxcturnalTransformInput): BaseProfile {
+  const environment = input.options.customTransformOptions?.environment;
+  if (input.options.customTransformOptions?.dom != null) return 'webview';
+  if (
+    input.options.platform === 'web' ||
+    environment === 'node' ||
+    environment === 'react-server'
+  ) {
+    return 'web';
+  }
+  if (
+    input.options.unstable_transformProfile === 'hermes-stable' ||
+    input.options.unstable_transformProfile === 'hermes-canary'
+  ) {
+    return 'hermes-v1';
+  }
+  return 'hermes-v0';
+}
+
+export function usesPublicEnvPlugin(input: NoxcturnalTransformInput): boolean {
+  const environment = input.options.customTransformOptions?.environment;
+  return !isNodeModule(input.filename) && environment !== 'node' && environment !== 'react-server';
+}
+
+export function isPathInsideRoot(
+  root: string,
+  candidate: string,
+  pathImplementation: Pick<typeof path, 'relative' | 'isAbsolute' | 'sep'> = path
+): boolean {
+  const relative = pathImplementation.relative(root, candidate);
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${pathImplementation.sep}`) &&
+    !pathImplementation.isAbsolute(relative)
+  );
+}
+
+function isInExpoRouterAppDirectory(input: NoxcturnalTransformInput): boolean {
+  const routerRootOption = input.options.customTransformOptions?.routerRoot;
+  const routerRoot = typeof routerRootOption === 'string' ? decodeURI(routerRootOption) : 'app';
+  const absoluteRouterRoot = path.isAbsolute(routerRoot)
+    ? routerRoot
+    : path.join(input.projectRoot, routerRoot);
+  return isPathInsideRoot(absoluteRouterRoot, input.filename);
+}
+
+function isSupportedJavaScriptSource(filename: string): boolean {
+  return (
+    /\.(?:[cm]?[jt]s|jsx|tsx)$/.test(filename) ||
+    filename.startsWith('\0polyfill:') ||
+    /(?:^|[/\\])[^/\\?]+\?ctx=[^/\\]+$/.test(filename)
+  );
+}
+
+function getEarlyFallbackReason(
+  input: NoxcturnalTransformInput,
+  allowProductionAppSource = false,
+  sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source)
+): string | null {
+  const { filename, options, source } = input;
+  const isDependency = isNodeModule(filename);
+  if (!isDependency && !allowProductionAppSource) {
+    return 'not-node-modules';
+  }
+  if (!isDependency) {
+    const reactCompiler = options.customTransformOptions?.reactCompiler as
+      | 'true'
+      | true
+      | undefined;
+    if (reactCompiler === true || reactCompiler === 'true') {
+      if (sourceFacts.hasFlowPragma) {
+        return 'react-compiler-flow-source';
+      }
+    }
+    const directive = sourceFacts.directive;
+    if (
+      directive &&
+      !(
+        directive === 'dom' ||
+        directive === 'server' ||
+        (directive === 'client' && options.customTransformOptions?.environment === 'react-server')
+      )
+    ) {
+      return 'expo-directive';
+    }
+  }
+  if (!input.isDefaultExpoTransformer) return 'custom-babel-transformer';
+  if (input.hasNonDefaultBabelConfig) return 'non-default-babel-config';
+  if (options.type === 'asset') return 'asset';
+  if (!isSupportedJavaScriptSource(filename)) return 'unsupported-source-extension';
+  const directive = sourceFacts.directive;
+  if (
+    directive &&
+    !(
+      (directive === 'client' &&
+        (options.customTransformOptions?.environment == null ||
+          options.customTransformOptions?.environment === 'react-server')) ||
+      directive === 'dom' ||
+      directive === 'server'
+    )
+  ) {
+    return 'expo-directive';
+  }
+  if (source.includes('worklet') && WORKLET_DIRECTIVE.test(source)) return 'worklets';
+  if (mayAutoWorkletize(source)) {
+    return 'worklets-candidate';
+  }
+  return null;
+}
+
+/** A function the worklets plugin workletizes because it says so itself. */
+const WORKLET_DIRECTIVE = /^[\t ]*["']worklet["']/m;
+
+/**
+ * Calls whose function arguments the worklets plugin workletizes without a
+ * directive, taken from the plugin's own `reanimatedFunctionHooks` and
+ * `reanimatedObjectHooks`. Matching the call rather than the bare name keeps a
+ * barrel file that merely re-exports `withTiming` out of the gate.
+ */
+const REANIMATED_AUTOWORKLETIZED =
+  /\b(?:useFrameCallback|useAnimatedStyle|useAnimatedProps|createAnimatedPropAdapter|useDerivedValue|useAnimatedScrollHandler|useAnimatedReaction|withTiming|withSpring|withDecay|withRepeat|runOnUI|executeOnUIRuntimeSync|scheduleOnUI|runOnUISync|runOnUIAsync|runOnRuntime|runOnRuntimeSync|runOnRuntimeAsync|scheduleOnRuntime|runOnRuntimeSyncWithId|scheduleOnRuntimeWithId)\s*[(<]/;
+
+/** The plugin's `gestureHandlerObjectHooks`, which workletize a config object. */
+const GESTURE_HANDLER_OBJECT_HOOK =
+  /\b(?:useTapGesture|usePanGesture|usePinchGesture|useRotationGesture|useFlingGesture|useLongPressGesture|useNativeGesture|useManualGesture|useHoverGesture)\s*[(<]/;
+
+/**
+ * The plugin's `gestureHandlerBuilderMethods`, which are ordinary callback names
+ * and say nothing on their own. The plugin only acts on one whose receiver is a
+ * `Gesture.<Kind>()` chain, so both have to be present — otherwise every
+ * `onStart(` in the graph matches, including the gesture library's own source.
+ */
+const GESTURE_HANDLER_BUILDER_CALL =
+  /\.(?:onBegin|onStart|onEnd|onFinalize|onUpdate|onChange|onTouchesDown|onTouchesMove|onTouchesUp|onTouchesCancelled)\s*\(/;
+const GESTURE_HANDLER_OBJECT_CALL =
+  /\bGesture\s*\.\s*(?:Tap|Pan|Pinch|Rotation|Fling|LongPress|ForceTouch|Native|Manual|Race|Simultaneous|Exclusive|Hover)\s*\(/;
+
+/**
+ * Whether the worklets Babel plugin could rewrite this file with no `'worklet'`
+ * directive to point at.
+ *
+ * This used to be a substring match on `react-native-reanimated` or
+ * `react-native-worklets`, which was wrong in both directions. Measured against
+ * the plugin itself over a 5.5k-module graph — running it on every file and
+ * comparing with a plain reprint — the package-name match missed 3 of the 246
+ * files the plugin changes and gated 48 (185 KB) it does not. The three it
+ * missed reach gesture APIs without naming either package, so they were
+ * transformed natively and their callbacks silently never workletized.
+ *
+ * Deriving the test from the plugin's own trigger sets, and matching call sites
+ * rather than names, catches all 246 and gates 15 (55 KB).
+ */
+function mayAutoWorkletize(source: string): boolean {
+  return (
+    ((source.includes('use') ||
+      source.includes('runOn') ||
+      source.includes('scheduleOn') ||
+      source.includes('with')) &&
+      REANIMATED_AUTOWORKLETIZED.test(source)) ||
+    (source.includes('Gesture') &&
+      (GESTURE_HANDLER_OBJECT_HOOK.test(source) ||
+        (source.includes('.on') &&
+          GESTURE_HANDLER_OBJECT_CALL.test(source) &&
+          GESTURE_HANDLER_BUILDER_CALL.test(source))))
+  );
+}
+
+function helperPolicy(input: NoxcturnalTransformInput): PreflightPlan['helpers'] {
+  const babelRuntimeVersion =
+    typeof input.enableBabelRuntime === 'string' ? input.enableBabelRuntime : undefined;
+  return input.enableBabelRuntime === false
+    ? { mode: 'inline' }
+    : {
+        mode: 'runtime',
+        moduleName: '@babel/runtime',
+        version: babelRuntimeVersion,
+      };
+}
+
+function getProfilePreflightConfig(
+  input: NoxcturnalTransformInput,
+  facts: ProfilePreflightFacts
+): PreflightTransforms {
+  switch (getBaseProfile(input)) {
+    case 'webview':
+      return getWebViewPreflightConfig(facts);
+    case 'web':
+      return getWebPreflightConfig(facts);
+    case 'hermes-v1':
+      return getHermesV1PreflightConfig(facts);
+    case 'hermes-v0':
+      return getHermesV0PreflightConfig(facts);
+  }
+}
+
+function createProfilePreflight(
+  input: NoxcturnalTransformInput,
+  sourceFacts: NoxcturnalSourceFacts
+): PreflightPlan | null {
+  const { options } = input;
+  // These are generated, already-lowered development bundles. Their diagnostic
+  // strings and comments contain JSX-looking `<Component>` text, while the
+  // DevTools bundle also contains URL fragments and colours that resemble
+  // private names (`#sourceloc`, `#ee78e6`). The cheap source facts therefore
+  // select a language preflight that parses the entire 600–700 KiB file only to
+  // return it unchanged. Keep the native Metro phase (dependency collection and
+  // module wrapping), but do not run this redundant language phase.
+  if (
+    /(?:^|[/\\])react-devtools-core[/\\]dist[/\\]backend\.js$/.test(input.filename) ||
+    /(?:^|[/\\])react-native[/\\]Libraries[/\\]Renderer[/\\]implementations[/\\]ReactFabric-dev\.js$/.test(
+      input.filename
+    )
+  ) {
+    return null;
+  }
+  const enableReactRefresh =
+    options.dev &&
+    !isNodeModule(input.filename) &&
+    options.customTransformOptions?.environment == null;
+  const isTypeScript = /\.(?:[cm]?ts|tsx)$/.test(input.filename);
+  const hasExplicitJsxExtension = /\.(?:jsx|tsx)$/.test(input.filename);
+  const allowsJsx = /\.(?:[cm]?js|jsx|tsx)$/.test(input.filename);
+  // Every JSX form contains `<`. This is only a lossless prerequisite for
+  // avoiding a native call; the native preflight decides from the parsed AST
+  // whether JSX is actually present.
+  const mayContainJsx = !hasExplicitJsxExtension && allowsJsx && sourceFacts.hasJsxCandidate;
+  const hasStaticBlock = sourceFacts.hasStaticBlock;
+  const hasAsyncGenerator = sourceFacts.hasAsyncGenerator;
+  const hasBlockScopedDeclaration = sourceFacts.hasLetOrConst;
+  const hasClassSyntax = sourceFacts.hasClass;
+  const hasForOfCandidate = sourceFacts.hasFor && sourceFacts.hasOf;
+  const hasSpreadCandidate = sourceFacts.hasSpread;
+  const hasAsyncCandidate = sourceFacts.hasAsync;
+  const hasRegexpLiteralCandidate = sourceFacts.hasSlash;
+  const hasDecoratorCandidate = /@\w/.test(input.source);
+  const nonHermes = options.customTransformOptions?.engine !== 'hermes';
+  const hasObjectRestSpread = nonHermes && hasSpreadCandidate;
+  const profileTransforms = getProfilePreflightConfig(input, {
+    hasAsync: hasAsyncCandidate,
+    hasAsyncGenerator,
+    hasBlockScopedDeclaration,
+    hasClass: hasClassSyntax,
+    hasForOf: hasForOfCandidate,
+    hasPrivateSyntax: sourceFacts.hasPrivateSyntax,
+    hasRegexpLiteral: hasRegexpLiteralCandidate,
+    hasStaticBlock,
+  });
+  const hasProfileWork = Object.values(profileTransforms).some(Boolean);
+  const hasOtherLanguageWork =
+    isTypeScript ||
+    enableReactRefresh ||
+    hasProfileWork ||
+    hasDecoratorCandidate ||
+    hasObjectRestSpread;
+  // Avoid a parse/codegen boundary for the overwhelmingly common file that has
+  // none of this recipe's language work. Flow without JSX is already rendered by
+  // its focused native erasure and does not need a second print.
+  if (
+    !isTypeScript &&
+    !hasExplicitJsxExtension &&
+    !mayContainJsx &&
+    !hasProfileWork &&
+    !hasDecoratorCandidate &&
+    !hasObjectRestSpread &&
+    !enableReactRefresh
+  ) {
+    return null;
+  }
+  return {
+    transforms: {
+      ...profileTransforms,
+      legacyDecorators: hasDecoratorCandidate,
+      objectRestSpread: hasObjectRestSpread
+        ? {
+            loose: true,
+            useBuiltIns: true,
+          }
+        : undefined,
+    },
+    // Expo owns this recipe. These choices mirror its Hermes-v1 and React configs
+    // without exposing either config name through Noxcturnal's capability API.
+    typescript: isTypeScript ? 'strip' : undefined,
+    reactRefresh: enableReactRefresh ? {} : undefined,
+    // babel-preset-expo deliberately uses the ordinary automatic runtime in
+    // both modes; development only changes purity/Refresh policy outside this
+    // native language phase.
+    jsx: hasExplicitJsxExtension
+      ? 'automatic'
+      : mayContainJsx
+        ? hasOtherLanguageWork
+          ? 'automatic'
+          : 'automatic-if-present'
+        : undefined,
+    jsxImportSource: hasExplicitJsxExtension || mayContainJsx ? 'react' : undefined,
+    helpers: helperPolicy(input),
+    // Metro's dependency pass still needs ordinary string literals. Compacting at
+    // this boundary can turn them into template literals, so output compaction
+    // remains a later consumer concern.
+    compact: false,
+    comments: true,
+  };
+}
+
+function createReactCompilerPreflight(input: NoxcturnalTransformInput): PreflightPlan | null {
+  const reactCompiler = input.options.customTransformOptions?.reactCompiler as
+    | 'true'
+    | true
+    | undefined;
+  const environment = input.options.customTransformOptions?.environment;
+  if (
+    (reactCompiler !== true && reactCompiler !== 'true') ||
+    isNodeModule(input.filename) ||
+    environment === 'node' ||
+    environment === 'react-server'
+  ) {
+    return null;
+  }
+  return {
+    reactCompiler: {
+      compilationMode: 'infer',
+      // babel-plugin-react-compiler defaults to critical errors in development;
+      // Babel preset Expo explicitly selects NONE in production.
+      panicThreshold: input.options.dev ? 'critical_errors' : 'none',
+      target: '19',
+      enableResetCacheOnSourceFileChanges: input.options.dev,
+      // Noxcturnal adds the compiler's `use no memo` and `use no forget`
+      // defaults, matching Babel preset Expo's merged directive list.
+      customOptOutDirectives: ['widget'],
+    },
+    jsx: 'preserve',
+    comments: true,
+    compact: false,
+  };
+}
+
+function parserMode(
+  input: NoxcturnalTransformInput,
+  sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source)
+): 'auto' | 'jsx' | 'tsx' {
+  // Flow must first reach Noxcturnal's native Flow erasure. For otherwise plain
+  // JavaScript files, Babel accepts JSX regardless of whether the extension
+  // spells `.jsx`. JSX parsing is therefore an extension policy, not a
+  // source-text guess. TypeScript keeps Babel's `.ts`/`.tsx` distinction.
+  if (sourceFacts.hasFlowPragma) return 'auto';
+  if (mayContainReactNativeCodegen(input.source)) return 'tsx';
+  return /\.(?:[cm]?js|jsx)$/.test(input.filename) ||
+    input.filename.startsWith('\0polyfill:') ||
+    /(?:^|[/\\])[^/\\?]+\?ctx=[^/\\]+$/.test(input.filename)
+    ? 'jsx'
+    : 'auto';
+}
+
+function fallbackReason(reason: string): string {
+  return reason.endsWith(':react-native-codegen') ? 'react-native-codegen' : reason;
+}
+
+const stableSourcePlugins = new Map<string, DefinedNativePlugin<any>>();
+const stableSourcePhases = new Map<string, PipelinePhase>();
+let metroInlineRequiresPhase: PipelinePhase | undefined;
+
+function stableSourcePlugin(
+  key: string,
+  create: () => DefinedNativePlugin<any>
+): DefinedNativePlugin<any> {
+  const cached = stableSourcePlugins.get(key);
+  if (cached) return cached;
+  const plugin = create();
+  stableSourcePlugins.set(key, plugin);
+  return plugin;
+}
+
+function stableSourcePhase(
+  nox: Noxcturnal,
+  keys: readonly string[],
+  plugins: readonly DefinedNativePlugin<any>[]
+): PipelinePhase {
+  const key = keys.join('\u001f');
+  const cached = stableSourcePhases.get(key);
+  if (cached) return cached;
+  const phase = nox.definePipelinePhase({ name: 'expo-source', plugins });
+  if (stableSourcePhases.size < 128) stableSourcePhases.set(key, phase);
+  return phase;
+}
+
+function getMetroInlineRequiresPhase(nox: Noxcturnal): PipelinePhase {
+  return (metroInlineRequiresPhase ??= nox.definePipelinePhase({
+    name: 'metro-inline-requires',
+    requiresPrintedInput: true,
+    plugins: [createInlineRequiresPlugin(nox)],
+  }));
+}
+
+function createPipeline(
+  nox: Noxcturnal,
+  input: NoxcturnalTransformInput,
+  pluginData: ExpoTransformPluginData,
+  includeModuleEligibility = true
+): NativePipeline {
+  const { options } = input;
+  const { sourceFacts } = pluginData;
+  const baseProfile = getBaseProfile(input);
+  const isHermesV1 = baseProfile === 'hermes-v1';
+  const supportsModernSyntax = isHermesV1 || baseProfile === 'web';
+  const plugins: DefinedNativePlugin<any>[] = [];
+  const sourcePluginKeys: string[] = [];
+  const addPlugin = (key: string, create: () => DefinedNativePlugin<any>) => {
+    sourcePluginKeys.push(key);
+    plugins.push(stableSourcePlugin(key, create));
+  };
+  // The complete Metro path folds the two read-only policy plugins into its
+  // existing dependency batch. The isolated source-pipeline test adapter needs them here.
+  if (includeModuleEligibility) {
+    if (options.experimentalImportSupport) {
+      addPlugin(`eligibility:${supportsModernSyntax}:native-esm`, () =>
+        createNativeEsmEligibilityPlugin(nox, supportsModernSyntax)
+      );
+    } else {
+      addPlugin(`eligibility:${supportsModernSyntax}:module-query`, () =>
+        createModuleEligibilityPlugin(nox, supportsModernSyntax)
+      );
+    }
+    addPlugin('cjs-detection', () => createCjsDetectionPlugin(nox));
+  }
+  if (isHermesV1 && sourceFacts.hasAsyncArrowNonSimpleParamsCandidate) {
+    addPlugin('async-arrow', () => createFixHermesV1AsyncArrowNonSimpleParamsPlugin(nox));
+  }
+  if (isHermesV1 && sourceFacts.hasClassInFinallyCandidate) {
+    addPlugin('class-finally', () => createFixHermesV1ClassInFinallyPlugin(nox));
+  }
+  if (isHermesV1 && sourceFacts.hasSuperInObjectAccessorCandidate) {
+    addPlugin('super-accessor', () => createFixHermesV1SuperInObjectAccessorPlugin(nox));
+  }
+  if (baseProfile === 'hermes-v0' || baseProfile === 'webview') {
+    addPlugin('display-name', () => createReactDisplayNamePlugin(nox));
+  }
+  if (sourceFacts.hasDefineCandidate) {
+    addPlugin('define-globals', () => createDefinePlugin(nox));
+  }
+  if (sourceFacts.hasProcess) {
+    addPlugin('process-env', () => createProcessEnvPlugin(nox));
+  }
+  if (!options.dev && sourceFacts.hasPlatform && sourceFacts.hasSelect) {
+    addPlugin(`platform-select:${options.platform ?? ''}`, () =>
+      createPlatformSelectPlugin(nox, options.platform)
+    );
+  }
+  if (input.source.includes('APP_MANIFEST')) {
+    addPlugin('inline-manifest', () => createExpoInlineManifestPlugin(nox));
+  }
+  if (input.source.includes('@expo/ui') && /from\s*["']@expo\/ui["']/.test(input.source)) {
+    addPlugin(`expo-ui:${options.platform ?? ''}`, () => createExpoUiPlugin(nox, options.platform));
+  }
+  if (
+    input.source.includes('widget') &&
+    /^[\t ]*["']widget["']/m.test(input.source) &&
+    hasExpoWidgets(input.projectRoot)
+  ) {
+    addPlugin('expo-widgets', () => createExpoWidgetsPlugin(nox));
+  }
+  if (
+    options.customTransformOptions?.environment !== 'react-server' &&
+    input.source.includes('server-only') &&
+    /["']server-only["']/.test(input.source)
+  ) {
+    addPlugin('restricted-imports:server-only', () =>
+      createEnvironmentRestrictedImportsPlugin(nox, 'server-only')
+    );
+  }
+  if (
+    options.platform === 'web' &&
+    input.source.includes('react-native') &&
+    /["']react-native(?:-web)?["']/.test(input.source)
+  ) {
+    addPlugin('react-native-web', () => createReactNativeWebPlugin(nox));
+  }
+  if (
+    options.dev &&
+    usesPublicEnvPlugin(input) &&
+    sourceFacts.hasProcess &&
+    sourceFacts.hasPublicEnv
+  ) {
+    addPlugin('development-public-env', () => createDevelopmentPublicEnvPlugin(nox));
+  }
+  const needsDeepImportWarnings =
+    options.dev &&
+    !isNodeModule(input.filename) &&
+    String(options.customTransformOptions?.disableDeepImportWarnings ?? 'false') !== 'true';
+  if (needsDeepImportWarnings && input.source.includes('react-native/')) {
+    addPlugin('deep-import-warnings', () => createDeepReactNativeImportWarningsPlugin(nox));
+  }
+  if (
+    String(options.customTransformOptions?.transformImportMeta) !== 'false' &&
+    input.source.includes('import.meta')
+  ) {
+    addPlugin('import-meta', () => createImportMetaPlugin(nox));
+  }
+  const native = createProfilePreflight(input, sourceFacts);
+  const reactCompiler = createReactCompilerPreflight(input);
+  const reactNativeCodegenEligibility =
+    baseProfile !== 'web' && mayContainReactNativeCodegen(input.source)
+      ? stableSourcePlugin('react-native-codegen-eligibility', () =>
+          createReactNativeCodegenEligibilityPlugin(nox)
+        )
+      : null;
+  // This phase handles directive-based server boundaries and a very small set
+  // of Expo Router exports. Most dependencies contain neither. Omitting it
+  // avoids an otherwise wasted JS dispatch and, when a native language phase
+  // follows, an AST parse whose unchanged result cannot be reused.
+  const includeServerExportsPhase = needsServerExportsPhase(input, sourceFacts);
+  const isReactServer = options.customTransformOptions?.environment === 'react-server';
+  // These plugins read the current file and their shared boundary facts from
+  // plugin data, so each is defined once for the process and interned. Their plans
+  // and routes therefore compile once rather than once per file.
+  const reactServerPlugins = isReactServer
+    ? [
+        stableSourcePlugin('react-server-client-proxy', () =>
+          createReactServerClientProxyPlugin(nox)
+        ),
+        stableSourcePlugin('react-server-module-actions', () =>
+          createReactServerModuleActionsPlugin(nox)
+        ),
+        stableSourcePlugin('react-server-directive-boundary', () =>
+          createReactServerDirectiveBoundaryPlugin(nox)
+        ),
+        stableSourcePlugin('restricted-imports:client-only', () =>
+          createEnvironmentRestrictedImportsPlugin(
+            nox,
+            'client-only',
+            (context) => serverBoundary(context).clientProxy
+          )
+        ),
+        stableSourcePlugin('restricted-react-apis', () =>
+          createEnvironmentRestrictedReactApisPlugin(
+            nox,
+            (context) => serverBoundary(context).clientProxy
+          )
+        ),
+      ]
+    : [];
+  const clientServerPlugins = isReactServer
+    ? []
+    : [
+        stableSourcePlugin('client-server-reference-proxy', () =>
+          createClientServerReferenceProxyPlugin(nox)
+        ),
+        stableSourcePlugin('client-server-directive-boundary', () =>
+          createClientServerDirectiveBoundaryPlugin(nox)
+        ),
+      ];
+  return nox.defineNativePipeline({
+    phases: [
+      ...(reactNativeCodegenEligibility == null
+        ? []
+        : [
+            {
+              name: 'react-native-codegen-eligibility',
+              plugins: [reactNativeCodegenEligibility],
+            },
+          ]),
+      ...(reactCompiler == null ? [] : [{ name: 'react-compiler', native: reactCompiler }]),
+      ...(includeServerExportsPhase
+        ? [
+            {
+              name: 'expo-router-server-exports',
+              editEffect: 'bindings' as const,
+              plugins: [
+                ...reactServerPlugins,
+                ...clientServerPlugins,
+                ...(isReactServer
+                  ? []
+                  : [stableSourcePlugin('dom-component', () => createExpoDomComponentPlugin(nox))]),
+                ...(isInExpoRouterAppDirectory(input)
+                  ? [
+                      stableSourcePlugin('router-server-exports', () =>
+                        createExpoRouterServerExportsPlugin(nox)
+                      ),
+                    ]
+                  : []),
+              ],
+            },
+          ]
+        : []),
+      ...(native == null ? [] : [{ name: 'expo-language', native }]),
+      // Type syntax must be erased before ordinary Expo visitors run. Besides
+      // matching Babel's ordering, this lets the native language plan lower
+      // the JavaScript emitted from TypeScript before Expo visitors observe it.
+      ...(plugins.length === 0 ? [] : [stableSourcePhase(nox, sourcePluginKeys, plugins)]),
+      ...(options.inlineRequires ? [getMetroInlineRequiresPhase(nox)] : []),
+    ],
+  });
+}
+
+const metroModulePhases = new Map<string, PipelinePhase>();
+let metroScriptPhase: PipelinePhase | undefined;
+let metroEsmGlobalsPhase: PipelinePhase | undefined;
+
+function getMetroEsmGlobalsPhase(nox: Noxcturnal): PipelinePhase {
+  if (metroEsmGlobalsPhase) return metroEsmGlobalsPhase;
+  metroEsmGlobalsPhase = nox.definePipelinePhase({
+    name: 'metro-esm-pseudo-global-renames',
+    editEffect: 'bindings',
+    plugins: [createMetroEsmGlobalsPlugin(nox)],
+  });
+  return metroEsmGlobalsPhase;
+}
+
+function getMetroModulePhase(nox: Noxcturnal, input: NoxcturnalMetroTransformInput): PipelinePhase {
+  const baseProfile = getBaseProfile(input);
+  const supportsModernSyntax = baseProfile === 'hermes-v1' || baseProfile === 'web';
+  const liveBindings = input.options.customTransformOptions?.liveBindings !== 'false';
+  const key = `${supportsModernSyntax}:${input.options.experimentalImportSupport === true}:${liveBindings}`;
+  const cached = metroModulePhases.get(key);
+  if (cached) return cached;
+  const phase = nox.definePipelinePhase({
+    name: 'module-and-dependencies',
+    // These visitors are routed by parsed node kinds, so installing them
+    // unconditionally is both cheap and correct for comment-prefixed,
+    // shebang-prefixed, and otherwise non-regex-detectable modules.
+    plugins: [
+      stableSourcePlugin(`eligibility:${supportsModernSyntax}:native-esm`, () =>
+        createNativeEsmEligibilityPlugin(nox, supportsModernSyntax)
+      ),
+      stableSourcePlugin('cjs-detection', () => createCjsDetectionPlugin(nox)),
+      createMetroDependencyPlugin(nox),
+      createMetroLiveBindingsPlugin(nox, liveBindings),
+    ],
+  });
+  metroModulePhases.set(key, phase);
+  return phase;
+}
+
+function getMetroScriptPhase(nox: Noxcturnal): PipelinePhase {
+  if (metroScriptPhase) return metroScriptPhase;
+  metroScriptPhase = nox.definePipelinePhase({
+    name: 'script',
+    plugins: [
+      nox.defineNativePlugin({
+        name: 'metro-native-script',
+        contract: {
+          metadata: { writes: ['dependencies', 'dependencyMapName'] },
+        },
+        visitors: [
+          nox.defineVisitor('ImportDeclaration', {}, (path) => path.unsupported('script-import')),
+          nox.defineVisitor('ExportAllDeclaration', {}, (path) =>
+            path.unsupported('script-export')
+          ),
+          nox.defineVisitor('ExportDefaultDeclaration', {}, (path) =>
+            path.unsupported('script-export')
+          ),
+          nox.defineVisitor('ExportNamedDeclaration', {}, (path) =>
+            path.unsupported('script-export')
+          ),
+        ],
+        post(context) {
+          context.metadata.set('dependencies', []);
+          context.metadata.set('dependencyMapName', '');
+          context.editor.prepend('(function (global) {\n');
+          context.editor.append(
+            `${context.source.endsWith('\n') ? '' : '\n'}})(typeof globalThis !== 'undefined' ? globalThis : typeof global !== 'undefined' ? global : typeof window !== 'undefined' ? window : this);`
+          );
+        },
+      }),
+    ],
+  });
+  return metroScriptPhase;
+}
+
+function createFullMetroPipeline(
+  nox: Noxcturnal,
+  input: NoxcturnalMetroTransformInput,
+  pluginData: MetroTransformPluginData
+): NativePipeline {
+  const preserveSourceComments =
+    pluginData.sourceFacts.hasComments &&
+    (!input.options.minify || input.config.minifierConfig?.output?.comments === true);
+  const sourcePhases = [...createPipeline(nox, input, pluginData, false).phases];
+  if (!input.options.dev && !preserveSourceComments) {
+    sourcePhases.push({
+      name: 'metro-optimization',
+      native: {
+        optimize: {
+          constantFolding: true,
+          deadCodeElimination: true,
+        },
+        comments: true,
+      },
+    });
+  }
+  const compactPhases = input.config.unstable_compactOutput
+    ? [
+        {
+          name: 'metro-compact-output',
+          native: { compact: true },
+        } satisfies NativePipeline['phases'][number],
+      ]
+    : [];
+  return nox.defineNativePipeline({
+    phases: [
+      ...sourcePhases,
+      ...(input.options.type === 'module' &&
+      input.options.experimentalImportSupport === true &&
+      String(input.options.customTransformOptions?.optimize) !== 'true'
+        ? [getMetroEsmGlobalsPhase(nox)]
+        : []),
+      input.options.type === 'script' ? getMetroScriptPhase(nox) : getMetroModulePhase(nox, input),
+      ...compactPhases,
+    ],
+  });
+}
+
+/**
+ * Transform a conservative Metro module or script entirely in Noxcturnal. Modules include
+ * dependency collection and `__d` wrapping; scripts use Metro's dependency-free polyfill
+ * wrapper. A fallback never exposes partially edited source.
+ */
+export function transformFileFullyWithNoxcturnalSync(
+  input: NoxcturnalMetroTransformInput
+): NoxcturnalMetroTransformAttempt {
+  const sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source);
+  const earlyReason = getEarlyFallbackReason(input, true, sourceFacts);
+  if (earlyReason) return { status: 'fallback', reason: earlyReason };
+  if (input.options.type !== 'module' && input.options.type !== 'script') {
+    return { status: 'fallback', reason: 'unsupported-input-type' };
+  }
+  if (input.options.type === 'script' && input.source.startsWith('#!')) {
+    return { status: 'fallback', reason: 'script-hashbang' };
+  }
+  const nox = loadNoxcturnal();
+  const pluginData = createMetroTransformPluginData(input, sourceFacts);
+  const pipeline = createFullMetroPipeline(nox, input, pluginData);
+  const result = nox.transform(input.source, input.filename, pipeline, {
+    parser: parserMode(input, sourceFacts),
+    sourceMapMode: 'boundary',
+    functionMap: true,
+    pluginData,
+  });
+  if (result.status !== 'complete') {
+    return { status: 'fallback', reason: fallbackReason(result.reason) };
+  }
+  const dependencies = result.metadata.dependencies;
+  const dependencyMapName = result.metadata.dependencyMapName;
+  if (!Array.isArray(dependencies) || typeof dependencyMapName !== 'string') {
+    throw new nox.NativeTransformError(
+      'A complete full-Metro transform returned invalid dependency metadata',
+      [
+        {
+          code: 'native-transform-error',
+          message: 'Missing or malformed dependencies or dependencyMapName',
+          phase: 'metro-module',
+        },
+      ],
+      ['metro-module'],
+      { phase: 'metro-module', reason: 'invalid-metro-metadata' }
+    );
+  }
+  return {
+    status: 'complete',
+    result,
+    dependencies: dependencies as readonly Dependency[],
+    dependencyMapName,
+  };
+}
+
+export async function transformFileFullyWithNoxcturnal(
+  input: NoxcturnalMetroTransformInput
+): Promise<NoxcturnalMetroTransformAttempt> {
+  return transformFileFullyWithNoxcturnalSync(input);
+}
+
+/**
+ * Low-level source-pipeline adapter for focused plugin tests.
+ * The production worker only uses the complete Metro pipeline above.
+ */
+export function transformNodeModuleWithNoxcturnalSync(
+  input: NoxcturnalTransformInput
+): NoxcturnalTransformAttempt {
+  const sourceFacts = input.sourceFacts ?? createNoxcturnalSourceFacts(input.source);
+  const earlyReason = getEarlyFallbackReason(input, true, sourceFacts);
+  if (earlyReason) return { status: 'fallback', reason: earlyReason };
+
+  const nox = loadNoxcturnal();
+  const pluginData = createExpoTransformPluginData(input, sourceFacts);
+  const result: TransformResult = nox.transform(
+    input.source,
+    input.filename,
+    createPipeline(nox, input, pluginData),
+    {
+      parser: parserMode(input, sourceFacts),
+      sourceMapMode: 'boundary',
+      functionMap: true,
+      pluginData,
+    }
+  );
+  return result.status === 'complete'
+    ? { status: 'complete', result }
+    : { status: 'fallback', reason: fallbackReason(result.reason) };
+}
+
+export async function transformNodeModuleWithNoxcturnal(
+  input: NoxcturnalTransformInput
+): Promise<NoxcturnalTransformAttempt> {
+  return transformNodeModuleWithNoxcturnalSync(input);
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/cjs-detection.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/cjs-detection.ts
@@ -1,0 +1,81 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createCjsDetectionPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<{ hasCjsExports: boolean }> {
+  return nox.defineNativePlugin<{ hasCjsExports: boolean }>({
+    name: 'expo-detect-cjs-exports',
+    contract: { metadata: { writes: ['hasCjsExports'] } },
+    createState: () => ({ hasCjsExports: false }),
+    visitors: [
+      nox.defineVisitor(
+        'StaticMemberExpression',
+        { fields: ['memberPath'], scope: true, ancestry: { mode: 'parent' } },
+        (path, state: { hasCjsExports: boolean }) => {
+          if (
+            path.parentPath?.node.type !== 'AssignmentExpression' ||
+            path.parentPath.node.start !== path.node.start
+          ) {
+            return;
+          }
+          const pattern = String(path.node.memberPath ?? '');
+          const isModuleExports =
+            (pattern === 'module.exports' || pattern.startsWith('module.exports.')) &&
+            !path.scope.hasBinding('module');
+          const isExportsProperty =
+            pattern.startsWith('exports.') && !path.scope.hasBinding('exports');
+          if (isModuleExports || isExportsProperty) state.hasCjsExports = true;
+        }
+      ),
+      nox.defineVisitor(
+        'AssignmentExpression',
+        {
+          scope: true,
+          children: { left: { route: 'Expression', fields: ['name'] } },
+        },
+        (path, state: { hasCjsExports: boolean }) => {
+          if (state.hasCjsExports) return;
+          const left = path.getChild('left');
+          if (
+            left?.node.type === 'Identifier' &&
+            left.node.name === 'exports' &&
+            !path.scope.hasBinding('exports')
+          ) {
+            state.hasCjsExports = true;
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          scope: true,
+          children: {
+            callee: { route: 'Expression', fields: ['memberPath'] },
+            arguments: { route: 'Expression', fields: ['name', 'memberPath'] },
+          },
+        },
+        (path, state: { hasCjsExports: boolean }) => {
+          if (state.hasCjsExports) return;
+          const callee = path.getChild('callee');
+          const args = path.getChildList('arguments');
+          if (
+            args.length > 1 &&
+            callee?.matchesPattern('Object.assign') &&
+            !path.scope.hasBinding('Object') &&
+            (args[0]?.matchesPattern('module.exports') ||
+              (args[0]?.node.type === 'Identifier' &&
+                args[0].node.name === 'exports' &&
+                !path.scope.hasBinding('exports')))
+          ) {
+            state.hasCjsExports = true;
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      context.metadata.set('hasCjsExports', state.hasCjsExports);
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/client-server-directive-boundary.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/client-server-directive-boundary.ts
@@ -1,0 +1,26 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { serverBoundary, type Noxcturnal } from '../noxcturnal-transformer';
+
+export function createClientServerDirectiveBoundaryPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-client-server-directive-boundary',
+    visitors: [
+      nox.defineVisitor(
+        'Directive',
+        { fields: ['value'], ancestry: { mode: 'parent' } },
+        (directive) => {
+          if (
+            directive.node.value === 'use server' &&
+            !(
+              serverBoundary(directive.context).serverProxy &&
+              directive.parentPath?.node.type === 'Program'
+            )
+          ) {
+            directive.unsupported('expo-directive');
+          }
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/client-server-reference-proxy.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/client-server-reference-proxy.ts
@@ -1,0 +1,175 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  expoPluginInput,
+  serverBoundary,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+  type ServerBoundaryShared,
+} from '../noxcturnal-transformer';
+
+interface ClientServerProxyState {
+  input: NoxcturnalTransformInput;
+  boundary: ServerBoundaryShared;
+  enabled: boolean;
+  exports: Set<string>;
+}
+
+export function createClientServerReferenceProxyPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<ClientServerProxyState> {
+  return nox.defineNativePlugin<ClientServerProxyState>({
+    name: 'expo-client-server-reference-proxy',
+    editEffect: 'bindings',
+    contract: {
+      metadata: { writes: ['proxyExports', 'reactServerReference'] },
+    },
+    createState: (context) => {
+      const boundary = serverBoundary(context);
+      boundary.serverProxy = false;
+      return {
+        input: expoPluginInput(context),
+        boundary,
+        enabled: false,
+        exports: new Set(),
+      };
+    },
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        {
+          children: {
+            directives: { route: 'Directive', fields: ['value'] },
+          },
+        },
+        (program, state) => {
+          state.enabled = program
+            .getChildList('directives')
+            .some((directive) => directive.node.value === 'use server');
+          state.boundary.serverProxy = state.enabled;
+        }
+      ),
+      nox.defineVisitor(
+        'AssignmentExpression',
+        {
+          children: {
+            left: {
+              route: 'MemberExpression',
+              fields: ['memberPath'],
+            },
+          },
+        },
+        (assignment, state) => {
+          if (!state.enabled) return;
+          const member = String(assignment.getChild('left')?.node.memberPath ?? '');
+          if (
+            member === 'module' ||
+            member.startsWith('module.') ||
+            member === 'exports' ||
+            member.startsWith('exports.')
+          ) {
+            assignment.unsupported('server-reference-commonjs-assignment');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          children: {
+            callee: { route: 'Expression', fields: ['memberPath'] },
+          },
+        },
+        (call, state) => {
+          if (!state.enabled) return;
+          const callee = String(call.getChild('callee')?.node.memberPath ?? '');
+          if (callee === 'Object.assign' || callee === 'exports.assign') {
+            call.unsupported('server-reference-commonjs-assignment');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportDefaultDeclaration',
+        { ancestry: { mode: 'programParent' } },
+        (exportPath, state) => {
+          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
+            state.exports.add('default');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportAllDeclaration',
+        { ancestry: { mode: 'programParent' } },
+        (exportPath, state) => {
+          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
+            exportPath.unsupported('server-reference-export-all');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          ancestry: { mode: 'programParent' },
+          children: {
+            declaration: {
+              route: 'Declaration',
+              fields: ['name', 'nodeKind'],
+              children: {
+                declarations: {
+                  route: 'VariableDeclarator',
+                  children: {
+                    id: { route: 'Identifier', fields: ['name'] },
+                  },
+                },
+              },
+            },
+            specifiers: {
+              route: 'ExportSpecifier',
+              fields: ['exported'],
+            },
+          } as any,
+        },
+        (exportPath, state) => {
+          if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          const declaration = exportPath.getChild('declaration') as any;
+          if (typeof declaration?.node.name === 'string') {
+            state.exports.add(declaration.node.name);
+          } else if (declaration?.node.type === 'VariableDeclaration') {
+            for (const declarator of declaration.getChildList('declarations')) {
+              const id = declarator.getChild('id');
+              if (id?.node.type === 'Identifier') {
+                state.exports.add(String(id.node.name));
+              }
+            }
+          }
+          for (const specifier of exportPath.getChildList('specifiers')) {
+            state.exports.add(String(specifier.node.exported));
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      if (!state.enabled) return;
+      const outputKey =
+        './' +
+        path.relative(state.input.projectRoot, state.input.filename).split(path.sep).join('/');
+      const exports = [...state.exports];
+      const proxy = [
+        `import { createServerReference } from "react-server-dom-webpack/client";`,
+        `import { callServerRSC } from "expo-router/rsc/internal";`,
+      ];
+      for (const exportName of exports) {
+        const reference = `createServerReference(${JSON.stringify(`${outputKey}#${exportName}`)}, callServerRSC)`;
+        proxy.push(
+          exportName === 'default'
+            ? `export default ${reference};`
+            : `export const ${exportName} = ${reference};`
+        );
+      }
+      context.editor.overwrite(0, context.source.length, proxy.join('\n'), 'sourceless');
+      context.metadata.set('proxyExports', exports);
+      context.metadata.set('reactServerReference', pathToFileURL(state.input.filename).href);
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/deep-react-native-import-warnings.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/deep-react-native-import-warnings.ts
@@ -1,0 +1,66 @@
+import type { DefinedNativePlugin, NativeNodePath } from 'noxcturnal';
+
+import { expoPluginInput } from '../noxcturnal-transformer';
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+interface DeepImportWarningState {
+  warnings: { source: string; line: number; column: number }[];
+}
+
+export function createDeepReactNativeImportWarningsPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<DeepImportWarningState> {
+  const record = (
+    source: unknown,
+    path: Pick<NativeNodePath, 'getLocation'>,
+    state: DeepImportWarningState
+  ) => {
+    if (
+      typeof source !== 'string' ||
+      !source.startsWith('react-native/') ||
+      source === 'react-native/Libraries/Core/InitializeCore'
+    )
+      return;
+    const location = path.getLocation().start;
+    state.warnings.push({
+      source,
+      line: location.line,
+      column: location.column,
+    });
+  };
+  return nox.defineNativePlugin<DeepImportWarningState>({
+    name: 'expo-warn-deep-react-native-imports',
+    createState: () => ({ warnings: [] }),
+    visitors: [
+      nox.defineVisitor('ImportDeclaration', { fields: ['source'] }, (path, state) =>
+        record(path.node.source, path, state)
+      ),
+      nox.defineVisitor('ExportNamedDeclaration', { fields: ['source'] }, (path, state) =>
+        record(path.node.source, path, state)
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          fields: ['calleeName', 'staticArgument', 'argumentCount'],
+        },
+        (path, state) => {
+          if (path.node.calleeName === 'require' && path.node.argumentCount === 1) {
+            record(path.node.staticArgument, path, state);
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      const { filename } = expoPluginInput(context);
+      for (const warning of state.warnings) {
+        const message =
+          `Deep imports from the 'react-native' package are deprecated ('${warning.source}').` +
+          ` Source: ${filename} ${warning.line}:${warning.column}`;
+        context.editor.prependLeft(
+          context.source.length,
+          `\nconsole.warn(${JSON.stringify(message)});`
+        );
+      }
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/define.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/define.ts
@@ -1,0 +1,113 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { expoPluginInput, isNodeModule, mappedLiteral } from '../noxcturnal-transformer';
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+interface DefineState {
+  identifiers: Map<string, unknown>;
+  members: Map<string, unknown>;
+  typeofValues: Map<string, unknown>;
+}
+
+export function createDefinePlugin(nox: Noxcturnal): DefinedNativePlugin<DefineState> {
+  return nox.defineNativePlugin<DefineState>({
+    name: 'expo-define-globals',
+    createState: (context) => {
+      const input = expoPluginInput(context);
+      const { options } = input;
+      const environment = options.customTransformOptions?.environment;
+      const isServer = environment === 'node' || environment === 'react-server';
+      const identifiers = new Map<string, unknown>();
+      const members = new Map<string, unknown>();
+      const typeofValues = new Map<string, unknown>();
+      members.set('process.env.EXPO_OS', options.platform);
+      members.set(
+        'process.env.EXPO_SERVER',
+        environment === 'node' || environment === 'react-server'
+      );
+      if (!options.dev) {
+        identifiers.set('__DEV__', false);
+        members.set('Platform.OS', options.platform);
+        members.set('process.env.NODE_ENV', 'production');
+      }
+      if (process.env.NODE_ENV !== 'test') {
+        const baseUrl = options.customTransformOptions?.baseUrl;
+        members.set(
+          'process.env.EXPO_BASE_URL',
+          typeof baseUrl === 'string' ? decodeURI(baseUrl) : ''
+        );
+      }
+      if (isNodeModule(input.filename) && process.env.EXPO_PUBLIC_USE_RN_FETCH != null) {
+        members.set('process.env.EXPO_PUBLIC_USE_RN_FETCH', process.env.EXPO_PUBLIC_USE_RN_FETCH);
+      }
+      const minifyTypeofWindow = options.customTransformOptions?.minifyTypeofWindow;
+      if (String(minifyTypeofWindow ?? isServer) !== 'false') {
+        typeofValues.set('window', isServer ? 'undefined' : 'object');
+      }
+      return { identifiers, members, typeofValues };
+    },
+    visitors: [
+      nox.defineVisitor(
+        'ReferencedIdentifier',
+        {
+          fields: ['name', 'global', 'read', 'write'],
+          where: { name: { equals: '__DEV__' } },
+        },
+        (path, state: DefineState) => {
+          const { identifiers } = state;
+          const name = String(path.node.name);
+          if (!identifiers.has(name) || path.node.global !== true || path.node.write === true) {
+            return;
+          }
+          path.replaceWith(mappedLiteral(path.context, identifiers.get(name)));
+        }
+      ),
+      nox.defineVisitor(
+        'StaticMemberExpression|ComputedMemberExpression',
+        {
+          fields: ['memberPath'],
+          where: {
+            memberPath: {
+              oneOf: [
+                'Platform.OS',
+                'process.env.EXPO_OS',
+                'process.env.EXPO_SERVER',
+                'process.env.NODE_ENV',
+                'process.env.EXPO_BASE_URL',
+                'process.env.EXPO_PUBLIC_USE_RN_FETCH',
+              ],
+            },
+            write: { equals: false },
+          },
+          scope: true,
+        },
+        (path, state: DefineState) => {
+          const { members } = state;
+          const pattern = String(path.node.memberPath ?? '');
+          if (!members.has(pattern)) return;
+          const root = pattern.slice(0, pattern.indexOf('.'));
+          if (path.scope.hasBinding(root)) return;
+          path.replaceWith(mappedLiteral(path.context, members.get(pattern)));
+        }
+      ),
+      nox.defineVisitor(
+        'UnaryExpression',
+        {
+          fields: ['operator'],
+          where: { operator: { equals: 'typeof' } },
+          scope: true,
+          children: { argument: { route: 'Expression', fields: ['name'] } },
+        },
+        (path, state: DefineState) => {
+          const { typeofValues } = state;
+          if (path.node.operator !== 'typeof') return;
+          const argument = path.getChild('argument');
+          if (!argument || argument.node.type !== 'Identifier') return;
+          const name = String(argument.node.name);
+          if (!typeofValues.has(name) || path.scope.hasBinding(name)) return;
+          path.replaceWith(mappedLiteral(path.context, typeofValues.get(name)));
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/development-public-env.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/development-public-env.ts
@@ -1,0 +1,59 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+import { staticProcessEnvName } from './process-env';
+
+interface PublicEnvState {
+  binding: string;
+  insertion: number;
+  names: Set<string>;
+}
+
+export function createDevelopmentPublicEnvPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<PublicEnvState> {
+  return nox.defineNativePlugin<PublicEnvState>({
+    name: 'expo-reference-development-public-env',
+    contract: { metadata: { writes: ['publicEnvVars'] } },
+    createState: () => ({ binding: '', insertion: 0, names: new Set() }),
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        {
+          scope: true,
+          children: { directives: { route: 'Directive', fields: ['value'] } },
+        },
+        (program, state) => {
+          state.binding = program.scope.generateUid('env');
+          state.insertion = program.getChildList('directives').at(-1)?.end ?? 0;
+        }
+      ),
+      nox.defineVisitor(
+        'StaticMemberExpression|ComputedMemberExpression',
+        {
+          fields: ['memberPath', 'property'],
+          where: { write: { equals: false } },
+          scope: true,
+        },
+        (member, state) => {
+          const name = staticProcessEnvName(member.node);
+          if (name === null || !name.startsWith('EXPO_PUBLIC_')) return;
+          if (member.scope.hasBinding('process')) return;
+          state.names.add(name);
+          member.replaceWith({
+            code: `${state.binding}.env.${name}`,
+            mapping: 'anchor-boundaries',
+          });
+        }
+      ),
+    ],
+    post(context, state) {
+      context.metadata.set('publicEnvVars', [...state.names]);
+      if (state.names.size === 0) return;
+      context.editor.appendRight(
+        state.insertion,
+        `${state.insertion === 0 ? '' : '\n'}var ${state.binding}=require("expo/virtual/env");\n`
+      );
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/environment-restricted-imports.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/environment-restricted-imports.ts
@@ -1,0 +1,67 @@
+import type { DefinedNativePlugin, NativeNodePath } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createEnvironmentRestrictedImportsPlugin(
+  nox: Noxcturnal,
+  forbidden: 'server-only' | 'client-only',
+  skip: (context: { pluginData: unknown }) => boolean = () => false
+): DefinedNativePlugin {
+  const reject = (
+    path: Pick<NativeNodePath, 'unsupported'> & {
+      context: { pluginData: unknown };
+    },
+    source: unknown
+  ) => {
+    if (skip(path.context)) return;
+    if (source === forbidden) {
+      path.unsupported(`environment-restricted-import:${forbidden}`);
+    }
+  };
+  return nox.defineNativePlugin({
+    name: `expo-environment-restricted-imports-${forbidden}`,
+    visitors: [
+      nox.defineVisitor('ImportDeclaration', { fields: ['source'] }, (path) =>
+        reject(path, path.node.source)
+      ),
+      nox.defineVisitor('ExportAllDeclaration', { fields: ['source'] }, (path) =>
+        reject(path, path.node.source)
+      ),
+      nox.defineVisitor('ExportNamedDeclaration', { fields: ['source'] }, (path) =>
+        reject(path, path.node.source)
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          fields: ['calleeName', 'staticArgument', 'argumentCount'],
+          children: {
+            callee: { route: 'Expression', fields: ['memberPath', 'name'] },
+          },
+        },
+        (call) => {
+          if (call.node.argumentCount < 1 || call.node.staticArgument !== forbidden) return;
+          const calleePath = call.getChild('callee');
+          const callee = String(
+            call.node.calleeName ?? calleePath?.node.memberPath ?? calleePath?.node.name ?? ''
+          );
+          const allowed =
+            (calleePath?.node.type === 'Identifier' && callee === 'require') ||
+            (calleePath?.node.type !== 'Identifier' &&
+              ['resolveWeak', 'importAll', 'importDefault'].some(
+                (property) => callee === property || callee.endsWith(`.${property}`)
+              ));
+          if (allowed) reject(call, call.node.staticArgument);
+        }
+      ),
+      nox.defineVisitor(
+        'ImportExpression',
+        {
+          children: {
+            source: { route: 'StringLiteral', fields: ['value'] },
+          },
+        },
+        (importPath) => reject(importPath, importPath.getChild('source')?.node.value)
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/environment-restricted-react-apis.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/environment-restricted-react-apis.ts
@@ -1,0 +1,134 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+const INVALID_SERVER_REACT_APIS = new Set([
+  'Component',
+  'createContext',
+  'createFactory',
+  'PureComponent',
+  'useDeferredValue',
+  'useEffect',
+  'useImperativeHandle',
+  'useInsertionEffect',
+  'useLayoutEffect',
+  'useReducer',
+  'useRef',
+  'useState',
+  'useSyncExternalStore',
+  'useTransition',
+  'useOptimistic',
+]);
+const INVALID_SERVER_REACT_DOM_APIS = new Set([
+  'findDOMNode',
+  'flushSync',
+  'unstable_batchedUpdates',
+  'useFormStatus',
+  'useFormState',
+]);
+
+interface RestrictedReactApiState {
+  named: Map<number, string>;
+  namespaces: Map<number, string>;
+}
+
+export function createEnvironmentRestrictedReactApisPlugin(
+  nox: Noxcturnal,
+  skip: (context: { pluginData: unknown }) => boolean = () => false
+): DefinedNativePlugin<RestrictedReactApiState> {
+  const forbiddenFor = (source: unknown) =>
+    source === 'react'
+      ? INVALID_SERVER_REACT_APIS
+      : source === 'react-dom'
+        ? INVALID_SERVER_REACT_DOM_APIS
+        : null;
+  return nox.defineNativePlugin({
+    name: 'expo-environment-restricted-react-apis',
+    createState: () => ({ named: new Map(), namespaces: new Map() }),
+    visitors: [
+      nox.defineVisitor(
+        'ImportDeclaration',
+        {
+          fields: ['source'],
+          scope: true,
+          children: {
+            specifiers: {
+              route: 'ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier',
+              fields: ['local', 'imported'],
+            },
+          },
+        },
+        (importPath, state) => {
+          if (skip(importPath.context)) return;
+          const source = String(importPath.node.source);
+          const forbidden = forbiddenFor(source);
+          if (!forbidden) return;
+          for (const specifier of importPath.getChildList('specifiers')) {
+            const local = String(specifier.node.local);
+            const binding = importPath.scope.getBinding(local);
+            const declarationId = binding?.declaration?.id;
+            if (declarationId == null) continue;
+            if (specifier.node.type === 'ImportSpecifier') {
+              const imported = String(specifier.node.imported);
+              if (!forbidden.has(imported)) continue;
+              if (imported === 'Component' || imported === 'PureComponent') {
+                importPath.unsupported(`react-server-client-api-import:${source}:${imported}`);
+              }
+              state.named.set(declarationId, imported);
+            } else {
+              state.namespaces.set(declarationId, source);
+            }
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'VariableDeclarator',
+        {
+          scope: true,
+          children: {
+            init: {
+              route: 'CallExpression',
+              children: {
+                callee: { route: 'Identifier', fields: ['name'] },
+              },
+            },
+          },
+        },
+        (declarator, state) => {
+          if (skip(declarator.context)) return;
+          const init = declarator.getChild('init');
+          if (!init || init.node.type !== 'CallExpression') return;
+          const callee = init.getChild('callee');
+          if (!callee) return;
+          const binding = declarator.scope.getBinding(String(callee.node.name));
+          const api =
+            binding?.declaration?.id == null ? undefined : state.named.get(binding.declaration.id);
+          if (api) declarator.unsupported(`react-server-client-api-use:${api}`);
+        }
+      ),
+      nox.defineVisitor(
+        'MemberExpression',
+        {
+          scope: true,
+          children: {
+            object: { route: 'Identifier', fields: ['name'] },
+            property: { route: 'Identifier', fields: ['name'] },
+          },
+        },
+        (member, state) => {
+          if (skip(member.context)) return;
+          const object = member.getChild('object');
+          const property = member.getChild('property');
+          if (!object || !property) return;
+          const binding = member.scope.getBinding(String(object.node.name));
+          const source =
+            binding?.declaration?.id == null
+              ? undefined
+              : state.namespaces.get(binding.declaration.id);
+          if (!source || !forbiddenFor(source)?.has(String(property.node.name))) return;
+          member.unsupported(`react-server-client-api-use:${source}:${String(property.node.name)}`);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-dom-component.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-dom-component.ts
@@ -1,0 +1,119 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  expoPluginInput,
+  isNodeModule,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+} from '../noxcturnal-transformer';
+
+interface ExpoDomComponentState {
+  input: NoxcturnalTransformInput;
+  enabled: boolean;
+  hasDefault: boolean;
+  displayName: string;
+}
+
+export function createExpoDomComponentPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<ExpoDomComponentState> {
+  return nox.defineNativePlugin<ExpoDomComponentState>({
+    name: 'expo-dom-component',
+    editEffect: 'bindings',
+    contract: { metadata: { writes: ['expoDomComponentReference'] } },
+    createState: (context) => ({
+      input: expoPluginInput(context),
+      enabled: false,
+      hasDefault: false,
+      displayName: 'Component',
+    }),
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        {
+          children: {
+            directives: { route: 'Directive', fields: ['value'] },
+          },
+        },
+        (program, state) => {
+          state.enabled =
+            state.input.options.platform !== 'web' &&
+            program
+              .getChildList('directives')
+              .some((directive) => directive.node.value === 'use dom');
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          fields: ['exportKind'],
+          ancestry: { mode: 'programParent' },
+          children: {
+            declaration: { route: 'Declaration', fields: ['nodeKind'] },
+          },
+        },
+        (exportPath, state) => {
+          if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          if (exportPath.node.exportKind === 'type') return;
+          const kind = exportPath.getChild('declaration')?.node.type;
+          if (kind === 'TSInterfaceDeclaration' || kind === 'TSTypeAliasDeclaration') return;
+          exportPath.unsupported('dom-component-named-export');
+        }
+      ),
+      nox.defineVisitor(
+        'ExportDefaultDeclaration',
+        {
+          ancestry: { mode: 'programParent' },
+          children: {
+            declaration: {
+              route: 'Declaration|Expression',
+              fields: ['nodeKind', 'name'],
+            },
+          },
+        },
+        (exportPath, state) => {
+          if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          state.hasDefault = true;
+          const declaration = exportPath.getChild('declaration') as any;
+          if (
+            declaration?.node.nodeKind === 'FunctionDeclaration' &&
+            typeof declaration.node.name === 'string'
+          ) {
+            state.displayName = declaration.node.name;
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      if (!state.enabled) return;
+      if (!state.hasDefault) context.unsupported('dom-component-missing-default');
+      const basename = path.basename(state.input.filename);
+      if (
+        state.input.filename.includes(state.input.projectRoot) &&
+        !isNodeModule(state.input.filename)
+      ) {
+        if (/^_layout\.[jt]sx?$/.test(basename)) {
+          context.unsupported('dom-component-layout-route');
+        }
+        if (/\+api\.[jt]sx?$/.test(basename)) {
+          context.unsupported('dom-component-api-route');
+        }
+      }
+      const outputKey = pathToFileURL(state.input.filename).href;
+      const filePath = state.input.options.dev
+        ? `${JSON.stringify(`${basename}?file=`)} + ${JSON.stringify(outputKey)}`
+        : JSON.stringify(`${createHash('md5').update(outputKey).digest('hex')}.html`);
+      const proxy = `import React from "react";
+import { WebView } from "expo/dom/internal";
+const filePath = ${filePath};
+const _Expo_DOMProxyComponent = React.forwardRef((props, ref) => React.createElement(WebView, { ref, ...props, filePath }));
+if (__DEV__) _Expo_DOMProxyComponent.displayName = ${JSON.stringify(`DOM(${state.displayName})`)};
+export default _Expo_DOMProxyComponent;`;
+      context.editor.overwrite(0, context.source.length, proxy, 'sourceless');
+      context.metadata.set('expoDomComponentReference', outputKey);
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-inline-manifest.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-inline-manifest.ts
@@ -1,0 +1,116 @@
+import type { ExpoConfig, ProjectConfig } from '@expo/config';
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { expoPluginInput, type Noxcturnal } from '../noxcturnal-transformer';
+
+interface ExpoManifestConfig {
+  config: ProjectConfig;
+  appName: string | undefined;
+  webName: string | undefined;
+}
+
+const expoManifestConfigByRoot = new Map<string, ExpoManifestConfig>();
+
+function getExpoConfigPluginProps(
+  config: ExpoConfig,
+  pluginName: string
+): Record<string, unknown> | null {
+  const plugin = (config.plugins ?? []).find((value) =>
+    Array.isArray(value) ? value[0] === pluginName : value === pluginName
+  );
+  return Array.isArray(plugin) ? ((plugin[1] ?? null) as Record<string, unknown> | null) : null;
+}
+
+function getExpoManifestConfig(projectRoot: string): ExpoManifestConfig {
+  const cached = expoManifestConfigByRoot.get(projectRoot);
+  if (cached) return cached;
+  // Loading Expo config is comparatively expensive and most transforms never
+  // reference APP_MANIFEST. Keep it off module initialization and mobile paths.
+  const { getConfig, getNameFromConfig } = require('@expo/config') as typeof import('@expo/config');
+  const config = getConfig(projectRoot, {
+    isPublicConfig: true,
+    skipSDKVersionRequirement: true,
+  });
+  const { appName, webName } = getNameFromConfig(config.exp);
+  const result = { config, appName, webName };
+  expoManifestConfigByRoot.set(projectRoot, result);
+  return result;
+}
+
+function getExpoAppManifest(projectRoot: string): string {
+  const environmentManifest = process.env.APP_MANIFEST;
+  if (environmentManifest) return environmentManifest;
+  const { config, appName, webName } = getExpoManifestConfig(projectRoot);
+  const appJSON = config.exp;
+  const { web: webManifest = {}, ios = {}, android = {} } = appJSON;
+  const splash = getExpoConfigPluginProps(appJSON, 'expo-splash-screen');
+  const orientation = (webManifest.orientation || appJSON.orientation)?.toLowerCase();
+  const manifest: Record<string, unknown> = {
+    ...appJSON,
+    name: appName,
+    description: appJSON.description,
+    primaryColor: appJSON.primaryColor,
+    ios: { ...ios },
+    android: { ...android },
+    web: {
+      ...webManifest,
+      meta: undefined,
+      build: undefined,
+      scope: webManifest.scope,
+      crossorigin: webManifest.crossorigin,
+      description: appJSON.description,
+      startUrl: webManifest.startUrl,
+      shortName: webManifest.shortName || webName,
+      display: webManifest.display,
+      orientation: orientation === 'default' ? undefined : orientation,
+      dir: webManifest.dir,
+      barStyle: webManifest.barStyle,
+      backgroundColor:
+        webManifest.backgroundColor ||
+        (typeof splash?.backgroundColor === 'string' ? splash.backgroundColor : undefined),
+      themeColor: webManifest.themeColor || appJSON.primaryColor,
+      lang: webManifest.lang,
+      name: webName,
+    },
+  };
+  for (const field of [
+    'androidNavigationBar',
+    'androidStatusBar',
+    'privacy',
+    'ios',
+    'android',
+    'plugins',
+    'hooks',
+    '_internal',
+    'assetBundlePatterns',
+  ] as const) {
+    delete manifest[field];
+  }
+  return JSON.stringify(manifest);
+}
+
+export function createExpoInlineManifestPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<{ manifest?: string }> {
+  return nox.defineNativePlugin({
+    name: 'expo-inline-manifest',
+    createState: () => ({}),
+    visitors: [
+      nox.defineVisitor(
+        'StaticMemberExpression',
+        {
+          where: {
+            memberPath: { equals: 'process.env.APP_MANIFEST' },
+            write: { equals: false },
+          },
+        },
+        (member, state: { manifest?: string }) => {
+          const manifest = (state.manifest ??= getExpoAppManifest(
+            expoPluginInput(member.context).projectRoot
+          ));
+          member.replaceWith(JSON.stringify(manifest));
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-router-server-exports.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-router-server-exports.ts
@@ -1,0 +1,141 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+import path from 'path';
+
+import {
+  expoPluginInput,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+} from '../noxcturnal-transformer';
+
+interface ExpoRouterExportState {
+  input: NoxcturnalTransformInput;
+  isLoaderBundle: boolean;
+  isServer: boolean;
+  loaderReference?: string;
+  performConstantFolding: boolean;
+}
+
+export function createExpoRouterServerExportsPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<ExpoRouterExportState> {
+  return nox.defineNativePlugin<ExpoRouterExportState>({
+    name: 'expo-router-server-exports',
+    editEffect: 'bindings',
+    contract: {
+      metadata: { writes: ['loaderReference', 'performConstantFolding'] },
+    },
+    createState: (context) => {
+      const input = expoPluginInput(context);
+      return {
+        input,
+        isLoaderBundle: String(input.options.customTransformOptions?.isLoaderBundle) === 'true',
+        isServer: input.options.customTransformOptions?.environment === 'node',
+        performConstantFolding: false,
+      };
+    },
+    visitors: [
+      nox.defineVisitor('ExportDefaultDeclaration', {}, (exportPath, state) => {
+        if (!state.isLoaderBundle) return;
+        exportPath.remove();
+        state.performConstantFolding = true;
+      }),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          fields: ['source', 'exportKind'],
+          children: {
+            declaration: {
+              route: 'FunctionDeclaration|VariableDeclaration',
+              fields: ['nodeKind', 'name', 'kind'],
+              children: {
+                declarations: {
+                  route: 'VariableDeclarator',
+                  children: {
+                    id: {
+                      route: 'Identifier|ObjectPattern|ArrayPattern',
+                      fields: ['name'],
+                    },
+                  },
+                },
+              },
+            },
+            specifiers: { route: 'ExportSpecifier' },
+          },
+        },
+        (exportPath, state) => {
+          if (
+            exportPath.node.source ||
+            (exportPath.node.exportKind && exportPath.node.exportKind !== 'value') ||
+            exportPath.getChildList('specifiers').length > 0
+          ) {
+            return;
+          }
+          const declaration = exportPath.getChild('declaration');
+          if (!declaration) return;
+          if (declaration.node.type === 'Function') {
+            const name = declaration.node.name;
+            if (typeof name !== 'string') {
+              throw declaration.buildCodeFrameError(
+                'FunctionDeclaration route omitted its parsed declaration name'
+              );
+            }
+            if (name === 'loader') {
+              state.loaderReference = path.resolve(state.input.projectRoot, state.input.filename);
+            }
+            const remove = state.isLoaderBundle
+              ? name !== 'loader'
+              : name === 'loader' || (!state.isServer && name === 'generateMetadata');
+            if (remove) {
+              exportPath.remove();
+              state.performConstantFolding = true;
+            }
+            return;
+          }
+          if (declaration.node.type !== 'VariableDeclaration') return;
+          const declarators = declaration.getChildList('declarations');
+          const retained = declarators.filter((declarator) => {
+            const id = declarator.getChild('id');
+            const name = id?.node.type === 'Identifier' ? id.node.name : undefined;
+            if (name === 'loader') {
+              state.loaderReference = path.resolve(state.input.projectRoot, state.input.filename);
+            }
+            return state.isLoaderBundle
+              ? name === 'loader'
+              : name !== 'loader' && (state.isServer || name !== 'generateMetadata');
+          });
+          if (retained.length === declarators.length) return;
+          state.performConstantFolding = true;
+          if (retained.length === 0) {
+            exportPath.remove();
+          } else {
+            const kind = declaration.node.kind;
+            if (typeof kind !== 'string') {
+              throw declaration.buildCodeFrameError(
+                'VariableDeclaration route omitted its parsed declaration kind'
+              );
+            }
+            exportPath.replaceWith({
+              kind: 'composite',
+              parts: [
+                `export ${kind} `,
+                ...retained.flatMap((declarator, index) => [
+                  ...(index === 0 ? [] : [', ']),
+                  declarator.getSource(),
+                ]),
+                ';',
+              ],
+            });
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      if (state.loaderReference) {
+        context.metadata.set('loaderReference', state.loaderReference);
+      }
+      if (state.performConstantFolding) {
+        context.metadata.set('performConstantFolding', true);
+      }
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-ui.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-ui.ts
@@ -1,0 +1,137 @@
+import type { Code, DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+interface ExpoUiState {
+  iconLocals: Set<string>;
+  namespaceLocals: Set<string>;
+}
+
+export function createExpoUiPlugin(
+  nox: Noxcturnal,
+  platform: string | null | undefined
+): DefinedNativePlugin<ExpoUiState> {
+  return nox.defineNativePlugin({
+    name: 'expo-ui-icon-select',
+    createState: () => ({ iconLocals: new Set(), namespaceLocals: new Set() }),
+    visitors: [
+      nox.defineVisitor(
+        'ImportDeclaration',
+        {
+          fields: ['source', 'importKind'],
+          children: {
+            specifiers: {
+              route: 'ImportSpecifier|ImportNamespaceSpecifier|ImportDefaultSpecifier',
+              fields: ['local', 'imported', 'importKind'],
+            },
+          },
+        },
+        (importPath, state) => {
+          if (
+            importPath.node.source !== '@expo/ui' ||
+            (importPath.node.importKind && importPath.node.importKind !== 'value')
+          ) {
+            return;
+          }
+          for (const specifier of importPath.getChildList('specifiers')) {
+            if (
+              specifier.node.type === 'ImportSpecifier' &&
+              specifier.node.imported === 'Icon' &&
+              (!specifier.node.importKind || specifier.node.importKind === 'value')
+            ) {
+              state.iconLocals.add(String(specifier.node.local));
+            } else if (specifier.node.type === 'ImportNamespaceSpecifier') {
+              state.namespaceLocals.add(String(specifier.node.local));
+            }
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          fields: ['argumentCount'],
+          children: {
+            callee: { route: 'Expression', fields: ['memberPath'] },
+            arguments: {
+              route: 'ObjectExpression',
+              children: {
+                properties: {
+                  route: 'ObjectProperty|SpreadElement',
+                  fields: ['key', 'kind', 'computed', 'method', 'shorthand'],
+                  children: {
+                    value: { route: 'Expression', fields: ['staticArgument'] },
+                  },
+                },
+              },
+            },
+          },
+        },
+        (call, state) => {
+          if (call.node.argumentCount !== 1) return;
+          const callee = call.getChild('callee');
+          if (!callee) return;
+          const direct = [...state.iconLocals].some((name) =>
+            callee.matchesPattern(`${name}.select`)
+          );
+          const namespace =
+            !direct &&
+            [...state.namespaceLocals].some((name) => callee.matchesPattern(`${name}.Icon.select`));
+          if (!direct && !namespace) return;
+
+          const argument = call.getChildList('arguments')[0];
+          if (!argument?.is('ObjectExpression')) return;
+          const properties = argument.getChildList('properties');
+          const values = new Map<string, Code>();
+          for (const property of properties) {
+            if (property.node.type !== 'ObjectProperty') return;
+            const key = property.node.key;
+            if (
+              property.node.kind !== 'init' ||
+              property.node.computed ||
+              property.node.method ||
+              property.node.shorthand ||
+              (key !== 'ios' && key !== 'android')
+            ) {
+              return;
+            }
+            const value = property.getChild('value');
+            if (!value) return;
+            values.set(key, value.getSource());
+          }
+          const iosSource = values.get('ios');
+          let androidSource = values.get('android');
+          if (!iosSource || !androidSource) return;
+
+          const androidValue = properties
+            .find(
+              (property) =>
+                property.node.type === 'ObjectProperty' && property.node.key === 'android'
+            )
+            ?.getChild('value');
+          if (
+            platform !== 'ios' &&
+            platform !== 'web' &&
+            androidValue?.node.type === 'ImportExpression'
+          ) {
+            const source = androidValue.node.staticArgument;
+            if (typeof source !== 'string') return;
+            androidSource = call.context.code
+              .template`require(${call.context.code.stringLiteral(source)})`;
+          }
+          if (platform === 'ios') {
+            call.replaceWith(iosSource);
+          } else if (platform === 'android') {
+            call.replaceWith(androidSource);
+          } else if (platform === 'web') {
+            call.replaceWith('undefined');
+          } else {
+            call.replaceWith(
+              call.context.code
+                .template`process.env.EXPO_OS === "ios" ? ${iosSource} : process.env.EXPO_OS === "android" ? ${androidSource} : undefined`
+            );
+          }
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-widgets.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-widgets.ts
@@ -1,0 +1,218 @@
+import generate from '@babel/generator';
+import path from 'node:path';
+import type {
+  Code,
+  DefinedNativePlugin,
+  NativeNodePath,
+  PluginContext,
+  SourceFragment,
+} from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+type HermesProgram = Record<string, unknown>;
+type HermesTransform = (
+  program: HermesProgram,
+  options: Record<string, unknown>
+) => HermesProgram | null;
+const hermesParser = require('hermes-parser') as {
+  parse(source: string, options: Record<string, unknown>): HermesProgram;
+  Transforms: {
+    transformEnumSyntax: HermesTransform;
+    transformMatchSyntax: HermesTransform;
+    transformComponentSyntax: HermesTransform;
+    transformRecordSyntax: HermesTransform;
+    stripFlowTypes: HermesTransform;
+  };
+};
+const transformESTreeToBabel = (
+  require(
+    path.join(path.dirname(require.resolve('hermes-parser')), 'babel/TransformESTreeToBabel.js')
+  ) as {
+    transformProgram(
+      program: HermesProgram,
+      options: Record<string, unknown>
+    ): Parameters<typeof generate>[0];
+  }
+).transformProgram;
+
+function compactWidgetFunction(source: string): string {
+  let pureCalls = source.match(/\/\*\s*@__PURE__\s*\*\//g)?.length ?? 0;
+  const ast = hermesParser.parse(`const __expoWidget = ${source};`, {
+    babel: false,
+    flow: 'detect',
+    sourceType: 'module',
+  });
+  const file = transformESTreeToBabel(ast, {}) as any;
+  const declaration = file.program.body[0].declarations[0];
+  return generate(declaration.init, {
+    compact: true,
+    comments: true,
+  }).code.replace(/\s*\b(_jsx[\w$]*\()/g, (call: string) =>
+    pureCalls-- > 0 ? `/*#__PURE__*/${call.trimStart()}` : call
+  );
+}
+
+function escapeWidgetTemplate(source: string): string {
+  return source.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+}
+
+const expoWidgetsAvailabilityByRoot = new Map<string, boolean>();
+
+export function hasExpoWidgets(projectRoot: string): boolean {
+  const cached = expoWidgetsAvailabilityByRoot.get(projectRoot);
+  if (cached != null) return cached;
+  let available = false;
+  try {
+    require.resolve('expo-widgets/package.json', {
+      paths: [projectRoot, __dirname],
+    });
+    available = true;
+  } catch {}
+  expoWidgetsAvailabilityByRoot.set(projectRoot, available);
+  return available;
+}
+
+export function createExpoWidgetsPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  type WidgetParentPath = {
+    node: {
+      type: string;
+      method?: boolean;
+      kind?: string;
+      computed?: boolean;
+    };
+    context: PluginContext;
+    getChild(role: 'key'): Pick<NativeNodePath, 'getSource'> | null;
+    replaceWith(code: Code): void;
+  };
+  type WidgetFunctionPath = {
+    node: {
+      async?: boolean;
+      generator?: boolean;
+      nodeKind?: string;
+      name?: string;
+    };
+    parentPath: WidgetParentPath | null;
+    getChild(role: 'body'): {
+      node: { type: string };
+      getChildList(role: 'directives'): readonly {
+        node: { value?: string; start: number; end: number };
+      }[];
+      getSource(): SourceFragment;
+      sourceText(): string;
+    } | null;
+    getChildList(role: 'params'): readonly Pick<NativeNodePath, 'sourceText'>[];
+    replaceWith(code: Code): void;
+  };
+  const transformFunction = (functionPath: WidgetFunctionPath) => {
+    const bodyPath = functionPath.getChild('body');
+    if (!bodyPath || bodyPath.node.type !== 'FunctionBody') return;
+    const directive = bodyPath
+      .getChildList('directives')
+      .find((candidate) => candidate.node.value === 'widget');
+    if (!directive) return;
+    const bodyRange = bodyPath.getSource();
+    const bodySource = bodyPath.sourceText();
+    const directiveStart = directive.node.start - bodyRange.start;
+    const directiveEnd = directive.node.end - bodyRange.start;
+    const withoutDirective = bodySource.slice(0, directiveStart) + bodySource.slice(directiveEnd);
+    const parameters = functionPath
+      .getChildList('params')
+      .map((parameter) => parameter.sourceText())
+      .join(',');
+    const expression =
+      `${functionPath.node.async === true ? 'async ' : ''}function` +
+      `${functionPath.node.generator === true ? '*' : ''}(${parameters})${withoutDirective}`;
+    const template = `\`${escapeWidgetTemplate(compactWidgetFunction(expression))}\``;
+
+    if (
+      functionPath.node.nodeKind === 'FunctionDeclaration' &&
+      functionPath.parentPath?.node.type === 'ExportDefaultDeclaration'
+    ) {
+      functionPath.parentPath.replaceWith(`export default ${template};`);
+    } else if (
+      functionPath.node.nodeKind === 'FunctionDeclaration' &&
+      typeof functionPath.node.name === 'string'
+    ) {
+      functionPath.replaceWith(`var ${functionPath.node.name} = ${template};`);
+    } else if (
+      functionPath.parentPath?.node.type === 'ObjectProperty' &&
+      functionPath.parentPath.node.method === true
+    ) {
+      const property = functionPath.parentPath;
+      if (property.node.kind !== 'init') return;
+      const key = property.getChild('key');
+      if (!key) return;
+      property.replaceWith(
+        property.node.computed
+          ? property.context.code.template`[${key.getSource()}]: ${template}`
+          : property.context.code.template`${key.getSource()}: ${template}`
+      );
+    } else {
+      functionPath.replaceWith(template);
+    }
+  };
+
+  return nox.defineNativePlugin({
+    name: 'expo-widgets',
+    editEffect: 'bindings',
+    visitors: [
+      nox.defineVisitor(
+        'Function',
+        {
+          fields: ['nodeKind', 'name', 'async', 'generator', 'bodyStart', 'bodyEnd'],
+          ancestry: {
+            mode: 'parent',
+            routes: {
+              ObjectProperty: {
+                fields: ['key', 'computed', 'kind', 'method'],
+                children: { key: { route: 'Expression' } },
+              },
+            },
+          },
+          children: {
+            body: {
+              route: 'FunctionBody',
+              children: {
+                directives: { route: 'Directive', fields: ['value'] },
+              },
+            },
+            params: {
+              route: 'FormalParameter|FormalParameterRest',
+            },
+          },
+        },
+        (functionPath) => transformFunction(functionPath)
+      ),
+      nox.defineVisitor(
+        'ArrowFunctionExpression',
+        {
+          fields: ['async', 'expression', 'bodyStart', 'bodyEnd'],
+          ancestry: {
+            mode: 'parent',
+            routes: {
+              ObjectProperty: {
+                fields: ['key', 'computed', 'kind', 'method'],
+                children: { key: { route: 'Expression' } },
+              },
+            },
+          },
+          children: {
+            body: {
+              route: 'FunctionBody',
+              children: {
+                directives: { route: 'Directive', fields: ['value'] },
+              },
+            },
+            params: {
+              route: 'FormalParameter|FormalParameterRest|BindingRestElement',
+            },
+          },
+        },
+        (functionPath) => {
+          if (functionPath.node.expression === false) transformFunction(functionPath);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-async-arrow-non-simple-params.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-async-arrow-non-simple-params.ts
@@ -1,0 +1,123 @@
+import type { CompositeFragment, DefinedNativePlugin, SourceFragment } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createFixHermesV1AsyncArrowNonSimpleParamsPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-fix-hermes-v1-async-arrow-non-simple-params',
+    visitors: [
+      nox.defineVisitor(
+        'ArrowFunctionExpression',
+        {
+          fields: ['async', 'expression', 'parameterCount'],
+          scope: true,
+          children: {
+            params: {
+              route: 'FormalParameter|FormalParameterRest|BindingRestElement',
+              children: {
+                pattern: { route: 'Identifier|ObjectPattern|ArrayPattern' },
+                default: { route: 'Expression' },
+              },
+            },
+            body: { route: 'FunctionBody' },
+          },
+        },
+        (arrow) => {
+          if (!arrow.node.async) return;
+          const params = arrow.getChildList('params');
+          if (params.length === 0) return;
+          if (
+            params.every((parameter) => {
+              if (parameter.node.type !== 'FormalParameter') return false;
+              return (
+                parameter.getChild('pattern')?.node.type === 'Identifier' &&
+                !parameter.getChild('default')
+              );
+            })
+          )
+            return;
+
+          const body = arrow.getChild('body');
+          if (!body) arrow.unsupported('missing-async-arrow-body');
+          const bodySource = body!.getSource();
+          const blockBody = arrow.node.expression
+            ? arrow.context.code.template`{ return ${bodySource}; }`
+            : bodySource;
+
+          // Hermes rejects every rest-parameter async arrow. Keep its original
+          // parameter binding in a synchronous closure and invoke a zero-argument
+          // async arrow inside it, matching Expo's maintained Babel transform.
+          if (
+            params.some(
+              (parameter) =>
+                parameter.node.type === 'FormalParameterRest' ||
+                parameter.node.type === 'BindingRestElement'
+            )
+          ) {
+            arrow.context.editor.remove(arrow.getSource().start, arrow.getSource().start + 5);
+            body!.replaceWith(arrow.context.code.template`(async () => ${blockBody})()`);
+            return;
+          }
+
+          const initializerParts: CompositeFragment['parts'][number][] = [];
+          const replacements: {
+            path: { getSource(): SourceFragment };
+            temporary: string;
+          }[] = [];
+          for (let index = 0; index < params.length; index++) {
+            const parameter = params[index]!;
+            const pattern = parameter.getChild('pattern');
+            const initializer = parameter.getChild('default');
+            if (pattern?.node.type === 'Identifier' && !initializer) continue;
+            if (!pattern) {
+              arrow.unsupported('missing-async-arrow-parameter-pattern');
+              return;
+            }
+            const temporary = arrow.scope.generateUid('p');
+            replacements.push({
+              path: parameter,
+              temporary,
+            });
+            if (initializer) {
+              initializerParts.push(
+                'var ',
+                pattern.getSource(),
+                ` = ${temporary} === undefined ? `,
+                initializer.getSource(),
+                ` : ${temporary}; `
+              );
+            } else {
+              initializerParts.push('var ', pattern.getSource(), ` = ${temporary}; `);
+            }
+          }
+
+          const replacementBodyParts: CompositeFragment['parts'] = arrow.node.expression
+            ? ['{ ', ...initializerParts, 'return ', bodySource, '; }']
+            : [
+                arrow.context.sourceSlice(bodySource.start, bodySource.start + 1),
+                ...initializerParts,
+                arrow.context.sourceSlice(bodySource.start + 1, bodySource.end),
+              ];
+          const arrowSource = arrow.getSource();
+          const replacementParts: CompositeFragment['parts'][number][] = [];
+          let cursor = arrowSource.start;
+          for (const replacement of replacements) {
+            const source = replacement.path.getSource();
+            replacementParts.push(
+              arrow.context.sourceSlice(cursor, source.start),
+              replacement.temporary
+            );
+            cursor = source.end;
+          }
+          replacementParts.push(
+            arrow.context.sourceSlice(cursor, bodySource.start),
+            ...replacementBodyParts
+          );
+          arrow.replaceWith({ kind: 'composite', parts: replacementParts });
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-class-in-finally.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-class-in-finally.ts
@@ -1,0 +1,75 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+import { isFunctionType } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createFixHermesV1ClassInFinallyPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<Set<number>> {
+  return nox.defineNativePlugin<Set<number>>({
+    name: 'expo-fix-hermes-v1-class-in-finally',
+    createState: () => new Set(),
+    visitors: [
+      nox.defineVisitor(
+        'TryStatement',
+        {
+          controlFlow: ['nested-traverse'],
+          nested: [
+            nox.defineVisitor(
+              'Class',
+              {
+                fields: ['nodeKind', 'name'],
+                ancestry: { mode: 'findParent' },
+              },
+              () => {}
+            ),
+          ],
+          children: { finalizer: { route: 'BlockStatement' } },
+        },
+        (statement, rewritten: Set<number>) => {
+          const finalizer = statement.getChild('finalizer');
+          if (!finalizer) return;
+          finalizer.traverse([
+            nox.defineVisitor(
+              'Class',
+              {
+                fields: ['nodeKind', 'name'],
+                ancestry: { mode: 'findParent' },
+              },
+              (classPath) => {
+                if (rewritten.has(classPath.id)) return;
+                let parent = classPath.parentPath;
+                while (parent && parent.id !== finalizer.id) {
+                  if (
+                    isFunctionType(parent.node.type) ||
+                    parent.node.type === 'ObjectProperty' ||
+                    parent.node.type === 'MethodDefinition' ||
+                    parent.node.type === 'StaticBlock' ||
+                    parent.node.type === 'Class'
+                  ) {
+                    return;
+                  }
+                  parent = parent.parentPath;
+                }
+                if (!parent) return;
+                rewritten.add(classPath.id);
+
+                const source = classPath.getSource();
+                if (classPath.node.nodeKind === 'ClassDeclaration') {
+                  const name = classPath.node.name;
+                  if (!name) return;
+                  classPath.replaceWith(
+                    classPath.context.code
+                      .template`var ${name} = (() => { ${source} return ${name}; })();`
+                  );
+                } else {
+                  classPath.replaceWith(classPath.context.code.template`(() => ${source})()`);
+                }
+              }
+            ),
+          ]);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-super-in-object-accessor.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-super-in-object-accessor.ts
@@ -1,0 +1,78 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createFixHermesV1SuperInObjectAccessorPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<Set<number>> {
+  const superAncestry = {
+    ancestry: {
+      mode: 'findParent',
+      routes: {
+        'StaticMemberExpression|ComputedMemberExpression': {
+          children: { object: { route: 'Expression|Super' } },
+        },
+      },
+    },
+  } as const;
+  return nox.defineNativePlugin<Set<number>>({
+    name: 'expo-fix-hermes-v1-super-in-object-accessor',
+    createState: () => new Set(),
+    visitors: [
+      nox.defineVisitor(
+        'ObjectProperty',
+        {
+          fields: ['kind', 'computed', 'key'],
+          controlFlow: ['nested-traverse'],
+          nested: [nox.defineVisitor('Super', superAncestry, () => {})],
+          children: { key: { route: 'Expression' } },
+        },
+        (accessor, rewritten: Set<number>) => {
+          if (
+            accessor.node.computed ||
+            (accessor.node.kind !== 'get' && accessor.node.kind !== 'set') ||
+            typeof accessor.node.key !== 'string'
+          ) {
+            return;
+          }
+          const key = accessor.getChild('key');
+          if (!key || (key.node.type !== 'Identifier' && key.node.type !== 'StringLiteral')) {
+            return;
+          }
+          accessor.traverse([
+            nox.defineVisitor('Super', superAncestry, (superPath) => {
+              const member = superPath.parentPath;
+              if (
+                !member ||
+                (member.node.type !== 'StaticMemberExpression' &&
+                  member.node.type !== 'ComputedMemberExpression') ||
+                member.getChild('object')?.id !== superPath.id
+              ) {
+                return;
+              }
+
+              let parent = member.parentPath;
+              while (parent && parent.id !== accessor.id) {
+                if (
+                  parent.node.type === 'Class' ||
+                  parent.node.type === 'MethodDefinition' ||
+                  (parent.node.type === 'Function' && parent.parentPath?.id !== accessor.id) ||
+                  parent.node.type === 'StaticBlock' ||
+                  parent.node.type === 'PropertyDefinition' ||
+                  parent.node.type === 'AccessorProperty' ||
+                  parent.node.type === 'ObjectProperty'
+                ) {
+                  return;
+                }
+                parent = parent.parentPath;
+              }
+              if (!parent || rewritten.has(accessor.id)) return;
+              rewritten.add(accessor.id);
+              key.replaceWith(`[${JSON.stringify(accessor.node.key)}]`);
+            }),
+          ]);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/import-meta.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/import-meta.ts
@@ -1,0 +1,14 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createImportMetaPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-import-meta-transform',
+    visitors: [
+      nox.defineVisitor('MetaProperty', {}, (path) => {
+        path.replaceWith(path.context.code.parseExpression('globalThis.__ExpoImportMetaRegistry'));
+      }),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/inline-requires.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/inline-requires.ts
@@ -1,0 +1,151 @@
+import type { DefinedNativePlugin, NativeBinding } from 'noxcturnal';
+
+import { expoPluginData } from '../noxcturnal-transformer';
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+interface InlineRequiresBindingFacts {
+  declarationId: number | undefined;
+  references: NativeBinding['references'];
+  unsafe: boolean;
+}
+
+interface InlineRequiresState {
+  ignored: ReadonlySet<string>;
+  bindings: Map<string, InlineRequiresBindingFacts | null>;
+}
+
+export function createInlineRequiresPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<InlineRequiresState> {
+  return nox.defineNativePlugin<InlineRequiresState>({
+    name: 'metro-inline-requires',
+    editEffect: 'bindings',
+    createState(context) {
+      const { input } = expoPluginData(context);
+      return {
+        ignored: new Set(input.options.nonInlinedRequires ?? []),
+        bindings: new Map(),
+      };
+    },
+    visitors: [
+      nox.defineVisitor(
+        'VariableDeclaration',
+        {
+          fields: ['kind'],
+          ancestry: { mode: 'parent' },
+          scope: true,
+          children: {
+            declarations: {
+              route: 'VariableDeclarator',
+              children: {
+                id: { route: 'Identifier', fields: ['name'] },
+                init: {
+                  route: 'CallExpression|StaticMemberExpression|ComputedMemberExpression',
+                  fields: ['calleeName', 'calleeGlobal', 'staticArgument', 'argumentCount'],
+                  children: {
+                    object: {
+                      route: 'CallExpression',
+                      fields: ['calleeName', 'calleeGlobal', 'staticArgument', 'argumentCount'],
+                    },
+                  },
+                },
+              },
+            },
+          } as any,
+        },
+        (declaration, state) => {
+          if (declaration.parentPath?.node.type !== 'Program') return;
+          const declarators = declaration.getChildList('declarations');
+          const retained: (typeof declarators)[number][] = [];
+          const replacements: { start: number; end: number; code: string }[] = [];
+
+          for (const declaratorPath of declarators) {
+            // The nested union route is valid at runtime, but the public child-path
+            // inference cannot currently retain its named children through `any`.
+            const declarator = declaratorPath as typeof declaratorPath & {
+              getChild(role: 'id' | 'init'): any;
+            };
+            const id = declarator.getChild('id');
+            const init = declarator.getChild('init');
+            if (id?.node.type !== 'Identifier' || !init) {
+              retained.push(declarator);
+              continue;
+            }
+            const call =
+              init.node.type === 'CallExpression'
+                ? init
+                : init.node.type === 'StaticMemberExpression' ||
+                    init.node.type === 'ComputedMemberExpression'
+                  ? init.getChild('object')
+                  : undefined;
+            const inlineable =
+              call?.node.type === 'CallExpression' &&
+              call.node.calleeName === 'require' &&
+              call.node.calleeGlobal === true &&
+              call.node.argumentCount === 1 &&
+              typeof call.node.staticArgument === 'string'
+                ? { moduleName: call.node.staticArgument }
+                : undefined;
+            if (
+              !inlineable ||
+              state.ignored.has(inlineable.moduleName) ||
+              inlineable.moduleName.startsWith('@babel/runtime/')
+            ) {
+              retained.push(declarator);
+              continue;
+            }
+            const name = String(id.node.name);
+            let binding = state.bindings.get(name);
+            if (binding === undefined) {
+              const resolved = declaration.scope.getBinding(name);
+              binding = resolved
+                ? {
+                    declarationId: resolved.declaration?.id,
+                    references: resolved.references,
+                    unsafe: resolved.references.some(
+                      (reference) => reference.write || reference.memberWrite
+                    ),
+                  }
+                : null;
+              state.bindings.set(name, binding);
+            }
+            if (!binding || binding.declarationId !== id.id) {
+              retained.push(declarator);
+              continue;
+            }
+            if (binding.unsafe) {
+              retained.push(declarator);
+              continue;
+            }
+            const code = init.sourceText();
+            for (const reference of binding.references) {
+              replacements.push({
+                start: reference.start,
+                end: reference.end,
+                code,
+              });
+            }
+          }
+
+          if (retained.length === declarators.length) return;
+          for (const replacement of replacements) {
+            declaration.context.editor.overwrite(
+              replacement.start,
+              replacement.end,
+              replacement.code
+            );
+          }
+          if (retained.length === 0) {
+            declaration.remove();
+          } else {
+            declaration.replaceWith(
+              `${String(declaration.node.kind)} ${retained
+                .map((declarator) => declarator.sourceText())
+                .join(', ')};`
+            );
+          }
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-dependency.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-dependency.ts
@@ -1,0 +1,838 @@
+import { createHash } from 'node:crypto';
+import type { DefinedNativePlugin, NativeNodePath } from 'noxcturnal';
+import { isStatementType } from 'noxcturnal';
+
+import type { AsyncDependencyType, Dependency } from '../../collect-dependencies';
+import {
+  metroPluginData,
+  type Noxcturnal,
+  type NoxcturnalMetroTransformInput,
+} from '../noxcturnal-transformer';
+
+export interface MetroDependencyState {
+  dependencies: Map<
+    string,
+    Dependency & { index: number; imports: number; exportNameSet?: Set<string> }
+  >;
+  requireName: string;
+  importDefaultName: string;
+  importAllName: string;
+  dependencyMapName: string;
+}
+
+const OPTIONAL_DEPENDENCY_ANCESTRY = {
+  mode: 'findParent',
+  routes: {
+    MemberExpression: {
+      fields: ['computed', 'property'],
+      children: { object: { route: 'Expression' } },
+    },
+    CallExpression: {
+      fields: ['optional', 'argumentCount'],
+      children: {
+        callee: { route: 'Expression' },
+        arguments: { route: 'Expression', fields: ['name', 'value'] },
+      },
+    },
+    Statement: {},
+    TryStatement: {
+      children: { block: { route: 'BlockStatement' } },
+    },
+  },
+} as const;
+
+interface OptionalDependencyChild {
+  readonly id: number;
+  readonly node: {
+    readonly type: string;
+    readonly name?: unknown;
+    readonly computed?: unknown;
+    readonly property?: unknown;
+  };
+}
+
+interface OptionalDependencyAncestor extends OptionalDependencyChild {
+  readonly node: OptionalDependencyChild['node'] & {
+    readonly optional?: unknown;
+    readonly argumentCount?: number;
+  };
+  readonly parentPath: OptionalDependencyAncestor | null;
+  getChild(role: string): OptionalDependencyChild | null;
+  getChildList(role: string): readonly OptionalDependencyChild[];
+}
+
+function isOptionalMetroDependency(
+  input: NoxcturnalMetroTransformInput,
+  name: string,
+  path: {
+    readonly id: number;
+    readonly parentPath: OptionalDependencyAncestor | null;
+  },
+  checkPromiseChain = false
+): boolean {
+  if (name === input.config.asyncRequireModulePath) return false;
+  const setting = input.config.allowOptionalDependencies;
+  if (!setting || (typeof setting === 'object' && setting.exclude.includes(name))) {
+    return false;
+  }
+  let promiseChainActive = checkPromiseChain;
+  let expectedObjectId = path.id;
+  let memberId: number | null = null;
+  let method: unknown = null;
+  let statementCount = 0;
+  let tryBlockResolved = false;
+
+  for (let ancestor = path.parentPath; ancestor; ancestor = ancestor.parentPath) {
+    if (promiseChainActive) {
+      if (memberId == null) {
+        if (
+          (ancestor.node.type === 'StaticMemberExpression' ||
+            ancestor.node.type === 'ComputedMemberExpression') &&
+          ancestor.node.computed === false &&
+          ancestor.getChild('object')?.id === expectedObjectId
+        ) {
+          memberId = ancestor.id;
+          method = ancestor.node.property;
+        } else {
+          promiseChainActive = false;
+        }
+      } else {
+        if (
+          ancestor.node.type === 'CallExpression' &&
+          ancestor.node.optional !== true &&
+          ancestor.getChild('callee')?.id === memberId
+        ) {
+          const callback =
+            method === 'catch' && (ancestor.node.argumentCount ?? 0) >= 1
+              ? ancestor.getChildList('arguments')[0]
+              : method === 'then' && (ancestor.node.argumentCount ?? 0) >= 2
+                ? ancestor.getChildList('arguments')[1]
+                : null;
+          if (
+            callback != null &&
+            callback.node.type !== 'NullLiteral' &&
+            !(callback.node.type === 'Identifier' && callback.node.name === 'undefined')
+          ) {
+            return true;
+          }
+          expectedObjectId = ancestor.id;
+          memberId = null;
+          method = null;
+        } else {
+          promiseChainActive = false;
+        }
+      }
+    }
+
+    if (!tryBlockResolved && isStatementType(ancestor.node.type)) {
+      if (ancestor.node.type === 'BlockStatement') {
+        tryBlockResolved = true;
+        const parent = ancestor.parentPath;
+        if (parent?.node.type === 'TryStatement' && parent.getChild('block')?.id === ancestor.id) {
+          return true;
+        }
+      } else if (++statementCount >= 3) {
+        tryBlockResolved = true;
+      }
+    }
+
+    if (!promiseChainActive && tryBlockResolved) return false;
+  }
+  return false;
+}
+
+function reconcileDependencyOptionality(
+  state: MetroDependencyState,
+  key: string,
+  dependency: MetroDependencyState['dependencies'] extends Map<string, infer T> ? T : never,
+  optional: boolean
+) {
+  if (dependency.data.isOptional && !optional) {
+    const required = {
+      ...dependency,
+      data: {
+        ...dependency.data,
+        isOptional: false,
+      },
+    };
+    state.dependencies.set(key, required);
+    return required;
+  }
+  return dependency;
+}
+
+function isIgnoredDynamicImport(path: {
+  getComments(relation: 'inner'): readonly { value: string }[];
+}): boolean {
+  return path
+    .getComments('inner')
+    .some((comment) => /@metro-ignore|webpackIgnore\s*:\s*true/.test(comment.value));
+}
+
+function registerCommonJsDependency(
+  state: MetroDependencyState,
+  name: string,
+  location: ReturnType<NativeNodePath['getLocation']>,
+  optional = false
+) {
+  const key = `${name}\0require`;
+  let dependency = state.dependencies.get(key);
+  if (!dependency) {
+    dependency = {
+      name,
+      index: state.dependencies.size,
+      imports: 0,
+      data: {
+        key: dependencyKeyHash(key),
+        asyncType: null,
+        isESMImport: false,
+        ...(optional ? { isOptional: true } : {}),
+        locs: [],
+        exportNames: ['*'],
+      },
+    };
+    state.dependencies.set(key, dependency);
+  } else {
+    dependency = reconcileDependencyOptionality(state, key, dependency, optional);
+  }
+  dependency.imports++;
+  (dependency.data.locs as any[]).push(location);
+  return dependency;
+}
+
+export function registerNativeEsmDependency(
+  state: MetroDependencyState,
+  name: string,
+  location: ReturnType<NativeNodePath['getLocation']>,
+  exportNames: readonly string[] = ['*']
+) {
+  const key = `${name}\0import`;
+  let dependency = state.dependencies.get(key);
+  if (!dependency) {
+    dependency = {
+      name,
+      index: state.dependencies.size,
+      imports: 0,
+      data: {
+        key: dependencyKeyHash(key),
+        asyncType: null,
+        isESMImport: true,
+        locs: [],
+        exportNames: [],
+      },
+      exportNameSet: new Set(exportNames),
+    };
+    state.dependencies.set(key, dependency);
+  } else {
+    for (const exportName of exportNames) {
+      dependency.exportNameSet!.add(exportName);
+    }
+  }
+  dependency.imports++;
+  (dependency.data.locs as any[]).push(location);
+  return dependency;
+}
+
+function dependencyKeyHash(key: string): string {
+  return createHash('sha1').update(key).digest('base64');
+}
+
+export function createMetroDependencyPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<MetroDependencyState> {
+  const nativeRequire = (
+    context: { pluginData: unknown },
+    state: MetroDependencyState,
+    index: number,
+    name: string,
+    keepName = false
+  ) => {
+    const { input } = metroPluginData(context);
+    return `${state.requireName}(${state.dependencyMapName}[${index}]${
+      input.options.dev || keepName ? `, ${JSON.stringify(name)}` : ''
+    })`;
+  };
+  return nox.defineNativePlugin<MetroDependencyState>({
+    name: 'metro-collect-static-commonjs-dependencies',
+    contract: {
+      queries: [
+        {
+          globals: [{ name: '_$$_IMPORT_DEFAULT' }, { name: '_$$_IMPORT_ALL' }],
+        },
+      ],
+      metadata: {
+        writes: [
+          'dependencies',
+          'dependencyMapName',
+          'metroRequireName',
+          'metroImportDefaultName',
+          'metroImportAllName',
+        ],
+      },
+    },
+    pre(context) {
+      // One declared query seeds both program-level global checks. The scope
+      // facade then serves hasGlobal() from the session cache instead of making
+      // two synchronous native calls for every module.
+      context.query({
+        globals: [{ name: '_$$_IMPORT_DEFAULT' }, { name: '_$$_IMPORT_ALL' }],
+      });
+    },
+    createState: (context) => {
+      const { shared } = metroPluginData(context);
+      shared.sawImportSyntax = false;
+      return (shared.state = {
+        dependencies: new Map(),
+        requireName: 'require',
+        importDefaultName: '$$_IMPORT_DEFAULT',
+        importAllName: '$$_IMPORT_ALL',
+        dependencyMapName: 'dependencyMap',
+      });
+    },
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        { scope: true },
+        {
+          enter(program, state: MetroDependencyState) {
+            const { input, normalizePseudoGlobals } = metroPluginData(program.context);
+            if (normalizePseudoGlobals) {
+              state.requireName = 'r';
+              state.importDefaultName = 'i';
+              state.importAllName = 'a';
+            } else if (input.config.unstable_disableModuleWrapping !== true) {
+              state.requireName =
+                input.config.unstable_renameRequire === false
+                  ? 'require'
+                  : program.scope.generateUid('$$_REQUIRE');
+              state.importDefaultName = program.scope.hasGlobal('_$$_IMPORT_DEFAULT')
+                ? '_$$_IMPORT_DEFAULT'
+                : program.scope.generateUid('$$_IMPORT_DEFAULT');
+              state.importAllName = program.scope.hasGlobal('_$$_IMPORT_ALL')
+                ? '_$$_IMPORT_ALL'
+                : program.scope.generateUid('$$_IMPORT_ALL');
+            }
+            const reservedDependencyMap = input.config.unstable_dependencyMapReservedName;
+            if (reservedDependencyMap && program.scope.hasBinding(reservedDependencyMap)) {
+              program.unsupported('reserved-dependency-map-name-collision');
+            }
+            state.dependencyMapName =
+              reservedDependencyMap ??
+              (normalizePseudoGlobals && !program.scope.hasBinding('d')
+                ? 'd'
+                : program.scope.generateUid('dependencyMap'));
+          },
+        }
+      ),
+      nox.defineVisitor(
+        'ImportExpression',
+        {
+          ancestry: OPTIONAL_DEPENDENCY_ANCESTRY,
+          comments: 'inner',
+          children: { source: { route: 'StringLiteral', fields: ['value'] } },
+        },
+        (call, state: MetroDependencyState) => {
+          const { input, collectOnly } = metroPluginData(call.context);
+          if (isIgnoredDynamicImport(call)) return;
+          const source = call.getChild('source');
+          const sourceValue = source?.node.value;
+          if (source?.node.type !== 'StringLiteral' || typeof sourceValue !== 'string') {
+            call.unsupported('dynamic-async-dependency');
+            return;
+          }
+          const name = sourceValue;
+          const optional = isOptionalMetroDependency(input, name, call, true);
+          const targetKey = `${name}\0import\0async`;
+          let target = state.dependencies.get(targetKey);
+          if (!target) {
+            target = {
+              name,
+              index: state.dependencies.size,
+              imports: 0,
+              data: {
+                key: dependencyKeyHash(targetKey),
+                asyncType: 'async',
+                isESMImport: true,
+                ...(optional ? { isOptional: true } : {}),
+                locs: [],
+                exportNames: ['*'],
+              },
+            };
+            state.dependencies.set(targetKey, target);
+          } else {
+            target = reconcileDependencyOptionality(state, targetKey, target, optional);
+          }
+          target.imports++;
+          (target.data.locs as any[]).push(call.getLocation());
+
+          const runtimeName = input.config.asyncRequireModulePath;
+          const runtimeKey = `${runtimeName}\0require`;
+          let runtime = state.dependencies.get(runtimeKey);
+          if (!runtime) {
+            runtime = {
+              name: runtimeName,
+              index: state.dependencies.size,
+              imports: 0,
+              data: {
+                key: dependencyKeyHash(runtimeKey),
+                asyncType: null,
+                isESMImport: false,
+                locs: [],
+                exportNames: ['*'],
+              },
+            };
+            state.dependencies.set(runtimeKey, runtime);
+          }
+          runtime.imports++;
+          (runtime.data.locs as any[]).push(call.getLocation());
+          if (!collectOnly && input.config.unstable_disableModuleWrapping !== true) {
+            call.replaceWith({
+              code: `${nativeRequire(call.context, state, runtime.index, runtimeName)}(${state.dependencyMapName}[${target.index}], ${state.dependencyMapName}.paths, ${JSON.stringify(name)})`,
+              mapping: 'anchor-boundaries',
+            });
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'NewExpression',
+        {
+          fields: ['calleeName', 'argumentCount'],
+        },
+        (worker, state: MetroDependencyState) => {
+          const callee = worker.node.calleeName;
+          if (callee !== 'Worker' && callee !== 'SharedWorker') return;
+          const source = worker.getSource().text();
+          const match = source.match(
+            /^(new\s+(?:Worker|SharedWorker)\s*\(\s*new\s+URL\s*\(\s*)(['"])([^'"]+)\2/
+          );
+          if (!match) return;
+          const name = match[3]!;
+
+          const { input, collectOnly } = metroPluginData(worker.context);
+          const targetKey = `${name}\0require\0worker`;
+          let target = state.dependencies.get(targetKey);
+          if (!target) {
+            target = {
+              name,
+              index: state.dependencies.size,
+              imports: 0,
+              data: {
+                key: dependencyKeyHash(targetKey),
+                asyncType: 'worker',
+                isESMImport: false,
+                locs: [],
+                exportNames: ['*'],
+              },
+            };
+            state.dependencies.set(targetKey, target);
+          }
+          target.imports++;
+          (target.data.locs as any[]).push(worker.getLocation());
+
+          const runtimeName = input.config.asyncRequireModulePath;
+          const runtimeKey = `${runtimeName}\0require`;
+          let runtime = state.dependencies.get(runtimeKey);
+          if (!runtime) {
+            runtime = {
+              name: runtimeName,
+              index: state.dependencies.size,
+              imports: 0,
+              data: {
+                key: dependencyKeyHash(runtimeKey),
+                asyncType: null,
+                isESMImport: false,
+                locs: [],
+                exportNames: ['*'],
+              },
+            };
+            state.dependencies.set(runtimeKey, runtime);
+          }
+          runtime.imports++;
+          (runtime.data.locs as any[]).push(worker.getLocation());
+          if (collectOnly) return;
+
+          const requireRuntime = nativeRequire(worker.context, state, runtime.index, runtimeName);
+          const resolved = `${requireRuntime}.unstable_resolve(${state.dependencyMapName}[${target.index}], ${state.dependencyMapName}.paths)`;
+          const rewritten = source
+            .replace(
+              /^new\s+(?:Worker|SharedWorker)/,
+              `new (${requireRuntime}.unstable_createWorker)`
+            )
+            .replace(`${match[2]}${name}${match[2]}`, resolved);
+          worker.replaceWith({
+            code: rewritten,
+            mapping: 'anchor-boundaries',
+          });
+        }
+      ),
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          fields: ['calleeName', 'calleePath', 'calleeGlobal', 'staticArgument', 'argumentCount'],
+          comments: 'inner',
+          where: {
+            calleePath: {
+              oneOf: [
+                '__noxcturnalImport',
+                'require.context',
+                'require.resolveWeak',
+                'require.unstable_resolveWorker',
+                'import',
+                '__prefetchImport',
+                'require.unstable_importMaybeSync',
+                'require',
+              ],
+            },
+          },
+          ancestry: OPTIONAL_DEPENDENCY_ANCESTRY,
+          children: {
+            arguments: {
+              route: 'Expression',
+              fields: ['name', 'value', 'pattern', 'flags'],
+            },
+          },
+        },
+        (call, state: MetroDependencyState) => {
+          const { input, collectOnly } = metroPluginData(call.context);
+          const callee = String(call.node.calleePath ?? call.node.calleeName ?? '');
+          const isGlobalRequire = call.node.calleeGlobal === true;
+          if (callee === '__noxcturnalImport' && call.node.calleeGlobal === true) {
+            if (call.node.argumentCount !== 1 || typeof call.node.staticArgument !== 'string') {
+              call.unsupported('invalid-native-esm-import');
+            }
+            const name = call.node.staticArgument as string;
+            const dependency = registerNativeEsmDependency(state, name, call.getLocation());
+            if (!collectOnly) {
+              call.replaceWith({
+                code: nativeRequire(call.context, state, dependency.index, name),
+                mapping: 'anchor-boundaries',
+              });
+            }
+            return;
+          }
+          if (
+            callee === 'require.context' &&
+            isGlobalRequire &&
+            input.config.unstable_allowRequireContext === true
+          ) {
+            const args = call.getChildList('arguments');
+            const directory = args[0]?.node.value;
+            if (args.length < 1 || args.length > 4 || typeof directory !== 'string') {
+              call.unsupported('unsupported-require-context-arguments');
+            }
+            const recursiveArg = args[1];
+            const recursive =
+              recursiveArg == null ||
+              (recursiveArg.node.type === 'Identifier' && recursiveArg.node.name === 'undefined')
+                ? true
+                : recursiveArg.node.type === 'BooleanLiteral' &&
+                    typeof recursiveArg.node.value === 'boolean'
+                  ? recursiveArg.node.value
+                  : null;
+            if (recursive == null) call.unsupported('unsupported-require-context-recursive');
+
+            let pattern = '.*';
+            let flags = '';
+            const filterArg = args[2];
+            if (
+              filterArg &&
+              !(filterArg.node.type === 'Identifier' && filterArg.node.name === 'undefined')
+            ) {
+              if (filterArg.node.type !== 'RegExpLiteral') {
+                call.unsupported('unsupported-require-context-filter');
+              }
+              if (
+                typeof filterArg.node.pattern !== 'string' ||
+                typeof filterArg.node.flags !== 'string'
+              ) {
+                call.unsupported('unsupported-require-context-filter');
+              }
+              pattern = filterArg.node.pattern as string;
+              flags = filterArg.node.flags as string;
+            }
+
+            const modeArg = args[3];
+            const modeValue = modeArg?.node.value;
+            const mode =
+              modeArg == null ||
+              (modeArg.node.type === 'Identifier' && modeArg.node.name === 'undefined')
+                ? 'sync'
+                : typeof modeValue === 'string' &&
+                    ['sync', 'eager', 'lazy', 'lazy-once'].includes(modeValue)
+                  ? modeValue
+                  : null;
+            if (mode == null) call.unsupported('unsupported-require-context-mode');
+
+            const optional = isOptionalMetroDependency(input, directory as string, call);
+            const key = `${directory}\0require\0context\0${recursive}\0${pattern}\0${flags}\0${mode}`;
+            let dependency = state.dependencies.get(key);
+            if (!dependency) {
+              dependency = {
+                name: directory as string,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(key),
+                  asyncType: null,
+                  isESMImport: false,
+                  ...(optional ? { isOptional: true } : {}),
+                  locs: [],
+                  exportNames: ['*'],
+                  contextParams: {
+                    recursive: recursive as boolean,
+                    filter: { pattern, flags },
+                    mode: mode as 'sync' | 'eager' | 'lazy' | 'lazy-once',
+                  },
+                },
+              };
+              state.dependencies.set(key, dependency);
+            } else {
+              dependency = reconcileDependencyOptionality(state, key, dependency, optional);
+            }
+            dependency.imports++;
+            (dependency.data.locs as any[]).push(call.getLocation());
+            if (!collectOnly) {
+              call.replaceWith({
+                code: nativeRequire(
+                  call.context,
+                  state,
+                  dependency.index,
+                  directory as string,
+                  optional
+                ),
+                mapping: 'anchor-boundaries',
+              });
+            }
+            return;
+          }
+          if (callee === 'require.resolveWeak' && isGlobalRequire) {
+            if (call.node.argumentCount !== 1 || typeof call.node.staticArgument !== 'string') {
+              call.unsupported('invalid-require-resolve-weak');
+            }
+            const name = call.node.staticArgument as string;
+            const optional = isOptionalMetroDependency(input, name, call);
+            const key = `${name}\0require\0weak`;
+            let dependency = state.dependencies.get(key);
+            if (!dependency) {
+              dependency = {
+                name,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(key),
+                  asyncType: 'weak',
+                  isESMImport: false,
+                  ...(optional ? { isOptional: true } : {}),
+                  locs: [],
+                  exportNames: ['*'],
+                },
+              };
+              state.dependencies.set(key, dependency);
+            } else {
+              dependency = reconcileDependencyOptionality(state, key, dependency, optional);
+            }
+            dependency.imports++;
+            (dependency.data.locs as any[]).push(call.getLocation());
+            if (!collectOnly) {
+              call.replaceWith({
+                code: `${state.dependencyMapName}[${dependency.index}]`,
+                mapping: 'anchor-boundaries',
+              });
+            }
+            return;
+          }
+          if (callee === 'require.unstable_resolveWorker' && isGlobalRequire) {
+            if (call.node.argumentCount !== 1 || typeof call.node.staticArgument !== 'string') {
+              call.unsupported('invalid-require-resolve-worker');
+            }
+            const name = call.node.staticArgument as string;
+            const optional = isOptionalMetroDependency(input, name, call);
+            const targetKey = `${name}\0require\0worker`;
+            let target = state.dependencies.get(targetKey);
+            if (!target) {
+              target = {
+                name,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(targetKey),
+                  asyncType: 'worker',
+                  isESMImport: false,
+                  ...(optional ? { isOptional: true } : {}),
+                  locs: [],
+                  exportNames: ['*'],
+                },
+              };
+              state.dependencies.set(targetKey, target);
+            } else {
+              target = reconcileDependencyOptionality(state, targetKey, target, optional);
+            }
+            target.imports++;
+            (target.data.locs as any[]).push(call.getLocation());
+
+            const runtimeName = input.config.asyncRequireModulePath;
+            const runtimeKey = `${runtimeName}\0require`;
+            let runtime = state.dependencies.get(runtimeKey);
+            if (!runtime) {
+              runtime = {
+                name: runtimeName,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(runtimeKey),
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                  exportNames: ['*'],
+                },
+              };
+              state.dependencies.set(runtimeKey, runtime);
+            }
+            runtime.imports++;
+            (runtime.data.locs as any[]).push(call.getLocation());
+            if (!collectOnly) {
+              call.replaceWith({
+                code: `${nativeRequire(call.context, state, runtime.index, runtimeName)}.unstable_resolve(${state.dependencyMapName}[${target.index}], ${state.dependencyMapName}.paths)`,
+                mapping: 'anchor-boundaries',
+              });
+            }
+            return;
+          }
+          const asyncType: AsyncDependencyType | null =
+            callee === 'import'
+              ? 'async'
+              : callee === '__prefetchImport' && call.node.calleeGlobal === true
+                ? 'prefetch'
+                : callee === 'require.unstable_importMaybeSync' && isGlobalRequire
+                  ? 'maybeSync'
+                  : null;
+          if (asyncType) {
+            if (callee === 'import' && isIgnoredDynamicImport(call)) return;
+            if (call.node.argumentCount !== 1 || typeof call.node.staticArgument !== 'string') {
+              call.unsupported(`dynamic-${asyncType}-dependency`);
+            }
+            const name = call.node.staticArgument as string;
+            const optional = isOptionalMetroDependency(input, name, call, true);
+            const targetKey = `${name}\0import\0${asyncType}`;
+            let target = state.dependencies.get(targetKey);
+            if (!target) {
+              target = {
+                name,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(targetKey),
+                  asyncType,
+                  isESMImport: true,
+                  ...(optional ? { isOptional: true } : {}),
+                  locs: [],
+                  exportNames: ['*'],
+                },
+              };
+              state.dependencies.set(targetKey, target);
+            } else {
+              target = reconcileDependencyOptionality(state, targetKey, target, optional);
+            }
+            target.imports++;
+            (target.data.locs as any[]).push(call.getLocation());
+
+            const runtimeName = input.config.asyncRequireModulePath;
+            const runtimeKey = `${runtimeName}\0require`;
+            let runtime = state.dependencies.get(runtimeKey);
+            if (!runtime) {
+              runtime = {
+                name: runtimeName,
+                index: state.dependencies.size,
+                imports: 0,
+                data: {
+                  key: dependencyKeyHash(runtimeKey),
+                  asyncType: null,
+                  isESMImport: false,
+                  locs: [],
+                  exportNames: ['*'],
+                },
+              };
+              state.dependencies.set(runtimeKey, runtime);
+            }
+            runtime.imports++;
+            (runtime.data.locs as any[]).push(call.getLocation());
+
+            const runtimeRequire = nativeRequire(call.context, state, runtime.index, runtimeName);
+            const method =
+              asyncType === 'prefetch'
+                ? '.prefetch'
+                : asyncType === 'maybeSync'
+                  ? '.unstable_importMaybeSync'
+                  : '';
+            if (!collectOnly) {
+              call.replaceWith({
+                code: `${runtimeRequire}${method}(${state.dependencyMapName}[${target.index}], ${state.dependencyMapName}.paths, ${JSON.stringify(name)})`,
+                mapping: 'anchor-boundaries',
+              });
+            }
+            return;
+          }
+          if (
+            (callee === 'require.context' && input.config.unstable_allowRequireContext === true) ||
+            (callee === '__prefetchImport' && call.node.calleeGlobal === true) ||
+            (callee === 'require.unstable_importMaybeSync' && isGlobalRequire)
+          ) {
+            call.unsupported(`unsupported-metro-dependency-call:${callee}`);
+          }
+          if (callee !== 'require' || call.node.calleeGlobal !== true) return;
+          if (call.node.argumentCount !== 1 || typeof call.node.staticArgument !== 'string') {
+            call.unsupported('dynamic-require');
+          }
+
+          const name = call.node.staticArgument as string;
+          const optional = isOptionalMetroDependency(input, name, call);
+          const registered = registerCommonJsDependency(state, name, call.getLocation(), optional);
+          if (!collectOnly && input.config.unstable_disableModuleWrapping !== true) {
+            const dependencyArgument = `${state.dependencyMapName}[${registered.index}]`;
+            const replacement = /^@babel\/runtime\/helpers\/[^/]+$/.test(name)
+              ? `${state.importDefaultName}(${dependencyArgument}, ${JSON.stringify(name)})`
+              : nativeRequire(call.context, state, registered.index, name, optional);
+            call.replaceWith({
+              code: replacement,
+              mapping: 'anchor-boundaries',
+            });
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      const { input, collectOnly, normalizePseudoGlobals } = metroPluginData(context);
+      const dependencies = [...state.dependencies.values()].map(
+        ({ index, imports, exportNameSet, ...dependency }) =>
+          Object.freeze({
+            ...dependency,
+            data: Object.freeze({
+              ...dependency.data,
+              ...(exportNameSet ? { exportNames: [...exportNameSet] } : {}),
+              imports,
+            }),
+          })
+      );
+      context.metadata.set('dependencies', dependencies);
+      context.metadata.set('dependencyMapName', state.dependencyMapName);
+      context.metadata.set('metroRequireName', state.requireName);
+      context.metadata.set('metroImportDefaultName', state.importDefaultName);
+      context.metadata.set('metroImportAllName', state.importAllName);
+      if (!collectOnly && input.config.unstable_disableModuleWrapping !== true) {
+        const parameters = [
+          normalizePseudoGlobals ? 'g' : 'global',
+          state.requireName,
+          state.importDefaultName,
+          state.importAllName,
+          normalizePseudoGlobals ? 'm' : 'module',
+          normalizePseudoGlobals ? 'e' : 'exports',
+          state.dependencyMapName,
+        ];
+        context.editor.prepend(
+          `${input.config.globalPrefix}__d(function (${parameters.join(', ')}) {\n`
+        );
+        context.editor.append('\n});');
+      }
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-esm-globals.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-esm-globals.ts
@@ -1,0 +1,37 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { metroPluginData, type Noxcturnal } from '../noxcturnal-transformer';
+
+export function createMetroEsmGlobalsPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'metro-native-esm-pseudo-global-renames',
+    visitors: [
+      nox.defineVisitor('Program', { scope: true }, (program) => {
+        for (const name of ['global', 'require', 'module', 'exports']) {
+          if (program.scope.hasBinding(name)) {
+            program.scope.rename(name, program.scope.generateUid(name));
+          }
+        }
+      }),
+      nox.defineVisitor(
+        'Identifier',
+        {
+          fields: ['name', 'global'],
+          where: { name: { oneOf: ['global', 'module', 'exports'] } },
+        },
+        (identifier) => {
+          if (
+            identifier.node.global !== true ||
+            !metroPluginData(identifier.context).normalizePseudoGlobals
+          ) {
+            return;
+          }
+          const replacement = { global: 'g', module: 'm', exports: 'e' }[
+            String(identifier.node.name)
+          ];
+          if (replacement) identifier.replaceWith(replacement);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-live-bindings.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-live-bindings.ts
@@ -1,0 +1,627 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  metroPluginData,
+  type MetroLiveBindingsState,
+  type Noxcturnal,
+} from '../noxcturnal-transformer';
+import { registerNativeEsmDependency } from './metro-dependency';
+
+export function createMetroLiveBindingsPlugin(
+  nox: Noxcturnal,
+  liveBindings = true
+): DefinedNativePlugin<MetroLiveBindingsState> {
+  const generateUid = (scope: { generateUid(name: string): string }, input: string) => {
+    let name = input.replace(/[^$0-9A-Z_a-z]/g, '-').replace(/^[-0-9]+/, '');
+    name = name.replace(/[-\s]+(.)?/g, (_match, next: string | undefined) =>
+      next ? next.toUpperCase() : ''
+    );
+    if (!/^[$A-Z_a-z]/.test(name)) name = `_${name}`;
+    name = (name || '_').replace(/^_+/, '').replace(/\d+$/g, '');
+    return scope.generateUid(name);
+  };
+  const property = (object: string, name: string) => `${object}.${name}`;
+  const exportsName = (context: { pluginData: unknown }) =>
+    metroPluginData(context).normalizePseudoGlobals ? 'e' : 'exports';
+  const liveExport = (name: string, expression: string, target = 'exports') =>
+    `Object.defineProperty(${target}, ${JSON.stringify(name)}, { enumerable: true, get: function () { return ${expression}; } });`;
+  const exportValue = (name: string, expression: string, target = 'exports') =>
+    liveBindings ? liveExport(name, expression, target) : `${target}.${name} = ${expression};`;
+  const defaultInterop = `function _interopDefault(e) {
+  return e && e.__esModule ? e : { default: e };
+}`;
+  const namespaceInterop = `function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () { return e[k]; }
+    });
+  });
+  n.default = e;
+  return n;
+}`;
+
+  return nox.defineNativePlugin<MetroLiveBindingsState>({
+    name: 'metro-native-import-export-live-bindings',
+    createState: () => ({
+      sawEsm: false,
+      modules: new Map(),
+      moduleOrder: [],
+      importedBindings: new Map(),
+      exportStatements: [],
+      deferredExports: [],
+    }),
+    post(context, state) {
+      const { collectOnly } = metroPluginData(context);
+      if (collectOnly || !state.sawEsm) return;
+      const target = exportsName(context);
+      const trailingExports: string[] = [];
+
+      for (const deferred of state.deferredExports) {
+        if (deferred.kind === 'declaration') {
+          const statement =
+            (!liveBindings || deferred.assign) && deferred.name !== '__proto__'
+              ? `${target}.${deferred.name} = ${deferred.name};`
+              : exportValue(deferred.name, deferred.name, target);
+          if (liveBindings) state.exportStatements.push(statement);
+          else trailingExports.push(statement);
+          continue;
+        }
+        const expression = state.importedBindings.get(deferred.local) ?? deferred.local;
+        for (const module of state.moduleOrder) {
+          if (
+            (module.defaultLocal != null &&
+              (expression === module.defaultLocal ||
+                expression.startsWith(`${module.defaultLocal}.`))) ||
+            (module.namespaceLocal != null && expression === module.namespaceLocal) ||
+            expression.startsWith(`${module.requiredLocal}.`)
+          ) {
+            module.referenced = true;
+            if (
+              module.defaultLocal != null &&
+              (expression === module.defaultLocal ||
+                expression.startsWith(`${module.defaultLocal}.`))
+            ) {
+              module.defaultReferenced = true;
+            }
+            if (module.namespaceLocal != null && expression === module.namespaceLocal) {
+              module.namespaceReferenced = true;
+            }
+          }
+        }
+        const statement = exportValue(deferred.exported, expression, target);
+        if (liveBindings) state.exportStatements.push(statement);
+        else trailingExports.push(statement);
+      }
+      const preamble: string[] = [];
+      if (
+        state.exportStatements.length > 0 ||
+        trailingExports.length > 0 ||
+        state.moduleOrder.some((module) =>
+          module.afterImport.some((operation) => operation.kind === 'statement')
+        )
+      ) {
+        preamble.push(`Object.defineProperty(${target}, '__esModule', { value: true });`);
+      }
+      const emittedInterops = new Set<'default' | 'namespace'>();
+      for (const module of state.moduleOrder) {
+        for (const operation of module.afterImport) {
+          const interop =
+            operation.kind === 'default-interop'
+              ? 'default'
+              : operation.kind === 'namespace-interop'
+                ? 'namespace'
+                : null;
+          if (
+            interop != null &&
+            !emittedInterops.has(interop) &&
+            (interop === 'default' ? module.defaultReferenced : module.namespaceReferenced)
+          ) {
+            emittedInterops.add(interop);
+            preamble.push(interop === 'default' ? defaultInterop : namespaceInterop);
+          }
+        }
+      }
+      if (liveBindings) preamble.push(...state.exportStatements);
+      for (const module of state.moduleOrder) {
+        if (!module.referenced) {
+          if (module.sideEffect) preamble.push(`${module.requireCall};`);
+          continue;
+        }
+        preamble.push(`var ${module.requiredLocal} = ${module.requireCall};`);
+        for (const operation of module.afterImport) {
+          if (
+            operation.kind === 'statement' ||
+            (operation.kind === 'default-interop' && module.defaultReferenced) ||
+            (operation.kind === 'namespace-interop' && module.namespaceReferenced)
+          ) {
+            preamble.push(operation.code);
+          }
+        }
+      }
+      if (!liveBindings) trailingExports.unshift(...state.exportStatements);
+      if (preamble.length > 0) {
+        context.prependToProgram(preamble.join('\n'));
+      }
+      if (trailingExports.length > 0) {
+        context.appendToProgram(trailingExports.join('\n'));
+      }
+    },
+    visitors: [
+      nox.defineVisitor(
+        'ImportDeclaration',
+        {
+          fields: ['source', 'importKind'],
+          scope: true,
+          ancestry: { mode: 'parent' },
+          children: {
+            specifiers: {
+              route: 'ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier',
+              fields: ['local', 'imported', 'importKind'],
+            },
+          },
+        },
+        (importPath, state) => {
+          const { collectOnly, shared, input } = metroPluginData(importPath.context);
+          state.sawEsm = true;
+          if (importPath.node.importKind && importPath.node.importKind !== 'value') {
+            if (!collectOnly) importPath.remove();
+            return;
+          }
+          const source = importPath.node.source;
+          if (collectOnly) {
+            const dependencyState = shared.state;
+            if (!dependencyState) importPath.unsupported('missing-shared-dependency-state');
+            registerNativeEsmDependency(
+              dependencyState!,
+              source,
+              importPath.getLocation(),
+              importPath
+                .getChildList('specifiers')
+                .map((specifier) =>
+                  specifier.node.type === 'ImportNamespaceSpecifier'
+                    ? '*'
+                    : specifier.node.type === 'ImportDefaultSpecifier'
+                      ? 'default'
+                      : String(specifier.node.imported)
+                )
+            );
+            return;
+          }
+          const specifiers = importPath.getChildList('specifiers');
+          const valueSpecifiers = specifiers.filter(
+            (specifier) =>
+              specifier.node.type !== 'ImportSpecifier' ||
+              !specifier.node.importKind ||
+              specifier.node.importKind === 'value'
+          );
+          if (specifiers.length > 0 && valueSpecifiers.length === 0) {
+            importPath.remove();
+            return;
+          }
+          let module = state.modules.get(source);
+          if (!module) {
+            const dependencyState = shared.state;
+            if (!dependencyState) importPath.unsupported('missing-shared-dependency-state');
+            const dependency = registerNativeEsmDependency(
+              dependencyState!,
+              source,
+              importPath.getLocation()
+            );
+            const dependencyArgument = `${dependencyState!.dependencyMapName}[${dependency.index}]`;
+            const requiredLocal = generateUid(importPath.scope.getProgramParent(), source);
+            module = {
+              source,
+              requiredLocal,
+              requireCall: `${dependencyState!.requireName}(${dependencyArgument}, ${JSON.stringify(source)})`,
+              afterImport: [],
+              exportAll: false,
+              referenced: false,
+              defaultReferenced: false,
+              namespaceReferenced: false,
+              sideEffect:
+                input.options.dev &&
+                importPath.context.metadata.get('performConstantFolding') !== true,
+            };
+            state.modules.set(source, module);
+            state.moduleOrder.push(module);
+          }
+          if (specifiers.length === 0) module.sideEffect = true;
+          const bindings = new Map(
+            importPath.scope
+              .getBindings(valueSpecifiers.map((specifier) => String(specifier.node.local)))
+              .map((binding) => [binding.name, binding])
+          );
+          for (const specifier of specifiers) {
+            if (
+              specifier.node.type === 'ImportSpecifier' &&
+              specifier.node.importKind &&
+              specifier.node.importKind !== 'value'
+            ) {
+              continue;
+            }
+            const local = String(specifier.node.local);
+            const requiredLocal = module.requiredLocal;
+            let expression: string;
+            if (specifier.node.type === 'ImportNamespaceSpecifier') {
+              if (module.namespaceLocal == null) {
+                module.namespaceLocal = local;
+                module.afterImport.push({
+                  kind: 'namespace-interop',
+                  code: `var ${module.namespaceLocal} = _interopNamespace(${module.requiredLocal});`,
+                });
+              }
+              expression = module.namespaceLocal;
+            } else {
+              const imported =
+                specifier.node.type === 'ImportDefaultSpecifier'
+                  ? 'default'
+                  : String(specifier.node.imported);
+              if (imported === 'default') {
+                if (module.defaultLocal == null) {
+                  module.defaultLocal = local;
+                  module.afterImport.push({
+                    kind: 'default-interop',
+                    code: `var ${module.defaultLocal} = _interopDefault(${module.requiredLocal});`,
+                  });
+                }
+                expression = property(module.defaultLocal, 'default');
+              } else {
+                if (liveBindings) {
+                  expression = property(requiredLocal, imported);
+                } else {
+                  expression = local;
+                  module.afterImport.push({
+                    kind: 'statement',
+                    code: `var ${local} = ${property(requiredLocal, imported)};`,
+                  });
+                }
+              }
+            }
+            state.importedBindings.set(local, expression);
+            const binding = bindings.get(local);
+            if (!binding) importPath.unsupported(`missing-import-binding:${local}`);
+            for (const reference of binding?.references ?? []) {
+              module.referenced = true;
+              if (specifier.node.type === 'ImportNamespaceSpecifier') {
+                module.namespaceReferenced = true;
+              } else if (
+                specifier.node.type === 'ImportDefaultSpecifier' ||
+                String(specifier.node.imported) === 'default'
+              ) {
+                module.defaultReferenced = true;
+              }
+              if (reference.parentType === 'ExportSpecifier') continue;
+              if (expression === local) continue;
+              if (reference.start == null || reference.end == null) {
+                importPath.unsupported(`missing-import-reference-range:${local}`);
+              }
+              const preservesLocalReference =
+                expression.startsWith(`${local}.`) || expression.startsWith(`${local}[`);
+              if (preservesLocalReference) {
+                if (
+                  reference.parentType === 'CallExpression' &&
+                  reference.parentStart === reference.start
+                ) {
+                  importPath.context.editor.appendLeft(reference.start!, '(0, ');
+                  importPath.context.editor.appendRight(
+                    reference.end!,
+                    `${expression.slice(local.length)})`
+                  );
+                } else if (
+                  reference.parentType === 'ObjectProperty' &&
+                  reference.parentStart === reference.start
+                ) {
+                  importPath.context.editor.appendRight(reference.end!, `: ${expression}`);
+                } else {
+                  importPath.context.editor.appendRight(
+                    reference.end!,
+                    expression.slice(local.length)
+                  );
+                }
+              } else {
+                const replacement =
+                  reference.parentType === 'CallExpression' &&
+                  reference.parentStart === reference.start
+                    ? `(0, ${expression})`
+                    : reference.parentType === 'ObjectProperty' &&
+                        reference.parentStart === reference.start
+                      ? `${local}: ${expression}`
+                      : expression;
+                importPath.context.editor.overwrite(
+                  reference.start!,
+                  reference.end!,
+                  replacement,
+                  'anchor-start'
+                );
+              }
+            }
+          }
+          importPath.remove();
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          fields: ['source', 'exportKind'],
+          scope: true,
+          controlFlow: ['nested-traverse'],
+          nested: [
+            nox.defineVisitor('Identifier', { fields: ['name', 'binding'], scope: true }, () => {}),
+          ],
+          children: {
+            declaration: { route: 'Declaration', fields: ['name', 'nodeKind'] },
+            specifiers: {
+              route: 'ExportSpecifier',
+              fields: ['local', 'exported', 'exportKind'],
+            },
+          },
+        },
+        (exportPath, state) => {
+          const { collectOnly, shared } = metroPluginData(exportPath.context);
+          state.sawEsm = true;
+          if (exportPath.node.exportKind && exportPath.node.exportKind !== 'value') {
+            if (!collectOnly) exportPath.remove();
+            return;
+          }
+          if (exportPath.node.source) {
+            const source = exportPath.node.source;
+            const exportSpecifiers = exportPath.getChildList('specifiers');
+            const valueExportSpecifiers = exportSpecifiers.filter(
+              (specifier) => !specifier.node.exportKind || specifier.node.exportKind === 'value'
+            );
+            if (collectOnly) {
+              const dependencyState = shared.state;
+              if (!dependencyState) exportPath.unsupported('missing-shared-dependency-state');
+              registerNativeEsmDependency(
+                dependencyState!,
+                source,
+                exportPath.getLocation(),
+                exportSpecifiers.map((specifier) => String(specifier.node.local))
+              );
+              return;
+            }
+            if (exportSpecifiers.length > 0 && valueExportSpecifiers.length === 0) {
+              exportPath.remove();
+              return;
+            }
+            let module = state.modules.get(source);
+            if (!module) {
+              const dependencyState = shared.state;
+              if (!dependencyState) exportPath.unsupported('missing-shared-dependency-state');
+              const dependency = registerNativeEsmDependency(
+                dependencyState!,
+                source,
+                exportPath.getLocation()
+              );
+              const dependencyArgument = `${dependencyState!.dependencyMapName}[${dependency.index}]`;
+              const requiredLocal = generateUid(exportPath.scope.getProgramParent(), source);
+              module = {
+                source,
+                requiredLocal,
+                requireCall: `${dependencyState!.requireName}(${dependencyArgument}, ${JSON.stringify(source)})`,
+                afterImport: [],
+                exportAll: false,
+                referenced: valueExportSpecifiers.length > 0,
+                defaultReferenced: false,
+                namespaceReferenced: false,
+                sideEffect: exportSpecifiers.length === 0,
+              };
+              state.modules.set(source, module);
+              state.moduleOrder.push(module);
+            }
+            if (exportSpecifiers.length === 0) module.sideEffect = true;
+            else module.referenced = true;
+            const requiredLocal = module.requiredLocal;
+            for (const specifier of valueExportSpecifiers) {
+              const imported = String(specifier.node.local);
+              let expression: string;
+              if (imported === 'default') {
+                if (module.defaultLocal == null) {
+                  module.defaultLocal = generateUid(
+                    exportPath.scope.getProgramParent(),
+                    requiredLocal
+                  );
+                  module.afterImport.push({
+                    kind: 'default-interop',
+                    code: `var ${module.defaultLocal} = _interopDefault(${module.requiredLocal});`,
+                  });
+                }
+                module.defaultReferenced = true;
+                expression = property(module.defaultLocal, 'default');
+              } else {
+                expression = property(requiredLocal, imported);
+              }
+              if (!liveBindings) {
+                const snapshot = generateUid(exportPath.scope.getProgramParent(), imported);
+                module.afterImport.push({
+                  kind: 'statement',
+                  code: `var ${snapshot} = ${expression};`,
+                });
+                expression = snapshot;
+              }
+              state.exportStatements.push(
+                exportValue(
+                  String(specifier.node.exported),
+                  expression,
+                  exportsName(exportPath.context)
+                )
+              );
+            }
+            exportPath.remove();
+            return;
+          }
+          if (collectOnly) return;
+          const declaration = exportPath.getChild('declaration');
+          if (declaration) {
+            const names = new Set<string>();
+            if (typeof declaration.node.name === 'string') {
+              names.add(declaration.node.name);
+            } else {
+              declaration.traverse([
+                nox.defineVisitor(
+                  'Identifier',
+                  { fields: ['name', 'binding'], scope: true },
+                  (identifier) => {
+                    if (
+                      identifier.node.binding === true &&
+                      identifier.scope.id === exportPath.scope.id
+                    ) {
+                      names.add(String(identifier.node.name));
+                    }
+                  }
+                ),
+              ]);
+            }
+            exportPath.replaceWith(declaration.getSource());
+            for (const name of names) {
+              state.deferredExports.push({
+                kind: 'declaration',
+                name,
+                assign: declaration.node.nodeKind === 'FunctionDeclaration',
+              });
+            }
+            return;
+          }
+          for (const specifier of exportPath.getChildList('specifiers')) {
+            if (specifier.node.exportKind && specifier.node.exportKind !== 'value') continue;
+            state.deferredExports.push({
+              kind: 'specifier',
+              local: String(specifier.node.local),
+              exported: String(specifier.node.exported),
+            });
+          }
+          exportPath.remove();
+        }
+      ),
+      nox.defineVisitor(
+        'ExportDefaultDeclaration',
+        {
+          fields: ['declaredName'],
+          scope: true,
+          children: {
+            declaration: {
+              route: 'Declaration|Expression',
+              fields: ['nodeKind', 'declarationNameAnchor', 'declarationNamePrefix'],
+            },
+          },
+        },
+        (exportPath, state) => {
+          const { collectOnly } = metroPluginData(exportPath.context);
+          state.sawEsm = true;
+          if (collectOnly) return;
+          const declaration = exportPath.getChild('declaration');
+          if (!declaration) exportPath.unsupported('missing-default-export-declaration');
+          const hasDeclaredName = typeof exportPath.node.declaredName === 'string';
+          let local = hasDeclaredName ? exportPath.node.declaredName! : null;
+          if (local) {
+            exportPath.replaceWith(declaration!.getSource());
+          } else {
+            if (declaration!.node.type === 'Class' || declaration!.node.type === 'Function') {
+              local = exportPath.scope.generateUid('ref');
+              exportPath.replaceWith(declaration!.withDeclarationName(local));
+            } else {
+              local = exportPath.scope.generateUid('default');
+              exportPath.replaceWith(
+                exportPath.context.code.template`var ${local} = ${declaration!.getSource()};`
+              );
+            }
+          }
+          if (liveBindings)
+            state.exportStatements.push(
+              exportValue('default', local, exportsName(exportPath.context))
+            );
+          else state.deferredExports.push({ kind: 'specifier', local, exported: 'default' });
+        }
+      ),
+      nox.defineVisitor(
+        'ExportAllDeclaration',
+        { fields: ['source', 'exportKind', 'exported'], scope: true },
+        (exportPath, state) => {
+          const { collectOnly, shared } = metroPluginData(exportPath.context);
+          state.sawEsm = true;
+          if (exportPath.node.exportKind && exportPath.node.exportKind !== 'value') {
+            if (!collectOnly) exportPath.remove();
+            return;
+          }
+          const source = exportPath.node.source;
+          if (collectOnly) {
+            const dependencyState = shared.state;
+            if (!dependencyState) exportPath.unsupported('missing-shared-dependency-state');
+            registerNativeEsmDependency(dependencyState!, source, exportPath.getLocation(), ['*']);
+            return;
+          }
+          let module = state.modules.get(source);
+          if (!module) {
+            const dependencyState = shared.state;
+            if (!dependencyState) exportPath.unsupported('missing-shared-dependency-state');
+            const dependency = registerNativeEsmDependency(
+              dependencyState!,
+              source,
+              exportPath.getLocation()
+            );
+            const dependencyArgument = `${dependencyState!.dependencyMapName}[${dependency.index}]`;
+            const requiredLocal = generateUid(exportPath.scope.getProgramParent(), source);
+            module = {
+              source,
+              requiredLocal,
+              requireCall: `${dependencyState!.requireName}(${dependencyArgument}, ${JSON.stringify(source)})`,
+              afterImport: [],
+              exportAll: false,
+              referenced: true,
+              defaultReferenced: false,
+              namespaceReferenced: false,
+              sideEffect: false,
+            };
+            state.modules.set(source, module);
+            state.moduleOrder.push(module);
+          }
+          module.referenced = true;
+          const requiredLocal = module.requiredLocal;
+          if (typeof exportPath.node.exported === 'string') {
+            if (module.namespaceLocal == null) {
+              module.namespaceLocal = generateUid(exportPath.scope.getProgramParent(), source);
+              module.afterImport.push({
+                kind: 'namespace-interop',
+                code: `var ${module.namespaceLocal} = _interopNamespace(${module.requiredLocal});`,
+              });
+            }
+            module.namespaceReferenced = true;
+            state.exportStatements.push(
+              exportValue(
+                exportPath.node.exported,
+                module.namespaceLocal,
+                exportsName(exportPath.context)
+              )
+            );
+          } else {
+            if (!module.exportAll) {
+              module.exportAll = true;
+              const target = exportsName(exportPath.context);
+              const code = liveBindings
+                ? `Object.keys(${requiredLocal}).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(${target}, k)) {
+    Object.defineProperty(${target}, k, {
+      enumerable: true,
+      get: function () { return ${requiredLocal}[k]; }
+    });
+  }
+});`
+                : `Object.keys(${requiredLocal}).forEach(function (k) {
+  if (k !== 'default' && !Object.prototype.hasOwnProperty.call(${target}, k)) {
+    ${target}[k] = ${requiredLocal}[k];
+  }
+});`;
+              if (liveBindings) module.afterImport.push({ kind: 'statement', code });
+              else state.exportStatements.push(code);
+            }
+          }
+          exportPath.remove();
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/module-eligibility.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/module-eligibility.ts
@@ -1,0 +1,36 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createEligibilityVisitors(nox: Noxcturnal, isHermesV1: boolean) {
+  return [
+    nox.defineVisitor('Decorator', {}, (path) => {
+      path.unsupported('decorator-lowering');
+    }),
+    nox.defineVisitor('Function', { fields: ['async', 'generator'] }, (fn) => {
+      if (fn.node.async === true && !isHermesV1) {
+        fn.unsupported(fn.node.generator === true ? 'async-generator-lowering' : 'async-lowering');
+      }
+    }),
+  ];
+}
+
+export function createModuleEligibilityPlugin(
+  nox: Noxcturnal,
+  isHermesV1: boolean
+): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-metro-eligibility',
+    contract: { queries: [{ imports: true, exports: true }] },
+    analyze(context) {
+      const modules = context.query({ imports: true, exports: true });
+      return modules.imports.length === 0 && modules.exports.length === 0
+        ? { status: 'supported', analysis: undefined }
+        : {
+            status: 'unsupported',
+            reason: 'esm-requires-babel-module-transform',
+          };
+    },
+    visitors: createEligibilityVisitors(nox, isHermesV1),
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/native-esm-eligibility.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/native-esm-eligibility.ts
@@ -1,0 +1,14 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+import { createEligibilityVisitors } from './module-eligibility';
+
+export function createNativeEsmEligibilityPlugin(
+  nox: Noxcturnal,
+  isHermesV1: boolean
+): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-metro-eligibility',
+    visitors: createEligibilityVisitors(nox, isHermesV1),
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/platform-select.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/platform-select.ts
@@ -1,0 +1,64 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createPlatformSelectPlugin(
+  nox: Noxcturnal,
+  platform: string | null | undefined
+): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-minify-platform-select',
+    visitors: [
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          scope: true,
+          children: {
+            callee: { route: 'Expression', fields: ['memberPath', 'name'] },
+            arguments: {
+              route: 'ObjectExpression',
+              children: {
+                properties: {
+                  route: 'ObjectProperty',
+                  fields: ['key', 'computed'],
+                  children: { value: { route: 'Expression' } },
+                },
+              },
+            },
+          },
+        },
+        (call) => {
+          const callee = call.getChild('callee');
+          if (!callee?.matchesPattern('Platform.select') || call.scope.hasBinding('Platform'))
+            return;
+          const argument = call.getChildList('arguments')[0];
+          if (!argument?.is('ObjectExpression')) return;
+          const properties = argument.getChildList('properties');
+          if (
+            properties.some(
+              (property) =>
+                property.node.type !== 'ObjectProperty' || property.node.computed === true
+            )
+          ) {
+            return;
+          }
+          const find = (key: string) => {
+            for (let index = properties.length - 1; index >= 0; index--) {
+              const property = properties[index]!;
+              if (String(property.node.key) === key) return property;
+            }
+            return undefined;
+          };
+          const selected =
+            (platform ? find(platform) : undefined) ??
+            (platform === 'web' ? undefined : find('native')) ??
+            find('default');
+          const value = selected?.getChild('value');
+          call.replaceWith(
+            value ? value.getSource() : call.context.code.parseExpression('undefined')
+          );
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/process-env.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/process-env.ts
@@ -1,0 +1,81 @@
+import path from 'node:path';
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  expoPluginInput,
+  mappedLiteral,
+  usesPublicEnvPlugin,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+} from '../noxcturnal-transformer';
+
+const NO_PROCESS_ENV_REPLACEMENT = Symbol('NO_PROCESS_ENV_REPLACEMENT');
+
+interface ProcessEnvState {
+  input: NoxcturnalTransformInput;
+  absoluteRouterRoot?: string;
+}
+
+export function staticProcessEnvName(node: {
+  memberPath?: unknown;
+  property?: unknown;
+}): string | null {
+  if (typeof node.property !== 'string' || node.memberPath !== `process.env.${node.property}`) {
+    return null;
+  }
+  return node.property;
+}
+
+function routerRoot(state: ProcessEnvState): string {
+  return (state.absoluteRouterRoot ??= (() => {
+    const option = state.input.options.customTransformOptions?.routerRoot;
+    const root = typeof option === 'string' ? decodeURI(option) : 'app';
+    return path.isAbsolute(root) ? root : path.join(state.input.projectRoot, root);
+  })());
+}
+
+function processEnvReplacement(
+  name: string,
+  state: ProcessEnvState
+): unknown | typeof NO_PROCESS_ENV_REPLACEMENT {
+  const { filename, options, projectRoot } = state.input;
+  switch (name) {
+    case 'EXPO_PROJECT_ROOT':
+      return projectRoot;
+    case 'EXPO_ROUTER_ABS_APP_ROOT':
+      return routerRoot(state);
+    case 'EXPO_ROUTER_APP_ROOT':
+      return path.relative(path.dirname(filename), routerRoot(state));
+    case 'EXPO_ROUTER_IMPORT_MODE':
+      return String(options.customTransformOptions?.asyncRoutes) === 'true' ? 'lazy' : 'sync';
+    default:
+      return !options.dev && usesPublicEnvPlugin(state.input) && name.startsWith('EXPO_PUBLIC_')
+        ? process.env[name]
+        : NO_PROCESS_ENV_REPLACEMENT;
+  }
+}
+
+export function createProcessEnvPlugin(nox: Noxcturnal): DefinedNativePlugin<ProcessEnvState> {
+  return nox.defineNativePlugin<ProcessEnvState>({
+    name: 'expo-process-env',
+    createState: (context) => ({ input: expoPluginInput(context) }),
+    visitors: [
+      nox.defineVisitor(
+        'StaticMemberExpression|ComputedMemberExpression',
+        {
+          fields: ['memberPath', 'property'],
+          where: { write: { equals: false } },
+          scope: true,
+        },
+        (member, state) => {
+          const name = staticProcessEnvName(member.node);
+          if (name === null) return;
+          if (member.scope.hasBinding('process')) return;
+          const replacement = processEnvReplacement(name, state);
+          if (replacement === NO_PROCESS_ENV_REPLACEMENT) return;
+          member.replaceWith(mappedLiteral(member.context, replacement));
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-display-name.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-display-name.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import type { DefinedNativePlugin } from 'noxcturnal';
+import { isStatementType } from 'noxcturnal';
+
+import { expoPluginInput } from '../noxcturnal-transformer';
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+export function createReactDisplayNamePlugin(nox: Noxcturnal): DefinedNativePlugin {
+  interface DisplayNameAncestor {
+    readonly node: {
+      readonly type: string;
+      readonly bindingName?: unknown;
+      readonly key?: unknown;
+      readonly targetName?: unknown;
+    };
+    readonly parentPath: DisplayNameAncestor | null;
+  }
+  const inferName = (call: { readonly parentPath: DisplayNameAncestor | null }): string | null => {
+    let parent = call.parentPath;
+    while (parent) {
+      if (parent.node.type === 'VariableDeclarator') {
+        return typeof parent.node.bindingName === 'string' ? parent.node.bindingName : null;
+      }
+      if (parent.node.type === 'ObjectProperty') {
+        return typeof parent.node.key === 'string' ? parent.node.key : null;
+      }
+      if (parent.node.type === 'AssignmentExpression') {
+        return typeof parent.node.targetName === 'string' ? parent.node.targetName : null;
+      }
+      if (isStatementType(parent.node.type)) return null;
+      parent = parent.parentPath;
+    }
+    return null;
+  };
+
+  return nox.defineNativePlugin({
+    name: 'expo-transform-react-display-name',
+    visitors: [
+      nox.defineVisitor(
+        'CallExpression',
+        {
+          fields: ['argumentCount'],
+          where: {
+            calleePath: { oneOf: ['React.createClass', 'createReactClass'] },
+          },
+          ancestry: {
+            mode: 'findParent',
+            routes: {
+              VariableDeclarator: { fields: ['bindingName'] },
+              AssignmentExpression: { fields: ['targetName'] },
+              ObjectProperty: { fields: ['key'] },
+            },
+          },
+          children: {
+            arguments: {
+              route: 'ObjectExpression',
+              children: {
+                properties: { route: 'ObjectProperty', fields: ['key'] },
+              },
+            },
+          },
+        },
+        (call) => {
+          if (call.node.argumentCount !== 1) return;
+          const object = call.getChildList('arguments')[0];
+          if (!object?.is('ObjectExpression')) return;
+          if (
+            object
+              .getChildList('properties')
+              .some((property) => String(property.node.key) === 'displayName')
+          ) {
+            return;
+          }
+
+          let displayName = inferName(call);
+          if (
+            !displayName &&
+            call.findParent((parent) => parent.node.type === 'ExportDefaultDeclaration') != null
+          ) {
+            const { filename } = expoPluginInput(call.context);
+            displayName = path.basename(filename, path.extname(filename));
+            if (displayName === 'index') displayName = path.basename(path.dirname(filename));
+          }
+          if (!displayName) return;
+          call.context.editor.appendLeft(
+            object.getSource().start + 1,
+            `displayName: ${JSON.stringify(displayName)},`
+          );
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-native-codegen.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-native-codegen.ts
@@ -1,0 +1,59 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { TURBO_MODULE_SPEC } from '../codegen';
+import { expoPluginInput, type Noxcturnal } from '../noxcturnal-transformer';
+
+const CODEGEN_MODULE = /(?:^|\/)codegenNative(?:Component|Commands)$/;
+
+export function createReactNativeCodegenEligibilityPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-react-native-codegen-eligibility',
+    visitors: [
+      nox.defineVisitor('Program', {}, (program) => {
+        if (TURBO_MODULE_SPEC.test(expoPluginInput(program.context).source)) {
+          program.unsupported('react-native-codegen');
+        }
+      }),
+      nox.defineVisitor(
+        'ImportDeclaration',
+        {
+          fields: ['source'],
+          children: {
+            specifiers: {
+              route: 'ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier',
+              fields: ['imported'],
+            },
+          },
+        },
+        (declaration) => {
+          const source = String(declaration.node.source);
+          if (CODEGEN_MODULE.test(source)) {
+            declaration.unsupported('react-native-codegen');
+            return;
+          }
+          if (
+            source === 'react-native' &&
+            declaration
+              .getChildList('specifiers')
+              .some(
+                (specifier) =>
+                  specifier.node.imported === 'codegenNativeComponent' ||
+                  specifier.node.imported === 'codegenNativeCommands'
+              )
+          ) {
+            declaration.unsupported('react-native-codegen');
+          }
+        }
+      ),
+      nox.defineVisitor('CallExpression', { fields: ['calleeName', 'calleeGlobal'] }, (call) => {
+        if (
+          call.node.calleeGlobal === true &&
+          (call.node.calleeName === 'codegenNativeComponent' ||
+            call.node.calleeName === 'codegenNativeCommands')
+        ) {
+          call.unsupported('react-native-codegen');
+        }
+      }),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-native-web.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-native-web.ts
@@ -1,0 +1,277 @@
+import type { Code, CompositeFragment, DefinedNativePlugin, SourceFragment } from 'noxcturnal';
+
+import type { Noxcturnal } from '../noxcturnal-transformer';
+
+const REACT_NATIVE_WEB_EXPORTS = new Set<string>([
+  'AccessibilityInfo',
+  'ActivityIndicator',
+  'Alert',
+  'Animated',
+  'AppRegistry',
+  'AppState',
+  'Appearance',
+  'BackHandler',
+  'Button',
+  'CheckBox',
+  'Clipboard',
+  'DeviceEventEmitter',
+  'Dimensions',
+  'Easing',
+  'FlatList',
+  'I18nManager',
+  'Image',
+  'ImageBackground',
+  'InputAccessoryView',
+  'InteractionManager',
+  'Keyboard',
+  'KeyboardAvoidingView',
+  'LayoutAnimation',
+  'Linking',
+  'LogBox',
+  'Modal',
+  'NativeEventEmitter',
+  'NativeModules',
+  'PanResponder',
+  'Picker',
+  'PixelRatio',
+  'Platform',
+  'Pressable',
+  'ProgressBar',
+  'RefreshControl',
+  'SafeAreaView',
+  'ScrollView',
+  'SectionList',
+  'Share',
+  'StatusBar',
+  'StyleSheet',
+  'Switch',
+  'Text',
+  'TextInput',
+  'Touchable',
+  'TouchableHighlight',
+  'TouchableNativeFeedback',
+  'TouchableOpacity',
+  'TouchableWithoutFeedback',
+  'UIManager',
+  'Vibration',
+  'View',
+  'VirtualizedList',
+  'YellowBox',
+  'createElement',
+  'findNodeHandle',
+  'processColor',
+  'render',
+  'unmountComponentAtNode',
+  'useColorScheme',
+  'useLocaleContext',
+  'useWindowDimensions',
+]);
+
+function reactNativeWebLocation(name: string): string | null {
+  const internal = name === 'unstable_createElement' ? 'createElement' : name;
+  return REACT_NATIVE_WEB_EXPORTS.has(internal)
+    ? `react-native-web/dist/exports/${internal}`
+    : null;
+}
+
+export function createReactNativeWebPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  const isRoot = (source: unknown) => source === 'react-native' || source === 'react-native-web';
+  return nox.defineNativePlugin({
+    name: 'expo-react-native-web',
+    editEffect: 'bindings',
+    visitors: [
+      nox.defineVisitor(
+        'ImportDeclaration',
+        {
+          fields: ['source'],
+          children: {
+            specifiers: {
+              route: 'ImportSpecifier|ImportDefaultSpecifier|ImportNamespaceSpecifier',
+              fields: ['local', 'imported'],
+            },
+          },
+        },
+        (importPath) => {
+          if (!isRoot(importPath.node.source)) return;
+          const specifiers = importPath.getChildList('specifiers');
+          if (specifiers.length === 0) return;
+          importPath.replaceWithMultiple(
+            specifiers.map((specifier) => {
+              if (specifier.node.type === 'ImportSpecifier') {
+                const location = reactNativeWebLocation(String(specifier.node.imported));
+                if (location) {
+                  return `import ${String(specifier.node.local)} from ${JSON.stringify(location)};`;
+                }
+                return `import { ${specifier.sourceText()} } from "react-native-web/dist/index";`;
+              }
+              return `import ${specifier.sourceText()} from "react-native-web/dist/index";`;
+            })
+          );
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          fields: ['source'],
+          children: {
+            specifiers: {
+              route: 'ExportSpecifier',
+              fields: ['local', 'exported'],
+            },
+          },
+        },
+        (exportPath) => {
+          if (!isRoot(exportPath.node.source)) return;
+          const specifiers = exportPath.getChildList('specifiers');
+          if (specifiers.length === 0) return;
+          exportPath.replaceWithMultiple(
+            specifiers.map((specifier) => {
+              const local = String(specifier.node.local);
+              const exported = String(specifier.node.exported);
+              const location = reactNativeWebLocation(local);
+              return location
+                ? `export { default as ${exported} } from ${JSON.stringify(location)};`
+                : `export { ${specifier.sourceText()} } from "react-native-web/dist/index";`;
+            })
+          );
+        }
+      ),
+      nox.defineVisitor(
+        'VariableDeclaration',
+        {
+          fields: ['kind'],
+          children: {
+            declarations: {
+              route: 'VariableDeclarator',
+              children: {
+                id: {
+                  route: 'Identifier|ObjectPattern|ArrayPattern',
+                  fields: ['name'],
+                  children: {
+                    properties: {
+                      route: 'BindingProperty|BindingRestElement',
+                      fields: ['key', 'computed', 'shorthand'],
+                      children: {
+                        value: {
+                          route: 'Identifier|ObjectPattern|ArrayPattern|AssignmentPattern',
+                          fields: ['name'],
+                        },
+                      },
+                    },
+                  },
+                },
+                init: {
+                  route: 'Expression',
+                  fields: ['calleeName', 'calleeGlobal', 'staticArgument'],
+                },
+              },
+            },
+          },
+        },
+        (declaration) => {
+          const kind = declaration.node.kind;
+          const retained: { getSource(): SourceFragment }[] = [];
+          const replacements: Code[] = [];
+          let changed = false;
+
+          for (const declarator of declaration.getChildList('declarations')) {
+            const id = declarator.getChild('id');
+            const init = declarator.getChild('init');
+            if (
+              !id ||
+              init?.node.type !== 'CallExpression' ||
+              init.node.calleeName !== 'require' ||
+              init.node.calleeGlobal !== true ||
+              !isRoot(init.node.staticArgument)
+            ) {
+              retained.push(declarator);
+              continue;
+            }
+
+            if (id.node.type === 'Identifier') {
+              replacements.push(
+                `${kind} ${String(id.node.name)} = require("react-native-web/dist/index");`
+              );
+              changed = true;
+              continue;
+            }
+            if (id.node.type !== 'ObjectPattern') {
+              retained.push(declarator);
+              continue;
+            }
+
+            const properties = id.getChildList('properties');
+            const supported: {
+              imported: string;
+              local: string;
+              source: SourceFragment;
+            }[] = [];
+            let valid = true;
+            for (const property of properties) {
+              if (
+                property.node.type !== 'BindingProperty' ||
+                property.node.computed === true ||
+                typeof property.node.key !== 'string'
+              ) {
+                valid = false;
+                break;
+              }
+              const value = property.getChild('value');
+              if (
+                !value ||
+                value.node.type !== 'Identifier' ||
+                typeof value.node.name !== 'string'
+              ) {
+                valid = false;
+                break;
+              }
+              supported.push({
+                imported: property.node.key,
+                local: value.node.name,
+                source: property.getSource(),
+              });
+            }
+            if (!valid) {
+              retained.push(declarator);
+              continue;
+            }
+
+            const unknown: SourceFragment[] = [];
+            for (const property of supported) {
+              const location = reactNativeWebLocation(property.imported);
+              if (location) {
+                replacements.push(
+                  `${kind} ${property.local} = require(${JSON.stringify(location)}).default;`
+                );
+              } else {
+                unknown.push(property.source);
+              }
+            }
+            if (unknown.length > 0) {
+              const parts: CompositeFragment['parts'][number][] = [`${kind} { `];
+              for (const [index, property] of unknown.entries()) {
+                if (index > 0) parts.push(', ');
+                parts.push(property);
+              }
+              parts.push(' } = require("react-native-web/dist/index");');
+              replacements.push({ kind: 'composite', parts });
+            }
+            changed = true;
+          }
+
+          if (!changed) return;
+          if (retained.length > 0) {
+            const parts: CompositeFragment['parts'][number][] = [`${kind} `];
+            for (const [index, declarator] of retained.entries()) {
+              if (index > 0) parts.push(', ');
+              parts.push(declarator.getSource());
+            }
+            parts.push(';');
+            replacements.unshift({ kind: 'composite', parts });
+          }
+          declaration.replaceWithMultiple(replacements);
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-client-proxy.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-client-proxy.ts
@@ -1,0 +1,165 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  expoPluginInput,
+  serverBoundary,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+  type ServerBoundaryShared,
+} from '../noxcturnal-transformer';
+
+interface ReactClientProxyState {
+  input: NoxcturnalTransformInput;
+  boundary: ServerBoundaryShared;
+  enabled: boolean;
+  mockConsolePolyfill: boolean;
+  server: boolean;
+  exports: Set<string>;
+}
+
+export function createReactServerClientProxyPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<ReactClientProxyState> {
+  return nox.defineNativePlugin<ReactClientProxyState>({
+    name: 'expo-react-server-client-proxy',
+    editEffect: 'bindings',
+    contract: {
+      metadata: { writes: ['proxyExports', 'reactClientReference'] },
+    },
+    createState: (context) => {
+      const boundary = serverBoundary(context);
+      boundary.clientProxy = false;
+      boundary.moduleServerActions = false;
+      boundary.handledDirectives.clear();
+      return {
+        input: expoPluginInput(context),
+        boundary,
+        enabled: false,
+        mockConsolePolyfill: false,
+        server: false,
+        exports: new Set(),
+      };
+    },
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        {
+          children: {
+            directives: { route: 'Directive', fields: ['value'] },
+          },
+        },
+        (program, state) => {
+          const directives = new Set(
+            program.getChildList('directives').map((directive) => String(directive.node.value))
+          );
+          state.enabled = directives.has('use client') || directives.has('use dom');
+          state.mockConsolePolyfill =
+            state.enabled &&
+            (state.input.filename.endsWith('@react-native/js-polyfills/console.js') ||
+              state.input.filename.endsWith('@react-native\\js-polyfills\\console.js'));
+          state.server = directives.has('use server');
+          state.boundary.clientProxy = state.enabled;
+          if (state.enabled && state.server) {
+            program.unsupported('conflicting-client-server-directives');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportDefaultDeclaration',
+        { ancestry: { mode: 'programParent' } },
+        (exportPath, state) => {
+          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
+            state.exports.add('default');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportAllDeclaration',
+        { ancestry: { mode: 'programParent' } },
+        (exportPath, state) => {
+          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
+            state.exports.add('*');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          ancestry: { mode: 'programParent' },
+          scope: true,
+          children: {
+            declaration: {
+              route: 'Declaration',
+              fields: ['name', 'nodeKind'],
+              children: {
+                declarations: {
+                  route: 'VariableDeclarator',
+                  children: {
+                    id: { route: 'Identifier', fields: ['name'] },
+                  },
+                },
+              },
+            },
+            specifiers: {
+              route: 'ExportSpecifier',
+              fields: ['exported'],
+            },
+          } as any,
+        },
+        (exportPath, state) => {
+          if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          const declaration = exportPath.getChild('declaration') as any;
+          if (typeof declaration?.node.name === 'string') {
+            state.exports.add(declaration.node.name);
+          } else if (declaration?.node.type === 'VariableDeclaration') {
+            for (const declarator of declaration.getChildList('declarations')) {
+              const id = declarator.getChild('id');
+              if (id?.node.type === 'Identifier') {
+                state.exports.add(String(id.node.name));
+              }
+            }
+          }
+          for (const specifier of exportPath.getChildList('specifiers')) {
+            state.exports.add(String(specifier.node.exported));
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      if (!state.enabled) return;
+      if (state.mockConsolePolyfill) {
+        const shebang = context.source.match(/^#![^\r\n]*(?:\r?\n|$)/)?.[0] ?? '';
+        // Emptying the module leaves nothing that traces back to it.
+        context.editor.overwrite(0, context.source.length, shebang, 'sourceless');
+        return;
+      }
+      const outputKey =
+        './' +
+        path.relative(state.input.projectRoot, state.input.filename).split(path.sep).join('/');
+      const exports = [...state.exports];
+      const proxy = [
+        `const proxy = /*@__PURE__*/ require("react-server-dom-webpack/server").createClientModuleProxy(${JSON.stringify(outputKey)});`,
+        'module.exports = proxy;',
+      ];
+      for (const exportName of exports) {
+        if (exportName === '*') continue;
+        const message =
+          exportName === 'default'
+            ? `Attempted to call the default export of ${state.input.filename} from the server but it's on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.`
+            : `Attempted to call ${exportName}() of ${state.input.filename} from the server but ${exportName} is on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.`;
+        const registered = `require("react-server-dom-webpack/server").registerClientReference(function () { throw new Error(${JSON.stringify(message)}); }, ${JSON.stringify(outputKey)}, ${JSON.stringify(exportName)})`;
+        proxy.push(
+          exportName === 'default'
+            ? `export default ${registered};`
+            : `export const ${exportName} = ${registered};`
+        );
+      }
+      const shebang = context.source.match(/^#![^\r\n]*(?:\r?\n|$)/)?.[0] ?? '';
+      context.editor.overwrite(0, context.source.length, shebang + proxy.join('\n'), 'sourceless');
+      context.metadata.set('proxyExports', exports);
+      context.metadata.set('reactClientReference', pathToFileURL(state.input.filename).href);
+    },
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-directive-boundary.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-directive-boundary.ts
@@ -1,0 +1,27 @@
+import type { DefinedNativePlugin } from 'noxcturnal';
+
+import { serverBoundary, type Noxcturnal } from '../noxcturnal-transformer';
+
+export function createReactServerDirectiveBoundaryPlugin(nox: Noxcturnal): DefinedNativePlugin {
+  return nox.defineNativePlugin({
+    name: 'expo-react-server-directive-boundary',
+    visitors: [
+      nox.defineVisitor(
+        'Directive',
+        { fields: ['value'], ancestry: { mode: 'parent' } },
+        (directive) => {
+          const boundary = serverBoundary(directive.context);
+          if (
+            boundary.handledDirectives.has(directive.id) ||
+            ((boundary.clientProxy || boundary.moduleServerActions) &&
+              directive.parentPath?.node.type === 'Program')
+          )
+            return;
+          if (directive.node.value === 'use server') {
+            directive.unsupported('expo-directive');
+          }
+        }
+      ),
+    ],
+  });
+}

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-module-actions.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-module-actions.ts
@@ -1,0 +1,428 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { Code, DefinedNativePlugin } from 'noxcturnal';
+
+import {
+  expoPluginInput,
+  serverBoundary,
+  sortedUniqueCaptureNames,
+  type Noxcturnal,
+  type NoxcturnalTransformInput,
+  type ServerBoundaryShared,
+} from '../noxcturnal-transformer';
+
+interface ReactServerActionsState {
+  input: NoxcturnalTransformInput;
+  boundary: ServerBoundaryShared;
+  enabled: boolean;
+  moduleId: string;
+  registerBinding: string;
+  wrapperBinding: string;
+  usesCapturedArgs: boolean;
+  actions: { localName?: string; exportedName: string }[];
+}
+
+export function createReactServerModuleActionsPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<ReactServerActionsState> {
+  return nox.defineNativePlugin<ReactServerActionsState>({
+    name: 'expo-react-server-module-actions',
+    editEffect: 'bindings',
+    contract: {
+      metadata: { writes: ['reactServerActions', 'reactServerReference'] },
+    },
+    createState: (context) => {
+      const input = expoPluginInput(context);
+      return {
+        input,
+        boundary: serverBoundary(context),
+        enabled: false,
+        moduleId: './' + path.relative(input.projectRoot, input.filename).split(path.sep).join('/'),
+        registerBinding: '',
+        wrapperBinding: '',
+        usesCapturedArgs: false,
+        actions: [],
+      };
+    },
+    visitors: [
+      nox.defineVisitor(
+        'Program',
+        {
+          scope: true,
+          children: {
+            directives: { route: 'Directive', fields: ['value'] },
+          },
+        },
+        (program, state) => {
+          state.registerBinding = program.scope.generateUid('registerServerReference');
+          state.wrapperBinding = program.scope.generateUid('wrapBoundArgs');
+          const directive = program
+            .getChildList('directives')
+            .find((item) => item.node.value === 'use server');
+          if (!directive) return;
+          state.enabled = true;
+          state.boundary.moduleServerActions = true;
+          directive.remove();
+        }
+      ),
+      nox.defineVisitor(
+        'ArrowFunctionExpression',
+        {
+          fields: ['async', 'bodyEnd'],
+          scope: true,
+          ancestry: { mode: 'programParent' },
+          children: {
+            body: {
+              route: 'FunctionBody',
+              children: {
+                directives: { route: 'Directive', fields: ['value'] },
+              },
+            },
+            params: {
+              route: 'FormalParameter|FormalParameterRest|BindingRestElement',
+            },
+          },
+        },
+        (arrow, state) => {
+          if (state.enabled) return;
+          const body = arrow.getChild('body');
+          if (!body || body.node.type !== 'FunctionBody') return;
+          const directive = body
+            .getChildList('directives')
+            .find((item) => item.node.value === 'use server');
+          if (!directive) return;
+          if (arrow.node.async !== true) {
+            arrow.unsupported('server-action-non-async-inline');
+          }
+          const captures =
+            arrow.context.query({
+              captures: [{ functionId: arrow.node.id, programBindings: false }],
+            }).captures[arrow.node.id] ?? [];
+          const capturedNames = sortedUniqueCaptureNames(captures);
+          const actionId = arrow.scope.getProgramParent().generateUid('$$INLINE_ACTION');
+          const parameters = arrow
+            .getChildList('params')
+            .map((parameter) => parameter.sourceText())
+            .join(', ');
+          const bodySource = arrow.context.source.slice(
+            directive.node.end,
+            Number(arrow.node.bodyEnd)
+          );
+          const closureParameter =
+            capturedNames.length === 0 ? '' : arrow.scope.generateUid('$$CLOSURE');
+          const extractedParameters = [...(closureParameter ? [closureParameter] : []), parameters]
+            .filter(Boolean)
+            .join(', ');
+          const closureInit = closureParameter
+            ? `var [${capturedNames.join(', ')}] = ${closureParameter}.value;`
+            : '';
+          arrow
+            .getProgramParent()!
+            .unshiftContainer(
+              'body',
+              `export var ${actionId} = ${state.registerBinding}(async (${extractedParameters}) => {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+            );
+          arrow.replaceWith(
+            closureParameter
+              ? `${actionId}.bind(null, ${state.wrapperBinding}(() => [${capturedNames.join(', ')}]))`
+              : actionId
+          );
+          if (closureParameter) state.usesCapturedArgs = true;
+          state.boundary.handledDirectives.add(directive.id);
+          state.actions.push({ exportedName: actionId });
+        }
+      ),
+      nox.defineVisitor(
+        'FunctionExpression',
+        {
+          fields: ['async', 'generator', 'name', 'bodyEnd'],
+          scope: true,
+          ancestry: { mode: 'programParent' },
+          children: {
+            body: {
+              route: 'FunctionBody',
+              children: {
+                directives: { route: 'Directive', fields: ['value'] },
+              },
+            },
+            params: {
+              route: 'FormalParameter|FormalParameterRest',
+            },
+          },
+        },
+        (fn, state) => {
+          if (state.enabled) return;
+          const body = fn.getChild('body');
+          if (!body || body.node.type !== 'FunctionBody') return;
+          const directive = body
+            .getChildList('directives')
+            .find((item) => item.node.value === 'use server');
+          if (!directive) return;
+          if (fn.node.async !== true || fn.node.generator === true) {
+            fn.unsupported('server-action-non-async-inline');
+          }
+          const captures =
+            fn.context.query({
+              captures: [{ functionId: fn.node.id, programBindings: false }],
+            }).captures[fn.node.id] ?? [];
+          const capturedNames = sortedUniqueCaptureNames(captures);
+          const actionId = fn.scope.getProgramParent().generateUid('$$INLINE_ACTION');
+          const parameters = fn
+            .getChildList('params')
+            .map((parameter) => parameter.sourceText())
+            .join(', ');
+          const bodySource = fn.context.source.slice(directive.node.end, Number(fn.node.bodyEnd));
+          const name = typeof fn.node.name === 'string' ? ` ${fn.node.name}` : '';
+          const closureParameter =
+            capturedNames.length === 0 ? '' : fn.scope.generateUid('$$CLOSURE');
+          const extractedParameters = [...(closureParameter ? [closureParameter] : []), parameters]
+            .filter(Boolean)
+            .join(', ');
+          const closureInit = closureParameter
+            ? `var [${capturedNames.join(', ')}] = ${closureParameter}.value;`
+            : '';
+          fn.scope
+            .getProgramParent()
+            .path!.unshiftContainer(
+              'body',
+              `export var ${actionId} = ${state.registerBinding}(async function${name}(${extractedParameters}) {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+            );
+          fn.replaceWith(
+            closureParameter
+              ? `${actionId}.bind(null, ${state.wrapperBinding}(() => [${capturedNames.join(', ')}]))`
+              : actionId
+          );
+          if (closureParameter) state.usesCapturedArgs = true;
+          state.boundary.handledDirectives.add(directive.id);
+          state.actions.push({ exportedName: actionId });
+        }
+      ),
+      nox.defineVisitor(
+        'FunctionDeclaration',
+        {
+          fields: ['async', 'generator', 'name', 'bodyEnd'],
+          scope: true,
+          ancestry: { mode: 2 },
+          children: {
+            body: {
+              route: 'FunctionBody',
+              children: {
+                directives: { route: 'Directive', fields: ['value'] },
+              },
+            },
+            params: {
+              route: 'FormalParameter|FormalParameterRest',
+            },
+          },
+        },
+        (fn, state) => {
+          if (state.enabled) return;
+          const body = fn.getChild('body');
+          if (!body || body.node.type !== 'FunctionBody') return;
+          const directive = body
+            .getChildList('directives')
+            .find((item) => item.node.value === 'use server');
+          if (!directive) return;
+          if (fn.node.async !== true || fn.node.generator === true) {
+            fn.unsupported('server-action-non-async-inline');
+          }
+          const topLevel =
+            fn.parentPath?.node.type === 'Program' ||
+            (fn.parentPath?.node.type === 'ExportNamedDeclaration' &&
+              fn.parentPath.parentPath?.node.type === 'Program');
+          if (!topLevel || typeof fn.node.name !== 'string') {
+            fn.unsupported('server-action-nested-function-declaration');
+          }
+          const actionId = fn.scope.getProgramParent().generateUid('$$INLINE_ACTION');
+          const parameters = fn
+            .getChildList('params')
+            .map((parameter) => parameter.sourceText())
+            .join(', ');
+          const bodySource = fn.context.source.slice(directive.node.end, Number(fn.node.bodyEnd));
+          fn.scope
+            .getProgramParent()
+            .path!.unshiftContainer(
+              'body',
+              `export var ${actionId} = ${state.registerBinding}(async function ${fn.node.name}(${parameters}) {${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+            );
+          fn.replaceWith(`var ${fn.node.name} = ${actionId};`);
+          state.boundary.handledDirectives.add(directive.id);
+          state.actions.push({
+            localName: fn.node.name,
+            exportedName: actionId,
+          });
+        }
+      ),
+      nox.defineVisitor(
+        'ExportDefaultDeclaration',
+        {
+          ancestry: { mode: 'programParent' },
+          scope: true,
+          children: {
+            declaration: {
+              route: 'Function|Expression',
+              fields: [
+                'nodeKind',
+                'name',
+                'async',
+                'declarationNameAnchor',
+                'declarationNamePrefix',
+              ],
+            },
+          },
+        },
+        (exportPath, state) => {
+          if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          const declaration = exportPath.getChild('declaration') as any;
+          if (!declaration) {
+            exportPath.unsupported('server-action-default-export');
+            return;
+          }
+          let name: string;
+          let declarationSource: Code;
+          if (declaration.node.nodeKind === 'FunctionDeclaration') {
+            if (declaration.node.async !== true) {
+              exportPath.unsupported('server-action-non-async-function');
+              return;
+            }
+            name =
+              typeof declaration.node.name === 'string'
+                ? declaration.node.name
+                : exportPath.scope.getProgramParent().generateUid('$$INLINE_ACTION');
+            declarationSource =
+              typeof declaration.node.name === 'string'
+                ? declaration.getSource()
+                : declaration.withDeclarationName(name);
+          } else if (
+            declaration.node.type === 'ArrowFunctionExpression' &&
+            declaration.node.async === true
+          ) {
+            name = exportPath.scope.getProgramParent().generateUid('$$INLINE_ACTION');
+            declarationSource = exportPath.context.code
+              .template`var ${name} = ${declaration.getSource()};`;
+          } else if (declaration.node.type === 'Identifier') {
+            name = declaration.sourceText();
+            declarationSource = '';
+          } else {
+            exportPath.unsupported('server-action-default-export');
+            return;
+          }
+          exportPath.replaceWith(exportPath.context.code.template`${declarationSource}
+;(() => ${state.registerBinding}(${name}, ${JSON.stringify(state.moduleId)}, "default"))();
+export { ${name} as default };`);
+          state.actions.push({ localName: name, exportedName: 'default' });
+        }
+      ),
+      nox.defineVisitor(
+        'ExportAllDeclaration',
+        { ancestry: { mode: 'programParent' } },
+        (exportPath, state) => {
+          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
+            exportPath.unsupported('server-action-export-all');
+          }
+        }
+      ),
+      nox.defineVisitor(
+        'ExportNamedDeclaration',
+        {
+          fields: ['source', 'exportKind'],
+          ancestry: { mode: 'programParent' },
+          children: {
+            declaration: {
+              route: 'Declaration',
+              fields: ['name', 'nodeKind', 'async'],
+              children: {
+                declarations: {
+                  route: 'VariableDeclarator',
+                  children: {
+                    id: { route: 'Identifier', fields: ['name'] },
+                  },
+                },
+              },
+            },
+            specifiers: {
+              route: 'ExportSpecifier',
+              fields: ['local', 'exported', 'exportKind'],
+            },
+          } as any,
+        },
+        (exportPath, state) => {
+          if (
+            !state.enabled ||
+            exportPath.parentPath?.node.type !== 'Program' ||
+            exportPath.node.exportKind === 'type'
+          )
+            return;
+          if (exportPath.node.source) {
+            exportPath.unsupported('server-action-reexport');
+          }
+          const registrations: string[] = [];
+          const declaration = exportPath.getChild('declaration') as any;
+          if (declaration) {
+            if (declaration.node.nodeKind === 'FunctionDeclaration') {
+              if (declaration.node.async !== true) {
+                exportPath.unsupported('server-action-non-async-function');
+              }
+              const name = String(declaration.node.name);
+              state.actions.push({ localName: name, exportedName: name });
+              registrations.push(name);
+            } else if (declaration.node.type === 'VariableDeclaration') {
+              for (const declarator of declaration.getChildList('declarations')) {
+                const id = declarator.getChild('id');
+                if (id?.node.type !== 'Identifier') {
+                  exportPath.unsupported('server-action-pattern-export');
+                }
+                const name = String(id!.node.name);
+                state.actions.push({ localName: name, exportedName: name });
+                registrations.push(name);
+              }
+            } else if (
+              declaration.node.type !== 'TSInterfaceDeclaration' &&
+              declaration.node.type !== 'TSTypeAliasDeclaration'
+            ) {
+              exportPath.unsupported('server-action-export-kind');
+            }
+          }
+          for (const specifier of exportPath.getChildList('specifiers')) {
+            if (specifier.node.exportKind === 'type') continue;
+            const localName = String(specifier.node.local);
+            const exportedName = String(specifier.node.exported);
+            if (!state.actions.some((action) => action.localName === localName)) {
+              exportPath.insertBefore(
+                `;(() => ${state.registerBinding}(${localName}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(exportedName)}))();`
+              );
+            }
+            state.actions.push({ localName, exportedName });
+          }
+          if (registrations.length > 0) {
+            exportPath.insertAfter(
+              registrations
+                .map(
+                  (name) =>
+                    `;(() => ${state.registerBinding}(${name}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(name)}))();`
+                )
+                .join('\n')
+            );
+          }
+        }
+      ),
+    ],
+    post(context, state) {
+      if (state.actions.length === 0) return;
+      const payload = {
+        id: state.moduleId,
+        names: state.actions.map((action) => action.exportedName),
+      };
+      context.editor.appendRight(
+        0,
+        `/* rsc/actions: ${JSON.stringify(payload)} */\nimport { registerServerReference as ${state.registerBinding} } from "react-server-dom-webpack/server";\n${
+          state.usesCapturedArgs
+            ? `var ${state.wrapperBinding} = (thunk) => { let cache; return { get value() { return cache || (cache = thunk()); } }; };\n`
+            : ''
+        }`
+      );
+      context.metadata.set('reactServerActions', payload);
+      context.metadata.set('reactServerReference', pathToFileURL(state.input.filename).href);
+    },
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2651,6 +2651,9 @@ importers:
       lightningcss:
         specifier: ^1.30.1
         version: 1.32.0
+      noxcturnal:
+        specifier: 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+        version: 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -2661,6 +2664,15 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
     devDependencies:
+      '@babel/plugin-transform-explicit-resource-management':
+        specifier: ^7.28.6
+        version: 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-exponentiation-operator':
+        specifier: ^7.28.6
+        version: 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-sticky-regex':
+        specifier: ^7.27.1
+        version: 7.29.7(@babel/core@7.29.7)
       '@jridgewell/trace-mapping':
         specifier: ^0.3.31
         version: 0.3.31
@@ -8084,6 +8096,58 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@noxcturnal/noxcturnal-darwin-arm64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-jxiuwa80/CjzlMcWsXyvMiP17M0/F00v+fl3pbF5oPB5kc8oyB3B9cC9jdq1zEpkwl//EgceNMOybD49nhYbyA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@noxcturnal/noxcturnal-darwin-x64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-lPEt5SnKC+A0sKpMTQ0VdDKk7tXSqteewasAiJJuuNvcdt7OWz+wYjy2Q5IVhpWNhSYKKiTLoBQhynX0bI9xzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-sP7c5EDnCSRw5McqZVfmEd+zbULbZby0Bm/OwGUp0oTYMjYFHzn7DVrRCKDFk69JpKphV78THF9GpIM7zAMMcg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-WgxQaZWZ2xAJB3vri3T7H+2lggLlmesjQ2b+JugRmWHmeDRgnm8+bO9pTTkdUYiwgJjtxgRbZsAdg96jXOyMXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-dEraHw0g9OHoqsROD6XZhZkr1bUA0nbwMXdovwo3xbtkAYc/ZuRofoz8+eM6g3wULphe0LauI8wDe8qPRGi7gA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-CqYPb/cSb3P+DxP7nuZ/MhH5Ta16QhR0+YqMpyeeRj1hkeDEF+xNtodvZJb9t1xw7JzWk/rfTg3DuzUzWsVE3g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-3VNTWxkFMu8+s4vWdFjWQIdcwEIo9/EJKcDPSNulKM5zOrMe35H883ht5KqUhAXnPaQ7/KGwdzd4l/bxxl45UA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    resolution: {integrity: sha512-lZhOmUPSdekQ6lnzOAQeC7O1aKpr2vco2RKUz+aDAUmRXZgzpirdK1jri1cpgWemb278Za5FXXZq+O0v0aYVTQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@octokit/auth-token@3.0.4':
     resolution: {integrity: sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==}
     engines: {node: '>= 14'}
@@ -8161,6 +8225,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@oxc-project/types@0.141.0':
+    resolution: {integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==}
 
   '@oxfmt/binding-android-arm-eabi@0.55.0':
     resolution: {integrity: sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==}
@@ -12949,6 +13016,10 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
+  noxcturnal@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc:
+    resolution: {integrity: sha512-kR6JyVKbh4wVjll329UI+jA2OBoTeCX65I0wejTFX+KAP1poW6XR5+r+TcO6PbbyASTWNThc4UFqTM2dv1ee2A==}
+    engines: {node: '>=18'}
+
   npm-bundled@2.0.1:
     resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -15654,13 +15725,11 @@ snapshots:
       '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -15922,7 +15991,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
   '@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -16947,6 +17015,30 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@noxcturnal/noxcturnal-darwin-arm64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-darwin-x64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
+  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+    optional: true
+
   '@octokit/auth-token@3.0.4': {}
 
   '@octokit/core@4.2.4(encoding@0.1.13)':
@@ -17048,6 +17140,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@oxc-project/types@0.141.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.55.0':
     optional: true
@@ -22326,6 +22420,20 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
+
+  noxcturnal@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@oxc-project/types': 0.141.0
+    optionalDependencies:
+      '@noxcturnal/noxcturnal-darwin-arm64': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-darwin-x64': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-linux-arm64-gnu': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-linux-arm64-musl': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-linux-x64-gnu': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-linux-x64-musl': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-win32-arm64-msvc': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-win32-x64-msvc': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
 
   npm-bundled@2.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,10 +44,12 @@ minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:
   - '@expo/*'
+  - '@noxcturnal/*'
   - '@react-native/*'
   - '@turbo/*'
   - 'react-native'
   - multitars
+  - noxcturnal
   - 'react-native-gesture-handler'
   - 'react-native-reanimated'
   - 'react-native-screens'


### PR DESCRIPTION
# Why

tl;dr: When Babel won't be used (TBD), this new transformer can speed up end-to-end cold bundling times by 2x (3x per-module transform times)

## Context

This branch uses [noxcturnal](https://github.com/expo/noxcturnal), a new internal project, for transforming apps that don't have a custom Babel config or Babel transformer.

> [!WARNING]
> This is an **internal experiment** and not reflective of final changes in SDK 58, or representative of what the implementation, which is currently a **proof of concept**, may look like in the future!

Currently, the transform worker has several modes, of which we're mostly focused on the JS part. The JS pipeline (most of the times) can be thought of as being split into two parts:
- the `babel-preset-expo` run (split itself into: language preset, platform preset, and plugins)
- the post-processing/deps run (`collectDependencies`, `importExport`, etc)

The Babel pipeline is Metro-native, but has a cap on performance. While the cache smooths this over, every transformation has to pay a cost that is almost irreducible for us. Other changes, like the source-map format switch (which is built-into the upcoming, latest version of Metro) do not unlock a high enough performance benefit to ignore Babel indefinitely. And ultimately, when a transform isn't cached, the time-per-module on Babel is higher than we'd like with a ceiling on how much we can improve it.

While Hermes v1 reduced the [amount of plugins](https://github.com/expo/expo/blob/91d17018889b9eaa4e9eb63a757bfa41633e7fde/packages/babel-preset-expo/src/configs/hermes-v1.ts) we have to apply in Babel (and 3 of them are temporary), it hasn't reduced the cost by as much as we'd hoped, since Babel's inherent cost is quite high, to support the rich plugin API it comes with.

## Proposal

`noxcturnal` is an experiment to wholesale replace the Babel pipeline entirely. When a user isn't customising Babel, we're free to replace the Babel pipeline for every module that isn't using `react-native-worklets` or `react-native-codegen`. Every other module — assuming `babel-preset-expo`'s defaults are used — is a known set of transforms.

However, our internal plugins are a shifting target and must stay maintainable, which means `noxcturnal` itself is split into two parts:
- a fully native part
- a JS-driven plugin API layer

The fully native part takes care of Flow transformation (via `hermes-parser`), TypeScript lowering, JSX (modern) transforms, and other language transforms. It also takes care of "language lowering" i.e. transforming language features, such as block scoping, async generators, etc.

However, the JS-drive plugin API layer is an API that _vaguely_ resembles Babel (with more configuration to introduce constraints) that takes care of our "business logic". This is mostly the plugins that live in `babel-preset-expo`'s `plugins` folder (without the few language-feature plugins): https://github.com/expo/expo/tree/91d17018889b9eaa4e9eb63a757bfa41633e7fde/packages/babel-preset-expo/src/plugins

# How

The main pipeline that this is driven by is a NAPI-rs library, which uses `oxc` for parsing, and orchestrates commands to and from the JS side to run the plugins.

Most transforms that are "fixed" (as in, they'll never change), are implemented natively. However, all of our own plugins are implemented in the plugin API.

The latter is an imitation of Rollup's acorn + magic-string concept. The AST is used to navigate the input code, but the plugins then instruct edits to be made, which later collapse into generating output code and source-map edits.

The `functionMap` funcionality from Metro is built into `noxcturnal` however.

When `noxcturnal` rejects a file (due to it being unsupported) or a plugin bails to Babel's worklets or react-native-codegen plugins, the transformer will switch over to the old Babel pipeline. The same happens for every module, and the transformer will immediately bail, if the Babel config (or Babel transformer) have been customised.

> [!NOTE]
> In the future, we can consider several levels of support here such as:
> - Only applying Babel to non-`node_modules` code
> - Only applying Babel as a post-processing step after noxcturnal
> - Applying the two options above partially or dynamically
> - Allow custom transform plugins to be added
> However, many of these features require API changes in Expo first

# Test Plan

- `apps/router-e2e` enables `experiments.noxcturnalTransformWorker` by default
- `apps/native-component-list` enables `experiments.noxcturnalTransformWorker` by default

Not everything will yet be 100% identical, but differential testing on the outputs should ensure that we're very close to identical output. Further modifications and testing should be done after merging this initial implementation.

As for performance, typically we achieve an approx. 2x speed up and a 3x faster per-module transform time. Further improvements are possible.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
