### PR TITLE
[submit-expo-feedback] Add evals feedback category

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -73,6 +73,9 @@ describe('help output', () => {
       );
       expect(helpOutput).toContain('| eas-cli    | Full EAS CLI command, such as eas build');
       expect(helpOutput).toContain(
+        '| evals      | Expo package, command, or capability the task involves'
+      );
+      expect(helpOutput).toContain(
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
       expect(helpOutput).toContain('--resume <feedbackId>');

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -17,7 +17,15 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'evals', 'unknown'] as const;
+const FEEDBACK_CATEGORIES = [
+  'skills',
+  'expo-cli',
+  'eas-cli',
+  'mcp',
+  'docs',
+  'evals',
+  'unknown',
+] as const;
 
 type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
 

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -17,7 +17,7 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'unknown'] as const;
+const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'evals', 'unknown'] as const;
 
 type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
 
@@ -186,7 +186,12 @@ export async function resolveFeedbackAsync(
         name: 'category',
         message: 'What is your feedback about?',
         choices: FEEDBACK_CATEGORIES.map((value) => ({
-          title: value === 'unknown' ? 'Other / unknown' : value,
+          title:
+            value === 'unknown'
+              ? 'Other / unknown'
+              : value === 'evals'
+                ? 'evals (a task an AI agent failed at)'
+                : value,
           value,
         })),
       },
@@ -521,6 +526,7 @@ function printHelp(): void {
     | mcp        | Exact MCP tool name used                                          |
     | expo-cli   | Full Expo CLI command, such as npx expo install                   |
     | eas-cli    | Full EAS CLI command, such as eas build                           |
+    | evals      | Expo package, command, or capability the task involves            |
     | unknown    | Concise Expo product, package, feature, or topic, or leave empty  |
 `);
 }


### PR DESCRIPTION
# Why

The Expo skills now instruct AI agents to report Expo tasks that models repeatedly fail at as **eval candidates** (expo/skills#126) — structured leads the team turns into agent evals. Those submissions need a first-class `evals` category so they can be filtered and clustered downstream, but the category list is validated client-side in this CLI, so `--category evals` currently exits with `Invalid feedback category`. The feedback API itself accepts the new value without changes.

# How

- Added `evals` to `FEEDBACK_CATEGORIES` (before `unknown`).
- Added the subject guidance row to the `--help` table: the Expo package, command, or capability the failed task involves.
- Gave the interactive category picker a descriptive title for `evals`, matching the special-cased `unknown` entry.

# Test Plan

- Updated the help-output test to assert the new table row; the invalid-category error message picks up the new value automatically from the enum.
- Existing category resolution tests are unaffected (`evals` follows the same `resolveFeedbackCategory` path as the other values).