### PR TITLE
[docs] Fix WCAG AA contrast for tertiary text

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -3,13 +3,18 @@
 
 @import './tailwind-compat.css';
 
-:root {
+/* Selectors are doubled to outrank the same-specificity declarations in
+   @expo/styleguide/dist/expo-theme.css, which _app.tsx imports after this file. */
+:root:root {
   /* AA contrast on palette blue3/blue4 backgrounds, where text-link falls short */
   --expo-theme-text-link-on-blue: #0c6bbf;
+  /* AA contrast: styleguide maps tertiary text to slate-10, a solid-background step */
+  --expo-theme-text-tertiary: #686c75;
 }
 
-.dark-theme {
+.dark-theme.dark-theme {
   --expo-theme-text-link-on-blue: var(--blue-11);
+  --expo-theme-text-tertiary: #888c94;
 }
 
 @layer base {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25642

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix WCAG AA contrast for tertiary text used in the sidebar progress indicator for tutorials.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run pnpm test and it should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
