### PR TITLE
[docs] allow omitting agent instructions from markdown responses

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -164,6 +164,13 @@ Every published page is served in two formats: HTML for browsers, and markdown f
 curl -H "Accept: text/markdown" https://docs.expo.dev/get-started/set-up-your-environment/
 ```
 
+The generated markdown includes an `<AgentInstructions>` block by default. To omit it from a
+content-negotiated response, set `includeAgentInstructions=false`:
+
+```sh
+curl -H "Accept: text/markdown" "https://docs.expo.dev/get-started/set-up-your-environment/?includeAgentInstructions=false"
+```
+
 ### 3. Sibling `.md` URLs via `_redirects`
 
 Some agents prefer to append `.md` to a URL rather than negotiate via headers. Three rules at the bottom of `public/_redirects` handle that:

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,16 +164,19 @@ Every published page is served in two formats: HTML for browsers, and markdown f
 curl -H "Accept: text/markdown" https://docs.expo.dev/get-started/set-up-your-environment/
 ```
 
-The generated markdown includes an `<AgentInstructions>` block by default. To omit it from a
-content-negotiated response, set `includeAgentInstructions=false`:
+The generated markdown includes an `<AgentInstructions>` block by default. To omit it, set
+`includeAgentInstructions=false` on either a content-negotiated request or a direct `.md` URL:
 
 ```sh
 curl -H "Accept: text/markdown" "https://docs.expo.dev/get-started/set-up-your-environment/?includeAgentInstructions=false"
+curl "https://docs.expo.dev/get-started/set-up-your-environment/index.md?includeAgentInstructions=false"
 ```
 
-### 3. Sibling `.md` URLs via `_redirects`
+### 3. Direct `.md` URLs
 
-Some agents prefer to append `.md` to a URL rather than negotiate via headers. Three rules at the bottom of `public/_redirects` handle that:
+Some agents prefer to append `.md` to a URL rather than negotiate via headers. The worker resolves
+these requests to the generated `index.md` asset. Three equivalent fallback rules at the bottom of
+`public/_redirects` preserve this behavior in contexts where the worker is bypassed:
 
 ```
 /index.md /index.md 200
@@ -197,12 +200,12 @@ Every page renders a discovery link in `<head>`:
 
 A single page (for example, `/get-started/set-up-your-environment/`) is reachable as markdown four ways:
 
-| Request                                          | Served by                     |
-| ------------------------------------------------ | ----------------------------- |
-| `Accept: text/markdown` on the canonical URL     | `_worker.js`                  |
-| `/get-started/set-up-your-environment.md`        | `_redirects` sibling rule     |
-| `/get-started/set-up-your-environment/index.md`  | static asset (canonical path) |
-| Following `<link rel="alternate">` from the HTML | discovery hint                |
+| Request                                          | Served by      |
+| ------------------------------------------------ | -------------- |
+| `Accept: text/markdown` on the canonical URL     | `_worker.js`   |
+| `/get-started/set-up-your-environment.md`        | `_worker.js`   |
+| `/get-started/set-up-your-environment/index.md`  | `_worker.js`   |
+| Following `<link rel="alternate">` from the HTML | discovery hint |
 
 ## Search
 

--- a/docs/public/_routes.json
+++ b/docs/public/_routes.json
@@ -5,7 +5,6 @@
     "/_next/*",
     "/static/*",
     "/data/*",
-    "/*.md",
     "/*.txt",
     "/*.xml",
     "/*.ico",

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -11,6 +11,13 @@ function upgradeHelperPairPath(url) {
   return `/bare/upgrade/${from}-to-${to}/index.md`;
 }
 
+const AGENT_INSTRUCTIONS_BLOCK_REGEX =
+  /<AgentInstructions>[\S\s]*?<\/AgentInstructions>\n*/g;
+
+function stripAgentInstructions(markdown) {
+  return markdown.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, "");
+}
+
 export default {
   async fetch(request, env) {
     const accept = request.headers.get("Accept") || "";
@@ -36,7 +43,12 @@ export default {
 
         const contentType = mdResponse.headers.get("Content-Type") || "";
         if (mdResponse.ok && contentType.includes("text/markdown")) {
-          return new Response(mdResponse.body, {
+          const body =
+            url.searchParams.get("includeAgentInstructions") === "false"
+              ? stripAgentInstructions(await mdResponse.text())
+              : mdResponse.body;
+
+          return new Response(body, {
             status: 200,
             headers: {
               "Content-Type": "text/markdown; charset=utf-8",

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -18,10 +18,47 @@ function stripAgentInstructions(markdown) {
   return markdown.replace(AGENT_INSTRUCTIONS_BLOCK_REGEX, "");
 }
 
+function directMarkdownAssetPath(pathname) {
+  if (pathname === "/index.md" || pathname.endsWith("/index.md")) {
+    return pathname;
+  }
+  return pathname.replace(/\.md$/, "/index.md");
+}
+
+async function markdownResponse(mdResponse, excludeAgentInstructions) {
+  const body = excludeAgentInstructions
+    ? stripAgentInstructions(await mdResponse.text())
+    : mdResponse.body;
+
+  return new Response(body, {
+    status: mdResponse.status,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+    },
+  });
+}
+
 export default {
   async fetch(request, env) {
     const accept = request.headers.get("Accept") || "";
     const url = new URL(request.url);
+    const excludeAgentInstructions =
+      url.searchParams.get("includeAgentInstructions") === "false";
+
+    if (url.pathname.endsWith(".md")) {
+      url.pathname = directMarkdownAssetPath(url.pathname);
+      const mdResponse = await env.ASSETS.fetch(new Request(url, request));
+      const contentType = mdResponse.headers.get("Content-Type") || "";
+
+      if (mdResponse.ok && contentType.includes("text/markdown")) {
+        if (!excludeAgentInstructions) {
+          return mdResponse;
+        }
+        return markdownResponse(mdResponse, excludeAgentInstructions);
+      }
+      return mdResponse;
+    }
+
     const pairPath = upgradeHelperPairPath(url);
 
     const wantsMarkdown =
@@ -43,17 +80,7 @@ export default {
 
         const contentType = mdResponse.headers.get("Content-Type") || "";
         if (mdResponse.ok && contentType.includes("text/markdown")) {
-          const body =
-            url.searchParams.get("includeAgentInstructions") === "false"
-              ? stripAgentInstructions(await mdResponse.text())
-              : mdResponse.body;
-
-          return new Response(body, {
-            status: 200,
-            headers: {
-              "Content-Type": "text/markdown; charset=utf-8",
-            },
-          });
+          return markdownResponse(mdResponse, excludeAgentInstructions);
         }
       }
 

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -58,8 +58,7 @@ function setupTestDirectory(): void {
   fs.mkdirSync(`${TEST_DIR}/html-only-page`, { recursive: true });
   fs.mkdirSync(`${TEST_DIR}/bare/upgrade/52-to-57`, { recursive: true });
 
-  // Copy worker files, including the real _redirects: its /*.md wildcard
-  // rewrite shapes how .md URLs resolve, so tests must run against it
+  // Copy worker files and the real redirects so routing behavior matches deployment.
   const routesContent = fs.readFileSync('public/_routes.json', 'utf8');
   const workerContent = fs.readFileSync('public/_worker.js', 'utf8');
   const redirectsContent = fs.readFileSync('public/_redirects', 'utf8');
@@ -128,7 +127,7 @@ async function testHttpResponseAsync(): Promise<void> {
 }
 
 async function testDirectMarkdownAccessAsync(): Promise<void> {
-  console.log('\n--- Testing direct .md file access (bypasses worker) ---');
+  console.log('\n--- Testing direct .md file access ---');
 
   const response = await fetch(`${BASE_URL}/test-page/index.md`);
 
@@ -141,7 +140,34 @@ async function testDirectMarkdownAccessAsync(): Promise<void> {
   if (!body.includes('Test Markdown Content')) {
     throw new Error('Direct .md request did not return markdown content');
   }
+  if (!body.includes('<AgentInstructions>')) {
+    throw new Error('Direct .md request did not include agent instructions by default');
+  }
   console.log('✓ Direct .md file request serves content correctly');
+
+  const excludedResponse = await fetch(
+    `${BASE_URL}/test-page/index.md?includeAgentInstructions=false`
+  );
+  const excludedBody = await excludedResponse.text();
+
+  if (excludedBody.includes('<AgentInstructions>')) {
+    throw new Error('Direct index.md request did not omit agent instructions');
+  }
+  if (!excludedBody.includes('Test Markdown Content')) {
+    throw new Error('Direct index.md request did not preserve markdown content');
+  }
+  console.log('✓ Direct index.md request can omit agent instructions');
+
+  const siblingResponse = await fetch(`${BASE_URL}/test-page.md?includeAgentInstructions=false`);
+  const siblingBody = await siblingResponse.text();
+
+  if (siblingBody.includes('<AgentInstructions>')) {
+    throw new Error('Sibling .md request did not omit agent instructions');
+  }
+  if (!siblingBody.includes('Test Markdown Content')) {
+    throw new Error('Sibling .md request did not preserve markdown content');
+  }
+  console.log('✓ Sibling .md request can omit agent instructions');
 }
 
 async function testMarkdownContentNegotiationAsync(): Promise<void> {
@@ -279,7 +305,7 @@ async function testUpgradePairNegotiationAsync(): Promise<void> {
   }
   console.log('✓ Invalid version params fall back to default markdown');
 
-  // The /<slug>.md convention resolves pair pages via the _redirects wildcard
+  // The /<slug>.md convention resolves pair pages through the worker
   const slugUrl = await fetch(`${BASE_URL}/bare/upgrade/52-to-57.md`);
   const slugBody = await slugUrl.text();
 
@@ -288,9 +314,9 @@ async function testUpgradePairNegotiationAsync(): Promise<void> {
   }
   console.log('✓ Pair page resolves at the /<slug>.md convention');
 
-  // Known limit: .md paths bypass the worker (excluded in _routes.json) and
-  // _redirects cannot read query strings, so a pair query on the .md page
-  // path serves the default markdown, whose top note points at pair URLs.
+  // Known limit: a direct .md page path resolves to its default index.md asset,
+  // so version-pair query parameters do not select a pair-specific asset. The
+  // default markdown's top note points at pair URLs.
   const mdPathWithQuery = await fetch(`${BASE_URL}/bare/upgrade.md?fromSdk=52&toSdk=57`);
   const mdPathWithQueryBody = await mdPathWithQuery.text();
 
@@ -326,7 +352,7 @@ async function testUpgradePairNegotiationAsync(): Promise<void> {
   }
   console.log('✓ Regular /<slug>.md path serves markdown through the worker');
 
-  // The canonical index.md file path serves directly (bypassing the worker)
+  // The canonical index.md file path resolves through the worker
   const direct = await fetch(`${BASE_URL}/bare/upgrade/52-to-57/index.md`);
   const directBody = await direct.text();
 

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -74,7 +74,19 @@ function setupTestDirectory(): void {
   );
   fs.writeFileSync(
     `${TEST_DIR}/test-page/index.md`,
-    '# Test Markdown Content\n\nThis is test content.'
+    [
+      '<AgentInstructions>',
+      '',
+      '## Test agent instructions',
+      '',
+      'These instructions are included by default.',
+      '',
+      '</AgentInstructions>',
+      '',
+      '# Test Markdown Content',
+      '',
+      'This is test content.',
+    ].join('\n')
   );
   // Page with HTML but no .md — for fallback testing
   fs.writeFileSync(
@@ -161,6 +173,33 @@ async function testMarkdownContentNegotiationAsync(): Promise<void> {
     throw new Error(`Expected Content-Type text/markdown, got: ${mdContentType}`);
   }
   console.log('✓ Accept: text/markdown request returns correct Content-Type');
+}
+
+async function testAgentInstructionsParameterAsync(): Promise<void> {
+  console.log('\n--- Testing agent instructions query parameter ---');
+
+  const defaultResponse = await fetch(`${BASE_URL}/test-page`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  const defaultBody = await defaultResponse.text();
+
+  if (!defaultBody.includes('<AgentInstructions>')) {
+    throw new Error('Expected agent instructions to be included by default');
+  }
+  console.log('✓ Agent instructions are included by default');
+
+  const excludedResponse = await fetch(`${BASE_URL}/test-page?includeAgentInstructions=false`, {
+    headers: { Accept: 'text/markdown' },
+  });
+  const excludedBody = await excludedResponse.text();
+
+  if (excludedBody.includes('<AgentInstructions>')) {
+    throw new Error('Expected includeAgentInstructions=false to remove agent instructions');
+  }
+  if (!excludedBody.includes('Test Markdown Content')) {
+    throw new Error('Expected markdown content to remain after removing agent instructions');
+  }
+  console.log('✓ includeAgentInstructions=false removes only the agent instructions');
 }
 
 async function testMarkdownNotFoundAsync(): Promise<void> {
@@ -351,6 +390,7 @@ async function mainAsync(): Promise<void> {
     await testHttpResponseAsync();
     await testDirectMarkdownAccessAsync();
     await testMarkdownContentNegotiationAsync();
+    await testAgentInstructionsParameterAsync();
     await testMarkdownNotFoundAsync();
     await testUpgradePairNegotiationAsync();
     await testDeletedPageRedirectsAsync();


### PR DESCRIPTION
Adds a new url parameter `?includeAgentInstructions=false` when fetching markdown docs that will disable the agent instruction block. This is needed for the MCP server's search_documentation tool because Anthropic review did not allow prompt injection in the connector marktplace.