### PR TITLE
[router] Remove `navigationKey` API

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### 🛠 Breaking changes
 
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
+- Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. ([#48498](https://github.com/expo/expo/pull/48498) by [@Ubax](https://github.com/Ubax))
 - Make `beforeRemove` non-preventable and add `removePrevented` event. ([#48347](https://github.com/expo/expo/pull/48347) by [@Ubax](https://github.com/Ubax))
+- Remove the `navigationKey` prop from layout `<Screen>` and `<Group>` components.
 - Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Migrate the JS `TopTabs` navigator to the `standard-navigation` integration. ([#48498](https://github.com/expo/expo/pull/48498) by [@Ubax](https://github.com/Ubax))
 - Make `beforeRemove` non-preventable and add `removePrevented` event. ([#48347](https://github.com/expo/expo/pull/48347) by [@Ubax](https://github.com/Ubax))
-- Remove the `navigationKey` prop from layout `<Screen>` and `<Group>` components.
+- Remove the `navigationKey` prop from layout `<Screen>` and `<Group>` components. ([#48502](https://github.com/expo/expo/pull/48502) by [@Ubax](https://github.com/Ubax))
 - Remove the `redirect` prop from layout `<Screen>` components. ([#48369](https://github.com/expo/expo/pull/48369) by [@Ubax](https://github.com/Ubax))
 - Add `redirectTo` to protected routes and render guarded screens as redirects instead of removing them from navigators. ([#47744](https://github.com/expo/expo/pull/47744) by [@Ubax](https://github.com/Ubax))
 - Migrate the `Drawer` navigator to the `standard-navigation` integration. ([#47839](https://github.com/expo/expo/pull/47839) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -643,13 +643,6 @@ export type RouteConfigProps<
   Navigation,
 > = {
   /**
-   * Optional key for this screen. This doesn't need to be unique.
-   * If the key changes, existing screens with this name will be removed or reset.
-   * Useful when we have some common screens and have conditional rendering.
-   */
-  navigationKey?: string;
-
-  /**
    * Route name of this screen.
    */
   name: RouteName;
@@ -721,12 +714,6 @@ export type RouteGroupConfig<
   ScreenOptions extends {},
   Navigation,
 > = {
-  /**
-   * Optional key for the screens in this group.
-   * If the key changes, all existing screens in this group will be removed or reset.
-   */
-  navigationKey?: string;
-
   /**
    * Navigator options for this screen.
    */

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -35,7 +35,6 @@ export type ScreenConfigWithParent<
   ScreenOptions extends {},
   EventMap extends EventMapBase,
 > = {
-  keys: (string | undefined)[];
   options: (ScreenOptionsOrCallback<ScreenOptions> | undefined)[] | undefined;
   layout: ScreenLayout<ScreenOptions> | undefined;
   props: RouteConfig<ParamListBase, string, State, ScreenOptions, EventMap, unknown>;

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -27,7 +27,6 @@ import { Screen } from './Screen';
 import { UnhandledActionContext } from './UnhandledActionContext';
 import { deepFreeze } from './deepFreeze';
 import { isArrayEqual } from './isArrayEqual';
-import { isRecordEqual } from './isRecordEqual';
 import {
   type DefaultNavigatorOptions,
   type EventMapBase,
@@ -71,7 +70,6 @@ const isScreen = (
   child: React.ReactElement<unknown>
 ): child is React.ReactElement<{
   name?: unknown;
-  navigationKey?: unknown;
 }> => {
   return child.type === Screen;
 };
@@ -79,16 +77,12 @@ const isScreen = (
 const isGroup = (
   child: React.ReactElement<unknown>
 ): child is React.ReactElement<{
-  navigationKey?: unknown;
   screenOptions?: unknown;
   screenLayout?: unknown;
   children?: unknown;
 }> => {
   return child.type === React.Fragment || child.type === Group;
 };
-
-const isValidKey = (key: unknown): key is string | undefined =>
-  key === undefined || (typeof key === 'string' && key !== '');
 
 /**
  * Extract route config object from React children elements.
@@ -101,7 +95,6 @@ const getRouteConfigsFromChildren = <
   EventMap extends EventMapBase,
 >(
   children: React.ReactNode,
-  groupKey?: string,
   groupOptions?: ScreenConfigWithParent<State, ScreenOptions, EventMap>['options'],
   groupLayout?: ScreenConfigWithParent<State, ScreenOptions, EventMap>['layout']
 ) => {
@@ -125,19 +118,7 @@ const getRouteConfigsFromChildren = <
           );
         }
 
-        if (
-          child.props.navigationKey !== undefined &&
-          (typeof child.props.navigationKey !== 'string' || child.props.navigationKey === '')
-        ) {
-          throw new Error(
-            `Got an invalid 'navigationKey' prop (${JSON.stringify(
-              child.props.navigationKey
-            )}) for the screen '${child.props.name}'. It must be a non-empty string or 'undefined'.`
-          );
-        }
-
         acc.push({
-          keys: [groupKey, child.props.navigationKey],
           options: groupOptions,
           layout: groupLayout,
           props: child.props as RouteConfig<
@@ -154,20 +135,11 @@ const getRouteConfigsFromChildren = <
       }
 
       if (isGroup(child)) {
-        if (!isValidKey(child.props.navigationKey)) {
-          throw new Error(
-            `Got an invalid 'navigationKey' prop (${JSON.stringify(
-              child.props.navigationKey
-            )}) for the group. It must be a non-empty string or 'undefined'.`
-          );
-        }
-
         // When we encounter a fragment or group, we need to dive into its children to extract the configs
         // This is handy to conditionally define a group of screens
         acc.push(
           ...getRouteConfigsFromChildren<State, ScreenOptions, EventMap>(
             child.props.children as React.ReactNode,
-            child.props.navigationKey,
             // FIXME
             // @ts-expect-error: add validation
             child.type !== Group
@@ -369,10 +341,6 @@ export function useNavigationBuilder<
   }, {});
 
   const routeNames = routeConfigs.map((config) => config.props.name);
-  const routeKeyList = routeNames.reduce<Record<string, React.Key | undefined>>((acc, curr) => {
-    acc[curr] = screens[curr]!.keys.map((key) => key ?? '').join(':');
-    return acc;
-  }, {});
   const routeParamList = routeNames.reduce<Record<string, object | undefined>>((acc, curr) => {
     const { initialParams } = screens[curr]!.props;
     acc[curr] = initialParams;
@@ -520,14 +488,6 @@ export function useNavigationBuilder<
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [currentState, router, isStateValid]);
 
-  const previousRouteKeyListRef = React.useRef(routeKeyList);
-
-  React.useEffect(() => {
-    previousRouteKeyListRef.current = routeKeyList;
-  });
-
-  const previousRouteKeyList = previousRouteKeyListRef.current;
-
   let state =
     // If the state isn't initialized, or stale, use the state we initialized instead
     // The state won't update until there's a change needed in the state we have initialized locally
@@ -535,18 +495,12 @@ export function useNavigationBuilder<
     isStateInitialized(currentState) ? (currentState as State) : (initializedState as State);
 
   let nextState: State = state;
-  if (
-    !isArrayEqual(state.routeNames, routeNames) ||
-    !isRecordEqual(routeKeyList, previousRouteKeyList)
-  ) {
+  if (!isArrayEqual(state.routeNames, routeNames)) {
     // When the list of route names change, the router should handle it to remove invalid routes
     nextState = router.getStateForRouteNamesChange(state, {
       routeNames,
       routeParamList,
       routeGetIdList,
-      routeKeyChanges: Object.keys(routeKeyList).filter(
-        (name) => name in previousRouteKeyList && routeKeyList[name] !== previousRouteKeyList[name]
-      ),
     });
   }
 

--- a/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
@@ -184,20 +184,16 @@ export function getRoutesForRouteNames(
   routeNames: string[],
   {
     routeParamList,
-    routeKeyChanges = [],
     initialRouteName,
   }: {
     routeParamList: ParamListBase;
-    routeKeyChanges?: string[];
     initialRouteName?: string;
   }
 ): Pick<StackNavigationState<ParamListBase>, 'routes' | 'index'> {
   const { activeRoutes, preloadedRoutes } = getStackRoutes(state);
-  const routes = activeRoutes.filter(
-    (route) => routeNames.includes(route.name) && !routeKeyChanges.includes(route.name)
-  );
-  const filteredPreloadedRoutes = preloadedRoutes.filter(
-    (route) => routeNames.includes(route.name) && !routeKeyChanges.includes(route.name)
+  const routes = activeRoutes.filter((route) => routeNames.includes(route.name));
+  const filteredPreloadedRoutes = preloadedRoutes.filter((route) =>
+    routeNames.includes(route.name)
   );
 
   if (routes.length === 0) {
@@ -316,13 +312,12 @@ export function StackRouter(options: StackRouterOptions) {
       };
     },
 
-    getStateForRouteNamesChange(state, { routeNames, routeParamList, routeKeyChanges }) {
+    getStateForRouteNamesChange(state, { routeNames, routeParamList }) {
       return {
         ...state,
         routeNames,
         ...getRoutesForRouteNames(state, routeNames, {
           routeParamList,
-          routeKeyChanges,
           initialRouteName: options.initialRouteName,
         }),
       };

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -310,18 +310,8 @@ export function TabRouter({
       );
     },
 
-    getStateForRouteNamesChange(state, { routeNames, routeParamList, routeKeyChanges }) {
-      const routes = state.routes
-        .filter((route) => routeNames.includes(route.name))
-        .map((route) =>
-          routeKeyChanges.includes(route.name)
-            ? {
-                name: route.name,
-                key: `${route.name}-${nanoid()}`,
-                params: routeParamList[route.name],
-              }
-            : route
-        );
+    getStateForRouteNamesChange(state, { routeNames, routeParamList }) {
+      const routes = state.routes.filter((route) => routeNames.includes(route.name));
 
       for (const name of routeNames) {
         if (!routes.some((route) => route.name === name)) {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -89,7 +89,6 @@ test('preserves drawer status when route names change', () => {
   const state = router.getStateForRouteNamesChange(openState, {
     ...options,
     routeNames: ['baz', 'bar'],
-    routeKeyChanges: [],
   });
 
   expect(state.history).toContainEqual({ type: 'drawer', status: 'open' });
@@ -112,7 +111,6 @@ test('restores route history without dropping drawer status when the active rout
   const state = router.getStateForRouteNamesChange(openState, {
     ...options,
     routeNames: ['baz'],
-    routeKeyChanges: [],
   });
 
   expect(state.history).toEqual([

--- a/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
@@ -236,7 +236,6 @@ test('gets state on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -270,7 +269,6 @@ test('gets state on route names change', () => {
           baz: { name: 'John' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -305,7 +303,6 @@ test('gets state on route names change with initialRouteName', () => {
           baz: { name: 'John' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,6 +1,5 @@
 import { expect, jest, test } from '@jest/globals';
 import { expectTypeOf } from 'expect-type';
-import { nanoid } from 'nanoid/non-secure';
 
 import {
   CommonActions,
@@ -13,8 +12,6 @@ import {
 } from '../index';
 
 jest.mock('nanoid/non-secure', () => ({ nanoid: jest.fn(() => 'test') }));
-
-const mockNanoid = jest.mocked(nanoid);
 
 test('types replace action helper params', () => {
   type Params = {
@@ -669,40 +666,6 @@ test('preserves focused route on route names change', () => {
     stale: false,
     type: 'tab',
     preloadedRouteKeys: [],
-  });
-});
-
-test('preserves focused route when its key changes', () => {
-  const router = TabRouter({});
-  mockNanoid.mockReturnValueOnce('changed');
-
-  const state = router.getStateForRouteNamesChange(
-    {
-      index: 1,
-      key: 'tab-test',
-      routeNames: ['bar', 'baz', 'qux'],
-      routes: [
-        { key: 'bar-test', name: 'bar' },
-        { key: 'baz-test', name: 'baz' },
-        { key: 'qux-test', name: 'qux' },
-      ],
-      history: [{ type: 'route', key: 'baz-test' }],
-      stale: false,
-      type: 'tab',
-      preloadedRouteKeys: [],
-    },
-    {
-      routeNames: ['bar', 'baz', 'qux'],
-      routeParamList: {},
-      routeGetIdList: {},
-      routeKeyChanges: ['baz'],
-    }
-  );
-
-  expect(state.routes[state.index]).toEqual({
-    key: 'baz-changed',
-    name: 'baz',
-    params: undefined,
   });
 });
 

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -567,7 +567,6 @@ test('gets state on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -608,7 +607,6 @@ test('gets state on route names change', () => {
         routeNames: ['foo', 'fiz'],
         routeParamList: {},
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -652,7 +650,6 @@ test('preserves focused route on route names change', () => {
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({
@@ -735,7 +732,6 @@ test('falls back to first route if route is removed on route names change', () =
           fiz: { fruit: 'apple' },
         },
         routeGetIdList: {},
-        routeKeyChanges: [],
       }
     )
   ).toEqual({

--- a/packages/expo-router/src/react-navigation/routers/__tests__/getRoutesForRouteNames.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/getRoutesForRouteNames.test.tsx
@@ -53,23 +53,6 @@ test('clamps the index to the last remaining route', () => {
   });
 });
 
-test('excludes routes whose name changed key', () => {
-  const state = stackState(
-    [
-      { name: 'a', key: 'a-1' },
-      { name: 'b', key: 'b-1' },
-    ],
-    1
-  );
-
-  expect(
-    getRoutesForRouteNames(state, ['a', 'b'], { routeParamList: {}, routeKeyChanges: ['b'] })
-  ).toEqual({
-    routes: [{ name: 'a', key: 'a-1' }],
-    index: 0,
-  });
-});
-
 test('falls back to the initial route when nothing remains', () => {
   const state = stackState([{ name: 'secret', key: 'secret-1' }], 0);
 

--- a/packages/expo-router/src/react-navigation/routers/types.tsx
+++ b/packages/expo-router/src/react-navigation/routers/types.tsx
@@ -173,16 +173,7 @@ export type Router<State extends NavigationState, Action extends NavigationActio
    * @param options.routeNames New list of route names.
    * @param options.routeParamsList Object containing params for each route.
    */
-  getStateForRouteNamesChange(
-    state: State,
-    options: RouterConfigOptions & {
-      /**
-       * List of routes whose key has changed even if they still have the same name.
-       * This allows to remove screens declaratively.
-       */
-      routeKeyChanges: string[];
-    }
-  ): State;
+  getStateForRouteNamesChange(state: State, options: RouterConfigOptions): State;
 
   /**
    * Take the current state and key of a route, and return a new state with the route focused


### PR DESCRIPTION
# Why

Remove `navigationKey` API. It was never supported in router, so we can safely remove it.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>