### PR TITLE
[ios][jsi] Add JavaScriptRuntime.collectGarbage

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add `JavaScriptRuntime.collectGarbage(cause:)` that requests a full garbage collection through the runtime's JSI instrumentation. It is a no-op on engines whose runtime doesn't implement GC instrumentation, unlike the Hermes-only `gc()` global that the tests used to evaluate. ([#48446](https://github.com/expo/expo/pull/48446) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add `JavaScriptRuntime.runOrSchedule` that runs the given closure synchronously when called on the JavaScript thread and schedules it asynchronously otherwise. ([#47915](https://github.com/expo/expo/pull/47915) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptPromise.resolve` overload that takes a `JavaScriptEncodable` value, encoding it on the JavaScript thread and rejecting the promise if encoding or the resolver call throws. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Add a `JavaScriptEncodable` conformance for `Task` that encodes it to a JS `Promise` settling with the task's result, so native code can hand JavaScript a promise as a value. ([#47861](https://github.com/expo/expo/pull/47861) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -5,6 +5,9 @@
 
 #include <TargetConditionals.h>
 
+// `jsi.h` only forward-declares `jsi::Instrumentation`.
+#include <jsi/instrumentation.h>
+
 #include "HostFunctionClosure.h"
 #include "CppError.h"
 #include "IRuntimeCompat.h"
@@ -139,6 +142,11 @@ inline jsi::Value evaluateJavaScript(jsi::IRuntime &runtime, const std::shared_p
   return expo::CppError::tryCatch(runtime, [&] {
     return runtime.evaluateJavaScript(buffer, sourceURL);
   });
+}
+
+// `jsi::Instrumentation` is not imported into Swift, so reach it from here.
+inline void collectGarbage(jsi::IRuntime &runtime, const std::string &cause) {
+  runtime.instrumentation().collectGarbage(cause);
 }
 
 inline jsi::Value callFunction(jsi::IRuntime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -686,6 +686,22 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     return result.is("Promise") ? try await result.getPromise().await() : result
   }
 
+  // MARK: - Garbage collection
+
+  /// Requests a full, synchronous garbage collection of the JavaScript heap.
+  ///
+  /// Intended for tests and memory diagnostics. The engine collects on its own, so calling this in
+  /// production code usually costs more than it saves.
+  ///
+  /// - Note: This is a no-op on engines whose runtime doesn't implement GC instrumentation. JSI's
+  ///   default implementation does nothing; Hermes overrides it with a real collection.
+  /// - Parameter cause: Reason for the collection, as the engine should report it in its logs.
+  ///   Defaults to the calling function's name.
+  @JavaScriptActor
+  public func collectGarbage(cause: String = #function) {
+    expo.collectGarbage(pointee, std.string(cause))
+  }
+
   // MARK: - Equatable
 
   public static func == (lhs: JavaScriptRuntime, rhs: JavaScriptRuntime) -> Bool {

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
@@ -182,8 +182,8 @@ struct JavaScriptArrayBufferTests {
       // Buffer goes out of scope here
     }
 
-    // Hermes gc() is synchronous, so the buffer should be collected immediately.
-    try runtime.eval("gc()")
+    // Hermes collects synchronously, so the buffer should be collected immediately.
+    runtime.collectGarbage()
 
     cleanupCalled = flag.pointee
     flag.deallocate()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptNativeStateTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptNativeStateTests.swift
@@ -78,7 +78,7 @@ struct JavaScriptNativeStateTests {
     object1.unsetNativeState()
 
     // Force garbage collection so the previous C++ pointee is dropped.
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     // Reattaching transparently materializes a fresh pointee.
     object2.setNativeState(nativeState)
@@ -106,7 +106,7 @@ struct JavaScriptNativeStateTests {
     object.unsetNativeState()
 
     // Force garbage collection
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     #expect(deallocatorCalled == true)
   }
@@ -125,12 +125,12 @@ struct JavaScriptNativeStateTests {
 
     // Unset from the first object — deallocator should not fire yet.
     object1.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
     #expect(deallocatorCallCount == 0)
 
     // Unset from the second object — now the deallocator should fire exactly once.
     object2.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
     #expect(deallocatorCallCount == 1)
   }
 
@@ -141,7 +141,7 @@ struct JavaScriptNativeStateTests {
     object.setNativeState(nativeState)
 
     // GC shouldn't release the underlying C++ pointee while the JS object is reachable.
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     #expect(object.getNativeState() === nativeState)
   }
@@ -183,7 +183,7 @@ struct JavaScriptNativeStateTests {
 
     object1.setNativeState(nativeState)
     object1.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
     #expect(deallocatorCallCount == 1)
 
     // Re-attaching builds a new C++ pointee; the wrapper-level deallocator
@@ -192,7 +192,7 @@ struct JavaScriptNativeStateTests {
     #expect(object2.getNativeState() === nativeState)
 
     object2.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
     #expect(deallocatorCallCount == 2)
   }
 
@@ -209,7 +209,7 @@ struct JavaScriptNativeStateTests {
       // baked into the C++ pointee is the only Swift-side strong reference.
     }
 
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     // The wrapper is still alive because the C++ pointee (held by JSI's slot)
     // retains it via Unmanaged. `getNativeState` recovers it.
@@ -219,7 +219,7 @@ struct JavaScriptNativeStateTests {
     // Once detached and GC'd, the C++ pointee dies, releases the Unmanaged,
     // and the Swift wrapper finally deallocates.
     object.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
     #expect(weakWrapper == nil)
   }
 
@@ -232,7 +232,7 @@ struct JavaScriptNativeStateTests {
     object2.setNativeState(nativeState)
 
     object1.unsetNativeState()
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     #expect(object1.hasNativeState() == false)
     #expect(object2.hasNativeState() == true)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -1005,6 +1005,35 @@ struct JavaScriptRuntimeTests {
     wrapper = nil
     _ = wrapper
   }
+
+  // MARK: - Garbage collection
+
+  @Test
+  func `collecting garbage releases an unreachable object`() {
+    var weakObject: JavaScriptWeakObject? = nil
+
+    do {
+      let object = runtime.createObject()
+      weakObject = JavaScriptWeakObject(runtime, object)
+      #expect((weakObject?.lock() != nil) == true)
+    }
+
+    runtime.collectGarbage()
+
+    #expect((weakObject?.lock() == nil) == true)
+  }
+
+  @Test
+  func `collecting garbage keeps a reachable object alive`() {
+    let object = runtime.createObject()
+    object.setProperty("survives", value: true)
+    let weakObject = JavaScriptWeakObject(runtime, object)
+
+    runtime.collectGarbage(cause: "test")
+
+    let survives = weakObject.lock()?.getProperty("survives").getBool()
+    #expect(survives == true)
+  }
 }
 
 private final class TestRuntimeScheduler: @unchecked Sendable {

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
@@ -172,7 +172,7 @@ struct JavaScriptTypedArrayTests {
     let typedArray = try runtime.eval("(() => new Uint8Array([1, 2, 3, 4]))()").getTypedArray()
 
     // The backing ArrayBuffer should remain alive because `JavaScriptTypedArray` holds it.
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     typedArray.withUnsafeBytes { bytes in
       #expect(bytes[0] == 1)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
@@ -51,11 +51,11 @@ struct JavaScriptValuesBufferTests {
     // Allocate a buffer that captures the JS object as an argument; the result is
     // discarded and `deinit` runs at the end of this statement. If `deinit` skipped
     // `deinitialize`, the contained `jsi::Value` would still hold a strong ref and
-    // the weak handle would survive `gc()`.
+    // the weak handle would survive the collection below.
     _ = JavaScriptValuesBuffer.allocate(in: runtime, with: object.asValue())
     _ = consume object
 
-    try runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     let stillAlive = weak.lock() != nil
     #expect(stillAlive == false)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptWeakObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptWeakObjectTests.swift
@@ -57,7 +57,7 @@ struct JavaScriptWeakObjectTests {
     #expect((weakObject?.lock() != nil) == true)
 
     // Force garbage collection
-    _ = try! runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     // Object should be collected now
     // Note: This test may be flaky depending on GC behavior
@@ -79,7 +79,7 @@ struct JavaScriptWeakObjectTests {
     }
 
     // Force garbage collection
-    _ = try! runtime.eval("gc() && gc() && gc()")
+    runtime.collectGarbage()
 
     // After collection, asValue should return undefined
     // Note: This test may be flaky depending on GC behavior

--- a/packages/expo-modules-jsi/apple/scripts/generate-modulemap.sh
+++ b/packages/expo-modules-jsi/apple/scripts/generate-modulemap.sh
@@ -46,10 +46,19 @@ if [[ ! -f "$JSI_UMBRELLA" ]]; then
 fi
 [[ -f "$JSI_UMBRELLA" ]] || { echo "error: cannot locate jsi.h" >&2; exit 1; }
 
+# The umbrella header doesn't include `instrumentation.h`, so declare it explicitly.
+# Otherwise including it warns about a missing `jsi.instrumentation` submodule.
+JSI_INSTRUMENTATION="$(dirname "$JSI_UMBRELLA")/instrumentation.h"
+JSI_EXTRA_HEADERS=""
+if [[ -f "$JSI_INSTRUMENTATION" ]]; then
+  JSI_EXTRA_HEADERS="
+  header \"${JSI_INSTRUMENTATION}\""
+fi
+
 # Avoid touching the file when contents would be identical, so the xcframework
 # hash cache and Xcode don't see a spurious change when inputs are unchanged.
 NEW_CONTENT="module jsi {
-  umbrella header \"${JSI_UMBRELLA}\"
+  umbrella header \"${JSI_UMBRELLA}\"${JSI_EXTRA_HEADERS}
 
   export *
   module * { export * }


### PR DESCRIPTION
# Why

There was no way to force a GC from native code, so the JSI tests were calling the Hermes-only `gc()` global through `eval`.

# How

Added `JavaScriptRuntime.collectGarbage(cause:)`. It just forwards to `collectGarbage` on the runtime's JSI instrumentation, through a tiny C++ helper since `jsi::Instrumentation` isn't imported into Swift. On engines that don't implement GC instrumentation it does nothing (JSI's default impl is empty), so the doc comment mentions it.

I also had to declare `instrumentation.h` in the generated `jsi` modulemap, since `jsi.h` doesn't include it.

Tests use this now instead of `gc()`.

# Test Plan

Two new cases in `JavaScriptRuntimeTests`: an unreachable object gets released, a reachable one survives. `pnpm test:integration` passes and the xcframework still builds for all slices.
