### PR TITLE
[observe][app-metrics] Allow disabling unhandled JS error handling via configure

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Add a `caught` source to the private `reportError` for errors reported from user code. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
+- Add an internal `setErrorHandlerEnabled` so the installed unhandled-error handler can stop reporting without being uninstalled. ([#48506](https://github.com/expo/expo/pull/48506) by [@tsapeta](https://github.com/tsapeta))
 - Add session shared object API ([#46652](https://github.com/expo/expo/pull/46652) by [@Ubax](https://github.com/Ubax))
 
 ## 57.0.7 — 2026-07-29

--- a/packages/expo-app-metrics/src/__tests__/installErrorHandler.test.native.ts
+++ b/packages/expo-app-metrics/src/__tests__/installErrorHandler.test.native.ts
@@ -1,0 +1,96 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+export {};
+
+const mockAppMetrics = {
+  reportError: jest.fn(),
+};
+
+jest.mock('../module', () => ({
+  __esModule: true,
+  default: mockAppMetrics,
+}));
+
+type GlobalHandler = (error: any, isFatal?: boolean) => void;
+
+let previousHandler: jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.resetModules();
+  jest.doMock('../module', () => ({ __esModule: true, default: mockAppMetrics }));
+
+  previousHandler = jest.fn();
+  let currentHandler: GlobalHandler = previousHandler;
+  (globalThis as any).ErrorUtils = {
+    getGlobalHandler: () => currentHandler,
+    setGlobalHandler: (handler: GlobalHandler) => {
+      currentHandler = handler;
+    },
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as any).ErrorUtils;
+});
+
+function loadModule() {
+  return require('../installErrorHandler') as typeof import('../installErrorHandler');
+}
+
+/** Installs the handler and returns the one now registered on `ErrorUtils`. */
+function installAndGetHandler(module: ReturnType<typeof loadModule>): GlobalHandler {
+  module.installErrorHandler();
+  return (globalThis as any).ErrorUtils.getGlobalHandler();
+}
+
+describe('setErrorHandlerEnabled', () => {
+  it('reports errors by default', () => {
+    const module = loadModule();
+    const handler = installAndGetHandler(module);
+    handler(new Error('boom'), true);
+    expect(mockAppMetrics.reportError).toHaveBeenCalledTimes(1);
+    expect(mockAppMetrics.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'global', message: 'boom', isFatal: true })
+    );
+  });
+
+  it('stops reporting when disabled', () => {
+    const module = loadModule();
+    const handler = installAndGetHandler(module);
+    module.setErrorHandlerEnabled(false);
+    handler(new Error('boom'), true);
+    expect(mockAppMetrics.reportError).not.toHaveBeenCalled();
+  });
+
+  it('still chains to the previous handler when disabled', () => {
+    const module = loadModule();
+    const handler = installAndGetHandler(module);
+    module.setErrorHandlerEnabled(false);
+    const error = new Error('boom');
+    handler(error, true);
+    expect(previousHandler).toHaveBeenCalledTimes(1);
+    expect(previousHandler).toHaveBeenCalledWith(error, true);
+  });
+
+  it('resumes reporting when re-enabled', () => {
+    const module = loadModule();
+    const handler = installAndGetHandler(module);
+    module.setErrorHandlerEnabled(false);
+    handler(new Error('dropped'), false);
+    expect(mockAppMetrics.reportError).not.toHaveBeenCalled();
+    module.setErrorHandlerEnabled(true);
+    handler(new Error('recorded'), false);
+    expect(mockAppMetrics.reportError).toHaveBeenCalledTimes(1);
+    expect(mockAppMetrics.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'recorded' })
+    );
+  });
+
+  it('takes effect for a handler installed before the call, since install happens at import time', () => {
+    const module = loadModule();
+    module.setErrorHandlerEnabled(false);
+    const handler = installAndGetHandler(module);
+    handler(new Error('boom'), false);
+    expect(mockAppMetrics.reportError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/expo-app-metrics/src/index.ts
+++ b/packages/expo-app-metrics/src/index.ts
@@ -1,6 +1,7 @@
 import { installErrorHandler } from './installErrorHandler';
 
 export { default } from './module';
+export { setErrorHandlerEnabled } from './installErrorHandler';
 export { AppMetricsRoot } from './AppMetricsRoot';
 export { AppMetricsErrorBoundary } from './AppMetricsErrorBoundary';
 export type {

--- a/packages/expo-app-metrics/src/installErrorHandler.ts
+++ b/packages/expo-app-metrics/src/installErrorHandler.ts
@@ -3,6 +3,23 @@ import type { ErrorHandlerCallback } from 'react-native';
 import AppMetrics from './module';
 
 let installed = false;
+let enabled = true;
+
+/**
+ * Enables or disables reporting from the unhandled-JS-error handler.
+ *
+ * The handler itself is installed once at import time, before any configuration call can run, so
+ * this toggles whether it records anything rather than whether it is installed. When disabled, the
+ * handler still chains to the previously-installed handler, leaving React Native's behavior (red box
+ * in development, fatal termination in production) unchanged.
+ *
+ * Meant for the packages that wrap this one, not for host apps to call directly.
+ *
+ * @internal
+ */
+export function setErrorHandlerEnabled(value: boolean): void {
+  enabled = value;
+}
 
 /**
  * Installs a handler for unhandled JavaScript errors by wrapping React Native's
@@ -13,6 +30,8 @@ let installed = false;
  *
  * Idempotent: only the first call installs. Called automatically when `expo-app-metrics` is
  * imported, so capture is live as early as the app pulls the module in.
+ *
+ * Reporting can be turned off afterwards with `setErrorHandlerEnabled(false)`.
  */
 export function installErrorHandler(): void {
   if (installed) {
@@ -27,13 +46,17 @@ export function installErrorHandler(): void {
   const previousHandler = ErrorUtils.getGlobalHandler();
   const handler: ErrorHandlerCallback = (error, isFatal) => {
     try {
-      AppMetrics.reportError({
-        source: 'global',
-        type: error?.name,
-        message: error?.message ?? String(error),
-        stacktrace: error?.stack,
-        isFatal: isFatal ?? false,
-      });
+      // Checked per error, not at install time: the handler is installed on import, before
+      // anything has had a chance to disable it.
+      if (enabled) {
+        AppMetrics.reportError({
+          source: 'global',
+          type: error?.name,
+          message: error?.message ?? String(error),
+          stacktrace: error?.stack,
+          isFatal: isFatal ?? false,
+        });
+      }
     } finally {
       // Always chain to the previous handler so React Native's behavior (red box in development,
       // fatal termination in production) is preserved even if recording the error throws.

--- a/packages/expo-app-metrics/src/installErrorHandler.ts
+++ b/packages/expo-app-metrics/src/installErrorHandler.ts
@@ -6,14 +6,14 @@ let installed = false;
 let enabled = true;
 
 /**
- * Enables or disables reporting from the unhandled-JS-error handler.
+ * Enables or disables reporting of unhandled JavaScript errors.
  *
- * The handler itself is installed once at import time, before any configuration call can run, so
- * this toggles whether it records anything rather than whether it is installed. When disabled, the
- * handler still chains to the previously-installed handler, leaving React Native's behavior (red box
- * in development, fatal termination in production) unchanged.
+ * The handler is installed once when this package is imported, before any configuration call can
+ * run, so this toggles whether errors are recorded rather than whether the handler is installed.
+ * Disabling it leaves React Native's own behavior (red box in development, fatal termination in
+ * production) unchanged.
  *
- * Meant for the packages that wrap this one, not for host apps to call directly.
+ * Exported for the packages that wrap this one, not for host apps to call directly.
  *
  * @internal
  */
@@ -29,9 +29,12 @@ export function setErrorHandlerEnabled(value: boolean): void {
  * fatal termination in production) is unchanged.
  *
  * Idempotent: only the first call installs. Called automatically when `expo-app-metrics` is
- * imported, so capture is live as early as the app pulls the module in.
+ * imported, so capture is live as early as the app pulls the module in. Nothing else needs to call
+ * it, which is why it isn't part of the package's exports.
  *
  * Reporting can be turned off afterwards with `setErrorHandlerEnabled(false)`.
+ *
+ * @private
  */
 export function installErrorHandler(): void {
   if (installed) {

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `Observe.registerIntegration` to register an integration ([#48245](https://github.com/expo/expo/pull/48245), [#48268](https://github.com/expo/expo/pull/48268) by [@Ubax](https://github.com/Ubax))
 - Expose `ObserveErrorBoundary`, a React error boundary that records render-phase errors. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Add `reportError` to report caught, non-fatal errors from your own `try`/`catch` blocks. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
+- Add an `errorHandlingEnabled` option to `configure` to opt out of recording unhandled JavaScript errors. ([#48506](https://github.com/expo/expo/pull/48506) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -170,9 +170,12 @@ describe('module Proxy', () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it('forwards errorHandlingEnabled to native along with the rest of the config', () => {
+  it('passes the config through to the native module unchanged', () => {
     const Observe = loadModule();
     Observe.configure({ environment: 'test', errorHandlingEnabled: false });
+    // The native `Config` record has no `errorHandlingEnabled` field, so decoding drops it. This
+    // asserts the JS layer doesn't strip or rewrite the object on its way out, not that native
+    // reads the flag: the gate lives entirely in JS.
     expect(mockNative.configure).toHaveBeenCalledWith({
       environment: 'test',
       errorHandlingEnabled: false,

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -21,6 +21,8 @@ const mockAppMetrics = {
   reportError: jest.fn(),
 };
 
+const mockSetErrorHandlerEnabled = jest.fn();
+
 jest.mock('expo', () => ({
   requireNativeModule: jest.fn(() => mockNative),
 }));
@@ -28,6 +30,7 @@ jest.mock('expo', () => ({
 jest.mock('expo-app-metrics', () => ({
   __esModule: true,
   default: mockAppMetrics,
+  setErrorHandlerEnabled: mockSetErrorHandlerEnabled,
 }));
 
 jest.mock('../integrations/expo-router/router', () => ({
@@ -60,7 +63,11 @@ beforeEach(() => {
   jest.resetModules();
   warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   jest.doMock('expo', () => ({ requireNativeModule: jest.fn(() => mockNative) }));
-  jest.doMock('expo-app-metrics', () => ({ __esModule: true, default: mockAppMetrics }));
+  jest.doMock('expo-app-metrics', () => ({
+    __esModule: true,
+    default: mockAppMetrics,
+    setErrorHandlerEnabled: mockSetErrorHandlerEnabled,
+  }));
   jest.doMock('../integrations/expo-router/router', () => ({
     isRouterInstalled: true,
     optionalRouter: undefined,
@@ -146,6 +153,38 @@ describe('module Proxy', () => {
     expect(initRouterIntegration).toHaveBeenCalledTimes(1);
     expect(initRouterIntegration).toHaveBeenCalledWith(true);
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaves unhandled-error reporting enabled when errorHandlingEnabled is unset', () => {
+    const Observe = loadModule();
+    Observe.configure({ environment: 'test' });
+    expect(mockSetErrorHandlerEnabled).toHaveBeenCalledWith(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])('applies errorHandlingEnabled: %s to the error handler', (enabled) => {
+    const Observe = loadModule();
+    Observe.configure({ environment: 'test', errorHandlingEnabled: enabled });
+    expect(mockSetErrorHandlerEnabled).toHaveBeenCalledTimes(1);
+    expect(mockSetErrorHandlerEnabled).toHaveBeenCalledWith(enabled);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards errorHandlingEnabled to native along with the rest of the config', () => {
+    const Observe = loadModule();
+    Observe.configure({ environment: 'test', errorHandlingEnabled: false });
+    expect(mockNative.configure).toHaveBeenCalledWith({
+      environment: 'test',
+      errorHandlingEnabled: false,
+    });
+  });
+
+  it('applies the latest errorHandlingEnabled on a repeat configure call', () => {
+    const Observe = loadModule();
+    Observe.configure({ errorHandlingEnabled: false });
+    Observe.configure({ errorHandlingEnabled: true });
+    expect(mockSetErrorHandlerEnabled).toHaveBeenNthCalledWith(1, false);
+    expect(mockSetErrorHandlerEnabled).toHaveBeenNthCalledWith(2, true);
   });
 
   it('skips initRouterIntegration by default', () => {

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -1,5 +1,5 @@
 import { requireNativeModule } from 'expo';
-import AppMetrics from 'expo-app-metrics';
+import AppMetrics, { setErrorHandlerEnabled } from 'expo-app-metrics';
 
 import { initRouterIntegration } from './integrations/expo-router/init';
 import { isRouterInstalled } from './integrations/expo-router/router';
@@ -14,6 +14,10 @@ const Observe: ObserveModule = new Proxy(native, {
   get(target, prop, receiver) {
     if (prop === 'configure') {
       return (config: ObserveConfig) => {
+        // The handler is already installed at this point (it installs on import), so this only
+        // toggles whether it records anything.
+        setErrorHandlerEnabled(config.errorHandlingEnabled ?? true);
+
         const routerEnabled = !!config.integrations?.['expo-router'];
         const reactNavigationEnabled = !!config.integrations?.['react-navigation'];
 

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -62,6 +62,20 @@ export type ObserveConfig = {
    */
   sampleRate?: number;
   /**
+   * Whether to record unhandled JavaScript errors as `exception` log events.
+   *
+   * When `false`, unhandled errors are no longer recorded. React Native's own handling is
+   * unaffected either way: the red box in development and fatal termination in production still
+   * happen. Errors you report yourself with `reportError`, and render-phase errors captured by
+   * `ObserveErrorBoundary`, are also unaffected.
+   *
+   * > Note: The handler is installed when the package is first imported, which is earlier than any
+   * > `configure` call. An error thrown before `configure` runs is therefore still recorded.
+   *
+   * @default true
+   */
+  errorHandlingEnabled?: boolean;
+  /**
    * Opt in to per-integration behavior.
    */
   integrations?: ObserveIntegrationsConfig;


### PR DESCRIPTION
# Why

We install the unhandled-JS-error handler as soon as `expo-app-metrics` is imported, and there was no way for an app to turn that off.

Closes ENG-21940.

# How

Added an `errorHandlingEnabled` option to `ObserveConfig`, defaulting to `true`.

It can't stop the handler from being installed (that happens on import, long before anyone calls `configure`), so it gates the reporting inside the handler instead. Errors thrown before `configure` runs still get recorded. Everything else is untouched: the red box, `reportError`, `ObserveErrorBoundary`, native crash reporting.

# Test Plan

New unit tests for the default, both explicit values, suppression, re-enabling, and that the previous handler still runs while reporting is off. `pnpm jest` passes in both packages (40 and 538), as do `typecheck`, `lint` and `format`.

They install a fake `ErrorUtils` though, so the real red box is worth a manual check in `apps/observe-tester` with the option off.