### PR TITLE
fix(expo-router): remove double-decoding of route params

### DIFF
--- a/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getRouteInfoFromState.test.ios.ts
@@ -224,13 +224,13 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/feed');
   });
 
-  it('decodes URI-encoded params', () => {
+  it('passes through params unchanged (already decoded upstream)', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
           name: '__root',
           state: {
-            routes: [{ name: '[name]', params: { name: 'hello%20world' } }],
+            routes: [{ name: '[name]', params: { name: 'hello world' } }],
             index: 0,
           },
         },
@@ -242,7 +242,10 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/hello world');
   });
 
-  it('handles malformed URI component (returns as-is)', () => {
+  it('preserves percent-encoded values without double-decoding', () => {
+    // Params containing percent-encoded sequences should pass through unchanged
+    // since decoding already happened upstream (URLSearchParams / getStateFromPath).
+    // This prevents double-decoding that corrupts values like AWS SigV4 URLs.
     const result = getRouteInfoFromState({
       routes: [
         {
@@ -256,7 +259,6 @@ describe('getRouteInfoFromState', () => {
       index: 0,
     });
 
-    // Malformed URI should be returned as-is
     expect(result.params.name).toBe('%E0%A4%A');
     expect(result.pathname).toBe('/%E0%A4%A');
     expect(result.pathnameWithParams).toBe('/%E0%A4%A');
@@ -309,13 +311,13 @@ describe('getRouteInfoFromState', () => {
     expect(result.pathname).toBe('/dashboard');
   });
 
-  it('decodes array params in catch-all', () => {
+  it('passes through array params unchanged (already decoded upstream)', () => {
     const result = getRouteInfoFromState({
       routes: [
         {
           name: '__root',
           state: {
-            routes: [{ name: '[...path]', params: { path: ['hello%20world', 'foo%2Fbar'] } }],
+            routes: [{ name: '[...path]', params: { path: ['hello world', 'foo/bar'] } }],
             index: 0,
           },
         },

--- a/packages/expo-router/src/global-state/getRouteInfoFromState.ts
+++ b/packages/expo-router/src/global-state/getRouteInfoFromState.ts
@@ -1,7 +1,6 @@
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '../constants';
 import { appendBaseUrl } from '../fork/getPathFromState-forks';
 import type { NavigationState, PartialState } from '../react-navigation/native';
-import { safeDecodeURIComponent } from '../utils/url';
 import type { FocusedRouteState } from './types';
 
 export type UrlObject = {
@@ -86,17 +85,11 @@ export function getRouteInfoFromState(state?: StrictState): UrlObject {
     state = route.state;
   }
 
-  params = Object.fromEntries(
-    Object.entries(params).map(([key, value]) => {
-      if (typeof value === 'string') {
-        return [key, safeDecodeURIComponent(value)];
-      } else if (Array.isArray(value)) {
-        return [key, value.map((v) => safeDecodeURIComponent(v))];
-      } else {
-        return [key, value];
-      }
-    })
-  );
+  // Params are already decoded upstream: query params by URLSearchParams (in
+  // parseQueryParams) and path params by decodeURIComponent (in getStateFromPath).
+  // Applying safeDecodeURIComponent again here would double-decode percent-encoded
+  // values (e.g. `%2F` → `/`), corrupting URLs like AWS SigV4 presigned URLs.
+  // See: https://github.com/expo/expo/issues/48421
 
   /**
    * If React Navigation didn't render the entire tree (e.g it was interrupted in a layout)

--- a/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
@@ -103,21 +103,25 @@ describe(useLocalSearchParams, () => {
       initialUrl: '/?test=%2Fhello%2Fworld%2F',
     });
 
+    // URLSearchParams auto-decodes %2F → / (single decode, correct)
     expect(result.current).toEqual({
       test: '/hello/world/',
     });
 
-    act(() => router.setParams({ test: '%2Fhello%2Fworld%2Fagain' }));
+    // setParams sets literal values — no encoding/decoding cycle
+    act(() => router.setParams({ test: '/hello/world/again' }));
 
     expect(result.current).toEqual({
       test: '/hello/world/again',
     });
 
+    // router.push encodes via encodeURIComponent, then URLSearchParams decodes once.
+    // The round-trip should preserve the original value exactly.
     act(() =>
       router.push({
         pathname: '/',
         params: {
-          test: '%2Ffoo%2Fbar%2F',
+          test: '/foo/bar/',
         },
       })
     );
@@ -125,5 +129,36 @@ describe(useLocalSearchParams, () => {
     expect(result.current).toEqual({
       test: '/foo/bar/',
     });
+  });
+
+  it(`preserves percent-encoded characters without double-decoding`, () => {
+    // This is the fix for https://github.com/expo/expo/issues/48421
+    // Values containing %2F, %2B etc. should survive the round-trip intact.
+    act(() =>
+      router.push({
+        pathname: '/',
+        params: {
+          url: 'https://s3.amazonaws.com/bucket?token=abc%2Fdef%2Bghi',
+        },
+      })
+    );
+
+    const { result } = renderHook(() => useLocalSearchParams(), ['index'], {
+      initialUrl: '/',
+    });
+
+    // The value should be exactly what was passed in
+    act(() =>
+      router.push({
+        pathname: '/',
+        params: {
+          url: 'https://s3.amazonaws.com/bucket?token=abc%2Fdef%2Bghi',
+        },
+      })
+    );
+
+    expect(result.current.url).toEqual(
+      'https://s3.amazonaws.com/bucket?token=abc%2Fdef%2Bghi'
+    );
   });
 });

--- a/packages/expo-router/src/hooks/useLocalSearchParams.ts
+++ b/packages/expo-router/src/hooks/useLocalSearchParams.ts
@@ -48,33 +48,19 @@ export function useLocalSearchParams<
 export function useLocalSearchParams() {
   const params = React.use(LocalRouteParamsContext) ?? {};
   const { params: previewParams } = usePreviewInfo();
+  // Params are already decoded upstream: query params by URLSearchParams (in
+  // parseQueryParams) and path params by decodeURIComponent (in getStateFromPath).
+  // Applying decodeURIComponent again here would double-decode percent-encoded
+  // values (e.g. `%2F` → `/`), corrupting URLs like AWS SigV4 presigned URLs.
+  // See: https://github.com/expo/expo/issues/48421
   return Object.fromEntries(
     Object.entries(previewParams ?? params).map(([key, value]) => {
       // React Navigation doesn't remove `undefined` values from the params object, and you cannot remove them via
-      // `navigation.setParams()` as it shallow merges. Hence, we hide them here. We also pass `null` through unchanged
-      // for the same reason; running it through `decodeURIComponent()` would otherwise stringify it to `null`.
+      // `navigation.setParams()` as it shallow merges. Hence, we hide them here.
       if (value == null) {
         return [key, value];
       }
-
-      if (Array.isArray(value)) {
-        return [
-          key,
-          value.map((v) => {
-            try {
-              return decodeURIComponent(v);
-            } catch {
-              return v;
-            }
-          }),
-        ];
-      } else {
-        try {
-          return [key, decodeURIComponent(value as string)];
-        } catch {
-          return [key, value];
-        }
-      }
+      return [key, value];
     })
   ) as any;
 }


### PR DESCRIPTION
## Summary

Fixes #48421 — Route params are encoded once but decoded twice, corrupting AWS SigV4 presigned URLs (and any value containing percent-encoded characters like `%2F`, `%2B`).

## Root Cause

The encode/decode flow was asymmetric:

| Step | Location | Operation |
|------|----------|-----------|
| encode ×1 | `createQueryParams()` | `encodeURIComponent(value)` |
| decode ×1 | `parseQueryParams()` | `URLSearchParams.getAll()` (auto-decodes) |
| decode ×2 ❌ | `useLocalSearchParams()` | `decodeURIComponent(value)` |
| decode ×2 ❌ | `getRouteInfoFromState()` | `safeDecodeURIComponent(value)` |

After step 2, values are already fully decoded in the navigation state. The additional decodes in steps 3 and 4 are redundant and destructive.

## Changes

- **`src/hooks/useLocalSearchParams.ts`** — Removed `decodeURIComponent()` mapping. Params pass through unchanged since they are already decoded upstream.
- **`src/global-state/getRouteInfoFromState.ts`** — Removed `safeDecodeURIComponent()` mapping and its import.
- **Tests updated** to reflect correct behavior (no double-decode) and added a new test specifically for the SigV4 URL preservation scenario.

## Test Plan

- Updated existing tests in `useLocalSearchParams.test.ios.tsx` and `getRouteInfoFromState.test.ios.ts`
- Added new test case: passing a URL with `%2F` and `%2B` through `router.push` → `useLocalSearchParams` preserves the value exactly

## Impact

This is a **breaking change for code that relied on the double-decode** (e.g., passing `%2Fhello` as a literal param value to `router.setParams()` and expecting it to become `/hello`). However, this was always incorrect behavior — the correct approach is to pass the actual decoded value directly.