### PR TITLE
[autolinking][Android] Fix Android Studio failing to sync with `Missing ExternalProject for :`

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Fix autolinking pure C++ React Native modules published without `includesGeneratedCode: true`. ([#48514](https://github.com/expo/expo/pull/48514) by [@satya164](https://github.com/satya164))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
+- [Android] Resolve symlinks in the Gradle plugin `sourceDir` before it reaches `includeBuild`. Android Studio failed to sync with `Missing ExternalProject for :` in pnpm workspaces with a patched dependency. ([#48495](https://github.com/expo/expo/pull/48495) by [@lukmccall](https://github.com/lukmccall))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/src/platforms/__tests__/android-test.ts
+++ b/packages/expo-modules-autolinking/src/platforms/__tests__/android-test.ts
@@ -106,6 +106,87 @@ describe(resolveModuleAsync, () => {
     });
   });
 
+  describe('symlinked package path', () => {
+    const storeDir =
+      '/app/node_modules/.pnpm/react-native-third-party@1.0.0_patch_hash=abc/node_modules/react-native-third-party';
+    const linkDir = '/app/lib/node_modules/react-native-third-party';
+
+    beforeEach(() => {
+      vol.fromJSON({
+        [path.join(storeDir, 'third-party-gradle-plugin', 'build.gradle.kts')]: '',
+        [path.join(storeDir, 'android', 'build.gradle')]: '',
+      });
+      vol.mkdirSync(path.dirname(linkDir), { recursive: true });
+      vol.symlinkSync(storeDir, linkDir);
+    });
+
+    it('should resolve symlinks in the gradle plugin sourceDir', async () => {
+      const name = 'react-native-third-party';
+      const result = await resolveModuleAsync(name, {
+        name,
+        path: linkDir,
+        version: '1.0.0',
+        config: new ExpoModuleConfig({
+          platforms: ['android'],
+          android: {
+            gradlePlugins: [
+              {
+                id: 'third-party-gradle-plugin',
+                group: 'com.thirdparty',
+                sourceDir: 'third-party-gradle-plugin',
+                applyToRootProject: true,
+              },
+            ],
+          },
+        }),
+      });
+      expect(result?.plugins).toEqual([
+        {
+          id: 'third-party-gradle-plugin',
+          group: 'com.thirdparty',
+          sourceDir: path.join(storeDir, 'third-party-gradle-plugin'),
+          applyToRootProject: true,
+        },
+      ]);
+    });
+
+    it('should keep the symlinked project sourceDir', async () => {
+      const name = 'react-native-third-party';
+      const result = await resolveModuleAsync(name, {
+        name,
+        path: linkDir,
+        version: '1.0.0',
+        config: new ExpoModuleConfig({
+          platforms: ['android'],
+          android: { path: 'android' },
+        }),
+      });
+      expect(result?.projects?.[0]?.sourceDir).toBe(path.join(linkDir, 'android'));
+    });
+
+    it('should fall back to the unresolved path when the gradle plugin sourceDir is missing', async () => {
+      const name = 'react-native-third-party';
+      const result = await resolveModuleAsync(name, {
+        name,
+        path: linkDir,
+        version: '1.0.0',
+        config: new ExpoModuleConfig({
+          platforms: ['android'],
+          android: {
+            gradlePlugins: [
+              {
+                id: 'missing-gradle-plugin',
+                group: 'com.thirdparty',
+                sourceDir: 'missing-gradle-plugin',
+              },
+            ],
+          },
+        }),
+      });
+      expect(result?.plugins?.[0]?.sourceDir).toBe(path.join(linkDir, 'missing-gradle-plugin'));
+    });
+  });
+
   it('should resolve multiple gradle files', async () => {
     const name = 'react-native-third-party';
     const pkgDir = path.join('node_modules', name);

--- a/packages/expo-modules-autolinking/src/platforms/android/android.ts
+++ b/packages/expo-modules-autolinking/src/platforms/android/android.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import type { AutolinkingOptions } from '../../commands/autolinkingOptions';
 import { taskAll } from '../../concurrency';
 import type { ExtraDependencies, ModuleDescriptorAndroid, PackageRevision } from '../../types';
-import { scanFilesRecursively } from '../../utils';
+import { maybeRealpath, scanFilesRecursively } from '../../utils';
 
 const ANDROID_PROPERTIES_FILE = 'gradle.properties';
 const ANDROID_EXTRA_BUILD_DEPS_KEY = 'android.extraMavenRepos';
@@ -37,16 +37,23 @@ export async function resolveModuleAsync(
     return null;
   }
 
-  const plugins = (revision.config?.androidGradlePlugins() ?? []).map(
-    ({ id, group, sourceDir, version, applyToRootProject }) =>
-      sourceDir
-        ? {
-            id,
-            group,
-            sourceDir: path.join(revision.path, sourceDir),
-            applyToRootProject,
-          }
-        : { id, group, version, applyToRootProject }
+  const plugins = await taskAll(
+    revision.config?.androidGradlePlugins() ?? [],
+    async ({ id, group, sourceDir, version, applyToRootProject }) => {
+      if (!sourceDir) {
+        return { id, group, version, applyToRootProject };
+      }
+      const pluginPath = path.join(revision.path, sourceDir);
+      return {
+        id,
+        group,
+        // The plugin source dir ends up in Gradle's `includeBuild`, which must not receive a
+        // symlink - Android Studio's Tooling API fails to import symlinked included builds.
+        // See: https://youtrack.jetbrains.com/issue/IDEA-329756.
+        sourceDir: (await maybeRealpath(pluginPath)) ?? pluginPath,
+        applyToRootProject,
+      };
+    }
   );
 
   const defaultProjectName = convertPackageToProjectName(packageName);


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/48490

Android Studio fails to sync with `Missing ExternalProject for :` in a pnpm workspace that has a patched dependency. The Gradle CLI builds the same project fine.

# How

Resolve the symlink for the Gradle plugin `sourceDir`.

# Test Plan

- `jest` ✅ 
- https://github.com/blazejkustra/repro-expo-symlink-android-studio?rgh-link-date=2026-08-04T09%3A51%3A50.000Z ✅ 