### PR TITLE
[sdk-57][submit-expo-feedback] Add evals feedback category

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -73,6 +73,9 @@ describe('help output', () => {
       );
       expect(helpOutput).toContain('| eas-cli    | Full EAS CLI command, such as eas build');
       expect(helpOutput).toContain(
+        '| evals      | Expo package, command, or capability the task involves'
+      );
+      expect(helpOutput).toContain(
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
       expect(helpOutput).toContain('--resume <feedbackId>');

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -17,7 +17,15 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'evals', 'unknown'] as const;
+const FEEDBACK_CATEGORIES = [
+  'skills',
+  'expo-cli',
+  'eas-cli',
+  'mcp',
+  'docs',
+  'evals',
+  'unknown',
+] as const;
 
 type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
 

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -17,7 +17,7 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'unknown'] as const;
+const FEEDBACK_CATEGORIES = ['skills', 'expo-cli', 'eas-cli', 'mcp', 'docs', 'evals', 'unknown'] as const;
 
 type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
 
@@ -186,7 +186,12 @@ export async function resolveFeedbackAsync(
         name: 'category',
         message: 'What is your feedback about?',
         choices: FEEDBACK_CATEGORIES.map((value) => ({
-          title: value === 'unknown' ? 'Other / unknown' : value,
+          title:
+            value === 'unknown'
+              ? 'Other / unknown'
+              : value === 'evals'
+                ? 'evals (a task an AI agent failed at)'
+                : value,
           value,
         })),
       },
@@ -521,6 +526,7 @@ function printHelp(): void {
     | mcp        | Exact MCP tool name used                                          |
     | expo-cli   | Full Expo CLI command, such as npx expo install                   |
     | eas-cli    | Full EAS CLI command, such as eas build                           |
+    | evals      | Expo package, command, or capability the task involves            |
     | unknown    | Concise Expo product, package, feature, or topic, or leave empty  |
 `);
 }


### PR DESCRIPTION
# Why

Cherry-pick of #48511 onto `sdk-57` so the `evals` feedback category ships with the next SDK release. The Expo skills (expo/skills#126) instruct AI agents to report Expo tasks that models repeatedly fail at as eval candidates using `--category evals`; the category enum is validated client-side in this CLI, so agents need a released CLI that accepts it.

# How

Clean cherry-pick of the two commits from #48511 (`1ab2fe4a` category + help table + interactive picker, `5ea05c31` formatting): adds `evals` to `FEEDBACK_CATEGORIES`, the `--help` subject-guidance row, and a descriptive interactive picker title.

# Test Plan

Help-output test updated to assert the new table row; the invalid-category error message picks up the value from the enum automatically.