### PR TITLE
[expo-calendar][ios] Fix crash reading `calendarId` when `EKCalendarItem.calendar` is nil

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix a crash when reading `calendarId` on an event or reminder whose `EKCalendarItem.calendar` is nil. The property is `null_unspecified` in the EventKit headers, so the bare access was an implicit force-unwrap that trapped the JS thread. ([#48445](https://github.com/expo/expo/pull/48445) by [@cvburgess](https://github.com/cvburgess))
 - [ios] Fix typo in the internal permissions exception name (`MissionPermissionsException` -> `MissingPermissionsException`), which corrects the error code surfaced to JS from `ERR_MISSION_PERMISSIONS` to `ERR_MISSING_PERMISSIONS`. ([#47804](https://github.com/expo/expo/pull/47804) by [@conanm](https://github.com/conanm))
 
 ### 💡 Others

--- a/packages/expo-calendar/ios/Conversions/Conversions.swift
+++ b/packages/expo-calendar/ios/Conversions/Conversions.swift
@@ -108,7 +108,7 @@ func serializeCalendar(item: EKCalendarItem, with formatter: DateFormatter) -> [
   var serailizedItem = [String: Any?]()
 
   serailizedItem["id"] = item.calendarItemIdentifier
-  serailizedItem["calendarId"] = item.calendar.calendarIdentifier
+  serailizedItem["calendarId"] = item.calendar?.calendarIdentifier
   if let title = item.title {
     serailizedItem["title"] = title
   }

--- a/packages/expo-calendar/ios/Next/CalendarNextModule.swift
+++ b/packages/expo-calendar/ios/Next/CalendarNextModule.swift
@@ -381,7 +381,7 @@ public final class CalendarNextModule: Module {
       }
 
       Property("calendarId") { (expoEvent: ExpoCalendarEvent) in
-        expoEvent.event?.calendar.calendarIdentifier
+        expoEvent.event?.calendar?.calendarIdentifier
       }
 
       Property("title") { (expoEvent: ExpoCalendarEvent) in
@@ -544,7 +544,7 @@ public final class CalendarNextModule: Module {
       }
 
       Property("calendarId") { (expoReminder: ExpoCalendarReminder) in
-        expoReminder.reminder?.calendar.calendarIdentifier
+        expoReminder.reminder?.calendar?.calendarIdentifier
       }
 
       Property("title") { (expoReminder: ExpoCalendarReminder) in


### PR DESCRIPTION
# Why

Fixes #48444.

`EKCalendarItem.calendar` is declared `null_unspecified` in the EventKit headers, and its documentation states *"This will be nil for new calendar items until you set it."* `null_unspecified` imports into Swift as `EKCalendar!`, so a bare member access on it is a force-unwrap.

Three call sites access it that way. In two of them the `?.` guards the wrong value — `event` / `reminder` rather than `calendar`:

```swift
expoEvent.event?.calendar.calendarIdentifier       // guards `event`, force-unwraps `calendar`
expoReminder.reminder?.calendar.calendarIdentifier // ditto
item.calendar.calendarIdentifier                   // unguarded
```

When an `EKEvent` or `EKReminder` has a nil `calendar`, reading the `calendarId` property from JS traps the JS thread with `EXC_BREAKPOINT` inside `_assertionFailure` and takes the app down. It cannot be caught from JS, because the trap is inside the property getter.

`Conversions.swift:111` is in `serializeCalendar(item:with:)`, which both the event and reminder serializers call, so the legacy (non-`Next`) API is affected too.

Reproducible on Mac Catalyst (macOS 26.5 / Xcode 26.6): some events EventKit returns on macOS have a nil `calendar`, so listing a day's events and reading `.calendarId` crashes immediately. I could not produce a calendar-less event on iOS, so there it appears latent rather than actively broken — but it is a force-unwrap of a value Apple documents as nullable.

# How

Optional-chain `calendar` in all three places. This matches the safe form already used for the calendar class in the same file:

https://github.com/expo/expo/blob/main/packages/expo-calendar/ios/Next/CalendarNextModule.swift#L202

`calendarId` becomes `string | undefined` for items with no calendar, which seems strictly preferable to a hard crash. The TypeScript types already model the surrounding record loosely enough that this needs no type change; happy to adjust if you'd rather it be explicit.

# Test Plan

- Built and ran a React Native 0.86 / SDK 57 app as a Mac Catalyst target on macOS 26.5.
- Before: navigating between days in a calendar-backed view crashed on every day change with `EXC_BREAKPOINT` in `closure #2 in closure #16 in CalendarNextModule.definition()`.
- After: no crash across repeated day navigation; events with a calendar still resolve `calendarId` normally, and events without one report `undefined`.
- No behavior change on iOS, where `calendar` was already non-nil in testing.

# Checklist

- [x] Documentation is up to date to reflect these changes (no user-facing API change).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no native changes beyond the guarded accesses).
