### PR TITLE
fix(cli): filter noisy media/vision framework logs from Metro output

### DIFF
--- a/packages/@expo/cli/src/start/platforms/ios/simctlLogging.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/simctlLogging.ts
@@ -58,6 +58,7 @@ export type SimControlLog = {
     | 'com.apple.CoreTelephony'
     | 'com.apple.WebKit'
     | 'com.apple.runningboard'
+    | 'com.apple.VisionKit'
     | string;
   category: '' | 'access' | 'connection' | 'plugin';
   /**
@@ -237,6 +238,25 @@ function isRunningBoardServicesLog(simLog: SimControlLog): boolean {
   return simLog.subsystem === 'com.apple.runningboard';
 }
 
+// Apple media/vision framework noise that appears in simulator when playing video
+// or when Live Text / Visual Look Up / Translation scans frames on unsupported devices.
+// These are benign simulator-only messages that drown out app logs.
+const NOISY_MEDIA_FRAMEWORK_IMAGES = new Set([
+  'VideoToolbox',
+  'MediaToolbox',
+  'CoreMedia',
+  'CoreGraphics',
+  'TranslationUI',
+  'VisionKitCore',
+]);
+
+function isMediaFrameworkLog(simLog: SimControlLog): boolean {
+  if (simLog.source?.image && NOISY_MEDIA_FRAMEWORK_IMAGES.has(simLog.source.image)) {
+    return true;
+  }
+  return false;
+}
+
 function formatMessage(simLog: SimControlLog): string {
   // TODO: Maybe change "TCC" to "Consent" or "System".
   const category = chalk.gray(`[${simLog.source?.image ?? simLog.subsystem}]`);
@@ -255,7 +275,9 @@ export function onMessage(simLog: SimControlLog) {
       !isReactLog(simLog) &&
       !isCoreTelephonyLog(simLog) &&
       !isWebKitLog(simLog) &&
-      !isRunningBoardServicesLog(simLog)
+      !isRunningBoardServicesLog(simLog) &&
+      // Hide noisy Apple media/vision framework logs (VideoToolbox, MediaToolbox, etc.)
+      !isMediaFrameworkLog(simLog)
     ) {
       hasLogged = true;
       // Sim: This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.


### PR DESCRIPTION
## Summary

Filters Apple media and vision framework log messages from the Metro terminal output on iOS Simulator, routing them to `Log.debug` (visible with `EXPO_DEBUG=1`).

Fixes #47643

## Problem

When playing video via `expo-video` (or any AVPlayer usage), the iOS Simulator emits a flood of benign system-level messages from Apple's media and vision frameworks:

```
[VideoToolbox] (Fig) signalled err=-12900 at <>:1233
[MediaToolbox] <<<< VRP >>>> signalled err=-12852 at <>:2326
[TranslationUI] Visual isTranslatable: NO; reason: observation failure: noObservations
[CoreGraphics] verify_image_parameters: invalid image bits/pixel or bytes/row.
[VisionKitCore] Request to remove background on an unsupported device...
```

These are simulator-only messages (software video decode + Live Text / Visual Look Up / Translation running on unsupported simulator devices) that drown out the app's own JS logs.

## Solution

Added an `isMediaFrameworkLog` filter in `simctlLogging.ts` that matches logs from these `source.image` values:

- `VideoToolbox`
- `MediaToolbox`
- `CoreMedia`
- `CoreGraphics`
- `TranslationUI`
- `VisionKitCore`

This follows the same pattern as the existing `isNetworkLog`, `isWebKitLog`, `isCoreTelephonyLog`, and `isRunningBoardServicesLog` filters.

## Test Plan

- Ran `npx expo run:ios` with an expo-video VideoView — media framework noise no longer appears in Metro terminal
- Verified logs still appear with `EXPO_DEBUG=1`
- Verified app-level JS logs (`console.log`, `console.error`) are unaffected
- Verified other filtered categories (network, WebKit, CoreTelephony) still work as before