### PR TITLE
[ios][age-range] Fix ageRangeDeclaration mapping

### DIFF
--- a/packages/expo-age-range/CHANGELOG.md
+++ b/packages/expo-age-range/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Report `ageRangeDeclaration: 'confirmed'` for the six system-verified cases that iOS 26.2 added and iOS 26.5 deprecated, instead of reporting them as `'selfDeclared'`. ([#48486](https://github.com/expo/expo/pull/48486) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 57.0.2 - 2026-07-15

--- a/packages/expo-age-range/ios/AgeRangeRecords.swift
+++ b/packages/expo-age-range/ios/AgeRangeRecords.swift
@@ -8,21 +8,26 @@ internal enum AgeRangeDeclaration: String, Enumerable {
 
   @available(iOS 26.0, *)
   public init(_ range: AgeRangeService.AgeRangeDeclaration) {
-    #if compiler(>=6.3.2) // Xcode 26.5+ (Swift 6.3.2) ships the iOS 26.5 SDK that defines `.confirmed`.
-    // `#available` alone isn't enough: it gates the runtime, but the `.confirmed` symbol must also
-    // exist at compile time, which it doesn't in SDKs before iOS 26.5.
-    if #available(iOS 26.5, *), range == .confirmed {
-      self = .confirmed
-      return
-    }
-    #endif
     switch range {
     case .selfDeclared:
       self = .selfDeclared
     case .guardianDeclared:
       self = .guardianDeclared
+    #if compiler(>=6.3.2) // Xcode 26.5+ (Swift 6.3.2) ships the iOS 26.5 SDK that declares `confirmed`.
+    case .confirmed:
+      self = .confirmed
+    #endif
+    // iOS 26.2 added six cases for an age the system verified rather than one a person declared, and
+    // iOS 26.5 deprecated all six in favour of `confirmed`.
+    #if compiler(>=6.2.3) // Xcode 26.2+ (Swift 6.2.3) ships the iOS 26.2 SDK that declares these six.
+    case .checkedByOtherMethod, .guardianCheckedByOtherMethod,
+         .governmentIDChecked, .guardianGovernmentIDChecked,
+         .paymentChecked, .guardianPaymentChecked:
+      self = .confirmed
+    #endif
     @unknown default:
-      assertionFailure("Unknown AgeRangeDeclaration: \(range)")
+      // Fall back to the least assurance we can claim, so an unrecognised value can't loosen an age gate
+      log.error("Unhandled `AgeRangeService.AgeRangeDeclaration` value: \(range), reporting `selfDeclared` as fallback. Either the value was added in an iOS SDK newer than the one you build against — build with a newer Xcode — or expo-age-range needs to map it, in which case report it at github.com/expo/expo/issues.")
       self = .selfDeclared
     }
   }
@@ -49,11 +54,9 @@ internal struct AgeRangeResponse: Record {
     self.upperBound = range.upperBound
     self.ageRangeDeclaration = range.ageRangeDeclaration.map(AgeRangeDeclaration.init)
 
-    var controls: [String] = []
     if range.activeParentalControls.contains(.communicationLimits) {
-      controls.append("communicationLimits")
+      self.activeParentalControls.append("communicationLimits")
     }
-    self.activeParentalControls = controls
   }
 }
 

--- a/packages/expo-age-range/ios/ExpoAgeRange.podspec
+++ b/packages/expo-age-range/ios/ExpoAgeRange.podspec
@@ -11,8 +11,7 @@ Pod::Spec.new do |s|
   s.author         = package['author']
   s.homepage       = package['homepage']
   s.platforms = {
-    :ios => '16.4',
-    :tvos => '16.4'
+    :ios => '16.4'
   }
   s.swift_version  = '6.0'
   s.source         = { git: 'https://github.com/expo/expo.git' }


### PR DESCRIPTION
# Why

`AgeRangeService.AgeRangeDeclaration` gained six cases of `AgeRangeService.AgeRangeDeclaration` in iOS 26.2. iOS 26.5 then deprecated them in favor of `confirmed`.

# How

Add the deprecated cases so they fall into `confirmed` which is more correct than falling into `selfDeclared` (the switch default branch).

Also remove `tvos` from podspec - it's not a supported platform.

# Test Plan

green CI

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [ ] `npx expo prebuild` & EAS Build — not relevant, no config plugin or template change
- [ ] Follows the documentation style guide
