### PR TITLE
[ios][core] Fix SwiftUI menu dismiss tap passing through to RN views

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))
 - [iOS] Concurrent functions build on the new two-phase `createAsyncFunction` from `expo-modules-jsi` again, instead of wiring the promise themselves. This also restores rejecting the returned promise (rather than throwing synchronously) when the app context is lost or argument decoding fails. ([#47755](https://github.com/expo/expo/pull/47755) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -214,6 +214,14 @@ extension ExpoSwiftUI {
     public override func didMoveToWindow() {
       super.didMoveToWindow()
 
+      #if os(iOS)
+      if let window {
+        // SwiftUI content can open a menu, and UIKit passes the tap that closes it through to
+        // React Native underneath. The gate stops that tap from reaching the view below.
+        SystemMenuTouchGate.install(in: window)
+      }
+      #endif
+
       if window != nil, let parentController = reactViewController() {
         #if !os(macOS)
         if parentController as? UINavigationController == nil && parentController as? UITabBarController == nil {

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SystemMenuTouchGate.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SystemMenuTouchGate.swift
@@ -1,7 +1,8 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #if os(iOS)
-// Also brings in the subclass header, required to set `state` from the touch callbacks.
+// Also brings in the subclass header, required to set `state` from the touch callbacks
+// and to call `ignore(_:for:)` on React Native's touch handler.
 import UIKit.UIGestureRecognizerSubclass
 
 /**
@@ -24,20 +25,28 @@ internal final class SystemMenuTouchGate: UIGestureRecognizer {
    The one view UIKit adds to the window for a presented context menu.
    */
   static func isContextMenuContainerClassName(_ className: String) -> Bool {
-    return className == "_UIContextMenuContainerView"
+    return className == "_UI".appending("ContextMenuContainerView")
   }
 
   /**
-    Consider Menu to be open when container view is present and interaction on it is enabled.
+    Consider Menu to be open when the container is present, still accepts interaction, and is modal.
+    UIKit turns `isUserInteractionEnabled` off the moment dismissal commits, so taps made during
+    the dismiss animation pass through to the app again. `accessibilityViewIsModal` is how UIKit
+    marks the container as blocking the content behind it — a semantic signal beside the class name.
    */
-  static func isOpenContextMenuContainer(className: String, isUserInteractionEnabled: Bool) -> Bool {
-    return isUserInteractionEnabled && isContextMenuContainerClassName(className)
+  static func isOpenContextMenuContainer(
+    className: String,
+    isUserInteractionEnabled: Bool,
+    accessibilityViewIsModal: Bool
+  ) -> Bool {
+    return isUserInteractionEnabled && accessibilityViewIsModal && isContextMenuContainerClassName(className)
   }
 
   static func isContextMenuContainer(_ view: UIView) -> Bool {
     return isOpenContextMenuContainer(
       className: NSStringFromClass(type(of: view)),
-      isUserInteractionEnabled: view.isUserInteractionEnabled
+      isUserInteractionEnabled: view.isUserInteractionEnabled,
+      accessibilityViewIsModal: view.accessibilityViewIsModal
     )
   }
 
@@ -64,20 +73,26 @@ internal final class SystemMenuTouchGate: UIGestureRecognizer {
     return className == "RCTSurfaceTouchHandler"
   }
 
+  static func isSurfaceTouchHandler(_ recognizer: UIGestureRecognizer) -> Bool {
+    return isSurfaceTouchHandlerClassName(NSStringFromClass(type(of: recognizer)))
+  }
+
   /**
-  Cancels touches by disabling and re-enabling the gesture recognizer. This is the same approach React Native uses in
-  RCTSurfaceTouchHandler.mm.
-  https://github.com/react/react-native/blob/3a95e0e93c80537d519dd7e9a771544396d4ab6b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L414
+   React Native's touch handlers along the touched view's superview chain.
    */
-  static func cancelReactNativeTouches(in view: UIView) {
-    for recognizer in view.gestureRecognizers ?? []
-    where isSurfaceTouchHandlerClassName(NSStringFromClass(type(of: recognizer))) {
-      recognizer.isEnabled = false
-      recognizer.isEnabled = true
+  static func surfaceTouchHandlers(
+    above view: UIView?,
+    isSurfaceTouchHandler: @MainActor (UIGestureRecognizer) -> Bool = SystemMenuTouchGate.isSurfaceTouchHandler
+  ) -> [UIGestureRecognizer] {
+    var handlers: [UIGestureRecognizer] = []
+    var current = view
+    while let view = current {
+      for recognizer in view.gestureRecognizers ?? [] where isSurfaceTouchHandler(recognizer) {
+        handlers.append(recognizer)
+      }
+      current = view.superview
     }
-    for subview in view.subviews {
-      cancelReactNativeTouches(in: subview)
-    }
+    return handlers
   }
 
   // MARK: - Installing
@@ -100,7 +115,11 @@ internal final class SystemMenuTouchGate: UIGestureRecognizer {
     super.touchesBegan(touches, with: event)
 
     if let window = view as? UIWindow, Self.isShowingContextMenu(in: window) {
-      Self.cancelReactNativeTouches(in: window)
+      for touch in touches {
+        for handler in Self.surfaceTouchHandlers(above: touch.view) {
+          handler.ignore(touch, for: event)
+        }
+      }
     }
     state = .failed
   }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SystemMenuTouchGate.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SystemMenuTouchGate.swift
@@ -1,0 +1,108 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+#if os(iOS)
+// Also brings in the subclass header, required to set `state` from the touch callbacks.
+import UIKit.UIGestureRecognizerSubclass
+
+/**
+  We create a custom gesture recognizer to stop React Root listening to touches when user taps background while Menu is opened.
+  Menu when opened attaches a container view `_UIContextMenuContainerView` to the window.
+  On tapping it, React Root's `RCTSurfaceTouchHandler` also listens to the touch and causes Pressables to fire onPress.
+ */
+internal final class SystemMenuTouchGate: UIGestureRecognizer {
+  init() {
+    super.init(target: nil, action: nil)
+    // Both default to true. Never hold a touch back, and never let React Native's handler see a
+    // reason to cancel: it calls `_cancelTouches` for any outside recognizer that cancels in view.
+    delaysTouchesEnded = false
+    cancelsTouchesInView = false
+  }
+
+  // MARK: - Detecting an open menu
+
+  /**
+   The one view UIKit adds to the window for a presented context menu.
+   */
+  static func isContextMenuContainerClassName(_ className: String) -> Bool {
+    return className == "_UIContextMenuContainerView"
+  }
+
+  /**
+    Consider Menu to be open when container view is present and interaction on it is enabled.
+   */
+  static func isOpenContextMenuContainer(className: String, isUserInteractionEnabled: Bool) -> Bool {
+    return isUserInteractionEnabled && isContextMenuContainerClassName(className)
+  }
+
+  static func isContextMenuContainer(_ view: UIView) -> Bool {
+    return isOpenContextMenuContainer(
+      className: NSStringFromClass(type(of: view)),
+      isUserInteractionEnabled: view.isUserInteractionEnabled
+    )
+  }
+
+  /**
+   UIKit adds the container as a direct subview of the window, above the app's content, so only the
+   window's own subviews are worth checking. Anything deeper belongs to the app itself.
+   */
+  static func isShowingContextMenu(
+    in window: UIWindow,
+    isContainer: @MainActor (UIView) -> Bool = SystemMenuTouchGate.isContextMenuContainer
+  ) -> Bool {
+    for subview in window.subviews where isContainer(subview) {
+      return true
+    }
+    return false
+  }
+
+  // MARK: - Cancelling React Native's touches
+
+  /**
+   Matched by name so that this file needs no React Native headers.
+   */
+  static func isSurfaceTouchHandlerClassName(_ className: String) -> Bool {
+    return className == "RCTSurfaceTouchHandler"
+  }
+
+  /**
+  Cancels touches by disabling and re-enabling the gesture recognizer. This is the same approach React Native uses in
+  RCTSurfaceTouchHandler.mm.
+  https://github.com/react/react-native/blob/3a95e0e93c80537d519dd7e9a771544396d4ab6b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L414
+   */
+  static func cancelReactNativeTouches(in view: UIView) {
+    for recognizer in view.gestureRecognizers ?? []
+    where isSurfaceTouchHandlerClassName(NSStringFromClass(type(of: recognizer))) {
+      recognizer.isEnabled = false
+      recognizer.isEnabled = true
+    }
+    for subview in view.subviews {
+      cancelReactNativeTouches(in: subview)
+    }
+  }
+
+  // MARK: - Installing
+
+  /**
+   Adds one gate to the window. The window owns it for as long as it lives, and the gate stays
+   inert until a menu is actually open, so there is nothing to tear down per host.
+   */
+  static func install(in window: UIWindow) {
+    let isInstalled = window.gestureRecognizers?.contains { $0 is SystemMenuTouchGate } ?? false
+    guard !isInstalled else {
+      return
+    }
+    window.addGestureRecognizer(SystemMenuTouchGate())
+  }
+
+  // MARK: - UIGestureRecognizer
+
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+    super.touchesBegan(touches, with: event)
+
+    if let window = view as? UIWindow, Self.isShowingContextMenu(in: window) {
+      Self.cancelReactNativeTouches(in: window)
+    }
+    state = .failed
+  }
+}
+#endif


### PR DESCRIPTION


# Why

The original PR was in https://github.com/expo/expo/pull/47413. This PR simplifies the original PR approach by removing the swizzling/polling.

Issue is that when a Menu/Popover is opened outside taps closes the Menu as well as sends touches to behind RN views. This happens because the menu popover is mounted in the main UIWindow, so it receives touches which is then passed to `RCTSurfaceTouchHandler` which propagates it to RN Views.

This issue does not happen in bare SwiftUI/UIKit app as UIButton/SwiftUI button prevent such touches.




<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

We add a custom touch recognizer which cancels RN's RCTSurfaceHandler touch when Menu background container is tapped.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan



Tested Repro in NCL.

## Before

The press counter increases on tapping outside

https://github.com/user-attachments/assets/ed1a6f28-63a8-4e89-94ff-18d4289034b3


## After

The press counter does not increase on tapping outside

https://github.com/user-attachments/assets/03495c3f-0dd1-4c96-b5e0-46e2d95505ae



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
