### PR TITLE
fix(expo-router): prevent parentheses in query params from being stripped as groups

### DIFF
--- a/packages/expo-router/src/fork/getStateFromPath-forks.ts
+++ b/packages/expo-router/src/fork/getStateFromPath-forks.ts
@@ -55,7 +55,7 @@ export function getUrlWithReactNavigationConcessions(
   path: string,
   baseUrl: string | undefined = process.env.EXPO_BASE_URL
 ): UrlWithReactNavigationConcessions {
-  const pathWithoutGroups = stripGroupSegmentsFromPath(stripBaseUrl(path, baseUrl));
+  const pathWithoutGroups = stripGroupSegmentsFromPath(stripBaseUrl(path, baseUrl).split('?')[0]!);
 
   let pathname = '';
   let hash = '';


### PR DESCRIPTION
## Summary

Fixes #26664 — `router.push` drops all query parameters when any parameter value contains parentheses (e.g., `(a)`).

## Problem

`getUrlWithReactNavigationConcessions` calls `stripGroupSegmentsFromPath` on the **full path including query string**:

```ts
const pathWithoutGroups = stripGroupSegmentsFromPath(stripBaseUrl(path, baseUrl));
// path = "/test?a=(a)&b=b"
```

When split by `/`, the segment `test?a=(a)&b=b` matches `matchGroupName` regex because it finds `(a)`. The entire segment is then stripped as if it were a route group, losing all query parameters.

## Fix

One-line change — strip the query string before applying group-segment removal:

```ts
const pathWithoutGroups = stripGroupSegmentsFromPath(stripBaseUrl(path, baseUrl).split("?")[0]!);
```

This is safe because:
- `pathWithoutGroups` is only used as `route.path` (the clean pathname)
- Query params are already parsed separately via `parseQueryParams` using `URLSearchParams`

## Test Plan

- `router.push({ pathname: "/test", params: { a: "(a)", b: "b" } })` now correctly passes both params
- Group segments in the actual pathname (e.g., `/(tabs)/home`) are still stripped correctly
- No change to query parameter handling (still parsed via `URLSearchParams`)

## Scope

This is a long-standing bug (open since 2023-12-09) affecting all platforms. The fix is minimal and focused.