### PR TITLE
fix(expo-auth-session): throw descriptive error instead of opaque SyntaxError

### DIFF
--- a/packages/expo-auth-session/src/Fetch.ts
+++ b/packages/expo-auth-session/src/Fetch.ts
@@ -56,6 +56,29 @@ export async function requestAsync<T>(requestUrl: string, fetchRequest: FetchReq
 
   const response = await fetch(correctedUrl, request);
 
+  // Check for HTTP errors before attempting to parse the body.
+  // Without this, a non-2xx response with an empty or non-JSON body would throw
+  // an opaque SyntaxError from JSON.parse, hiding the actual HTTP error.
+  // See: https://github.com/expo/expo/issues/45384
+  if (!response.ok) {
+    const bodyText = await response.text().catch(() => '');
+    const contentType = response.headers.get('content-type');
+    // If the error response is JSON, try to parse it and return it so callers
+    // (like TokenRequest.performAsync) can inspect the `error` field.
+    if (contentType?.includes('application/json') && bodyText) {
+      try {
+        return JSON.parse(bodyText);
+      } catch {
+        // Fall through to throw a descriptive error
+      }
+    }
+    // For non-JSON error responses or empty bodies, throw a clear error
+    const statusText = response.statusText || 'Unknown';
+    throw new Error(
+      `Request to ${correctedUrl} failed with status ${response.status} (${statusText})${bodyText ? `: ${bodyText}` : ''}`
+    );
+  }
+
   const contentType = response.headers.get('content-type');
   if (isJsonDataType || contentType?.includes('application/json')) {
     return response.json();

--- a/packages/expo-auth-session/src/__tests__/Fetch-test.ts
+++ b/packages/expo-auth-session/src/__tests__/Fetch-test.ts
@@ -1,0 +1,189 @@
+import { requestAsync } from '../Fetch';
+
+// Mock global fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('requestAsync', () => {
+  it('returns parsed JSON for successful response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ name: 'test-user' }),
+      text: () => Promise.resolve('{"name":"test-user"}'),
+    });
+
+    const result = await requestAsync('https://example.com/userinfo', {
+      dataType: 'json',
+      method: 'GET',
+    });
+
+    expect(result).toEqual({ name: 'test-user' });
+  });
+
+  it('returns text for non-JSON successful response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      text: () => Promise.resolve('hello world'),
+    });
+
+    const result = await requestAsync('https://example.com/text', {
+      method: 'GET',
+    });
+
+    expect(result).toBe('hello world');
+  });
+
+  it('throws descriptive error for non-2xx response with empty body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: new Headers({}),
+      text: () => Promise.resolve(''),
+    });
+
+    await expect(
+      requestAsync('https://example.com/userinfo', {
+        dataType: 'json',
+        method: 'GET',
+      })
+    ).rejects.toThrow('Request to https://example.com/userinfo failed with status 401 (Unauthorized)');
+  });
+
+  it('throws descriptive error for non-2xx response with text body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: new Headers({ 'content-type': 'text/plain' }),
+      text: () => Promise.resolve('Access denied'),
+    });
+
+    await expect(
+      requestAsync('https://example.com/resource', {
+        dataType: 'json',
+        method: 'GET',
+      })
+    ).rejects.toThrow('Request to https://example.com/resource failed with status 403 (Forbidden): Access denied');
+  });
+
+  it('returns parsed JSON error body for non-2xx with JSON content-type (for callers like TokenRequest)', async () => {
+    const errorResponse = { error: 'invalid_token', error_description: 'Token expired' };
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve(JSON.stringify(errorResponse)),
+    });
+
+    // When the error response is valid JSON, it should be returned (not thrown)
+    // so callers like TokenRequest.performAsync can check for 'error' in response
+    const result = await requestAsync('https://example.com/token', {
+      dataType: 'json',
+      method: 'POST',
+    });
+
+    expect(result).toEqual(errorResponse);
+  });
+
+  it('throws error for non-2xx with JSON content-type but empty body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve(''),
+    });
+
+    await expect(
+      requestAsync('https://example.com/userinfo', {
+        dataType: 'json',
+        method: 'GET',
+      })
+    ).rejects.toThrow('Request to https://example.com/userinfo failed with status 401 (Unauthorized)');
+  });
+
+  it('throws error for non-2xx with JSON content-type but malformed JSON', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve('not valid json'),
+    });
+
+    await expect(
+      requestAsync('https://example.com/api', {
+        dataType: 'json',
+        method: 'GET',
+      })
+    ).rejects.toThrow(
+      'Request to https://example.com/api failed with status 500 (Internal Server Error): not valid json'
+    );
+  });
+
+  it('sets Accept header for JSON dataType', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve('{}'),
+    });
+
+    await requestAsync('https://example.com/api', {
+      dataType: 'json',
+      method: 'GET',
+    });
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.headers.Accept).toBe('application/json, text/javascript; q=0.01');
+  });
+
+  it('sends body as URL-encoded form for POST requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({ success: true }),
+      text: () => Promise.resolve('{"success":true}'),
+    });
+
+    await requestAsync('https://example.com/token', {
+      dataType: 'json',
+      method: 'POST',
+      body: { grant_type: 'authorization_code', code: 'abc123' },
+    });
+
+    const [, requestInit] = mockFetch.mock.calls[0];
+    expect(requestInit.body).toBe('grant_type=authorization_code&code=abc123');
+  });
+
+  it('appends body as query params for GET requests', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: () => Promise.resolve({}),
+      text: () => Promise.resolve('{}'),
+    });
+
+    await requestAsync('https://example.com/api', {
+      dataType: 'json',
+      method: 'GET',
+      body: { key: 'value' },
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('key=value');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #45384 — `fetchUserInfoAsync` (and any `requestAsync` caller) throws an opaque `SyntaxError: JSON Parse error: Unexpected end of input` when the server returns a non-2xx response with an empty or non-JSON body.

## Problem

`requestAsync` in `Fetch.ts` unconditionally calls `response.json()` without checking `response.ok`. When a server responds with HTTP 401/403/500 and an empty body, `JSON.parse("")` throws an unhelpful `SyntaxError`.

This makes it impossible to distinguish between:
- A network error
- A 401 with empty body (e.g., expired token on Keycloak)
- A malformed JSON response

## Solution

Check `response.ok` before attempting to parse:

1. **If error response has `application/json` content-type with a valid body** → return the parsed object. This preserves backward compatibility with `TokenRequest.performAsync`, which checks for `"error" in response` to throw a `TokenError`.

2. **Otherwise** → throw a descriptive `Error` with status code, status text, and body text.

### Before
```
SyntaxError: JSON Parse error: Unexpected end of input
```

### After
```
Error: Request to https://keycloak.example.com/userinfo failed with status 401 (Unauthorized)
```

## Files Changed

| File | Change |
|------|--------|
| `packages/expo-auth-session/src/Fetch.ts` | Add `response.ok` check before parsing |
| `packages/expo-auth-session/src/__tests__/Fetch-test.ts` | New: comprehensive tests for `requestAsync` |

## Test Plan

- Added 9 test cases covering: success, text responses, empty body errors, JSON error bodies, malformed JSON errors, header handling, POST body encoding, GET query params
- Backward compatible: JSON error responses (like OAuth `{"error":"invalid_token"}`) are still returned to callers for inspection