### PR TITLE
[autolinking][Android] Don't hardcode default `cmakeListsPath` for pure C++ modules

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix autolinking pure C++ React Native modules published without `includesGeneratedCode: true`. ([#48514](https://github.com/expo/expo/pull/48514) by [@satya164](https://github.com/satya164))
 - [iOS] Only stub a source pod bundled inside a prebuilt XCFramework (e.g. `SDWebImage` in `ExpoImage.xcframework`) when one of its consumers also links the owning prebuilt pod. An app extension that depends on such a pod on its own now keeps building it from source instead of failing to link with undefined symbols. ([#47847](https://github.com/expo/expo/pull/47847) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fix a duplicate pod error (`multiple dependencies with different sources`) for precompiled modules in a Podfile with multiple targets. `prebuilt_react_active?` now mirrors React Native's default for `RCT_USE_PREBUILT_RNCORE` (prebuilt unless explicitly `0`), since `use_react_native!` only sets it after `use_expo_modules!` has run. ([#47329](https://github.com/expo/expo/pull/47329) by [@janicduplessis](https://github.com/janicduplessis))
 

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/androidResolver-test.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/__tests__/androidResolver-test.ts
@@ -117,7 +117,7 @@ public class TestPackage implements ReactPackage {
       expect(result).toMatchInlineSnapshot(`
       {
         "buildTypes": [],
-        "cmakeListsPath": "/app/node_modules/react-native-test/cpp/build/generated/source/codegen/jni/CMakeLists.txt",
+        "cmakeListsPath": null,
         "componentDescriptors": [],
         "cxxModuleCMakeListsModuleName": "TestMod",
         "cxxModuleCMakeListsPath": "/app/node_modules/react-native-test/cpp/CMakeLists.txt",
@@ -130,6 +130,24 @@ public class TestPackage implements ReactPackage {
     `);
     }
   );
+
+  itWithMemoize('should preserve a custom CMake path for a C++-only config', async () => {
+    vol.fromJSON({
+      '/app/node_modules/react-native-test/package.json': JSON.stringify({ version: '1.0.0' }),
+    });
+    const result = await resolveDependencyConfigImplAndroidAsync(
+      '/app/node_modules/react-native-test',
+      {
+        cmakeListsPath: 'generated/jni/CMakeLists.txt',
+        cxxModuleCMakeListsModuleName: 'TestMod',
+        cxxModuleCMakeListsPath: 'CMakeLists.txt',
+        cxxModuleHeaderName: 'TestModSpec',
+      }
+    );
+    expect(result?.cmakeListsPath).toBe(
+      '/app/node_modules/react-native-test/android/generated/jni/CMakeLists.txt'
+    );
+  });
 
   itWithMemoize(
     'should not misdetect an Expo module as a C++-only React Native module',

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
@@ -72,14 +72,18 @@ export async function resolveDependencyConfigImplAndroidAsync(
     (await parseComponentDescriptorsAsync(packageRoot, packageJson));
   let cmakeListsPath = reactNativeConfig?.cmakeListsPath
     ? path.join(androidDir, reactNativeConfig?.cmakeListsPath)
-    : path.join(androidDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
+    : isPureCxxDependency
+      ? null
+      : path.join(androidDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
   const cxxModuleCMakeListsModuleName = reactNativeConfig?.cxxModuleCMakeListsModuleName || null;
   const cxxModuleHeaderName = reactNativeConfig?.cxxModuleHeaderName || null;
   let cxxModuleCMakeListsPath = reactNativeConfig?.cxxModuleCMakeListsPath
     ? path.join(androidDir, reactNativeConfig?.cxxModuleCMakeListsPath)
     : null;
   if (process.platform === 'win32') {
-    cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
+    if (cmakeListsPath) {
+      cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
+    }
     if (cxxModuleCMakeListsPath) {
       cxxModuleCMakeListsPath = cxxModuleCMakeListsPath.replace(/\\/g, '/');
     }

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
@@ -81,7 +81,9 @@ export async function resolveDependencyConfigImplAndroidAsync(
     ? path.join(androidDir, reactNativeConfig?.cxxModuleCMakeListsPath)
     : null;
   if (process.platform === 'win32') {
-    cmakeListsPath = cmakeListsPath?.replace(/\\/g, '/');
+    if (cmakeListsPath) {
+      cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
+    }
     if (cxxModuleCMakeListsPath) {
       cxxModuleCMakeListsPath = cxxModuleCMakeListsPath.replace(/\\/g, '/');
     }

--- a/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
+++ b/packages/expo-modules-autolinking/src/reactNativeConfig/androidResolver.ts
@@ -81,9 +81,7 @@ export async function resolveDependencyConfigImplAndroidAsync(
     ? path.join(androidDir, reactNativeConfig?.cxxModuleCMakeListsPath)
     : null;
   if (process.platform === 'win32') {
-    if (cmakeListsPath) {
-      cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
-    }
+    cmakeListsPath = cmakeListsPath?.replace(/\\/g, '/');
     if (cxxModuleCMakeListsPath) {
       cxxModuleCMakeListsPath = cxxModuleCMakeListsPath.replace(/\\/g, '/');
     }


### PR DESCRIPTION
# Why

Currently, the `cmakeListsPath` path is always defaulted to a generated file path in the library. This breaks autolinking when a C++ library doesn't ship with prebuilt codegen files (with `includesGeneratedCode: false`).

# How

This removes the incorrect default `cmakeListsPath` from android autolinking for pure C++ modules.

Mirrors the same change in Community CLI: https://github.com/react-native-community/cli/pull/2799

Related fix in react-native: https://github.com/react/react-native/pull/56938

# Test Plan

TODO

<img width="1080" height="2340" alt="60741" src="https://github.com/user-attachments/assets/157dbf44-5714-445a-967f-d1f4d8906ddc" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
