### PR TITLE
[router] Migrate top-tabs to standard-navigation

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. ([#48498](https://github.com/expo/expo/pull/48498) by [@Ubax](https://github.com/Ubax))
 - Make `beforeRemove` non-preventable and add `removePrevented` event. ([#48347](https://github.com/expo/expo/pull/48347) by [@Ubax](https://github.com/Ubax))
-- Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. (by [@Ubax](https://github.com/Ubax))
 - Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Make `beforeRemove` non-preventable and add `removePrevented` event. ([#48347](https://github.com/expo/expo/pull/48347) by [@Ubax](https://github.com/Ubax))
+- Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. (by [@Ubax](https://github.com/Ubax))
 - Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -346,9 +346,11 @@
     "expect-type": "^1.3.0",
     "immer": "^10.1.1",
     "react-native-gesture-handler": "~3.1.0",
+    "react-native-pager-view": "^8.0.2",
     "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "^4.26.0",
+    "react-native-tab-view": "^4.3.0",
     "react-native-web": "~0.21.0",
     "react-server-dom-webpack": "~19.0.8"
   },

--- a/packages/expo-router/src/layouts/TopTabs.tsx
+++ b/packages/expo-router/src/layouts/TopTabs.tsx
@@ -8,19 +8,21 @@ TopTabs.Protected = Protected;
 export { TopTabs };
 
 export {
-  createMaterialTopTabNavigator,
+  createStandardMaterialTopTabNavigator,
   MaterialTopTabBar,
   MaterialTopTabView,
   useTabAnimation,
 } from './TopTabsClient';
 export type {
   MaterialTopTabBarProps,
+  MaterialTopTabEmitter,
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationProp,
-  MaterialTopTabNavigatorProps,
   MaterialTopTabOptionsArgs,
   MaterialTopTabScreenProps,
+  MaterialTopTabViewState,
 } from '../react-navigation/material-top-tabs';
+export type { JSTopTabsProps } from './TopTabsClient';
 
 export default TopTabs;

--- a/packages/expo-router/src/layouts/TopTabsClient.tsx
+++ b/packages/expo-router/src/layouts/TopTabsClient.tsx
@@ -2,42 +2,38 @@
 
 import type { ComponentProps } from 'react';
 
+import {
+  createStandardMaterialTopTabNavigator,
+  type MaterialTopTabNavigatorCreateProps,
+} from '../react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator';
 import type {
+  MaterialTopTabNavigationConfig,
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
-} from '../react-navigation/material-top-tabs';
-import { createMaterialTopTabNavigator } from '../react-navigation/material-top-tabs';
-import type { ParamListBase, TabNavigationState } from '../react-navigation/native';
-import { Protected } from '../views/Protected';
-import { Screen } from '../views/Screen';
-import { withLayoutContext } from './withLayoutContext';
+} from '../react-navigation/material-top-tabs/types';
+import {
+  type ParamListBase,
+  type TabNavigationState,
+  TabRouter,
+  type TabRouterOptions,
+} from '../react-navigation/native';
+import { unstable_integrateWithRouter } from '../standard-navigation';
 
 // Keep React Navigation client-only so the entry evaluates in React Server Components.
 export * from '../react-navigation/material-top-tabs';
 
-const MaterialTopTabNavigator = createMaterialTopTabNavigator().Navigator;
-
-const MaterialTopTabs = withLayoutContext<
+const TopTabs = unstable_integrateWithRouter<
   MaterialTopTabNavigationOptions,
-  typeof MaterialTopTabNavigator,
   TabNavigationState<ParamListBase>,
-  MaterialTopTabNavigationEventMap
->(MaterialTopTabNavigator);
+  MaterialTopTabNavigationEventMap,
+  MaterialTopTabNavigationConfig,
+  TabRouterOptions,
+  MaterialTopTabNavigatorCreateProps
+>(createStandardMaterialTopTabNavigator, TabRouter, {
+  createProps: ({ state }) => ({ preloadedRouteKeys: state.preloadedRouteKeys }),
+});
 
-/**
- * Renders a material top tab navigator.
- *
- * @hideType
- */
-const TopTabs = Object.assign(
-  (props: ComponentProps<typeof MaterialTopTabs>) => {
-    return <MaterialTopTabs {...props} />;
-  },
-  {
-    Screen,
-    Protected,
-  }
-);
+export type JSTopTabsProps = ComponentProps<typeof TopTabs>;
 
 export { TopTabs };
 

--- a/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
@@ -3,7 +3,7 @@
 import TopTabs, {
   MaterialTopTabBar,
   MaterialTopTabView,
-  createMaterialTopTabNavigator,
+  createStandardMaterialTopTabNavigator,
   useTabAnimation,
 } from '../TopTabs';
 
@@ -14,7 +14,7 @@ function expectClientReference(value: unknown) {
 }
 
 it('resolves React Navigation exports as client references', () => {
-  expectClientReference(createMaterialTopTabNavigator);
+  expectClientReference(createStandardMaterialTopTabNavigator);
   expectClientReference(MaterialTopTabBar);
   expectClientReference(MaterialTopTabView);
   expectClientReference(useTabAnimation);

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
@@ -1,22 +1,31 @@
-import { expect, jest, test } from '@jest/globals';
-import { fireEvent, render } from '@testing-library/react-native';
-import { Button, View } from 'react-native';
+import { userEvent } from '@testing-library/react-native';
+import { useEffect } from 'react';
+import { View } from 'react-native';
+import type { PagerViewProps } from 'react-native-pager-view';
+import { TabView, type TabBarProps, type TabViewProps } from 'react-native-tab-view';
 
-import { NavigationContainer } from '../../../fork/NavigationContainer';
+import { router } from '../../../imperative-api';
+import { TopTabs } from '../../../layouts/TopTabs';
+import { act, renderRouter, screen } from '../../../testing-library';
+import { useNavigation } from '../../../useNavigation';
 import { Text } from '../../elements';
-import { createMaterialTopTabNavigator, type MaterialTopTabScreenProps } from '../index';
+import type { ParamListBase } from '../../native';
+import type {
+  MaterialTopTabBarProps,
+  MaterialTopTabNavigationProp,
+  MaterialTopTabViewRoute,
+} from '../types';
 
-type TopTabParamList = {
-  A: undefined;
-  B: undefined;
+const getTabViewProps = () => {
+  const mockTabView = jest.mocked(TabView);
+  return mockTabView.mock.calls.at(-1)![0];
 };
 
 jest.mock('react-native-pager-view', () => {
-  const React = require('react');
-  const { View } = require('react-native');
+  const React = require('react') as typeof import('react');
+  const { View } = require('react-native') as typeof import('react-native');
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  return class ViewPager extends React.Component<React.PropsWithChildren<{}>> {
+  return class ViewPager extends React.Component<PagerViewProps> {
     setPage() {}
 
     render() {
@@ -28,30 +37,63 @@ jest.mock('react-native-pager-view', () => {
 jest.mock(
   'react-native-tab-view',
   () => {
-    const { View, Text, Pressable } = require('react-native');
+    const { Animated, View, Text, Pressable } =
+      require('react-native') as typeof import('react-native');
 
     return {
-      TabView: ({ navigationState, renderScene, renderTabBar }: any) => {
+      TabView: jest.fn((props: TabViewProps<MaterialTopTabViewRoute>) => {
+        const { navigationState, renderScene, renderTabBar, lazy, onIndexChange } = props;
+        const position = new Animated.Value(0).interpolate({
+          inputRange: [0, 1],
+          outputRange: [0, 1],
+        });
+        const layout = { width: 0, height: 0 };
+        const jumpTo = (routeKey: string) => {
+          onIndexChange(navigationState.routes.findIndex((route) => route.key === routeKey));
+        };
+
         return (
           <View>
-            {renderTabBar({
-              navigationState,
-              options: {},
-            })}
-            {renderScene({
-              route: navigationState.routes[navigationState.index],
-              position: { interpolate: () => 0 },
+            {renderTabBar?.({ navigationState, options: {}, jumpTo, layout, position })}
+            {navigationState.routes.map((route, index) => {
+              const isLazy = typeof lazy === 'function' ? lazy({ route }) : lazy;
+
+              return index === navigationState.index || !isLazy ? (
+                <View
+                  key={route.key}
+                  style={index === navigationState.index ? undefined : { display: 'none' }}>
+                  {renderScene({ route, position, layout, jumpTo })}
+                </View>
+              ) : null;
             })}
           </View>
         );
-      },
-      TabBar: ({ navigationState, onTabPress, options }: any) => {
+      }),
+      TabBar: ({
+        navigationState,
+        onTabPress,
+        options,
+        jumpTo,
+      }: TabBarProps<MaterialTopTabViewRoute>) => {
         return (
           <View>
-            {navigationState.routes.map((route: any) => (
+            {navigationState.routes.map((route) => (
               <Pressable
                 key={route.key}
-                onPress={() => onTabPress({ route, preventDefault: () => {} })}>
+                accessibilityRole="tab"
+                onPress={() => {
+                  let defaultPrevented = false;
+                  onTabPress?.({
+                    route,
+                    defaultPrevented,
+                    preventDefault: () => {
+                      defaultPrevented = true;
+                    },
+                  });
+                  if (!defaultPrevented) {
+                    jumpTo(route.key);
+                  }
+                }}>
                 <Text>{options?.[route.key]?.labelText ?? route.name}</Text>
               </Pressable>
             ))}
@@ -64,30 +106,222 @@ jest.mock(
   { virtual: true }
 );
 
-test('renders a material top tab navigator with screens', async () => {
-  const Test = ({ route, navigation }: MaterialTopTabScreenProps<TopTabParamList>) => (
-    <View>
-      <Text>Screen {route.name}</Text>
-      <Button onPress={() => navigation.navigate('A')} title="Go to A" />
-      <Button onPress={() => navigation.navigate('B')} title="Go to B" />
-    </View>
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('renders a material top tab navigator and navigates between screens on tab press', async () => {
+  renderRouter({
+    _layout: () => (
+      <TopTabs>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" />
+      </TopTabs>
+    ),
+    index: () => <Text>Screen index</Text>,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  expect(screen.getByText('Screen index')).toBeVisible();
+  expect(screen.queryByText('Screen second')).not.toBeVisible();
+
+  await userEvent.press(screen.getByRole('tab', { name: 'second' }));
+
+  expect(screen.getByText('Screen second')).toBeVisible();
+  expect(screen).toHavePathname('/second');
+});
+
+test('renders filesystem routes not declared in the layout', async () => {
+  renderRouter({
+    _layout: () => (
+      <TopTabs>
+        <TopTabs.Screen name="index" />
+      </TopTabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  await userEvent.press(screen.getByRole('tab', { name: 'second' }));
+
+  expect(screen.getByTestId('second')).toBeVisible();
+  expect(screen).toHavePathname('/second');
+});
+
+test('does not navigate when a tabPress listener prevents the default action', async () => {
+  renderRouter({
+    _layout: () => (
+      <TopTabs
+        screenListeners={{
+          tabPress: (event: { preventDefault: () => void }) => event.preventDefault(),
+        }}>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" />
+      </TopTabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  await userEvent.press(screen.getByRole('tab', { name: 'second' }));
+
+  expect(screen).toHavePathname('/');
+});
+
+test('renders a custom tabBar with standard navigation props', async () => {
+  let tabBarProps: MaterialTopTabBarProps | undefined;
+
+  renderRouter({
+    _layout: () => (
+      <TopTabs
+        tabBar={(props: MaterialTopTabBarProps) => {
+          tabBarProps = props;
+          return (
+            <Text
+              testID="second-tab"
+              onPress={() => props.navigateToTab(props.state.routes[1]!.key)}>
+              {props.descriptors[props.state.routes[1]!.key]!.options.title}
+            </Text>
+          );
+        }}>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" options={{ title: 'Second' }} />
+      </TopTabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  expect(screen.getByTestId('second-tab')).toHaveTextContent('Second');
+  expect(tabBarProps).toEqual(
+    expect.objectContaining({
+      state: expect.any(Object),
+      descriptors: expect.any(Object),
+      emitter: expect.any(Object),
+      navigateToTab: expect.any(Function),
+    })
   );
+  expect(tabBarProps).not.toHaveProperty('navigation');
 
-  const Tab = createMaterialTopTabNavigator<TopTabParamList>();
+  await userEvent.press(screen.getByTestId('second-tab'));
 
-  const { findByText, queryByText } = render(
-    <NavigationContainer>
-      <Tab.Navigator>
-        <Tab.Screen name="A" component={Test} />
-        <Tab.Screen name="B" component={Test} />
-      </Tab.Navigator>
-    </NavigationContainer>
-  );
+  expect(screen).toHavePathname('/second');
+});
 
-  expect(queryByText('Screen A')).not.toBeNull();
-  expect(queryByText('Screen B')).toBeNull();
+test('lets a tabPress listener prevent navigation from a custom tabBar', async () => {
+  function CustomTabBar({ state, emitter, navigateToTab }: MaterialTopTabBarProps) {
+    const route = state.routes[1]!;
+    return (
+      <Text
+        testID="second-tab"
+        onPress={() => {
+          const event = emitter.emit({
+            type: 'tabPress',
+            target: route.key,
+            canPreventDefault: true,
+          });
+          if (!event.defaultPrevented) {
+            navigateToTab(route.key);
+          }
+        }}>
+        {route.name}
+      </Text>
+    );
+  }
 
-  fireEvent(await findByText('Go to B'), 'press');
+  renderRouter({
+    _layout: () => (
+      <TopTabs
+        screenListeners={{
+          tabPress: (event: { preventDefault: () => void }) => event.preventDefault(),
+        }}
+        tabBar={(props: MaterialTopTabBarProps) => <CustomTabBar {...props} />}>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" />
+      </TopTabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
 
-  expect(queryByText('Screen B')).not.toBeNull();
+  await userEvent.press(screen.getByTestId('second-tab'));
+
+  expect(screen).toHavePathname('/');
+});
+
+test('handles screens preloading', () => {
+  renderRouter({
+    _layout: () => (
+      <TopTabs>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" options={{ lazy: true }} />
+      </TopTabs>
+    ),
+    index: () => null,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  expect(screen.queryByText('Screen second', { includeHiddenElements: true })).toBeNull();
+
+  act(() => router.prefetch('/second'));
+
+  const tabViewProps = getTabViewProps();
+  const secondRoute = tabViewProps.navigationState.routes[1]!;
+  if (typeof tabViewProps.lazy !== 'function') {
+    throw new Error('Expected `lazy` to be a function.');
+  }
+  expect(tabViewProps.lazy({ route: secondRoute })).toBe(false);
+  expect(screen.queryByText('Screen second', { includeHiddenElements: true })).not.toBeNull();
+});
+
+test('warns when navigateToTab receives an unknown route key', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  renderRouter({
+    _layout: () => (
+      <TopTabs
+        tabBar={({ navigateToTab }: MaterialTopTabBarProps) => (
+          <Text testID="unknown-tab" onPress={() => navigateToTab('unknown-key')} />
+        )}
+      />
+    ),
+    index: () => null,
+  });
+
+  act(() => screen.getByTestId('unknown-tab').props.onPress());
+
+  expect(warn).toHaveBeenCalledWith(expect.stringContaining('Top tabs could not switch'));
+});
+
+test('emits swipeStart and swipeEnd events', async () => {
+  const onSwipeStart = jest.fn();
+  const onSwipeEnd = jest.fn();
+
+  function Index() {
+    const navigation = useNavigation<MaterialTopTabNavigationProp<ParamListBase>>();
+    useEffect(() => {
+      const removeStart = navigation.addListener('swipeStart', onSwipeStart);
+      const removeEnd = navigation.addListener('swipeEnd', onSwipeEnd);
+      return () => {
+        removeStart();
+        removeEnd();
+      };
+    }, [navigation]);
+    return null;
+  }
+
+  renderRouter({
+    _layout: () => <TopTabs />,
+    index: Index,
+  });
+
+  const tabViewProps = getTabViewProps();
+  if (!tabViewProps.onSwipeStart || !tabViewProps.onSwipeEnd) {
+    throw new Error('Expected swipe callbacks.');
+  }
+  act(() => tabViewProps.onSwipeStart?.());
+  act(() => tabViewProps.onSwipeEnd?.());
+
+  expect(onSwipeStart).toHaveBeenCalledTimes(1);
+  expect(onSwipeEnd).toHaveBeenCalledTimes(1);
 });

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
@@ -9,11 +9,7 @@ jest.mock(
 );
 
 test('throws an error when react-native-tab-view is not installed', () => {
-  jest.resetModules();
-  jest.doMock('react-native-tab-view', () => {
-    throw new Error();
-  });
-  expect(() => require('../index')).toThrow(
+  expect(() => jest.isolateModules(() => require('../index'))).toThrow(
     "Install the 'react-native-tab-view' package and its peer dependencies to use the Expo Router's TopTabs."
   );
 });

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
@@ -15,12 +15,14 @@ type IsAny<T> = 0 extends 1 & T ? true : false;
 type IndicatorProps = Parameters<
   NonNullable<MaterialTopTabNavigationOptions['tabBarIndicator']>
 >[0];
+type TabBarCallbackProps = Parameters<NonNullable<MaterialTopTabNavigationConfig['tabBar']>>[0];
 
 export type _PublicPropsIncludeTabBar = Expect<
   'tabBar' extends keyof JSTopTabsProps ? true : false
 >;
 export type _NavigationConfigIsNotAny = Expect<Equal<IsAny<MaterialTopTabNavigationConfig>, false>>;
 export type _TabBarPropsAreNotAny = Expect<Equal<IsAny<MaterialTopTabBarProps>, false>>;
+export type _TabBarCallbackPropsAreNotAny = Expect<Equal<IsAny<TabBarCallbackProps>, false>>;
 export type _TabBarPropsExcludeNavigation = Expect<
   'navigation' extends keyof MaterialTopTabBarProps ? false : true
 >;

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
@@ -1,0 +1,38 @@
+import type { JSTopTabsProps } from '../../../layouts/TopTabs';
+import type { MaterialTopTabNavigatorContentProps } from '../navigators/createMaterialTopTabNavigator';
+import type {
+  MaterialTopTabBarProps,
+  MaterialTopTabNavigationConfig,
+  MaterialTopTabNavigationOptions,
+  MaterialTopTabViewState,
+} from '../types';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type IndicatorProps = Parameters<
+  NonNullable<MaterialTopTabNavigationOptions['tabBarIndicator']>
+>[0];
+
+export type _PublicPropsIncludeTabBar = Expect<
+  'tabBar' extends keyof JSTopTabsProps ? true : false
+>;
+export type _NavigationConfigIsNotAny = Expect<Equal<IsAny<MaterialTopTabNavigationConfig>, false>>;
+export type _TabBarPropsAreNotAny = Expect<Equal<IsAny<MaterialTopTabBarProps>, false>>;
+export type _TabBarPropsExcludeNavigation = Expect<
+  'navigation' extends keyof MaterialTopTabBarProps ? false : true
+>;
+export type _IndicatorUsesTopTabViewState = Expect<
+  Equal<IndicatorProps['state'], MaterialTopTabViewState>
+>;
+export type _ContentRequiresPreloadedRouteKeys = Expect<
+  Equal<MaterialTopTabNavigatorContentProps['preloadedRouteKeys'], string[]>
+>;
+
+describe('material top tabs types', () => {
+  it('type-checks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/expo-router/src/react-navigation/material-top-tabs/index.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/index.tsx
@@ -1,13 +1,15 @@
+import { MaterialTopTabView } from './views/MaterialTopTabView';
+
 /**
- * Navigators
+ * > **warning** This API is unstable and may change between minor releases.
  */
-export { createMaterialTopTabNavigator } from './navigators/createMaterialTopTabNavigator';
+export { createStandardMaterialTopTabNavigator } from './navigators/createMaterialTopTabNavigator';
 
 /**
  * Views
  */
 export { MaterialTopTabBar } from './views/MaterialTopTabBar';
-export { MaterialTopTabView } from './views/MaterialTopTabView';
+export { MaterialTopTabView };
 
 /**
  * Utilities
@@ -19,10 +21,11 @@ export { useTabAnimation } from './utils/useTabAnimation';
  */
 export type {
   MaterialTopTabBarProps,
+  MaterialTopTabEmitter,
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationProp,
-  MaterialTopTabNavigatorProps,
   MaterialTopTabOptionsArgs,
   MaterialTopTabScreenProps,
+  MaterialTopTabViewState,
 } from './types';

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -1,82 +1,66 @@
-import {
-  createNavigatorFactory,
-  type NavigatorTypeBagBase,
-  type ParamListBase,
-  type TabActionHelpers,
-  type TabNavigationState,
-  TabRouter,
-  type TabRouterOptions,
-  type TypedNavigator,
-  useNavigationBuilder,
-} from '../../native';
+'use client';
+// TODO: Rename this file to `createStandardMaterialTopTabNavigator.tsx` in a follow-up.
+import { createStandardNavigator } from 'standard-navigation';
+
+import type { NavigatorContentProps } from '../../../standard-navigation/types';
 import type {
+  MaterialTopTabDescriptorMap,
+  MaterialTopTabNavigationConfig,
   MaterialTopTabNavigationEventMap,
   MaterialTopTabNavigationOptions,
-  MaterialTopTabNavigationProp,
-  MaterialTopTabNavigatorProps,
 } from '../types';
 import { MaterialTopTabView } from '../views/MaterialTopTabView';
 
-function MaterialTopTabNavigator({
-  id,
-  initialRouteName,
-  backBehavior,
-  children,
-  layout,
-  screenListeners,
-  screenOptions,
-  screenLayout,
-  UNSTABLE_router,
+export interface MaterialTopTabNavigatorCreateProps {
+  preloadedRouteKeys: string[];
+}
+
+export type MaterialTopTabNavigatorContentProps = MaterialTopTabNavigationConfig &
+  MaterialTopTabNavigatorCreateProps;
+
+type ContentArgs = NavigatorContentProps<
+  MaterialTopTabNavigationOptions,
+  MaterialTopTabNavigationEventMap,
+  MaterialTopTabNavigationConfig,
+  MaterialTopTabNavigatorCreateProps
+>;
+
+function MaterialTopTabNavigatorContent({
+  state,
+  descriptors,
+  actions,
+  emitter,
+  preloadedRouteKeys,
   ...rest
-}: MaterialTopTabNavigatorProps) {
-  const { state, descriptors, navigation, NavigationContent } = useNavigationBuilder<
-    TabNavigationState<ParamListBase>,
-    TabRouterOptions,
-    TabActionHelpers<ParamListBase>,
-    MaterialTopTabNavigationOptions,
-    MaterialTopTabNavigationEventMap
-  >(TabRouter, {
-    id,
-    initialRouteName,
-    backBehavior,
-    children,
-    layout,
-    screenListeners,
-    screenOptions,
-    screenLayout,
-    UNSTABLE_router,
-  });
+}: ContentArgs) {
+  const navigateToTab = (routeKey: string) => {
+    const route = state.routes.find((route) => route.key === routeKey);
+    if (route) {
+      actions.navigate(route.name, route.params);
+    } else if (__DEV__) {
+      console.warn(
+        `Top tabs could not switch to the tab "${routeKey}" because no tab with that key exists. ` +
+          `'navigateToTab' takes a route key, not a route name — pass 'route.key' from the tab bar props.`
+      );
+    }
+  };
 
   return (
-    <NavigationContent>
-      <MaterialTopTabView
-        {...rest}
-        state={state}
-        navigation={navigation}
-        descriptors={descriptors}
-      />
-    </NavigationContent>
+    <MaterialTopTabView
+      {...rest}
+      state={state}
+      // TODO(@ubax): SDK-58: Try to remove the casting from here to ensure type safety
+      // Integration supplies full descriptors, including preload placeholders; standard types omit route/navigation.
+      descriptors={descriptors as unknown as MaterialTopTabDescriptorMap}
+      emitter={emitter}
+      navigateToTab={navigateToTab}
+      preloadedRouteKeys={preloadedRouteKeys}
+    />
   );
 }
 
-export function createMaterialTopTabNavigator<
-  const ParamList extends ParamListBase,
-  const NavigatorID extends string | undefined = string | undefined,
-  const TypeBag extends NavigatorTypeBagBase = {
-    ParamList: ParamList;
-    NavigatorID: NavigatorID;
-    State: TabNavigationState<ParamList>;
-    ScreenOptions: MaterialTopTabNavigationOptions;
-    EventMap: MaterialTopTabNavigationEventMap;
-    NavigationList: {
-      [RouteName in keyof ParamList]: MaterialTopTabNavigationProp<
-        ParamList,
-        RouteName,
-        NavigatorID
-      >;
-    };
-    Navigator: typeof MaterialTopTabNavigator;
-  },
->(): TypedNavigator<TypeBag> {
-  return createNavigatorFactory(MaterialTopTabNavigator)();
-}
+export const createStandardMaterialTopTabNavigator = createStandardNavigator<
+  MaterialTopTabNavigationOptions,
+  MaterialTopTabNavigationEventMap,
+  MaterialTopTabNavigatorContentProps
+>(MaterialTopTabNavigatorContent);

--- a/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
@@ -7,17 +7,16 @@ import type {
   TextStyle,
   ViewStyle,
 } from 'react-native';
+import type { SceneRendererProps, TabBarIndicatorProps, TabViewProps } from 'react-native-tab-view';
+import type { NavigatorArgs } from 'standard-navigation';
 
 import type {
-  DefaultNavigatorOptions,
   Descriptor,
-  NavigationHelpers,
   NavigationProp,
   ParamListBase,
   RouteProp,
   TabActionHelpers,
   TabNavigationState,
-  TabRouterOptions,
   Theme,
 } from '../native';
 
@@ -29,22 +28,35 @@ export type MaterialTopTabNavigationEventMap = {
   /**
    * Event which fires on long press on the tab in the tab bar.
    */
-  tabLongPress: { data: undefined };
+  tabLongPress: { data: undefined; canPreventDefault: false };
   /**
    * Event which fires when a swipe gesture starts, i.e. finger touches the screen.
    */
-  swipeStart: { data: undefined };
+  swipeStart: { data: undefined; canPreventDefault: false };
   /**
    * Event which fires when a swipe gesture ends, i.e. finger leaves the screen.
    */
-  swipeEnd: { data: undefined };
+  swipeEnd: { data: undefined; canPreventDefault: false };
 };
 
-export type MaterialTopTabNavigationHelpers = NavigationHelpers<
-  ParamListBase,
+export type MaterialTopTabViewRoute = {
+  key: string;
+  name: string;
+  params?: object;
+};
+
+/**
+ * The navigator state consumed by `MaterialTopTabView` and the tab bar.
+ */
+export type MaterialTopTabViewState = {
+  index: number;
+  routes: MaterialTopTabViewRoute[];
+};
+
+export type MaterialTopTabEmitter = NavigatorArgs<
+  Record<string, never>,
   MaterialTopTabNavigationEventMap
-> &
-  TabActionHelpers<ParamListBase>;
+>['emitter'];
 
 export type MaterialTopTabNavigationProp<
   ParamList extends ParamListBase,
@@ -128,10 +140,9 @@ export type MaterialTopTabNavigationOptions = {
    * Function that returns a React element as the tab bar indicator.
    */
   tabBarIndicator?: (
-    props: Omit<
-      Parameters<NonNullable<React.ComponentProps<any>['renderIndicator']>>[0],
-      'navigationState'
-    > & { state: TabNavigationState<ParamListBase> }
+    props: Omit<TabBarIndicatorProps<MaterialTopTabViewRoute>, 'navigationState'> & {
+      state: MaterialTopTabViewState;
+    }
   ) => React.ReactNode;
 
   /**
@@ -270,7 +281,7 @@ export type MaterialTopTabDescriptor = Descriptor<
 export type MaterialTopTabDescriptorMap = Record<string, MaterialTopTabDescriptor>;
 
 export type MaterialTopTabNavigationConfig = Omit<
-  any,
+  TabViewProps<MaterialTopTabViewRoute>,
   | 'navigationState'
   | 'onIndexChange'
   | 'onSwipeStart'
@@ -282,7 +293,8 @@ export type MaterialTopTabNavigationConfig = Omit<
   | 'animationEnabled'
   | 'lazy'
   | 'lazyPreloadDistance'
-  | 'lazyPlaceholder'
+  | 'options'
+  | 'direction'
 > & {
   /**
    * Function that returns a React element to display as the tab bar.
@@ -290,23 +302,13 @@ export type MaterialTopTabNavigationConfig = Omit<
   tabBar?: (props: MaterialTopTabBarProps) => React.ReactNode;
 };
 
-export type MaterialTopTabBarProps = any & {
-  state: TabNavigationState<ParamListBase>;
-  navigation: NavigationHelpers<ParamListBase, MaterialTopTabNavigationEventMap>;
+export type MaterialTopTabBarProps = SceneRendererProps & {
+  state: MaterialTopTabViewState;
   descriptors: MaterialTopTabDescriptorMap;
+  emitter: MaterialTopTabEmitter;
+  navigateToTab: (routeKey: string) => void;
 };
 
 export type MaterialTopTabAnimationContext = {
   position: Animated.AnimatedInterpolation<number>;
 };
-
-export type MaterialTopTabNavigatorProps = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  TabNavigationState<ParamListBase>,
-  MaterialTopTabNavigationOptions,
-  MaterialTopTabNavigationEventMap,
-  MaterialTopTabNavigationProp<ParamListBase>
-> &
-  TabRouterOptions &
-  MaterialTopTabNavigationConfig;

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabBar.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabBar.tsx
@@ -3,19 +3,13 @@ import { StyleSheet } from 'react-native';
 
 import { Color } from '../../../utils/color';
 import { Text } from '../../elements';
-import {
-  type ParamListBase,
-  type TabNavigationState,
-  useLinkBuilder,
-  useLocale,
-  useTheme,
-} from '../../native';
+import { useLinkBuilder, useLocale, useTheme } from '../../native';
 import type { MaterialTopTabBarProps } from '../types';
 
 // Use dynamic import to avoid having direct dependency on react-native-tab-view.
 // import { TabBar, TabBarIndicator } from 'react-native-tab-view';
-let TabBar: any;
-let TabBarIndicator: any;
+let TabBar: typeof import('react-native-tab-view').TabBar;
+let TabBarIndicator: typeof import('react-native-tab-view').TabBarIndicator;
 try {
   const tabViewModule = require('react-native-tab-view');
   TabBar = tabViewModule.TabBar;
@@ -36,15 +30,18 @@ const renderLabelDefault = ({ color, labelText, style, allowFontScaling }: any) 
 
 export function MaterialTopTabBar({
   state,
-  navigation,
   descriptors,
+  emitter,
+  // The built-in bar switches through `jumpTo`; only strip the custom callback from forwarded props.
+  navigateToTab: _navigateToTab,
   ...rest
 }: MaterialTopTabBarProps) {
   const { colors } = useTheme();
   const { direction } = useLocale();
   const { buildHref } = useLinkBuilder();
 
-  const focusedOptions = descriptors[state.routes[state.index].key].options;
+  const focusedRoute = state.routes[state.index]!;
+  const focusedOptions = descriptors[focusedRoute.key]!.options;
 
   const activeColor: ColorValue = focusedOptions.tabBarActiveTintColor ?? colors.primary;
   const inactiveColor: ColorValue =
@@ -54,7 +51,7 @@ export function MaterialTopTabBar({
 
   const tabBarOptions = Object.fromEntries(
     state.routes.map((route: any) => {
-      const { options } = descriptors[route.key];
+      const { options } = descriptors[route.key]!;
 
       const {
         title,
@@ -83,7 +80,7 @@ export function MaterialTopTabBar({
               : typeof tabBarLabel === 'function'
                 ? ({ labelText, color }: any) =>
                     tabBarLabel({
-                      focused: state.routes[state.index].key === route.key,
+                      focused: focusedRoute.key === route.key,
                       color,
                       children: labelText ?? route.name,
                     })
@@ -111,9 +108,9 @@ export function MaterialTopTabBar({
       direction={direction}
       scrollEnabled={focusedOptions.tabBarScrollEnabled}
       bounces={focusedOptions.tabBarBounces}
-      activeColor={activeColor}
-      inactiveColor={inactiveColor}
-      pressColor={focusedOptions.tabBarPressColor}
+      activeColor={activeColor as string}
+      inactiveColor={inactiveColor as string}
+      pressColor={focusedOptions.tabBarPressColor as string | undefined}
       pressOpacity={focusedOptions.tabBarPressOpacity}
       tabStyle={focusedOptions.tabBarItemStyle}
       indicatorStyle={[{ backgroundColor: colors.primary }, focusedOptions.tabBarIndicatorStyle]}
@@ -123,7 +120,7 @@ export function MaterialTopTabBar({
       contentContainerStyle={focusedOptions.tabBarContentContainerStyle}
       style={[{ backgroundColor: colors.card }, focusedOptions.tabBarStyle]}
       onTabPress={({ route, preventDefault }: any) => {
-        const event = navigation.emit({
+        const event = emitter.emit({
           type: 'tabPress',
           target: route.key,
           canPreventDefault: true,
@@ -134,7 +131,7 @@ export function MaterialTopTabBar({
         }
       }}
       onTabLongPress={({ route }: any) =>
-        navigation.emit({
+        emitter.emit({
           type: 'tabLongPress',
           target: route.key,
         })
@@ -142,7 +139,7 @@ export function MaterialTopTabBar({
       renderIndicator={({ navigationState: state, ...rest }: any) => {
         return focusedOptions.tabBarIndicator ? (
           focusedOptions.tabBarIndicator({
-            state: state as TabNavigationState<ParamListBase>,
+            state,
             ...rest,
           })
         ) : (

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabBar.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabBar.tsx
@@ -1,10 +1,11 @@
 import type { ColorValue } from 'react-native';
 import { StyleSheet } from 'react-native';
+import type { TabDescriptor } from 'react-native-tab-view';
 
 import { Color } from '../../../utils/color';
 import { Text } from '../../elements';
 import { useLinkBuilder, useLocale, useTheme } from '../../native';
-import type { MaterialTopTabBarProps } from '../types';
+import type { MaterialTopTabBarProps, MaterialTopTabViewRoute } from '../types';
 
 // Use dynamic import to avoid having direct dependency on react-native-tab-view.
 // import { TabBar, TabBarIndicator } from 'react-native-tab-view';
@@ -20,7 +21,12 @@ try {
   );
 }
 
-const renderLabelDefault = ({ color, labelText, style, allowFontScaling }: any) => {
+const renderLabelDefault: NonNullable<TabDescriptor<MaterialTopTabViewRoute>['label']> = ({
+  color,
+  labelText,
+  style,
+  allowFontScaling,
+}) => {
   return (
     <Text style={[{ color }, styles.label, style]} allowFontScaling={allowFontScaling}>
       {labelText}
@@ -50,7 +56,7 @@ export function MaterialTopTabBar({
     colors.text;
 
   const tabBarOptions = Object.fromEntries(
-    state.routes.map((route: any) => {
+    state.routes.map((route) => {
       const { options } = descriptors[route.key]!;
 
       const {
@@ -66,37 +72,36 @@ export function MaterialTopTabBar({
         tabBarLabelStyle,
       } = options;
 
-      return [
-        route.key,
-        {
-          href: buildHref(route.name, route.params),
-          testID: tabBarButtonTestID,
-          accessibilityLabel: tabBarAccessibilityLabel,
-          badge: tabBarBadge,
-          icon: tabBarShowIcon === false ? undefined : tabBarIcon,
-          label:
-            tabBarShowLabel === false
-              ? undefined
-              : typeof tabBarLabel === 'function'
-                ? ({ labelText, color }: any) =>
-                    tabBarLabel({
-                      focused: focusedRoute.key === route.key,
-                      color,
-                      children: labelText ?? route.name,
-                    })
-                : renderLabelDefault,
-          labelAllowFontScaling: tabBarAllowFontScaling,
-          labelStyle: tabBarLabelStyle,
-          labelText:
-            options.tabBarShowLabel === false
-              ? undefined
-              : typeof tabBarLabel === 'string'
-                ? tabBarLabel
-                : title !== undefined
-                  ? title
-                  : route.name,
-        },
-      ];
+      const tabBarOption: TabDescriptor<MaterialTopTabViewRoute> = {
+        href: buildHref(route.name, route.params),
+        testID: tabBarButtonTestID,
+        accessibilityLabel: tabBarAccessibilityLabel,
+        badge: tabBarBadge,
+        icon: tabBarShowIcon === false ? undefined : tabBarIcon,
+        label:
+          tabBarShowLabel === false
+            ? undefined
+            : typeof tabBarLabel === 'function'
+              ? ({ labelText, color }) =>
+                  tabBarLabel({
+                    focused: focusedRoute.key === route.key,
+                    color,
+                    children: labelText ?? route.name,
+                  })
+              : renderLabelDefault,
+        labelAllowFontScaling: tabBarAllowFontScaling,
+        labelStyle: tabBarLabelStyle,
+        labelText:
+          options.tabBarShowLabel === false
+            ? undefined
+            : typeof tabBarLabel === 'string'
+              ? tabBarLabel
+              : title !== undefined
+                ? title
+                : route.name,
+      };
+
+      return [route.key, tabBarOption];
     })
   );
 
@@ -108,6 +113,7 @@ export function MaterialTopTabBar({
       direction={direction}
       scrollEnabled={focusedOptions.tabBarScrollEnabled}
       bounces={focusedOptions.tabBarBounces}
+      // TabBar declares strings, but Expo callbacks, style color, and android_ripple accept OpaqueColorValue at runtime, so PlatformColor works.
       activeColor={activeColor as string}
       inactiveColor={inactiveColor as string}
       pressColor={focusedOptions.tabBarPressColor as string | undefined}
@@ -119,7 +125,7 @@ export function MaterialTopTabBar({
       indicatorContainerStyle={focusedOptions.tabBarIndicatorContainerStyle}
       contentContainerStyle={focusedOptions.tabBarContentContainerStyle}
       style={[{ backgroundColor: colors.card }, focusedOptions.tabBarStyle]}
-      onTabPress={({ route, preventDefault }: any) => {
+      onTabPress={({ route, preventDefault }) => {
         const event = emitter.emit({
           type: 'tabPress',
           target: route.key,
@@ -130,13 +136,13 @@ export function MaterialTopTabBar({
           preventDefault();
         }
       }}
-      onTabLongPress={({ route }: any) =>
+      onTabLongPress={({ route }) =>
         emitter.emit({
           type: 'tabLongPress',
           target: route.key,
         })
       }
-      renderIndicator={({ navigationState: state, ...rest }: any) => {
+      renderIndicator={({ navigationState: state, ...rest }) => {
         return focusedOptions.tabBarIndicator ? (
           focusedOptions.tabBarIndicator({
             state,

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
@@ -1,3 +1,5 @@
+import type { TabViewProps } from 'react-native-tab-view';
+
 import { type Route, useLocale, useTheme } from '../../native';
 import type {
   MaterialTopTabBarProps,
@@ -43,20 +45,22 @@ export function MaterialTopTabView({
   const { colors } = useTheme();
   const { direction } = useLocale();
 
-  const renderTabBar: React.ComponentProps<any>['renderTabBar'] = ({
+  const renderTabBar: NonNullable<TabViewProps<Route<string>>['renderTabBar']> = ({
     /* eslint-disable @typescript-eslint/no-unused-vars */
     navigationState,
     options,
     /* eslint-enable @typescript-eslint/no-unused-vars */
     ...rest
-  }: any) => {
-    return tabBar({
+  }) => {
+    const tabBarProps = {
       ...rest,
       state,
       descriptors,
       emitter,
       navigateToTab,
-    });
+    } satisfies MaterialTopTabBarProps;
+
+    return tabBar(tabBarProps);
   };
 
   const focusedOptions = descriptors[state.routes[state.index]!.key]!.options;
@@ -65,17 +69,17 @@ export function MaterialTopTabView({
     <TabView<Route<string>>
       {...rest}
       onIndexChange={(index: number) => navigateToTab(state.routes[index]!.key)}
-      renderScene={({ route, position }: any) => (
+      renderScene={({ route, position }) => (
         <TabAnimationContext.Provider value={{ position }}>
           {descriptors[route.key]!.render()}
         </TabAnimationContext.Provider>
       )}
       navigationState={state}
       renderTabBar={renderTabBar}
-      renderLazyPlaceholder={({ route }: any) =>
+      renderLazyPlaceholder={({ route }) =>
         descriptors[route.key]!.options.lazyPlaceholder?.() ?? null
       }
-      lazy={({ route }: any) =>
+      lazy={({ route }) =>
         descriptors[route.key]!.options.lazy === true && !preloadedRouteKeys.includes(route.key)
       }
       lazyPreloadDistance={focusedOptions.lazyPreloadDistance}

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
@@ -1,23 +1,17 @@
-import {
-  CommonActions,
-  type ParamListBase,
-  type Route,
-  type TabNavigationState,
-  useLocale,
-  useTheme,
-} from '../../native';
+import { type Route, useLocale, useTheme } from '../../native';
 import type {
   MaterialTopTabBarProps,
   MaterialTopTabDescriptorMap,
+  MaterialTopTabEmitter,
   MaterialTopTabNavigationConfig,
-  MaterialTopTabNavigationHelpers,
+  MaterialTopTabViewState,
 } from '../types';
 import { TabAnimationContext } from '../utils/TabAnimationContext';
 import { MaterialTopTabBar } from './MaterialTopTabBar';
 
 // Use dynamic import to avoid having direct dependency on react-native-tab-view.
 // import { TabView } from 'react-native-tab-view';
-let TabView: any;
+let TabView: typeof import('react-native-tab-view').TabView;
 try {
   const tabViewModule = require('react-native-tab-view');
   TabView = tabViewModule.TabView;
@@ -28,9 +22,11 @@ try {
 }
 
 type Props = MaterialTopTabNavigationConfig & {
-  state: TabNavigationState<ParamListBase>;
-  navigation: MaterialTopTabNavigationHelpers;
+  state: MaterialTopTabViewState;
   descriptors: MaterialTopTabDescriptorMap;
+  emitter: MaterialTopTabEmitter;
+  navigateToTab: (routeKey: string) => void;
+  preloadedRouteKeys: string[];
 };
 
 const renderTabBarDefault = (props: MaterialTopTabBarProps) => <MaterialTopTabBar {...props} />;
@@ -38,8 +34,10 @@ const renderTabBarDefault = (props: MaterialTopTabBarProps) => <MaterialTopTabBa
 export function MaterialTopTabView({
   tabBar = renderTabBarDefault,
   state,
-  navigation,
   descriptors,
+  emitter,
+  navigateToTab,
+  preloadedRouteKeys,
   ...rest
 }: Props) {
   const { colors } = useTheme();
@@ -55,8 +53,9 @@ export function MaterialTopTabView({
     return tabBar({
       ...rest,
       state,
-      navigation,
       descriptors,
+      emitter,
+      navigateToTab,
     });
   };
 
@@ -65,12 +64,7 @@ export function MaterialTopTabView({
   return (
     <TabView<Route<string>>
       {...rest}
-      onIndexChange={(index: number) => {
-        navigation.dispatch({
-          ...CommonActions.navigate(state.routes[index]!),
-          target: state.key,
-        });
-      }}
+      onIndexChange={(index: number) => navigateToTab(state.routes[index]!.key)}
       renderScene={({ route, position }: any) => (
         <TabAnimationContext.Provider value={{ position }}>
           {descriptors[route.key]!.render()}
@@ -82,14 +76,13 @@ export function MaterialTopTabView({
         descriptors[route.key]!.options.lazyPlaceholder?.() ?? null
       }
       lazy={({ route }: any) =>
-        descriptors[route.key]!.options.lazy === true &&
-        !state.preloadedRouteKeys.includes(route.key)
+        descriptors[route.key]!.options.lazy === true && !preloadedRouteKeys.includes(route.key)
       }
       lazyPreloadDistance={focusedOptions.lazyPreloadDistance}
       swipeEnabled={focusedOptions.swipeEnabled}
       animationEnabled={focusedOptions.animationEnabled}
-      onSwipeStart={() => navigation.emit({ type: 'swipeStart' })}
-      onSwipeEnd={() => navigation.emit({ type: 'swipeEnd' })}
+      onSwipeStart={() => emitter.emit({ type: 'swipeStart' })}
+      onSwipeEnd={() => emitter.emit({ type: 'swipeEnd' })}
       direction={direction}
       options={Object.fromEntries(
         state.routes.map((route) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5392,12 +5392,18 @@ importers:
       react-native-gesture-handler:
         specifier: ~3.1.0
         version: 3.1.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-pager-view:
+        specifier: ^8.0.2
+        version: 8.0.2(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.5.1
         version: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context:
         specifier: ~5.7.0
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-tab-view:
+        specifier: ^4.3.0
+        version: 4.3.0(react-native-pager-view@8.0.2(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
# Why

`TopTabs` is the last navigator needing the migration to standard-navigation

# How

Similar to other navigators (mostly JS Tabs):
- replace `createNavigatorFactory` with `unstable_integrateWithRouter`
- extract needed properties from `navigation` and `state` and pass them via `createProps`
- fix playwright tests - now all routes needs to be declared

Additionally improve type safety

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>