### PR TITLE
fix(expo-app-metrics): skip delegate wrapping for GTMSessionFetcher

### DIFF
--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestTaskSwizzling.swift
@@ -471,7 +471,21 @@ enum NetworkRequestTaskSwizzling {
         // Apple's docs say a nil delegate puts the session in "completion handler" mode; in that
         // mode the metrics callback never fires anyway, but wrapping nil is still safe — the
         // proxy responds only to the two selectors it handles.
-        let wrapped = DelegateProxy(wrapping: delegate)
+        //
+        // Skip wrapping delegates whose class belongs to GTMSessionFetcher (used by Firebase
+        // Auth, Google Sign-In, etc.). GTMSessionFetcher calls -setFetcher:forTask: on
+        // session.delegate assuming it is its own dispatcher; the proxy doesn't implement that
+        // selector and forwarding can't reach the wrapped object when the ObjC runtime
+        // short-circuits through a direct cast. These sessions are still observed via the
+        // resume/setState: hooks — they just won't carry per-phase URLSessionTaskMetrics.
+        let shouldSkipWrapping: Bool = {
+          guard let delegate else { return false }
+          let className = String(describing: type(of: delegate))
+          return className.contains("GTMSessionFetcher")
+        }()
+        let effectiveDelegate: AnyObject? = shouldSkipWrapping
+          ? (delegate as AnyObject?)
+          : DelegateProxy(wrapping: delegate)
         guard let imp = originalSessionInitImp.withLock({ $0 }) else {
           return nil
         }
@@ -484,7 +498,7 @@ enum NetworkRequestTaskSwizzling {
           to: (@convention(c) (AnyObject, Selector, URLSessionConfiguration, AnyObject?, OperationQueue?) -> URLSession?)
             .self
         )
-        return fn(cls, selector, config, wrapped, queue)
+        return fn(cls, selector, config, effectiveDelegate, queue)
       }
     let newImp = imp_implementationWithBlock(block as Any)
     let original = method_setImplementation(method, newImp)


### PR DESCRIPTION
## Summary

Fixes the crash when using `expo-observe` / `expo-app-metrics` with Firebase Auth phone OTP (or any Firebase feature that uses `GTMSessionFetcher`).

Fixes #48194

## Problem

`expo-app-metrics` swizzles `+[NSURLSession sessionWithConfiguration:delegate:delegateQueue:]` and wraps every delegate in a `DelegateProxy`. GTMSessionFetcher (Firebase's HTTP layer) creates a session with its own private dispatcher, then calls `-setFetcher:forTask:` on `session.delegate` — assuming it's the dispatcher. After wrapping, the proxy receives that selector, doesn't implement it, and crashes with `NSInvalidArgumentException`.

## Solution

Skip wrapping delegates whose class name contains `GTMSessionFetcher`. The check is a simple string match on `type(of: delegate)` — no new imports or framework dependencies.

These sessions are still observed via the `resume`/`setState:` hooks that fire on every `URLSessionTask` regardless of delegate wrapping. They just won't carry per-phase `URLSessionTaskMetrics` detail — acceptable since Firebase's HTTP traffic isn't the kind apps typically need redirect-chain timing for.

## Test Plan

- Firebase Auth `signInWithPhoneNumber` no longer crashes when `expo-observe` is active
- Non-Firebase sessions still get full metrics observation via `DelegateProxy`
- Firebase HTTP requests still appear in network observation (via resume/setState hooks)