### PR TITLE
[ui][Android] Expose `getMaterialColorTokens` for `expo-widgets`

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - [Android] Change modifiers type and provide appContext. ([#47616](https://github.com/expo/expo/pull/47616) by [@jakex7](https://github.com/jakex7))
 - [Android] Change `Text` color props to `ColorValue`. ([#47739](https://github.com/expo/expo/pull/47739) by [@jakex7](https://github.com/jakex7))
+- [Android] Expose `getMaterialColorTokens` for `expo-widgets`. ([48453](https://github.com/expo/expo/pull/48453) by [@jakex7](https://github.com/jakex7))
 
 ## 57.0.8 - 2026-07-29
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - [Android] Change modifiers type and provide appContext. ([#47616](https://github.com/expo/expo/pull/47616) by [@jakex7](https://github.com/jakex7))
 - [Android] Change `Text` color props to `ColorValue`. ([#47739](https://github.com/expo/expo/pull/47739) by [@jakex7](https://github.com/jakex7))
-- [Android] Expose `getMaterialColorTokens` for `expo-widgets`. ([48453](https://github.com/expo/expo/pull/48453) by [@jakex7](https://github.com/jakex7))
+- [Android] Expose `getMaterialColorTokens` for `expo-widgets`. ([#48453](https://github.com/expo/expo/pull/48453) by [@jakex7](https://github.com/jakex7))
 
 ## 57.0.8 - 2026-07-29
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/colors/MaterialColors.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/colors/MaterialColors.kt
@@ -35,6 +35,14 @@ internal fun Context.isSystemInDarkTheme(): Boolean {
 }
 
 /**
+ * Allows `expo-widgets` to back `getMaterialColors` inside the widgets JS runtime.
+ */
+fun getMaterialColorTokens(context: Context, isDark: Boolean): Map<String, String> {
+  val scheme = if (isDark) ExpoColorScheme.DARK else ExpoColorScheme.LIGHT
+  return scheme.toColorScheme(context).toTokenMap()
+}
+
+/**
  * Build a Material 3 `ColorScheme` from a single seed color, matching the
  * `SchemeTonalSpot` variant used by Material You. Works on every Android API
  * level (no wallpaper required).


### PR DESCRIPTION
# Why

`expo-widgets` does not provide Expo Modules so it needs to access these values directly.

# How

Expose `getMaterialColorTokens` so `expo-widgets` can resolve Material 3 palettes without the module.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>