### PR TITLE
[router] Abandon and abort loader requests removed by navigation

### DIFF
--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -41,6 +41,7 @@ const IndexScreen = () => {
 
       <SiteLinks>
         <SiteLink href="/second">Go to Second</SiteLink>
+        <SiteLink href="/slow">Go to Slow</SiteLink>
         <SiteLink href="/env">Go to Env</SiteLink>
         <SiteLink href="/request">Go to Request</SiteLink>
         <SiteLink href="/response">Go to Response</SiteLink>

--- a/apps/router-e2e/__e2e__/server-loader/app/slow.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/slow.tsx
@@ -1,0 +1,50 @@
+import { useLoaderData } from 'expo-router';
+import { Suspense } from 'react';
+
+import { Loading } from '../components/Loading';
+import { SiteLinks, SiteLink } from '../components/SiteLink';
+import { Table, TableRow } from '../components/Table';
+
+export async function loader() {
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+  return {
+    data: 'slow',
+    loadedAt: new Date().toISOString(),
+  };
+}
+
+export default function SlowRoute() {
+  return (
+    <Suspense fallback={<SlowFallback />}>
+      <SlowScreen />
+    </Suspense>
+  );
+}
+
+function SlowFallback() {
+  return (
+    <>
+      <Loading />
+      <SiteLinks>
+        <SiteLink href="/second">Go to Second</SiteLink>
+      </SiteLinks>
+    </>
+  );
+}
+
+function SlowScreen() {
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <Table>
+        <TableRow label="Loader Data" value={data} testID="loader-result" />
+      </Table>
+
+      <SiteLinks>
+        <SiteLink href="/">Go to Index</SiteLink>
+        <SiteLink href="/second">Go to Second</SiteLink>
+      </SiteLinks>
+    </>
+  );
+}

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -49,6 +49,7 @@ describe.each(
     expect(files).not.toContain('request.html');
     expect(files).not.toContain('response.html');
     expect(files).not.toContain('second.html');
+    expect(files).not.toContain('slow.html');
     expect(files).not.toContain('nested/index.html');
     expect(files).not.toContain('nullish/[value].html');
     expect(files).not.toContain('nullish/null.html');
@@ -66,6 +67,7 @@ describe.each(
     expect(files).toContain('_expo/loaders/request.js');
     expect(files).toContain('_expo/loaders/response.js');
     expect(files).toContain('_expo/loaders/second.js');
+    expect(files).toContain('_expo/loaders/slow.js');
     expect(files).toContain('_expo/loaders/nullish/[value].js');
     expect(files).toContain('_expo/loaders/posts/[postId].js');
     expect(files).toContain('_expo/loaders/(group)/index.js');

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -50,6 +50,7 @@ describe.each(
     expect(files).toContain('request.html');
     expect(files).toContain('response.html');
     expect(files).toContain('second.html');
+    expect(files).toContain('slow.html');
     expect(files).toContain('nested/index.html');
     expect(files).toContain('nullish/[value].html');
     expect(files).toContain('nullish/null.html');
@@ -67,6 +68,7 @@ describe.each(
     expect(files).toContain('_expo/loaders/request');
     expect(files).toContain('_expo/loaders/response');
     expect(files).toContain('_expo/loaders/second');
+    expect(files).toContain('_expo/loaders/slow');
     expect(files).toContain('_expo/loaders/nested/index');
     expect(files).toContain('_expo/loaders/nullish/[value]');
     expect(files).toContain('_expo/loaders/nullish/null');
@@ -274,6 +276,7 @@ describe.each(
         { namedRegex: '^/posts/static\\-post\\-1(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/posts/static\\-post\\-2(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/request(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/slow(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/static\\-helper(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/\\(group\\)/index(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/env(?:/)?$', headers: SSG_DEFAULT },
@@ -288,6 +291,7 @@ describe.each(
         { namedRegex: '^/_expo/loaders/posts/static\\-post\\-1(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/posts/static\\-post\\-2(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/request(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/slow(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/static\\-helper(?:/)?$', headers: SSG_DEFAULT },
         // Loader-declared headers: appended last so they win, applied to page and loader file.
         {

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -172,6 +172,34 @@ for (const outputMode of outputModes) {
       await expect(suspenseFallback).not.toBeVisible();
     });
 
+    test('abandons a suspended load on Back and starts fresh on revisit', async ({ page }) => {
+      const pageErrors = pageCollectErrors(page);
+      const slowRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/slow')) {
+          slowRequests.push(request.url());
+        }
+      });
+
+      await page.goto(expoStart.url.href);
+      await page.click('a[href="/slow"]');
+      await expect(page.locator('[data-testid="suspense-fallback"]')).toBeVisible();
+      await expect.poll(() => slowRequests).toHaveLength(1);
+
+      await page.goBack();
+      await expect(page).toHaveURL(expoStart.url.href);
+
+      await page.click('a[href="/slow"]');
+      await expect(page.locator('[data-testid="suspense-fallback"]')).toBeVisible();
+      await expect.poll(() => slowRequests).toHaveLength(2);
+
+      const loaderResult = page.locator('[data-testid="loader-result"]');
+      await expect(loaderResult).toBeVisible({ timeout: 10_000 });
+      expect(JSON.parse((await loaderResult.textContent())!)).toMatchObject({ data: 'slow' });
+      expect(slowRequests).toHaveLength(2);
+      expect(pageErrors.all).toEqual([]);
+    });
+
     test('navigates from route without loader to route with loader', async ({ page }) => {
       const pageErrors = pageCollectErrors(page);
 

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -174,6 +174,34 @@ for (const outputMode of outputModes) {
       await expect(suspenseFallback).not.toBeVisible();
     });
 
+    test('abandons a suspended load on Back and starts fresh on revisit', async ({ page }) => {
+      const pageErrors = pageCollectErrors(page);
+      const slowRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/slow')) {
+          slowRequests.push(request.url());
+        }
+      });
+
+      await page.goto(expoStart.url.href);
+      await page.click('a[href="/slow"]');
+      await expect(page.locator('[data-testid="suspense-fallback"]')).toBeVisible();
+      await expect.poll(() => slowRequests).toHaveLength(1);
+
+      await page.goBack();
+      await expect(page).toHaveURL(expoStart.url.href);
+
+      await page.click('a[href="/slow"]');
+      await expect(page.locator('[data-testid="suspense-fallback"]')).toBeVisible();
+      await expect.poll(() => slowRequests).toHaveLength(2);
+
+      const loaderResult = page.locator('[data-testid="loader-result"]');
+      await expect(loaderResult).toBeVisible({ timeout: 10_000 });
+      expect(JSON.parse((await loaderResult.textContent())!)).toMatchObject({ data: 'slow' });
+      expect(slowRequests).toHaveLength(2);
+      expect(pageErrors.all).toEqual([]);
+    });
+
     test('navigates from route without loader to route with loader', async ({ page }) => {
       const pageErrors = pageCollectErrors(page);
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Add a `processScreens` option to the `standard-navigation` integration. ([#48290](https://github.com/expo/expo/pull/48290) by [@Ubax](https://github.com/Ubax))
 - Hide the splash screen when the built-in `+not-found` screen renders ([#48721](https://github.com/expo/expo/pull/48721) by [@Ubax](https://github.com/Ubax))
 - Honor loader `Cache-Control` headers via the platform HTTP cache instead of caching loader data in memory ([#48087](https://github.com/expo/expo/pull/48087) by [@hassankhan](https://github.com/hassankhan))
+- Add best-effort cancellation of pending loader requests when their committed route shells are removed during navigation. ([#48451](https://github.com/expo/expo/pull/48451) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -59,6 +59,7 @@
 - Add a `processScreens` option to the `standard-navigation` integration. ([#48290](https://github.com/expo/expo/pull/48290) by [@Ubax](https://github.com/Ubax))
 - Hide the splash screen when the built-in `+not-found` screen renders ([#48721](https://github.com/expo/expo/pull/48721) by [@Ubax](https://github.com/Ubax))
 - Honor loader `Cache-Control` headers via the platform HTTP cache instead of caching loader data in memory ([#48087](https://github.com/expo/expo/pull/48087) by [@hassankhan](https://github.com/hassankhan))
+- Cancel pending loader requests when their routes are removed during navigation ([#48451](https://github.com/expo/expo/pull/48451) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/__tests__/getId.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/getId.test.ios.tsx
@@ -1,4 +1,4 @@
-import { getSingularId } from '../useScreens';
+import { getSingularId } from '../utils/getSingularId';
 
 describe(getSingularId, () => {
   it(`returns the context string when the route is not dynamic and there are no search params`, () => {

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -1,6 +1,6 @@
-import { act } from '@testing-library/react-native';
+import { act, render, renderAsync } from '@testing-library/react-native';
 import { expectTypeOf } from 'expect-type';
-import { type ReactNode, useLayoutEffect } from 'react';
+import { type ReactNode, StrictMode, Suspense, use, useLayoutEffect } from 'react';
 import { Text } from 'react-native';
 
 import { router, Slot } from '../../exports';
@@ -11,9 +11,11 @@ import {
   defaultLoaderContextValue,
   LoaderContext,
 } from '../../loaders/LoaderContext';
+import { LoaderRouteLifecycle } from '../../loaders/LoaderRouteLifecycle';
 import { ServerDataLoaderContext } from '../../loaders/ServerDataLoaderContext';
+import { readLoaderData } from '../../loaders/readLoaderData';
 import { fetchLoader } from '../../loaders/utils';
-import { renderRouter } from '../../testing-library';
+import { renderRouter, screen } from '../../testing-library';
 import { useLoaderData } from '../useLoaderData';
 import { renderHook } from './renderHook';
 
@@ -438,7 +440,9 @@ describe(useLoaderData, () => {
 
     ctx.client.execute('/index', () => oldFetch.promise);
     ctx.client.clear();
-    const replacementUnsubscribe = ctx.client.subscribeLoader('/index');
+    const replacementUnsubscribe = ctx.client.subscribeLoader('/index', undefined, {
+      committed: true,
+    });
     ctx.store.set('/index', { data: { version: 2 } });
     hook.rerender(undefined);
     const rendersBeforeOldSettle = renders;
@@ -493,6 +497,224 @@ describe(useLoaderData, () => {
 
     expect(latestData).toEqual({ id: 2 });
     expect(renders).toBe(rendersBeforeOldSettle);
+  });
+
+  it('aborts a suspended dynamic route through the real route shell and refetches on revisit', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    const signals: AbortSignal[] = [];
+    const resolvers: ((value: unknown) => void)[] = [];
+    fetchLoaderMock.mockImplementation((_path, requestInit) => {
+      const signal = requestInit!.signal as AbortSignal;
+      return new Promise((resolve, reject) => {
+        signals.push(signal);
+        resolvers.push(resolve);
+        signal.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+    renderRouter({
+      _layout: {
+        default: () => <Slot />,
+        SuspenseFallback: () => <Text>Loading</Text>,
+      },
+      index: () => <Text>Home</Text>,
+      'users/[id]': function UserScreen() {
+        const data = useLoaderData();
+        return <Text testID="user-data">{JSON.stringify(data)}</Text>;
+      },
+    });
+    jest.useRealTimers();
+
+    await act(async () => router.push('/users/1'));
+    expect(screen.getByText('Loading')).toBeVisible();
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/users/1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(signals).toHaveLength(1);
+
+    await act(async () => router.back());
+    expect(signals[0]!.aborted).toBe(true);
+    expect(defaultLoaderContextValue.store.get('/users/1')).toBeUndefined();
+
+    await act(async () => router.push('/users/1'));
+    expect(signals).toHaveLength(2);
+    expect(signals[1]).not.toBe(signals[0]);
+
+    await act(async () => {
+      resolvers[1]!({ fresh: true });
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId('user-data')).toHaveTextContent('{"fresh":true}');
+    expect(defaultLoaderContextValue.store.get('/users/1')).toEqual({ data: { fresh: true } });
+  });
+
+  it.each([
+    ['params', '/users/1', '/users/2'],
+    ['query', '/users/1?sort=asc', '/users/1?sort=desc'],
+  ])(
+    'abandons an old pending path when a mounted route changes %s',
+    async (_, oldPath, newPath) => {
+      const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+      const signals: AbortSignal[] = [];
+      fetchLoaderMock.mockImplementation((_path, requestInit) => {
+        const signal = requestInit!.signal as AbortSignal;
+        signals.push(signal);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+      const { ctx } = createLoaderTestContext();
+
+      function UserScreen({ path }: { path: string }) {
+        const result = readLoaderData(ctx, path, fetchLoaderMock);
+        if (result instanceof Promise) {
+          use(result);
+        }
+        return <Text>User</Text>;
+      }
+
+      function UserRouteShell({ path }: { path: string }) {
+        return (
+          <>
+            <LoaderRouteLifecycle path={path} />
+            <Suspense fallback={<Text>Loading</Text>}>
+              <UserScreen path={path} />
+            </Suspense>
+          </>
+        );
+      }
+
+      const route = await renderAsync(
+        <LoaderContext value={ctx}>
+          <UserRouteShell path={oldPath} />
+        </LoaderContext>
+      );
+
+      await route.rerenderAsync(
+        <LoaderContext value={ctx}>
+          <UserRouteShell path={newPath} />
+        </LoaderContext>
+      );
+
+      expect(fetchLoaderMock.mock.calls.map(([path]) => path)).toEqual([oldPath, newPath]);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+      expect(ctx.store.get(oldPath)).toBeUndefined();
+    }
+  );
+
+  it('keeps a pending route load through Strict Mode effect replay', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/slow', (_path, requestInit) => {
+      signal = requestInit.signal as AbortSignal;
+      return new Promise(() => {});
+    });
+
+    const lifecycle = render(
+      <StrictMode>
+        <LoaderContext value={ctx}>
+          <LoaderRouteLifecycle path="/slow" />
+        </LoaderContext>
+      </StrictMode>
+    );
+    await act(async () => {});
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/slow')).toBeDefined();
+
+    lifecycle.unmount();
+    await act(async () => {});
+    expect(signal.aborted).toBe(true);
+    expect(ctx.store.get('/slow')).toBeUndefined();
+  });
+
+  it('keeps a pending load when replacing the current route with the same path', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    let signal!: AbortSignal;
+    let resolveFetch!: (value: { fresh: boolean }) => void;
+    let fallbackMounts = 0;
+    let fallbackCleanups = 0;
+
+    fetchLoaderMock.mockImplementation((_path, requestInit) => {
+      const requestSignal = requestInit!.signal!;
+      signal = requestSignal;
+      return new Promise((resolve, reject) => {
+        resolveFetch = resolve;
+        requestSignal.addEventListener('abort', () => reject(requestSignal.reason));
+      });
+    });
+
+    function LoadingFallback() {
+      useLayoutEffect(() => {
+        fallbackMounts++;
+        return () => {
+          fallbackCleanups++;
+        };
+      }, []);
+      return <Text>Loading</Text>;
+    }
+
+    renderRouter({
+      _layout: {
+        default: () => <Slot />,
+        SuspenseFallback: LoadingFallback,
+      },
+      index: () => <Text>Home</Text>,
+      'users/[id]': function UserScreen() {
+        const data = useLoaderData();
+        return <Text testID="user-data">{JSON.stringify(data)}</Text>;
+      },
+    });
+    jest.useRealTimers();
+
+    await act(async () => router.push('/users/1'));
+    const pending = defaultLoaderContextValue.store.get('/users/1');
+    expect(screen.getByText('Loading')).toBeVisible();
+    expect(fallbackMounts).toBe(1);
+    expect(fallbackCleanups).toBe(0);
+
+    await act(async () => router.replace('/users/1'));
+    await act(async () => {});
+
+    expect(fallbackCleanups).toBe(1);
+    expect(fallbackMounts).toBe(2);
+    expect(signal.aborted).toBe(false);
+    expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
+    expect(defaultLoaderContextValue.store.get('/users/1')).toBe(pending);
+
+    await act(async () => {
+      resolveFetch({ fresh: true });
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId('user-data')).toHaveTextContent('{"fresh":true}');
+  });
+
+  it('keeps a pending load when a committed sibling reader remains', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/slow', (_path, requestInit) => {
+      signal = requestInit.signal as AbortSignal;
+      return new Promise(() => {});
+    });
+    const unsubscribeSibling = ctx.client.subscribeLoader('/slow', undefined, {
+      committed: true,
+    });
+
+    const lifecycle = render(
+      <LoaderContext value={ctx}>
+        <LoaderRouteLifecycle path="/slow" />
+      </LoaderContext>
+    );
+    lifecycle.unmount();
+    await act(async () => {});
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/slow')).toBeDefined();
+    unsubscribeSibling();
+    ctx.client.clear();
+    ctx.store.reset();
   });
 
   it(`uses the loader function's return types`, () => {

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -54,6 +54,11 @@ describe(useLoaderData, () => {
       initialUrl: '/users/123',
       expectedPath: '/users/123',
     },
+    {
+      route: 'docs/[...rest]',
+      initialUrl: '/docs/guides/loaders/',
+      expectedPath: '/docs/guides/loaders',
+    },
   ])('resolves $route to $expectedPath', ({ route, initialUrl, expectedPath }) => {
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
       [expectedPath]: { correct: true },
@@ -125,7 +130,10 @@ describe(useLoaderData, () => {
       wrapper: LoaderWrapper,
     });
     expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
-    expect(fetchLoaderMock).toHaveBeenCalledWith('/index');
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/index',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 
   it('retrieves fresh data from `fetchLoaderModule()`', async () => {
@@ -143,7 +151,10 @@ describe(useLoaderData, () => {
       wrapper: LoaderWrapper,
     });
 
-    expect(fetchLoaderMock).toHaveBeenCalledWith('/users/123');
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/users/123',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
 
     await act(async () => {
       await fetchLoaderMock.mock.results[0]!.value;

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent, screen } from '@testing-library/react-native';
+import { act, fireEvent, render, renderAsync, screen } from '@testing-library/react-native';
 import { expectTypeOf } from 'expect-type';
-import { type ReactNode, useLayoutEffect, useState } from 'react';
+import { type ReactNode, StrictMode, Suspense, use, useLayoutEffect, useState } from 'react';
 import { Text } from 'react-native';
 
 import { router, Slot } from '../../exports';
@@ -11,7 +11,9 @@ import {
   defaultLoaderContextValue,
   LoaderContext,
 } from '../../loaders/LoaderContext';
+import { LoaderRouteLifecycle } from '../../loaders/LoaderRouteLifecycle';
 import { ServerDataLoaderContext } from '../../loaders/ServerDataLoaderContext';
+import { readLoaderData } from '../../loaders/readLoaderData';
 import { fetchLoader } from '../../loaders/utils';
 import { renderRouterAsync } from '../../testing-library';
 import { useLoaderData } from '../useLoaderData';
@@ -464,7 +466,9 @@ describe(useLoaderData, () => {
 
     ctx.client.execute('/index', () => oldFetch.promise);
     ctx.client.clear();
-    const replacementUnsubscribe = ctx.client.subscribeLoader('/index');
+    const replacementUnsubscribe = ctx.client.subscribeLoader('/index', undefined, {
+      committed: true,
+    });
     ctx.store.set('/index', { data: { version: 2 } });
     await hook.rerenderAsync(undefined);
     const rendersBeforeOldSettle = renders;
@@ -519,6 +523,224 @@ describe(useLoaderData, () => {
 
     expect(latestData).toEqual({ id: 2 });
     expect(renders).toBe(rendersBeforeOldSettle);
+  });
+
+  it('aborts a suspended dynamic route through the real route shell and refetches on revisit', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    const signals: AbortSignal[] = [];
+    const resolvers: ((value: unknown) => void)[] = [];
+    fetchLoaderMock.mockImplementation((_path, requestInit) => {
+      const signal = requestInit!.signal as AbortSignal;
+      return new Promise((resolve, reject) => {
+        signals.push(signal);
+        resolvers.push(resolve);
+        signal.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+    await renderRouterAsync({
+      _layout: {
+        default: () => <Slot />,
+        SuspenseFallback: () => <Text>Loading</Text>,
+      },
+      index: () => <Text>Home</Text>,
+      'users/[id]': function UserScreen() {
+        const data = useLoaderData();
+        return <Text testID="user-data">{JSON.stringify(data)}</Text>;
+      },
+    });
+    jest.useRealTimers();
+
+    await act(async () => router.push('/users/1'));
+    expect(screen.getByText('Loading')).toBeVisible();
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/users/1',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(signals).toHaveLength(1);
+
+    await act(async () => router.back());
+    expect(signals[0]!.aborted).toBe(true);
+    expect(defaultLoaderContextValue.store.get('/users/1')).toBeUndefined();
+
+    await act(async () => router.push('/users/1'));
+    expect(signals).toHaveLength(2);
+    expect(signals[1]).not.toBe(signals[0]);
+
+    await act(async () => {
+      resolvers[1]!({ fresh: true });
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId('user-data')).toHaveTextContent('{"fresh":true}');
+    expect(defaultLoaderContextValue.store.get('/users/1')).toEqual({ data: { fresh: true } });
+  });
+
+  it.each([
+    ['params', '/users/1', '/users/2'],
+    ['query', '/users/1?sort=asc', '/users/1?sort=desc'],
+  ])(
+    'abandons an old pending path when a mounted route changes %s',
+    async (_, oldPath, newPath) => {
+      const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+      const signals: AbortSignal[] = [];
+      fetchLoaderMock.mockImplementation((_path, requestInit) => {
+        const signal = requestInit!.signal as AbortSignal;
+        signals.push(signal);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+      const { ctx } = createLoaderTestContext();
+
+      function UserScreen({ path }: { path: string }) {
+        const result = readLoaderData(ctx, path, fetchLoaderMock);
+        if (result instanceof Promise) {
+          use(result);
+        }
+        return <Text>User</Text>;
+      }
+
+      function UserRouteShell({ path }: { path: string }) {
+        return (
+          <>
+            <LoaderRouteLifecycle path={path} />
+            <Suspense fallback={<Text>Loading</Text>}>
+              <UserScreen path={path} />
+            </Suspense>
+          </>
+        );
+      }
+
+      const route = await renderAsync(
+        <LoaderContext value={ctx}>
+          <UserRouteShell path={oldPath} />
+        </LoaderContext>
+      );
+
+      await route.rerenderAsync(
+        <LoaderContext value={ctx}>
+          <UserRouteShell path={newPath} />
+        </LoaderContext>
+      );
+
+      expect(fetchLoaderMock.mock.calls.map(([path]) => path)).toEqual([oldPath, newPath]);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+      expect(ctx.store.get(oldPath)).toBeUndefined();
+    }
+  );
+
+  it('keeps a pending route load through Strict Mode effect replay', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/slow', (_path, requestInit) => {
+      signal = requestInit.signal as AbortSignal;
+      return new Promise(() => {});
+    });
+
+    const lifecycle = render(
+      <StrictMode>
+        <LoaderContext value={ctx}>
+          <LoaderRouteLifecycle path="/slow" />
+        </LoaderContext>
+      </StrictMode>
+    );
+    await act(async () => {});
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/slow')).toBeDefined();
+
+    lifecycle.unmount();
+    await act(async () => {});
+    expect(signal.aborted).toBe(true);
+    expect(ctx.store.get('/slow')).toBeUndefined();
+  });
+
+  it('keeps a pending load when replacing the current route with the same path', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    let signal!: AbortSignal;
+    let resolveFetch!: (value: { fresh: boolean }) => void;
+    let fallbackMounts = 0;
+    let fallbackCleanups = 0;
+
+    fetchLoaderMock.mockImplementation((_path, requestInit) => {
+      const requestSignal = requestInit!.signal!;
+      signal = requestSignal;
+      return new Promise((resolve, reject) => {
+        resolveFetch = resolve;
+        requestSignal.addEventListener('abort', () => reject(requestSignal.reason));
+      });
+    });
+
+    function LoadingFallback() {
+      useLayoutEffect(() => {
+        fallbackMounts++;
+        return () => {
+          fallbackCleanups++;
+        };
+      }, []);
+      return <Text>Loading</Text>;
+    }
+
+    await renderRouterAsync({
+      _layout: {
+        default: () => <Slot />,
+        SuspenseFallback: LoadingFallback,
+      },
+      index: () => <Text>Home</Text>,
+      'users/[id]': function UserScreen() {
+        const data = useLoaderData();
+        return <Text testID="user-data">{JSON.stringify(data)}</Text>;
+      },
+    });
+    jest.useRealTimers();
+
+    await act(async () => router.push('/users/1'));
+    const pending = defaultLoaderContextValue.store.get('/users/1');
+    expect(screen.getByText('Loading')).toBeVisible();
+    expect(fallbackMounts).toBe(1);
+    expect(fallbackCleanups).toBe(0);
+
+    await act(async () => router.replace('/users/1'));
+    await act(async () => {});
+
+    expect(fallbackCleanups).toBe(1);
+    expect(fallbackMounts).toBe(2);
+    expect(signal.aborted).toBe(false);
+    expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
+    expect(defaultLoaderContextValue.store.get('/users/1')).toBe(pending);
+
+    await act(async () => {
+      resolveFetch({ fresh: true });
+      await Promise.resolve();
+    });
+    expect(await screen.findByTestId('user-data')).toHaveTextContent('{"fresh":true}');
+  });
+
+  it('keeps a pending load when a committed sibling reader remains', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/slow', (_path, requestInit) => {
+      signal = requestInit.signal as AbortSignal;
+      return new Promise(() => {});
+    });
+    const unsubscribeSibling = ctx.client.subscribeLoader('/slow', undefined, {
+      committed: true,
+    });
+
+    const lifecycle = render(
+      <LoaderContext value={ctx}>
+        <LoaderRouteLifecycle path="/slow" />
+      </LoaderContext>
+    );
+    lifecycle.unmount();
+    await act(async () => {});
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/slow')).toBeDefined();
+    unsubscribeSibling();
+    ctx.client.clear();
+    ctx.store.reset();
   });
 
   it(`uses the loader function's return types`, async () => {

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -54,6 +54,11 @@ describe(useLoaderData, () => {
       initialUrl: '/users/123',
       expectedPath: '/users/123',
     },
+    {
+      route: 'docs/[...rest]',
+      initialUrl: '/docs/guides/loaders/',
+      expectedPath: '/docs/guides/loaders',
+    },
   ])('resolves $route to $expectedPath', async ({ route, initialUrl, expectedPath }) => {
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
       [expectedPath]: { correct: true },
@@ -126,7 +131,10 @@ describe(useLoaderData, () => {
       wrapper: LoaderWrapper,
     });
     expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
-    expect(fetchLoaderMock).toHaveBeenCalledWith('/index');
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/index',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 
   it('retrieves fresh data from `fetchLoaderModule()`', async () => {
@@ -145,7 +153,10 @@ describe(useLoaderData, () => {
       wrapper: LoaderWrapper,
     });
 
-    expect(fetchLoaderMock).toHaveBeenCalledWith('/users/123');
+    expect(fetchLoaderMock).toHaveBeenCalledWith(
+      '/users/123',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
 
     await act(async () => {
       await fetchLoaderMock.mock.results[0]!.value;

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -70,12 +70,16 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
   useEffect(() => {
     // Seeded routes do not reach a read miss, so register their fetcher explicitly for HMR.
     client.registerFetcher(resolvedPath, fetchLoader);
-    const unsubscribe = client.subscribeLoader(resolvedPath, (result, isCurrentSource) => {
-      if (isCurrentSource) {
-        store.set(resolvedPath, result);
-        setVersion((version) => version + 1);
-      }
-    });
+    const unsubscribe = client.subscribeLoader(
+      resolvedPath,
+      (result, isCurrentSource) => {
+        if (isCurrentSource) {
+          store.set(resolvedPath, result);
+          setVersion((version) => version + 1);
+        }
+      },
+      { committed: true }
+    );
     if (store.get(resolvedPath) !== entryAtRender) {
       setVersion((version) => version + 1);
     }

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -4,13 +4,12 @@ import type { LoaderFunction } from 'expo-server';
 import { use, useEffect, useMemo, useState } from 'react';
 
 import { useContextKey } from '../Route';
-import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
 import { LoaderContext } from '../loaders/LoaderContext';
 import { ServerDataLoaderContext } from '../loaders/ServerDataLoaderContext';
 import { readLoaderData } from '../loaders/readLoaderData';
+import { resolveLoaderPath } from '../loaders/resolveLoaderPath';
 import { fetchLoader } from '../loaders/utils';
 import { useStateForPath } from '../react-navigation/native';
-import { getSingularId } from '../useScreens';
 
 type LoaderFunctionResult<T extends LoaderFunction<any>> =
   T extends LoaderFunction<infer R> ? R : unknown;
@@ -42,14 +41,10 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
   const stateForPath = useStateForPath();
   const contextKey = useContextKey();
 
-  const resolvedPath = useMemo(() => {
-    const routeInfo = getRouteInfoFromState(stateForPath);
-    const contextPath = contextKey.startsWith('/') ? contextKey.slice(1) : contextKey;
-    const resolvedPathname = `/${getSingularId(contextPath, { params: routeInfo.params })}`;
-    const searchString = routeInfo.searchParams?.toString() || '';
-
-    return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
-  }, [contextKey, stateForPath]);
+  const resolvedPath = useMemo(
+    () => resolveLoaderPath(contextKey, stateForPath),
+    [contextKey, stateForPath]
+  );
 
   // Loader data stays in the shared Suspense store; local state only invalidates this reader.
   const [, setVersion] = useState(0);

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -9,7 +9,7 @@ import { ServerDataLoaderContext } from '../loaders/ServerDataLoaderContext';
 import { readLoaderData } from '../loaders/readLoaderData';
 import { resolveLoaderPath } from '../loaders/resolveLoaderPath';
 import { fetchLoader } from '../loaders/utils';
-import { useStateForPath } from '../react-navigation/native';
+import { useCurrentRouteInfo } from './useCurrentRouteInfo';
 
 type LoaderFunctionResult<T extends LoaderFunction<any>> =
   T extends LoaderFunction<infer R> ? R : unknown;
@@ -38,12 +38,12 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
 
   const { client, store } = ctx;
 
-  const stateForPath = useStateForPath();
+  const routeInfo = useCurrentRouteInfo();
   const contextKey = useContextKey();
 
   const resolvedPath = useMemo(
-    () => resolveLoaderPath(contextKey, stateForPath),
-    [contextKey, stateForPath]
+    () => resolveLoaderPath(contextKey, routeInfo),
+    [contextKey, routeInfo]
   );
 
   // Loader data stays in the shared Suspense store; local state only invalidates this reader.

--- a/packages/expo-router/src/layouts/stack-router.ts
+++ b/packages/expo-router/src/layouts/stack-router.ts
@@ -21,7 +21,7 @@ import {
 } from '../react-navigation/native';
 import type { NativeStackNavigatorProps } from '../react-navigation/native-stack';
 import type { SingularOptions } from '../useScreens';
-import { getSingularId } from '../useScreens';
+import { getSingularId } from '../utils/getSingularId';
 
 type GetId = NonNullable<RouterConfigOptions['routeGetIdList'][string]>;
 

--- a/packages/expo-router/src/layouts/stack-router.ts
+++ b/packages/expo-router/src/layouts/stack-router.ts
@@ -22,7 +22,7 @@ import { attachRouteState } from '../react-navigation/routers/attachRouteState';
 import { ensureStateType } from '../react-navigation/routers/ensureStateType';
 import { createRouteKeyMinter } from '../react-navigation/routers/stateKeys';
 import type { SingularOptions } from '../useScreens';
-import { getSingularId } from '../useScreens';
+import { getSingularId } from '../utils/getSingularId';
 
 type GetId = NonNullable<RouterConfigOptions['routeGetIdList'][string]>;
 

--- a/packages/expo-router/src/loaders/LoaderClient.ts
+++ b/packages/expo-router/src/loaders/LoaderClient.ts
@@ -1,11 +1,16 @@
-type LoaderFetcher = (path: string) => Promise<unknown>;
+type LoaderFetcher = (path: string, requestInit: RequestInit) => Promise<unknown>;
 export type LoaderResult = { data: unknown } | { error: unknown };
 type LoaderSubscriber = (result: LoaderResult, isCurrentSource: boolean) => void;
 export type LoaderUnsubscribe = (onSourceTeardown?: () => void) => void;
 
+interface LoaderSubscription {
+  callback: LoaderSubscriber;
+  committed: boolean;
+}
+
 interface LoaderSource {
-  subscribers: Set<LoaderSubscriber>;
-  isFetching: boolean;
+  subscribers: Set<LoaderSubscription>;
+  controller: AbortController | null;
   onTeardown?: () => void;
 }
 
@@ -19,14 +24,15 @@ export class LoaderClient {
   private active = new Map<string, LoaderSource>();
   private fetchers = new Map<string, LoaderFetcher>();
 
-  subscribeLoader(path: string, callback: LoaderSubscriber = () => {}): LoaderUnsubscribe {
-    let source = this.active.get(path);
-    if (!source) {
-      source = { subscribers: new Set(), isFetching: false };
-      this.active.set(path, source);
-    }
+  subscribeLoader(
+    path: string,
+    callback: LoaderSubscriber = () => {},
+    { committed = false }: { committed?: boolean } = {}
+  ): LoaderUnsubscribe {
+    const source = this.getOrCreateSource(path);
+    const subscription = { callback, committed };
     source.onTeardown = undefined;
-    source.subscribers.add(callback);
+    source.subscribers.add(subscription);
 
     let subscribed = true;
     return (onSourceTeardown) => {
@@ -34,7 +40,7 @@ export class LoaderClient {
         return;
       }
       subscribed = false;
-      source.subscribers.delete(callback);
+      source.subscribers.delete(subscription);
       if (source.subscribers.size === 0) {
         this.scheduleTeardown(path, source, onSourceTeardown);
       }
@@ -45,21 +51,52 @@ export class LoaderClient {
     this.fetchers.set(path, fetcher);
   }
 
-  execute(path: string, fetcher?: LoaderFetcher) {
+  /** Aborts and detaches a source unless a committed reader still owns it. */
+  abort(path: string): boolean {
+    const source = this.active.get(path);
+    if (!source) {
+      return false;
+    }
+
+    const hasCommittedSubscription = [...source.subscribers].some(
+      (subscriber) => subscriber.committed
+    );
+    if (hasCommittedSubscription) {
+      return false;
+    }
+
+    // Detach before aborting because an abort listener may synchronously start replacement work.
+    this.active.delete(path);
+    source.onTeardown = undefined;
+    source.subscribers.clear();
+    this.abortSourceRequest(source);
+    return true;
+  }
+
+  execute(path: string, fetcher?: LoaderFetcher): void {
     if (fetcher) {
       this.fetchers.set(path, fetcher);
     }
     const source = this.active.get(path);
     const fetcherFn = this.fetchers.get(path);
-    if (!source || !fetcherFn || source.isFetching) {
+    if (!source || !fetcherFn || source.controller) {
       return;
     }
 
-    source.isFetching = true;
-    fetcherFn(path).then(
-      (data) => this.settle(path, source, { data }),
+    const controller = new AbortController();
+    source.controller = controller;
+
+    let request: Promise<unknown>;
+    try {
+      request = fetcherFn(path, { signal: controller.signal });
+    } catch (error) {
+      request = Promise.reject(error);
+    }
+
+    request.then(
+      (data) => this.settle(path, source, controller, { data }),
       (error) =>
-        this.settle(path, source, {
+        this.settle(path, source, controller, {
           error: new Error(`Failed to load loader data for route: ${path}`, {
             cause: error,
           }),
@@ -72,15 +109,39 @@ export class LoaderClient {
     for (const [path, source] of this.active) {
       if (source.subscribers.size > 0) {
         livePaths.add(path);
+        this.abortSourceRequest(source);
         this.execute(path);
+      } else {
+        this.active.delete(path);
+        source.onTeardown = undefined;
+        source.subscribers.clear();
+        this.abortSourceRequest(source);
       }
     }
     return livePaths;
   }
 
   clear() {
+    const sources = [...this.active.values()];
     this.active.clear();
     this.fetchers.clear();
+    for (const source of sources) {
+      source.onTeardown = undefined;
+      source.subscribers.clear();
+      this.abortSourceRequest(source);
+    }
+  }
+
+  private getOrCreateSource(path: string): LoaderSource {
+    let source = this.active.get(path);
+    if (!source) {
+      source = {
+        subscribers: new Set(),
+        controller: null,
+      };
+      this.active.set(path, source);
+    }
+    return source;
   }
 
   private scheduleTeardown(path: string, source: LoaderSource, onSourceTeardown?: () => void) {
@@ -92,6 +153,7 @@ export class LoaderClient {
       ) {
         this.active.delete(path);
         source.onTeardown = undefined;
+        this.abortSourceRequest(source);
         onSourceTeardown?.();
       }
     };
@@ -99,11 +161,28 @@ export class LoaderClient {
     queueMicrotask(onTeardown);
   }
 
-  private settle(path: string, source: LoaderSource, result: LoaderResult) {
-    source.isFetching = false;
+  private abortSourceRequest(source: LoaderSource) {
+    const controller = source.controller;
+    source.controller = null;
+    controller?.abort();
+  }
+
+  private settle(
+    path: string,
+    source: LoaderSource,
+    controller: AbortController,
+    result: LoaderResult
+  ) {
+    if (source.controller === controller) {
+      source.controller = null;
+    }
+    if (controller.signal.aborted) {
+      return;
+    }
+
     const isCurrentSource = this.active.get(path) === source;
-    for (const subscriber of source.subscribers) {
-      subscriber(result, isCurrentSource);
+    for (const { callback } of source.subscribers) {
+      callback(result, isCurrentSource);
     }
   }
 }

--- a/packages/expo-router/src/loaders/LoaderClient.ts
+++ b/packages/expo-router/src/loaders/LoaderClient.ts
@@ -1,11 +1,16 @@
-type LoaderFetcher = (path: string) => Promise<unknown>;
+type LoaderFetcher = (path: string, requestInit: RequestInit) => Promise<unknown>;
 export type LoaderResult = { data: unknown } | { error: unknown };
 type LoaderSubscriber = (result: LoaderResult, isCurrentSource: boolean) => void;
 export type LoaderUnsubscribe = (onSourceTeardown?: () => void) => void;
 
+interface LoaderSubscription {
+  callback: LoaderSubscriber;
+  committed: boolean;
+}
+
 interface LoaderSource {
-  subscribers: Set<LoaderSubscriber>;
-  isFetching: boolean;
+  subscribers: Set<LoaderSubscription>;
+  controller: AbortController | null;
   onTeardown?: () => void;
 }
 
@@ -19,14 +24,15 @@ export class LoaderClient {
   private active = new Map<string, LoaderSource>();
   private fetchers = new Map<string, LoaderFetcher>();
 
-  subscribeLoader(path: string, callback: LoaderSubscriber = () => {}): LoaderUnsubscribe {
-    let source = this.active.get(path);
-    if (!source) {
-      source = { subscribers: new Set(), isFetching: false };
-      this.active.set(path, source);
-    }
+  subscribeLoader(
+    path: string,
+    callback: LoaderSubscriber = () => {},
+    { committed = false }: { committed?: boolean } = {}
+  ): LoaderUnsubscribe {
+    const source = this.getOrCreateSource(path);
+    const subscription = { callback, committed };
     source.onTeardown = undefined;
-    source.subscribers.add(callback);
+    source.subscribers.add(subscription);
 
     let subscribed = true;
     return (onSourceTeardown) => {
@@ -34,7 +40,7 @@ export class LoaderClient {
         return;
       }
       subscribed = false;
-      source.subscribers.delete(callback);
+      source.subscribers.delete(subscription);
       if (source.subscribers.size === 0) {
         this.scheduleTeardown(path, source, onSourceTeardown);
       }
@@ -45,21 +51,45 @@ export class LoaderClient {
     this.fetchers.set(path, fetcher);
   }
 
-  execute(path: string, fetcher?: LoaderFetcher) {
+  /** Aborts and detaches a source unless a committed reader still owns it. */
+  abort(path: string): boolean {
+    const source = this.active.get(path);
+    if (!source || hasCommittedSubscription(source)) {
+      return false;
+    }
+
+    // Detach before aborting because an abort listener may synchronously start replacement work.
+    this.active.delete(path);
+    source.onTeardown = undefined;
+    source.subscribers.clear();
+    this.abortSourceRequest(source);
+    return true;
+  }
+
+  execute(path: string, fetcher?: LoaderFetcher): void {
     if (fetcher) {
       this.fetchers.set(path, fetcher);
     }
     const source = this.active.get(path);
     const fetcherFn = this.fetchers.get(path);
-    if (!source || !fetcherFn || source.isFetching) {
+    if (!source || !fetcherFn || source.controller) {
       return;
     }
 
-    source.isFetching = true;
-    fetcherFn(path).then(
-      (data) => this.settle(path, source, { data }),
+    const controller = new AbortController();
+    source.controller = controller;
+
+    let request: Promise<unknown>;
+    try {
+      request = fetcherFn(path, { signal: controller.signal });
+    } catch (error) {
+      request = Promise.reject(error);
+    }
+
+    request.then(
+      (data) => this.settle(path, source, controller, { data }),
       (error) =>
-        this.settle(path, source, {
+        this.settle(path, source, controller, {
           error: new Error(`Failed to load loader data for route: ${path}`, {
             cause: error,
           }),
@@ -70,17 +100,41 @@ export class LoaderClient {
   revalidate(): ReadonlySet<string> {
     const livePaths = new Set<string>();
     for (const [path, source] of this.active) {
-      if (source.subscribers.size > 0) {
+      if (hasCommittedSubscription(source)) {
         livePaths.add(path);
+        this.abortSourceRequest(source);
         this.execute(path);
+      } else {
+        this.active.delete(path);
+        source.onTeardown = undefined;
+        source.subscribers.clear();
+        this.abortSourceRequest(source);
       }
     }
     return livePaths;
   }
 
   clear() {
+    const sources = [...this.active.values()];
     this.active.clear();
     this.fetchers.clear();
+    for (const source of sources) {
+      source.onTeardown = undefined;
+      source.subscribers.clear();
+      this.abortSourceRequest(source);
+    }
+  }
+
+  private getOrCreateSource(path: string): LoaderSource {
+    let source = this.active.get(path);
+    if (!source) {
+      source = {
+        subscribers: new Set(),
+        controller: null,
+      };
+      this.active.set(path, source);
+    }
+    return source;
   }
 
   private scheduleTeardown(path: string, source: LoaderSource, onSourceTeardown?: () => void) {
@@ -92,6 +146,7 @@ export class LoaderClient {
       ) {
         this.active.delete(path);
         source.onTeardown = undefined;
+        this.abortSourceRequest(source);
         onSourceTeardown?.();
       }
     };
@@ -99,11 +154,37 @@ export class LoaderClient {
     queueMicrotask(onTeardown);
   }
 
-  private settle(path: string, source: LoaderSource, result: LoaderResult) {
-    source.isFetching = false;
+  private abortSourceRequest(source: LoaderSource) {
+    const controller = source.controller;
+    source.controller = null;
+    controller?.abort();
+  }
+
+  private settle(
+    path: string,
+    source: LoaderSource,
+    controller: AbortController,
+    result: LoaderResult
+  ) {
+    if (source.controller === controller) {
+      source.controller = null;
+    }
+    if (controller.signal.aborted) {
+      return;
+    }
+
     const isCurrentSource = this.active.get(path) === source;
-    for (const subscriber of source.subscribers) {
-      subscriber(result, isCurrentSource);
+    for (const { callback } of source.subscribers) {
+      callback(result, isCurrentSource);
     }
   }
+}
+
+function hasCommittedSubscription(source: LoaderSource): boolean {
+  for (const subscription of source.subscribers) {
+    if (subscription.committed) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/packages/expo-router/src/loaders/LoaderRouteLifecycle.tsx
+++ b/packages/expo-router/src/loaders/LoaderRouteLifecycle.tsx
@@ -1,0 +1,47 @@
+import { use, useEffect } from 'react';
+
+import { LoaderContext, type LoaderContextValue } from './LoaderContext';
+import { scheduleAbandonLoaderPath } from './abandonLoaderPath';
+
+interface ScheduledAbandonment {
+  cancel: () => void;
+}
+
+// This coordinates only same-turn cleanup/setup handoffs. It does not retain route ownership.
+const scheduledAbandonments = new Map<string, ScheduledAbandonment>();
+
+function cancelScheduledAbandonment(path: string) {
+  const scheduled = scheduledAbandonments.get(path);
+  if (!scheduled) {
+    return;
+  }
+
+  scheduled.cancel();
+  scheduledAbandonments.delete(path);
+}
+
+function scheduleRouteAbandonment(ctx: LoaderContextValue, path: string) {
+  cancelScheduledAbandonment(path);
+
+  const scheduled = { cancel: scheduleAbandonLoaderPath(ctx, path) };
+  scheduledAbandonments.set(path, scheduled);
+  queueMicrotask(() => {
+    if (scheduledAbandonments.get(path) === scheduled) {
+      scheduledAbandonments.delete(path);
+    }
+  });
+}
+
+/** Adapts the committed route-shell lifecycle to the framework-neutral abandonment primitive. */
+export function LoaderRouteLifecycle({ path }: { path: string }) {
+  const ctx = use(LoaderContext);
+
+  useEffect(() => {
+    cancelScheduledAbandonment(path);
+    return () => {
+      scheduleRouteAbandonment(ctx, path);
+    };
+  }, [ctx, path]);
+
+  return null;
+}

--- a/packages/expo-router/src/loaders/LoaderRouteLifecycle.tsx
+++ b/packages/expo-router/src/loaders/LoaderRouteLifecycle.tsx
@@ -1,0 +1,45 @@
+import { use, useEffect } from 'react';
+
+import { LoaderContext, type LoaderContextValue } from './LoaderContext';
+import { scheduleAbandonLoaderPath } from './abandonLoaderPath';
+
+interface ScheduledAbandonment {
+  cancel: () => void;
+}
+
+const scheduledAbandonments = new Map<string, ScheduledAbandonment>();
+
+function cancelScheduledAbandonment(path: string) {
+  const scheduled = scheduledAbandonments.get(path);
+  if (!scheduled) {
+    return;
+  }
+
+  scheduled.cancel();
+  scheduledAbandonments.delete(path);
+}
+
+function scheduleRouteAbandonment(ctx: LoaderContextValue, path: string) {
+  cancelScheduledAbandonment(path);
+
+  const scheduled = { cancel: scheduleAbandonLoaderPath(ctx, path) };
+  scheduledAbandonments.set(path, scheduled);
+  queueMicrotask(() => {
+    if (scheduledAbandonments.get(path) === scheduled) {
+      scheduledAbandonments.delete(path);
+    }
+  });
+}
+
+export function LoaderRouteLifecycle({ path }: { path: string }) {
+  const ctx = use(LoaderContext);
+
+  useEffect(() => {
+    cancelScheduledAbandonment(path);
+    return () => {
+      scheduleRouteAbandonment(ctx, path);
+    };
+  }, [ctx, path]);
+
+  return null;
+}

--- a/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
@@ -1,6 +1,17 @@
 import { LoaderClient } from '../LoaderClient';
 
 const tick = () => Promise.resolve();
+const getSignal = (requestInit: RequestInit) => requestInit.signal as AbortSignal;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
 
 describe(LoaderClient, () => {
   describe('subscribeLoader + execute', () => {
@@ -52,7 +63,7 @@ describe(LoaderClient, () => {
       expect(error.cause).toEqual(new Error('boom'));
     });
 
-    it('marks results from a cleared source as stale', async () => {
+    it('does not publish results from a cleared source', async () => {
       const client = new LoaderClient();
       let resolveFetch!: (value: string) => void;
       const subscriber = jest.fn();
@@ -69,7 +80,120 @@ describe(LoaderClient, () => {
       resolveFetch('stale');
       await tick();
 
-      expect(subscriber).toHaveBeenCalledWith({ data: 'stale' }, false);
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('passes a fresh signal to every replacement execution', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const fetcher = jest.fn(async (_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return signals.length;
+      });
+      client.subscribeLoader('/p');
+
+      client.execute('/p', fetcher);
+      await tick();
+      expect(client.abort('/p')).toBe(true);
+      client.subscribeLoader('/p');
+      client.execute('/p', fetcher);
+      await tick();
+
+      expect(signals).toHaveLength(2);
+      expect(signals[0]).not.toBe(signals[1]);
+    });
+  });
+
+  describe('abort', () => {
+    it('allows a render-time subscription to be aborted', () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      client.subscribeLoader('/p');
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise(() => {});
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('refuses to abort while a committed subscription remains', () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      client.subscribeLoader('/p', undefined, { committed: true });
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise(() => {});
+      });
+
+      expect(client.abort('/p')).toBe(false);
+      expect(signal.aborted).toBe(false);
+    });
+
+    it('detaches the source before abort listeners run', async () => {
+      const client = new LoaderClient();
+      const oldRequest = createDeferred<string>();
+      let oldSignal!: AbortSignal;
+      const replacementSubscriber = jest.fn();
+      client.subscribeLoader('/p');
+      client.execute('/p', (_path, requestInit) => {
+        oldSignal = getSignal(requestInit);
+        oldSignal.addEventListener('abort', () => {
+          client.subscribeLoader('/p', replacementSubscriber);
+          client.execute('/p', async () => 'replacement');
+          oldRequest.reject(oldSignal.reason);
+        });
+        return oldRequest.promise;
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      await tick();
+
+      expect(oldSignal.aborted).toBe(true);
+      expect(replacementSubscriber).toHaveBeenCalledWith({ data: 'replacement' }, true);
+    });
+
+    it('does not publish an intentional abort as a route error', async () => {
+      const client = new LoaderClient();
+      const subscriber = jest.fn();
+      client.subscribeLoader('/p', subscriber);
+      client.execute('/p', (_path, requestInit) => {
+        const signal = getSignal(requestInit);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      await tick();
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('keeps a fetcher that ignores abort stale after a replacement starts', async () => {
+      const client = new LoaderClient();
+      const oldRequest = createDeferred<string>();
+      const oldSubscriber = jest.fn();
+      const replacementSubscriber = jest.fn();
+      client.subscribeLoader('/p', oldSubscriber);
+      client.execute('/p', () => oldRequest.promise);
+
+      expect(client.abort('/p')).toBe(true);
+      client.subscribeLoader('/p', replacementSubscriber);
+      client.execute('/p', async () => 'fresh');
+      oldRequest.resolve('stale');
+      await tick();
+
+      expect(oldSubscriber).not.toHaveBeenCalled();
+      expect(replacementSubscriber).toHaveBeenCalledTimes(1);
+      expect(replacementSubscriber).toHaveBeenCalledWith({ data: 'fresh' }, true);
+    });
+
+    it('returns false for an unknown path', () => {
+      const client = new LoaderClient();
+
+      expect(client.abort('/missing')).toBe(false);
     });
   });
 
@@ -152,6 +276,24 @@ describe(LoaderClient, () => {
 
       expect(subscriber).not.toHaveBeenCalled();
     });
+
+    it('aborts pending work after the final subscriber teardown is confirmed', async () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      const unsubscribe = client.subscribeLoader('/p', undefined, { committed: true });
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+
+      unsubscribe();
+      expect(signal.aborted).toBe(false);
+      await tick();
+
+      expect(signal.aborted).toBe(true);
+    });
   });
 
   describe('revalidate', () => {
@@ -163,7 +305,7 @@ describe(LoaderClient, () => {
         .mockResolvedValueOnce('v2');
       const results: unknown[] = [];
 
-      client.subscribeLoader('/p', (result) => results.push(result));
+      client.subscribeLoader('/p', (result) => results.push(result), { committed: true });
       client.execute('/p', fetcher);
       await tick();
 
@@ -185,7 +327,7 @@ describe(LoaderClient, () => {
       const fetcher = jest.fn(async () => 'post-edit');
       const subscriber = jest.fn();
 
-      client.subscribeLoader('/index', subscriber);
+      client.subscribeLoader('/index', subscriber, { committed: true });
       client.registerFetcher('/index', fetcher);
       const livePaths = client.revalidate();
       await tick();
@@ -193,6 +335,98 @@ describe(LoaderClient, () => {
       expect(livePaths).toEqual(new Set(['/index']));
       expect(fetcher).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+
+    it('aborts and replaces an in-flight request for committed readers', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const requests = [createDeferred<string>(), createDeferred<string>()];
+      const subscriber = jest.fn();
+      const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return requests[signals.length - 1]!.promise;
+      });
+      client.subscribeLoader('/p', subscriber, { committed: true });
+      client.execute('/p', fetcher);
+
+      const livePaths = client.revalidate();
+
+      expect(livePaths).toEqual(new Set(['/p']));
+      expect(signals).toHaveLength(2);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+
+      requests[0]!.resolve('pre-edit');
+      await tick();
+      expect(subscriber).not.toHaveBeenCalled();
+
+      requests[1]!.resolve('post-edit');
+      await tick();
+      expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+
+    it('detaches uncommitted pending work so the next render starts fresh', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const requests = [createDeferred<string>(), createDeferred<string>()];
+      const oldSubscriber = jest.fn();
+      const newSubscriber = jest.fn();
+      const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return requests[signals.length - 1]!.promise;
+      });
+      client.subscribeLoader('/pending', oldSubscriber);
+      client.execute('/pending', fetcher);
+
+      expect(client.revalidate()).toEqual(new Set());
+      client.subscribeLoader('/pending', newSubscriber);
+      client.execute('/pending', fetcher);
+
+      expect(signals).toHaveLength(2);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+
+      requests[0]!.resolve('pre-edit');
+      await tick();
+      expect(oldSubscriber).not.toHaveBeenCalled();
+      requests[1]!.resolve('post-edit');
+      await tick();
+      expect(newSubscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+  });
+
+  describe('clear', () => {
+    it('aborts every active execution despite committed readers', () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      for (let index = 0; index < 2; index++) {
+        client.subscribeLoader(`/${index}`, undefined, { committed: true });
+        client.execute(`/${index}`, (_path, requestInit) => {
+          signals.push(getSignal(requestInit));
+          return new Promise(() => {});
+        });
+      }
+
+      client.clear();
+
+      expect(signals.every((signal) => signal.aborted)).toBe(true);
+    });
+
+    it('drops registered fetchers and cancels queued teardown', async () => {
+      const client = new LoaderClient();
+      const fetcher = jest.fn(async () => 'v1');
+      const onTeardown = jest.fn();
+      client.registerFetcher('/p', fetcher);
+      const unsubscribe = client.subscribeLoader('/p');
+      unsubscribe(onTeardown);
+
+      client.clear();
+      client.subscribeLoader('/p');
+      client.execute('/p');
+      await tick();
+
+      expect(fetcher).not.toHaveBeenCalled();
+      expect(onTeardown).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
@@ -1,6 +1,17 @@
 import { LoaderClient } from '../LoaderClient';
 
 const tick = () => Promise.resolve();
+const getSignal = (requestInit: RequestInit) => requestInit.signal as AbortSignal;
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, reject, resolve };
+}
 
 describe(LoaderClient, () => {
   describe('subscribeLoader + execute', () => {
@@ -52,7 +63,7 @@ describe(LoaderClient, () => {
       expect(error.cause).toEqual(new Error('boom'));
     });
 
-    it('marks results from a cleared source as stale', async () => {
+    it('does not publish results from a cleared source', async () => {
       const client = new LoaderClient();
       let resolveFetch!: (value: string) => void;
       const subscriber = jest.fn();
@@ -69,7 +80,120 @@ describe(LoaderClient, () => {
       resolveFetch('stale');
       await tick();
 
-      expect(subscriber).toHaveBeenCalledWith({ data: 'stale' }, false);
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('passes a fresh signal to every replacement execution', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const fetcher = jest.fn(async (_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return signals.length;
+      });
+      client.subscribeLoader('/p');
+
+      client.execute('/p', fetcher);
+      await tick();
+      expect(client.abort('/p')).toBe(true);
+      client.subscribeLoader('/p');
+      client.execute('/p', fetcher);
+      await tick();
+
+      expect(signals).toHaveLength(2);
+      expect(signals[0]).not.toBe(signals[1]);
+    });
+  });
+
+  describe('abort', () => {
+    it('allows a render-time subscription to be aborted', () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      client.subscribeLoader('/p');
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise(() => {});
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      expect(signal.aborted).toBe(true);
+    });
+
+    it('refuses to abort while a committed subscription remains', () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      client.subscribeLoader('/p', undefined, { committed: true });
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise(() => {});
+      });
+
+      expect(client.abort('/p')).toBe(false);
+      expect(signal.aborted).toBe(false);
+    });
+
+    it('detaches the source before abort listeners run', async () => {
+      const client = new LoaderClient();
+      const oldRequest = createDeferred<string>();
+      let oldSignal!: AbortSignal;
+      const replacementSubscriber = jest.fn();
+      client.subscribeLoader('/p');
+      client.execute('/p', (_path, requestInit) => {
+        oldSignal = getSignal(requestInit);
+        oldSignal.addEventListener('abort', () => {
+          client.subscribeLoader('/p', replacementSubscriber);
+          client.execute('/p', async () => 'replacement');
+          oldRequest.reject(oldSignal.reason);
+        });
+        return oldRequest.promise;
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      await tick();
+
+      expect(oldSignal.aborted).toBe(true);
+      expect(replacementSubscriber).toHaveBeenCalledWith({ data: 'replacement' }, true);
+    });
+
+    it('does not publish an intentional abort as a route error', async () => {
+      const client = new LoaderClient();
+      const subscriber = jest.fn();
+      client.subscribeLoader('/p', subscriber);
+      client.execute('/p', (_path, requestInit) => {
+        const signal = getSignal(requestInit);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+
+      expect(client.abort('/p')).toBe(true);
+      await tick();
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('keeps a fetcher that ignores abort stale after a replacement starts', async () => {
+      const client = new LoaderClient();
+      const oldRequest = createDeferred<string>();
+      const oldSubscriber = jest.fn();
+      const replacementSubscriber = jest.fn();
+      client.subscribeLoader('/p', oldSubscriber);
+      client.execute('/p', () => oldRequest.promise);
+
+      expect(client.abort('/p')).toBe(true);
+      client.subscribeLoader('/p', replacementSubscriber);
+      client.execute('/p', async () => 'fresh');
+      oldRequest.resolve('stale');
+      await tick();
+
+      expect(oldSubscriber).not.toHaveBeenCalled();
+      expect(replacementSubscriber).toHaveBeenCalledTimes(1);
+      expect(replacementSubscriber).toHaveBeenCalledWith({ data: 'fresh' }, true);
+    });
+
+    it('returns false for an unknown path', () => {
+      const client = new LoaderClient();
+
+      expect(client.abort('/missing')).toBe(false);
     });
   });
 
@@ -152,6 +276,24 @@ describe(LoaderClient, () => {
 
       expect(subscriber).not.toHaveBeenCalled();
     });
+
+    it('aborts pending work after the final subscriber teardown is confirmed', async () => {
+      const client = new LoaderClient();
+      let signal!: AbortSignal;
+      const unsubscribe = client.subscribeLoader('/p', undefined, { committed: true });
+      client.execute('/p', (_path, requestInit) => {
+        signal = getSignal(requestInit);
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason));
+        });
+      });
+
+      unsubscribe();
+      expect(signal.aborted).toBe(false);
+      await tick();
+
+      expect(signal.aborted).toBe(true);
+    });
   });
 
   describe('revalidate', () => {
@@ -163,7 +305,7 @@ describe(LoaderClient, () => {
         .mockResolvedValueOnce('v2');
       const results: unknown[] = [];
 
-      client.subscribeLoader('/p', (result) => results.push(result));
+      client.subscribeLoader('/p', (result) => results.push(result), { committed: true });
       client.execute('/p', fetcher);
       await tick();
 
@@ -185,7 +327,7 @@ describe(LoaderClient, () => {
       const fetcher = jest.fn(async () => 'post-edit');
       const subscriber = jest.fn();
 
-      client.subscribeLoader('/index', subscriber);
+      client.subscribeLoader('/index', subscriber, { committed: true });
       client.registerFetcher('/index', fetcher);
       const livePaths = client.revalidate();
       await tick();
@@ -193,6 +335,95 @@ describe(LoaderClient, () => {
       expect(livePaths).toEqual(new Set(['/index']));
       expect(fetcher).toHaveBeenCalledTimes(1);
       expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+
+    it('aborts and replaces an in-flight request for committed readers', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const requests = [createDeferred<string>(), createDeferred<string>()];
+      const subscriber = jest.fn();
+      const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return requests[signals.length - 1]!.promise;
+      });
+      client.subscribeLoader('/p', subscriber, { committed: true });
+      client.execute('/p', fetcher);
+
+      const livePaths = client.revalidate();
+
+      expect(livePaths).toEqual(new Set(['/p']));
+      expect(signals).toHaveLength(2);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+
+      requests[0]!.resolve('pre-edit');
+      await tick();
+      expect(subscriber).not.toHaveBeenCalled();
+
+      requests[1]!.resolve('post-edit');
+      await tick();
+      expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+
+    it('restarts uncommitted pending work in place', async () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      const requests = [createDeferred<string>(), createDeferred<string>()];
+      const subscriber = jest.fn();
+      const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+        signals.push(getSignal(requestInit));
+        return requests[signals.length - 1]!.promise;
+      });
+      client.subscribeLoader('/pending', subscriber);
+      client.execute('/pending', fetcher);
+
+      expect(client.revalidate()).toEqual(new Set(['/pending']));
+
+      expect(signals).toHaveLength(2);
+      expect(signals[0]!.aborted).toBe(true);
+      expect(signals[1]!.aborted).toBe(false);
+
+      requests[0]!.resolve('pre-edit');
+      await tick();
+      expect(subscriber).not.toHaveBeenCalled();
+      requests[1]!.resolve('post-edit');
+      await tick();
+      expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
+    });
+  });
+
+  describe('clear', () => {
+    it('aborts every active execution despite committed readers', () => {
+      const client = new LoaderClient();
+      const signals: AbortSignal[] = [];
+      for (let index = 0; index < 2; index++) {
+        client.subscribeLoader(`/${index}`, undefined, { committed: true });
+        client.execute(`/${index}`, (_path, requestInit) => {
+          signals.push(getSignal(requestInit));
+          return new Promise(() => {});
+        });
+      }
+
+      client.clear();
+
+      expect(signals.every((signal) => signal.aborted)).toBe(true);
+    });
+
+    it('drops registered fetchers and cancels queued teardown', async () => {
+      const client = new LoaderClient();
+      const fetcher = jest.fn(async () => 'v1');
+      const onTeardown = jest.fn();
+      client.registerFetcher('/p', fetcher);
+      const unsubscribe = client.subscribeLoader('/p');
+      unsubscribe(onTeardown);
+
+      client.clear();
+      client.subscribeLoader('/p');
+      client.execute('/p');
+      await tick();
+
+      expect(fetcher).not.toHaveBeenCalled();
+      expect(onTeardown).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/abandonLoaderPath.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/abandonLoaderPath.test.ts
@@ -1,0 +1,125 @@
+import { LoaderClient } from '../LoaderClient';
+import { createLoaderContextValue } from '../LoaderContext';
+import { abandonLoaderPath, scheduleAbandonLoaderPath } from '../abandonLoaderPath';
+import { readLoaderData } from '../readLoaderData';
+
+const tick = () => Promise.resolve();
+const getSignal = (requestInit: RequestInit) => requestInit.signal as AbortSignal;
+
+describe(abandonLoaderPath, () => {
+  it('does nothing when the path has no store entry', () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    const abort = jest.spyOn(ctx.client, 'abort');
+
+    abandonLoaderPath(ctx, '/missing');
+
+    expect(abort).not.toHaveBeenCalled();
+  });
+
+  it('aborts and identity-clears a pending entry without caching an abort error', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/p', (_path, requestInit) => {
+      signal = getSignal(requestInit);
+      return new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason));
+      });
+    });
+
+    abandonLoaderPath(ctx, '/p');
+    await tick();
+
+    expect(signal.aborted).toBe(true);
+    expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('cannot resurrect an entry when a fetcher ignores abort', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let resolveFetch!: (value: string) => void;
+    readLoaderData(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    abandonLoaderPath(ctx, '/p');
+    resolveFetch('ignored-abort');
+    await tick();
+
+    expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('preserves pending state while a committed reader remains', () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/p', (_path, requestInit) => {
+      signal = getSignal(requestInit);
+      return new Promise(() => {});
+    });
+    ctx.client.subscribeLoader('/p', undefined, { committed: true });
+    const entry = ctx.store.get('/p');
+
+    abandonLoaderPath(ctx, '/p');
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/p')).toBe(entry);
+  });
+
+  it('does not discard settled state', () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    const entry = { data: 'settled' };
+    ctx.store.set('/p', entry);
+
+    abandonLoaderPath(ctx, '/p');
+
+    expect(ctx.store.get('/p')).toBe(entry);
+  });
+
+  it('preserves a replacement installed synchronously by an abort listener', () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    const replacement = { data: 'replacement' };
+    readLoaderData(ctx, '/p', (_path, requestInit) => {
+      getSignal(requestInit).addEventListener('abort', () => ctx.store.set('/p', replacement));
+      return new Promise(() => {});
+    });
+
+    abandonLoaderPath(ctx, '/p');
+
+    expect(ctx.store.get('/p')).toBe(replacement);
+  });
+
+  it('re-checks committed-reader liveness when scheduled work runs', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/p', (_path, requestInit) => {
+      signal = getSignal(requestInit);
+      return new Promise(() => {});
+    });
+
+    scheduleAbandonLoaderPath(ctx, '/p');
+    ctx.client.subscribeLoader('/p', undefined, { committed: true });
+    await tick();
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/p')).toBeDefined();
+  });
+
+  it('allows a same-turn lifecycle setup to cancel scheduled abandonment', async () => {
+    const ctx = createLoaderContextValue(new LoaderClient());
+    let signal!: AbortSignal;
+    readLoaderData(ctx, '/p', (_path, requestInit) => {
+      signal = getSignal(requestInit);
+      return new Promise(() => {});
+    });
+
+    const cancel = scheduleAbandonLoaderPath(ctx, '/p');
+    cancel();
+    await tick();
+
+    expect(signal.aborted).toBe(false);
+    expect(ctx.store.get('/p')).toBeDefined();
+  });
+});

--- a/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
@@ -4,8 +4,16 @@ import { readLoaderData } from '../readLoaderData';
 
 const tick = () => Promise.resolve();
 const createLoaderContext = () => createLoaderContextValue(new LoaderClient());
-const read = <T>(ctx: LoaderContextValue, path: string, fetcher: (path: string) => Promise<T>) =>
-  readLoaderData(ctx, path, fetcher);
+const subscribeCommitted = (
+  { client }: LoaderContextValue,
+  path: string,
+  callback?: Parameters<LoaderClient['subscribeLoader']>[1]
+) => client.subscribeLoader(path, callback, { committed: true });
+const read = <T>(
+  ctx: LoaderContextValue,
+  path: string,
+  fetcher: (path: string, requestInit: RequestInit) => Promise<T>
+) => readLoaderData(ctx, path, fetcher);
 const revalidate = ({ client, store }: LoaderContextValue) => {
   store.retain(client.revalidate());
 };
@@ -56,7 +64,7 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    const unsubscribe = ctx.client.subscribeLoader('/p');
+    const unsubscribe = subscribeCommitted(ctx, '/p');
     ctx.store.dispose('/p');
     unsubscribe(() => ctx.store.teardown('/p'));
     await tick();
@@ -73,10 +81,10 @@ describe(readLoaderData, () => {
     const fetcher = jest.fn(async () => 'v1');
 
     await read(ctx, '/sm', fetcher);
-    const unsubscribe = ctx.client.subscribeLoader('/sm');
+    const unsubscribe = subscribeCommitted(ctx, '/sm');
     ctx.store.dispose('/sm');
     unsubscribe(() => ctx.store.teardown('/sm'));
-    ctx.client.subscribeLoader('/sm');
+    subscribeCommitted(ctx, '/sm');
     await tick();
 
     expect(read(ctx, '/sm', fetcher)).toBe('v1');
@@ -86,7 +94,7 @@ describe(readLoaderData, () => {
   it('keeps a fresh result written between disposal and confirmed teardown', async () => {
     const ctx = createLoaderContext();
     ctx.store.set('/p', { data: 'old' });
-    const unsubscribe = ctx.client.subscribeLoader('/p');
+    const unsubscribe = subscribeCommitted(ctx, '/p');
 
     ctx.store.dispose('/p');
     unsubscribe(() => ctx.store.teardown('/p'));
@@ -169,38 +177,75 @@ describe(readLoaderData, () => {
     expect(ctx.store.get('/p')).toBeUndefined();
   });
 
-  it('lets a detached source resolve its caller without restoring reset state', async () => {
+  it('does not restore reset state when an aborted fetcher later resolves', async () => {
     const ctx = createLoaderContext();
     let resolveFetch!: (result: string) => void;
-    const pending = read(
+    read(
       ctx,
       '/p',
       () =>
         new Promise<string>((resolve) => {
           resolveFetch = resolve;
         })
-    ) as Promise<string>;
+    );
 
     ctx.client.clear();
     ctx.store.reset();
     resolveFetch('detached');
+    await tick();
 
-    await expect(pending).resolves.toBe('detached');
     expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('keeps intentional abort pending without caching an error or emitting an unhandled rejection', async () => {
+    const ctx = createLoaderContext();
+    const onUnhandledRejection = jest.fn();
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const pending = read(
+        ctx,
+        '/p',
+        (_path, requestInit) =>
+          new Promise<string>((_resolve, reject) => {
+            const signal = requestInit.signal as AbortSignal;
+            signal.addEventListener('abort', () => reject(signal.reason));
+          })
+      ) as Promise<string>;
+      let settled = false;
+      pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        }
+      );
+
+      ctx.client.abort('/p');
+      await tick();
+      await tick();
+
+      expect(settled).toBe(false);
+      expect(ctx.store.get('/p')).toBe(pending);
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 
   it('does not let a replaced source overwrite the newer pending entry', async () => {
     const ctx = createLoaderContext();
     let resolveOld!: (result: string) => void;
     let resolveNew!: (result: string) => void;
-    const oldPending = read(
+    read(
       ctx,
       '/p',
       () =>
         new Promise<string>((resolve) => {
           resolveOld = resolve;
         })
-    ) as Promise<string>;
+    );
 
     ctx.client.clear();
     ctx.store.reset();
@@ -214,7 +259,7 @@ describe(readLoaderData, () => {
     ) as Promise<string>;
 
     resolveOld('old');
-    await expect(oldPending).resolves.toBe('old');
+    await tick();
     expect(ctx.store.get('/p')).toBe(newPending);
 
     resolveNew('new');
@@ -222,27 +267,25 @@ describe(readLoaderData, () => {
     expect(ctx.store.get('/p')).toEqual({ data: 'new' });
   });
 
-  it('keeps a settled result from an abandoned render for the next mount to adopt', async () => {
+  it('starts a fresh request after an abandoned pending entry is removed', async () => {
     const ctx = createLoaderContext();
-    let resolveFetch!: (result: string) => void;
-    const fetcher = jest.fn(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveFetch = resolve;
-        })
-    );
+    const signals: AbortSignal[] = [];
+    const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+      signals.push(requestInit.signal as AbortSignal);
+      return new Promise<string>(() => {});
+    });
 
-    const mountedUnsubscribe = ctx.client.subscribeLoader('/p');
-    const abandoned = read(ctx, '/p', fetcher) as Promise<string>;
-    ctx.store.dispose('/p');
-    mountedUnsubscribe(() => ctx.store.teardown('/p'));
-    await tick();
+    const first = read(ctx, '/p', fetcher);
+    ctx.client.abort('/p');
+    if (ctx.store.get('/p') === first) {
+      ctx.store.clear('/p');
+    }
+    const second = read(ctx, '/p', fetcher);
 
-    resolveFetch('adopted');
-    await expect(abandoned).resolves.toBe('adopted');
-
-    expect(read(ctx, '/p', fetcher)).toBe('adopted');
-    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(second).not.toBe(first);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(signals[0]!.aborted).toBe(true);
+    expect(signals[1]!.aborted).toBe(false);
   });
 
   it('refreshes a live entry in place during invalidation', async () => {
@@ -253,7 +296,7 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+    subscribeCommitted(ctx, '/p', (result, isCurrentSource) => {
       if (isCurrentSource) {
         ctx.store.set('/p', result);
       }
@@ -275,8 +318,8 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    const sibling = ctx.client.subscribeLoader('/p');
-    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+    const sibling = subscribeCommitted(ctx, '/p');
+    subscribeCommitted(ctx, '/p', (result, isCurrentSource) => {
       if (isCurrentSource) {
         ctx.store.set('/p', result);
       }
@@ -306,5 +349,41 @@ describe(readLoaderData, () => {
     expect(revisit).toBeInstanceOf(Promise);
     await expect(revisit).resolves.toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('abandons an uncommitted pending read during invalidation', async () => {
+    const ctx = createLoaderContext();
+    const signals: AbortSignal[] = [];
+    let resolveFirst!: (value: string) => void;
+    let resolveSecond!: (value: string) => void;
+    const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+      signals.push(requestInit.signal as AbortSignal);
+      return new Promise<string>((resolve) => {
+        if (signals.length === 1) {
+          resolveFirst = resolve;
+        } else {
+          resolveSecond = resolve;
+        }
+      });
+    });
+    const first = read(ctx, '/pending', fetcher);
+
+    revalidate(ctx);
+
+    expect(signals[0]!.aborted).toBe(true);
+    expect(ctx.store.get('/pending')).toBeUndefined();
+
+    const second = read(ctx, '/pending', fetcher);
+    expect(second).not.toBe(first);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(signals[1]!.aborted).toBe(false);
+
+    resolveFirst('pre-edit');
+    await tick();
+    expect(ctx.store.get('/pending')).toBe(second);
+
+    resolveSecond('post-edit');
+    await expect(second).resolves.toBe('post-edit');
+    expect(ctx.store.get('/pending')).toEqual({ data: 'post-edit' });
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
@@ -4,8 +4,16 @@ import { readLoaderData } from '../readLoaderData';
 
 const tick = () => Promise.resolve();
 const createLoaderContext = () => createLoaderContextValue(new LoaderClient());
-const read = <T>(ctx: LoaderContextValue, path: string, fetcher: (path: string) => Promise<T>) =>
-  readLoaderData(ctx, path, fetcher);
+const subscribeCommitted = (
+  { client }: LoaderContextValue,
+  path: string,
+  callback?: Parameters<LoaderClient['subscribeLoader']>[1]
+) => client.subscribeLoader(path, callback, { committed: true });
+const read = <T>(
+  ctx: LoaderContextValue,
+  path: string,
+  fetcher: (path: string, requestInit: RequestInit) => Promise<T>
+) => readLoaderData(ctx, path, fetcher);
 const revalidate = ({ client, store }: LoaderContextValue) => {
   store.retain(client.revalidate());
 };
@@ -56,7 +64,7 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    const unsubscribe = ctx.client.subscribeLoader('/p');
+    const unsubscribe = subscribeCommitted(ctx, '/p');
     ctx.store.dispose('/p');
     unsubscribe(() => ctx.store.teardown('/p'));
     await tick();
@@ -73,10 +81,10 @@ describe(readLoaderData, () => {
     const fetcher = jest.fn(async () => 'v1');
 
     await read(ctx, '/sm', fetcher);
-    const unsubscribe = ctx.client.subscribeLoader('/sm');
+    const unsubscribe = subscribeCommitted(ctx, '/sm');
     ctx.store.dispose('/sm');
     unsubscribe(() => ctx.store.teardown('/sm'));
-    ctx.client.subscribeLoader('/sm');
+    subscribeCommitted(ctx, '/sm');
     await tick();
 
     expect(read(ctx, '/sm', fetcher)).toBe('v1');
@@ -86,7 +94,7 @@ describe(readLoaderData, () => {
   it('keeps a fresh result written between disposal and confirmed teardown', async () => {
     const ctx = createLoaderContext();
     ctx.store.set('/p', { data: 'old' });
-    const unsubscribe = ctx.client.subscribeLoader('/p');
+    const unsubscribe = subscribeCommitted(ctx, '/p');
 
     ctx.store.dispose('/p');
     unsubscribe(() => ctx.store.teardown('/p'));
@@ -169,38 +177,75 @@ describe(readLoaderData, () => {
     expect(ctx.store.get('/p')).toBeUndefined();
   });
 
-  it('lets a detached source resolve its caller without restoring reset state', async () => {
+  it('does not restore reset state when an aborted fetcher later resolves', async () => {
     const ctx = createLoaderContext();
     let resolveFetch!: (result: string) => void;
-    const pending = read(
+    read(
       ctx,
       '/p',
       () =>
         new Promise<string>((resolve) => {
           resolveFetch = resolve;
         })
-    ) as Promise<string>;
+    );
 
     ctx.client.clear();
     ctx.store.reset();
     resolveFetch('detached');
+    await tick();
 
-    await expect(pending).resolves.toBe('detached');
     expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('keeps intentional abort pending without caching an error or emitting an unhandled rejection', async () => {
+    const ctx = createLoaderContext();
+    const onUnhandledRejection = jest.fn();
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const pending = read(
+        ctx,
+        '/p',
+        (_path, requestInit) =>
+          new Promise<string>((_resolve, reject) => {
+            const signal = requestInit.signal as AbortSignal;
+            signal.addEventListener('abort', () => reject(signal.reason));
+          })
+      ) as Promise<string>;
+      let settled = false;
+      pending.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        }
+      );
+
+      ctx.client.abort('/p');
+      await tick();
+      await tick();
+
+      expect(settled).toBe(false);
+      expect(ctx.store.get('/p')).toBe(pending);
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
   });
 
   it('does not let a replaced source overwrite the newer pending entry', async () => {
     const ctx = createLoaderContext();
     let resolveOld!: (result: string) => void;
     let resolveNew!: (result: string) => void;
-    const oldPending = read(
+    read(
       ctx,
       '/p',
       () =>
         new Promise<string>((resolve) => {
           resolveOld = resolve;
         })
-    ) as Promise<string>;
+    );
 
     ctx.client.clear();
     ctx.store.reset();
@@ -214,7 +259,7 @@ describe(readLoaderData, () => {
     ) as Promise<string>;
 
     resolveOld('old');
-    await expect(oldPending).resolves.toBe('old');
+    await tick();
     expect(ctx.store.get('/p')).toBe(newPending);
 
     resolveNew('new');
@@ -222,27 +267,25 @@ describe(readLoaderData, () => {
     expect(ctx.store.get('/p')).toEqual({ data: 'new' });
   });
 
-  it('keeps a settled result from an abandoned render for the next mount to adopt', async () => {
+  it('starts a fresh request after an abandoned pending entry is removed', async () => {
     const ctx = createLoaderContext();
-    let resolveFetch!: (result: string) => void;
-    const fetcher = jest.fn(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveFetch = resolve;
-        })
-    );
+    const signals: AbortSignal[] = [];
+    const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+      signals.push(requestInit.signal as AbortSignal);
+      return new Promise<string>(() => {});
+    });
 
-    const mountedUnsubscribe = ctx.client.subscribeLoader('/p');
-    const abandoned = read(ctx, '/p', fetcher) as Promise<string>;
-    ctx.store.dispose('/p');
-    mountedUnsubscribe(() => ctx.store.teardown('/p'));
-    await tick();
+    const first = read(ctx, '/p', fetcher);
+    ctx.client.abort('/p');
+    if (ctx.store.get('/p') === first) {
+      ctx.store.clear('/p');
+    }
+    const second = read(ctx, '/p', fetcher);
 
-    resolveFetch('adopted');
-    await expect(abandoned).resolves.toBe('adopted');
-
-    expect(read(ctx, '/p', fetcher)).toBe('adopted');
-    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(second).not.toBe(first);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(signals[0]!.aborted).toBe(true);
+    expect(signals[1]!.aborted).toBe(false);
   });
 
   it('refreshes a live entry in place during invalidation', async () => {
@@ -253,7 +296,7 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+    subscribeCommitted(ctx, '/p', (result, isCurrentSource) => {
       if (isCurrentSource) {
         ctx.store.set('/p', result);
       }
@@ -275,8 +318,8 @@ describe(readLoaderData, () => {
       .mockResolvedValueOnce('v2');
 
     await read(ctx, '/p', fetcher);
-    const sibling = ctx.client.subscribeLoader('/p');
-    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+    const sibling = subscribeCommitted(ctx, '/p');
+    subscribeCommitted(ctx, '/p', (result, isCurrentSource) => {
       if (isCurrentSource) {
         ctx.store.set('/p', result);
       }
@@ -306,5 +349,39 @@ describe(readLoaderData, () => {
     expect(revisit).toBeInstanceOf(Promise);
     await expect(revisit).resolves.toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('restarts an uncommitted pending read in place during invalidation', async () => {
+    const ctx = createLoaderContext();
+    const signals: AbortSignal[] = [];
+    let resolveFirst!: (value: string) => void;
+    let resolveSecond!: (value: string) => void;
+    const fetcher = jest.fn((_path: string, requestInit: RequestInit) => {
+      signals.push(requestInit.signal as AbortSignal);
+      return new Promise<string>((resolve) => {
+        if (signals.length === 1) {
+          resolveFirst = resolve;
+        } else {
+          resolveSecond = resolve;
+        }
+      });
+    });
+    const first = read(ctx, '/pending', fetcher);
+
+    revalidate(ctx);
+
+    expect(signals[0]!.aborted).toBe(true);
+    expect(ctx.store.get('/pending')).toBe(first);
+    expect(read(ctx, '/pending', fetcher)).toBe(first);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(signals[1]!.aborted).toBe(false);
+
+    resolveFirst('pre-edit');
+    await tick();
+    expect(ctx.store.get('/pending')).toBe(first);
+
+    resolveSecond('post-edit');
+    await expect(first).resolves.toBe('post-edit');
+    expect(ctx.store.get('/pending')).toEqual({ data: 'post-edit' });
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/utils.test.web.ts
+++ b/packages/expo-router/src/loaders/__tests__/utils.test.web.ts
@@ -37,11 +37,29 @@ describe(fetchLoader, () => {
     return (global.fetch as jest.Mock).mock.calls[0][0];
   }
 
+  function fetchedInit(): RequestInit {
+    return (global.fetch as jest.Mock).mock.calls[0][1];
+  }
+
   // These tests run in order: the revision is module state that only ever increments.
   it('fetches the plain loader URL before any dev invalidation', async () => {
     await fetchLoader('/about');
 
     expect(fetchedUrl()).toBe('/_expo/loaders/about');
+  });
+
+  it('forwards request options while enforcing the JSON Accept header', async () => {
+    const controller = new AbortController();
+
+    await fetchLoader('/about', {
+      signal: controller.signal,
+      headers: { Accept: 'text/plain', 'X-Test': 'yes' },
+    });
+
+    expect(fetchedInit().signal).toBe(controller.signal);
+    const headers = fetchedInit().headers as Headers;
+    expect(headers.get('Accept')).toBe('application/json');
+    expect(headers.get('X-Test')).toBe('yes');
   });
 
   it('appends a cache-busting revision to loader URLs after a dev invalidation', async () => {

--- a/packages/expo-router/src/loaders/abandonLoaderPath.ts
+++ b/packages/expo-router/src/loaders/abandonLoaderPath.ts
@@ -1,0 +1,29 @@
+import type { LoaderContextValue } from './LoaderContext';
+
+/** Abandons an unobserved pending loader without disturbing settled or replacement state. */
+export function abandonLoaderPath({ client, store }: LoaderContextValue, path: string): void {
+  const entry = store.get(path);
+  if (!(entry instanceof Promise)) {
+    return;
+  }
+
+  if (!client.abort(path)) {
+    return;
+  }
+  if (store.get(path) === entry) {
+    store.clear(path);
+  }
+}
+
+/** Defers abandonment so effect cleanup/setup handoffs can retain the loader in the same turn. */
+export function scheduleAbandonLoaderPath(ctx: LoaderContextValue, path: string): () => void {
+  let cancelled = false;
+  queueMicrotask(() => {
+    if (!cancelled) {
+      abandonLoaderPath(ctx, path);
+    }
+  });
+  return () => {
+    cancelled = true;
+  };
+}

--- a/packages/expo-router/src/loaders/readLoaderData.ts
+++ b/packages/expo-router/src/loaders/readLoaderData.ts
@@ -1,6 +1,6 @@
 import type { LoaderContextValue } from './LoaderContext';
 
-type LoaderFetcher<T> = (path: string) => Promise<T>;
+type LoaderFetcher<T> = (path: string, requestInit: RequestInit) => Promise<T>;
 
 export function readLoaderData<T>(
   { client, store }: LoaderContextValue,
@@ -23,6 +23,8 @@ export function readLoaderData<T>(
     return suspended.data;
   }
 
+  // Like urql's Suspense integration, this render-time subscription waits only for request
+  // completion. It is not a committed reader and therefore does not prevent route abandonment.
   const promise = new Promise<T>((resolve, reject) => {
     const unsubscribe = client.subscribeLoader(resolvedPath, (result, isCurrentSource) => {
       if (isCurrentSource && store.get(resolvedPath) === promise) {

--- a/packages/expo-router/src/loaders/readLoaderData.ts
+++ b/packages/expo-router/src/loaders/readLoaderData.ts
@@ -1,6 +1,6 @@
 import type { LoaderContextValue } from './LoaderContext';
 
-type LoaderFetcher<T> = (path: string) => Promise<T>;
+type LoaderFetcher<T> = (path: string, requestInit: RequestInit) => Promise<T>;
 
 export function readLoaderData<T>(
   { client, store }: LoaderContextValue,

--- a/packages/expo-router/src/loaders/resolveLoaderPath.ts
+++ b/packages/expo-router/src/loaders/resolveLoaderPath.ts
@@ -1,0 +1,15 @@
+import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
+import { getSingularId } from '../utils/getSingularId';
+
+/** Resolves the route context and navigation state to the loader request/store key. */
+export function resolveLoaderPath(
+  contextKey: string,
+  stateForPath: Parameters<typeof getRouteInfoFromState>[0]
+): string {
+  const routeInfo = getRouteInfoFromState(stateForPath);
+  const contextPath = contextKey.startsWith('/') ? contextKey.slice(1) : contextKey;
+  const resolvedPathname = `/${getSingularId(contextPath, { params: routeInfo.params })}`;
+  const searchString = routeInfo.searchParams?.toString() || '';
+
+  return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
+}

--- a/packages/expo-router/src/loaders/resolveLoaderPath.ts
+++ b/packages/expo-router/src/loaders/resolveLoaderPath.ts
@@ -1,15 +1,11 @@
-import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
+import type { UrlObject } from '../global-state/getRouteInfoFromState';
 import { getSingularId } from '../utils/getSingularId';
 
-/** Resolves the route context and navigation state to the loader request/store key. */
-export function resolveLoaderPath(
-  contextKey: string,
-  stateForPath: Parameters<typeof getRouteInfoFromState>[0]
-): string {
-  const routeInfo = getRouteInfoFromState(stateForPath);
+/** Resolves the route context and current route info to the loader request/store key. */
+export function resolveLoaderPath(contextKey: string, routeInfo: UrlObject | undefined): string {
   const contextPath = contextKey.startsWith('/') ? contextKey.slice(1) : contextKey;
-  const resolvedPathname = `/${getSingularId(contextPath, { params: routeInfo.params })}`;
-  const searchString = routeInfo.searchParams?.toString() || '';
+  const resolvedPathname = `/${getSingularId(contextPath, { params: routeInfo?.params ?? {} })}`;
+  const searchString = routeInfo?.searchParams?.toString() || '';
 
   return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
 }

--- a/packages/expo-router/src/loaders/utils.ts
+++ b/packages/expo-router/src/loaders/utils.ts
@@ -35,17 +35,15 @@ export function bumpDevLoaderRevision() {
  * @see import('packages/@expo/cli/src/start/server/metro/createServerRouteMiddleware.ts').createRouteHandlerMiddleware
  * @see import('packages/expo-server/src/vendor/environment/common.ts').createEnvironment
  */
-export async function fetchLoader(routePath: string): Promise<any> {
+export async function fetchLoader(routePath: string, requestInit: RequestInit = {}): Promise<any> {
   let loaderPath = getLoaderModulePath(routePath);
   if (__DEV__ && devLoaderCacheRevision > 0) {
     loaderPath += `${loaderPath.includes('?') ? '&' : '?'}_expo_loader_v=${devLoaderCacheRevision}`;
   }
 
-  const response = await fetch(loaderPath, {
-    headers: {
-      Accept: 'application/json',
-    },
-  });
+  const headers = new Headers(requestInit.headers);
+  headers.set('Accept', 'application/json');
+  const response = await fetch(loaderPath, { ...requestInit, headers });
   if (!response.ok) {
     throw new Error(`Failed to fetch loader data: ${response.status}`);
   }

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -20,6 +20,9 @@ import { isRouteGuarded, useGuardRedirect, type GuardedRedirects } from './layou
 import { Redirect } from './link/Redirect';
 import { ZoomTransitionEnabler } from './link/zoom/ZoomTransitionEnabler';
 import { ZoomTransitionTargetContextProvider } from './link/zoom/zoom-transition-context-providers';
+import { LoaderRouteLifecycle } from './loaders/LoaderRouteLifecycle';
+import { resolveLoaderPath } from './loaders/resolveLoaderPath';
+import { getContextKey } from './matchers';
 import { unstable_navigationEvents } from './navigationEvents';
 import {
   hasParam,
@@ -42,6 +45,7 @@ import {
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
 import type { UnknownOutputParams } from './types';
+import { getSingularId } from './utils/getSingularId';
 import { EmptyRoute } from './views/EmptyRoute';
 import {
   SuspenseFallback as DefaultSuspenseFallback,
@@ -303,6 +307,15 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
     const redirectHref = useGuardRedirect(value.route);
     const isGuarded = redirectHref !== undefined;
+    const isRouteType = value.type === 'route';
+    const resolvedLoaderPath = React.useMemo(() => {
+      if (!isRouteType || isGuarded) {
+        return null;
+      }
+      // NOTE(@hassankhan): `RouteNode` does not expose whether its module has a loader without
+      // eagerly loading it. Static loader metadata would let loader-free routes skip this work.
+      return resolveLoaderPath(getContextKey(value.contextKey), stateForPath);
+    }, [isGuarded, isRouteType, stateForPath]);
 
     const ResolvedSuspenseFallback =
       EXPO_ROUTER_IMPORT_MODE === 'lazy'
@@ -355,7 +368,6 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       }
     }, [isFocused, isGuarded, redirectHref]);
 
-    const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;
 
     if (isGuarded) {
@@ -372,6 +384,10 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     return (
       <Route node={value} params={route?.params}>
         <SuspenseFallbackContext value={providedSuspenseFallback}>
+          {/* This committed-shell signal is intentionally best-effort. A navigator may unmount a
+              retained route shell, which aborts pending work and causes a later visit to refetch.
+              Activity visibility and transition-attempt ownership need explicit lifecycle APIs. */}
+          {resolvedLoaderPath && <LoaderRouteLifecycle path={resolvedLoaderPath} />}
           {unstable_navigationEvents.isEnabled() && isRouteType && hasRouteKey && (
             <AnalyticsListeners navigation={navigation} screenId={route.key} />
           )}
@@ -546,17 +562,4 @@ export function routeToScreen<
   );
 }
 
-export function getSingularId(name: string, options: Record<string, any> = {}) {
-  return name
-    .split('/')
-    .map((segment) => {
-      if (segment.startsWith('[...')) {
-        return options.params?.[segment.slice(4, -1)]?.join('/') || segment;
-      } else if (segment.startsWith('[') && segment.endsWith(']')) {
-        return options.params?.[segment.slice(1, -1)] || segment;
-      } else {
-        return segment;
-      }
-    })
-    .join('/');
-}
+export { getSingularId } from './utils/getSingularId';

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { use, useEffect } from 'react';
+import React, { use, useEffect, useMemo } from 'react';
 
 import type { LoadedRoute, RouteNode } from './Route';
 import {
@@ -41,7 +41,6 @@ import {
   type RouteProp,
   type RouteSource,
   type ScreenListeners,
-  useStateForPath,
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
 import type { UnknownOutputParams } from './types';
@@ -324,21 +323,21 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       getState(): NavigationState | undefined;
     };
   }) {
-    const stateForPath = useStateForPath();
+    const routeInfo = useCurrentRouteInfo();
     const isFocused = navigation.isFocused();
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
     const ScreenErrorBoundary = use(ScreenErrorBoundaryContext);
     const redirectHref = useGuardRedirect(value.route);
     const isGuarded = redirectHref !== undefined;
     const isRouteType = value.type === 'route';
-    const resolvedLoaderPath = React.useMemo(() => {
+    const resolvedLoaderPath = useMemo(() => {
       if (!isRouteType || isGuarded) {
         return null;
       }
       // NOTE(@hassankhan): `RouteNode` does not expose whether its module has a loader without
       // eagerly loading it. Static loader metadata would let loader-free routes skip this work.
-      return resolveLoaderPath(getContextKey(value.contextKey), stateForPath);
-    }, [isGuarded, isRouteType, stateForPath]);
+      return resolveLoaderPath(getContextKey(value.contextKey), routeInfo);
+    }, [isGuarded, isRouteType, routeInfo]);
 
     const ResolvedSuspenseFallback =
       EXPO_ROUTER_IMPORT_MODE === 'lazy'

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -19,6 +19,9 @@ import { isRouteGuarded, useGuardRedirect, type GuardedRedirects } from './layou
 import { Redirect } from './link/Redirect';
 import { ZoomTransitionEnabler } from './link/zoom/ZoomTransitionEnabler';
 import { ZoomTransitionTargetContextProvider } from './link/zoom/zoom-transition-context-providers';
+import { LoaderRouteLifecycle } from './loaders/LoaderRouteLifecycle';
+import { resolveLoaderPath } from './loaders/resolveLoaderPath';
+import { getContextKey } from './matchers';
 import { unstable_navigationEvents } from './navigationEvents';
 import {
   hasParam,
@@ -38,9 +41,11 @@ import {
   type RouteProp,
   type RouteSource,
   type ScreenListeners,
+  useStateForPath,
 } from './react-navigation/native';
 import type { NativeStackNavigationEventMap } from './react-navigation/native-stack';
 import type { UnknownOutputParams } from './types';
+import { getSingularId } from './utils/getSingularId';
 import { EmptyRoute } from './views/EmptyRoute';
 import {
   SuspenseFallback as DefaultSuspenseFallback,
@@ -319,11 +324,21 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       getState(): NavigationState | undefined;
     };
   }) {
+    const stateForPath = useStateForPath();
     const isFocused = navigation.isFocused();
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
     const ScreenErrorBoundary = use(ScreenErrorBoundaryContext);
     const redirectHref = useGuardRedirect(value.route);
     const isGuarded = redirectHref !== undefined;
+    const isRouteType = value.type === 'route';
+    const resolvedLoaderPath = React.useMemo(() => {
+      if (!isRouteType || isGuarded) {
+        return null;
+      }
+      // NOTE(@hassankhan): `RouteNode` does not expose whether its module has a loader without
+      // eagerly loading it. Static loader metadata would let loader-free routes skip this work.
+      return resolveLoaderPath(getContextKey(value.contextKey), stateForPath);
+    }, [isGuarded, isRouteType, stateForPath]);
 
     const ResolvedSuspenseFallback =
       EXPO_ROUTER_IMPORT_MODE === 'lazy'
@@ -358,7 +373,6 @@ export function getQualifiedRouteComponent(value: RouteNode) {
       }
     }, [isFocused, isGuarded, redirectHref]);
 
-    const isRouteType = value.type === 'route';
     const hasRouteKey = !!route?.key;
 
     if (isGuarded) {
@@ -384,6 +398,10 @@ export function getQualifiedRouteComponent(value: RouteNode) {
     return (
       <Route node={value} params={route?.params}>
         <SuspenseFallbackContext value={providedSuspenseFallback}>
+          {/* This committed-shell signal is intentionally best-effort. A navigator may unmount a
+              retained route shell, which aborts pending work and causes a later visit to refetch.
+              Activity visibility and transition-attempt ownership need explicit lifecycle APIs. */}
+          {resolvedLoaderPath && <LoaderRouteLifecycle path={resolvedLoaderPath} />}
           {unstable_navigationEvents.isEnabled() && isRouteType && hasRouteKey && (
             <AnalyticsListeners navigation={navigation} screenId={route.key} />
           )}
@@ -557,17 +575,4 @@ export function routeToScreen<
   );
 }
 
-export function getSingularId(name: string, options: Record<string, any> = {}) {
-  return name
-    .split('/')
-    .map((segment) => {
-      if (segment.startsWith('[...')) {
-        return options.params?.[segment.slice(4, -1)]?.join('/') || segment;
-      } else if (segment.startsWith('[') && segment.endsWith(']')) {
-        return options.params?.[segment.slice(1, -1)] || segment;
-      } else {
-        return segment;
-      }
-    })
-    .join('/');
-}
+export { getSingularId } from './utils/getSingularId';

--- a/packages/expo-router/src/utils/getSingularId.ts
+++ b/packages/expo-router/src/utils/getSingularId.ts
@@ -1,0 +1,14 @@
+export function getSingularId(name: string, options: Record<string, any> = {}) {
+  return name
+    .split('/')
+    .map((segment) => {
+      if (segment.startsWith('[...')) {
+        return options.params?.[segment.slice(4, -1)]?.join('/') || segment;
+      } else if (segment.startsWith('[') && segment.endsWith(']')) {
+        return options.params?.[segment.slice(1, -1)] || segment;
+      } else {
+        return segment;
+      }
+    })
+    .join('/');
+}


### PR DESCRIPTION
# Why

Followup to  #48087.

When navigating to a route with a loader, the loader will start to fetch and React will suspend the route till it does. If the route is changed before the loader settles (pressing back in the browser or swiping back in a stack), there was no logic to clean up the in-flight request, the request would complete and be incorrectly set in the suspense store to be picked up by a future visit, serving potentially stale data.

# How

- `useLoaderData()` registers a "committed" subscription after a suspended route commits
- Each fetch now has an `AbortController`. The controller aborts on abandonment/teardown while the fetch is still in flight
- Every route now has a minimal lifecycle adapter above its Suspense boundary. When that route's shell unmounts, it schedules abandonment of its pending loader path

# Test Plan

- CI
- Manual testing with the `server-loader` fixture in `apps/router-e2e`: navigate to `/slow` in a browser with DevTools open, press back before it settles and see a cancelled network request. Navigate back to `/slow` and ensure a new loader fetch request is triggered.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
