### PR TITLE
[macos] Fix build by guarding the `bundleConfiguration` override

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))
 - [Android] `ExpoReactHostFactory` now passes host handlers' `DevSupportManagerFactory` to `ReactHostImpl`. ([#47637](https://github.com/expo/expo/pull/47637) by [@alanjhughes](https://github.com/alanjhughes))
+- [macOS] Fix build by guarding the `bundleConfiguration` override, which requires react-native 0.84+. ([#48494](https://github.com/expo/expo/pull/48494) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - Restore RCTHostRuntimeDelegate conformance for react-native-macos ([#46420](https://github.com/expo/expo/pull/46420) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Add explicit `react-native/Libraries/Core/InitializeCore` import to native runtime entrypoint ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))
 - [Internal] Update logbox imports ([#46640](https://github.com/expo/expo/pull/46640) by [@kitten](https://github.com/kitten))

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.swift
@@ -4,7 +4,6 @@ import React
 
 public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNativeFactoryProtocol {
   private let defaultModuleName = "main"
-  private var _bundleConfiguration: RCTBundleConfiguration?
 
   @MainActor
   private lazy var reactDelegate: ExpoReactDelegate = {
@@ -27,24 +26,23 @@ public class ExpoReactNativeFactory: ExpoReactNativeFactoryObjC, ExpoReactNative
     super.init(delegate: delegate, releaseLevel: releaseLevel)
   }
 
+  // `RCTBundleConfiguration` is only available in react-native 0.84+, so it doesn't exist yet on react-native-macos.
+#if os(iOS) || os(tvOS)
+  private var _bundleConfiguration: RCTBundleConfiguration?
+
   public override var bundleConfiguration: RCTBundleConfiguration {
     get {
       if let _bundleConfiguration {
         return _bundleConfiguration
       }
-#if os(iOS) || os(tvOS)
       adoptInfoPlistMetroPort()
       return ExpoBundleConfiguration.configuration(bundleURL: self.delegate?.bundleURL())
-#else
-      return super.bundleConfiguration
-#endif
     }
     set {
       _bundleConfiguration = newValue
     }
   }
 
-#if os(iOS) || os(tvOS)
   private func adoptInfoPlistMetroPort() {
 #if DEBUG
     if NSClassFromString("EXDevLauncherController") != nil {


### PR DESCRIPTION
# Why

Test macOS CI step is failing - https://github.com/expo/expo/actions/runs/30879780425/job/91898480525

PR #48010 added `RCTBundleConfiguration` which does not exist on react-native-macos yet. So it needed a platform check.

# How

Added platform check to skip `RCTBundleConfiguration` usage in macOS.

# Test Plan

CI should pass 

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [x] Conforms to the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (platform native code changed) — macOS only, not covered by prebuild

