### PR TITLE
[ios][font] report font family names from getLoadedFonts

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [android] Apply `fontWeight` and `fontStyle` to fonts loaded with `useFonts`, instancing a variable font's `wght` axis at each weight. Bold and italic text previously fell back to a system font. ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
 - [iOS] Fixed `renderToImageAsync` reporting the main screen's scale rather than the scale the image was rendered at. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
+- [ios] Apply `fontWeight` to variable fonts loaded with `useFonts`. ([#48432](https://github.com/expo/expo/pull/48432) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [ios] `getLoadedFonts()` now returns font family names and the names passed to `loadAsync`, no longer the PostScript names read out of font files. ([#48481](https://github.com/expo/expo/pull/48481) by [@vonovak](https://github.com/vonovak))
+
 ### 🎉 New features
 
 - [android] Support variable fonts in the config plugin ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))

--- a/packages/expo-font/ios/FontFamilyAliasManager.swift
+++ b/packages/expo-font/ios/FontFamilyAliasManager.swift
@@ -1,9 +1,11 @@
 import ExpoModulesCore
 
 /**
- A registry of font family aliases mapped to their real font family names.
+ Maps each font family alias to the PostScript names of the fonts in the file it was registered for.
+ A file usually provides one name. A variable font provides one per named instance, which is what
+ lets `fontWeight` reach the weights it declares.
  */
-private var fontFamilyAliases = [String: String]()
+private var fontFamilyAliases = [String: [String]]()
 
 /**
  A flag that is set to `true` when the ``UIFont.fontNames(forFamilyName:)`` is already swizzled.
@@ -29,20 +31,20 @@ internal struct FontFamilyAliasManager {
   }
 
   /**
-   Sets the alias for the given family name.
-   If the alias has already been set, its family name will be overridden.
+   Sets the alias for the given PostScript names.
+   If the alias has already been set, its PostScript names will be overridden.
    */
-  internal static func setAlias(_ familyNameAlias: String, forFont font: String) {
+  internal static func setAlias(_ familyNameAlias: String, forPostScriptNames postScriptNames: [String]) {
     maybeSwizzleUIFont()
     queue.sync(flags: .barrier) {
-      fontFamilyAliases[familyNameAlias] = font
+      fontFamilyAliases[familyNameAlias] = postScriptNames
     }
   }
 
   /**
-   Returns the family name for the given alias or `nil` when it's not set yet.
+   Returns the PostScript names for the given alias or `nil` when it's not set yet.
    */
-  internal static func familyName(forAlias familyNameAlias: String) -> String? {
+  internal static func postScriptNames(forAlias familyNameAlias: String) -> [String]? {
     return queue.sync {
       fontFamilyAliases[familyNameAlias]
     }
@@ -50,9 +52,8 @@ internal struct FontFamilyAliasManager {
 }
 
 /**
- Swizzles ``UIFont.fontNames(forFamilyName:)`` to support font family aliases.
- This is necessary because the user provides a custom family name that is then used in stylesheets,
- however the font usually has a different name encoded in the binary, thus the system may use a different name.
+ Swizzles ``UIFont.fontNames(forFamilyName:)`` to support font family aliases. RN core asks for a family's font faces (postScript names) to pick from:
+ https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm#L355
  */
 private func maybeSwizzleUIFont() {
   if hasSwizzled {

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -24,25 +24,21 @@ public final class FontLoaderModule: Module {
     AsyncFunction("loadAsync") { (fontFamilyAlias: String, localUri: URL) in
       let fontUrl = localUri as CFURL
       // If the font was already registered, unregister it first. Otherwise CTFontManagerRegisterFontsForURL
-      // would fail because of a duplicated font name when the app reloads or someone wants to override a font.
-      if FontFamilyAliasManager.familyName(forAlias: fontFamilyAlias) != nil {
+      // would fail because of a duplicated font name when the app reloads or someone wants to override a font. Note that re-registering under an existing alias is skipped in the JS layer.
+      if FontFamilyAliasManager.hasAlias(fontFamilyAlias) {
         guard try unregisterFont(url: fontUrl) else {
           return
         }
       }
 
-      // Register the font
       try registerFont(fontUrl: fontUrl, fontFamilyAlias: fontFamilyAlias)
 
-      // Create a font object from the given URL
-      let font = try loadFont(fromUrl: fontUrl, alias: fontFamilyAlias)
+      // Alias every name the file provides to `fontFamilyAlias` — one per named instance for a variable font — that makes its weights reachable through `fontWeight` style prop.
+      let aliasedNames = try postScriptNames(inFileAt: fontUrl, alias: fontFamilyAlias)
 
-      if let postScriptName = font.postScriptName as? String {
-        FontFamilyAliasManager.setAlias(fontFamilyAlias, forFont: postScriptName)
-        registeredFonts = Array(Set(registeredFonts).union([postScriptName, fontFamilyAlias]))
-      } else {
-        throw FontNoPostScriptException(fontFamilyAlias)
-      }
+      FontFamilyAliasManager.setAlias(fontFamilyAlias, forPostScriptNames: aliasedNames)
+
+      registeredFonts = Array(Set(registeredFonts).union([aliasedNames[0], fontFamilyAlias]))
     }
   }
 }

--- a/packages/expo-font/ios/FontLoaderModule.swift
+++ b/packages/expo-font/ios/FontLoaderModule.swift
@@ -38,7 +38,11 @@ public final class FontLoaderModule: Module {
 
       FontFamilyAliasManager.setAlias(fontFamilyAlias, forPostScriptNames: aliasedNames)
 
-      registeredFonts = Array(Set(registeredFonts).union([aliasedNames[0], fontFamilyAlias]))
+      // Report the alias and nothing else. Every name read out of the file stays in the alias
+      // registry above, which is where `fontWeight` resolution reads it from. Reporting one here
+      // would claim it: `Font.isLoaded` would be true for a name the app never chose, so a later
+      // `loadAsync` under that name would silently do nothing.
+      registeredFonts = Array(Set(registeredFonts).union([fontFamilyAlias]))
     }
   }
 }

--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -9,41 +9,83 @@ internal func queryCustomNativeFonts() -> [String] {
     return []
   }
 
-  // [1] Get font family names for each font file
-  let fontFamilies: [[String]] = fontFilePaths.compactMap { fontFilePath in
-    guard let fontUrl = Bundle.main.url(forResource: fontFilePath, withExtension: nil) else {
-      return []
+  // [1] Get font family names for each font file. A variable font file has one descriptor per named
+  // instance of its variation axes, and they all share a family name, so the family names are
+  // deduplicated to avoid looking up — and returning — the same family once per instance.
+  var fontFamilyNames = [String]()
+
+  for fontFilePath in fontFilePaths {
+    guard let fontUrl = Bundle.main.url(forResource: fontFilePath, withExtension: nil),
+      let fontDescriptors = CTFontManagerCreateFontDescriptorsFromURL(fontUrl as CFURL) as? [CTFontDescriptor] else {
+      continue
     }
-    guard let fontDescriptors = CTFontManagerCreateFontDescriptorsFromURL(fontUrl as CFURL) as? [CTFontDescriptor] else {
-      return []
-    }
-    return fontDescriptors.compactMap { descriptor in
-      return CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String
+    for descriptor in fontDescriptors {
+      guard let fontFamilyName = CTFontDescriptorCopyAttribute(descriptor, kCTFontFamilyNameAttribute) as? String else {
+        continue
+      }
+      if !fontFamilyNames.contains(fontFamilyName) {
+        fontFamilyNames.append(fontFamilyName)
+      }
     }
   }
 
   // [2] Retrieve font names by family names
-  return fontFamilies.flatMap { fontFamilyNames in
-    return fontFamilyNames.flatMap { fontFamilyName in
-    #if os(iOS) || os(tvOS)
-      return UIFont.fontNames(forFamilyName: fontFamilyName)
-    #elseif os(macOS)
-      return NSFontManager.shared.availableMembers(ofFontFamily: fontFamilyName)?.compactMap { $0[0] as? String } ?? []
-    #endif
-    }
+  return fontFamilyNames.flatMap { fontFamilyName in
+  #if os(iOS) || os(tvOS)
+    return UIFont.fontNames(forFamilyName: fontFamilyName)
+  #elseif os(macOS)
+    return NSFontManager.shared.availableMembers(ofFontFamily: fontFamilyName)?.compactMap { $0[0] as? String } ?? []
+  #endif
   }
 }
 
 /**
- Loads the font from the given url and returns it as ``CGFont``.
+ Returns the PostScript names to register an alias for, for the file at the given url.
+
+ A variable font file exposes each of the named instances of its variation axes under its own
+ PostScript name. RN walks every name the family reports and keeps the one
+ whose weight is closest to the requested one, so a name it cannot see is a weight it cannot pick:
+ https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm#L372-L386
+
+ Every other file resolves to the single name of its default font, which leaves the alias behaving
+ as it did before variable fonts were handled: ``UIFont/_expo_fontNames(forFamilyName:)`` looks that
+ name up as a family name, so fonts registered elsewhere under the same family stay reachable
+ through the alias.
  */
-internal func loadFont(fromUrl url: CFURL, alias: String) throws -> CGFont {
-  guard let provider = CGDataProvider(url: url),
-    let cgFont = CGFont(provider) else {
+internal func postScriptNames(inFileAt url: CFURL, alias: String) throws -> [String] {
+  guard let fontDescriptors = CTFontManagerCreateFontDescriptorsFromURL(url) as? [CTFontDescriptor] else {
     throw FontCreationFailedException(alias)
   }
 
-  return cgFont
+  var postScriptNames = fontDescriptors.compactMap { descriptor in
+    return CTFontDescriptorCopyAttribute(descriptor, kCTFontNameAttribute) as? String
+  }
+
+  if postScriptNames.isEmpty {
+    throw FontNoPostScriptException(alias)
+  }
+
+  // ``CGFont`` reports the default instance of a variable font, which is the one to move up front.
+  let defaultPostScriptName = CGDataProvider(url: url).flatMap { CGFont($0)?.postScriptName as String? }
+
+  let hasVariationAxes = fontDescriptors.contains { descriptor in
+    let axes = CTFontDescriptorCopyAttribute(descriptor, kCTFontVariationAxesAttribute) as? [Any]
+    return !(axes?.isEmpty ?? true)
+  }
+
+  if hasVariationAxes, postScriptNames.count > 1 {
+    // RN falls back to the first name when no font matches the requested traits (e.g. an
+    // italic style against a font with only upright instances) so the first name has to be the default weight:
+    // https://github.com/facebook/react-native/blob/v0.86.0/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm#L388-L393
+    if let defaultPostScriptName,
+      let defaultIndex = postScriptNames.firstIndex(of: defaultPostScriptName) {
+      postScriptNames.remove(at: defaultIndex)
+      postScriptNames.insert(defaultPostScriptName, at: 0)
+    }
+    return postScriptNames
+  }
+
+  return [defaultPostScriptName ?? postScriptNames[0]]
 }
 
 /**
@@ -76,11 +118,11 @@ internal func unregisterFont(url: CFURL) throws -> Bool {
 
   if !CTFontManagerUnregisterFontsForURL(url, .process, &error), let error = error?.takeRetainedValue() {
     if let ctFontManagerError = CTFontManagerError(rawValue: CFErrorGetCode(error as CFError)) {
-      switch ctFontManagerError {
+      return switch ctFontManagerError {
       case .systemRequired, .inUse:
-        return false
+        false
       case .notRegistered:
-        return true
+        true
       default:
         throw UnregisteringFontFailedException(error)
       }

--- a/packages/expo-font/ios/FontUtils.swift
+++ b/packages/expo-font/ios/FontUtils.swift
@@ -1,7 +1,7 @@
 import CoreGraphics
 
 /**
- * Queries custom native font names from the Info.plist `UIAppFonts`.
+ * Queries the family names of the fonts the app embeds through the Info.plist `UIAppFonts`.
  */
 internal func queryCustomNativeFonts() -> [String] {
   // [0] Read from main bundle's Info.plist
@@ -9,9 +9,9 @@ internal func queryCustomNativeFonts() -> [String] {
     return []
   }
 
-  // [1] Get font family names for each font file. A variable font file has one descriptor per named
-  // instance of its variation axes, and they all share a family name, so the family names are
-  // deduplicated to avoid looking up — and returning — the same family once per instance.
+  // [1] Collect the family name of every font file, deduplicated. One file can contribute several
+  // descriptors (a variable font has one per named instance) and they share a family name,
+  // so the same family would otherwise be reported several times.
   var fontFamilyNames = [String]()
 
   for fontFilePath in fontFilePaths {
@@ -29,14 +29,7 @@ internal func queryCustomNativeFonts() -> [String] {
     }
   }
 
-  // [2] Retrieve font names by family names
-  return fontFamilyNames.flatMap { fontFamilyName in
-  #if os(iOS) || os(tvOS)
-    return UIFont.fontNames(forFamilyName: fontFamilyName)
-  #elseif os(macOS)
-    return NSFontManager.shared.availableMembers(ofFontFamily: fontFamilyName)?.compactMap { $0[0] as? String } ?? []
-  #endif
-  }
+  return fontFamilyNames
 }
 
 /**

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -5,6 +5,9 @@
 public extension UIFont {
   /**
    Returns an array of font names for the specified family name or its alias.
+
+   "Font names" is UIKit's term for what the rest of this module calls PostScript names — one per
+   face. An alias resolves to the names registered under it; see ``FontFamilyAliasManager.postScriptNames(inFileAt:alias:)``.
    */
   @objc
   static dynamic func _expo_fontNames(forFamilyName familyName: String) -> [String] {
@@ -12,15 +15,21 @@ public extension UIFont {
     let fontNames = UIFont._expo_fontNames(forFamilyName: familyName)
 
     // If no font names were found, let's try with the alias.
-    if fontNames.isEmpty, let postScriptName = FontFamilyAliasManager.familyName(forAlias: familyName) {
-      let fontNames = UIFont._expo_fontNames(forFamilyName: postScriptName)
-
-      // If we still don't find any font names, we can assume it was not a family name but a font name.
-      // In that case we can safely return the original font name.
-      if fontNames.isEmpty {
-        return [postScriptName]
+    if fontNames.isEmpty, let aliasedFontNames = FontFamilyAliasManager.postScriptNames(forAlias: familyName) {
+      // Only a variable font stored more than one name: ``postScriptNames(inFileAt:alias:)`` records one
+      // per named instance for those, and a single name for every other file. Handing the whole set
+      // back is what lets RN match `fontWeight` against the weights the font really has.
+      if aliasedFontNames.count > 1 {
+        return aliasedFontNames
       }
-      return fontNames
+
+      // Every other font keeps the original lookup: the PostScript name is tried as a family name
+      // first, so faces already registered under that family stay reachable through the alias.
+      // The postScriptName itself is returned when it is not a family name.
+      if let postScriptName = aliasedFontNames.first {
+        let familyFontNames = UIFont._expo_fontNames(forFamilyName: postScriptName)
+        return familyFontNames.isEmpty ? [postScriptName] : familyFontNames
+      }
     }
 
     return fontNames

--- a/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
+++ b/packages/expo-font/ios/UIFont+FontFamilyAlias.swift
@@ -7,7 +7,7 @@ public extension UIFont {
    Returns an array of font names for the specified family name or its alias.
 
    "Font names" is UIKit's term for what the rest of this module calls PostScript names — one per
-   face. An alias resolves to the names registered under it; see ``FontFamilyAliasManager.postScriptNames(inFileAt:alias:)``.
+   face. An alias resolves to the names registered under it; see ``postScriptNames(inFileAt:alias:)``.
    */
   @objc
   static dynamic func _expo_fontNames(forFamilyName familyName: String) -> [String] {

--- a/packages/expo-font/src/Font.ts
+++ b/packages/expo-font/src/Font.ts
@@ -36,7 +36,8 @@ export function isLoaded(fontFamily: string): boolean {
  * Synchronously get all the fonts that have been loaded.
  * This includes fonts that were bundled at build time using the config plugin, as well as those loaded at runtime using `loadAsync`.
  *
- * @returns Returns array of strings which you can use as `fontFamily` [style prop](https://reactnative.dev/docs/text#style).
+ * @returns Returns array of strings which you can use as `fontFamily` [style prop](https://reactnative.dev/docs/text#style):
+ * the family names of the fonts embedded at build time, and the names passed to `loadAsync`.
  */
 export function getLoadedFonts(): string[] {
   return ExpoFontLoader.getLoadedFonts();

--- a/packages/expo-font/src/Font.ts
+++ b/packages/expo-font/src/Font.ts
@@ -61,6 +61,8 @@ export function isLoading(fontFamily: string): boolean {
  *
  * > **Note**: We recommend using the [config plugin](#configuration-in-app-config) instead whenever possible.
  *
+ * > **Note**: When the `fontFamily` is already loaded, this method resolves without replacing it.
+ *
  * @param fontFamilyOrFontMap String or map of values that can be used as the `fontFamily` [style prop](https://reactnative.dev/docs/text#style)
  * with React Native `Text` elements.
  * @param source The font asset that should be loaded into the `fontFamily` namespace.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>