### PR TITLE
docs: clarify Android SDK version vs outdated screenshot

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx
@@ -32,12 +32,14 @@ Verify the settings and click **Next**. Then, accept the license agreement and c
 
 <Step label="3">
 
-By default, Android Studio will install the latest version of the Android SDK. However, Android 16 (`Baklava`) SDK is required to compile a React Native app.
+By default, Android Studio will install the latest version of the Android SDK. However, building a React Native app for the current Expo SDK requires at least the **Android 16 (`Baklava`)** SDK.
 
-Open Android Studio, go to **Settings** &gt; **Languages & Frameworks** &gt; **Android SDK**. From the **SDK Platforms** tab, and under **Android 16 (`Baklava`)**, select **Android SDK Platform 36** and **Sources for Android 36**.
+Open Android Studio, go to **Settings** &gt; **Languages & Frameworks** &gt; **Android SDK**. From the **SDK Platforms** tab, select the checkbox for **Android SDK Platform 36** and **Sources for Android 36** (listed under **Android 16.0 ("Baklava")**).
+
+> **Note:** The screenshot below may show a previous SDK version. Make sure you install **Android SDK Platform 36** or higher.
 
 <ContentSpotlight
-  alt="Android SDK Platforms"
+  alt="Android SDK Platforms settings showing installed SDK versions"
   src="/static/images/android-studio/sdk-platforms.webp"
   className="max-w-[640px]"
 />
@@ -168,12 +170,14 @@ In the next window, accept licenses for all available components.
 
 <Step label="6">
 
-By default, Android Studio will install the latest version of the Android SDK. However, Android 16 (`Baklava`) SDK is required to compile a React Native app.
+By default, Android Studio will install the latest version of the Android SDK. However, building a React Native app for the current Expo SDK requires at least the **Android 16 (`Baklava`)** SDK.
 
-Open Android Studio, go to **Settings** &gt; **Languages & Frameworks** &gt; **Android SDK**. From the **SDK Platforms** tab, and under **Android 16 (`Baklava`)**, select **Android SDK Platform 36** and **Sources for Android 36**.
+Open Android Studio, go to **Settings** &gt; **Languages & Frameworks** &gt; **Android SDK**. From the **SDK Platforms** tab, select the checkbox for **Android SDK Platform 36** and **Sources for Android 36** (listed under **Android 16.0 ("Baklava")**).
+
+> **Note:** The screenshot below may show a previous SDK version. Make sure you install **Android SDK Platform 36** or higher.
 
 <ContentSpotlight
-  alt="Android SDK Platforms"
+  alt="Android SDK Platforms settings showing installed SDK versions"
   src="/static/images/android-studio/windows-sdk-platforms.webp"
   className="max-w-[640px]"
 />


### PR DESCRIPTION
## Summary

Fixes #48373 — The "Set up your environment" docs page states Android SDK Platform 36 is required, but the screenshots show SDK 35 (Android 15). This confuses new users.

## Changes

Updated `docs/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx`:

- Clarified wording: "requires at least the **Android 16 (Baklava)** SDK"
- Added a `> Note:` callout below the screenshot explaining it may show a previous version
- Made instructions more explicit about what checkbox to select
- Updated alt text to be more descriptive
- Applied to both macOS (step 3) and Windows (step 6) sections

## Why not just update the screenshots?

The screenshots need to be taken in Android Studio with SDK 36 installed. This text fix resolves the user confusion immediately. Screenshots can be updated separately in a follow-up.

## Test Plan

Visual review only — no code changes.