### PR TITLE
fix(expo-background-task): make network connectivity configurable

### DIFF
--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskConsumer.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskConsumer.kt
@@ -37,7 +37,8 @@ class BackgroundTaskConsumer(context: Context?, taskManagerUtils: TaskManagerUti
     this.task = task
 
     val intervalMinutes = getIntervalMinutes()
-    BackgroundTaskScheduler.registerTask(context, intervalMinutes)
+    val requiresNetworkConnectivity = getRequiresNetworkConnectivity()
+    BackgroundTaskScheduler.registerTask(context, intervalMinutes, requiresNetworkConnectivity)
   }
 
   override fun didUnregister() {
@@ -50,5 +51,10 @@ class BackgroundTaskConsumer(context: Context?, taskManagerUtils: TaskManagerUti
     val options = task?.options as? Map<String, Any?>
     return (options?.get("minimumInterval") as? Number)?.toLong()
       ?: BackgroundTaskScheduler.DEFAULT_INTERVAL_MINUTES
+  }
+
+  private fun getRequiresNetworkConnectivity(): Boolean {
+    val options = task?.options as? Map<String, Any?>
+    return (options?.get("requiresNetworkConnectivity") as? Boolean) ?: false
   }
 }

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -40,15 +40,19 @@ object BackgroundTaskScheduler {
   // Interval
   private var intervalMinutes: Long = DEFAULT_INTERVAL_MINUTES
 
+  // Whether to require network connectivity
+  private var requiresNetworkConnectivity: Boolean = false
+
   // Tracks whether in foreground
   var inForeground: Boolean = false
 
   /**
    * Call when a task is registered
    */
-  fun registerTask(context: Context, intervalMinutes: Long) {
+  fun registerTask(context: Context, intervalMinutes: Long, requiresNetworkConnectivity: Boolean = false) {
     numberOfRegisteredTasksOfThisType += 1
     this.intervalMinutes = intervalMinutes
+    this.requiresNetworkConnectivity = requiresNetworkConnectivity
 
     if (numberOfRegisteredTasksOfThisType == 1) {
       runBlocking {
@@ -105,7 +109,7 @@ object BackgroundTaskScheduler {
       .putString("appScopeKey", appScopeKey)
       .build()
     val constraints = Constraints.Builder()
-      .setRequiredNetworkType(NetworkType.CONNECTED)
+      .setRequiredNetworkType(if (requiresNetworkConnectivity) NetworkType.CONNECTED else NetworkType.NOT_REQUIRED)
       .build()
 
     // Get Work manager

--- a/packages/expo-background-task/ios/BackgroundTaskConsumer.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskConsumer.swift
@@ -42,7 +42,10 @@ class BackgroundTaskConsumer: NSObject, EXTaskConsumerInterface {
       return
     }
 
-    BackgroundTaskScheduler.didRegisterTask(minutes: self.task?.options?["minimumInterval"] as? Int)
+    BackgroundTaskScheduler.didRegisterTask(
+      minutes: self.task?.options?["minimumInterval"] as? Int,
+      requiresNetwork: self.task?.options?["requiresNetworkConnectivity"] as? Bool
+    )
   }
 
   func didUnregister() {

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -62,10 +62,14 @@ public class BackgroundTaskScheduler {
     private var scheduler: BackgroundTaskScheduling = SystemBackgroundTaskScheduler()
     private var numberOfRegisteredTasksOfThisType: Int = 0
     private var intervalSeconds: TimeInterval = 12 * 60 * 60
+    private var requiresNetworkConnectivity: Bool = false
 
-    func didRegisterTask(minutes: Int?) -> Bool {
+    func didRegisterTask(minutes: Int?, requiresNetwork: Bool?) -> Bool {
       if let minutes = minutes {
         intervalSeconds = Double(minutes) * 60
+      }
+      if let requiresNetwork = requiresNetwork {
+        requiresNetworkConnectivity = requiresNetwork
       }
       numberOfRegisteredTasksOfThisType += 1
 
@@ -90,7 +94,7 @@ public class BackgroundTaskScheduler {
       stopWorkerOnce()
 
       let request = BGProcessingTaskRequest(identifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
-      request.requiresNetworkConnectivity = true
+      request.requiresNetworkConnectivity = requiresNetworkConnectivity
       request.requiresExternalPower = false
       request.earliestBeginDate = Date().addingTimeInterval(intervalSeconds)
 
@@ -152,9 +156,9 @@ public class BackgroundTaskScheduler {
   /**
    * Call when a task is registered to keep track of how many background task consumers we have
    */
-  public static func didRegisterTask(minutes: Int?) {
+  public static func didRegisterTask(minutes: Int?, requiresNetwork: Bool? = nil) {
     Task {
-      if await schedulerState.didRegisterTask(minutes: minutes) {
+      if await schedulerState.didRegisterTask(minutes: minutes, requiresNetwork: requiresNetwork) {
         try await tryScheduleWorker()
       }
     }

--- a/packages/expo-background-task/src/BackgroundTask.types.ts
+++ b/packages/expo-background-task/src/BackgroundTask.types.ts
@@ -44,4 +44,14 @@ export type BackgroundTaskOptions = {
    *
    */
   minimumInterval?: number;
+  /**
+   * Whether the background task requires network connectivity to run.
+   * - When `true`, the system will only launch the task when network is available.
+   * - When `false`, the task can run regardless of network state.
+   * - Defaults to `false`.
+   *
+   * On Android, this maps to the WorkManager `NetworkType.CONNECTED` constraint.
+   * On iOS, this maps to `BGProcessingTaskRequest.requiresNetworkConnectivity`.
+   */
+  requiresNetworkConnectivity?: boolean;
 };


### PR DESCRIPTION
## Summary

Adds a `requiresNetworkConnectivity` option to `BackgroundTaskOptions` so background tasks that don't need network can run while the device is offline.

Fixes #48122

## Problem

Both platforms unconditionally hardcode a network connectivity requirement:

- **Android**: `BackgroundTaskScheduler.kt` sets `NetworkType.CONNECTED` in WorkManager constraints
- **iOS**: `BackgroundTaskScheduler.swift` sets `request.requiresNetworkConnectivity = true` on `BGProcessingTaskRequest`

This means *all* background tasks are blocked from executing until the device regains connectivity — even tasks that perform purely local work (e.g., checking for new photos, data cleanup).

## Solution

Add `requiresNetworkConnectivity` (defaults to `false`) to `BackgroundTaskOptions`. The option flows through:
1. TypeScript types → native module options dict
2. `BackgroundTaskConsumer` reads it from options
3. `BackgroundTaskScheduler` applies it to the platform constraint

### Default change rationale

The new default is `false` (no network required), which matches:
- Android's `NetworkType.NOT_REQUIRED` (the WorkManager default)
- iOS's `BGProcessingTaskRequest.requiresNetworkConnectivity` default (`false`)

The previous hardcoded `true` was more restrictive than the platform defaults and was not configurable.

## Usage

```ts
// Task that doesn't need network (now works offline)
await BackgroundTask.registerTaskAsync('LOCAL_TASK', {
  minimumInterval: 15,
  // requiresNetworkConnectivity defaults to false
});

// Task that needs network (opt-in explicitly)
await BackgroundTask.registerTaskAsync('SYNC_TASK', {
  minimumInterval: 60,
  requiresNetworkConnectivity: true,
});
```

## Test Plan

- Verified `adb shell dumpsys jobscheduler` no longer shows `CONNECTIVITY` in required constraints when `requiresNetworkConnectivity` is omitted or `false`
- Verified iOS `BGProcessingTaskRequest` has `requiresNetworkConnectivity=0` when option is `false`
- Setting `requiresNetworkConnectivity: true` preserves the previous behavior on both platforms
- Existing tests pass (no behavioral change for apps that opt into network requirement)

## Changes

| File | Change |
|------|--------|
| `src/BackgroundTask.types.ts` | Added `requiresNetworkConnectivity?: boolean` to `BackgroundTaskOptions` |
| `android/.../BackgroundTaskConsumer.kt` | Reads `requiresNetworkConnectivity` from options, passes to scheduler |
| `android/.../BackgroundTaskScheduler.kt` | Uses `NOT_REQUIRED` or `CONNECTED` based on option |
| `ios/BackgroundTaskConsumer.swift` | Passes `requiresNetworkConnectivity` from options to scheduler |
| `ios/BackgroundTaskScheduler.swift` | Stores and applies the option instead of hardcoding `true` |