### PR TITLE
[filesystem][android] Encode the renamed URI

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `./next` subpath to package `exports` field to resolve Metro bundler warning. ([#44793](https://github.com/expo/expo/pull/44793) by [@chang-in](https://github.com/chang-in))
 - Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support. ([#47176](https://github.com/expo/expo/pull/47176) by [@barthap](https://github.com/barthap))
 - Fixed potential file offset races when asynchronous and synchronous `FileHandle` operations overlap on Android and iOS. ([#47945](https://github.com/expo/expo/pull/47945) by [@wh201906](https://github.com/wh201906))
+- [android] Fixed `rename()` storing an unencoded URI, so reading `.uri` afterwards threw for names containing a space. ([#48496](https://github.com/expo/expo/issues/48496) by [@yagiz2000](https://github.com/yagiz2000), [#48510](https://github.com/expo/expo/pull/48510) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -212,7 +212,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     val currentUri = uri.toString()
     val currentPath = currentUri.trimEnd('/')
     val parentUri = currentUri.substring(0, currentPath.lastIndexOf('/') + 1)
-    val renamedUri = Uri.withAppendedPath(Uri.parse(parentUri), newName).toString()
+    val renamedUri = Uri.parse(parentUri).buildUpon().appendPath(newName).build().toString()
     return Uri.parse(if (this is FileSystemDirectory) "$renamedUri/" else renamedUri)
   }
 

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -217,6 +217,48 @@ class FileSystemFileTest {
     assertTrue(source.exists())
   }
 
+  @Test
+  fun renameEncodesNameSoTheFileStaysReadableThroughItsUri() {
+    val parent = temporaryFolder.newFolder("rename-parent-with-space")
+    val source = File(parent, "source.pdf").apply {
+      writeText("content")
+    }
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(
+        permissionServiceReturning(
+          EnumSet.of(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE)
+        )
+      )
+
+    file.rename("My Report.pdf")
+
+    val renamed = File(parent, "My Report.pdf")
+    assertTrue(renamed.exists())
+    assertEquals(Uri.fromFile(renamed).toString(), file.uri.toString())
+    assertTrue(file.exists)
+  }
+
+  @Test
+  fun renameEncodesDirectoryNameAndKeepsTheTrailingSlash() {
+    val parent = temporaryFolder.newFolder("rename-dir-parent-with-space")
+    val source = File(parent, "source-dir").apply {
+      mkdir()
+    }
+    val directory = FileSystemDirectory(Uri.fromFile(source))
+      .withAppContext(
+        permissionServiceReturning(
+          EnumSet.of(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE)
+        )
+      )
+
+    directory.rename("My Folder")
+
+    val renamed = File(parent, "My Folder")
+    assertTrue(renamed.isDirectory)
+    assertEquals("${Uri.fromFile(renamed)}/", directory.uri.toString())
+    assertTrue(directory.exists)
+  }
+
   private fun createSymbolicLink(link: File, target: File) {
     Files.createSymbolicLink(link.toPath(), target.toPath())
   }


### PR DESCRIPTION




# Why

Fixes https://github.com/expo/expo/issues/48496

As shown in the above repro, when trying to read `file.uri` of a file name that includes spaces it throws below exception.

```
import { File, Paths } from "expo-file-system";

const file = new File(Paths.cache, "source.pdf");
file.create();

file.rename("My Report.pdf"); // succeeds — the file really does move on disk
console.log(file.uri);        // ← throws on Android, fine on iOS

// Exception
at java.net.URI.create(URI.java:848)
at expo.modules.filesystem.unifiedfile.JavaFile.<init>(JavaFile.kt:22)
at expo.modules.filesystem.FileSystemPath.getFile(FileSystemPath.kt:73)
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use [appendPath](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/net/Uri.java#1475) when renaming file which encodes the file name. The existing [withAppendedPath](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/net/Uri.java#2342) required already encoded string.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added test cases for user shared repro in `FileSystemFileTest.kt`.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
