### PR TITLE
fix(expo-video): prevent teardown from clearing other modules' media state

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android][iOS] Prevent player teardown from clearing Now Playing metadata and notifications owned by other modules. ([#48470](https://github.com/expo/expo/pull/48470) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -97,9 +97,9 @@ class ExpoVideoPlaybackService : MediaSessionService() {
 
   fun unregisterPlayer(player: ExoPlayer) {
     appContext.mainQueue.launch {
+      val session = mediaSessions.remove(player) ?: return@launch
       hidePlayerNotification(player)
-      val session = mediaSessions.remove(player)
-      session?.release()
+      session.release()
       if (mediaSessions.isEmpty()) {
         cleanup()
         stopSelf()
@@ -233,7 +233,12 @@ class ExpoVideoPlaybackService : MediaSessionService() {
   @MainThread
   private fun hideAllNotifications() {
     val notificationManager: NotificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    notificationManager.cancelAll()
+    for (session in mediaSessions.values) {
+      notificationManager.cancel(session.player.hashCode())
+    }
+    mostRecentInteractionSession?.let {
+      notificationManager.cancel(it.player.hashCode())
+    }
   }
 
   private fun MediaSession.wantsToShowNotification(): Boolean =

--- a/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/playbackService/ExpoVideoPlaybackService.kt
@@ -236,9 +236,6 @@ class ExpoVideoPlaybackService : MediaSessionService() {
     for (session in mediaSessions.values) {
       notificationManager.cancel(session.player.hashCode())
     }
-    mostRecentInteractionSession?.let {
-      notificationManager.cancel(it.player.hashCode())
-    }
   }
 
   private fun MediaSession.wantsToShowNotification(): Boolean =

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -42,6 +42,10 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
   }
 
   func unregisterPlayer(_ player: VideoPlayer) {
+    guard players.allObjects.contains(where: { $0 === player }) else {
+      return
+    }
+
     players.remove(player)
     player.observer?.unregisterDelegate(delegate: self)
 


### PR DESCRIPTION
## Summary

Prevents expo-video's player teardown from clearing Now Playing metadata and media notifications that belong to other modules, such as an independent native audio player.

Fixes #48068

## Problem

**iOS:** `VideoPlayer.releasePlayer()` can call `NowPlayingManager.unregisterPlayer(_:)` for a player that never registered for Now Playing. The empty-manager cleanup then clears process-wide `MPNowPlayingInfoCenter` state and remote-command targets owned by another module.

**Android:** `hideAllNotifications()` uses `NotificationManager.cancelAll()`, so notification-session switches and final cleanup can remove every app notification instead of only expo-video's notifications.

## Solution

**iOS:** Return from `unregisterPlayer(_:)` unless the player is present in the manager's registered-player collection.

**Android:**
- Remove the player from `mediaSessions` first and return when it has no owned session.
- Replace app-wide `cancelAll()` with cancellation of the notification IDs belonging to sessions in `mediaSessions`.

## Test Plan

- Expo sandbox verification reproduced the iOS defect on stock `expo-video@57.0.2` and confirmed the fix at `ae7623e`: unregistered release and assigning `showNowPlayingNotification = false` preserve another module's Now Playing metadata, while registered-player release still clears expo-video's own state.
- Android behavior was reviewed from the service/session ownership path; no Android device verification was performed by the Expo sandbox run.
- Existing CI Android unit tests and Native Component List build passed on the original PR head.
- `git diff --check` passes for the review update. Local package checks could not run because this checkout does not have the monorepo dependencies installed.

## Review follow-up

- Removed the redundant `mostRecentInteractionSession` cancellation noted in review; that session is already included in `mediaSessions.values`.
- Added the required `packages/expo-video/CHANGELOG.md` entry.

## Changes

| File | Change |
|------|--------|
| `ios/NowPlayingManager.swift` | Guard unregister cleanup by registered-player ownership |
| `android/.../ExpoVideoPlaybackService.kt` | Guard session unregister and target expo-video notification IDs |
| `packages/expo-video/CHANGELOG.md` | Document the Android/iOS bug fix |
