### PR TITLE
[expo][fetch] Trim comments verbosity + fix changelog entries

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,9 +10,10 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))
+- Fix `expo/fetch` body-stream teardown races: aborting via an `AbortSignal` now rejects the in-flight read with an `AbortError` instead of hanging forever, and late native events no longer throw `The stream is not in a state that permits enqueue`/`close` from outside any consumer `try`/`catch`. ([#47573](https://github.com/expo/expo/pull/47573) by [@idoyana](https://github.com/idoyana))
 - [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered. ([#48230](https://github.com/expo/expo/pull/48230) by [@zoontek](https://github.com/zoontek))
 - Fix iOS build against React Native 0.87+ by dropping the legacy architecture (bridge) `RCTRootViewFactoryConfiguration` setup. ([#46641](https://github.com/expo/expo/pull/46641) by [@zoontek](https://github.com/zoontek))
-- Fix `expo/fetch` body-stream teardown races: aborting via an `AbortSignal` now rejects the in-flight read with an `AbortError` instead of hanging forever, and late native events no longer throw `The stream is not in a state that permits enqueue`/`close` from outside any consumer `try`/`catch`. ([#47573](https://github.com/expo/expo/pull/47573) by [@idoyana](https://github.com/idoyana))
 - Adopted the UIKit scene-based life cycle on iOS so apps built with the iOS 27 SDK launch correctly. ([#46733](https://github.com/expo/expo/pull/46733) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in extensions. ([#46799](https://github.com/expo/expo/pull/46799) by [@jakex7](https://github.com/jakex7))
 - [iOS] Fix `Linking.getInitialURL()` returning `null` and deep links being dropped when a URL cold-starts an app on the UIKit scene life cycle. ([#47628](https://github.com/expo/expo/pull/47628) by [@tsapeta](https://github.com/tsapeta))
@@ -22,7 +23,6 @@
 
 ### 💡 Others
 
-- [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))
 - [Android] `ExpoReactHostFactory` now passes host handlers' `DevSupportManagerFactory` to `ReactHostImpl`. ([#47637](https://github.com/expo/expo/pull/47637) by [@alanjhughes](https://github.com/alanjhughes))
 - [macOS] Fix build by guarding the `bundleConfiguration` override, which requires react-native 0.84+. ([#48494](https://github.com/expo/expo/pull/48494) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - Restore RCTHostRuntimeDelegate conformance for react-native-macos ([#46420](https://github.com/expo/expo/pull/46420) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -129,14 +129,8 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
 
   // MARK: - ExpoURLSessionTaskDelegate implementations
 
-  // URLSession invokes these callbacks on its own serial delegate queue while
-  // `startStreaming`/`cancelStreaming` run on `dispatchQueue`. `state` and the
-  // sink are unsynchronized, so routing a chunk could race a concurrent state
-  // transition: the chunk lands in an already-finalized sink, or `didComplete`
-  // overtakes the flushed data and the stream closes empty even though the
-  // request succeeded. Hopping every callback onto `dispatchQueue` — where the
-  // JS-driven methods already run — serializes the whole state machine on one
-  // queue.
+  // URLSession runs these callbacks on its own queue, racing `state` / sink access on `dispatchQueue`.
+  // Hop every callback onto `dispatchQueue` to serialize the whole state machine on one queue.
 
   func urlSessionDidStart(_ session: ExpoURLSessionTask) {
     dispatchQueue.async { [weak self] in

--- a/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
@@ -139,12 +139,9 @@ describe('FetchResponse', () => {
   });
 
   describe('abort()', () => {
-    // The existing guards above cover cancellation via the JS stream
-    // (reader.cancel()). abort() covers cancellation via an AbortSignal, which
-    // fetch() routes to a native request.cancel() that never reaches the JS
-    // controller — leaving the in-flight read hung and any late
-    // didReceiveResponseData enqueued onto an abandoned controller
-    // (expo/expo#34804 / #33549 / #33553).
+    // abort() covers cancellation via an AbortSignal: fetch() routes it to a native
+    // request.cancel() that never reaches the JS controller, leaving the in-flight
+    // read hung (expo/expo#34804 / #33549 / #33553).
 
     it('rejects the in-flight body read with an AbortError', async () => {
       const response = makeResponse();
@@ -198,29 +195,28 @@ describe('FetchResponse', () => {
   });
 
   describe('internally errored stream (rejected pull)', () => {
-    // When pull() rejects (a failed native startStreaming call), the streams
-    // implementation errors the stream through its internal error routine —
-    // controller.error() is never called, so bodyStreamClosed is never set
-    // and the guard goes stale. Native events landing after that used to call
-    // close()/enqueue() on an errored stream and throw ("The stream is not in
-    // a state that permits close") out of the event listener, where no
-    // consumer try/catch can reach.
+    // When pull() rejects, the streams implementation errors the stream internally
+    // without calling controller.error(), so the bodyStreamClosed guard goes stale.
+    // Native events landing after that used to throw on the errored stream.
 
     it('surfaces the underlying error to the reader', async () => {
       const response = makeResponse();
+
       (response as any).startStreaming = async () => {
         throw new Error('native module call failed');
       };
-      const reader = response.body!.getReader();
 
+      const reader = response.body!.getReader();
       await expect(reader.read()).rejects.toThrow('native module call failed');
     });
 
     it('does not throw on native events that arrive after pull() rejected', async () => {
       const response = makeResponse();
+
       (response as any).startStreaming = async () => {
         throw new Error('native module call failed');
       };
+
       const reader = response.body!.getReader();
       await expect(reader.read()).rejects.toThrow('native module call failed');
 


### PR DESCRIPTION
# Why

Both https://github.com/expo/expo/pull/47796 and https://github.com/expo/expo/pull/47573 have been written with LLMs, without human sanitization. This resulted in extremely verbose comments.

This PR fixes this. It also moves the changelog entry into the correct category (Bug fixes)

# How

- Reduce the comment length, so a human reader can read it quickly
- Move the changelog entry to the appropriate section

# Test Plan

- Nothing to test here

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
