### PR TITLE
fix(expo-router): skip URL sync for partially-mounted group routes on web

### DIFF
--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -367,6 +367,15 @@ export function useLinking(
 
       if (state) {
         const route = findFocusedRoute(state);
+
+        // START FORK
+        // Skip URL sync for partially-mounted group routes (same guard as onStateChange).
+        // See: https://github.com/expo/expo/issues/48439
+        if (route && /^\([^/]+\)$/.test(route.name) && !('state' in route && route.state)) {
+          return;
+        }
+        // END FORK
+
         const path = getPathForRoute(route, state);
 
         if (previousStateRef.current === undefined) {
@@ -403,6 +412,19 @@ export function useLinking(
 
       const pendingPath = pendingPopStatePathRef.current;
       const route = findFocusedRoute(state);
+
+      // START FORK
+      // If the focused route is a group whose nested navigator has not mounted yet,
+      // the state is still partial. Resolving a path from it would fall back to the
+      // group's first defined screen, briefly rewriting the URL to the wrong path.
+      // Skip the sync — the next state event (when the child navigator mounts) will
+      // carry the real route and write the correct URL.
+      // See: https://github.com/expo/expo/issues/48439
+      if (route && /^\([^/]+\)$/.test(route.name) && !('state' in route && route.state)) {
+        return;
+      }
+      // END FORK
+
       const path = getPathForRoute(route, state);
 
       // START FORK


### PR DESCRIPTION
## Summary

Fixes #48439 — On web, refreshing a page inside a route group briefly rewrites the URL to the group's first defined screen before correcting it. For example, refreshing `/sign-in` shows `/change-password` for ~50-300ms.

## Problem

When a group route's nested navigator has not mounted yet (due to async layout gates like `useFonts` + `SplashScreen` or auth checks), `findFocusedRoute` returns the bare group `(group)` with no nested state. `getPathFromState` then applies its "navigated to a group without a target screen" rule, falling back to `Object.keys(screens)[0]` — the first screen alphabetically — and writes that URL via `history.replaceState`.

Once the nested navigator mounts (next state event), the URL is corrected. But the blink is visible in the address bar, and any code reading `location` during that window sees the wrong path.

## Fix

In `useLinking.ts`, before computing the path and syncing it to history, check if the focused route is a group (`/^\([^/]+\)$/`) without nested state. If so, skip the sync — the next state event will carry the real route.

Applied to both:
1. Initial state sync (first render `history.replace`)
2. `onStateChange` handler

## Test Plan

- Verified against the reproduction described in the issue: `/b` no longer blinks to `/a`
- Does not affect normal navigation (push, back, deep links) since those have fully-resolved state
- Web-only change (`useLinking.ts` is not used on native)

## Related

- #34668 — Added the `Object.keys(screens)[0]` fallback that produces the wrong path
- Reporter has been running this exact patch in production since 2026-07-30