### PR TITLE
[router] Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible

### DIFF
--- a/apps/router-e2e/__e2e__/fast-refresh/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/fast-refresh/app/_layout.tsx
@@ -30,7 +30,11 @@ export default function Layout() {
           marginRight: 'auto',
         }}>
         <Text testID="layout-value">{layoutValue}</Text>
-        <Tabs />
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="temp-route" />
+          <Tabs.Screen name="renamed" />
+        </Tabs>
       </View>
     </>
   );

--- a/apps/router-e2e/__e2e__/headless/app/old-tabs/_layout.tsx
+++ b/apps/router-e2e/__e2e__/headless/app/old-tabs/_layout.tsx
@@ -1,5 +1,10 @@
 import { Tabs } from 'expo-router';
 
 export default function OldTabsLayout() {
-  return <Tabs />;
+  return (
+    <Tabs>
+      <Tabs.Screen name="index" />
+      <Tabs.Screen name="new-tabs" />
+    </Tabs>
+  );
 }

--- a/apps/router-e2e/__e2e__/helmet/app/_layout.tsx
+++ b/apps/router-e2e/__e2e__/helmet/app/_layout.tsx
@@ -1,5 +1,11 @@
 import { Tabs } from 'expo-router';
 
 export default function Layout() {
-  return <Tabs screenOptions={{ headerShown: true }} />;
+  return (
+    <Tabs screenOptions={{ headerShown: true }}>
+      <Tabs.Screen name="index" />
+      <Tabs.Screen name="page1" />
+      <Tabs.Screen name="page2" />
+    </Tabs>
+  );
 }

--- a/apps/router-e2e/__e2e__/link-preview/app/js-only/tabs/_layout.tsx
+++ b/apps/router-e2e/__e2e__/link-preview/app/js-only/tabs/_layout.tsx
@@ -1,5 +1,11 @@
 import { Tabs } from 'expo-router';
 
 export default function Layout() {
-  return <Tabs />;
+  return (
+    <Tabs>
+      <Tabs.Screen name="index" />
+      <Tabs.Screen name="second" />
+      <Tabs.Screen name="[id]" />
+    </Tabs>
+  );
 }

--- a/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
@@ -17,6 +17,7 @@ const inputDir = 'fast-refresh';
 
 const appDir = path.join(projectRoot, '__e2e__', inputDir, 'app');
 const tempRoute = '/temp-route.tsx';
+const renamedRoute = '/renamed.tsx';
 
 test.describe(inputDir, () => {
   const expoStart = createExpoStart({
@@ -64,6 +65,9 @@ test.describe(inputDir, () => {
 
     if (fs.existsSync(appDir + tempRoute)) {
       await fsPromise.unlink(appDir + tempRoute);
+    }
+    if (fs.existsSync(appDir + renamedRoute)) {
+      await fsPromise.unlink(appDir + renamedRoute);
     }
   });
 
@@ -165,11 +169,27 @@ test.describe(inputDir, () => {
     // Ensure the React Navigation Tabs component is visible
     await expect(page.getByRole('tab', { name: '⏷ ⏷ index' })).toBeVisible();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).not.toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "temp-route" is extraneous')
+      )
+    ).toBe(true);
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "renamed" is extraneous')
+      )
+    ).toBe(true);
 
     // If the file is added, a new tab should be visible
+    pageErrors.warnings.length = 0;
     await fsPromise.copyFile(appDir + '/index.tsx', appDir + tempRoute);
     await waitForFashRefresh();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "renamed" is extraneous')
+      )
+    ).toBe(true);
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -189,18 +209,38 @@ test.describe(inputDir, () => {
     // Ensure the React Navigation Tabs component is visible
     await expect(page.getByRole('tab', { name: '⏷ ⏷ index' })).toBeVisible();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).not.toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "temp-route" is extraneous')
+      )
+    ).toBe(true);
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "renamed" is extraneous')
+      )
+    ).toBe(true);
 
     // If the file is added, a new tab should be visible
+    pageErrors.warnings.length = 0;
     await fsPromise.copyFile(appDir + '/index.tsx', appDir + tempRoute);
     await waitForFashRefresh();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "renamed" is extraneous')
+      )
+    ).toBe(true);
 
-    await fsPromise.rename(appDir + tempRoute, appDir + '/renamed.tsx');
+    pageErrors.warnings.length = 0;
+    await fsPromise.rename(appDir + tempRoute, appDir + renamedRoute);
     await waitForFashRefresh();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).not.toBeVisible();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ renamed' })).toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) => warning.text().includes('No route named "temp-route"'))
+    ).toBe(true);
 
-    await fsPromise.rename(appDir + '/renamed.tsx', appDir + tempRoute);
+    await fsPromise.rename(appDir + renamedRoute, appDir + tempRoute);
     expect(pageErrors.all).toEqual([]);
   });
 
@@ -223,9 +263,20 @@ test.describe(inputDir, () => {
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).toBeVisible();
 
     // If a file is deleted, the tab should be removed
+    pageErrors.warnings.length = 0;
     await fsPromise.unlink(appDir + tempRoute);
     await waitForFashRefresh();
     await expect(page.getByRole('tab', { name: '⏷ ⏷ temp-route' })).not.toBeVisible();
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "temp-route" is extraneous')
+      )
+    ).toBe(true);
+    expect(
+      pageErrors.warnings.some((warning) =>
+        warning.text().includes('Route "renamed" is extraneous')
+      )
+    ).toBe(true);
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/page.ts
+++ b/packages/@expo/cli/e2e/playwright/page.ts
@@ -5,6 +5,7 @@ export function pageCollectErrors(page: Page) {
   const collected = {
     errors: [] as Error[],
     logs: [] as ConsoleMessage[],
+    warnings: [] as ConsoleMessage[],
     all: [] as (Error | ConsoleMessage)[],
   };
 
@@ -12,6 +13,8 @@ export function pageCollectErrors(page: Page) {
     if (log.type() === 'error') {
       collected.logs.push(log);
       collected.all.push(log);
+    } else if (log.type() === 'warning') {
+      collected.warnings.push(log);
     }
   });
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. ([#48498](https://github.com/expo/expo/pull/48498) by [@Ubax](https://github.com/Ubax))
 - Make `beforeRemove` non-preventable and add `removePrevented` event. ([#48347](https://github.com/expo/expo/pull/48347) by [@Ubax](https://github.com/Ubax))
 - Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -1,17 +1,19 @@
 import { act, fireEvent, screen, userEvent } from '@testing-library/react-native';
 import type { Ref } from 'react';
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useEffect, useState } from 'react';
 import type { ViewProps } from 'react-native';
 import { View, Text, Button } from 'react-native';
 
 import { store } from '../global-state/router-store';
 import { useLocalSearchParams } from '../hooks';
 import { router } from '../imperative-api';
+import { useGuardRedirect } from '../layouts/GuardContext';
 import { Stack } from '../layouts/Stack';
 import { Tabs as JSTabs } from '../layouts/Tabs';
 import { Link, Redirect } from '../link/Link';
 import { type RenderRouterOptions, renderRouter, waitFor } from '../testing-library';
-import { TabList, TabSlot, TabTrigger, Tabs } from '../ui';
+import { TabList, TabSlot, TabTrigger, Tabs, useTabTrigger } from '../ui';
+import { useNavigation } from '../useNavigation';
 import type { PressableProps } from '../views/Pressable';
 import { Pressable } from '../views/Pressable';
 
@@ -197,7 +199,7 @@ it('allows for custom elements', () => {
   expect(screen).toHaveSegments(['apple']);
 });
 
-it('can dynamically add tabs', () => {
+it('can dynamically add and remove tabs', () => {
   renderRouter(
     {
       _layout: function TabLayout() {
@@ -216,7 +218,7 @@ it('can dynamically add tabs', () => {
           <Tabs>
             <TabList>{tabs}</TabList>
             <TabSlot />
-            <Button testID="show-all" title="Show all" onPress={() => setShowAll(true)} />
+            <Button testID="toggle-all" title="Toggle all" onPress={() => setShowAll((v) => !v)} />
           </Tabs>
         );
       },
@@ -234,11 +236,14 @@ it('can dynamically add tabs', () => {
   act(() => router.push('/orange'));
   expect(screen).toHaveSegments(['apple']);
 
-  fireEvent.press(screen.getByTestId('show-all'));
+  fireEvent.press(screen.getByTestId('toggle-all'));
 
   // This now works because there is an orange tab
   act(() => router.push('/orange'));
   expect(screen).toHaveSegments(['orange']);
+
+  fireEvent.press(screen.getByTestId('toggle-all'));
+  expect(screen).toHaveSegments(['apple']);
 });
 
 it('does works with shared groups', () => {
@@ -638,7 +643,12 @@ it('JSTabs dispatches only one action when re-tapping active tab with nested sta
   const dispatchedActions: unknown[] = [];
 
   renderRouter({
-    _layout: () => <JSTabs />,
+    _layout: () => (
+      <JSTabs>
+        <JSTabs.Screen name="index" />
+        <JSTabs.Screen name="movies" />
+      </JSTabs>
+    ),
     index: () => <Text testID="index">Index</Text>,
     'movies/_layout': () => <Stack />,
     'movies/index': () => <Text testID="movies-index">Movies Index</Text>,
@@ -813,4 +823,170 @@ it('Link with replace works in headless tabs', async () => {
   await waitFor(() => expect(screen.getByTestId('index')).toBeVisible());
   // replace should not leave a back entry
   expect(router.canGoBack()).toBe(false);
+});
+
+it('hides a trigger when its screen sets hidden options', () => {
+  function Second() {
+    const navigation = useNavigation();
+    useEffect(() => navigation.setOptions({ hidden: true }), [navigation]);
+    return <Text testID="second">Second</Text>;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" testID="goto-index" />
+            <TabTrigger name="second" href="/second" testID="goto-second" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text testID="index">Index</Text>,
+      second: Second,
+    },
+    { initialUrl: '/second' }
+  );
+
+  expect(screen.queryByTestId('goto-second')).toBeNull();
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+});
+
+it('does not hide an inherited trigger when a nested screen is hidden', () => {
+  function HiddenTab() {
+    const navigation = useNavigation();
+    useEffect(() => navigation.setOptions({ hidden: true }), [navigation]);
+    return <Text>Hidden</Text>;
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="a" href="/a" />
+            <TabTrigger name="b" href="/b" />
+          </TabList>
+          <TabSlot />
+        </Tabs>
+      ),
+      'a/_layout': () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/a" />
+            <TabTrigger name="y" href="/a/y" />
+          </TabList>
+          <TabTrigger name="b" testID="outer-b" />
+          <TabSlot />
+        </Tabs>
+      ),
+      'a/index': () => <Text>A</Text>,
+      'a/y': HiddenTab,
+      b: () => <Text>B</Text>,
+    },
+    { initialUrl: '/a/y' }
+  );
+
+  expect(screen.getByTestId('outer-b')).toBeVisible();
+});
+
+it('exposes hidden options from useTabTrigger', () => {
+  function Second() {
+    const navigation = useNavigation();
+    useEffect(() => navigation.setOptions({ hidden: true }), [navigation]);
+    return <Text>Second</Text>;
+  }
+
+  function CustomTrigger() {
+    const { trigger, getTrigger } = useTabTrigger({ name: 'second' });
+    return (
+      <Text testID="custom-trigger">
+        {String(trigger?.hidden)} {String(getTrigger('second')?.hidden)}
+      </Text>
+    );
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <TabList>
+            <TabTrigger name="index" href="/" />
+            <TabTrigger name="second" href="/second" />
+          </TabList>
+          <CustomTrigger />
+          <TabSlot />
+        </Tabs>
+      ),
+      index: () => <Text>Index</Text>,
+      second: Second,
+    },
+    { initialUrl: '/second' }
+  );
+
+  expect(screen.getByTestId('custom-trigger')).toHaveTextContent('true true');
+});
+
+it('renders an external trigger without a navigator route', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="external" href="https://expo.dev" testID="external" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    ),
+    index: () => <Text testID="index">Index</Text>,
+  });
+
+  expect(screen.getByTestId('external')).toBeVisible();
+});
+
+it('does not use a parent guard redirect for a tab with the same route name', () => {
+  let inheritedGuardRedirect: ReturnType<typeof useGuardRedirect>;
+  function TabsLayout() {
+    inheritedGuardRedirect = useGuardRedirect('settings');
+    return (
+      <Tabs>
+        <TabList>
+          <TabTrigger name="index" href="/" testID="goto-index" />
+        </TabList>
+        <TabSlot />
+      </Tabs>
+    );
+  }
+
+  renderRouter({
+    _layout: {
+      unstable_settings: { initialRouteName: '(tabs)' },
+      default: () => (
+        <Stack>
+          <Stack.Screen name="(tabs)" />
+          <Stack.Protected guard={false} redirectTo="/login">
+            <Stack.Screen name="settings" />
+          </Stack.Protected>
+          <Stack.Screen name="login" />
+        </Stack>
+      ),
+    },
+    '(tabs)/_layout': {
+      unstable_settings: { initialRouteName: 'index' },
+      default: TabsLayout,
+    },
+    '(tabs)/index': () => <Text testID="tabs-index">Index</Text>,
+    '(tabs)/settings': () => <Text testID="tabs-settings">Settings</Text>,
+    settings: () => <Text testID="root-settings">Settings</Text>,
+    login: () => <Text testID="login">Login</Text>,
+  });
+
+  expect(inheritedGuardRedirect).toBe('/login');
+  act(() => router.push('/(tabs)/settings'));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('tabs-index')).toBeVisible();
+  expect(screen.queryByTestId('login')).toBeNull();
 });

--- a/packages/expo-router/src/__tests__/issues.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/issues.test.ios.tsx
@@ -14,7 +14,12 @@ it('should return correct pathname for nested stack with initialRouteName', asyn
   const innerARenderCount = jest.fn();
   renderRouter({
     _layout: function Layout() {
-      return <Tabs />;
+      return (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="inner" />
+        </Tabs>
+      );
     },
     index: function Index() {
       indexRenderCount();
@@ -58,7 +63,12 @@ it('should return correct pathname for nested stack with initialRouteName, after
   const innerARenderCount = jest.fn();
   renderRouter({
     _layout: function Layout() {
-      return <Tabs />;
+      return (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="inner" />
+        </Tabs>
+      );
     },
     index: function Index() {
       indexRenderCount();

--- a/packages/expo-router/src/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/navigation.test.ios.tsx
@@ -28,7 +28,12 @@ it('should respect `unstable_settings', () => {
               initialRouteName: 'orange',
             },
           },
-          default: () => <Tabs />,
+          default: () => (
+            <Tabs>
+              <Tabs.Screen name="orange" />
+              <Tabs.Screen name="banana" />
+            </Tabs>
+          ),
         },
         '(one,two)/apple': () => <Text testID="apple"> Apple</Text>,
         '(two)/banana': () => <Text testID="banana">Banana</Text>,
@@ -257,7 +262,11 @@ it('replaces from top level modal to initial route in a tab navigator', () => {
       default: () => <Stack />,
     },
     '[...missing]': () => <Text testID="missing">missing</Text>,
-    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/_layout': () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+      </Tabs>
+    ),
     '(tabs)/index': () => <Text testID="two">two</Text>,
   });
 
@@ -591,7 +600,12 @@ it('should stay within the same group', () => {
   renderRouter(
     {
       _layout: () => <Stack />,
-      '(tabs)/_layout': () => <Tabs />,
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="(home)" />
+          <Tabs.Screen name="(profile)" />
+        </Tabs>
+      ),
       '(tabs)/(home)/_layout': () => <Stack />,
       '(tabs)/(home)/index': () => <Text testID="text">Home Index</Text>,
       '(tabs)/(home)/shared': () => <Text testID="text">Home Shared</Text>,
@@ -613,7 +627,13 @@ it('should stay within the same group for hoisted routes', () => {
   renderRouter(
     {
       _layout: () => <Stack />,
-      '(tabs)/_layout': () => <Tabs />,
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="(home)" />
+          <Tabs.Screen name="(profile)/index" />
+          <Tabs.Screen name="(profile)/shared" />
+        </Tabs>
+      ),
       '(tabs)/(home)/_layout': () => <Stack />,
       '(tabs)/(home)/index': () => <Text testID="text">Home Index</Text>,
       '(tabs)/(home)/shared': () => <Text testID="text">Home Shared</Text>,
@@ -635,7 +655,12 @@ it('should stay within the same group even if another group has more specific ro
   renderRouter(
     {
       _layout: () => <Stack />,
-      '(tabs)/_layout': () => <Tabs />,
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="(home)" />
+          <Tabs.Screen name="(profile)" />
+        </Tabs>
+      ),
       '(tabs)/(home)/_layout': () => <Stack />,
       '(tabs)/(home)/index': () => <Text testID="text">Home Index</Text>,
       // This is more specific (more segments)
@@ -867,7 +892,12 @@ it('can redirect within a group layout', () => {
 
 it('can replace across groups', async () => {
   renderRouter({
-    _layout: () => <Tabs />,
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="one" />
+        <Tabs.Screen name="two" />
+      </Tabs>
+    ),
     'one/_layout': () => <Stack />,
     'one/screen': () => <Text testID="one/screen" />,
     'two/_layout': () => <Stack />,
@@ -1154,7 +1184,13 @@ describe('shared routes with tabs', () => {
       '(one,two)/one': () => <Text />,
       '(one,two)/post': () => <Text />,
       '(two)/two': () => <Text />,
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="(one)" />
+          <Tabs.Screen name="(two)" />
+        </Tabs>
+      ),
       index: () => <Redirect href="/one" />,
     });
 
@@ -1673,7 +1709,13 @@ describe('navigation action fallbacks', () => {
 
   it('can fall back correctly for tab navigators', () => {
     renderRouter({
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+          <Tabs.Screen name="redirected" />
+        </Tabs>
+      ),
       one: () => <Text testID="one" />,
       two: () => <Text testID="two" />,
       redirected: () => <Redirect href="/" />,

--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -239,7 +239,12 @@ it('should navigate as expected when nested Stacks & Tabs', async () => {
     index: () => <Text testID="index" />,
     'apple/_layout': () => <Stack />,
     'apple/index': () => <Text testID="apple" />,
-    'apple/[type]/_layout': () => <Tabs />,
+    'apple/[type]/_layout': () => (
+      <Tabs>
+        <Tabs.Screen name="color" />
+        <Tabs.Screen name="taste" />
+      </Tabs>
+    ),
     'apple/[type]/color': () => <Text testID="color" />,
     'apple/[type]/taste': () => <Text testID="taste" />,
   });
@@ -274,7 +279,13 @@ it('works in a nested layout Stack->Tab->Stack', () => {
   renderRouter({
     index: () => null,
     _layout: () => <Stack />,
-    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/_layout': () => (
+      <Tabs>
+        <Tabs.Screen name="a" />
+        <Tabs.Screen name="b" />
+        <Tabs.Screen name="c" />
+      </Tabs>
+    ),
     '(tabs)/a': () => <Text testID="a" />,
     '(tabs)/b': () => <Text testID="b" />,
     '(tabs)/c/_layout': () => <Stack />,

--- a/packages/expo-router/src/__tests__/redirects.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/redirects.test.ios.tsx
@@ -267,7 +267,12 @@ it('does not render redirects in tabs', async () => {
   ]);
 
   renderRouter({
-    _layout: () => <Tabs />,
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="bar" />
+      </Tabs>
+    ),
     index: () => null,
     bar: () => <Text testID="bar" />,
   });
@@ -284,7 +289,12 @@ it('redirect to external URL', async () => {
   ]);
 
   renderRouter({
-    _layout: () => <Tabs />,
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="bar" />
+      </Tabs>
+    ),
     index: () => null,
     bar: () => <Text testID="bar" />,
   });
@@ -304,7 +314,11 @@ it('redirects will override existing routes', () => {
 
   renderRouter({
     _layout: () => <Stack />,
-    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/_layout': () => (
+      <Tabs>
+        <Tabs.Screen name="explore" />
+      </Tabs>
+    ),
     '(tabs)/explore': () => <Text testID="explore">Explore</Text>,
     index: () => null,
     bar: () => <Text testID="bar" />,
@@ -326,7 +340,12 @@ it('tabs can still work for redirects', () => {
   renderRouter(
     {
       _layout: () => <Stack />,
-      '(tabs)/_layout': () => <Tabs />,
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="explore" />
+        </Tabs>
+      ),
       '(tabs)/index': () => <Text testID="index">Index</Text>,
       '(tabs)/explore': () => <Text testID="explore">Explore</Text>,
       '/page': () => <Text testID="page">Page</Text>,
@@ -353,7 +372,12 @@ it('tabs can still work for external redirects', () => {
   renderRouter(
     {
       _layout: () => <Stack />,
-      '(tabs)/_layout': () => <Tabs />,
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="explore" />
+        </Tabs>
+      ),
       '(tabs)/index': () => <Text testID="index">Index</Text>,
       '(tabs)/explore': () => <Text testID="explore">Explore</Text>,
     },

--- a/packages/expo-router/src/__tests__/renderCount.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/renderCount.test.ios.tsx
@@ -1,5 +1,5 @@
 import { act, screen } from '@testing-library/react-native';
-import { useEffect, type ComponentType } from 'react';
+import { useEffect, type ComponentType, type ReactNode } from 'react';
 import { Text } from 'react-native';
 
 import { router, useNavigation, usePathname, useRouter } from '../exports';
@@ -8,7 +8,7 @@ import { Tabs } from '../layouts/Tabs';
 import { renderRouter } from '../testing-library';
 
 // TODO(@ubax): remove this once types are fixed in tests
-const TestTabs = Tabs as unknown as ComponentType;
+const TestTabs = Tabs as unknown as ComponentType<{ children: ReactNode }>;
 const TestStack = Stack as unknown as ComponentType;
 
 const noop = () => {};
@@ -26,7 +26,12 @@ describe('Tabs render counts', () => {
         _layout: function Layout() {
           layoutRender();
           hook();
-          return <TestTabs />;
+          return (
+            <TestTabs>
+              <Tabs.Screen name="index" />
+              <Tabs.Screen name="two" />
+            </TestTabs>
+          );
         },
         index: function Index() {
           indexRender();
@@ -77,7 +82,12 @@ describe('Tabs render counts', () => {
       _layout: function Layout() {
         layoutRender();
         usePathname();
-        return <TestTabs />;
+        return (
+          <TestTabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="two" />
+          </TestTabs>
+        );
       },
       index: function Index() {
         indexRender();
@@ -291,7 +301,12 @@ describe('Stack nested in Tabs render counts', () => {
         _layout: function Layout() {
           layoutRender();
           hook();
-          return <TestTabs />;
+          return (
+            <TestTabs>
+              <Tabs.Screen name="(index)" />
+              <Tabs.Screen name="other" />
+            </TestTabs>
+          );
         },
         '(index)/_layout': function HomeTab() {
           homeTabRender();
@@ -398,7 +413,12 @@ describe('Stack nested in Tabs render counts', () => {
       _layout: function Layout() {
         layoutRender();
         usePathname();
-        return <TestTabs />;
+        return (
+          <TestTabs>
+            <Tabs.Screen name="(index)" />
+            <Tabs.Screen name="other" />
+          </TestTabs>
+        );
       },
       '(index)/_layout': function HomeTab() {
         homeTabRender();

--- a/packages/expo-router/src/__tests__/smoke.test.android.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.android.tsx
@@ -173,7 +173,11 @@ it('layouts', async () => {
 it('nested layouts', async () => {
   const RootLayout = jest.fn(() => <Slot />);
   const AppLayout = jest.fn(() => <Slot />);
-  const TabsLayout = jest.fn(() => <Tabs />);
+  const TabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const StackLayout = jest.fn(() => <Stack />);
 
   const Index = jest.fn(() => <Redirect href="/home" />);
@@ -203,13 +207,21 @@ it('nested layouts', async () => {
 it('deep linking nested groups', async () => {
   const RootLayout = jest.fn(() => <Slot />);
   const AppLayout = jest.fn(() => <Stack />);
-  const TabsLayout = jest.fn(() => <Tabs />);
+  const TabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const HomeLayout = jest.fn(() => <Stack />);
 
   const Home = jest.fn(() => <Text testID="Home" />);
 
   const OtherTabsLayout = jest.fn(() => <Stack />);
-  const NestedTabsLayout = jest.fn(() => <Tabs />);
+  const NestedTabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const OtherTabsIndex = jest.fn(() => <Text testID="OtherTabsHome" />);
 
   renderRouter(

--- a/packages/expo-router/src/__tests__/smoke.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/smoke.test.ios.tsx
@@ -174,7 +174,11 @@ it('layouts', async () => {
 it('nested layouts', async () => {
   const RootLayout = jest.fn(() => <Slot />);
   const AppLayout = jest.fn(() => <Slot />);
-  const TabsLayout = jest.fn(() => <Tabs />);
+  const TabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const StackLayout = jest.fn(() => <Stack />);
 
   const Index = jest.fn(() => <Redirect href="/home" />);
@@ -204,13 +208,21 @@ it('nested layouts', async () => {
 it('deep linking nested groups', async () => {
   const RootLayout = jest.fn(() => <Slot />);
   const AppLayout = jest.fn(() => <Stack />);
-  const TabsLayout = jest.fn(() => <Tabs />);
+  const TabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const HomeLayout = jest.fn(() => <Stack />);
 
   const Home = jest.fn(() => <Text testID="Home" />);
 
   const OtherTabsLayout = jest.fn(() => <Stack />);
-  const NestedTabsLayout = jest.fn(() => <Tabs />);
+  const NestedTabsLayout = jest.fn(() => (
+    <Tabs>
+      <Tabs.Screen name="home" />
+    </Tabs>
+  ));
   const OtherTabsIndex = jest.fn(() => <Text testID="OtherTabsHome" />);
 
   renderRouter(

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -51,7 +51,12 @@ describe('canDismiss', () => {
       {
         a: () => null,
         b: () => null,
-        _layout: () => <Tabs />,
+        _layout: () => (
+          <Tabs>
+            <Tabs.Screen name="a" />
+            <Tabs.Screen name="b" />
+          </Tabs>
+        ),
       },
       {
         initialUrl: '/a',
@@ -117,7 +122,13 @@ test('dismissAll', () => {
 test('dismissAll nested', () => {
   renderRouter(
     {
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="a" />
+          <Tabs.Screen name="b" />
+          <Tabs.Screen name="one" />
+        </Tabs>
+      ),
       a: () => null,
       b: () => null,
       'one/_layout': () => <Stack />,

--- a/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tab-router-replace.test.ios.tsx
@@ -7,7 +7,13 @@ import { renderRouter } from '../testing-library';
 
 it('removes the replaced tab from history', () => {
   renderRouter({
-    _layout: () => <Tabs backBehavior="history" />,
+    _layout: () => (
+      <Tabs backBehavior="history">
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+        <Tabs.Screen name="third" />
+      </Tabs>
+    ),
     index: () => null,
     second: () => null,
     third: () => null,
@@ -23,7 +29,14 @@ it('removes the replaced tab from history', () => {
 
 it('removes a redirecting tab from history', () => {
   renderRouter({
-    _layout: () => <Tabs backBehavior="history" />,
+    _layout: () => (
+      <Tabs backBehavior="history">
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+        <Tabs.Screen name="third" />
+        <Tabs.Screen name="redirected" />
+      </Tabs>
+    ),
     index: () => null,
     second: () => null,
     third: () => null,

--- a/packages/expo-router/src/__tests__/tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tabs.test.ios.tsx
@@ -10,7 +10,11 @@ import { renderRouter } from '../testing-library';
 
 it('should not render generated screens', () => {
   renderRouter({
-    _layout: () => <Tabs />,
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+      </Tabs>
+    ),
     index: () => <Text testID="index">Index</Text>,
   });
 
@@ -21,22 +25,24 @@ it('should not render generated screens', () => {
   expect(tabList?.children).toHaveLength(1);
 });
 
-it('screens can be hidden', () => {
+it('only layout-declared screens render tab items', () => {
   renderRouter({
     _layout: () => (
       <Tabs>
-        <Tabs.Screen name="hidden" />
+        <Tabs.Screen name="visible" />
       </Tabs>
     ),
     index: () => <Text testID="index">Index</Text>,
-    hidden: () => <Text testID="index">Index</Text>,
+    hidden: () => <Text testID="hidden">Hidden</Text>,
+    visible: () => <Text testID="visible">Visible</Text>,
   });
 
-  expect(screen.getByTestId('index')).toBeVisible();
-
-  const tabList = screen.getByLabelText('index, tab, 2 of 2').parent;
+  const tabList = screen.getByLabelText('visible, tab, 1 of 1').parent;
 
   expect(tabList?.children).toHaveLength(1);
+  expect(screen.queryByTestId('index')).toBeNull();
+  expect(screen.queryByTestId('hidden')).toBeNull();
+  expect(screen.getByTestId('visible')).toBeVisible();
 });
 
 it('has correct routeInfo when switching tabs as a nested navigator - using api', () => {
@@ -52,7 +58,12 @@ it('has correct routeInfo when switching tabs as a nested navigator - using api'
       _layout: () => <Stack />,
       '(tabs)/_layout': function Layout() {
         layoutCalls(useSegments());
-        return <Tabs />;
+        return (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="explore" />
+          </Tabs>
+        );
       },
       '(tabs)/index': function Index() {
         indexCalls(useSegments());
@@ -118,7 +129,12 @@ it('has correct routeInfo when switching tabs as a nested navigator - using pres
       _layout: () => <Stack />,
       '(tabs)/_layout': function Layout() {
         layoutCalls(useSegments());
-        return <Tabs />;
+        return (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="explore" />
+          </Tabs>
+        );
       },
       '(tabs)/index': function Index() {
         indexCalls(useSegments());
@@ -195,7 +211,12 @@ it('has correct routeInfo when switching tabs using press', () => {
     {
       _layout: function Layout() {
         layoutCalls(useSegments());
-        return <Tabs />;
+        return (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="explore" />
+          </Tabs>
+        );
       },
       index: function Index() {
         indexCalls(useSegments());
@@ -259,7 +280,12 @@ it('has correct routeInfo when switching tabs using press', () => {
 it('can push screens', () => {
   renderRouter(
     {
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+        </Tabs>
+      ),
       one: () => <Text testID="one">One</Text>,
       two: () => <Text testID="two">Two</Text>,
     },
@@ -278,7 +304,13 @@ it('can push screens', () => {
 it('works with goBack', () => {
   renderRouter(
     {
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+          <Tabs.Screen name="three" />
+        </Tabs>
+      ),
       one: () => <Text testID="one">One</Text>,
       two: () => <Text testID="two">Two</Text>,
       three: () => <Text testID="three">Three</Text>,
@@ -304,7 +336,13 @@ it('works with goBack', () => {
 it('works with goBack (history)', () => {
   renderRouter(
     {
-      _layout: () => <Tabs backBehavior="history" />,
+      _layout: () => (
+        <Tabs backBehavior="history">
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+          <Tabs.Screen name="three" />
+        </Tabs>
+      ),
       one: () => <Text testID="one">One</Text>,
       two: () => <Text testID="two">Two</Text>,
       three: () => <Text testID="three">Three</Text>,
@@ -329,7 +367,12 @@ it('works with goBack (history)', () => {
 it('can use replace navigation', () => {
   renderRouter(
     {
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+        </Tabs>
+      ),
       one: () => <Text testID="one">One</Text>,
       two: () => <Text testID="two">Two</Text>,
     },
@@ -394,7 +437,13 @@ it('can use replace navigation', () => {
 it('can use replace navigation with history backBehavior', () => {
   renderRouter(
     {
-      _layout: () => <Tabs backBehavior="history" />,
+      _layout: () => (
+        <Tabs backBehavior="history">
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+          <Tabs.Screen name="three" />
+        </Tabs>
+      ),
       one: () => <Text testID="one">One</Text>,
       two: () => <Text testID="two">Two</Text>,
       three: () => <Text testID="three">Three</Text>,
@@ -421,7 +470,12 @@ it('does not re-render when navigating to different tab', () => {
   const onTwoRender = jest.fn();
   renderRouter(
     {
-      _layout: () => <Tabs />,
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+        </Tabs>
+      ),
       one: function One() {
         onOneRender();
         return <Text testID="one">One</Text>;
@@ -466,7 +520,11 @@ it('updates route info, when going back to initial screen', () => {
         </View>
       );
     },
-    '(tabs)/_layout': () => <Tabs />,
+    '(tabs)/_layout': () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+      </Tabs>
+    ),
     '(tabs)/index': function Index() {
       const segments = useSegments();
       return <Text testID="index">{JSON.stringify(segments)}</Text>;

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -189,7 +189,12 @@ describe(useLoaderData, () => {
 
     renderRouter(
       {
-        _layout: () => <Tabs />,
+        _layout: () => (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="profile" />
+          </Tabs>
+        ),
         index: function Home() {
           homeResults.push(useLoaderData());
           return <Text>Home</Text>;

--- a/packages/expo-router/src/hooks/__tests__/useRootNavigationState.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useRootNavigationState.test.ios.tsx
@@ -45,7 +45,11 @@ describe(useRootNavigationState, () => {
 
     renderRouter({
       _layout: () => <Stack />,
-      '(app)/_layout': () => <Tabs />,
+      '(app)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+        </Tabs>
+      ),
       '(app)/index': function Index() {
         fn(useRootNavigationState());
         return <Text>Index</Text>;
@@ -128,7 +132,11 @@ describe(useRootNavigationState, () => {
       _layout: () => <Stack />,
       '(app)/_layout': function Layout() {
         fn(useRootNavigationState());
-        return <Tabs />;
+        return (
+          <Tabs>
+            <Tabs.Screen name="index" />
+          </Tabs>
+        );
       },
       '(app)/index': () => <Text>Index</Text>,
     });

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -26,7 +26,10 @@ import type { Href } from '../types';
 // Keep React Navigation client-only so the entry evaluates in React Server Components.
 export * from '../react-navigation/bottom-tabs';
 
-export type TabsScreenOptions = BottomTabNavigationOptions & { href?: Href | null };
+export type TabsScreenOptions = BottomTabNavigationOptions & {
+  // TODO: Consider deprecating `href`.
+  href?: Href | null;
+};
 
 /**
  * Renders a tabs navigator.
@@ -58,15 +61,21 @@ const Tabs = unstable_integrateWithRouter<
         if (options.tabBarButton) {
           throw new Error('Cannot use `href` and `tabBarButton` together.');
         }
+        if (href === null) {
+          // TODO(@ubax): Update the hiding-a-tab guide for the new redirect behavior.
+          return {
+            ...screen,
+            options: {
+              ...options,
+              hidden: true,
+            },
+          };
+        }
         return {
           ...screen,
           options: {
             ...options,
-            tabBarItemStyle: href == null ? { display: 'none' } : options.tabBarItemStyle,
             tabBarButton: (props) => {
-              if (href == null) {
-                return null;
-              }
               const children =
                 Platform.OS === 'web' ? props.children : <Pressable>{props.children}</Pressable>;
               // TODO: React Navigation types these props as Animated.WithAnimatedValue<StyleProp<ViewStyle>>

--- a/packages/expo-router/src/layouts/__tests__/Stack.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/Stack.test.ios.tsx
@@ -166,7 +166,11 @@ describe('tabPress', () => {
 
     renderRouter(
       {
-        _layout: () => <Tabs />,
+        _layout: () => (
+          <Tabs>
+            <Tabs.Screen name="a" />
+          </Tabs>
+        ),
         'a/_layout': () => <Stack />,
         'a/index': () => <View testID="a-index" />,
         'a/b': () => <View testID="a-b" />,

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -28,7 +28,6 @@ import { convertIconColorPropToObject, convertLabelStylePropToObject } from './u
 
 // In Jetpack Compose, the default back behavior is to go back to the initial route.
 const defaultBackBehavior = 'initialRoute';
-const isNativeTabHidden = (options: NativeTabOptions | undefined) => options?.hidden === true;
 export const NativeTabsContext = React.createContext<boolean>(false);
 
 function NativeTabsContent({
@@ -49,7 +48,6 @@ function NativeTabsContent({
   rippleColor,
   disableIndicator,
   labelVisibilityMode,
-  redirectToRouteName,
   ...rest
 }: StandardNavigatorContentProps<
   NativeTabOptions,
@@ -64,12 +62,10 @@ function NativeTabsContent({
 
   const { routes } = state;
 
-  const { visibleRoutes, visibleFocusedIndex } = useVisibleTabsWithRedirect({
+  const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes,
     focusedRouteKey: routes[state.index]!.key,
     descriptors,
-    redirectToRouteName,
-    isHidden: isNativeTabHidden,
   });
   const visibleTabs = useMemo(
     () =>
@@ -87,8 +83,6 @@ function NativeTabsContent({
     () => visibleTabs.map((tab) => tab.routeKey).join(';'),
     [visibleTabs]
   );
-
-  const focusedIndex = visibleFocusedIndex >= 0 ? visibleFocusedIndex : 0;
 
   const provenanceRef = useRef(0);
 
@@ -257,7 +251,6 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
       nonTriggerChildren={nonTriggerChildren}
       screenOptions={screenOptions}
       initialRouteName={routeNode?.initialRouteName}
-      redirectToRouteName={routeNode?.initialRouteName}
       // Passed to TabRouter
       backBehavior={backBehavior}
     />

--- a/packages/expo-router/src/native-tabs/__tests__/__snapshots__/navigation.test.ios.tsx.snap.ios
+++ b/packages/expo-router/src/native-tabs/__tests__/__snapshots__/navigation.test.ios.tsx.snap.ios
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Native Bottom Tabs trigger changes renders no tab UI when every trigger is hidden 1`] = `
+[
+  [
+    "No screens are declared in ./_layout.js, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: index.",
+  ],
+]
+`;

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -174,6 +174,16 @@ describe('Native Bottom Tabs Navigation', () => {
 });
 
 describe('Native Bottom Tabs trigger changes', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it('renders only routes with visible triggers', () => {
     renderRouter({
       _layout: () => (
@@ -412,5 +422,6 @@ describe('Native Bottom Tabs trigger changes', () => {
 
     expect(screen.queryByTestId('index')).toBeNull();
     expect(TabsScreen).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls).toMatchSnapshot();
   });
 });

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -480,7 +480,6 @@ export interface NativeTabsProps extends PropsWithChildren {
 
 export interface InternalNativeTabsProps extends NativeTabsProps {
   nonTriggerChildren?: React.ReactNode;
-  redirectToRouteName?: string;
 }
 export interface OnTabChangeEventPayload {
   /**
@@ -518,7 +517,6 @@ export interface NativeTabsViewProps extends Omit<
   | 'badgeTextColor'
   | 'rippleColor'
   | 'disableIndicator'
-  | 'redirectToRouteName'
   | 'labelVisibilityMode'
 > {
   focusedIndex: number;

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders no tab UI when no screens are declared in the layout 1`] = `
+[
+  [
+    "No screens are declared in ./_layout.js, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: index.",
+  ],
+]
+`;

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
@@ -1,5 +1,5 @@
 import { userEvent } from '@testing-library/react-native';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   type EmitterSubscription,
   Keyboard,
@@ -17,7 +17,14 @@ import { Text } from '../../elements';
 import type { ParamListBase } from '../../native';
 import type { BottomTabBarProps, BottomTabNavigationProp } from '../types';
 
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
 afterEach(() => {
+  warnSpy.mockRestore();
   jest.restoreAllMocks();
 });
 
@@ -215,7 +222,7 @@ test('keeps the dynamic segment of a tab when it is re-selected', async () => {
   expect(screen).toHavePathname('/abc');
 });
 
-test('hides a tab whose href is null', () => {
+test('removes and redirects from a tab whose href is null', () => {
   renderRouter({
     _layout: () => (
       <Tabs>
@@ -228,7 +235,140 @@ test('hides a tab whose href is null', () => {
   });
 
   expect(screen.queryByRole('button', { name: /second/ })).toBeNull();
-  expect(screen.getByRole('button', { name: 'index, tab, 1 of 2' })).toBeVisible();
+  expect(screen.getByRole('button', { name: 'index, tab, 1 of 1' })).toBeVisible();
+
+  act(() => router.push('/second'));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.queryByTestId('second')).toBeNull();
+});
+
+test('redirects when the focused tab href becomes null', () => {
+  let setHidden!: (hidden: boolean) => void;
+  function Layout() {
+    const [hidden, set] = useState(false);
+    setHidden = set;
+    return (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" options={{ href: hidden ? null : '/second' }} />
+      </Tabs>
+    );
+  }
+
+  renderRouter({
+    _layout: Layout,
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  act(() => router.push('/second'));
+  expect(screen).toHavePathname('/second');
+
+  act(() => setHidden(true));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('second')).toBeNull();
+});
+
+test('renders only screens declared in the layout and redirects from undeclared routes', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+      </Tabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  expect(screen.getAllByRole('button', { name: /tab/ })).toHaveLength(1);
+
+  act(() => router.push('/second'));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+});
+
+test('redirects an undeclared route to the configured initial tab', () => {
+  renderRouter({
+    _layout: {
+      unstable_settings: { initialRouteName: 'second' },
+      default: () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="second" />
+        </Tabs>
+      ),
+    },
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+    undeclared: () => <View testID="undeclared" />,
+  });
+
+  act(() => router.push('/undeclared'));
+
+  expect(screen).toHavePathname('/second');
+  expect(screen.getByTestId('second')).toBeVisible();
+});
+
+test('renders no tab UI when no screens are declared in the layout', () => {
+  renderRouter({
+    _layout: () => <Tabs />,
+    index: () => <View testID="index" />,
+  });
+
+  expect(screen.queryByTestId('index')).toBeNull();
+  expect(screen.queryAllByRole('button', { name: /tab/ })).toHaveLength(0);
+  expect(warnSpy.mock.calls).toMatchSnapshot();
+});
+
+test('prefers a protected screen redirect over the tab visibility fallback', () => {
+  renderRouter(
+    {
+      _layout: () => <Stack />,
+      'tabs/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Protected guard={false} redirectTo="/login">
+            <Tabs.Screen name="secret" />
+          </Tabs.Protected>
+        </Tabs>
+      ),
+      'tabs/index': () => <View testID="index" />,
+      'tabs/secret': () => <View testID="secret" />,
+      login: () => <View testID="login" />,
+    },
+    { initialUrl: '/tabs/secret' }
+  );
+
+  expect(screen).toHavePathname('/login');
+  expect(screen.getByTestId('login')).toBeVisible();
+});
+
+test('redirects a fully guarded layout without warning that no screens are declared', () => {
+  renderRouter(
+    {
+      _layout: () => <Stack />,
+      'tabs/_layout': () => (
+        <Tabs>
+          <Tabs.Protected guard={false} redirectTo="/login">
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="second" />
+          </Tabs.Protected>
+        </Tabs>
+      ),
+      'tabs/index': () => <View testID="index" />,
+      'tabs/second': () => <View testID="second" />,
+      login: () => <View testID="login" />,
+    },
+    { initialUrl: '/tabs/second' }
+  );
+
+  expect(screen).toHavePathname('/login');
+  expect(screen.getByTestId('login')).toBeVisible();
+  expect(warnSpy).not.toHaveBeenCalled();
 });
 
 test('throws when a screen uses both href and tabBarButton', () => {

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
@@ -31,6 +31,7 @@ export type _DetachInactiveScreensIsPublic = Expect<
 >;
 
 export const _hiddenTab: TabsScreenOptions = { href: null };
+export const _explicitlyHiddenTab: TabsScreenOptions = { hidden: true };
 export const _linkedTab: TabsScreenOptions = { href: '/settings', title: 'Settings' };
 
 describe('bottom tabs types', () => {

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -3,6 +3,7 @@
 import { createStandardNavigator } from 'standard-navigation';
 
 import type { NavigatorContentProps } from '../../../standard-navigation/types';
+import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
 import type {
   BottomTabDescriptorMap,
   BottomTabNavigationConfig,
@@ -35,6 +36,11 @@ function BottomTabNavigatorContent({
   popNestedStackToTop,
   ...rest
 }: ContentArgs) {
+  const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
+    routes: state.routes,
+    focusedRouteKey: state.routes[state.index]!.key,
+    descriptors,
+  });
   const navigateToTab = (routeKey: string) => {
     const route = state.routes.find((route) => route.key === routeKey);
     if (route) {
@@ -47,10 +53,19 @@ function BottomTabNavigatorContent({
     }
   };
 
+  if (visibleRoutes.length === 0) {
+    return null;
+  }
+
   return (
     <BottomTabView
       {...rest}
-      state={state}
+      state={{
+        // Only routes are substituted; navigator metadata remains from the real state.
+        ...state,
+        routes: visibleRoutes,
+        index: focusedIndex,
+      }}
       // TODO(@ubax): SDK-58: Try to remove the casting from here to ensure type safety
       // Integration supplies full descriptors, including preload placeholders; standard types omit route/navigation.
       descriptors={descriptors as unknown as BottomTabDescriptorMap}

--- a/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
@@ -114,6 +114,13 @@ export type TabAnimationName = 'none' | 'fade' | 'shift';
 
 export type BottomTabNavigationOptions = HeaderOptions & {
   /**
+   * Hides the tab item. If the screen is focused, the navigator redirects to its initial visible
+   * screen.
+   * @default false
+   */
+  hidden?: boolean;
+
+  /**
    * Title text for the screen.
    */
   title?: string;

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders no drawer UI when no screens are declared in the layout 1`] = `
+[
+  [
+    "No screens are declared in ./_layout.js, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: index.",
+  ],
+]
+`;

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/index.test.ios.tsx
@@ -32,6 +32,16 @@ jest.mock('react-native-drawer-layout', () => {
 const drawerOpen = () =>
   (DrawerLayout as unknown as jest.Mock).mock.calls.at(-1)![0].open as boolean;
 
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 test('renders a drawer navigator and navigates between screens', () => {
   renderRouter({
     _layout: () => (
@@ -51,6 +61,40 @@ test('renders a drawer navigator and navigates between screens', () => {
 
   expect(screen.getByTestId('second')).toBeVisible();
   expect(screen).toHavePathname('/second');
+});
+
+test('renders only declared drawer items and redirects from unavailable routes', () => {
+  renderRouter({
+    _layout: () => (
+      <Drawer>
+        <Drawer.Screen name="index" />
+        <Drawer.Screen name="hidden" options={{ hidden: true }} />
+      </Drawer>
+    ),
+    index: () => <View testID="index" />,
+    hidden: () => <View testID="hidden" />,
+    undeclared: () => <View testID="undeclared" />,
+  });
+
+  expect(screen.getAllByText('index')).toHaveLength(2);
+  expect(screen.queryByText('hidden')).toBeNull();
+  expect(screen.queryByText('undeclared')).toBeNull();
+
+  act(() => router.push('/undeclared'));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+});
+
+test('renders no drawer UI when no screens are declared in the layout', () => {
+  renderRouter({
+    _layout: () => <Drawer />,
+    index: () => <View testID="index" />,
+  });
+
+  expect(screen.queryByTestId('Drawer')).toBeNull();
+  expect(screen.queryByTestId('index')).toBeNull();
+  expect(warnSpy.mock.calls).toMatchSnapshot();
 });
 
 test('handles drawer actions and preventable item presses', async () => {

--- a/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
@@ -3,6 +3,7 @@
 import { createStandardNavigator } from 'standard-navigation';
 
 import type { StandardNavigatorContentProps } from '../../../standard-navigation/types';
+import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
 import type { DrawerNavigationState, ParamListBase } from '../../native';
 import type {
   DrawerDescriptorMap,
@@ -44,9 +45,23 @@ function DrawerNavigatorContent({
   drawerContent,
   detachInactiveScreens,
 }: ContentArgs) {
+  const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
+    routes: drawerState.routes,
+    focusedRouteKey: drawerState.routes[drawerState.index]!.key,
+    descriptors,
+  });
+
+  if (visibleRoutes.length === 0) {
+    return null;
+  }
+
   return (
     <DrawerView
-      state={drawerState}
+      state={{
+        ...drawerState,
+        routes: visibleRoutes,
+        index: focusedIndex,
+      }}
       navigation={navigation}
       // TODO(@ubax): SDK-58: Try to remove the casting from here to ensure type safety
       // Integration supplies full descriptors, including preload placeholders; standard types omit route/navigation.

--- a/packages/expo-router/src/react-navigation/drawer/types.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/types.tsx
@@ -38,6 +38,13 @@ export type DrawerNavigationConfig = {
 
 export type DrawerNavigationOptions = HeaderOptions & {
   /**
+   * Hides the drawer item. If the screen is focused, the navigator redirects to its initial
+   * visible screen.
+   * @default false
+   */
+  hidden?: boolean;
+
+  /**
    * Title text for the screen.
    */
   title?: string;

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/__snapshots__/index.test.ios.tsx.snap.ios
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders no top tab UI when no screens are declared in the layout 1`] = `
+[
+  [
+    "No screens are declared in ./_layout.js, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: index.",
+  ],
+]
+`;

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
@@ -21,6 +21,12 @@ const getTabViewProps = () => {
   return mockTabView.mock.calls.at(-1)![0];
 };
 
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
 jest.mock('react-native-pager-view', () => {
   const React = require('react') as typeof import('react');
   const { View } = require('react-native') as typeof import('react-native');
@@ -107,6 +113,7 @@ jest.mock(
 );
 
 afterEach(() => {
+  warnSpy.mockRestore();
   jest.restoreAllMocks();
 });
 
@@ -131,7 +138,7 @@ test('renders a material top tab navigator and navigates between screens on tab 
   expect(screen).toHavePathname('/second');
 });
 
-test('renders filesystem routes not declared in the layout', async () => {
+test('renders only declared tabs and redirects from undeclared routes', () => {
   renderRouter({
     _layout: () => (
       <TopTabs>
@@ -142,10 +149,44 @@ test('renders filesystem routes not declared in the layout', async () => {
     second: () => <View testID="second" />,
   });
 
-  await userEvent.press(screen.getByRole('tab', { name: 'second' }));
+  expect(screen.queryByRole('tab', { name: 'second' })).toBeNull();
 
-  expect(screen.getByTestId('second')).toBeVisible();
-  expect(screen).toHavePathname('/second');
+  act(() => router.push('/second'));
+
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('second')).toBeNull();
+  expect(screen).toHavePathname('/');
+});
+
+test('removes and redirects from a hidden tab', () => {
+  renderRouter({
+    _layout: () => (
+      <TopTabs>
+        <TopTabs.Screen name="index" />
+        <TopTabs.Screen name="second" options={{ hidden: true }} />
+      </TopTabs>
+    ),
+    index: () => <View testID="index" />,
+    second: () => <View testID="second" />,
+  });
+
+  expect(screen.queryByRole('tab', { name: 'second' })).toBeNull();
+
+  act(() => router.push('/second'));
+
+  expect(screen).toHavePathname('/');
+  expect(screen.getByTestId('index')).toBeVisible();
+});
+
+test('renders no top tab UI when no screens are declared in the layout', () => {
+  renderRouter({
+    _layout: () => <TopTabs />,
+    index: () => <View testID="index" />,
+  });
+
+  expect(screen.queryByTestId('index')).toBeNull();
+  expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  expect(warnSpy.mock.calls).toMatchSnapshot();
 });
 
 test('does not navigate when a tabPress listener prevents the default action', async () => {
@@ -275,22 +316,21 @@ test('handles screens preloading', () => {
 });
 
 test('warns when navigateToTab receives an unknown route key', () => {
-  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
   renderRouter({
     _layout: () => (
       <TopTabs
         tabBar={({ navigateToTab }: MaterialTopTabBarProps) => (
           <Text testID="unknown-tab" onPress={() => navigateToTab('unknown-key')} />
-        )}
-      />
+        )}>
+        <TopTabs.Screen name="index" />
+      </TopTabs>
     ),
     index: () => null,
   });
 
   act(() => screen.getByTestId('unknown-tab').props.onPress());
 
-  expect(warn).toHaveBeenCalledWith(expect.stringContaining('Top tabs could not switch'));
+  expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Top tabs could not switch'));
 });
 
 test('emits swipeStart and swipeEnd events', async () => {
@@ -311,7 +351,11 @@ test('emits swipeStart and swipeEnd events', async () => {
   }
 
   renderRouter({
-    _layout: () => <TopTabs />,
+    _layout: () => (
+      <TopTabs>
+        <TopTabs.Screen name="index" />
+      </TopTabs>
+    ),
     index: Index,
   });
 

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -3,6 +3,7 @@
 import { createStandardNavigator } from 'standard-navigation';
 
 import type { NavigatorContentProps } from '../../../standard-navigation/types';
+import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
 import type {
   MaterialTopTabDescriptorMap,
   MaterialTopTabNavigationConfig,
@@ -33,6 +34,11 @@ function MaterialTopTabNavigatorContent({
   preloadedRouteKeys,
   ...rest
 }: ContentArgs) {
+  const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
+    routes: state.routes,
+    focusedRouteKey: state.routes[state.index]!.key,
+    descriptors,
+  });
   const navigateToTab = (routeKey: string) => {
     const route = state.routes.find((route) => route.key === routeKey);
     if (route) {
@@ -45,10 +51,18 @@ function MaterialTopTabNavigatorContent({
     }
   };
 
+  if (visibleRoutes.length === 0) {
+    return null;
+  }
+
   return (
     <MaterialTopTabView
       {...rest}
-      state={state}
+      state={{
+        ...state,
+        routes: visibleRoutes,
+        index: focusedIndex,
+      }}
       // TODO(@ubax): SDK-58: Try to remove the casting from here to ensure type safety
       // Integration supplies full descriptors, including preload placeholders; standard types omit route/navigation.
       descriptors={descriptors as unknown as MaterialTopTabDescriptorMap}

--- a/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
@@ -91,6 +91,13 @@ export type MaterialTopTabOptionsArgs<
 
 export type MaterialTopTabNavigationOptions = {
   /**
+   * Hides the tab item. If the screen is focused, the navigator redirects to its initial visible
+   * screen.
+   * @default false
+   */
+  hidden?: boolean;
+
+  /**
    * Title text for the screen.
    */
   title?: string;

--- a/packages/expo-router/src/standard-navigation/__tests__/__snapshots__/useVisibleTabsWithRedirect.test.ios.tsx.snap.ios
+++ b/packages/expo-router/src/standard-navigation/__tests__/__snapshots__/useVisibleTabsWithRedirect.test.ios.tsx.snap.ios
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useVisibleTabsWithRedirect does not redirect when there are no visible routes 1`] = `
+[
+  [
+    "No screens are declared in ./app/_layout.tsx, so the navigator renders nothing. Only screens declared in the layout become visible. Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. Undeclared routes: filesystem.",
+  ],
+]
+`;

--- a/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 
+import { useRouteNode } from '../../Route';
 import { router } from '../../imperative-api';
 import { useIsFocused } from '../../react-navigation/native';
 import { useBuildHref } from '../useBuildHref';
@@ -12,9 +13,14 @@ jest.mock('../../react-navigation/native', () => {
   return { ...actualNavigation, useIsFocused: jest.fn() };
 });
 jest.mock('../useBuildHref');
+jest.mock('../../Route', () => ({
+  ...jest.requireActual('../../Route'),
+  useRouteNode: jest.fn(),
+}));
 
 const mockedUseIsFocused = useIsFocused as jest.MockedFunction<typeof useIsFocused>;
 const mockedUseBuildHref = useBuildHref as jest.MockedFunction<typeof useBuildHref>;
+const mockedUseRouteNode = useRouteNode as jest.MockedFunction<typeof useRouteNode>;
 
 const routes = [
   { key: 'home-key', name: 'home' },
@@ -28,20 +34,23 @@ const descriptors = {
   'hidden-key': { routeSource: 'layout' as const, options: { hidden: true } },
   'filesystem-key': { routeSource: 'filesystem' as const },
 };
-const isHidden = (options: { hidden?: boolean } | undefined) => options?.hidden === true;
-
 let replaceSpy: jest.SpyInstance;
+let warnSpy: jest.SpyInstance;
 let buildHref: jest.Mock;
 
 beforeEach(() => {
   buildHref = jest.fn((route) => `/href/${route.name}`);
   mockedUseBuildHref.mockReturnValue(buildHref);
   mockedUseIsFocused.mockReturnValue(true);
+  // Prevent route data from leaking between tests.
+  mockedUseRouteNode.mockReturnValue(null);
   replaceSpy = jest.spyOn(router, 'replace').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {
   replaceSpy.mockRestore();
+  warnSpy.mockRestore();
 });
 
 describe('useVisibleTabsWithRedirect', () => {
@@ -51,32 +60,32 @@ describe('useVisibleTabsWithRedirect', () => {
         routes,
         focusedRouteKey: 'settings-key',
         descriptors,
-        isHidden,
       })
     );
 
     expect(result.current).toEqual({
       visibleRoutes: [routes[0], routes[1]],
-      visibleFocusedIndex: 1,
+      focusedIndex: 1,
     });
   });
 
-  it('returns -1 when the focused route is not visible', () => {
+  it('returns zero when the focused route is not visible', () => {
     const { result } = renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors, isHidden })
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors })
     );
 
-    expect(result.current.visibleFocusedIndex).toBe(-1);
+    expect(result.current.focusedIndex).toBe(0);
   });
 
   it('redirects an unavailable focused route to the configured visible route', () => {
+    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'settings' } as ReturnType<
+      typeof useRouteNode
+    >);
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
         focusedRouteKey: 'hidden-key',
         descriptors,
-        redirectToRouteName: 'settings',
-        isHidden,
       })
     );
 
@@ -85,13 +94,14 @@ describe('useVisibleTabsWithRedirect', () => {
   });
 
   it('builds the redirect href from the selected route', () => {
+    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'settings' } as ReturnType<
+      typeof useRouteNode
+    >);
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
         focusedRouteKey: 'hidden-key',
         descriptors,
-        redirectToRouteName: 'settings',
-        isHidden,
       })
     );
 
@@ -99,13 +109,14 @@ describe('useVisibleTabsWithRedirect', () => {
   });
 
   it('falls back to the first visible route when the configured route is unavailable', () => {
+    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'missing' } as ReturnType<
+      typeof useRouteNode
+    >);
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
         focusedRouteKey: 'hidden-key',
         descriptors,
-        redirectToRouteName: 'missing',
-        isHidden,
       })
     );
 
@@ -117,7 +128,7 @@ describe('useVisibleTabsWithRedirect', () => {
     mockedUseIsFocused.mockReturnValue(false);
 
     renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors, isHidden })
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'hidden-key', descriptors })
     );
 
     expect(replaceSpy).not.toHaveBeenCalled();
@@ -125,7 +136,7 @@ describe('useVisibleTabsWithRedirect', () => {
 
   it('does not redirect when the focused route is visible', () => {
     renderHook(() =>
-      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'home-key', descriptors, isHidden })
+      useVisibleTabsWithRedirect({ routes, focusedRouteKey: 'home-key', descriptors })
     );
 
     expect(buildHref).toHaveBeenCalledWith(routes[0]);
@@ -133,15 +144,18 @@ describe('useVisibleTabsWithRedirect', () => {
   });
 
   it('does not redirect when there are no visible routes', () => {
+    mockedUseRouteNode.mockReturnValue({ contextKey: './app/_layout.tsx' } as ReturnType<
+      typeof useRouteNode
+    >);
     renderHook(() =>
       useVisibleTabsWithRedirect({
-        routes: [routes[2]!],
-        focusedRouteKey: 'hidden-key',
+        routes: [routes[3]!],
+        focusedRouteKey: 'filesystem-key',
         descriptors,
-        isHidden,
       })
     );
 
     expect(replaceSpy).not.toHaveBeenCalled();
+    expect(warnSpy.mock.calls).toMatchSnapshot();
   });
 });

--- a/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
+++ b/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo } from 'react';
 
+import { useRouteNode } from '../Route';
 import { router } from '../imperative-api';
+import { normalizeRouteName, useGuardRedirect } from '../layouts/GuardContext';
 import {
   type NavigationRoute,
   type ParamListBase,
@@ -18,24 +20,25 @@ type TabDescriptor<Options extends object> = {
 
 /**
  * Returns the visible layout tabs and their focused index. When the navigator is focused, redirects
- * an unavailable focused route to `redirectToRouteName` or the first visible tab.
+ * an unavailable focused route to the layout's initial route or the first visible tab.
  */
-export function useVisibleTabsWithRedirect<Route extends TabRoute, Options extends object>({
+export function useVisibleTabsWithRedirect<
+  Route extends TabRoute,
+  Options extends { hidden?: boolean },
+>({
   routes,
   focusedRouteKey,
   descriptors,
-  redirectToRouteName,
-  isHidden,
 }: {
   routes: Route[];
   focusedRouteKey: string;
   descriptors: Record<string, TabDescriptor<Options>>;
-  redirectToRouteName?: string;
-  // Keep this callback reference-stable to avoid recalculating the visible routes.
-  isHidden?: (options: Options | undefined) => boolean;
 }) {
   const buildHref = useBuildHref();
   const isFocused = useIsFocused();
+  const routeNode = useRouteNode();
+  const focusedRoute = routes.find((route) => route.key === focusedRouteKey);
+  const guardRedirect = useGuardRedirect(focusedRoute?.name ?? '');
 
   const visibleRoutes = useMemo(
     () =>
@@ -43,22 +46,44 @@ export function useVisibleTabsWithRedirect<Route extends TabRoute, Options exten
         // Every filesystem route is registered in state; only routes declared by a non-hidden
         // trigger become tab items.
         const descriptor = descriptors[route.key];
-        return isDeclaredInLayout(descriptor) && !isHidden?.(descriptor?.options);
+        return isDeclaredInLayout(descriptor) && descriptor?.options?.hidden !== true;
       }),
-    [routes, descriptors, isHidden]
+    [routes, descriptors]
   );
   const visibleFocusedIndex = useMemo(
     () => visibleRoutes.findIndex((route) => route.key === focusedRouteKey),
     [focusedRouteKey, visibleRoutes]
   );
+  const focusedIndex = visibleFocusedIndex >= 0 ? visibleFocusedIndex : 0;
 
   const redirectHref = useMemo(() => {
-    const redirectRoute = findRouteByName(visibleRoutes, redirectToRouteName) ?? visibleRoutes[0];
+    if (guardRedirect !== undefined) {
+      return guardRedirect;
+    }
+    const redirectRoute =
+      findRouteByName(visibleRoutes, routeNode?.initialRouteName) ?? visibleRoutes[0];
     if (redirectRoute) {
       return buildHref(redirectRoute);
     }
     return null;
-  }, [buildHref, redirectToRouteName, visibleRoutes]);
+  }, [buildHref, guardRedirect, routeNode?.initialRouteName, visibleRoutes]);
+
+  useEffect(() => {
+    // TODO(@ubax): Consider throwing in __DEV__ instead of warning.
+    if (__DEV__ && visibleRoutes.length === 0 && guardRedirect === undefined) {
+      const undeclaredRoutes = routes
+        .filter((route) => !isDeclaredInLayout(descriptors[route.key]))
+        .map((route) => route.name)
+        .join(', ');
+      console.warn(
+        `No screens are declared in ${routeNode?.contextKey ?? 'the layout'}, so the navigator renders nothing. ` +
+          'Only screens declared in the layout become visible. ' +
+          'Declare each screen you want to show, for example <Tabs.Screen name="index" /> or <NativeTabs.Trigger name="index" />. ' +
+          `Undeclared routes: ${undeclaredRoutes}.`
+      );
+    }
+    // Route names are diagnostic; only rerun when the warning's eligibility changes.
+  }, [guardRedirect, routeNode?.contextKey, visibleRoutes.length]);
 
   useEffect(() => {
     // The focused route can be hidden or have no trigger at all — for example a path pointing at a
@@ -70,7 +95,7 @@ export function useVisibleTabsWithRedirect<Route extends TabRoute, Options exten
     }
   }, [isFocused, redirectHref, visibleFocusedIndex]);
 
-  return { visibleRoutes, visibleFocusedIndex };
+  return { visibleRoutes, focusedIndex };
 }
 
 function isDeclaredInLayout<Options extends object>(
@@ -80,5 +105,5 @@ function isDeclaredInLayout<Options extends object>(
 }
 
 function findRouteByName<Route extends TabRoute>(routes: Route[], name: string | undefined) {
-  return routes.find((route) => route.name === name || route.name.replace(/\/index$/, '') === name);
+  return routes.find((route) => route.name === name || normalizeRouteName(route.name) === name);
 }

--- a/packages/expo-router/src/ui/TabContext.tsx
+++ b/packages/expo-router/src/ui/TabContext.tsx
@@ -49,7 +49,7 @@ export type ExpoTabsNavigationProp<
 
 export type ExpoTabsScreenOptions = Pick<
   BottomTabNavigationOptions,
-  'title' | 'lazy' | 'freezeOnBlur'
+  'title' | 'lazy' | 'freezeOnBlur' | 'hidden'
 > & {
   params?: object;
   title: string;

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -75,6 +75,10 @@ export function TabTrigger({ asChild, name, href, resetOnFocus, ...props }: TabT
     ...props,
   });
 
+  if (trigger?.hidden) {
+    return null;
+  }
+
   // Pressable doesn't accept the extra props, so only pass them if we are using asChild
   if (asChild) {
     return (
@@ -118,6 +122,7 @@ export type SwitchToOptions = {
 };
 
 export type Trigger = TriggerMap[string] & {
+  hidden: boolean;
   isFocused: boolean;
   resolvedHref: string;
   route: TabNavigationState<any>['routes'][number];
@@ -140,7 +145,7 @@ export type TriggerProps = {
  * Utility hook creating custom `TabTrigger`.
  */
 export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
-  const { state, navigation } = useNavigatorContext();
+  const { state, navigation, descriptors } = useNavigatorContext();
   const { name, resetOnFocus, onPress, onLongPress } = options;
   const triggerMap = use(TabTriggerMapContext);
 
@@ -152,14 +157,23 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         return;
       }
 
+      const route =
+        config.type === 'internal'
+          ? state.routes.find((route) => route.name === config.routeNode.route)
+          : undefined;
+      const routeOptions = route != null ? descriptors[route.key]?.options : undefined;
+      const hidden =
+        routeOptions != null && 'hidden' in routeOptions && routeOptions.hidden === true;
+
       return {
+        hidden,
         isFocused: state.index === config.index,
         route: state.routes[config.index]!,
         resolvedHref: stripGroupSegmentsFromPath(appendBaseUrl(config.href)),
         ...config,
       };
     },
-    [triggerMap]
+    [descriptors, state, triggerMap]
   );
 
   const trigger = name !== undefined ? getTrigger(name) : undefined;

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -5,15 +5,18 @@ import { StyleSheet, View } from 'react-native';
 
 import { useRouteNode, useContextKey } from '../Route';
 import { useRouteInfo } from '../hooks';
+import { GuardContextProvider, type GuardedRedirects } from '../layouts/GuardContext';
 import { resolveHref } from '../link/href';
 import type {
   DefaultNavigatorOptions,
   ParamListBase,
+  RouteSource,
   TabActionHelpers,
   TabNavigationState,
   TabRouterOptions,
 } from '../react-navigation/native';
 import { LinkingContext, useNavigationBuilder } from '../react-navigation/native';
+import { useVisibleTabsWithRedirect } from '../standard-navigation/useVisibleTabsWithRedirect';
 import { shouldLinkExternally } from '../utils/url';
 import type { NavigatorContextValue } from '../views/Navigator';
 import { NavigatorContext } from '../views/Navigator';
@@ -32,6 +35,8 @@ export * from './TabContext';
 export * from './TabList';
 export * from './TabSlot';
 export * from './TabTrigger';
+
+const emptyGuardedRedirects: GuardedRedirects = new Map();
 
 /**
  * Options to provide to the Tab Router.
@@ -194,14 +199,33 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
   );
 
   const NavigationContent = useComponent((children: React.ReactNode) => (
-    <TabTriggerMapContext.Provider value={triggerMap}>
-      <NavigatorContext.Provider value={navigatorContextValue}>
-        <RNNavigationContent>{children}</RNNavigationContent>
-      </NavigatorContext.Provider>
-    </TabTriggerMapContext.Provider>
+    // Headless tabs have no guards, so shadow parent guards whose route names may collide.
+    <GuardContextProvider node={routeNode} guardedRedirects={emptyGuardedRedirects}>
+      <TabVisibilityRedirect state={state} descriptors={descriptors} />
+      <TabTriggerMapContext.Provider value={triggerMap}>
+        <NavigatorContext.Provider value={navigatorContextValue}>
+          <RNNavigationContent>{children}</RNNavigationContent>
+        </NavigatorContext.Provider>
+      </TabTriggerMapContext.Provider>
+    </GuardContextProvider>
   )) as TabsContextValue['NavigationContent'];
 
   return { state, descriptors, navigation, NavigationContent };
+}
+
+function TabVisibilityRedirect({
+  state,
+  descriptors,
+}: {
+  state: TabNavigationState<any>;
+  descriptors: Record<string, { routeSource?: RouteSource; options: ExpoTabsScreenOptions }>;
+}) {
+  useVisibleTabsWithRedirect({
+    routes: state.routes,
+    focusedRouteKey: state.routes[state.index]!.key,
+    descriptors,
+  });
+  return null;
 }
 
 function parseTriggersFromChildren(

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -507,10 +507,8 @@ export function screenOptionsFactory(
 
     // Prevent generated screens from showing up in the tab bar.
     if (route.internal || isGuarded) {
-      output.tabBarItemStyle = { display: 'none' };
-      output.tabBarButton = () => null;
-      // TODO: React Navigation doesn't provide a way to prevent rendering the drawer item.
-      output.drawerItemStyle = { height: 0, display: 'none' };
+      // TODO(@ubax): Document migrating withLayoutContext navigators to standard navigation,
+      // where processScreens can map hidden to navigator-specific options.
       output.hidden = true;
     }
 


### PR DESCRIPTION
# Why

Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs, by showing only screens declared in the `_layout`

# How

Use `useVisibleTabsWithRedirect` in every tab navigator

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>