### PR TITLE
[cli][server] serve loader `Cache-Control` headers with per-mode defaults

### DIFF
--- a/apps/router-e2e/__e2e__/server-loader/app/second.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/second.tsx
@@ -5,10 +5,8 @@ import { Loading } from '../components/Loading';
 import { SiteLinks, SiteLink } from '../components/SiteLink';
 import { Table, TableRow } from '../components/Table';
 
-export async function loader() {
-  return Promise.resolve({
-    data: 'second',
-  });
+export function loader() {
+  return Response.json({ data: 'second' }, { headers: { 'Cache-Control': 'private, no-store' } });
 }
 
 export default function SecondRoute() {

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))
 - Emit relative asset URLs and `bundleUrl` in manifest responses conditionally ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
 - Resolve `hostUri`, `debuggerHost`, and `/_expo/link` deep links from forwarded request addresses ([#48267](https://github.com/expo/expo/pull/48267) by [@kitten](https://github.com/kitten))
+- Preserve loader `Cache-Control` headers in development ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
+- Use default loader `Cache-Control` header value of `no-store` for loader responses in development ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
+- Use default `Cache-Control` header value of `public, max-age=0, must-revalidate` for SSG loader files and their pages ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
+- Use default `Cache-Control` header value of `no-store` for SSR loader responses ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-headers.test.ts
@@ -29,6 +29,10 @@ const PAGE_HEADERS = [
 
 const EXPECTED_PAGE_HEADERS = [
   {
+    namedRegex: '^/_expo/loaders/.+$',
+    headers: { 'Cache-Control': 'no-store' },
+  },
+  {
     namedRegex: '^/(?:/)?$',
     headers: { 'X-Page-Rule': 'index', 'X-Powered-By': 'page-override' },
   },

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -259,6 +259,13 @@ describe.each(
     expect(data).toEqual({ foo: 'bar' });
   });
 
+  it('defaults a headerless server loader to no-store', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/index');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
   it('sets custom headers on response using `setResponseHeaders()`', async () => {
     const response = await server.fetchAsync('/_expo/loaders/response?setresponseheaders=true');
     expect(response.status).toBe(200);

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -226,6 +226,23 @@ describe.each(
   });
 
   (server.isExpoStart ? it.skip : it)(
+    'applies the SSG default Cache-Control to a headerless loader',
+    async () => {
+      const response = await server.fetchAsync('/_expo/loaders/index');
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('cache-control')).toBe('private, must-revalidate, max-age=0');
+    }
+  );
+
+  it('passes a loader-declared no-store through verbatim', async () => {
+    const response = await server.fetchAsync('/_expo/loaders/second');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe('private, no-store');
+  });
+
+  (server.isExpoStart ? it.skip : it)(
     'applies loader-declared `Cache-Control` to the pre-rendered page',
     async () => {
       const response = await server.fetchAsync('/response');
@@ -235,19 +252,56 @@ describe.each(
   );
 
   (server.isExpoStart ? it.skip : it)(
-    'writes loader-declared `Cache-Control` rules to the manifest subset',
+    'writes loader and page `Cache-Control` rules to the manifest subset',
     () => {
       const routesJson = JSON.parse(
         fs.readFileSync(path.join(server.outputDir, '_expo/.routes.json'), 'utf8')
       );
+      const SSG_DEFAULT = { 'Cache-Control': 'private, must-revalidate, max-age=0' };
+
       expect(routesJson.pageHeaders).toEqual([
+        // Header-less loader routes: the SSG default, applied to each page and loader file.
+        { namedRegex: '^/(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/\\(group\\)(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/env(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/error(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/meta(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/nested(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/nullish/\\[value\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/nullish/null(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/nullish/undefined(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/posts/\\[postId\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/posts/static\\-post\\-1(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/posts/static\\-post\\-2(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/request(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/static\\-helper(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/\\(group\\)/index(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/env(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/error(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/index(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/meta(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/nested/index(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/nullish/\\[value\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/nullish/null(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/nullish/undefined(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/posts/\\[postId\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/posts/static\\-post\\-1(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/posts/static\\-post\\-2(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/request(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/_expo/loaders/static\\-helper(?:/)?$', headers: SSG_DEFAULT },
+        // Loader-declared headers: appended last so they win, applied to page and loader file.
         {
           namedRegex: '^/response(?:/)?$',
           headers: { 'Cache-Control': 'public, max-age=604800' },
         },
+        { namedRegex: '^/second(?:/)?$', headers: { 'Cache-Control': 'private, no-store' } },
         {
           namedRegex: '^/_expo/loaders/response(?:/)?$',
           headers: { 'Cache-Control': 'public, max-age=604800' },
+        },
+        {
+          namedRegex: '^/_expo/loaders/second(?:/)?$',
+          headers: { 'Cache-Control': 'private, no-store' },
         },
       ]);
     }

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -60,6 +60,20 @@ for (const outputMode of outputModes) {
       expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
     });
 
+    test('defaults headerless loaders to no-store without replacing declared headers', async ({
+      request,
+    }) => {
+      const headerless = await request.get(
+        new URL('/_expo/loaders/posts/static-post-1', expoStart.url).href
+      );
+      const declared = await request.get(new URL('/_expo/loaders/response', expoStart.url).href);
+
+      expect(headerless.headers()['cache-control']).toBe('no-store');
+      expect(declared.headers()['cache-control']).toBe(
+        outputMode === 'static' ? 'public, max-age=604800' : 'public, max-age=3600'
+      );
+    });
+
     test('caches loader data for subsequent navigations', async ({ page }) => {
       const loaderRequests: string[] = [];
       page.on('request', (request) => {

--- a/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportStaticAsync.test.ts
@@ -1,11 +1,15 @@
 import { getMockConfig as getMockConfigUntyped } from 'expo-router/build/testing-library/mock-config';
 
+import { resolveStaticHeaders } from '../../serve/static';
 import type { ExpoRouterRuntimeManifest } from '../../start/server/metro/MetroBundlerDevServer';
 import {
+  deriveStaticLoaderHeaders,
   getExactPathNamedRegex,
   getHtmlFiles,
   getPathVariations,
   getFilesToExportFromServerAsync,
+  SERVER_LOADER_DEFAULT_HEADER_RULE,
+  buildLoaderPageHeaderRules,
 } from '../exportStaticAsync';
 
 // `getMockConfig` returns a structurally-close subset of the runtime manifest (it omits the
@@ -406,6 +410,99 @@ describe(getFilesToExportFromServerAsync, () => {
     });
 
     expect([...files.keys()]).toEqual(['(a)/index.html', '(b)/index.html']);
+  });
+});
+
+describe(deriveStaticLoaderHeaders, () => {
+  it('fills in the SSG default for a headerless loader response', () => {
+    const entry = deriveStaticLoaderHeaders(new Headers());
+
+    expect(entry).toEqual({
+      declared: {},
+      defaults: { 'Cache-Control': 'private, must-revalidate, max-age=0' },
+    });
+  });
+
+  it('keeps a loader-declared Cache-Control out of the defaults', () => {
+    const entry = deriveStaticLoaderHeaders(
+      new Headers({ 'Cache-Control': 'public, max-age=3600' })
+    );
+
+    expect(entry).toEqual({
+      declared: { 'Cache-Control': 'public, max-age=3600' },
+      defaults: {},
+    });
+  });
+});
+
+describe(buildLoaderPageHeaderRules, () => {
+  const userRule = { namedRegex: '^/_expo/loaders/custom(?:/)?$', headers: { 'X-User': 'yes' } };
+  const derivedRule = {
+    namedRegex: '^/_expo/loaders/second(?:/)?$',
+    headers: { 'Cache-Control': 'no-store' },
+  };
+
+  it('orders rules as defaults, then user-configured, then loader-declared', () => {
+    const merged = buildLoaderPageHeaderRules([userRule], {
+      defaults: [SERVER_LOADER_DEFAULT_HEADER_RULE],
+      declared: [derivedRule],
+    });
+
+    expect(merged).toEqual([
+      { namedRegex: '^/_expo/loaders/.+$', headers: { 'Cache-Control': 'no-store' } },
+      userRule,
+      derivedRule,
+    ]);
+  });
+
+  // Resolved with `resolveStaticHeaders` so precedence reflects the hosts' later-rule-wins logic.
+  describe('resolved against host rule semantics', () => {
+    const USER_RULE = {
+      namedRegex: '^/_expo/loaders/foo(?:/)?$',
+      headers: { 'Cache-Control': 'private, max-age=60' },
+    };
+
+    function resolveForPath(rules: { namedRegex: string; headers: any }[], pathname: string) {
+      return resolveStaticHeaders(
+        {
+          pageHeaders: rules.map((rule) => ({ ...rule, namedRegex: new RegExp(rule.namedRegex) })),
+          redirects: [],
+        } as any,
+        pathname
+      );
+    }
+
+    it('lets a user-configured rule override the headerless default', () => {
+      const merged = buildLoaderPageHeaderRules([USER_RULE], {
+        defaults: [
+          SERVER_LOADER_DEFAULT_HEADER_RULE,
+          {
+            namedRegex: '^/_expo/loaders/foo(?:/)?$',
+            headers: deriveStaticLoaderHeaders(new Headers()).defaults,
+          },
+        ],
+        declared: [],
+      });
+
+      expect(resolveForPath(merged, '/_expo/loaders/foo')['cache-control']).toBe(
+        'private, max-age=60'
+      );
+    });
+
+    it('lets a loader-declared header override a user-configured rule', () => {
+      const merged = buildLoaderPageHeaderRules([USER_RULE], {
+        defaults: [SERVER_LOADER_DEFAULT_HEADER_RULE],
+        declared: [
+          {
+            namedRegex: '^/_expo/loaders/foo(?:/)?$',
+            headers: deriveStaticLoaderHeaders(new Headers({ 'Cache-Control': 'no-store' }))
+              .declared,
+          },
+        ],
+      });
+
+      expect(resolveForPath(merged, '/_expo/loaders/foo')['cache-control']).toBe('no-store');
+    });
   });
 });
 

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -87,6 +87,18 @@ function matchGroupName(name: string): string | undefined {
   return name.match(/^\(([^/]+?)\)$/)?.[1];
 }
 
+export const SERVER_LOADER_DEFAULT_HEADER_RULE: PageHeaderInfo<string> = {
+  namedRegex: '^/_expo/loaders/.+$',
+  headers: { 'Cache-Control': 'no-store' },
+};
+
+type LoaderHeaderEntry = {
+  /** Allowlisted headers the loader response actually carried. */
+  declared: Record<string, string>;
+  /** Default values for headers the loader left undeclared. */
+  defaults: Record<string, string>;
+};
+
 export async function getFilesToExportFromServerAsync(
   projectRoot: string,
   {
@@ -242,8 +254,8 @@ export async function exportFromServerAsync(
 
   // Group variations prerender several pathnames from one loader file, so these maps can differ
   // in size.
-  const loaderHeadersByPage = new Map<string, Record<string, string>>();
-  const loaderHeadersByFile = new Map<string, Record<string, string>>();
+  const loaderHeadersByPage = new Map<string, LoaderHeaderEntry>();
+  const loaderHeadersByFile = new Map<string, LoaderHeaderEntry>();
 
   await getFilesToExportFromServerAsync(projectRoot, {
     files,
@@ -272,20 +284,12 @@ export async function exportFromServerAsync(
             loaderId: loaderKey,
           });
 
-          const declaredHeaders: Record<string, string> = {};
-          for (const name of SSG_LOADER_HEADER_ALLOWLIST) {
-            const value = loaderResponse.headers.get(name);
-            if (value) {
-              declaredHeaders[name] = value;
-            }
-          }
-          if (Object.keys(declaredHeaders).length) {
-            loaderHeadersByPage.set(normalizedPathname, declaredHeaders);
-            // NOTE(@hassankhan): Last-write-wins when concurrent group
-            // variations share a loader file; fine for SSG as loaders don't get
-            // a `request` and will produce identical headers.
-            loaderHeadersByFile.set(`/${fileSystemPath}`, declaredHeaders);
-          }
+          const loaderHeaders = deriveStaticLoaderHeaders(loaderResponse.headers);
+          loaderHeadersByPage.set(normalizedPathname, loaderHeaders);
+          // NOTE(@hassankhan): Last-write-wins when concurrent group
+          // variations share a loader file; fine for SSG as loaders don't get
+          // a `request` and will produce identical headers.
+          loaderHeadersByFile.set(`/${fileSystemPath}`, loaderHeaders);
 
           renderOpts.loader = { data, key: loaderKey };
         }
@@ -315,14 +319,20 @@ export async function exportFromServerAsync(
     },
   });
 
-  const loaderHeaderRules = [
-    ...toLoaderRules(loaderHeadersByPage),
-    ...toLoaderRules(loaderHeadersByFile),
+  const defaultLoaderRules = [
+    ...toLoaderRules(loaderHeadersByPage, 'defaults'),
+    ...toLoaderRules(loaderHeadersByFile, 'defaults'),
+  ];
+  const declaredLoaderRules = [
+    ...toLoaderRules(loaderHeadersByPage, 'declared'),
+    ...toLoaderRules(loaderHeadersByFile, 'declared'),
   ];
 
-  // Appended after any pre-existing rules so the loader-declared values win.
-  if (loaderHeaderRules.length) {
-    serverManifest.pageHeaders = [...(serverManifest.pageHeaders ?? []), ...loaderHeaderRules];
+  if (defaultLoaderRules.length || declaredLoaderRules.length) {
+    serverManifest.pageHeaders = buildLoaderPageHeaderRules(serverManifest.pageHeaders, {
+      defaults: defaultLoaderRules,
+      declared: declaredLoaderRules,
+    });
   }
 
   if (!exportServer) {
@@ -371,12 +381,18 @@ export async function exportFromServerAsync(
       files.set(route, contents);
     }
 
-    // Add any loader-declared headers
-    if (loaderHeaderRules.length) {
+    const useServerLoaders = !!exp?.extra?.router?.unstable_useServerDataLoaders;
+    if (useServerLoaders || defaultLoaderRules.length || declaredLoaderRules.length) {
       updateExportManifestInFiles({
         files,
         callback: (manifest) => {
-          manifest.pageHeaders = [...(manifest.pageHeaders ?? []), ...loaderHeaderRules];
+          manifest.pageHeaders = buildLoaderPageHeaderRules(manifest.pageHeaders, {
+            defaults: [
+              ...(useServerLoaders ? [SERVER_LOADER_DEFAULT_HEADER_RULE] : []),
+              ...defaultLoaderRules,
+            ],
+            declared: declaredLoaderRules,
+          });
         },
       });
     }
@@ -390,7 +406,6 @@ export async function exportFromServerAsync(
       });
 
       // Export loader bundles for routes that have loader exports
-      const useServerLoaders = exp?.extra?.router?.unstable_useServerDataLoaders;
       if (useServerLoaders) {
         // Get `loaderReferences` from client bundle metadata to determine which routes have loaders
         const loaderReferences = resources.artifacts?.flatMap(
@@ -853,11 +868,47 @@ export function getExactPathNamedRegex(pathname: string): string {
  * Converts headers keyed by pathname into exact-match `pageHeaders` rules, sorted for
  * deterministic manifest output.
  */
-function toLoaderRules(rulesByPath: Map<string, Record<string, string>>): PageHeaderInfo<string>[] {
+function toLoaderRules(
+  rulesByPath: Map<string, LoaderHeaderEntry>,
+  origin: keyof LoaderHeaderEntry
+): PageHeaderInfo<string>[] {
   return [...rulesByPath.entries()]
+    .filter(([, entry]) => Object.keys(entry[origin]).length > 0)
     .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([pathname, headers]) => ({
+    .map(([pathname, entry]) => ({
       namedRegex: getExactPathNamedRegex(pathname),
-      headers,
+      headers: entry[origin],
     }));
+}
+
+/**
+ * Split a loader response's allowlisted headers from the SSG defaults for headers it left
+ * undeclared.
+ */
+export function deriveStaticLoaderHeaders(responseHeaders: Headers): LoaderHeaderEntry {
+  const declared: Record<string, string> = {};
+  for (const name of SSG_LOADER_HEADER_ALLOWLIST) {
+    const value = responseHeaders.get(name);
+    if (value) {
+      declared[name] = value;
+    }
+  }
+
+  const defaults: Record<string, string> = {};
+  if (!declared['Cache-Control']) {
+    defaults['Cache-Control'] = 'private, must-revalidate, max-age=0';
+  }
+
+  return { declared, defaults };
+}
+
+/**
+ * Order loader header rules around user-configured `pageHeaders`. Defaults come
+ * first so user configuration overrides them; loader-declared rules come last.
+ */
+export function buildLoaderPageHeaderRules(
+  pageHeaders: PageHeaderInfo<string>[] | undefined,
+  { defaults, declared }: { defaults: PageHeaderInfo<string>[]; declared: PageHeaderInfo<string>[] }
+): PageHeaderInfo<string>[] {
+  return [...defaults, ...(pageHeaders ?? []), ...declared];
 }

--- a/packages/@expo/cli/src/start/server/metro/createServerRouteMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/createServerRouteMiddleware.ts
@@ -262,7 +262,19 @@ export function createRouteHandlerMiddleware(
       },
       async getLoaderData(request, route) {
         const response = await options.executeLoaderAsync(route, new ImmutableRequest(request));
-        return response ?? new Response(null, { status: 404 });
+        const result = response ?? new Response(null, { status: 404 });
+        if (result.headers.has('Cache-Control')) {
+          return result;
+        }
+
+        // Default header-less loader responses to `no-store` in development
+        const headers = new Headers(result.headers);
+        headers.set('Cache-Control', 'no-store');
+        return new Response(result.body, {
+          status: result.status,
+          statusText: result.statusText,
+          headers,
+        });
       },
     }
   );

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -65,6 +65,21 @@ describe(createMetroMiddleware, () => {
     expect(response.headers.get('Expires')).toBe('0');
   });
 
+  it('does not apply blanket no-cache headers to loader requests', async () => {
+    metro.middleware.use('/_expo/loaders/cacheable', (_req, res) => {
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.end('{}');
+    });
+
+    const response = await server.fetch('/_expo/loaders/cacheable');
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=3600');
+    expect(response.headers.get('Surrogate-Control')).toBeNull();
+    expect(response.headers.get('Pragma')).toBeNull();
+    expect(response.headers.get('Expires')).toBeNull();
+  });
+
   it('responds to /status requests', async () => {
     const response = await server.fetch('/status');
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -50,7 +50,12 @@ export function createMetroMiddleware(
   };
 }
 
-const noCacheMiddleware: connect.NextHandleFunction = (_req, res, next) => {
+const noCacheMiddleware: connect.NextHandleFunction = (req, res, next) => {
+  // Loader responses set their own `Cache-Control`, so skip the blanket no-cache headers.
+  if (req.url?.startsWith('/_expo/loaders/')) {
+    return next();
+  }
+
   res.setHeader('Surrogate-Control', 'no-store');
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
   res.setHeader('Pragma', 'no-cache');

--- a/packages/expo-server/CHANGELOG.md
+++ b/packages/expo-server/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Apply per-path `pageHeaders` to matching page responses ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
+- Apply `pageHeaders` rules to loader responses ([#48497](https://github.com/expo/expo/pull/48497) by [@hassankhan](https://github.com/hassankhan))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-server/src/vendor/__tests__/abstract.test.ts
+++ b/packages/expo-server/src/vendor/__tests__/abstract.test.ts
@@ -178,6 +178,93 @@ describe(createRequestHandler, () => {
       expect(new URL(loaderRequest.url).pathname).toBe('/second');
     });
 
+    describe('Cache-Control resolution', () => {
+      const secondRoute = {
+        file: 'second.js',
+        page: '/second',
+        namedRegex: /^\/second\/?$/,
+        routeKeys: {},
+        loader: '_expo/loaders/second.js',
+      };
+
+      function createLoaderHandler(
+        manifest: Partial<Manifest>,
+        getLoaderData: () => Promise<Response>
+      ) {
+        return createRequestHandler({
+          getRoutesManifest: jest.fn(async () => ({
+            htmlRoutes: [secondRoute],
+            apiRoutes: [],
+            notFoundRoutes: [],
+            redirects: [],
+            rewrites: [],
+            ...manifest,
+          })),
+          getHtml: jest.fn(),
+          getApiRoute: jest.fn(),
+          getMiddleware: jest.fn(),
+          getLoaderData: jest.fn(getLoaderData),
+        });
+      }
+
+      it('applies global Cache-Control headers to a headerless loader response', async () => {
+        const handler = createLoaderHandler(
+          { headers: { 'Cache-Control': 'public, max-age=30' } },
+          async () => Response.json({})
+        );
+
+        const response = await handler(new Request('http://localhost/_expo/loaders/second'));
+
+        expect(response.headers.get('Cache-Control')).toBe('public, max-age=30');
+      });
+
+      it('prefers a loader-path rule over global headers', async () => {
+        const handler = createLoaderHandler(
+          {
+            headers: { 'Cache-Control': 'public, max-age=30' },
+            pageHeaders: [
+              { namedRegex: /^\/_expo\/loaders\/.+$/, headers: { 'Cache-Control': 'no-store' } },
+            ],
+          },
+          async () => Response.json({})
+        );
+
+        const response = await handler(new Request('http://localhost/_expo/loaders/second'));
+
+        expect(response.headers.get('Cache-Control')).toBe('no-store');
+      });
+
+      it('prefers a loader-declared header over a loader-path rule', async () => {
+        const handler = createLoaderHandler(
+          {
+            pageHeaders: [
+              { namedRegex: /^\/_expo\/loaders\/.+$/, headers: { 'Cache-Control': 'no-store' } },
+            ],
+          },
+          async () => Response.json({}, { headers: { 'Cache-Control': 'no-cache, private' } })
+        );
+
+        const response = await handler(new Request('http://localhost/_expo/loaders/second'));
+
+        expect(response.headers.get('Cache-Control')).toBe('no-cache, private');
+      });
+
+      it('does not apply page-path rules to the loader endpoint', async () => {
+        const handler = createLoaderHandler(
+          {
+            pageHeaders: [
+              { namedRegex: /^\/second\/?$/, headers: { 'Cache-Control': 'public, max-age=99' } },
+            ],
+          },
+          async () => Response.json({})
+        );
+
+        const response = await handler(new Request('http://localhost/_expo/loaders/second'));
+
+        expect(response.headers.get('Cache-Control')).toBeNull();
+      });
+    });
+
     it('passes the correctly modified request to `getLoaderData()`', async () => {
       const manifest: Manifest = {
         htmlRoutes: [
@@ -537,7 +624,7 @@ describe(createRequestHandler, () => {
       expect(response.headers.get('Set-Cookie')).toBe('session=1, a=1, b=2');
     });
 
-    it('applies only global headers to API routes and loader requests, and none to redirects', async () => {
+    it('applies only global headers to API routes, page-path rules never reach loaders, and redirects get none', async () => {
       const handler = createHandler(
         {
           htmlRoutes: [

--- a/packages/expo-server/src/vendor/abstract.ts
+++ b/packages/expo-server/src/vendor/abstract.ts
@@ -97,7 +97,7 @@ export function createRequestHandler({
     let request = incomingRequest;
     let url = new URL(request.url);
     const globalOverrides = manifest.headers ? { headers: manifest.headers } : undefined;
-    // `pageHeaders` rules only apply to HTML responses
+    // `pageHeaders` rules apply to HTML and loader responses, matched on the request pathname.
     const pageOverrides = { headers: resolveRouteHeaders(url.pathname) };
 
     if (manifest.middleware) {
@@ -170,7 +170,7 @@ export function createRequestHandler({
             'api',
             route,
             await getLoaderData(loaderRequest, route),
-            globalOverrides
+            pageOverrides
           );
         }
 


### PR DESCRIPTION
# Why

Data loaders can declare a cache policy by returning a `Response` with a `Cache-Control` header, but that header doesn't reliably reach the browser. In dev, we apply a `no-store` header which replaces it, and loaders without a `Cache-Control` header get no policy at all when exported.

# How

## `@expo/cli`

### Dev server

- `/_expo/loaders/*` is excluded from the dev server middleware that applies `Cache-Control: no-store`, allowing a user-declared header from a loader to be visible during development.
- Loaders without a caching header get a `Cache-Control: no-store`

### Static output

- Loaders without a header default to `private, must-revalidate, max-age=0`, added to the `pageHeaders` rules.
- The above default also applies to the loader route's page HTML (which embeds the seed data, so it must share the loader's cache policy). #47774 already did this for declared headers; this PR makes it apply to the defaults too.

### Server output

- A new rule (`^/_expo/loaders/.+$` with `Cache-Control: no-store`) is prepended to `pageHeaders`, so both user-configured rules and loader-returned headers can override.

## `expo-server`

- The request handler now applies `pageHeaders` rules to loader responses (SSR), as we already do for loader files (SSG).

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
