### PR TITLE
[app-metrics] Attach network connection quality to metrics

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. Replaces `expo.network.requests.slowestDuration` and `expo.network.requests.slowestHost`, which the group's `duration` and `host` supersede. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. Replaces `expo.network.requests.slowestDuration` and `expo.network.requests.slowestHost`, which the group's `duration` and `host` supersede. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `slowestTimeToFirstByte` and `throughputBytesPerSecond` on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `slowestTimeToFirstByte`, `throughputBytesPerSecond` and `fastestTcpHandshake` on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `slowestTimeToFirstByte` and `throughputBytesPerSecond` on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. Replaces `expo.network.requests.slowestDuration` and `expo.network.requests.slowestHost`, which the group's `duration` and `host` supersede. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `slowestTimeToFirstByte`, `throughputBytesPerSecond` and `fastestTcpHandshake` on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `timedOut`, `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
-- Attach network connection quality to metrics: `expo.network.isExpensive`, `expo.network.isConstrained` (iOS) and `expo.network.dataSaverEnabled` (Android), plus `throughputBytesPerSecond` and a `slowest.*` group (`host`, `duration`, `statusCode`, `timeToFirstByte`, `bytesReceived`) describing the slowest completed request on the `expo.network.requests.*` summary. Replaces `expo.network.requests.slowestDuration` and `expo.network.requests.slowestHost`, which the group's `duration` and `host` supersede. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -32,7 +32,11 @@ data class NetworkRequest(
   /** Number of bytes sent on the wire for the request (headers + body). */
   val requestBytesSent: Long?,
 
-  /** Number of bytes received on the wire for the response (headers + body). */
+  /**
+   * Number of bytes received on the wire for the response (headers + body), or `null` when the
+   * size wasn't reported: the request failed before a response, or the caller abandoned the body
+   * of a response that declared no `Content-Length`. Zero means a genuinely empty body.
+   */
   val responseBytesReceived: Long?,
 
   /** Phase-by-phase timings, populated from OkHttp `EventListener` callbacks where available. */

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -89,6 +89,17 @@ data class NetworkRequest(
     val responseEnd: Date?,
 
     /**
+     * When the last response byte arrived, or `null` if the listener never reported one.
+     *
+     * Unlike `responseEnd`, this is never synthesized. `responseEnd` falls back to a wall-clock
+     * timestamp taken when the snapshot was recorded, which is right for a duration but wrong for a
+     * transfer window: a request that got headers and then died reports an end long after its last
+     * byte, and dividing its bytes by that window describes the recording delay rather than the
+     * connection.
+     */
+    val measuredResponseEnd: Date?,
+
+    /**
      * Total wall-clock duration of the request in seconds. Convenience: callers don't have to
      * subtract `fetchStart` from `responseEnd` themselves, and we can populate this even when
      * individual phases are `null` (cache hits, errors before headers).

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -49,7 +49,17 @@ data class NetworkRequest(
    * directly. Each entry's `fromUrl` is the URL that returned the redirect, `toUrl` is where the
    * redirect pointed, and `statusCode` is the 3xx code that caused the hop.
    */
-  val redirects: List<Redirect>
+  val redirects: List<Redirect>,
+
+  /**
+   * Whether the request failed because the network stalled or went away, as opposed to reaching
+   * the server and getting an error back.
+   *
+   * Classified at capture time from the thrown exception, because `errorDescription` is a localized
+   * string and can't be matched on afterwards. A 5xx response is a failure but not a timeout: the
+   * server answered.
+   */
+  val isTimeout: Boolean = false
 ) {
   data class Redirect(
     /** The URL that returned the redirect. */
@@ -90,7 +100,49 @@ data class NetworkRequest(
      * individual phases are `null` (cache hits, errors before headers).
      */
     val totalDuration: Double
-  )
+  ) {
+    /**
+     * Time from the start of the fetch until the first response byte arrived, in seconds.
+     *
+     * This is not a measurement of network latency: it also covers DNS, the TCP and TLS handshakes,
+     * sending the request, and the server's own processing time. A slow backend inflates it the same
+     * way a slow network does. On a reused connection (the common case under keep-alive) the
+     * handshakes are already done, so it sits much closer to one round trip plus server time.
+     *
+     * `null` when the response never produced headers, so callers can tell "not measured" from a
+     * genuinely fast response.
+     */
+    val timeToFirstByte: Double?
+      get() = positiveInterval(fetchStart, responseStart)
+
+    /**
+     * Duration of the TCP handshake in seconds, which is roughly one network round trip and
+     * therefore the closest thing here to pure network latency.
+     *
+     * Ends at `secureConnectionStart` when TLS ran, so the value covers only the TCP handshake and
+     * not the TLS exchange layered on top of it. Falls back to `connectEnd` for cleartext
+     * connections, where no TLS phase exists.
+     *
+     * `null` when the connection was reused, which means "no new connection was opened", not "zero
+     * latency". Under keep-alive most requests report nothing here.
+     */
+    val tcpHandshakeDuration: Double?
+      get() = positiveInterval(connectStart, secureConnectionStart ?: connectEnd)
+
+    /**
+     * Returns the interval between two nullable timestamps in seconds, or `null` if either is
+     * missing or the result is negative. These are wall-clock dates, so a clock adjustment
+     * mid-request can invert them; a negative duration is meaningless and would poison a min/max
+     * fold.
+     */
+    private fun positiveInterval(start: Date?, end: Date?): Double? {
+      if (start == null || end == null) {
+        return null
+      }
+      val seconds = (end.time - start.time) / 1000.0
+      return if (seconds >= 0) seconds else null
+    }
+  }
 }
 
 /**

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -53,17 +53,7 @@ data class NetworkRequest(
    * directly. Each entry's `fromUrl` is the URL that returned the redirect, `toUrl` is where the
    * redirect pointed, and `statusCode` is the 3xx code that caused the hop.
    */
-  val redirects: List<Redirect>,
-
-  /**
-   * Whether the request failed because the network stalled or went away, as opposed to reaching
-   * the server and getting an error back.
-   *
-   * Classified at capture time from the thrown exception, because `errorDescription` is a localized
-   * string and can't be matched on afterwards. A 5xx response is a failure but not a timeout: the
-   * server answered.
-   */
-  val isTimeout: Boolean = false
+  val redirects: List<Redirect>
 ) {
   data class Redirect(
     /** The URL that returned the redirect. */

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -116,31 +116,19 @@ data class NetworkRequest(
       get() = positiveInterval(fetchStart, responseStart)
 
     /**
-     * Duration of the TCP handshake in seconds, which is roughly one network round trip and
-     * therefore the closest thing here to pure network latency.
-     *
-     * Ends at `secureConnectionStart` when TLS ran, so the value covers only the TCP handshake and
-     * not the TLS exchange layered on top of it. Falls back to `connectEnd` for cleartext
-     * connections, where no TLS phase exists.
-     *
-     * `null` when the connection was reused, which means "no new connection was opened", not "zero
-     * latency". Under keep-alive most requests report nothing here.
-     */
-    val tcpHandshakeDuration: Double?
-      get() = positiveInterval(connectStart, secureConnectionStart ?: connectEnd)
-
-    /**
      * Returns the interval between two nullable timestamps in seconds, or `null` if either is
-     * missing or the result is negative. These are wall-clock dates, so a clock adjustment
-     * mid-request can invert them; a negative duration is meaningless and would poison a min/max
-     * fold.
+     * missing or the result isn't strictly positive.
+     *
+     * Negative results are discarded because these are wall-clock dates and a clock adjustment
+     * mid-request can invert them. Exactly zero is discarded too: a phase that completes inside one
+     * clock tick was too fast to measure, and reporting `0` would claim it took no time at all.
      */
     private fun positiveInterval(start: Date?, end: Date?): Double? {
       if (start == null || end == null) {
         return null
       }
       val seconds = (end.time - start.time) / 1000.0
-      return if (seconds >= 0) seconds else null
+      return if (seconds > 0) seconds else null
     }
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -96,6 +96,10 @@ data class NetworkRequest(
      * transfer window: a request that got headers and then died reports an end long after its last
      * byte, and dividing its bytes by that window describes the recording delay rather than the
      * connection.
+     *
+     * Also what keeps cache hits out of the throughput ratio: OkHttp skips the response-body
+     * callbacks for a cached response, so this stays `null` and the request drops out. iOS needs an
+     * explicit flag for that, since `URLSession` timestamps a cache hit like any other response.
      */
     val measuredResponseEnd: Date?,
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -244,6 +244,11 @@ internal fun buildSnapshot(
     totalDuration = totalDuration
   )
 
+  // The interceptor only sees failures raised while `chain.proceed` runs. A response body that
+  // breaks after the headers arrive is reported to the event listener instead, and without folding
+  // that in here a truncated transfer would be recorded as the successful response it started as.
+  val failure = error ?: phases?.failure
+
   return NetworkRequest(
     id = id,
     url = originalRequest.url.toString(),
@@ -253,9 +258,9 @@ internal fun buildSnapshot(
     requestBytesSent = requestBytesSent,
     responseBytesReceived = responseBytesReceived,
     timings = timings,
-    errorDescription = error?.localizedMessage ?: error?.message,
+    errorDescription = failure?.localizedMessage ?: failure?.message,
     redirects = redirects,
-    isTimeout = error.isNetworkTimeout
+    isTimeout = failure.isNetworkTimeout
   )
 }
 
@@ -409,6 +414,9 @@ class NetworkRequestEventListener : EventListener() {
   }
 
   override fun callFailed(call: Call, ioe: IOException) {
+    // The interceptor's own `catch` only wraps `chain.proceed`, so a body that breaks after the
+    // headers arrive never reaches it. This is the only place that failure is reported.
+    builder.failure = ioe
     publish(call)
   }
 
@@ -442,7 +450,8 @@ class NetworkRequestEventListener : EventListener() {
     @Volatile var responseHeadersEnd: Date? = null,
     @Volatile var responseBodyEnd: Date? = null,
     @Volatile var requestBodyBytes: Long? = null,
-    @Volatile var responseBodyBytes: Long? = null
+    @Volatile var responseBodyBytes: Long? = null,
+    @Volatile var failure: IOException? = null
   ) {
     fun snapshot() = PhaseTimings(
       fetchStart, dnsStart, dnsEnd,
@@ -452,7 +461,8 @@ class NetworkRequestEventListener : EventListener() {
       requestBodyStart, requestBodyEnd,
       responseHeadersStart, responseHeadersEnd,
       responseBodyEnd,
-      requestBodyBytes, responseBodyBytes
+      requestBodyBytes, responseBodyBytes,
+      failure
     )
   }
 
@@ -466,6 +476,10 @@ class NetworkRequestEventListener : EventListener() {
    * `GzipSource`. They report the bytes actually on the wire, not the (gunzipped, app-layer)
    * view that the interceptor sees. `null` means the corresponding body-end callback never
    * fired (no request body / response not fully consumed / error before headers).
+   *
+   * `failure` carries the exception from `callFailed`. The interceptor's own `catch` only wraps
+   * `chain.proceed`, so a response body that breaks after the headers arrive is reported here and
+   * nowhere else.
    */
   data class PhaseTimings(
     val fetchStart: Date?,
@@ -483,7 +497,8 @@ class NetworkRequestEventListener : EventListener() {
     val responseHeadersEnd: Date?,
     val responseBodyEnd: Date?,
     val requestBodyBytes: Long?,
-    val responseBodyBytes: Long?
+    val responseBodyBytes: Long?,
+    val failure: IOException? = null
   )
 
   companion object {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -20,6 +20,7 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.util.Date
@@ -284,17 +285,30 @@ private fun Response.responseBodyByteCount(
  * Whether an OkHttp failure means the network stalled or went away, rather than the server
  * answering with something we didn't like.
  *
- * `SocketTimeoutException` covers OkHttp's connect/read/write timeouts. `UnknownHostException` is
- * included because DNS failing is what losing connectivity looks like from here, though it's an
- * imperfect signal: a typo'd endpoint, a dead CDN domain, or a removed DNS record produce the same
- * exception, and a misconfigured host recurs on every launch rather than averaging out. A
- * persistently high timeout count can therefore mean a broken hostname rather than a bad connection.
+ * Three conditions count, and `isNetworkTimeout` in `NetworkRequest.swift` matches the same three
+ * so the `timedOut` metric describes one population on both platforms:
+ *
+ * - The request stalled until the client gave up (`SocketTimeoutException`, which covers OkHttp's
+ *   connect, read and write timeouts).
+ * - The connection dropped mid-request (`SocketException`, which covers a reset or a truncated
+ *   stream).
+ * - The device couldn't reach the network at all (`UnknownHostException`). DNS failing is what
+ *   losing connectivity looks like from here, though it's an imperfect signal: a typo'd endpoint, a
+ *   dead CDN domain, or a removed DNS record produce the same exception, and a misconfigured host
+ *   recurs on every launch rather than averaging out. A persistently high timeout count can
+ *   therefore mean a broken hostname rather than a bad connection.
+ *
+ * `SSLException` is deliberately absent. A failed handshake is a certificate or trust problem
+ * rather than an absent network, and counting it here would also break parity, since no iOS TLS
+ * error maps to this flag.
  *
  * A deliberate `Call.cancel()` surfaces as a plain `IOException` and is not counted: the app
  * abandoned the request, which says nothing about the connection.
  */
 private val IOException?.isNetworkTimeout: Boolean
-  get() = this is SocketTimeoutException || this is UnknownHostException
+  get() = this is SocketTimeoutException ||
+    this is UnknownHostException ||
+    this is SocketException
 
 /**
  * Walks `Response.priorResponse()` chronologically and emits one `Redirect` per hop. The chain

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -285,7 +285,6 @@ private fun Response.responseBodyByteCount(
   return body?.contentLength()?.takeIf { it >= 0 }
 }
 
-
 /**
  * Walks `Response.priorResponse()` chronologically and emits one `Redirect` per hop. The chain
  * is naturally redirect-only — OkHttp doesn't surface intermediate protocol upgrades through

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -20,9 +20,6 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
-import java.net.SocketException
-import java.net.SocketTimeoutException
-import java.net.UnknownHostException
 import java.util.Date
 import java.util.UUID
 import java.util.WeakHashMap
@@ -258,9 +255,10 @@ internal fun buildSnapshot(
     requestBytesSent = requestBytesSent,
     responseBytesReceived = responseBytesReceived,
     timings = timings,
-    errorDescription = failure?.localizedMessage ?: failure?.message,
-    redirects = redirects,
-    isTimeout = failure.isNetworkTimeout
+    // Falls back to the class name because an exception is allowed to carry no message at all, and
+    // a null description would read as "this request succeeded" to `isFailed`.
+    errorDescription = failure?.let { it.localizedMessage ?: it.message ?: it.javaClass.simpleName },
+    redirects = redirects
   )
 }
 
@@ -286,34 +284,6 @@ private fun Response.responseBodyByteCount(
   return body?.contentLength()?.takeIf { it >= 0 }
 }
 
-/**
- * Whether an OkHttp failure means the network stalled or went away, rather than the server
- * answering with something we didn't like.
- *
- * Three conditions count, and `isNetworkTimeout` in `NetworkRequest.swift` matches the same three
- * so the `timedOut` metric describes one population on both platforms:
- *
- * - The request stalled until the client gave up (`SocketTimeoutException`, which covers OkHttp's
- *   connect, read and write timeouts).
- * - The connection dropped mid-request (`SocketException`, which covers a reset or a truncated
- *   stream).
- * - The device couldn't reach the network at all (`UnknownHostException`). DNS failing is what
- *   losing connectivity looks like from here, though it's an imperfect signal: a typo'd endpoint, a
- *   dead CDN domain, or a removed DNS record produce the same exception, and a misconfigured host
- *   recurs on every launch rather than averaging out. A persistently high timeout count can
- *   therefore mean a broken hostname rather than a bad connection.
- *
- * `SSLException` is deliberately absent. A failed handshake is a certificate or trust problem
- * rather than an absent network, and counting it here would also break parity, since no iOS TLS
- * error maps to this flag.
- *
- * A deliberate `Call.cancel()` surfaces as a plain `IOException` and is not counted: the app
- * abandoned the request, which says nothing about the connection.
- */
-private val IOException?.isNetworkTimeout: Boolean
-  get() = this is SocketTimeoutException ||
-    this is UnknownHostException ||
-    this is SocketException
 
 /**
  * Walks `Response.priorResponse()` chronologically and emits one `Redirect` per hop. The chain

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -218,11 +218,14 @@ internal fun buildSnapshot(
   } else {
     null
   }
-  val responseBytesReceived: Long? = response?.let {
-    val body = phases?.responseBodyBytes?.takeIf { it > 0 }
-      ?: it.body?.contentLength()?.takeIf { it > 0 }
-      ?: 0L
-    responseHeaderBytes + body
+  val responseBytesReceived: Long? = response?.let { received ->
+    val body = received.responseBodyByteCount(phases)
+    // `null` means the body size is genuinely unknown, so the whole count is unknown rather than
+    // the header estimate alone. Reporting headers-only would look like a measured near-empty
+    // response: it understates byte totals, and it still passes the `> 0` filter that decides
+    // which requests form the throughput ratio, so an unmeasured body would drag the denominator
+    // out with no bytes to match.
+    body?.let { responseHeaderBytes + it }
   }
 
   val timings = NetworkRequest.Timings(
@@ -253,6 +256,28 @@ internal fun buildSnapshot(
     redirects = redirects,
     isTimeout = error.isNetworkTimeout
   )
+}
+
+/**
+ * On-the-wire size of the response body, or `null` when it can't be determined.
+ *
+ * `EventListener.responseBodyEnd` is the source of truth: it fires on the network layer, below
+ * `GzipSource`, so it reports compressed bytes. It only fires once the caller drains the body,
+ * which a caller that abandons the response never does. `Content-Length` is the fallback for that
+ * case, and it's absent on a chunked response, which is how image and other streamed payloads
+ * usually arrive.
+ *
+ * Zero is a real measurement (a 204, or a 304 revalidation) and is reported as such. `null` is
+ * reserved for "nobody told us", so callers can tell an empty body from an unmeasured one.
+ */
+private fun Response.responseBodyByteCount(
+  phases: NetworkRequestEventListener.PhaseTimings?
+): Long? {
+  phases?.responseBodyBytes?.let {
+    return it
+  }
+  // `contentLength()` returns -1 when the header is absent, which is not a measurement.
+  return body?.contentLength()?.takeIf { it >= 0 }
 }
 
 /**

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -20,6 +20,8 @@ import java.io.IOException
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 import java.util.Date
 import java.util.UUID
 import java.util.WeakHashMap
@@ -248,9 +250,26 @@ internal fun buildSnapshot(
     responseBytesReceived = responseBytesReceived,
     timings = timings,
     errorDescription = error?.localizedMessage ?: error?.message,
-    redirects = redirects
+    redirects = redirects,
+    isTimeout = error.isNetworkTimeout
   )
 }
+
+/**
+ * Whether an OkHttp failure means the network stalled or went away, rather than the server
+ * answering with something we didn't like.
+ *
+ * `SocketTimeoutException` covers OkHttp's connect/read/write timeouts. `UnknownHostException` is
+ * included because DNS failing is what losing connectivity looks like from here, though it's an
+ * imperfect signal: a typo'd endpoint, a dead CDN domain, or a removed DNS record produce the same
+ * exception, and a misconfigured host recurs on every launch rather than averaging out. A
+ * persistently high timeout count can therefore mean a broken hostname rather than a bad connection.
+ *
+ * A deliberate `Call.cancel()` surfaces as a plain `IOException` and is not counted: the app
+ * abandoned the request, which says nothing about the connection.
+ */
+private val IOException?.isNetworkTimeout: Boolean
+  get() = this is SocketTimeoutException || this is UnknownHostException
 
 /**
  * Walks `Response.priorResponse()` chronologically and emits one `Redirect` per hop. The chain

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -238,6 +238,7 @@ internal fun buildSnapshot(
     requestEnd = phases?.requestBodyEnd ?: phases?.requestHeadersEnd,
     responseStart = phases?.responseHeadersStart,
     responseEnd = phases?.responseBodyEnd ?: phases?.responseHeadersEnd ?: fallbackEnd,
+    measuredResponseEnd = phases?.responseBodyEnd,
     totalDuration = totalDuration
   )
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -74,8 +74,10 @@ data class NetworkRequestSummary(
    * never reports one, so the bytes it contributes can't be divided by the milliseconds it took to
    * read them.
    *
-   * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
-   * interval covers it. `failed` is the signal for that case.
+   * Two cases it still can't see. A stall between requests: if the radio dies while nothing is in
+   * flight, no interval covers it, and `failed` is the signal instead. And a long-lived response
+   * that trickles, such as a server-sent event stream, whose window stays open across time when
+   * almost nothing is moving and drags the rate down for everything overlapping it.
    *
    * Being a ratio, it also degrades differently from the counts when the monitor's ring buffer evicts
    * the earliest requests in a window: both sides shrink together, so the value stays plausible while
@@ -216,11 +218,17 @@ data class NetworkRequestSummary(
      * stalled until the client gave up reports a window covering the whole stall, so it would hold
      * the denominator open across time when nothing was moving and report a connection far slower than
      * the one that served the requests around it.
+     *
+     * A transfer faster than a millisecond drops out, because `Date()` advances in whole
+     * milliseconds and can't describe it. iOS applies the same floor deliberately rather than
+     * dividing by the sub-millisecond windows its transaction metrics can resolve, so the two
+     * platforms agree on when the rate is unknown instead of Android quietly reporting only its
+     * slower transfers.
      */
     private fun measurableReceiving(requests: List<NetworkRequest>): List<NetworkRequest> {
       return requests.filter { request ->
         val start = request.timings.responseStart
-        val end = request.timings.responseEnd
+        val end = request.timings.measuredResponseEnd
         !request.isFailed && (request.responseBytesReceived ?: 0) > 0 && start != null &&
           end != null && end.time > start.time
       }
@@ -242,7 +250,7 @@ data class NetworkRequestSummary(
       val intervals = requests
         .mapNotNull { request ->
           val start = request.timings.responseStart ?: return@mapNotNull null
-          val end = request.timings.responseEnd ?: return@mapNotNull null
+          val end = request.timings.measuredResponseEnd ?: return@mapNotNull null
           if (end.time > start.time) start.time to end.time else null
         }
         .sortedBy { it.first }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -71,9 +71,9 @@ data class NetworkRequestSummary(
    *   parallel one-second requests would otherwise report a quarter of the real rate.
    * - The busy span rather than the whole window, so idle time isn't charged to the network. A
    *   launch that fetches briefly and then sits idle would otherwise look slow.
-   * - Only requests that received bytes, so a slow request returning nothing can't stretch the
-   *   denominator across time when no payload was in flight. Its latency belongs to
-   *   `slowest.timeToFirstByte`, not here.
+   * - Only requests that completed and received bytes, so neither a slow request returning nothing
+   *   nor one that stalled until the client gave up can stretch the denominator across time when no
+   *   payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
    * interval covers it. `timedOut` is the signal for that case.
@@ -210,20 +210,25 @@ data class NetworkRequestSummary(
     }
 
     /**
-     * The requests that both received bytes and reported a measurable span, which is the subset the
-     * throughput ratio is computed over.
+     * The requests that completed, received bytes, and reported a measurable span, which is the
+     * subset the throughput ratio is computed over.
      *
      * Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
      * inside the busy-time fold instead would let a request contribute its bytes while adding no
      * time, which reads as a faster connection than actually happened. A cache hit is the case that
      * matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+     *
+     * Failures are excluded for the opposite reason. A request that received a few bytes and then
+     * stalled until the client gave up reports a span covering the whole stall, so it would hold the
+     * denominator open across time when nothing was moving and report a connection far slower than
+     * the one that served the requests around it.
      */
     private fun measurableReceiving(requests: List<NetworkRequest>): List<NetworkRequest> {
       return requests.filter { request ->
         val start = request.timings.fetchStart
         val end = request.timings.responseEnd
-        (request.responseBytesReceived ?: 0) > 0 && start != null && end != null &&
-          end.time > start.time
+        !request.isFailed && (request.responseBytesReceived ?: 0) > 0 && start != null &&
+          end != null && end.time > start.time
       }
     }
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -36,20 +36,19 @@ data class NetworkRequestSummary(
   /** Sum of `timings.totalDuration` across all requests, in seconds. Can exceed wall-clock when requests overlap. */
   val totalDuration: Double,
 
-  /** Longest single request duration in seconds, or `null` if `count == 0`. */
-  val slowestDuration: Double?,
-
-  /** Host of the slowest request, or `null` if the URL had no resolvable host. */
-  val slowestHost: String?,
-
   /**
-   * Longest time-to-first-byte in the window in seconds, or `null` if no request reported one.
+   * The single longest-running request that completed, or `null` when the window held none.
    *
-   * A maximum rather than an average, so a single stalled request stays visible instead of being
-   * diluted by fast ones. Note this includes server processing time, so it's a proxy for network
-   * quality rather than a measurement of it - see `Timings.timeToFirstByte`.
+   * Every field describes that one request, so they can be read together: a `duration` mostly made
+   * up of `timeToFirstByte` means the server was slow to answer, while a small `timeToFirstByte`
+   * against a large `bytesReceived` means the transfer itself was.
+   *
+   * Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
+   * setting rather than a measurement of the server, so letting one win would make these fields
+   * report a config constant that barely varies with the network. `failed` and `timedOut` carry that
+   * signal instead.
    */
-  val slowestTimeToFirstByte: Double? = null,
+  val slowest: SlowestRequest? = null,
 
   /**
    * Received bytes over the time those bytes were actually moving, in bytes per second, or `null`
@@ -64,7 +63,7 @@ data class NetworkRequestSummary(
    *   launch that fetches briefly and then sits idle would otherwise look slow.
    * - Only requests that received bytes, so a slow request returning nothing can't stretch the
    *   denominator across time when no payload was in flight. Its latency belongs to
-   *   `slowestTimeToFirstByte`, not here.
+   *   `slowest.timeToFirstByte`, not here.
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
    * interval covers it. `timedOut` is the signal for that case.
@@ -76,6 +75,28 @@ data class NetworkRequestSummary(
    */
   val throughputBytesPerSecond: Double? = null
 ) {
+  /** Facts about the slowest completed request in a window. See `NetworkRequestSummary.slowest`. */
+  data class SlowestRequest(
+    /** Host of the request, or `null` if the URL had no resolvable host. */
+    val host: String?,
+
+    /** Total wall-clock duration of the request, in seconds. */
+    val duration: Double,
+
+    /**
+     * Time from the start of the fetch until the first response byte arrived, in seconds, or `null`
+     * if the request never reported one. Includes server processing time, so it's a proxy for
+     * network quality rather than a measurement of it - see `Timings.timeToFirstByte`.
+     */
+    val timeToFirstByte: Double?,
+
+    /**
+     * Response bytes received on the wire, or `null` if no count was reported. Distinguishes a
+     * request that was slow because it moved a lot of data from one that was slow while idle.
+     */
+    val bytesReceived: Long?
+  )
+
   val isEmpty: Boolean
     get() = count == 0
 
@@ -87,9 +108,7 @@ data class NetworkRequestSummary(
       bytesReceived = 0,
       bytesSent = 0,
       totalDuration = 0.0,
-      slowestDuration = null,
-      slowestHost = null,
-      slowestTimeToFirstByte = null,
+      slowest = null,
       throughputBytesPerSecond = null
     )
 
@@ -107,7 +126,6 @@ data class NetworkRequestSummary(
       var bytesSent = 0L
       var totalDuration = 0.0
       var slowest: NetworkRequest? = null
-      var slowestTimeToFirstByte: Double? = null
 
       for (request in requests) {
         if (request.isFailed) {
@@ -119,14 +137,15 @@ data class NetworkRequestSummary(
         bytesReceived += request.responseBytesReceived ?: 0
         bytesSent += request.requestBytesSent ?: 0
         totalDuration += request.timings.totalDuration
-        val current = slowest
-        if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
-          slowest = request
-        }
-        // Skips requests that didn't report the phase, so a header-less failure doesn't drag the
-        // result toward a value that was never measured.
-        request.timings.timeToFirstByte?.let {
-          slowestTimeToFirstByte = maxOf(it, slowestTimeToFirstByte ?: it)
+        // Only completed requests are candidates. A timeout's duration is the client's timeout
+        // setting, not a measurement of the server, so letting one win would make these fields
+        // report a config constant that barely varies with the network. Failures are already counted
+        // by `failed` and `timedOut`.
+        if (!request.isFailed) {
+          val current = slowest
+          if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
+            slowest = request
+          }
         }
       }
 
@@ -137,9 +156,14 @@ data class NetworkRequestSummary(
         bytesReceived = bytesReceived,
         bytesSent = bytesSent,
         totalDuration = totalDuration,
-        slowestDuration = slowest?.timings?.totalDuration,
-        slowestHost = slowest?.url?.toHttpUrlOrNull()?.host,
-        slowestTimeToFirstByte = slowestTimeToFirstByte,
+        slowest = slowest?.let { request ->
+          SlowestRequest(
+            host = request.url.toHttpUrlOrNull()?.host,
+            duration = request.timings.totalDuration,
+            timeToFirstByte = request.timings.timeToFirstByte,
+            bytesReceived = request.responseBytesReceived
+          )
+        },
         throughputBytesPerSecond = throughput(requests)
       )
     }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -52,29 +52,24 @@ data class NetworkRequestSummary(
   val slowestTimeToFirstByte: Double? = null,
 
   /**
-   * Received bytes over the time the network was actually busy, in bytes per second, or `null` when
-   * nothing was received or no request reported a usable interval.
+   * Received bytes over the time those bytes were actually moving, in bytes per second, or `null`
+   * when nothing was received or no receiving request reported a usable interval.
    *
-   * The denominator is the union of the request intervals, not the sum of their durations and not
-   * the elapsed window. Summing durations would divide by the app's request concurrency, so four
-   * parallel one-second requests would report a quarter of the real rate. Using the whole window
-   * would charge idle time to the network, so a launch that fetches briefly and then sits idle would
-   * look slow. Measuring only the busy span leaves a value that moves when the connection changes
-   * and holds still when the app's fetch pattern does.
+   * The denominator is the union of the intervals of the requests that received bytes. Three choices
+   * are folded into that:
+   *
+   * - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
+   *   parallel one-second requests would otherwise report a quarter of the real rate.
+   * - The busy span rather than the whole window, so idle time isn't charged to the network. A
+   *   launch that fetches briefly and then sits idle would otherwise look slow.
+   * - Only requests that received bytes, so a slow request returning nothing can't stretch the
+   *   denominator across time when no payload was in flight. Its latency belongs to
+   *   `slowestTimeToFirstByte`, not here.
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
    * interval covers it. `timedOut` is the signal for that case.
    */
-  val throughputBytesPerSecond: Double? = null,
-
-  /**
-   * Shortest TCP handshake in the window in seconds, or `null` if every connection was reused.
-   *
-   * A minimum rather than an average: a handshake that loses its SYN retries after a timeout of a
-   * second or more, so a mean over a few handshakes mostly reports retransmits. The fastest one
-   * approximates the true path latency.
-   */
-  val fastestTcpHandshake: Double? = null
+  val throughputBytesPerSecond: Double? = null
 ) {
   val isEmpty: Boolean
     get() = count == 0
@@ -90,8 +85,7 @@ data class NetworkRequestSummary(
       slowestDuration = null,
       slowestHost = null,
       slowestTimeToFirstByte = null,
-      throughputBytesPerSecond = null,
-      fastestTcpHandshake = null
+      throughputBytesPerSecond = null
     )
 
     /**
@@ -109,7 +103,6 @@ data class NetworkRequestSummary(
       var totalDuration = 0.0
       var slowest: NetworkRequest? = null
       var slowestTimeToFirstByte: Double? = null
-      var fastestTcpHandshake: Double? = null
 
       for (request in requests) {
         if (request.isFailed) {
@@ -125,13 +118,10 @@ data class NetworkRequestSummary(
         if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
           slowest = request
         }
-        // Both folds skip requests that didn't report the phase, so a reused connection or a
-        // header-less failure doesn't drag the result toward a value that was never measured.
+        // Skips requests that didn't report the phase, so a header-less failure doesn't drag the
+        // result toward a value that was never measured.
         request.timings.timeToFirstByte?.let {
           slowestTimeToFirstByte = maxOf(it, slowestTimeToFirstByte ?: it)
-        }
-        request.timings.tcpHandshakeDuration?.let {
-          fastestTcpHandshake = minOf(it, fastestTcpHandshake ?: it)
         }
       }
 
@@ -145,25 +135,29 @@ data class NetworkRequestSummary(
         slowestDuration = slowest?.timings?.totalDuration,
         slowestHost = slowest?.url?.toHttpUrlOrNull()?.host,
         slowestTimeToFirstByte = slowestTimeToFirstByte,
-        throughputBytesPerSecond = throughput(bytesReceived, requests),
-        fastestTcpHandshake = fastestTcpHandshake
+        throughputBytesPerSecond = throughput(requests)
       )
     }
 
     /**
-     * Received bytes over the time at least one request was in flight. Returns `null` when nothing
-     * was received or no request reported a usable interval, so the caller can tell "unknown" from
-     * a genuinely slow connection.
+     * Received bytes over the time those bytes were moving. Returns `null` when nothing was received
+     * or no receiving request reported a usable interval, so the caller can tell "unknown" from a
+     * genuinely slow connection.
+     *
+     * Both sides are computed from the same subset - the requests that actually received bytes - so
+     * the numerator and denominator always describe the same traffic.
      */
-    private fun throughput(bytesReceived: Long, requests: List<NetworkRequest>): Double? {
-      if (bytesReceived <= 0) {
+    private fun throughput(requests: List<NetworkRequest>): Double? {
+      val receiving = requests.filter { (it.responseBytesReceived ?: 0) > 0 }
+      val bytes = receiving.sumOf { it.responseBytesReceived ?: 0 }
+      if (bytes <= 0) {
         return null
       }
-      val busySeconds = busyDuration(requests)
+      val busySeconds = busyDuration(receiving)
       if (busySeconds <= 0) {
         return null
       }
-      return bytesReceived.toDouble() / busySeconds
+      return bytes.toDouble() / busySeconds
     }
 
     /**

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -18,15 +18,6 @@ data class NetworkRequestSummary(
   /** Requests that errored or returned a non-2xx status. */
   val failed: Int,
 
-  /**
-   * Subset of `failed` where the network stalled or went away rather than the server answering.
-   *
-   * Split out from `failed` because the two have different causes: timeouts point at the
-   * connection, 4xx/5xx point at the backend. A window where most failures are timeouts is the
-   * clearest signal available here that the user was on a bad network.
-   */
-  val timedOut: Int = 0,
-
   /** Sum of `responseBytesReceived` across all requests. */
   val bytesReceived: Long,
 
@@ -55,8 +46,8 @@ data class NetworkRequestSummary(
    *
    * Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
    * setting rather than a measurement of the server, so letting one win would make these fields
-   * report a config constant that barely varies with the network. `failed` and `timedOut` carry that
-   * signal instead.
+   * report a config constant that barely varies with the network. `failed` carries that signal
+   * instead.
    */
   val slowest: SlowestRequest? = null,
 
@@ -77,14 +68,14 @@ data class NetworkRequestSummary(
    *   launch that fetches briefly and then sits idle would otherwise look slow.
    * - Only requests that completed and received bytes, so neither a slow request returning nothing
    *   nor one that stalled until the client gave up can stretch the denominator across time when no
-   *   payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
+   *   payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `failed`.
    *
    * Requiring a first-byte timestamp also excludes cache hits for free: a response served from disk
    * never reports one, so the bytes it contributes can't be divided by the milliseconds it took to
    * read them.
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
-   * interval covers it. `timedOut` is the signal for that case.
+   * interval covers it. `failed` is the signal for that case.
    *
    * Being a ratio, it also degrades differently from the counts when the monitor's ring buffer evicts
    * the earliest requests in a window: both sides shrink together, so the value stays plausible while
@@ -131,7 +122,6 @@ data class NetworkRequestSummary(
     val empty = NetworkRequestSummary(
       count = 0,
       failed = 0,
-      timedOut = 0,
       bytesReceived = 0,
       bytesSent = 0,
       totalDuration = 0.0,
@@ -148,7 +138,6 @@ data class NetworkRequestSummary(
         return empty
       }
       var failed = 0
-      var timedOut = 0
       var bytesReceived = 0L
       var bytesSent = 0L
       var totalDuration = 0.0
@@ -158,16 +147,13 @@ data class NetworkRequestSummary(
         if (request.isFailed) {
           failed += 1
         }
-        if (request.isTimeout) {
-          timedOut += 1
-        }
         bytesReceived += request.responseBytesReceived ?: 0
         bytesSent += request.requestBytesSent ?: 0
         totalDuration += request.timings.totalDuration
         // Only completed requests are candidates. A timeout's duration is the client's timeout
         // setting, not a measurement of the server, so letting one win would make these fields
         // report a config constant that barely varies with the network. Failures are already counted
-        // by `failed` and `timedOut`.
+        // by `failed`.
         if (!request.isFailed) {
           val current = slowest
           if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
@@ -179,7 +165,6 @@ data class NetworkRequestSummary(
       return NetworkRequestSummary(
         count = requests.size,
         failed = failed,
-        timedOut = timedOut,
         bytesReceived = bytesReceived,
         bytesSent = bytesSent,
         totalDuration = totalDuration,

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -18,6 +18,15 @@ data class NetworkRequestSummary(
   /** Requests that errored or returned a non-2xx status. */
   val failed: Int,
 
+  /**
+   * Subset of `failed` where the network stalled or went away rather than the server answering.
+   *
+   * Split out from `failed` because the two have different causes: timeouts point at the
+   * connection, 4xx/5xx point at the backend. A window where most failures are timeouts is the
+   * clearest signal available here that the user was on a bad network.
+   */
+  val timedOut: Int = 0,
+
   /** Sum of `responseBytesReceived` across all requests. */
   val bytesReceived: Long,
 
@@ -31,7 +40,41 @@ data class NetworkRequestSummary(
   val slowestDuration: Double?,
 
   /** Host of the slowest request, or `null` if the URL had no resolvable host. */
-  val slowestHost: String?
+  val slowestHost: String?,
+
+  /**
+   * Longest time-to-first-byte in the window in seconds, or `null` if no request reported one.
+   *
+   * A maximum rather than an average, so a single stalled request stays visible instead of being
+   * diluted by fast ones. Note this includes server processing time, so it's a proxy for network
+   * quality rather than a measurement of it - see `Timings.timeToFirstByte`.
+   */
+  val slowestTimeToFirstByte: Double? = null,
+
+  /**
+   * Received bytes over the time the network was actually busy, in bytes per second, or `null` when
+   * nothing was received or no request reported a usable interval.
+   *
+   * The denominator is the union of the request intervals, not the sum of their durations and not
+   * the elapsed window. Summing durations would divide by the app's request concurrency, so four
+   * parallel one-second requests would report a quarter of the real rate. Using the whole window
+   * would charge idle time to the network, so a launch that fetches briefly and then sits idle would
+   * look slow. Measuring only the busy span leaves a value that moves when the connection changes
+   * and holds still when the app's fetch pattern does.
+   *
+   * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
+   * interval covers it. `timedOut` is the signal for that case.
+   */
+  val throughputBytesPerSecond: Double? = null,
+
+  /**
+   * Shortest TCP handshake in the window in seconds, or `null` if every connection was reused.
+   *
+   * A minimum rather than an average: a handshake that loses its SYN retries after a timeout of a
+   * second or more, so a mean over a few handshakes mostly reports retransmits. The fastest one
+   * approximates the true path latency.
+   */
+  val fastestTcpHandshake: Double? = null
 ) {
   val isEmpty: Boolean
     get() = count == 0
@@ -40,11 +83,15 @@ data class NetworkRequestSummary(
     val empty = NetworkRequestSummary(
       count = 0,
       failed = 0,
+      timedOut = 0,
       bytesReceived = 0,
       bytesSent = 0,
       totalDuration = 0.0,
       slowestDuration = null,
-      slowestHost = null
+      slowestHost = null,
+      slowestTimeToFirstByte = null,
+      throughputBytesPerSecond = null,
+      fastestTcpHandshake = null
     )
 
     /**
@@ -56,14 +103,20 @@ data class NetworkRequestSummary(
         return empty
       }
       var failed = 0
+      var timedOut = 0
       var bytesReceived = 0L
       var bytesSent = 0L
       var totalDuration = 0.0
       var slowest: NetworkRequest? = null
+      var slowestTimeToFirstByte: Double? = null
+      var fastestTcpHandshake: Double? = null
 
       for (request in requests) {
         if (request.isFailed) {
           failed += 1
+        }
+        if (request.isTimeout) {
+          timedOut += 1
         }
         bytesReceived += request.responseBytesReceived ?: 0
         bytesSent += request.requestBytesSent ?: 0
@@ -72,17 +125,85 @@ data class NetworkRequestSummary(
         if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
           slowest = request
         }
+        // Both folds skip requests that didn't report the phase, so a reused connection or a
+        // header-less failure doesn't drag the result toward a value that was never measured.
+        request.timings.timeToFirstByte?.let {
+          slowestTimeToFirstByte = maxOf(it, slowestTimeToFirstByte ?: it)
+        }
+        request.timings.tcpHandshakeDuration?.let {
+          fastestTcpHandshake = minOf(it, fastestTcpHandshake ?: it)
+        }
       }
 
       return NetworkRequestSummary(
         count = requests.size,
         failed = failed,
+        timedOut = timedOut,
         bytesReceived = bytesReceived,
         bytesSent = bytesSent,
         totalDuration = totalDuration,
         slowestDuration = slowest?.timings?.totalDuration,
-        slowestHost = slowest?.url?.toHttpUrlOrNull()?.host
+        slowestHost = slowest?.url?.toHttpUrlOrNull()?.host,
+        slowestTimeToFirstByte = slowestTimeToFirstByte,
+        throughputBytesPerSecond = throughput(bytesReceived, requests),
+        fastestTcpHandshake = fastestTcpHandshake
       )
+    }
+
+    /**
+     * Received bytes over the time at least one request was in flight. Returns `null` when nothing
+     * was received or no request reported a usable interval, so the caller can tell "unknown" from
+     * a genuinely slow connection.
+     */
+    private fun throughput(bytesReceived: Long, requests: List<NetworkRequest>): Double? {
+      if (bytesReceived <= 0) {
+        return null
+      }
+      val busySeconds = busyDuration(requests)
+      if (busySeconds <= 0) {
+        return null
+      }
+      return bytesReceived.toDouble() / busySeconds
+    }
+
+    /**
+     * Total length of the union of the requests' in-flight intervals, in seconds.
+     *
+     * Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
+     * requests are excluded so idle time isn't charged to the network. Requests missing either
+     * endpoint are skipped rather than treated as zero-length.
+     */
+    private fun busyDuration(requests: List<NetworkRequest>): Double {
+      val intervals = requests
+        .mapNotNull { request ->
+          val start = request.timings.fetchStart ?: return@mapNotNull null
+          val end = request.timings.responseEnd ?: return@mapNotNull null
+          if (end.time >= start.time) start.time to end.time else null
+        }
+        .sortedBy { it.first }
+
+      var totalMillis = 0L
+      var spanStart: Long? = null
+      var spanEnd: Long? = null
+      for ((start, end) in intervals) {
+        val currentStart = spanStart
+        val currentEnd = spanEnd
+        if (currentStart == null || currentEnd == null) {
+          spanStart = start
+          spanEnd = end
+          continue
+        }
+        if (start <= currentEnd) {
+          // Overlaps (or touches) the open span, so extend it instead of counting the time twice.
+          spanEnd = maxOf(currentEnd, end)
+        } else {
+          totalMillis += currentEnd - currentStart
+          spanStart = start
+          spanEnd = end
+        }
+      }
+      spanStart?.let { start -> spanEnd?.let { end -> totalMillis += end - start } }
+      return totalMillis / 1000.0
     }
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -53,36 +53,21 @@ data class NetworkRequestSummary(
 
   /**
    * Received bytes over the time those bytes were actually moving, in bytes per second, or `null`
-   * when nothing was received or no receiving request reported a usable interval.
+   * when nothing was received or no request reported a usable transfer window.
    *
    * The denominator is the union of the transfer windows of the requests that received bytes, each
-   * running from the first response byte to the last. Four choices are folded into that:
+   * running from the first response byte to the last. Measuring from the first byte keeps DNS,
+   * connect and server think time out of the rate, and it excludes cache hits for free, since a
+   * response served from disk never reports one. Taking the union rather than a sum keeps
+   * concurrency from deflating it, and gaps between requests are left out so idle time isn't charged
+   * to the network. Failures are excluded: a request that stalled until the client gave up would
+   * otherwise hold the window open while nothing moved.
    *
-   * - The transfer window rather than the whole request, so time spent resolving DNS, connecting,
-   *   and waiting on the server isn't charged to the connection. A request that waits four seconds
-   *   on a backend and then delivers a kilobyte instantly describes a fast network, not a slow one;
-   *   the wait belongs to `slowest.timeToFirstByte`.
-   * - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
-   *   parallel one-second requests would otherwise report a quarter of the real rate.
-   * - The busy span rather than the whole window, so idle time isn't charged to the network. A
-   *   launch that fetches briefly and then sits idle would otherwise look slow.
-   * - Only requests that completed and received bytes, so neither a slow request returning nothing
-   *   nor one that stalled until the client gave up can stretch the denominator across time when no
-   *   payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `failed`.
-   *
-   * Requiring a first-byte timestamp also excludes cache hits for free: a response served from disk
-   * never reports one, so the bytes it contributes can't be divided by the milliseconds it took to
-   * read them.
-   *
-   * Two cases it still can't see. A stall between requests: if the radio dies while nothing is in
-   * flight, no interval covers it, and `failed` is the signal instead. And a long-lived response
-   * that trickles, such as a server-sent event stream, whose window stays open across time when
-   * almost nothing is moving and drags the rate down for everything overlapping it.
-   *
-   * Being a ratio, it also degrades differently from the counts when the monitor's ring buffer evicts
-   * the earliest requests in a window: both sides shrink together, so the value stays plausible while
-   * describing only the requests that survived. Read it as the rate of a sample of the window rather
-   * than of all of it.
+   * Three things it can't see. A stall between requests, since no interval covers it; `failed` is
+   * the signal there. A long-lived trickle, such as an event stream, whose window stays open while
+   * almost nothing moves and drags down everything overlapping it. And eviction: when the ring
+   * buffer drops the earliest requests both sides shrink together, so read this as the rate of a
+   * sample of the window rather than all of it.
    */
   val throughputBytesPerSecond: Double? = null
 ) {
@@ -206,24 +191,14 @@ data class NetworkRequestSummary(
 
     /**
      * The requests that completed, received bytes, and reported a measurable transfer window, which
-     * is the subset the throughput ratio is computed over.
-     *
-     * Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
-     * inside the busy-time fold instead would let a request contribute its bytes while adding no
-     * time, which reads as a faster connection than actually happened. A cache hit is the case that
-     * matters: it reports bytes from the task counters but is served from disk, so it never gets a
-     * first-byte timestamp and drops out here.
-     *
-     * Failures are excluded for the opposite reason. A request that received a few bytes and then
-     * stalled until the client gave up reports a window covering the whole stall, so it would hold
-     * the denominator open across time when nothing was moving and report a connection far slower than
-     * the one that served the requests around it.
+     * is the subset the throughput ratio is computed over. Deciding it once keeps the numerator and
+     * denominator describing the same traffic; filtering inside the busy-time fold instead would let
+     * a request contribute bytes while adding no time.
      *
      * A transfer faster than a millisecond drops out, because `Date()` advances in whole
-     * milliseconds and can't describe it. iOS applies the same floor deliberately rather than
-     * dividing by the sub-millisecond windows its transaction metrics can resolve, so the two
-     * platforms agree on when the rate is unknown instead of Android quietly reporting only its
-     * slower transfers.
+     * milliseconds and can't describe it. iOS applies the same floor rather than dividing by the
+     * finer windows its transaction metrics can resolve, so the platforms agree on when the rate is
+     * unknown instead of Android quietly reporting only its slower transfers.
      */
     private fun measurableReceiving(requests: List<NetworkRequest>): List<NetworkRequest> {
       return requests.filter { request ->
@@ -235,16 +210,10 @@ data class NetworkRequestSummary(
     }
 
     /**
-     * Total length of the union of the requests' in-flight intervals, in seconds.
-     *
-     * Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
-     * requests are excluded so idle time isn't charged to the network.
-     *
-     * Requests are skipped unless they report both endpoints and a strictly positive span. A
-     * collapsed interval would otherwise let a request contribute its bytes to the numerator while
-     * adding nothing to the denominator, which reads as a faster connection than actually happened.
-     * A cache hit is the case that matters: it reports bytes from the task counters but is served
-     * from disk inside one clock tick.
+     * Total length of the union of the requests' transfer windows, in seconds. Overlapping requests
+     * are merged so concurrency doesn't inflate the total, and gaps between them are excluded so
+     * idle time isn't charged to the network. Callers computing a rate should pass a list already
+     * narrowed by `measurableReceiving`, so the same requests feed both sides of the ratio.
      */
     private fun busyDuration(requests: List<NetworkRequest>): Double {
       val intervals = requests

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -64,9 +64,13 @@ data class NetworkRequestSummary(
    * Received bytes over the time those bytes were actually moving, in bytes per second, or `null`
    * when nothing was received or no receiving request reported a usable interval.
    *
-   * The denominator is the union of the intervals of the requests that received bytes. Three choices
-   * are folded into that:
+   * The denominator is the union of the transfer windows of the requests that received bytes, each
+   * running from the first response byte to the last. Four choices are folded into that:
    *
+   * - The transfer window rather than the whole request, so time spent resolving DNS, connecting,
+   *   and waiting on the server isn't charged to the connection. A request that waits four seconds
+   *   on a backend and then delivers a kilobyte instantly describes a fast network, not a slow one;
+   *   the wait belongs to `slowest.timeToFirstByte`.
    * - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
    *   parallel one-second requests would otherwise report a quarter of the real rate.
    * - The busy span rather than the whole window, so idle time isn't charged to the network. A
@@ -74,6 +78,10 @@ data class NetworkRequestSummary(
    * - Only requests that completed and received bytes, so neither a slow request returning nothing
    *   nor one that stalled until the client gave up can stretch the denominator across time when no
    *   payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
+   *
+   * Requiring a first-byte timestamp also excludes cache hits for free: a response served from disk
+   * never reports one, so the bytes it contributes can't be divided by the milliseconds it took to
+   * read them.
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
    * interval covers it. `timedOut` is the signal for that case.
@@ -210,22 +218,23 @@ data class NetworkRequestSummary(
     }
 
     /**
-     * The requests that completed, received bytes, and reported a measurable span, which is the
-     * subset the throughput ratio is computed over.
+     * The requests that completed, received bytes, and reported a measurable transfer window, which
+     * is the subset the throughput ratio is computed over.
      *
      * Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
      * inside the busy-time fold instead would let a request contribute its bytes while adding no
      * time, which reads as a faster connection than actually happened. A cache hit is the case that
-     * matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+     * matters: it reports bytes from the task counters but is served from disk, so it never gets a
+     * first-byte timestamp and drops out here.
      *
      * Failures are excluded for the opposite reason. A request that received a few bytes and then
-     * stalled until the client gave up reports a span covering the whole stall, so it would hold the
-     * denominator open across time when nothing was moving and report a connection far slower than
+     * stalled until the client gave up reports a window covering the whole stall, so it would hold
+     * the denominator open across time when nothing was moving and report a connection far slower than
      * the one that served the requests around it.
      */
     private fun measurableReceiving(requests: List<NetworkRequest>): List<NetworkRequest> {
       return requests.filter { request ->
-        val start = request.timings.fetchStart
+        val start = request.timings.responseStart
         val end = request.timings.responseEnd
         !request.isFailed && (request.responseBytesReceived ?: 0) > 0 && start != null &&
           end != null && end.time > start.time
@@ -247,7 +256,7 @@ data class NetworkRequestSummary(
     private fun busyDuration(requests: List<NetworkRequest>): Double {
       val intervals = requests
         .mapNotNull { request ->
-          val start = request.timings.fetchStart ?: return@mapNotNull null
+          val start = request.timings.responseStart ?: return@mapNotNull null
           val end = request.timings.responseEnd ?: return@mapNotNull null
           if (end.time > start.time) start.time to end.time else null
         }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -41,7 +41,8 @@ data class NetworkRequestSummary(
    *
    * Every field describes that one request, so they can be read together: a `duration` mostly made
    * up of `timeToFirstByte` means the server was slow to answer, while a small `timeToFirstByte`
-   * against a large `bytesReceived` means the transfer itself was.
+   * against a large `bytesReceived` means the transfer itself was. `statusCode` explains a
+   * `bytesReceived` of 0, which is routine on a 304 and a problem on a 200.
    *
    * Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
    * setting rather than a measurement of the server, so letting one win would make these fields
@@ -82,6 +83,15 @@ data class NetworkRequestSummary(
 
     /** Total wall-clock duration of the request, in seconds. */
     val duration: Double,
+
+    /**
+     * Response status code. Never `null` in practice, since a request that never received headers
+     * counts as failed and so isn't a candidate.
+     *
+     * Disambiguates an empty response: a `bytesReceived` of 0 means a cache revalidation on a 304,
+     * an intentionally bodyless reply on a 204, and a broken transfer on a 200.
+     */
+    val statusCode: Int?,
 
     /**
      * Time from the start of the fetch until the first response byte arrived, in seconds, or `null`
@@ -160,6 +170,7 @@ data class NetworkRequestSummary(
           SlowestRequest(
             host = request.url.toHttpUrlOrNull()?.host,
             duration = request.timings.totalDuration,
+            statusCode = request.statusCode,
             timeToFirstByte = request.timings.timeToFirstByte,
             bytesReceived = request.responseBytesReceived
           )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -33,7 +33,16 @@ data class NetworkRequestSummary(
   /** Sum of `requestBytesSent` across all requests. */
   val bytesSent: Long,
 
-  /** Sum of `timings.totalDuration` across all requests, in seconds. Can exceed wall-clock when requests overlap. */
+  /**
+   * Sum of `timings.totalDuration` across all requests, in seconds. Can exceed wall-clock when
+   * requests overlap.
+   *
+   * Deliberately includes failures, unlike `slowest` and `throughputBytesPerSecond`, which describe
+   * only requests that completed. That makes it the one field that still accounts for time the app
+   * spent waiting on a request that never arrived: a window of timeouts reports the seconds they
+   * burned here even though nothing else measures them. The cost is that it can dwarf the other
+   * timings, since a single timeout contributes the client's whole timeout interval.
+   */
   val totalDuration: Double,
 
   /**

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -68,6 +68,11 @@ data class NetworkRequestSummary(
    *
    * This still can't see a stall between requests: if the radio dies while nothing is in flight, no
    * interval covers it. `timedOut` is the signal for that case.
+   *
+   * Being a ratio, it also degrades differently from the counts when the monitor's ring buffer evicts
+   * the earliest requests in a window: both sides shrink together, so the value stays plausible while
+   * describing only the requests that survived. Read it as the rate of a sample of the window rather
+   * than of all of it.
    */
   val throughputBytesPerSecond: Double? = null
 ) {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -144,16 +144,16 @@ data class NetworkRequestSummary(
      * or no receiving request reported a usable interval, so the caller can tell "unknown" from a
      * genuinely slow connection.
      *
-     * Both sides are computed from the same subset - the requests that actually received bytes - so
-     * the numerator and denominator always describe the same traffic.
+     * Both sides are computed from the same subset, so the numerator and denominator always describe
+     * the same traffic.
      */
     private fun throughput(requests: List<NetworkRequest>): Double? {
-      val receiving = requests.filter { (it.responseBytesReceived ?: 0) > 0 }
-      val bytes = receiving.sumOf { it.responseBytesReceived ?: 0 }
+      val measurable = measurableReceiving(requests)
+      val bytes = measurable.sumOf { it.responseBytesReceived ?: 0 }
       if (bytes <= 0) {
         return null
       }
-      val busySeconds = busyDuration(receiving)
+      val busySeconds = busyDuration(measurable)
       if (busySeconds <= 0) {
         return null
       }
@@ -161,18 +161,41 @@ data class NetworkRequestSummary(
     }
 
     /**
+     * The requests that both received bytes and reported a measurable span, which is the subset the
+     * throughput ratio is computed over.
+     *
+     * Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
+     * inside the busy-time fold instead would let a request contribute its bytes while adding no
+     * time, which reads as a faster connection than actually happened. A cache hit is the case that
+     * matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+     */
+    private fun measurableReceiving(requests: List<NetworkRequest>): List<NetworkRequest> {
+      return requests.filter { request ->
+        val start = request.timings.fetchStart
+        val end = request.timings.responseEnd
+        (request.responseBytesReceived ?: 0) > 0 && start != null && end != null &&
+          end.time > start.time
+      }
+    }
+
+    /**
      * Total length of the union of the requests' in-flight intervals, in seconds.
      *
      * Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
-     * requests are excluded so idle time isn't charged to the network. Requests missing either
-     * endpoint are skipped rather than treated as zero-length.
+     * requests are excluded so idle time isn't charged to the network.
+     *
+     * Requests are skipped unless they report both endpoints and a strictly positive span. A
+     * collapsed interval would otherwise let a request contribute its bytes to the numerator while
+     * adding nothing to the denominator, which reads as a faster connection than actually happened.
+     * A cache hit is the case that matters: it reports bytes from the task counters but is served
+     * from disk inside one clock tick.
      */
     private fun busyDuration(requests: List<NetworkRequest>): Double {
       val intervals = requests
         .mapNotNull { request ->
           val start = request.timings.fetchStart ?: return@mapNotNull null
           val end = request.timings.responseEnd ?: return@mapNotNull null
-          if (end.time >= start.time) start.time to end.time else null
+          if (end.time > start.time) start.time to end.time else null
         }
         .sortedBy { it.first }
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -257,15 +257,19 @@ data class NetworkRequestSummary(
  * headers arrived) counts as failed.
  */
 /**
- * Whether the request never produced a response at all: it errored, or it died before headers
- * arrived. Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+ * Whether the request never produced a response at all, so there is no status code to report.
+ * Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+ *
+ * Keyed on the missing status rather than on `errorDescription`, because a response can carry both:
+ * a transfer that breaks mid-body keeps the 200 its headers arrived with and gains an error string.
+ * That request waited real seconds and belongs in `slowest`.
  *
  * This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
  * eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is often
  * the answer; a timeout's duration is the client's own setting and says nothing about the network.
  */
 internal val NetworkRequest.neverCompleted: Boolean
-  get() = errorDescription != null || statusCode == null
+  get() = statusCode == null
 
 internal val NetworkRequest.isFailed: Boolean
   get() {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -250,27 +250,22 @@ data class NetworkRequestSummary(
 }
 
 /**
- * A request is treated as failed if it errored, or returned a 4xx (client error) or 5xx (server
- * error) status. 1xx (informational), 2xx (success), and 3xx (redirection — usually followed
- * transparently by OkHttp, but the unfollowed case is still a successful response from the
- * origin's perspective) are not failures. A missing status code (the request failed before
- * headers arrived) counts as failed.
- */
-/**
- * Whether the request never produced a response at all, so there is no status code to report.
- * Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+ * Whether the request never produced a response, so there is no status code to report. The
+ * predicate for `slowest` and the throughput subset.
  *
  * Keyed on the missing status rather than on `errorDescription`, because a response can carry both:
- * a transfer that breaks mid-body keeps the 200 its headers arrived with and gains an error string.
- * That request waited real seconds and belongs in `slowest`.
- *
- * This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
- * eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is often
- * the answer; a timeout's duration is the client's own setting and says nothing about the network.
+ * a transfer that breaks mid-body keeps the 200 its headers arrived with and gains an error string,
+ * and it waited real seconds. A 503 after eight seconds is likewise a measurement worth surfacing,
+ * whereas a timeout's duration is the client's own setting.
  */
 internal val NetworkRequest.neverCompleted: Boolean
   get() = statusCode == null
 
+/**
+ * A request is treated as failed if it errored, or returned a 4xx or 5xx status. 1xx, 2xx and 3xx
+ * are not failures: a redirect OkHttp didn't follow is still a successful response from the
+ * origin's perspective. A missing status code counts as failed.
+ */
 internal val NetworkRequest.isFailed: Boolean
   get() {
     if (errorDescription != null) {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummary.kt
@@ -44,10 +44,10 @@ data class NetworkRequestSummary(
    * against a large `bytesReceived` means the transfer itself was. `statusCode` explains a
    * `bytesReceived` of 0, which is routine on a 304 and a problem on a 200.
    *
-   * Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
-   * setting rather than a measurement of the server, so letting one win would make these fields
-   * report a config constant that barely varies with the network. `failed` carries that signal
-   * instead.
+   * A 4xx or 5xx that came back is a candidate: the app waited for it, and on a launch that felt
+   * slow that wait is often the answer. Only requests that never produced a response are excluded,
+   * because a timeout's duration is the client's own setting rather than a measurement of anything
+   * the server did.
    */
   val slowest: SlowestRequest? = null,
 
@@ -60,8 +60,8 @@ data class NetworkRequestSummary(
    * connect and server think time out of the rate, and it excludes cache hits for free, since a
    * response served from disk never reports one. Taking the union rather than a sum keeps
    * concurrency from deflating it, and gaps between requests are left out so idle time isn't charged
-   * to the network. Failures are excluded: a request that stalled until the client gave up would
-   * otherwise hold the window open while nothing moved.
+   * to the network. Requests that never produced a response are excluded: one that stalled until
+   * the client gave up would otherwise hold the window open while nothing moved.
    *
    * Three things it can't see. A stall between requests, since no interval covers it; `failed` is
    * the signal there. A long-lived trickle, such as an event stream, whose window stays open while
@@ -137,11 +137,10 @@ data class NetworkRequestSummary(
         bytesReceived += request.responseBytesReceived ?: 0
         bytesSent += request.requestBytesSent ?: 0
         totalDuration += request.timings.totalDuration
-        // Only completed requests are candidates. A timeout's duration is the client's timeout
-        // setting, not a measurement of the server, so letting one win would make these fields
-        // report a config constant that barely varies with the network. Failures are already counted
-        // by `failed`.
-        if (!request.isFailed) {
+        // A 4xx or 5xx that came back is still a candidate: the app waited for it, and that wait is
+        // what this field exists to surface. Only requests that never produced a response are
+        // skipped, since a timeout's duration is the client's setting rather than the server's.
+        if (!request.neverCompleted) {
           val current = slowest
           if (current == null || request.timings.totalDuration > current.timings.totalDuration) {
             slowest = request
@@ -204,7 +203,7 @@ data class NetworkRequestSummary(
       return requests.filter { request ->
         val start = request.timings.responseStart
         val end = request.timings.measuredResponseEnd
-        !request.isFailed && (request.responseBytesReceived ?: 0) > 0 && start != null &&
+        !request.neverCompleted && (request.responseBytesReceived ?: 0) > 0 && start != null &&
           end != null && end.time > start.time
       }
     }
@@ -257,6 +256,17 @@ data class NetworkRequestSummary(
  * origin's perspective) are not failures. A missing status code (the request failed before
  * headers arrived) counts as failed.
  */
+/**
+ * Whether the request never produced a response at all: it errored, or it died before headers
+ * arrived. Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+ *
+ * This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
+ * eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is often
+ * the answer; a timeout's duration is the client's own setting and says nothing about the network.
+ */
+internal val NetworkRequest.neverCompleted: Boolean
+  get() = errorDescription != null || statusCode == null
+
 internal val NetworkRequest.isFailed: Boolean
   get() {
     if (errorDescription != null) {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/DeviceConditions.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/DeviceConditions.kt
@@ -138,6 +138,11 @@ object DeviceConditions {
       isExpensive = capabilities
         ?.takeIf { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) }
         ?.let { !it.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) },
+      // Signals the user's intent to conserve data, not a restriction on the requests this is
+      // attached to: Data Saver limits background traffic, and a launch runs in the foreground, so
+      // the observed requests proceed at full speed even when this is `true`. `WHITELISTED` reports
+      // `false` because the question worth answering is whether Data Saver restricts *this app*,
+      // not whether the user switched it on somewhere.
       dataSaverEnabled = cm.restrictBackgroundStatus ==
         ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
     )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/DeviceConditions.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/DeviceConditions.kt
@@ -45,7 +45,28 @@ data class DeviceState(
  */
 data class NetworkState(
   val connected: Boolean,
-  val transport: NetworkTransport
+  val transport: NetworkTransport,
+  /**
+   * Whether using this network may cost the user money (a metered connection: cellular or a
+   * tethered hotspot). Mirrors iOS `NWPath.isExpensive`, so it's the inverse of
+   * `NET_CAPABILITY_NOT_METERED`.
+   *
+   * `null` when there's no usable network to describe. Absence of `NET_CAPABILITY_NOT_METERED` on a
+   * capability-poor network is absence of information, not evidence of metering, so this is only
+   * populated when the network also reports internet capability.
+   */
+  val isExpensive: Boolean? = null,
+  /**
+   * Whether Data Saver is restricting this app's background traffic.
+   *
+   * Deliberately *not* reported as `isConstrained`: iOS Low Data Mode is a per-path user setting
+   * that changes as the user moves between networks, while this is a process-wide Android setting
+   * that reads the same on Wi-Fi and cellular. Folding both onto one key would mix two different
+   * questions in the same column.
+   *
+   * `null` when no `ConnectivityManager` is available.
+   */
+  val dataSaverEnabled: Boolean? = null
 )
 
 /**
@@ -96,7 +117,12 @@ object DeviceConditions {
 
   fun networkState(context: Context): NetworkState {
     val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
-      ?: return NetworkState(connected = false, transport = NetworkTransport.NONE)
+      ?: return NetworkState(
+        connected = false,
+        transport = NetworkTransport.NONE,
+        isExpensive = null,
+        dataSaverEnabled = null
+      )
 
     // Read capabilities once: `cm.activeNetwork` and `getNetworkCapabilities`
     // can drift if the connection changes between calls, and a single read
@@ -105,7 +131,15 @@ object DeviceConditions {
     val connected = capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
     return NetworkState(
       connected = connected,
-      transport = mapTransport(capabilities)
+      transport = mapTransport(capabilities),
+      // Gated on the same capability `connected` uses, so a network that can't carry traffic reports
+      // nothing here instead of asserting it's metered. Inverted: the capability says "not metered",
+      // the field says "expensive".
+      isExpensive = capabilities
+        ?.takeIf { it.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) }
+        ?.let { !it.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED) },
+      dataSaverEnabled = cm.restrictBackgroundStatus ==
+        ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED
     )
   }
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -36,15 +36,33 @@ object MetricParamsBuilder {
     if (networkState != null) {
       params["expo.network.connected"] = networkState.connected
       params["expo.network.type"] = networkTransportString(networkState.transport)
+      networkState.isExpensive?.let { params["expo.network.isExpensive"] = it }
+      // Not `expo.network.isConstrained`: that key carries iOS Low Data Mode, which is per-path,
+      // while Data Saver is a process-wide setting. See `NetworkState.dataSaverEnabled`.
+      networkState.dataSaverEnabled?.let { params["expo.network.dataSaverEnabled"] = it }
     }
     if (networkRequests != null && !networkRequests.isEmpty) {
       params["expo.network.requests.count"] = networkRequests.count
       params["expo.network.requests.failed"] = networkRequests.failed
+      // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
+      // them timed out, which is a real measurement rather than a missing one.
+      params["expo.network.requests.timedOut"] = networkRequests.timedOut
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration
       networkRequests.slowestDuration?.let { params["expo.network.requests.slowestDuration"] = it }
       networkRequests.slowestHost?.let { params["expo.network.requests.slowestHost"] = it }
+      // Omitted rather than zeroed when unavailable: a reused connection or a window of cache hits
+      // never measured these, and a 0 would read as "instant" on a dashboard.
+      networkRequests.slowestTimeToFirstByte?.let {
+        params["expo.network.requests.slowestTimeToFirstByte"] = it
+      }
+      networkRequests.throughputBytesPerSecond?.let {
+        params["expo.network.requests.throughputBytesPerSecond"] = it
+      }
+      networkRequests.fastestTcpHandshake?.let {
+        params["expo.network.requests.fastestTcpHandshake"] = it
+      }
     }
     return params
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -60,9 +60,6 @@ object MetricParamsBuilder {
       networkRequests.throughputBytesPerSecond?.let {
         params["expo.network.requests.throughputBytesPerSecond"] = it
       }
-      networkRequests.fastestTcpHandshake?.let {
-        params["expo.network.requests.fastestTcpHandshake"] = it
-      }
     }
     return params
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -50,13 +50,16 @@ object MetricParamsBuilder {
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration
-      networkRequests.slowestDuration?.let { params["expo.network.requests.slowestDuration"] = it }
-      networkRequests.slowestHost?.let { params["expo.network.requests.slowestHost"] = it }
-      // Omitted rather than zeroed when unavailable: a reused connection or a window of cache hits
-      // never measured these, and a 0 would read as "instant" on a dashboard.
-      networkRequests.slowestTimeToFirstByte?.let {
-        params["expo.network.requests.slowestTimeToFirstByte"] = it
+      networkRequests.slowest?.let { slowest ->
+        params["expo.network.requests.slowest.duration"] = slowest.duration
+        slowest.host?.let { params["expo.network.requests.slowest.host"] = it }
+        slowest.timeToFirstByte?.let {
+          params["expo.network.requests.slowest.timeToFirstByte"] = it
+        }
+        slowest.bytesReceived?.let { params["expo.network.requests.slowest.bytesReceived"] = it }
       }
+      // Omitted rather than zeroed when unavailable: a window of cache hits never measured this, and
+      // a 0 would read as "instant" on a dashboard.
       networkRequests.throughputBytesPerSecond?.let {
         params["expo.network.requests.throughputBytesPerSecond"] = it
       }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -44,8 +44,6 @@ object MetricParamsBuilder {
     if (networkRequests != null && !networkRequests.isEmpty) {
       params["expo.network.requests.count"] = networkRequests.count
       params["expo.network.requests.failed"] = networkRequests.failed
-      // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
-      // them timed out, which is a real measurement rather than a missing one.
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -53,6 +53,7 @@ object MetricParamsBuilder {
       networkRequests.slowest?.let { slowest ->
         params["expo.network.requests.slowest.duration"] = slowest.duration
         slowest.host?.let { params["expo.network.requests.slowest.host"] = it }
+        slowest.statusCode?.let { params["expo.network.requests.slowest.statusCode"] = it }
         slowest.timeToFirstByte?.let {
           params["expo.network.requests.slowest.timeToFirstByte"] = it
         }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/MetricParamsBuilder.kt
@@ -46,7 +46,6 @@ object MetricParamsBuilder {
       params["expo.network.requests.failed"] = networkRequests.failed
       // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
       // them timed out, which is a real measurement rather than a missing one.
-      params["expo.network.requests.timedOut"] = networkRequests.timedOut
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -150,6 +150,32 @@ class NetworkRequestInterceptorTest {
   }
 
   @Test
+  fun `records a body that breaks mid-transfer as failed`() {
+    // Headers arrive and the body is cut off partway. The interceptor's own catch only wraps
+    // `chain.proceed`, which has already returned by then, so without the listener's report this
+    // lands as a clean 200 and the broken transfer is counted as a success.
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setBody("x".repeat(1024))
+        .setSocketPolicy(SocketPolicy.DISCONNECT_DURING_RESPONSE_BODY)
+    )
+
+    var thrown = false
+    try {
+      val response = client.newCall(Request.Builder().url(server.url("/truncated")).build()).execute()
+      response.body!!.string()
+    } catch (_: Exception) {
+      thrown = true
+    }
+    assertTrue("the body read should fail", thrown)
+    assertEquals(1, monitor.recent.size)
+    val snapshot = monitor.recent.first()
+    assertNotNull("a broken transfer should carry an error", snapshot.errorDescription)
+    assertTrue("a broken transfer should count as failed", snapshot.isFailed)
+  }
+
+  @Test
   fun `does not flag a server error as a timeout`() {
     server.enqueue(MockResponse().setResponseCode(503))
     client.newCall(Request.Builder().url(server.url("/boom")).build()).execute().close()

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -5,14 +5,17 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
+import java.time.Duration
 
 /**
  * End-to-end interceptor tests driven through OkHttp's `MockWebServer`. Each test installs a
@@ -89,6 +92,35 @@ class NetworkRequestInterceptorTest {
 
     // Re-create the server so the @After teardown's shutdown call doesn't trip on a closed socket.
     server = MockWebServer().apply { start() }
+  }
+
+  @Test
+  fun `flags a read timeout as a timeout`() {
+    // A response the server never finishes sending, against a client with a short read timeout,
+    // produces a real SocketTimeoutException rather than a simulated one.
+    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
+    val timingOutClient = client.newBuilder()
+      .readTimeout(Duration.ofMillis(200))
+      .build()
+
+    var thrown = false
+    try {
+      timingOutClient.newCall(Request.Builder().url(server.url("/stall")).build()).execute()
+    } catch (_: IOException) {
+      thrown = true
+    }
+    assertTrue("the network call should time out", thrown)
+    assertEquals(1, monitor.recent.size)
+    assertTrue(monitor.recent.first().isTimeout)
+  }
+
+  @Test
+  fun `does not flag a server error as a timeout`() {
+    server.enqueue(MockResponse().setResponseCode(503))
+    client.newCall(Request.Builder().url(server.url("/boom")).build()).execute().close()
+    val snapshot = monitor.recent.first()
+    assertEquals(503, snapshot.statusCode)
+    assertFalse(snapshot.isTimeout)
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -8,14 +8,12 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.IOException
-import java.time.Duration
 
 /**
  * End-to-end interceptor tests driven through OkHttp's `MockWebServer`. Each test installs a
@@ -122,12 +120,9 @@ class NetworkRequestInterceptorTest {
 
   @Test
   fun `treats a message-less failure as failed`() {
-    // `SocketException()` with no message: `localizedMessage` and `message` are both null, so a
-    // snapshot keyed off the description alone would keep the 200 the response started as and
-    // report a broken transfer as a success.
-    // The headers arrived, so the snapshot carries a 200; the body then broke. This is exactly the
-    // shape the body-read fix produces, and the only path where a null description isn't rescued by
-    // a missing status code.
+    // `SocketException()` carries no message at all, so a snapshot keyed off the description alone
+    // would keep the 200 the headers arrived with and report a broken transfer as a success. This
+    // is the only path where a null description isn't already caught by a missing status code.
     val request = Request.Builder().url("https://expo.dev/x").build()
     val response = okhttp3.Response.Builder()
       .request(request)

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -95,61 +95,6 @@ class NetworkRequestInterceptorTest {
   }
 
   @Test
-  fun `flags a read timeout as a timeout`() {
-    // A response the server never finishes sending, against a client with a short read timeout,
-    // produces a real SocketTimeoutException rather than a simulated one.
-    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE))
-    val timingOutClient = client.newBuilder()
-      .readTimeout(Duration.ofMillis(200))
-      .build()
-
-    var thrown = false
-    try {
-      timingOutClient.newCall(Request.Builder().url(server.url("/stall")).build()).execute()
-    } catch (_: IOException) {
-      thrown = true
-    }
-    assertTrue("the network call should time out", thrown)
-    assertEquals(1, monitor.recent.size)
-    assertTrue(monitor.recent.first().isTimeout)
-  }
-
-  @Test
-  fun `flags a dropped connection as a timeout`() {
-    // The server accepts the connection and then drops it, which is what the radio going away
-    // mid-request looks like to OkHttp. iOS reports this as NSURLErrorNetworkConnectionLost and
-    // counts it, so Android has to count it too for the metric to mean one thing.
-    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
-
-    var thrown = false
-    try {
-      client.newCall(Request.Builder().url(server.url("/dropped")).build()).execute()
-    } catch (_: IOException) {
-      thrown = true
-    }
-    assertTrue("the network call should fail", thrown)
-    assertEquals(1, monitor.recent.size)
-    assertTrue(monitor.recent.first().isTimeout)
-  }
-
-  @Test
-  fun `flags an unresolvable host as a timeout`() {
-    // DNS failing is what an offline device looks like from here. iOS counts the equivalent
-    // NSURLErrorNotConnectedToInternet and NSURLErrorCannotFindHost codes.
-    var thrown = false
-    try {
-      client
-        .newCall(Request.Builder().url("https://host.invalid/x").build())
-        .execute()
-    } catch (_: IOException) {
-      thrown = true
-    }
-    assertTrue("the network call should fail to resolve", thrown)
-    assertEquals(1, monitor.recent.size)
-    assertTrue(monitor.recent.first().isTimeout)
-  }
-
-  @Test
   fun `records a body that breaks mid-transfer as failed`() {
     // Headers arrive and the body is cut off partway. The interceptor's own catch only wraps
     // `chain.proceed`, which has already returned by then, so without the listener's report this
@@ -176,12 +121,31 @@ class NetworkRequestInterceptorTest {
   }
 
   @Test
-  fun `does not flag a server error as a timeout`() {
-    server.enqueue(MockResponse().setResponseCode(503))
-    client.newCall(Request.Builder().url(server.url("/boom")).build()).execute().close()
-    val snapshot = monitor.recent.first()
-    assertEquals(503, snapshot.statusCode)
-    assertFalse(snapshot.isTimeout)
+  fun `treats a message-less failure as failed`() {
+    // `SocketException()` with no message: `localizedMessage` and `message` are both null, so a
+    // snapshot keyed off the description alone would keep the 200 the response started as and
+    // report a broken transfer as a success.
+    // The headers arrived, so the snapshot carries a 200; the body then broke. This is exactly the
+    // shape the body-read fix produces, and the only path where a null description isn't rescued by
+    // a missing status code.
+    val request = Request.Builder().url("https://expo.dev/x").build()
+    val response = okhttp3.Response.Builder()
+      .request(request)
+      .protocol(okhttp3.Protocol.HTTP_1_1)
+      .code(200)
+      .message("OK")
+      .build()
+    val snapshot = buildSnapshot(
+      id = java.util.UUID.randomUUID(),
+      originalRequest = request,
+      response = response,
+      phases = null,
+      fallbackStart = java.util.Date(0),
+      fallbackEnd = java.util.Date(100),
+      totalDuration = 0.1,
+      error = java.net.SocketException()
+    )
+    assertTrue("a message-less failure should still count as failed", snapshot.isFailed)
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -115,6 +115,41 @@ class NetworkRequestInterceptorTest {
   }
 
   @Test
+  fun `flags a dropped connection as a timeout`() {
+    // The server accepts the connection and then drops it, which is what the radio going away
+    // mid-request looks like to OkHttp. iOS reports this as NSURLErrorNetworkConnectionLost and
+    // counts it, so Android has to count it too for the metric to mean one thing.
+    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+    var thrown = false
+    try {
+      client.newCall(Request.Builder().url(server.url("/dropped")).build()).execute()
+    } catch (_: IOException) {
+      thrown = true
+    }
+    assertTrue("the network call should fail", thrown)
+    assertEquals(1, monitor.recent.size)
+    assertTrue(monitor.recent.first().isTimeout)
+  }
+
+  @Test
+  fun `flags an unresolvable host as a timeout`() {
+    // DNS failing is what an offline device looks like from here. iOS counts the equivalent
+    // NSURLErrorNotConnectedToInternet and NSURLErrorCannotFindHost codes.
+    var thrown = false
+    try {
+      client
+        .newCall(Request.Builder().url("https://host.invalid/x").build())
+        .execute()
+    } catch (_: IOException) {
+      thrown = true
+    }
+    assertTrue("the network call should fail to resolve", thrown)
+    assertEquals(1, monitor.recent.size)
+    assertTrue(monitor.recent.first().isTimeout)
+  }
+
+  @Test
   fun `does not flag a server error as a timeout`() {
     server.enqueue(MockResponse().setResponseCode(503))
     client.newCall(Request.Builder().url(server.url("/boom")).build()).execute().close()

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -179,6 +179,47 @@ class NetworkRequestInterceptorTest {
   }
 
   @Test
+  fun `records response bytes for a chunked body with no declared length`() {
+    val body = "x".repeat(4096)
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setChunkedBody(body, 512)
+    )
+
+    val response = client.newCall(Request.Builder().url(server.url("/chunked")).build()).execute()
+    response.body!!.string()
+    response.close()
+
+    val snapshot = monitor.recent.first()
+    val received = snapshot.responseBytesReceived!!
+    // A chunked response declares no Content-Length, so the `contentLength()` fallback is -1.
+    // The count has to come from the event listener; without it we'd silently report headers only.
+    assertTrue("expected at least body length, got $received", received >= body.length)
+  }
+
+  @Test
+  fun `reports unknown response bytes rather than a headers-only count`() {
+    server.enqueue(
+      MockResponse()
+        .setResponseCode(200)
+        .setChunkedBody("y".repeat(2048), 256)
+    )
+
+    // Never drain the body: `responseBodyEnd` won't fire, so no byte count is available. The
+    // snapshot has to say "unknown" instead of reporting the header estimate as a measurement,
+    // which would both understate totals and let the request into the throughput denominator.
+    val response = client.newCall(Request.Builder().url(server.url("/abandoned")).build()).execute()
+    response.close()
+
+    val snapshot = monitor.recent.first()
+    assertNull(
+      "expected unknown byte count, got ${snapshot.responseBytesReceived}",
+      snapshot.responseBytesReceived
+    )
+  }
+
+  @Test
   fun `internal opt-out header skips observation and is stripped from the outgoing request`() {
     server.enqueue(MockResponse().setResponseCode(200))
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitorTest.kt
@@ -114,6 +114,7 @@ class NetworkRequestMonitorTest {
       requestEnd = null,
       responseStart = null,
       responseEnd = null,
+      measuredResponseEnd = null,
       totalDuration = 0.1
     ),
     errorDescription = null,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
@@ -55,6 +55,7 @@ class NetworkRequestObserverTest {
         requestEnd = null,
         responseStart = null,
         responseEnd = responseEnd,
+        measuredResponseEnd = responseEnd,
         totalDuration = 0.5
       ),
       errorDescription = null,
@@ -111,6 +112,7 @@ class NetworkRequestObserverTest {
         requestEnd = null,
         responseStart = null,
         responseEnd = null,
+        measuredResponseEnd = null,
         totalDuration = 0.1
       ),
       errorDescription = "timed out",

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -278,6 +278,43 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `excludes a request whose end was never measured from throughput`() {
+    // Headers arrived and then the request died, so `responseEnd` is the wall-clock moment the
+    // snapshot was recorded rather than the last byte. Dividing by that window would describe the
+    // recording delay: 100 kB over the 550ms fallback reads as 186 kB/s for a 50ms transfer.
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          responseBytesReceived = 102_400,
+          fetchStart = Date(0),
+          responseStart = Date(1000),
+          responseEnd = Date(1550),
+          endWasMeasured = false
+        )
+      )
+    )
+    assertNull(summary.throughputBytesPerSecond)
+  }
+
+  @Test
+  fun `excludes a transfer too fast for the clock to measure`() {
+    // `Date()` advances in whole milliseconds, so a sub-millisecond transfer records as a
+    // zero-length window. iOS applies the same floor rather than dividing by the finer windows it
+    // can resolve, so the two platforms agree on when the rate is unknown.
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          responseBytesReceived = 8192,
+          fetchStart = Date(0),
+          responseStart = Date(1),
+          responseEnd = Date(1)
+        )
+      )
+    )
+    assertNull(summary.throughputBytesPerSecond)
+  }
+
+  @Test
   fun `excludes a cache hit from throughput`() {
     // A cached read reports its bytes from the task counters but never touches the network, so it
     // has no first-byte timestamp. Counting it would add megabytes to the numerator against the
@@ -421,7 +458,11 @@ class NetworkRequestSummaryTest {
     totalDuration: Double = 0.1,
     fetchStart: Date = Date(0),
     responseStart: Date? = null,
-    responseEnd: Date? = Date(100)
+    responseEnd: Date? = Date(100),
+    // Defaults to whatever `responseEnd` is so a test that doesn't care gets a transfer window
+    // matching the span it set up. Pass `false` to model a request whose last byte was never
+    // reported, which is what an unmeasured end looks like in production.
+    endWasMeasured: Boolean = true
   ): NetworkRequest = NetworkRequest(
     id = UUID.randomUUID(),
     url = url,
@@ -442,6 +483,7 @@ class NetworkRequestSummaryTest {
       requestEnd = null,
       responseStart = responseStart,
       responseEnd = responseEnd,
+      measuredResponseEnd = if (endWasMeasured) responseEnd else null,
       totalDuration = totalDuration
     ),
     errorDescription = errorDescription,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -15,8 +15,7 @@ class NetworkRequestSummaryTest {
     assertEquals(0L, summary.bytesReceived)
     assertEquals(0L, summary.bytesSent)
     assertEquals(0.0, summary.totalDuration, 0.0001)
-    assertNull(summary.slowest?.duration)
-    assertNull(summary.slowest?.host)
+    assertNull(summary.slowest)
     assertEquals(true, summary.isEmpty)
   }
 

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -252,6 +252,30 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `excludes a stalled failed request from throughput`() {
+    // A healthy 1 MB download inside the span of a request that received a few bytes and then
+    // stalled until the client gave up. Counting the stall would merge the two spans and report the
+    // whole window as busy, which reads as a connection many times slower than the real one.
+    val requests = listOf(
+      makeRequest(
+        responseBytesReceived = 1_000_000,
+        fetchStart = Date(0),
+        responseEnd = Date(1000)
+      ),
+      makeRequest(
+        statusCode = null,
+        errorDescription = "timeout",
+        isTimeout = true,
+        responseBytesReceived = 2000,
+        fetchStart = Date(0),
+        responseEnd = Date(30000)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(1_000_000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
   fun `merges partially overlapping requests into one busy span`() {
     // 0-2s and 1-3s overlap, so busy time is 3s rather than the 4s of summed duration.
     val requests = listOf(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -168,6 +168,25 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `ignores requests that received no bytes when timing throughput`() {
+    // A slow API call that returns nothing spends real time in flight, but no bytes could have been
+    // flowing during it. Counting its span would describe time the payload wasn't moving; its
+    // latency is already covered by `slowestTimeToFirstByte`.
+    val requests = listOf(
+      makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(1000)),
+      makeRequest(
+        url = "https://httpbin.org/status/204",
+        statusCode = 204,
+        responseBytesReceived = 0,
+        fetchStart = Date(1000),
+        responseEnd = Date(4000)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(10000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
   fun `leaves throughput null when nothing was received`() {
     // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
     val summary = NetworkRequestSummary.from(
@@ -177,43 +196,11 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
-  fun `takes the fastest tcp handshake and excludes the tls portion`() {
-    val requests = listOf(
-      // TLS ran, so the window ends at secureConnectionStart: 0.2s, not the 0.5s connectEnd
-      // would report (it lands after the TLS exchange).
-      makeRequest(
-        connectStart = Date(0),
-        connectEnd = Date(500),
-        secureConnectionStart = Date(200)
-      ),
-      // Cleartext, so it falls back to connectEnd: 0.3s.
-      makeRequest(connectStart = Date(0), connectEnd = Date(300))
-    )
-    val summary = NetworkRequestSummary.from(requests)
-    assertEquals(0.2, summary.fastestTcpHandshake!!, 0.0001)
-  }
-
-  @Test
-  fun `leaves fastest tcp handshake null when every connection was reused`() {
-    // Under keep-alive connectStart is null, which means "no new connection", not "zero latency".
-    val summary = NetworkRequestSummary.from(listOf(makeRequest(), makeRequest()))
-    assertNull(summary.fastestTcpHandshake)
-  }
-
-  @Test
-  fun `ignores negative handshake and first-byte durations`() {
+  fun `ignores a negative first-byte duration`() {
     // A clock adjustment mid-request can invert these wall-clock dates.
     val summary = NetworkRequestSummary.from(
-      listOf(
-        makeRequest(
-          fetchStart = Date(500),
-          connectStart = Date(500),
-          connectEnd = Date(400),
-          responseStart = Date(300)
-        )
-      )
+      listOf(makeRequest(fetchStart = Date(500), responseStart = Date(300)))
     )
-    assertNull(summary.fastestTcpHandshake)
     assertNull(summary.slowestTimeToFirstByte)
   }
 
@@ -226,9 +213,6 @@ class NetworkRequestSummaryTest {
     totalDuration: Double = 0.1,
     isTimeout: Boolean = false,
     fetchStart: Date = Date(0),
-    connectStart: Date? = null,
-    connectEnd: Date? = null,
-    secureConnectionStart: Date? = null,
     responseStart: Date? = null,
     responseEnd: Date? = Date(100)
   ): NetworkRequest = NetworkRequest(
@@ -243,9 +227,9 @@ class NetworkRequestSummaryTest {
       fetchStart = fetchStart,
       domainLookupStart = null,
       domainLookupEnd = null,
-      connectStart = connectStart,
-      connectEnd = connectEnd,
-      secureConnectionStart = secureConnectionStart,
+      connectStart = null,
+      connectEnd = null,
+      secureConnectionStart = null,
       secureConnectionEnd = null,
       requestStart = null,
       requestEnd = null,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -93,6 +93,34 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `reports the slowest request's status code so an empty body can be explained`() {
+    // A 304 revalidation is successful, so it's a candidate, but carries no body. Without the status
+    // code a reader can't tell that from a 200 whose transfer broke.
+    val requests = listOf(
+      makeRequest(
+        statusCode = 304,
+        responseBytesReceived = 0,
+        totalDuration = 1.1,
+        fetchStart = Date(0),
+        responseEnd = Date(1100)
+      ),
+      makeRequest(
+        statusCode = 200,
+        responseBytesReceived = 7000,
+        totalDuration = 0.5,
+        fetchStart = Date(0),
+        responseStart = Date(100),
+        responseEnd = Date(500)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(304, summary.slowest!!.statusCode)
+    assertEquals(0L, summary.slowest!!.bytesReceived)
+    // Not filtered out: the status code explains the zero rather than hiding the request.
+    assertEquals(1.1, summary.slowest!!.duration, 0.0001)
+  }
+
+  @Test
   fun `leaves slowest null when every request failed`() {
     val summary = NetworkRequestSummary.from(
       listOf(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -68,8 +68,7 @@ class NetworkRequestSummaryTest {
         url = "http://192.168.0.104/bundle",
         statusCode = null,
         errorDescription = "timeout",
-        totalDuration = 10.0,
-        isTimeout = true
+        totalDuration = 10.0
       ),
       makeRequest(
         url = "https://cdn.expo.dev/asset",
@@ -88,7 +87,6 @@ class NetworkRequestSummaryTest {
     assertEquals(0.4, summary.slowest!!.timeToFirstByte!!, 0.0001)
     assertEquals(5000L, summary.slowest!!.bytesReceived)
     // The timeout is still counted, just not used to describe the slowest request.
-    assertEquals(1, summary.timedOut)
     assertEquals(1, summary.failed)
   }
 
@@ -127,14 +125,12 @@ class NetworkRequestSummaryTest {
         makeRequest(
           statusCode = null,
           errorDescription = "timeout",
-          totalDuration = 10.0,
-          isTimeout = true
+          totalDuration = 10.0
         )
       )
     )
     assertNull(summary.slowest)
     assertEquals(1, summary.count)
-    assertEquals(1, summary.timedOut)
   }
 
   @Test
@@ -160,31 +156,6 @@ class NetworkRequestSummaryTest {
     val summary = NetworkRequestSummary.from(requests)
     assertEquals(4.0, summary.slowest!!.duration, 0.0001)
     assertEquals(0.3, summary.slowest!!.timeToFirstByte!!, 0.0001)
-  }
-
-  @Test
-  fun `counts timeouts separately from other failures`() {
-    val requests = listOf(
-      makeRequest(
-        statusCode = null,
-        errorDescription = "timeout",
-        totalDuration = 30.0,
-        isTimeout = true
-      ),
-      // A 5xx is the backend failing, not the network.
-      makeRequest(statusCode = 503),
-      makeRequest(statusCode = 200)
-    )
-    val summary = NetworkRequestSummary.from(requests)
-    assertEquals(2, summary.failed)
-    assertEquals(1, summary.timedOut)
-  }
-
-  @Test
-  fun `reports no timeouts when every request reached the server`() {
-    val summary = NetworkRequestSummary.from(listOf(makeRequest(statusCode = 500)))
-    assertEquals(1, summary.failed)
-    assertEquals(0, summary.timedOut)
   }
 
   @Test
@@ -279,7 +250,6 @@ class NetworkRequestSummaryTest {
       makeRequest(
         statusCode = null,
         errorDescription = "timeout",
-        isTimeout = true,
         responseBytesReceived = 2000,
         fetchStart = Date(0),
         responseStart = Date(0),
@@ -449,7 +419,6 @@ class NetworkRequestSummaryTest {
     requestBytesSent: Long? = 0,
     responseBytesReceived: Long? = 0,
     totalDuration: Double = 0.1,
-    isTimeout: Boolean = false,
     fetchStart: Date = Date(0),
     responseStart: Date? = null,
     responseEnd: Date? = Date(100)
@@ -476,7 +445,6 @@ class NetworkRequestSummaryTest {
       totalDuration = totalDuration
     ),
     errorDescription = errorDescription,
-    redirects = emptyList(),
-    isTimeout = isTimeout
+    redirects = emptyList()
   )
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -187,6 +187,27 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `ignores a byte-carrying request whose interval collapsed to nothing`() {
+    // A cache hit reports its bytes but is served from disk inside one clock tick, so its interval
+    // collapses. Counting those bytes against another request's span would double the rate.
+    val requests = listOf(
+      makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(0)),
+      makeRequest(responseBytesReceived = 10000, fetchStart = Date(5000), responseEnd = Date(6000))
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    // Only the download's 10 kB over its own 1s span.
+    assertEquals(10000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `leaves throughput null when the only receiving request had no measurable span`() {
+    val summary = NetworkRequestSummary.from(
+      listOf(makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(0)))
+    )
+    assertNull(summary.throughputBytesPerSecond)
+  }
+
+  @Test
   fun `leaves throughput null when nothing was received`() {
     // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
     val summary = NetworkRequestSummary.from(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -213,11 +213,13 @@ class NetworkRequestSummaryTest {
       makeRequest(
         responseBytesReceived = 8000,
         fetchStart = Date(0),
+        responseStart = Date(0),
         responseEnd = Date(1000)
       ),
       makeRequest(
         responseBytesReceived = 2000,
         fetchStart = Date(1000),
+        responseStart = Date(1000),
         responseEnd = Date(2000)
       )
     )
@@ -233,6 +235,7 @@ class NetworkRequestSummaryTest {
       makeRequest(
         responseBytesReceived = 10000,
         fetchStart = Date(0),
+        responseStart = Date(0),
         responseEnd = Date(1000)
       )
     }
@@ -244,8 +247,18 @@ class NetworkRequestSummaryTest {
   fun `excludes idle gaps between requests from throughput`() {
     // 1s of transfer, a 10s idle gap, then another 1s: only the 2s of busy time counts.
     val requests = listOf(
-      makeRequest(responseBytesReceived = 5000, fetchStart = Date(0), responseEnd = Date(1000)),
-      makeRequest(responseBytesReceived = 5000, fetchStart = Date(11000), responseEnd = Date(12000))
+      makeRequest(
+        responseBytesReceived = 5000,
+        fetchStart = Date(0),
+        responseStart = Date(0),
+        responseEnd = Date(1000)
+      ),
+      makeRequest(
+        responseBytesReceived = 5000,
+        fetchStart = Date(11000),
+        responseStart = Date(11000),
+        responseEnd = Date(12000)
+      )
     )
     val summary = NetworkRequestSummary.from(requests)
     assertEquals(5000.0, summary.throughputBytesPerSecond!!, 0.0001)
@@ -260,6 +273,7 @@ class NetworkRequestSummaryTest {
       makeRequest(
         responseBytesReceived = 1_000_000,
         fetchStart = Date(0),
+        responseStart = Date(0),
         responseEnd = Date(1000)
       ),
       makeRequest(
@@ -268,6 +282,7 @@ class NetworkRequestSummaryTest {
         isTimeout = true,
         responseBytesReceived = 2000,
         fetchStart = Date(0),
+        responseStart = Date(0),
         responseEnd = Date(30000)
       )
     )
@@ -276,11 +291,62 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `measures throughput over the transfer window, not the whole request`() {
+    // 4 seconds waiting on the backend, then 1 kB delivered in 10ms. Charging the wait to the
+    // network reports ~256 B/s for a connection that moved 1 kB in a hundredth of a second.
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          responseBytesReceived = 1024,
+          fetchStart = Date(0),
+          responseStart = Date(4000),
+          responseEnd = Date(4010)
+        )
+      )
+    )
+    assertEquals(102_400.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `excludes a cache hit from throughput`() {
+    // A cached read reports its bytes from the task counters but never touches the network, so it
+    // has no first-byte timestamp. Counting it would add megabytes to the numerator against the
+    // few milliseconds it took to read from disk.
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          responseBytesReceived = 5_000_000,
+          fetchStart = Date(0),
+          responseStart = null,
+          responseEnd = Date(20)
+        ),
+        makeRequest(
+          responseBytesReceived = 100_000,
+          fetchStart = Date(0),
+          responseStart = Date(0),
+          responseEnd = Date(1000)
+        )
+      )
+    )
+    assertEquals(100_000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
   fun `merges partially overlapping requests into one busy span`() {
     // 0-2s and 1-3s overlap, so busy time is 3s rather than the 4s of summed duration.
     val requests = listOf(
-      makeRequest(responseBytesReceived = 3000, fetchStart = Date(0), responseEnd = Date(2000)),
-      makeRequest(responseBytesReceived = 3000, fetchStart = Date(1000), responseEnd = Date(3000))
+      makeRequest(
+        responseBytesReceived = 3000,
+        fetchStart = Date(0),
+        responseStart = Date(0),
+        responseEnd = Date(2000)
+      ),
+      makeRequest(
+        responseBytesReceived = 3000,
+        fetchStart = Date(1000),
+        responseStart = Date(1000),
+        responseEnd = Date(3000)
+      )
     )
     val summary = NetworkRequestSummary.from(requests)
     assertEquals(2000.0, summary.throughputBytesPerSecond!!, 0.0001)
@@ -301,12 +367,18 @@ class NetworkRequestSummaryTest {
     // flowing during it. Counting its span would describe time the payload wasn't moving; its
     // latency is already covered by `slowest.timeToFirstByte`.
     val requests = listOf(
-      makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(1000)),
+      makeRequest(
+        responseBytesReceived = 10000,
+        fetchStart = Date(0),
+        responseStart = Date(0),
+        responseEnd = Date(1000)
+      ),
       makeRequest(
         url = "https://httpbin.org/status/204",
         statusCode = 204,
         responseBytesReceived = 0,
         fetchStart = Date(1000),
+        responseStart = Date(1000),
         responseEnd = Date(4000)
       )
     )
@@ -319,8 +391,18 @@ class NetworkRequestSummaryTest {
     // A cache hit reports its bytes but is served from disk inside one clock tick, so its interval
     // collapses. Counting those bytes against another request's span would double the rate.
     val requests = listOf(
-      makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(0)),
-      makeRequest(responseBytesReceived = 10000, fetchStart = Date(5000), responseEnd = Date(6000))
+      makeRequest(
+        responseBytesReceived = 10000,
+        fetchStart = Date(0),
+        responseStart = Date(0),
+        responseEnd = Date(0)
+      ),
+      makeRequest(
+        responseBytesReceived = 10000,
+        fetchStart = Date(5000),
+        responseStart = Date(5000),
+        responseEnd = Date(6000)
+      )
     )
     val summary = NetworkRequestSummary.from(requests)
     // Only the download's 10 kB over its own 1s span.
@@ -330,7 +412,14 @@ class NetworkRequestSummaryTest {
   @Test
   fun `leaves throughput null when the only receiving request had no measurable span`() {
     val summary = NetworkRequestSummary.from(
-      listOf(makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(0)))
+      listOf(
+        makeRequest(
+          responseBytesReceived = 10000,
+          fetchStart = Date(0),
+          responseStart = Date(0),
+          responseEnd = Date(0)
+        )
+      )
     )
     assertNull(summary.throughputBytesPerSecond)
   }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -15,8 +15,8 @@ class NetworkRequestSummaryTest {
     assertEquals(0L, summary.bytesReceived)
     assertEquals(0L, summary.bytesSent)
     assertEquals(0.0, summary.totalDuration, 0.0001)
-    assertNull(summary.slowestDuration)
-    assertNull(summary.slowestHost)
+    assertNull(summary.slowest?.duration)
+    assertNull(summary.slowest?.host)
     assertEquals(true, summary.isEmpty)
   }
 
@@ -43,8 +43,8 @@ class NetworkRequestSummaryTest {
       makeRequest(url = "https://mid.example/z", totalDuration = 0.3)
     )
     val summary = NetworkRequestSummary.from(requests)
-    assertEquals(0.5, summary.slowestDuration!!, 0.0001)
-    assertEquals("slow.example", summary.slowestHost)
+    assertEquals(0.5, summary.slowest?.duration!!, 0.0001)
+    assertEquals("slow.example", summary.slowest?.host)
   }
 
   @Test
@@ -57,6 +57,81 @@ class NetworkRequestSummaryTest {
     val summary = NetworkRequestSummary.from(requests)
     assertEquals(130L, summary.bytesSent)
     assertEquals(250L, summary.bytesReceived)
+  }
+
+  @Test
+  fun `picks the slowest completed request rather than the slowest failure`() {
+    // A timeout's duration is the client's timeout setting, not a measurement of the server, so
+    // letting it win would make this field report a config constant instead of the network.
+    val requests = listOf(
+      makeRequest(
+        url = "http://192.168.0.104/bundle",
+        statusCode = null,
+        errorDescription = "timeout",
+        totalDuration = 10.0,
+        isTimeout = true
+      ),
+      makeRequest(
+        url = "https://cdn.expo.dev/asset",
+        responseBytesReceived = 5000,
+        totalDuration = 2.0,
+        fetchStart = Date(0),
+        responseStart = Date(400),
+        responseEnd = Date(2000)
+      ),
+      makeRequest(url = "https://api.expo.dev/v2", responseBytesReceived = 100, totalDuration = 0.2)
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(2.0, summary.slowest!!.duration, 0.0001)
+    assertEquals("cdn.expo.dev", summary.slowest!!.host)
+    // All fields describe that one request.
+    assertEquals(0.4, summary.slowest!!.timeToFirstByte!!, 0.0001)
+    assertEquals(5000L, summary.slowest!!.bytesReceived)
+    // The timeout is still counted, just not used to describe the slowest request.
+    assertEquals(1, summary.timedOut)
+    assertEquals(1, summary.failed)
+  }
+
+  @Test
+  fun `leaves slowest null when every request failed`() {
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          statusCode = null,
+          errorDescription = "timeout",
+          totalDuration = 10.0,
+          isTimeout = true
+        )
+      )
+    )
+    assertNull(summary.slowest)
+    assertEquals(1, summary.count)
+    assertEquals(1, summary.timedOut)
+  }
+
+  @Test
+  fun `reports the slowest request's own time to first byte, not the window maximum`() {
+    // The quick request has the higher TTFB; a window max would report 0.9 here. The slowest
+    // request's own TTFB is 0.3, which is what pairs with its duration.
+    val requests = listOf(
+      makeRequest(
+        responseBytesReceived = 9000,
+        totalDuration = 4.0,
+        fetchStart = Date(0),
+        responseStart = Date(300),
+        responseEnd = Date(4000)
+      ),
+      makeRequest(
+        responseBytesReceived = 100,
+        totalDuration = 1.0,
+        fetchStart = Date(0),
+        responseStart = Date(900),
+        responseEnd = Date(1000)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(4.0, summary.slowest!!.duration, 0.0001)
+    assertEquals(0.3, summary.slowest!!.timeToFirstByte!!, 0.0001)
   }
 
   @Test
@@ -85,21 +160,22 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
-  fun `aggregates slowest time to first byte and ignores requests without one`() {
+  fun `leaves slowest time to first byte null when the slowest request reported none`() {
     val requests = listOf(
-      makeRequest(fetchStart = Date(0), responseStart = Date(50)),
-      makeRequest(fetchStart = Date(0), responseStart = Date(300)),
-      // No responseStart (failed before headers arrived), so it contributes nothing.
-      makeRequest(statusCode = null, errorDescription = "timed out", totalDuration = 2.0)
+      makeRequest(totalDuration = 2.0, fetchStart = Date(0), responseStart = null),
+      makeRequest(totalDuration = 0.1, fetchStart = Date(0), responseStart = Date(50))
     )
     val summary = NetworkRequestSummary.from(requests)
-    assertEquals(0.3, summary.slowestTimeToFirstByte!!, 0.0001)
+    // The 2s request wins on duration but never produced a first byte, so the field is absent
+    // rather than borrowing the quick request's value.
+    assertEquals(2.0, summary.slowest!!.duration, 0.0001)
+    assertNull(summary.slowest!!.timeToFirstByte)
   }
 
   @Test
   fun `leaves slowest time to first byte null when no request reported one`() {
     val summary = NetworkRequestSummary.from(listOf(makeRequest()))
-    assertNull(summary.slowestTimeToFirstByte)
+    assertNull(summary.slowest?.timeToFirstByte)
   }
 
   @Test
@@ -171,7 +247,7 @@ class NetworkRequestSummaryTest {
   fun `ignores requests that received no bytes when timing throughput`() {
     // A slow API call that returns nothing spends real time in flight, but no bytes could have been
     // flowing during it. Counting its span would describe time the payload wasn't moving; its
-    // latency is already covered by `slowestTimeToFirstByte`.
+    // latency is already covered by `slowest.timeToFirstByte`.
     val requests = listOf(
       makeRequest(responseBytesReceived = 10000, fetchStart = Date(0), responseEnd = Date(1000)),
       makeRequest(
@@ -222,7 +298,7 @@ class NetworkRequestSummaryTest {
     val summary = NetworkRequestSummary.from(
       listOf(makeRequest(fetchStart = Date(500), responseStart = Date(300)))
     )
-    assertNull(summary.slowestTimeToFirstByte)
+    assertNull(summary.slowest?.timeToFirstByte)
   }
 
   private fun makeRequest(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -59,13 +59,178 @@ class NetworkRequestSummaryTest {
     assertEquals(250L, summary.bytesReceived)
   }
 
+  @Test
+  fun `counts timeouts separately from other failures`() {
+    val requests = listOf(
+      makeRequest(
+        statusCode = null,
+        errorDescription = "timeout",
+        totalDuration = 30.0,
+        isTimeout = true
+      ),
+      // A 5xx is the backend failing, not the network.
+      makeRequest(statusCode = 503),
+      makeRequest(statusCode = 200)
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(2, summary.failed)
+    assertEquals(1, summary.timedOut)
+  }
+
+  @Test
+  fun `reports no timeouts when every request reached the server`() {
+    val summary = NetworkRequestSummary.from(listOf(makeRequest(statusCode = 500)))
+    assertEquals(1, summary.failed)
+    assertEquals(0, summary.timedOut)
+  }
+
+  @Test
+  fun `aggregates slowest time to first byte and ignores requests without one`() {
+    val requests = listOf(
+      makeRequest(fetchStart = Date(0), responseStart = Date(50)),
+      makeRequest(fetchStart = Date(0), responseStart = Date(300)),
+      // No responseStart (failed before headers arrived), so it contributes nothing.
+      makeRequest(statusCode = null, errorDescription = "timed out", totalDuration = 2.0)
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(0.3, summary.slowestTimeToFirstByte!!, 0.0001)
+  }
+
+  @Test
+  fun `leaves slowest time to first byte null when no request reported one`() {
+    val summary = NetworkRequestSummary.from(listOf(makeRequest()))
+    assertNull(summary.slowestTimeToFirstByte)
+  }
+
+  @Test
+  fun `computes throughput over the time the network was actually busy`() {
+    // Two requests back to back: 1s each, no overlap, so 2s of busy time.
+    val requests = listOf(
+      makeRequest(
+        responseBytesReceived = 8000,
+        fetchStart = Date(0),
+        responseEnd = Date(1000)
+      ),
+      makeRequest(
+        responseBytesReceived = 2000,
+        fetchStart = Date(1000),
+        responseEnd = Date(2000)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(5000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `does not deflate throughput when requests run concurrently`() {
+    // Four parallel requests, each 1s and 10 kB. Summed request-seconds would be 4s and report
+    // 10 kB/s; the network actually moved 40 kB in one second of wall-clock.
+    val requests = (0 until 4).map {
+      makeRequest(
+        responseBytesReceived = 10000,
+        fetchStart = Date(0),
+        responseEnd = Date(1000)
+      )
+    }
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(40000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `excludes idle gaps between requests from throughput`() {
+    // 1s of transfer, a 10s idle gap, then another 1s: only the 2s of busy time counts.
+    val requests = listOf(
+      makeRequest(responseBytesReceived = 5000, fetchStart = Date(0), responseEnd = Date(1000)),
+      makeRequest(responseBytesReceived = 5000, fetchStart = Date(11000), responseEnd = Date(12000))
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(5000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `merges partially overlapping requests into one busy span`() {
+    // 0-2s and 1-3s overlap, so busy time is 3s rather than the 4s of summed duration.
+    val requests = listOf(
+      makeRequest(responseBytesReceived = 3000, fetchStart = Date(0), responseEnd = Date(2000)),
+      makeRequest(responseBytesReceived = 3000, fetchStart = Date(1000), responseEnd = Date(3000))
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(2000.0, summary.throughputBytesPerSecond!!, 0.0001)
+  }
+
+  @Test
+  fun `leaves throughput null when no request reported a usable interval`() {
+    // Without a responseEnd there's no busy span to divide by, so the rate is unknown rather than 0.
+    val summary = NetworkRequestSummary.from(
+      listOf(makeRequest(responseBytesReceived = 5000, responseEnd = null))
+    )
+    assertNull(summary.throughputBytesPerSecond)
+  }
+
+  @Test
+  fun `leaves throughput null when nothing was received`() {
+    // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
+    val summary = NetworkRequestSummary.from(
+      listOf(makeRequest(statusCode = 304, responseBytesReceived = 0, totalDuration = 0.01))
+    )
+    assertNull(summary.throughputBytesPerSecond)
+  }
+
+  @Test
+  fun `takes the fastest tcp handshake and excludes the tls portion`() {
+    val requests = listOf(
+      // TLS ran, so the window ends at secureConnectionStart: 0.2s, not the 0.5s connectEnd
+      // would report (it lands after the TLS exchange).
+      makeRequest(
+        connectStart = Date(0),
+        connectEnd = Date(500),
+        secureConnectionStart = Date(200)
+      ),
+      // Cleartext, so it falls back to connectEnd: 0.3s.
+      makeRequest(connectStart = Date(0), connectEnd = Date(300))
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(0.2, summary.fastestTcpHandshake!!, 0.0001)
+  }
+
+  @Test
+  fun `leaves fastest tcp handshake null when every connection was reused`() {
+    // Under keep-alive connectStart is null, which means "no new connection", not "zero latency".
+    val summary = NetworkRequestSummary.from(listOf(makeRequest(), makeRequest()))
+    assertNull(summary.fastestTcpHandshake)
+  }
+
+  @Test
+  fun `ignores negative handshake and first-byte durations`() {
+    // A clock adjustment mid-request can invert these wall-clock dates.
+    val summary = NetworkRequestSummary.from(
+      listOf(
+        makeRequest(
+          fetchStart = Date(500),
+          connectStart = Date(500),
+          connectEnd = Date(400),
+          responseStart = Date(300)
+        )
+      )
+    )
+    assertNull(summary.fastestTcpHandshake)
+    assertNull(summary.slowestTimeToFirstByte)
+  }
+
   private fun makeRequest(
     url: String = "https://expo.dev/x",
     statusCode: Int? = 200,
     errorDescription: String? = null,
     requestBytesSent: Long? = 0,
     responseBytesReceived: Long? = 0,
-    totalDuration: Double = 0.1
+    totalDuration: Double = 0.1,
+    isTimeout: Boolean = false,
+    fetchStart: Date = Date(0),
+    connectStart: Date? = null,
+    connectEnd: Date? = null,
+    secureConnectionStart: Date? = null,
+    responseStart: Date? = null,
+    responseEnd: Date? = Date(100)
   ): NetworkRequest = NetworkRequest(
     id = UUID.randomUUID(),
     url = url,
@@ -75,20 +240,21 @@ class NetworkRequestSummaryTest {
     requestBytesSent = requestBytesSent,
     responseBytesReceived = responseBytesReceived,
     timings = NetworkRequest.Timings(
-      fetchStart = Date(0),
+      fetchStart = fetchStart,
       domainLookupStart = null,
       domainLookupEnd = null,
-      connectStart = null,
-      connectEnd = null,
-      secureConnectionStart = null,
+      connectStart = connectStart,
+      connectEnd = connectEnd,
+      secureConnectionStart = secureConnectionStart,
       secureConnectionEnd = null,
       requestStart = null,
       requestEnd = null,
-      responseStart = null,
-      responseEnd = null,
+      responseStart = responseStart,
+      responseEnd = responseEnd,
       totalDuration = totalDuration
     ),
     errorDescription = errorDescription,
-    redirects = emptyList()
+    redirects = emptyList(),
+    isTimeout = isTimeout
   )
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -90,6 +90,38 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `picks a slow error response over a fast success`() {
+    // A 503 that took 8 seconds is the answer to "why was this launch slow": the app really did
+    // wait that long. Only requests that never completed are excluded, because a timeout's duration
+    // is the client's own setting rather than anything the server did.
+    val requests = listOf(
+      makeRequest(
+        url = "https://api.expo.dev/v2",
+        statusCode = 503,
+        responseBytesReceived = 900,
+        totalDuration = 8.0,
+        fetchStart = Date(0),
+        responseStart = Date(7800),
+        responseEnd = Date(8000)
+      ),
+      makeRequest(
+        url = "https://cdn.expo.dev/asset",
+        responseBytesReceived = 100,
+        totalDuration = 0.2,
+        fetchStart = Date(0),
+        responseStart = Date(100),
+        responseEnd = Date(200)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(8.0, summary.slowest!!.duration, 0.0001)
+    assertEquals("api.expo.dev", summary.slowest!!.host)
+    assertEquals(503, summary.slowest!!.statusCode)
+    // Still counted as a failure; the two fields answer different questions.
+    assertEquals(1, summary.failed)
+  }
+
+  @Test
   fun `reports the slowest request's status code so an empty body can be explained`() {
     // A 304 revalidation is successful, so it's a candidate, but carries no body. Without the status
     // code a reader can't tell that from a 200 whose transfer broke.

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestSummaryTest.kt
@@ -122,6 +122,36 @@ class NetworkRequestSummaryTest {
   }
 
   @Test
+  fun `keeps a slow response that broke mid-body as the slowest`() {
+    // The body-read fix gives a truncated transfer a 200 AND an error description. Keying
+    // "never completed" off the error string would drop it, which is backwards: a 9s response that
+    // died partway is exactly what a bad-network launch looks like.
+    val requests = listOf(
+      makeRequest(
+        url = "https://cdn.expo.dev/bundle",
+        statusCode = 200,
+        errorDescription = "unexpected end of stream",
+        responseBytesReceived = 4000,
+        totalDuration = 9.0,
+        fetchStart = Date(0),
+        responseStart = Date(500),
+        responseEnd = Date(9000)
+      ),
+      makeRequest(
+        url = "https://api.expo.dev/v2",
+        responseBytesReceived = 100,
+        totalDuration = 0.3,
+        fetchStart = Date(0),
+        responseStart = Date(100),
+        responseEnd = Date(300)
+      )
+    )
+    val summary = NetworkRequestSummary.from(requests)
+    assertEquals(9.0, summary.slowest!!.duration, 0.0001)
+    assertEquals("cdn.expo.dev", summary.slowest!!.host)
+  }
+
+  @Test
   fun `reports the slowest request's status code so an empty body can be explained`() {
     // A 304 revalidation is successful, so it's a candidate, but carries no body. Without the status
     // code a reader can't tell that from a 200 whose transfer broke.

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
@@ -129,8 +129,8 @@ class MetricParamsBuilderTest {
     assertNull(params["expo.network.requests.bytesSent"])
     assertNull(params["expo.network.requests.bytesReceived"])
     assertNull(params["expo.network.requests.totalDuration"])
-    assertNull(params["expo.network.requests.slowestDuration"])
-    assertNull(params["expo.network.requests.slowestHost"])
+    assertNull(params["expo.network.requests.slowest.duration"])
+    assertNull(params["expo.network.requests.slowest.host"])
   }
 
   @Test
@@ -141,8 +141,12 @@ class MetricParamsBuilderTest {
       bytesReceived = 1234,
       bytesSent = 567,
       totalDuration = 1.5,
-      slowestDuration = 0.7,
-      slowestHost = "expo.dev"
+      slowest = NetworkRequestSummary.SlowestRequest(
+        host = "expo.dev",
+        duration = 0.7,
+        timeToFirstByte = null,
+        bytesReceived = null
+      )
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(5, params["expo.network.requests.count"])
@@ -150,8 +154,8 @@ class MetricParamsBuilderTest {
     assertEquals(1234L, params["expo.network.requests.bytesReceived"])
     assertEquals(567L, params["expo.network.requests.bytesSent"])
     assertEquals(1.5, params["expo.network.requests.totalDuration"])
-    assertEquals(0.7, params["expo.network.requests.slowestDuration"])
-    assertEquals("expo.dev", params["expo.network.requests.slowestHost"])
+    assertEquals(0.7, params["expo.network.requests.slowest.duration"])
+    assertEquals("expo.dev", params["expo.network.requests.slowest.host"])
   }
 
   @Test
@@ -200,8 +204,12 @@ class MetricParamsBuilderTest {
       bytesReceived = 0,
       bytesSent = 0,
       totalDuration = 30.2,
-      slowestDuration = 30.0,
-      slowestHost = "slow.expo.dev"
+      slowest = NetworkRequestSummary.SlowestRequest(
+        host = "slow.expo.dev",
+        duration = 30.0,
+        timeToFirstByte = null,
+        bytesReceived = null
+      )
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(2, params["expo.network.requests.failed"])
@@ -220,8 +228,12 @@ class MetricParamsBuilderTest {
       bytesReceived = 10,
       bytesSent = 10,
       totalDuration = 0.1,
-      slowestDuration = 0.1,
-      slowestHost = "expo.dev"
+      slowest = NetworkRequestSummary.SlowestRequest(
+        host = "expo.dev",
+        duration = 0.1,
+        timeToFirstByte = null,
+        bytesReceived = null
+      )
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(0, params["expo.network.requests.timedOut"])
@@ -235,13 +247,19 @@ class MetricParamsBuilderTest {
       bytesReceived = 12000,
       bytesSent = 800,
       totalDuration = 1.4,
-      slowestDuration = 0.6,
-      slowestHost = "api.expo.dev",
-      slowestTimeToFirstByte = 0.35,
+      slowest = NetworkRequestSummary.SlowestRequest(
+        host = "api.expo.dev",
+        duration = 0.6,
+        timeToFirstByte = 0.35,
+        bytesReceived = 9000
+      ),
       throughputBytesPerSecond = 8571.4
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
-    assertEquals(0.35, params["expo.network.requests.slowestTimeToFirstByte"])
+    assertEquals(0.6, params["expo.network.requests.slowest.duration"])
+    assertEquals("api.expo.dev", params["expo.network.requests.slowest.host"])
+    assertEquals(0.35, params["expo.network.requests.slowest.timeToFirstByte"])
+    assertEquals(9000L, params["expo.network.requests.slowest.bytesReceived"])
     assertEquals(8571.4, params["expo.network.requests.throughputBytesPerSecond"])
   }
 
@@ -255,12 +273,16 @@ class MetricParamsBuilderTest {
       bytesReceived = 0,
       bytesSent = 40,
       totalDuration = 0.2,
-      slowestDuration = 0.1,
-      slowestHost = "api.expo.dev"
+      slowest = NetworkRequestSummary.SlowestRequest(
+        host = "api.expo.dev",
+        duration = 0.1,
+        timeToFirstByte = null,
+        bytesReceived = null
+      )
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(2, params["expo.network.requests.count"])
-    assertNull(params["expo.network.requests.slowestTimeToFirstByte"])
+    assertNull(params["expo.network.requests.slowest.timeToFirstByte"])
     assertNull(params["expo.network.requests.throughputBytesPerSecond"])
   }
 
@@ -272,12 +294,11 @@ class MetricParamsBuilderTest {
       bytesReceived = 0,
       bytesSent = 0,
       totalDuration = 0.1,
-      slowestDuration = null,
-      slowestHost = null
+      slowest = null
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(1, params["expo.network.requests.count"])
-    assertNull(params["expo.network.requests.slowestDuration"])
-    assertNull(params["expo.network.requests.slowestHost"])
+    assertNull(params["expo.network.requests.slowest.duration"])
+    assertNull(params["expo.network.requests.slowest.host"])
   }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
@@ -144,6 +144,7 @@ class MetricParamsBuilderTest {
       slowest = NetworkRequestSummary.SlowestRequest(
         host = "expo.dev",
         duration = 0.7,
+        statusCode = 200,
         timeToFirstByte = null,
         bytesReceived = null
       )
@@ -207,6 +208,7 @@ class MetricParamsBuilderTest {
       slowest = NetworkRequestSummary.SlowestRequest(
         host = "slow.expo.dev",
         duration = 30.0,
+        statusCode = 200,
         timeToFirstByte = null,
         bytesReceived = null
       )
@@ -231,6 +233,7 @@ class MetricParamsBuilderTest {
       slowest = NetworkRequestSummary.SlowestRequest(
         host = "expo.dev",
         duration = 0.1,
+        statusCode = 200,
         timeToFirstByte = null,
         bytesReceived = null
       )
@@ -250,6 +253,7 @@ class MetricParamsBuilderTest {
       slowest = NetworkRequestSummary.SlowestRequest(
         host = "api.expo.dev",
         duration = 0.6,
+        statusCode = 200,
         timeToFirstByte = 0.35,
         bytesReceived = 9000
       ),
@@ -258,6 +262,7 @@ class MetricParamsBuilderTest {
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(0.6, params["expo.network.requests.slowest.duration"])
     assertEquals("api.expo.dev", params["expo.network.requests.slowest.host"])
+    assertEquals(200, params["expo.network.requests.slowest.statusCode"])
     assertEquals(0.35, params["expo.network.requests.slowest.timeToFirstByte"])
     assertEquals(9000L, params["expo.network.requests.slowest.bytesReceived"])
     assertEquals(8571.4, params["expo.network.requests.throughputBytesPerSecond"])
@@ -276,6 +281,7 @@ class MetricParamsBuilderTest {
       slowest = NetworkRequestSummary.SlowestRequest(
         host = "api.expo.dev",
         duration = 0.1,
+        statusCode = 200,
         timeToFirstByte = null,
         bytesReceived = null
       )

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
@@ -155,6 +155,119 @@ class MetricParamsBuilderTest {
   }
 
   @Test
+  fun `emits path cost flags alongside the connection type`() {
+    val params = MetricParamsBuilder.build(
+      networkState = NetworkState(
+        connected = true,
+        transport = NetworkTransport.CELLULAR,
+        isExpensive = true,
+        dataSaverEnabled = true
+      )
+    )
+    assertEquals(true, params["expo.network.isExpensive"])
+    assertEquals(true, params["expo.network.dataSaverEnabled"])
+  }
+
+  @Test
+  fun `does not report Data Saver under the iOS isConstrained key`() {
+    // Low Data Mode is per-path; Data Saver is process-wide. Same column would mix two questions.
+    val params = MetricParamsBuilder.build(
+      networkState = NetworkState(
+        connected = true,
+        transport = NetworkTransport.CELLULAR,
+        dataSaverEnabled = true
+      )
+    )
+    assertNull(params["expo.network.isConstrained"])
+  }
+
+  @Test
+  fun `omits path cost flags when the OS did not report them`() {
+    val params = MetricParamsBuilder.build(
+      networkState = NetworkState(connected = true, transport = NetworkTransport.WIFI)
+    )
+    assertEquals(true, params["expo.network.connected"])
+    assertNull(params["expo.network.isExpensive"])
+    assertNull(params["expo.network.dataSaverEnabled"])
+  }
+
+  @Test
+  fun `emits the timeout count alongside the failure count`() {
+    val summary = NetworkRequestSummary(
+      count = 3,
+      failed = 2,
+      timedOut = 1,
+      bytesReceived = 0,
+      bytesSent = 0,
+      totalDuration = 30.2,
+      slowestDuration = 30.0,
+      slowestHost = "slow.expo.dev"
+    )
+    val params = MetricParamsBuilder.build(networkRequests = summary)
+    assertEquals(2, params["expo.network.requests.failed"])
+    assertEquals(1, params["expo.network.requests.timedOut"])
+  }
+
+  @Test
+  fun `emits a zero timeout count so its absence is not ambiguous`() {
+    // Unlike the optional latency fields, a count of zero is a real measurement: we saw requests
+    // and none of them timed out. Omitting it would make "no timeouts" and "not measured" look
+    // the same.
+    val summary = NetworkRequestSummary(
+      count = 1,
+      failed = 0,
+      timedOut = 0,
+      bytesReceived = 10,
+      bytesSent = 10,
+      totalDuration = 0.1,
+      slowestDuration = 0.1,
+      slowestHost = "expo.dev"
+    )
+    val params = MetricParamsBuilder.build(networkRequests = summary)
+    assertEquals(0, params["expo.network.requests.timedOut"])
+  }
+
+  @Test
+  fun `emits the derived latency and throughput keys when the summary has them`() {
+    val summary = NetworkRequestSummary(
+      count = 4,
+      failed = 1,
+      bytesReceived = 12000,
+      bytesSent = 800,
+      totalDuration = 1.4,
+      slowestDuration = 0.6,
+      slowestHost = "api.expo.dev",
+      slowestTimeToFirstByte = 0.35,
+      throughputBytesPerSecond = 8571.4,
+      fastestTcpHandshake = 0.04
+    )
+    val params = MetricParamsBuilder.build(networkRequests = summary)
+    assertEquals(0.35, params["expo.network.requests.slowestTimeToFirstByte"])
+    assertEquals(8571.4, params["expo.network.requests.throughputBytesPerSecond"])
+    assertEquals(0.04, params["expo.network.requests.fastestTcpHandshake"])
+  }
+
+  @Test
+  fun `omits the derived keys rather than emitting zero when they are unavailable`() {
+    // Every connection reused and nothing received: emitting 0 would read as "instant, no data"
+    // instead of "not measured" on a dashboard.
+    val summary = NetworkRequestSummary(
+      count = 2,
+      failed = 0,
+      bytesReceived = 0,
+      bytesSent = 40,
+      totalDuration = 0.2,
+      slowestDuration = 0.1,
+      slowestHost = "api.expo.dev"
+    )
+    val params = MetricParamsBuilder.build(networkRequests = summary)
+    assertEquals(2, params["expo.network.requests.count"])
+    assertNull(params["expo.network.requests.slowestTimeToFirstByte"])
+    assertNull(params["expo.network.requests.throughputBytesPerSecond"])
+    assertNull(params["expo.network.requests.fastestTcpHandshake"])
+  }
+
+  @Test
   fun `omits slowest keys when the summary has counts but missing slowest fields`() {
     val summary = NetworkRequestSummary(
       count = 1,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
@@ -197,52 +197,6 @@ class MetricParamsBuilderTest {
   }
 
   @Test
-  fun `emits the timeout count alongside the failure count`() {
-    val summary = NetworkRequestSummary(
-      count = 3,
-      failed = 2,
-      timedOut = 1,
-      bytesReceived = 0,
-      bytesSent = 0,
-      totalDuration = 30.2,
-      slowest = NetworkRequestSummary.SlowestRequest(
-        host = "slow.expo.dev",
-        duration = 30.0,
-        statusCode = 200,
-        timeToFirstByte = null,
-        bytesReceived = null
-      )
-    )
-    val params = MetricParamsBuilder.build(networkRequests = summary)
-    assertEquals(2, params["expo.network.requests.failed"])
-    assertEquals(1, params["expo.network.requests.timedOut"])
-  }
-
-  @Test
-  fun `emits a zero timeout count so its absence is not ambiguous`() {
-    // Unlike the optional latency fields, a count of zero is a real measurement: we saw requests
-    // and none of them timed out. Omitting it would make "no timeouts" and "not measured" look
-    // the same.
-    val summary = NetworkRequestSummary(
-      count = 1,
-      failed = 0,
-      timedOut = 0,
-      bytesReceived = 10,
-      bytesSent = 10,
-      totalDuration = 0.1,
-      slowest = NetworkRequestSummary.SlowestRequest(
-        host = "expo.dev",
-        duration = 0.1,
-        statusCode = 200,
-        timeToFirstByte = null,
-        bytesReceived = null
-      )
-    )
-    val params = MetricParamsBuilder.build(networkRequests = summary)
-    assertEquals(0, params["expo.network.requests.timedOut"])
-  }
-
-  @Test
   fun `emits the derived latency and throughput keys when the summary has them`() {
     val summary = NetworkRequestSummary(
       count = 4,

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/MetricParamsBuilderTest.kt
@@ -238,13 +238,11 @@ class MetricParamsBuilderTest {
       slowestDuration = 0.6,
       slowestHost = "api.expo.dev",
       slowestTimeToFirstByte = 0.35,
-      throughputBytesPerSecond = 8571.4,
-      fastestTcpHandshake = 0.04
+      throughputBytesPerSecond = 8571.4
     )
     val params = MetricParamsBuilder.build(networkRequests = summary)
     assertEquals(0.35, params["expo.network.requests.slowestTimeToFirstByte"])
     assertEquals(8571.4, params["expo.network.requests.throughputBytesPerSecond"])
-    assertEquals(0.04, params["expo.network.requests.fastestTcpHandshake"])
   }
 
   @Test
@@ -264,7 +262,6 @@ class MetricParamsBuilderTest {
     assertEquals(2, params["expo.network.requests.count"])
     assertNull(params["expo.network.requests.slowestTimeToFirstByte"])
     assertNull(params["expo.network.requests.throughputBytesPerSecond"])
-    assertNull(params["expo.network.requests.fastestTcpHandshake"])
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -110,29 +110,18 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
       return positiveInterval(from: fetchStart, to: responseStart)
     }
 
-    /// Duration of the TCP handshake, which is roughly one network round trip and therefore the
-    /// closest thing here to pure network latency.
-    ///
-    /// Ends at `secureConnectionStart` when TLS ran, so the value covers only the TCP handshake and
-    /// not the TLS exchange layered on top of it. `connectEnd` lands *after* the TLS handshake, so
-    /// using it for an HTTPS request would overstate the round trip. Falls back to `connectEnd` for
-    /// cleartext connections, where no TLS phase exists.
-    ///
-    /// `nil` when the connection was reused, which means "no new connection was opened", not "zero
-    /// latency". Under keep-alive most requests report nothing here.
-    public var tcpHandshakeDuration: TimeInterval? {
-      return positiveInterval(from: connectStart, to: secureConnectionStart ?? connectEnd)
-    }
-
     /// Returns the interval between two optional timestamps, or `nil` if either is missing or the
-    /// result is negative. These are wall-clock dates, so a clock adjustment mid-request can invert
-    /// them; a negative duration is meaningless and would poison a min/max fold.
+    /// result isn't strictly positive.
+    ///
+    /// Negative results are discarded because these are wall-clock dates and a clock adjustment
+    /// mid-request can invert them. Exactly zero is discarded too: a phase that completes inside one
+    /// clock tick was too fast to measure, and reporting `0` would claim it took no time at all.
     private func positiveInterval(from start: Date?, to end: Date?) -> TimeInterval? {
       guard let start, let end else {
         return nil
       }
       let interval = end.timeIntervalSince(start)
-      return interval >= 0 ? interval : nil
+      return interval > 0 ? interval : nil
     }
   }
 }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -82,6 +82,15 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
     public let responseStart: Date?
     public let responseEnd: Date?
 
+    /// When the last response byte arrived, or `nil` if the OS never reported one.
+    ///
+    /// Unlike `responseEnd`, this is never synthesized. `responseEnd` falls back to a wall-clock
+    /// timestamp taken when the snapshot was recorded, which is right for a duration but wrong for
+    /// a transfer window: a request that got headers and then died reports an end long after its
+    /// last byte, and dividing its bytes by that window describes the recording delay rather than
+    /// the connection.
+    public let measuredResponseEnd: Date?
+
     /// Total wall-clock duration of the task. Convenience: callers don't have to subtract
     /// `fetchStart` from `responseEnd` themselves, and we can populate this even when the
     /// individual phases are `nil` (cache hits, errors before headers).
@@ -127,6 +136,16 @@ public struct NetworkRequestStarted: Sendable, Equatable, Identifiable {
   public let startedAt: Date
 }
 
+/// Adds two non-negative byte counts, pinning at `Int64.max` instead of trapping.
+///
+/// The operands come from `URLSessionTaskTransactionMetrics`, and Swift aborts the process on
+/// `Int64` overflow. No honest response reaches that total, but an observability library must not
+/// be able to take its host app down over a counter that doesn't make sense.
+private func clampedSum(_ lhs: Int64, _ rhs: Int64) -> Int64 {
+  let (sum, overflowed) = lhs.addingReportingOverflow(rhs)
+  return overflowed ? Int64.max : sum
+}
+
 extension NetworkRequest {
   /// Builds a snapshot from the data we have at task completion. The metrics argument may be `nil`
   /// for cache-only responses or in tests; in that case, callers fall back to wall-clock timestamps
@@ -166,6 +185,7 @@ extension NetworkRequest {
       requestEnd: transaction?.requestEndDate,
       responseStart: transaction?.responseStartDate,
       responseEnd: transaction?.responseEndDate ?? fallbackEnd,
+      measuredResponseEnd: transaction?.responseEndDate,
       totalDuration: metrics?.taskInterval.duration ?? fallbackEnd.timeIntervalSince(fallbackStart)
     )
 
@@ -177,7 +197,12 @@ extension NetworkRequest {
     //     Received` is wall-clock accurate in both environments.
     let requestBytesSent: Int64? = {
       if let transaction {
-        let fromTransaction = transaction.countOfRequestHeaderBytesSent + transaction.countOfRequestBodyBytesSent
+        // Clamped: these come from the OS and Swift traps on overflow, which must never take a host
+        // app down from inside an observability library.
+        let fromTransaction = clampedSum(
+          transaction.countOfRequestHeaderBytesSent,
+          transaction.countOfRequestBodyBytesSent
+        )
         if fromTransaction > 0 {
           return fromTransaction
         }
@@ -187,7 +212,10 @@ extension NetworkRequest {
     let responseBytesReceived: Int64? = {
       if let transaction {
         let fromTransaction =
-          transaction.countOfResponseHeaderBytesReceived + transaction.countOfResponseBodyBytesReceived
+          clampedSum(
+            transaction.countOfResponseHeaderBytesReceived,
+            transaction.countOfResponseBodyBytesReceived
+          )
         if fromTransaction > 0 {
           return fromTransaction
         }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -42,6 +42,15 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// string rather than carrying `NSError` so the type stays `Sendable` and serializable.
   public let errorDescription: String?
 
+  /// Whether the request failed because the network stalled or went away, as opposed to reaching
+  /// the server and getting an error back.
+  ///
+  /// Classified at capture time from the underlying error, because `errorDescription` is a
+  /// localized string and can't be matched on afterwards. A 5xx response is a failure but not a
+  /// timeout: the server answered. Deliberate cancellation isn't one either, since the app
+  /// abandoned the request and that says nothing about the connection.
+  public var isTimeout: Bool = false
+
   /// Ordered list of redirect hops that preceded the final response. Empty when the task returned
   /// directly. Each entry describes one hop: `fromUrl` is the URL that returned the redirect,
   /// `statusCode` is the 3xx code it returned, and `toUrl` is where the redirect pointed. For a
@@ -86,6 +95,45 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
     /// `fetchStart` from `responseEnd` themselves, and we can populate this even when the
     /// individual phases are `nil` (cache hits, errors before headers).
     public let totalDuration: TimeInterval
+
+    /// Time from the start of the fetch until the first response byte arrived.
+    ///
+    /// This is not a measurement of network latency: it also covers DNS, the TCP and TLS
+    /// handshakes, sending the request, and the server's own processing time. A slow backend
+    /// inflates it the same way a slow network does. On a reused connection (the common case under
+    /// keep-alive) the handshakes are already done, so it sits much closer to one round trip plus
+    /// server time.
+    ///
+    /// `nil` when the response never produced headers, so callers can tell "not measured" from a
+    /// genuinely fast response.
+    public var timeToFirstByte: TimeInterval? {
+      return positiveInterval(from: fetchStart, to: responseStart)
+    }
+
+    /// Duration of the TCP handshake, which is roughly one network round trip and therefore the
+    /// closest thing here to pure network latency.
+    ///
+    /// Ends at `secureConnectionStart` when TLS ran, so the value covers only the TCP handshake and
+    /// not the TLS exchange layered on top of it. `connectEnd` lands *after* the TLS handshake, so
+    /// using it for an HTTPS request would overstate the round trip. Falls back to `connectEnd` for
+    /// cleartext connections, where no TLS phase exists.
+    ///
+    /// `nil` when the connection was reused, which means "no new connection was opened", not "zero
+    /// latency". Under keep-alive most requests report nothing here.
+    public var tcpHandshakeDuration: TimeInterval? {
+      return positiveInterval(from: connectStart, to: secureConnectionStart ?? connectEnd)
+    }
+
+    /// Returns the interval between two optional timestamps, or `nil` if either is missing or the
+    /// result is negative. These are wall-clock dates, so a clock adjustment mid-request can invert
+    /// them; a negative duration is meaningless and would poison a min/max fold.
+    private func positiveInterval(from start: Date?, to end: Date?) -> TimeInterval? {
+      guard let start, let end else {
+        return nil
+      }
+      let interval = end.timeIntervalSince(start)
+      return interval >= 0 ? interval : nil
+    }
   }
 }
 
@@ -205,7 +253,30 @@ extension NetworkRequest {
       responseBytesReceived: responseBytesReceived,
       timings: timings,
       errorDescription: error.map { ($0 as NSError).localizedDescription },
+      isTimeout: isNetworkTimeout(error),
       redirects: redirects
     )
+  }
+}
+
+/// Whether a `URLSession` error means the network stalled or went away, rather than the server
+/// answering with something we didn't like.
+///
+/// `NSURLErrorNetworkConnectionLost` counts because the radio dropping mid-request is the same
+/// condition from the user's point of view, and it's what walking into an elevator actually
+/// produces. `NSURLErrorCancelled` does not: the app abandoned the request.
+private func isNetworkTimeout(_ error: Error?) -> Bool {
+  guard let error else {
+    return false
+  }
+  let nsError = error as NSError
+  guard nsError.domain == NSURLErrorDomain else {
+    return false
+  }
+  switch nsError.code {
+  case NSURLErrorTimedOut, NSURLErrorNetworkConnectionLost:
+    return true
+  default:
+    return false
   }
 }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -251,9 +251,18 @@ extension NetworkRequest {
 /// Whether a `URLSession` error means the network stalled or went away, rather than the server
 /// answering with something we didn't like.
 ///
-/// `NSURLErrorNetworkConnectionLost` counts because the radio dropping mid-request is the same
-/// condition from the user's point of view, and it's what walking into an elevator actually
-/// produces. `NSURLErrorCancelled` does not: the app abandoned the request.
+/// Three conditions count, and `NetworkRequestInterceptor.isNetworkTimeout` on Android matches the
+/// same three so the `timedOut` metric describes one population on both platforms:
+///
+/// - The request stalled until the client gave up (`NSURLErrorTimedOut`).
+/// - The connection dropped mid-request (`NSURLErrorNetworkConnectionLost`). This is what walking
+///   into an elevator actually produces.
+/// - The device couldn't reach the network at all, whether that surfaced as no connectivity or as
+///   a name that wouldn't resolve. DNS failure is what losing connectivity looks like from here.
+///
+/// `NSURLErrorCancelled` does not count: the app abandoned the request, which says nothing about
+/// the connection. Neither does a TLS failure, which is a certificate or trust problem rather than
+/// an absent network.
 private func isNetworkTimeout(_ error: Error?) -> Bool {
   guard let error else {
     return false
@@ -263,7 +272,12 @@ private func isNetworkTimeout(_ error: Error?) -> Bool {
     return false
   }
   switch nsError.code {
-  case NSURLErrorTimedOut, NSURLErrorNetworkConnectionLost:
+  case NSURLErrorTimedOut,
+    NSURLErrorNetworkConnectionLost,
+    NSURLErrorNotConnectedToInternet,
+    NSURLErrorCannotFindHost,
+    NSURLErrorDNSLookupFailed,
+    NSURLErrorCannotConnectToHost:
     return true
   default:
     return false

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -42,15 +42,6 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// string rather than carrying `NSError` so the type stays `Sendable` and serializable.
   public let errorDescription: String?
 
-  /// Whether the request failed because the network stalled or went away, as opposed to reaching
-  /// the server and getting an error back.
-  ///
-  /// Classified at capture time from the underlying error, because `errorDescription` is a
-  /// localized string and can't be matched on afterwards. A 5xx response is a failure but not a
-  /// timeout: the server answered. Deliberate cancellation isn't one either, since the app
-  /// abandoned the request and that says nothing about the connection.
-  public var isTimeout: Bool = false
-
   /// Ordered list of redirect hops that preceded the final response. Empty when the task returned
   /// directly. Each entry describes one hop: `fromUrl` is the URL that returned the redirect,
   /// `statusCode` is the 3xx code it returned, and `toUrl` is where the redirect pointed. For a
@@ -242,44 +233,7 @@ extension NetworkRequest {
       responseBytesReceived: responseBytesReceived,
       timings: timings,
       errorDescription: error.map { ($0 as NSError).localizedDescription },
-      isTimeout: isNetworkTimeout(error),
       redirects: redirects
     )
-  }
-}
-
-/// Whether a `URLSession` error means the network stalled or went away, rather than the server
-/// answering with something we didn't like.
-///
-/// Three conditions count, and `NetworkRequestInterceptor.isNetworkTimeout` on Android matches the
-/// same three so the `timedOut` metric describes one population on both platforms:
-///
-/// - The request stalled until the client gave up (`NSURLErrorTimedOut`).
-/// - The connection dropped mid-request (`NSURLErrorNetworkConnectionLost`). This is what walking
-///   into an elevator actually produces.
-/// - The device couldn't reach the network at all, whether that surfaced as no connectivity or as
-///   a name that wouldn't resolve. DNS failure is what losing connectivity looks like from here.
-///
-/// `NSURLErrorCancelled` does not count: the app abandoned the request, which says nothing about
-/// the connection. Neither does a TLS failure, which is a certificate or trust problem rather than
-/// an absent network.
-private func isNetworkTimeout(_ error: Error?) -> Bool {
-  guard let error else {
-    return false
-  }
-  let nsError = error as NSError
-  guard nsError.domain == NSURLErrorDomain else {
-    return false
-  }
-  switch nsError.code {
-  case NSURLErrorTimedOut,
-    NSURLErrorNetworkConnectionLost,
-    NSURLErrorNotConnectedToInternet,
-    NSURLErrorCannotFindHost,
-    NSURLErrorDNSLookupFailed,
-    NSURLErrorCannotConnectToHost:
-    return true
-  default:
-    return false
   }
 }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -37,11 +37,10 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
 
   /// Whether the response came off the network rather than out of a cache.
   ///
-  /// `false` only when the OS positively identified a cache read. An unclassified fetch counts as
-  /// network, matching how the rest of this type treats missing information: `URLSession` timestamps
-  /// a cache hit like any other response, so this is the only way to tell a disk read from a
-  /// download, and guessing would cost real transfers. Android needs no equivalent, since OkHttp
-  /// skips the response-body callbacks for a cached response and it drops out on its own.
+  /// `true` only for a fetch the OS identified as a network load. `URLSession` timestamps a cache
+  /// hit like any other response, so this is the only way to tell a disk read from a download, and
+  /// an unclassified fetch is treated as unusable rather than assumed. Android needs no equivalent,
+  /// since OkHttp skips the response-body callbacks for a cached response.
   public let cameFromNetwork: Bool?
 
   /// Phase-by-phase timings pulled from the most recent (post-redirect) transaction.
@@ -172,11 +171,12 @@ extension NetworkRequest {
     // future need arises to surface per-hop timing, expose `metrics.transactionMetrics` here.
     let transaction = metrics?.transactionMetrics.last
 
-    // Only `.localCache` is positive evidence the bytes came off disk. `.unknown` means the OS
-    // didn't classify the fetch, which a task intercepted by an `NSURLProtocol` subclass reports
-    // routinely, so treating it as a cache read would drop real transfers from the throughput ratio
-    // for any app carrying such an SDK.
-    let cameFromNetwork = transaction.map { $0.resourceFetchType != .localCache }
+    // Only a fetch the OS positively identified as a network load counts. `.unknown` is excluded
+    // too: a cache hit reports byte counts and timestamps like any other response, so an
+    // unclassified fetch that was really a disk read would otherwise divide megabytes by the
+    // milliseconds it took to read them. Costs the rate for tasks an `NSURLProtocol` subclass
+    // intercepted, which also report `.unknown`, and a missing rate beats an impossible one.
+    let cameFromNetwork = transaction.map { $0.resourceFetchType == .networkLoad }
 
     let timings = NetworkRequest.Timings(
       fetchStart: transaction?.fetchStartDate ?? fallbackStart,

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -35,6 +35,13 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// Number of bytes received on the wire for the response (headers + body).
   public let responseBytesReceived: Int64?
 
+  /// Whether the response came off the network rather than out of a cache.
+  ///
+  /// `nil` when the OS reported no transaction. Cache hits still report byte counts and phase
+  /// timestamps, so this is the only reliable way to tell a disk read from a download: dividing
+  /// cached megabytes by the milliseconds it took to read them would describe the disk.
+  public let cameFromNetwork: Bool?
+
   /// Phase-by-phase timings pulled from the most recent (post-redirect) transaction.
   public let timings: Timings
 
@@ -173,6 +180,10 @@ extension NetworkRequest {
     // future need arises to surface per-hop timing, expose `metrics.transactionMetrics` here.
     let transaction = metrics?.transactionMetrics.last
 
+    // `.networkLoad` is the only fetch type that actually crossed the wire; `.localCache`,
+    // `.serverPush` and `.unknown` did not.
+    let cameFromNetwork = transaction.map { $0.resourceFetchType == .networkLoad }
+
     let timings = NetworkRequest.Timings(
       fetchStart: transaction?.fetchStartDate ?? fallbackStart,
       domainLookupStart: transaction?.domainLookupStartDate,
@@ -259,6 +270,7 @@ extension NetworkRequest {
       networkProtocol: transaction?.networkProtocolName,
       requestBytesSent: requestBytesSent,
       responseBytesReceived: responseBytesReceived,
+      cameFromNetwork: cameFromNetwork,
       timings: timings,
       errorDescription: error.map { ($0 as NSError).localizedDescription },
       redirects: redirects

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -37,10 +37,11 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
 
   /// Whether the response came off the network rather than out of a cache.
   ///
-  /// `nil` when the OS reported no transaction. `URLSession` timestamps a cache hit like any other
-  /// response, so this is the only way to tell a disk read from a download. Android needs no
-  /// equivalent: OkHttp skips the response-body callbacks for a cached response, so its
-  /// `measuredResponseEnd` stays null and the request drops out on its own.
+  /// `false` only when the OS positively identified a cache read. An unclassified fetch counts as
+  /// network, matching how the rest of this type treats missing information: `URLSession` timestamps
+  /// a cache hit like any other response, so this is the only way to tell a disk read from a
+  /// download, and guessing would cost real transfers. Android needs no equivalent, since OkHttp
+  /// skips the response-body callbacks for a cached response and it drops out on its own.
   public let cameFromNetwork: Bool?
 
   /// Phase-by-phase timings pulled from the most recent (post-redirect) transaction.
@@ -144,16 +145,6 @@ public struct NetworkRequestStarted: Sendable, Equatable, Identifiable {
   public let startedAt: Date
 }
 
-/// Adds two non-negative byte counts, pinning at `Int64.max` instead of trapping.
-///
-/// The operands come from `URLSessionTaskTransactionMetrics`, and Swift aborts the process on
-/// `Int64` overflow. No honest response reaches that total, but an observability library must not
-/// be able to take its host app down over a counter that doesn't make sense.
-private func clampedSum(_ lhs: Int64, _ rhs: Int64) -> Int64 {
-  let (sum, overflowed) = lhs.addingReportingOverflow(rhs)
-  return overflowed ? Int64.max : sum
-}
-
 extension NetworkRequest {
   /// Builds a snapshot from the data we have at task completion. The metrics argument may be `nil`
   /// for cache-only responses or in tests; in that case, callers fall back to wall-clock timestamps
@@ -181,9 +172,11 @@ extension NetworkRequest {
     // future need arises to surface per-hop timing, expose `metrics.transactionMetrics` here.
     let transaction = metrics?.transactionMetrics.last
 
-    // `.networkLoad` is the only fetch type that actually crossed the wire; `.localCache`,
-    // `.serverPush` and `.unknown` did not.
-    let cameFromNetwork = transaction.map { $0.resourceFetchType == .networkLoad }
+    // Only `.localCache` is positive evidence the bytes came off disk. `.unknown` means the OS
+    // didn't classify the fetch, which a task intercepted by an `NSURLProtocol` subclass reports
+    // routinely, so treating it as a cache read would drop real transfers from the throughput ratio
+    // for any app carrying such an SDK.
+    let cameFromNetwork = transaction.map { $0.resourceFetchType != .localCache }
 
     let timings = NetworkRequest.Timings(
       fetchStart: transaction?.fetchStartDate ?? fallbackStart,
@@ -211,10 +204,8 @@ extension NetworkRequest {
       if let transaction {
         // Clamped: these come from the OS and Swift traps on overflow, which must never take a host
         // app down from inside an observability library.
-        let fromTransaction = clampedSum(
-          transaction.countOfRequestHeaderBytesSent,
-          transaction.countOfRequestBodyBytesSent
-        )
+        let fromTransaction = transaction.countOfRequestHeaderBytesSent
+          .addingClamped(transaction.countOfRequestBodyBytesSent)
         if fromTransaction > 0 {
           return fromTransaction
         }
@@ -224,10 +215,8 @@ extension NetworkRequest {
     let responseBytesReceived: Int64? = {
       if let transaction {
         let fromTransaction =
-          clampedSum(
-            transaction.countOfResponseHeaderBytesReceived,
-            transaction.countOfResponseBodyBytesReceived
-          )
+          transaction.countOfResponseHeaderBytesReceived
+          .addingClamped(transaction.countOfResponseBodyBytesReceived)
         if fromTransaction > 0 {
           return fromTransaction
         }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -37,9 +37,10 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
 
   /// Whether the response came off the network rather than out of a cache.
   ///
-  /// `nil` when the OS reported no transaction. Cache hits still report byte counts and phase
-  /// timestamps, so this is the only reliable way to tell a disk read from a download: dividing
-  /// cached megabytes by the milliseconds it took to read them would describe the disk.
+  /// `nil` when the OS reported no transaction. `URLSession` timestamps a cache hit like any other
+  /// response, so this is the only way to tell a disk read from a download. Android needs no
+  /// equivalent: OkHttp skips the response-body callbacks for a cached response, so its
+  /// `measuredResponseEnd` stays null and the request drops out on its own.
   public let cameFromNetwork: Bool?
 
   /// Phase-by-phase timings pulled from the most recent (post-redirect) transaction.

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -34,7 +34,8 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///
   /// Every field describes that one request, so they can be read together: a `duration` mostly made
   /// up of `timeToFirstByte` means the server was slow to answer, while a small `timeToFirstByte`
-  /// against a large `bytesReceived` means the transfer itself was.
+  /// against a large `bytesReceived` means the transfer itself was. `statusCode` explains a
+  /// `bytesReceived` of 0, which is routine on a 304 and a problem on a 200.
   ///
   /// Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
   /// setting rather than a measurement of the server, so letting one win would make these fields
@@ -49,6 +50,13 @@ public struct NetworkRequestSummary: Sendable, Equatable {
 
     /// Total wall-clock duration of the request.
     public let duration: TimeInterval
+
+    /// Response status code. Never `nil` in practice, since a request that never received headers
+    /// counts as failed and so isn't a candidate.
+    ///
+    /// Disambiguates an empty response: a `bytesReceived` of 0 means a cache revalidation on a 304,
+    /// an intentionally bodyless reply on a 204, and a broken transfer on a 200.
+    public let statusCode: Int?
 
     /// Time from the start of the fetch until the first response byte arrived, or `nil` if the
     /// request never reported one. Includes server processing time, so it's a proxy for network
@@ -148,6 +156,7 @@ public struct NetworkRequestSummary: Sendable, Equatable {
         SlowestRequest(
           host: request.url.host,
           duration: request.timings.totalDuration,
+          statusCode: request.statusCode,
           timeToFirstByte: request.timings.timeToFirstByte,
           bytesReceived: request.responseBytesReceived
         )

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -43,26 +43,23 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// quality rather than a measurement of it — see `Timings.timeToFirstByte`.
   public let slowestTimeToFirstByte: TimeInterval?
 
-  /// Received bytes over the time the network was actually busy, in bytes per second, or `nil` when
-  /// nothing was received or no request reported a usable interval.
+  /// Received bytes over the time those bytes were actually moving, in bytes per second, or `nil`
+  /// when nothing was received or no receiving request reported a usable interval.
   ///
-  /// The denominator is the union of the request intervals, not the sum of their durations and not
-  /// the elapsed window. Summing durations would divide by the app's request concurrency, so four
-  /// parallel one-second requests would report a quarter of the real rate. Using the whole window
-  /// would charge idle time to the network, so a launch that fetches briefly and then sits idle
-  /// would look slow. Measuring only the busy span leaves a value that moves when the connection
-  /// changes and holds still when the app's fetch pattern does.
+  /// The denominator is the union of the intervals of the requests that received bytes. Three
+  /// choices are folded into that:
+  ///
+  /// - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
+  ///   parallel one-second requests would otherwise report a quarter of the real rate.
+  /// - The busy span rather than the whole window, so idle time isn't charged to the network. A
+  ///   launch that fetches briefly and then sits idle would otherwise look slow.
+  /// - Only requests that received bytes, so a slow request returning nothing can't stretch the
+  ///   denominator across time when no payload was in flight. Its latency belongs to
+  ///   `slowestTimeToFirstByte`, not here.
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
   /// no interval covers it. `timedOut` is the signal for that case.
   public let throughputBytesPerSecond: Double?
-
-  /// Shortest TCP handshake in the window, or `nil` if every connection was reused.
-  ///
-  /// A minimum rather than an average: a handshake that loses its SYN retries after a timeout of a
-  /// second or more, so a mean over a few handshakes mostly reports retransmits. The fastest one
-  /// approximates the true path latency.
-  public let fastestTcpHandshake: TimeInterval?
 
   /// Convenience: returns `nil` when the summary is empty so callers can skip emitting fields.
   public var isEmpty: Bool {
@@ -79,8 +76,7 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     slowestDuration: nil,
     slowestHost: nil,
     slowestTimeToFirstByte: nil,
-    throughputBytesPerSecond: nil,
-    fastestTcpHandshake: nil
+    throughputBytesPerSecond: nil
   )
 
   /// Folds a sequence of `NetworkRequest` into a summary. The caller is responsible for filtering
@@ -96,7 +92,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     var totalDuration: TimeInterval = 0
     var slowest: NetworkRequest?
     var slowestTimeToFirstByte: TimeInterval?
-    var fastestTcpHandshake: TimeInterval?
 
     for request in requests {
       if request.isFailed {
@@ -115,13 +110,10 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       } else {
         slowest = request
       }
-      // Both folds skip requests that didn't report the phase, so a reused connection or a
-      // header-less failure doesn't drag the result toward a value that was never measured.
+      // Skips requests that didn't report the phase, so a header-less failure doesn't drag the
+      // result toward a value that was never measured.
       if let timeToFirstByte = request.timings.timeToFirstByte {
         slowestTimeToFirstByte = max(timeToFirstByte, slowestTimeToFirstByte ?? timeToFirstByte)
-      }
-      if let handshake = request.timings.tcpHandshakeDuration {
-        fastestTcpHandshake = min(handshake, fastestTcpHandshake ?? handshake)
       }
     }
 
@@ -135,23 +127,27 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       slowestDuration: slowest?.timings.totalDuration,
       slowestHost: slowest?.url.host,
       slowestTimeToFirstByte: slowestTimeToFirstByte,
-      throughputBytesPerSecond: throughput(bytesReceived: bytesReceived, of: requests),
-      fastestTcpHandshake: fastestTcpHandshake
+      throughputBytesPerSecond: throughput(of: requests)
     )
   }
 
-  /// Received bytes over the time at least one request was in flight. Returns `nil` when nothing was
-  /// received or no request reported a usable interval, so the caller can tell "unknown" from a
+  /// Received bytes over the time those bytes were moving. Returns `nil` when nothing was received
+  /// or no receiving request reported a usable interval, so the caller can tell "unknown" from a
   /// genuinely slow connection.
-  private static func throughput(bytesReceived: Int64, of requests: [NetworkRequest]) -> Double? {
-    guard bytesReceived > 0 else {
+  ///
+  /// Both sides are computed from the same subset — the requests that actually received bytes — so
+  /// the numerator and denominator always describe the same traffic.
+  private static func throughput(of requests: [NetworkRequest]) -> Double? {
+    let receiving = requests.filter { ($0.responseBytesReceived ?? 0) > 0 }
+    let bytes = receiving.reduce(Int64(0)) { $0 + ($1.responseBytesReceived ?? 0) }
+    guard bytes > 0 else {
       return nil
     }
-    let busySeconds = busyDuration(of: requests)
+    let busySeconds = busyDuration(of: receiving)
     guard busySeconds > 0 else {
       return nil
     }
-    return Double(bytesReceived) / busySeconds
+    return Double(bytes) / busySeconds
   }
 
   /// Total length of the union of the requests' in-flight intervals, in seconds.

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -84,9 +84,9 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///   parallel one-second requests would otherwise report a quarter of the real rate.
   /// - The busy span rather than the whole window, so idle time isn't charged to the network. A
   ///   launch that fetches briefly and then sits idle would otherwise look slow.
-  /// - Only requests that received bytes, so a slow request returning nothing can't stretch the
-  ///   denominator across time when no payload was in flight. Its latency belongs to
-  ///   `slowest.timeToFirstByte`, not here.
+  /// - Only requests that completed and received bytes, so neither a slow request returning nothing
+  ///   nor one that stalled until the client gave up can stretch the denominator across time when
+  ///   no payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
   /// no interval covers it. `timedOut` is the signal for that case.
@@ -190,15 +190,23 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     return Double(bytes) / busySeconds
   }
 
-  /// The requests that both received bytes and reported a measurable span, which is the subset the
-  /// throughput ratio is computed over.
+  /// The requests that completed, received bytes, and reported a measurable span, which is the
+  /// subset the throughput ratio is computed over.
   ///
   /// Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
   /// inside the busy-time fold instead would let a request contribute its bytes while adding no
   /// time, which reads as a faster connection than actually happened. A cache hit is the case that
   /// matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+  ///
+  /// Failures are excluded for the opposite reason. A request that received a few bytes and then
+  /// stalled until the client gave up reports a span covering the whole stall, so it would hold the
+  /// denominator open across time when nothing was moving and report a connection far slower than
+  /// the one that served the requests around it.
   private static func measurableReceiving(in requests: [NetworkRequest]) -> [NetworkRequest] {
     return requests.filter { request in
+      guard !request.isFailed else {
+        return false
+      }
       guard (request.responseBytesReceived ?? 0) > 0 else {
         return false
       }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -14,13 +14,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// Requests that errored or returned a non-2xx status.
   public let failed: Int
 
-  /// Subset of `failed` where the network stalled or went away rather than the server answering.
-  ///
-  /// Split out from `failed` because the two have different causes: timeouts point at the
-  /// connection, 4xx/5xx point at the backend. A window where most failures are timeouts is the
-  /// clearest signal available here that the user was on a bad network.
-  public let timedOut: Int
-
   /// Sum of `responseBytesReceived` across all requests in the window.
   public let bytesReceived: Int64
 
@@ -45,8 +38,8 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///
   /// Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
   /// setting rather than a measurement of the server, so letting one win would make these fields
-  /// report a config constant that barely varies with the network. `failed` and `timedOut` carry
-  /// that signal instead.
+  /// report a config constant that barely varies with the network. `failed` carries that signal
+  /// instead.
   public let slowest: SlowestRequest?
 
   /// Facts about the slowest completed request in a window. See `NetworkRequestSummary.slowest`.
@@ -90,14 +83,14 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///   launch that fetches briefly and then sits idle would otherwise look slow.
   /// - Only requests that completed and received bytes, so neither a slow request returning nothing
   ///   nor one that stalled until the client gave up can stretch the denominator across time when
-  ///   no payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
+  ///   no payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `failed`.
   ///
   /// Requiring a first-byte timestamp also excludes cache hits for free: a response served from
   /// disk never reports one, so the megabytes it contributes can't be divided by the milliseconds
   /// it took to read them.
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
-  /// no interval covers it. `timedOut` is the signal for that case.
+  /// no interval covers it. `failed` is the signal for that case.
   ///
   /// Being a ratio, it also degrades differently from the counts when the monitor's ring buffer
   /// evicts the earliest requests in a window: both sides shrink together, so the value stays
@@ -113,7 +106,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   static let empty = NetworkRequestSummary(
     count: 0,
     failed: 0,
-    timedOut: 0,
     bytesReceived: 0,
     bytesSent: 0,
     totalDuration: 0,
@@ -128,7 +120,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       return .empty
     }
     var failed = 0
-    var timedOut = 0
     var bytesReceived: Int64 = 0
     var bytesSent: Int64 = 0
     var totalDuration: TimeInterval = 0
@@ -138,16 +129,13 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       if request.isFailed {
         failed += 1
       }
-      if request.isTimeout {
-        timedOut += 1
-      }
       bytesReceived += request.responseBytesReceived ?? 0
       bytesSent += request.requestBytesSent ?? 0
       totalDuration += request.timings.totalDuration
       // Only completed requests are candidates. A timeout's duration is the client's timeout
       // setting, not a measurement of the server, so letting one win would make these fields report
       // a config constant that barely varies with the network. Failures are already counted by
-      // `failed` and `timedOut`.
+      // `failed`.
       if !request.isFailed {
         if let current = slowest {
           if request.timings.totalDuration > current.timings.totalDuration {
@@ -162,7 +150,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     return NetworkRequestSummary(
       count: requests.count,
       failed: failed,
-      timedOut: timedOut,
       bytesReceived: bytesReceived,
       bytesSent: bytesSent,
       totalDuration: totalDuration,

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -59,6 +59,11 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
   /// no interval covers it. `timedOut` is the signal for that case.
+  ///
+  /// Being a ratio, it also degrades differently from the counts when the monitor's ring buffer
+  /// evicts the earliest requests in a window: both sides shrink together, so the value stays
+  /// plausible while describing only the requests that survived. Read it as the rate of a sample of
+  /// the window rather than of all of it.
   public let throughputBytesPerSecond: Double?
 
   /// Convenience: returns `nil` when the summary is empty so callers can skip emitting fields.

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -28,6 +28,12 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   public let bytesSent: Int64
 
   /// Sum of `timings.totalDuration` across all requests. Can exceed wall-clock when requests overlap.
+  ///
+  /// Deliberately includes failures, unlike `slowest` and `throughputBytesPerSecond`, which describe
+  /// only requests that completed. That makes it the one field that still accounts for time the app
+  /// spent waiting on a request that never arrived: a window of timeouts reports the seconds they
+  /// burned here even though nothing else measures them. The cost is that it can dwarf the other
+  /// timings, since a single timeout contributes the client's whole timeout interval.
   public let totalDuration: TimeInterval
 
   /// The single longest-running request that completed, or `nil` when the window held none.

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -135,32 +135,52 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// or no receiving request reported a usable interval, so the caller can tell "unknown" from a
   /// genuinely slow connection.
   ///
-  /// Both sides are computed from the same subset — the requests that actually received bytes — so
-  /// the numerator and denominator always describe the same traffic.
+  /// Both sides are computed from the same subset, so the numerator and denominator always describe
+  /// the same traffic.
   private static func throughput(of requests: [NetworkRequest]) -> Double? {
-    let receiving = requests.filter { ($0.responseBytesReceived ?? 0) > 0 }
-    let bytes = receiving.reduce(Int64(0)) { $0 + ($1.responseBytesReceived ?? 0) }
+    let measurable = measurableReceiving(in: requests)
+    let bytes = measurable.reduce(Int64(0)) { $0 + ($1.responseBytesReceived ?? 0) }
     guard bytes > 0 else {
       return nil
     }
-    let busySeconds = busyDuration(of: receiving)
+    let busySeconds = busyDuration(of: measurable)
     guard busySeconds > 0 else {
       return nil
     }
     return Double(bytes) / busySeconds
   }
 
+  /// The requests that both received bytes and reported a measurable span, which is the subset the
+  /// throughput ratio is computed over.
+  ///
+  /// Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
+  /// inside the busy-time fold instead would let a request contribute its bytes while adding no
+  /// time, which reads as a faster connection than actually happened. A cache hit is the case that
+  /// matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+  private static func measurableReceiving(in requests: [NetworkRequest]) -> [NetworkRequest] {
+    return requests.filter { request in
+      guard (request.responseBytesReceived ?? 0) > 0 else {
+        return false
+      }
+      guard let start = request.timings.fetchStart, let end = request.timings.responseEnd else {
+        return false
+      }
+      return end > start
+    }
+  }
+
   /// Total length of the union of the requests' in-flight intervals, in seconds.
   ///
   /// Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
-  /// requests are excluded so idle time isn't charged to the network. Requests missing either
-  /// endpoint are skipped rather than treated as zero-length.
+  /// requests are excluded so idle time isn't charged to the network. Requests without a measurable
+  /// span are skipped; callers computing a rate should pass a list already narrowed by
+  /// `measurableReceiving(in:)` so the same requests feed both sides of the ratio.
   private static func busyDuration(of requests: [NetworkRequest]) -> TimeInterval {
     let intervals = requests.compactMap { request -> (start: Date, end: Date)? in
       guard let start = request.timings.fetchStart, let end = request.timings.responseEnd else {
         return nil
       }
-      return end >= start ? (start, end) : nil
+      return end > start ? (start, end) : nil
     }
     .sorted { $0.start < $1.start }
 

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -30,18 +30,35 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// Sum of `timings.totalDuration` across all requests. Can exceed wall-clock when requests overlap.
   public let totalDuration: TimeInterval
 
-  /// Longest single request duration in the window, or `nil` if `count == 0`.
-  public let slowestDuration: TimeInterval?
-
-  /// Host of the slowest request, or `nil` if the request had no resolvable host.
-  public let slowestHost: String?
-
-  /// Longest time-to-first-byte in the window, or `nil` if no request reported one.
+  /// The single longest-running request that completed, or `nil` when the window held none.
   ///
-  /// A maximum rather than an average, so a single stalled request stays visible instead of being
-  /// diluted by fast ones. Note this includes server processing time, so it's a proxy for network
-  /// quality rather than a measurement of it — see `Timings.timeToFirstByte`.
-  public let slowestTimeToFirstByte: TimeInterval?
+  /// Every field describes that one request, so they can be read together: a `duration` mostly made
+  /// up of `timeToFirstByte` means the server was slow to answer, while a small `timeToFirstByte`
+  /// against a large `bytesReceived` means the transfer itself was.
+  ///
+  /// Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
+  /// setting rather than a measurement of the server, so letting one win would make these fields
+  /// report a config constant that barely varies with the network. `failed` and `timedOut` carry
+  /// that signal instead.
+  public let slowest: SlowestRequest?
+
+  /// Facts about the slowest completed request in a window. See `NetworkRequestSummary.slowest`.
+  public struct SlowestRequest: Sendable, Equatable {
+    /// Host of the request, or `nil` if the URL had no resolvable host.
+    public let host: String?
+
+    /// Total wall-clock duration of the request.
+    public let duration: TimeInterval
+
+    /// Time from the start of the fetch until the first response byte arrived, or `nil` if the
+    /// request never reported one. Includes server processing time, so it's a proxy for network
+    /// quality rather than a measurement of it — see `Timings.timeToFirstByte`.
+    public let timeToFirstByte: TimeInterval?
+
+    /// Response bytes received on the wire, or `nil` if the OS didn't report a count. Distinguishes
+    /// a request that was slow because it moved a lot of data from one that was slow while idle.
+    public let bytesReceived: Int64?
+  }
 
   /// Received bytes over the time those bytes were actually moving, in bytes per second, or `nil`
   /// when nothing was received or no receiving request reported a usable interval.
@@ -55,7 +72,7 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///   launch that fetches briefly and then sits idle would otherwise look slow.
   /// - Only requests that received bytes, so a slow request returning nothing can't stretch the
   ///   denominator across time when no payload was in flight. Its latency belongs to
-  ///   `slowestTimeToFirstByte`, not here.
+  ///   `slowest.timeToFirstByte`, not here.
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
   /// no interval covers it. `timedOut` is the signal for that case.
@@ -78,9 +95,7 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     bytesReceived: 0,
     bytesSent: 0,
     totalDuration: 0,
-    slowestDuration: nil,
-    slowestHost: nil,
-    slowestTimeToFirstByte: nil,
+    slowest: nil,
     throughputBytesPerSecond: nil
   )
 
@@ -96,7 +111,6 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     var bytesSent: Int64 = 0
     var totalDuration: TimeInterval = 0
     var slowest: NetworkRequest?
-    var slowestTimeToFirstByte: TimeInterval?
 
     for request in requests {
       if request.isFailed {
@@ -108,17 +122,18 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       bytesReceived += request.responseBytesReceived ?? 0
       bytesSent += request.requestBytesSent ?? 0
       totalDuration += request.timings.totalDuration
-      if let current = slowest {
-        if request.timings.totalDuration > current.timings.totalDuration {
+      // Only completed requests are candidates. A timeout's duration is the client's timeout
+      // setting, not a measurement of the server, so letting one win would make these fields report
+      // a config constant that barely varies with the network. Failures are already counted by
+      // `failed` and `timedOut`.
+      if !request.isFailed {
+        if let current = slowest {
+          if request.timings.totalDuration > current.timings.totalDuration {
+            slowest = request
+          }
+        } else {
           slowest = request
         }
-      } else {
-        slowest = request
-      }
-      // Skips requests that didn't report the phase, so a header-less failure doesn't drag the
-      // result toward a value that was never measured.
-      if let timeToFirstByte = request.timings.timeToFirstByte {
-        slowestTimeToFirstByte = max(timeToFirstByte, slowestTimeToFirstByte ?? timeToFirstByte)
       }
     }
 
@@ -129,9 +144,14 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       bytesReceived: bytesReceived,
       bytesSent: bytesSent,
       totalDuration: totalDuration,
-      slowestDuration: slowest?.timings.totalDuration,
-      slowestHost: slowest?.url.host,
-      slowestTimeToFirstByte: slowestTimeToFirstByte,
+      slowest: slowest.map { request in
+        SlowestRequest(
+          host: request.url.host,
+          duration: request.timings.totalDuration,
+          timeToFirstByte: request.timings.timeToFirstByte,
+          bytesReceived: request.responseBytesReceived
+        )
+      },
       throughputBytesPerSecond: throughput(of: requests)
     )
   }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -14,6 +14,13 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// Requests that errored or returned a non-2xx status.
   public let failed: Int
 
+  /// Subset of `failed` where the network stalled or went away rather than the server answering.
+  ///
+  /// Split out from `failed` because the two have different causes: timeouts point at the
+  /// connection, 4xx/5xx point at the backend. A window where most failures are timeouts is the
+  /// clearest signal available here that the user was on a bad network.
+  public let timedOut: Int
+
   /// Sum of `responseBytesReceived` across all requests in the window.
   public let bytesReceived: Int64
 
@@ -29,6 +36,34 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// Host of the slowest request, or `nil` if the request had no resolvable host.
   public let slowestHost: String?
 
+  /// Longest time-to-first-byte in the window, or `nil` if no request reported one.
+  ///
+  /// A maximum rather than an average, so a single stalled request stays visible instead of being
+  /// diluted by fast ones. Note this includes server processing time, so it's a proxy for network
+  /// quality rather than a measurement of it — see `Timings.timeToFirstByte`.
+  public let slowestTimeToFirstByte: TimeInterval?
+
+  /// Received bytes over the time the network was actually busy, in bytes per second, or `nil` when
+  /// nothing was received or no request reported a usable interval.
+  ///
+  /// The denominator is the union of the request intervals, not the sum of their durations and not
+  /// the elapsed window. Summing durations would divide by the app's request concurrency, so four
+  /// parallel one-second requests would report a quarter of the real rate. Using the whole window
+  /// would charge idle time to the network, so a launch that fetches briefly and then sits idle
+  /// would look slow. Measuring only the busy span leaves a value that moves when the connection
+  /// changes and holds still when the app's fetch pattern does.
+  ///
+  /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
+  /// no interval covers it. `timedOut` is the signal for that case.
+  public let throughputBytesPerSecond: Double?
+
+  /// Shortest TCP handshake in the window, or `nil` if every connection was reused.
+  ///
+  /// A minimum rather than an average: a handshake that loses its SYN retries after a timeout of a
+  /// second or more, so a mean over a few handshakes mostly reports retransmits. The fastest one
+  /// approximates the true path latency.
+  public let fastestTcpHandshake: TimeInterval?
+
   /// Convenience: returns `nil` when the summary is empty so callers can skip emitting fields.
   public var isEmpty: Bool {
     return count == 0
@@ -37,11 +72,15 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   static let empty = NetworkRequestSummary(
     count: 0,
     failed: 0,
+    timedOut: 0,
     bytesReceived: 0,
     bytesSent: 0,
     totalDuration: 0,
     slowestDuration: nil,
-    slowestHost: nil
+    slowestHost: nil,
+    slowestTimeToFirstByte: nil,
+    throughputBytesPerSecond: nil,
+    fastestTcpHandshake: nil
   )
 
   /// Folds a sequence of `NetworkRequest` into a summary. The caller is responsible for filtering
@@ -51,14 +90,20 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       return .empty
     }
     var failed = 0
+    var timedOut = 0
     var bytesReceived: Int64 = 0
     var bytesSent: Int64 = 0
     var totalDuration: TimeInterval = 0
     var slowest: NetworkRequest?
+    var slowestTimeToFirstByte: TimeInterval?
+    var fastestTcpHandshake: TimeInterval?
 
     for request in requests {
       if request.isFailed {
         failed += 1
+      }
+      if request.isTimeout {
+        timedOut += 1
       }
       bytesReceived += request.responseBytesReceived ?? 0
       bytesSent += request.requestBytesSent ?? 0
@@ -70,17 +115,81 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       } else {
         slowest = request
       }
+      // Both folds skip requests that didn't report the phase, so a reused connection or a
+      // header-less failure doesn't drag the result toward a value that was never measured.
+      if let timeToFirstByte = request.timings.timeToFirstByte {
+        slowestTimeToFirstByte = max(timeToFirstByte, slowestTimeToFirstByte ?? timeToFirstByte)
+      }
+      if let handshake = request.timings.tcpHandshakeDuration {
+        fastestTcpHandshake = min(handshake, fastestTcpHandshake ?? handshake)
+      }
     }
 
     return NetworkRequestSummary(
       count: requests.count,
       failed: failed,
+      timedOut: timedOut,
       bytesReceived: bytesReceived,
       bytesSent: bytesSent,
       totalDuration: totalDuration,
       slowestDuration: slowest?.timings.totalDuration,
-      slowestHost: slowest?.url.host
+      slowestHost: slowest?.url.host,
+      slowestTimeToFirstByte: slowestTimeToFirstByte,
+      throughputBytesPerSecond: throughput(bytesReceived: bytesReceived, of: requests),
+      fastestTcpHandshake: fastestTcpHandshake
     )
+  }
+
+  /// Received bytes over the time at least one request was in flight. Returns `nil` when nothing was
+  /// received or no request reported a usable interval, so the caller can tell "unknown" from a
+  /// genuinely slow connection.
+  private static func throughput(bytesReceived: Int64, of requests: [NetworkRequest]) -> Double? {
+    guard bytesReceived > 0 else {
+      return nil
+    }
+    let busySeconds = busyDuration(of: requests)
+    guard busySeconds > 0 else {
+      return nil
+    }
+    return Double(bytesReceived) / busySeconds
+  }
+
+  /// Total length of the union of the requests' in-flight intervals, in seconds.
+  ///
+  /// Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
+  /// requests are excluded so idle time isn't charged to the network. Requests missing either
+  /// endpoint are skipped rather than treated as zero-length.
+  private static func busyDuration(of requests: [NetworkRequest]) -> TimeInterval {
+    let intervals = requests.compactMap { request -> (start: Date, end: Date)? in
+      guard let start = request.timings.fetchStart, let end = request.timings.responseEnd else {
+        return nil
+      }
+      return end >= start ? (start, end) : nil
+    }
+    .sorted { $0.start < $1.start }
+
+    var total: TimeInterval = 0
+    var spanStart: Date?
+    var spanEnd: Date?
+    for interval in intervals {
+      guard let currentEnd = spanEnd, let currentStart = spanStart else {
+        spanStart = interval.start
+        spanEnd = interval.end
+        continue
+      }
+      if interval.start <= currentEnd {
+        // Overlaps (or touches) the open span, so extend it instead of counting the time twice.
+        spanEnd = max(currentEnd, interval.end)
+      } else {
+        total += currentEnd.timeIntervalSince(currentStart)
+        spanStart = interval.start
+        spanEnd = interval.end
+      }
+    }
+    if let spanStart, let spanEnd {
+      total += spanEnd.timeIntervalSince(spanStart)
+    }
+    return total
   }
 }
 

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -68,36 +68,21 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   }
 
   /// Received bytes over the time those bytes were actually moving, in bytes per second, or `nil`
-  /// when nothing was received or no receiving request reported a usable interval.
+  /// when nothing was received or no request reported a usable transfer window.
   ///
   /// The denominator is the union of the transfer windows of the requests that received bytes, each
-  /// running from the first response byte to the last. Four choices are folded into that:
+  /// running from the first response byte to the last. Measuring from the first byte keeps DNS,
+  /// connect and server think time out of the rate, and it excludes cache hits for free, since a
+  /// response served from disk never reports one. Taking the union rather than a sum keeps
+  /// concurrency from deflating it, and gaps between requests are left out so idle time isn't
+  /// charged to the network. Failures are excluded: a request that stalled until the client gave up
+  /// would otherwise hold the window open while nothing moved.
   ///
-  /// - The transfer window rather than the whole request, so time spent resolving DNS, connecting,
-  ///   and waiting on the server isn't charged to the connection. A request that waits four seconds
-  ///   on a backend and then delivers a kilobyte instantly describes a fast network, not a slow one;
-  ///   the wait belongs to `slowest.timeToFirstByte`.
-  /// - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
-  ///   parallel one-second requests would otherwise report a quarter of the real rate.
-  /// - The busy span rather than the whole window, so idle time isn't charged to the network. A
-  ///   launch that fetches briefly and then sits idle would otherwise look slow.
-  /// - Only requests that completed and received bytes, so neither a slow request returning nothing
-  ///   nor one that stalled until the client gave up can stretch the denominator across time when
-  ///   no payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `failed`.
-  ///
-  /// Requiring a first-byte timestamp also excludes cache hits for free: a response served from
-  /// disk never reports one, so the megabytes it contributes can't be divided by the milliseconds
-  /// it took to read them.
-  ///
-  /// Two cases it still can't see. A stall between requests: if the radio dies while nothing is in
-  /// flight, no interval covers it, and `failed` is the signal instead. And a long-lived response
-  /// that trickles, such as a server-sent event stream, whose window stays open across time when
-  /// almost nothing is moving and drags the rate down for everything overlapping it.
-  ///
-  /// Being a ratio, it also degrades differently from the counts when the monitor's ring buffer
-  /// evicts the earliest requests in a window: both sides shrink together, so the value stays
-  /// plausible while describing only the requests that survived. Read it as the rate of a sample of
-  /// the window rather than of all of it.
+  /// Three things it can't see. A stall between requests, since no interval covers it; `failed` is
+  /// the signal there. A long-lived trickle, such as an event stream, whose window stays open while
+  /// almost nothing moves and drags down everything overlapping it. And eviction: when the ring
+  /// buffer drops the earliest requests both sides shrink together, so read this as the rate of a
+  /// sample of the window rather than all of it.
   public let throughputBytesPerSecond: Double?
 
   /// Convenience: returns `nil` when the summary is empty so callers can skip emitting fields.
@@ -191,18 +176,9 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   }
 
   /// The requests that completed, received bytes, and reported a measurable transfer window, which
-  /// is the subset the throughput ratio is computed over.
-  ///
-  /// Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
-  /// inside the busy-time fold instead would let a request contribute its bytes while adding no
-  /// time, which reads as a faster connection than actually happened. A cache hit is the case that
-  /// matters: it reports bytes from the task counters but is served from disk, so it never gets a
-  /// first-byte timestamp and drops out here.
-  ///
-  /// Failures are excluded for the opposite reason. A request that received a few bytes and then
-  /// stalled until the client gave up reports a window covering the whole stall, so it would hold
-  /// the denominator open across time when nothing was moving and report a connection far slower
-  /// than the one that served the requests around it.
+  /// is the subset the throughput ratio is computed over. Deciding it once keeps the numerator and
+  /// denominator describing the same traffic; filtering inside the busy-time fold instead would let
+  /// a request contribute bytes while adding no time.
   private static func measurableReceiving(in requests: [NetworkRequest]) -> [NetworkRequest] {
     return requests.filter { request in
       guard !request.isFailed else {
@@ -222,15 +198,11 @@ public struct NetworkRequestSummary: Sendable, Equatable {
 
   /// Shortest transfer window this ratio will divide by, in seconds.
   ///
-  /// Android timestamps its phases with `Date()`, which advances in whole milliseconds, so a
-  /// transfer faster than that records as a zero-length window and drops out. iOS gets sub-
-  /// millisecond resolution from the transaction metrics and would otherwise keep those requests,
-  /// which is worse than it sounds: the platforms would disagree on whether the key is present at
-  /// all, and Android's surviving sample would skew slow while iOS's kept every fast transfer.
-  ///
-  /// Holding both to Android's floor costs the rate for transfers too quick to measure, which is
-  /// the honest outcome: dividing kilobytes by a duration the clock can't resolve produces a number
-  /// that says more about the timer than the network.
+  /// Matches Android, where `Date()` advances in whole milliseconds and a faster transfer records
+  /// as a zero-length window. iOS could resolve those from the transaction metrics, but keeping
+  /// them would make the platforms disagree on whether the key is present at all, and would leave
+  /// Android's sample skewed slow. Dividing bytes by a duration the clock can't resolve says more
+  /// about the timer than the network.
   private static let minimumTransferWindow: TimeInterval = 0.001
 
   /// Total length of the union of the requests' transfer windows, in seconds, each running from the

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -89,8 +89,10 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// disk never reports one, so the megabytes it contributes can't be divided by the milliseconds
   /// it took to read them.
   ///
-  /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
-  /// no interval covers it. `failed` is the signal for that case.
+  /// Two cases it still can't see. A stall between requests: if the radio dies while nothing is in
+  /// flight, no interval covers it, and `failed` is the signal instead. And a long-lived response
+  /// that trickles, such as a server-sent event stream, whose window stays open across time when
+  /// almost nothing is moving and drags the rate down for everything overlapping it.
   ///
   /// Being a ratio, it also degrades differently from the counts when the monitor's ring buffer
   /// evicts the earliest requests in a window: both sides shrink together, so the value stays
@@ -129,8 +131,11 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       if request.isFailed {
         failed += 1
       }
-      bytesReceived += request.responseBytesReceived ?? 0
-      bytesSent += request.requestBytesSent ?? 0
+      // Clamped rather than `+=`: Swift traps on overflow, and this library must not be able to
+      // abort a host app over an implausible byte count from the OS. A total pinned at the maximum
+      // is visibly wrong; a crash in someone else's app is not recoverable.
+      bytesReceived = bytesReceived.addingClamped(request.responseBytesReceived ?? 0)
+      bytesSent = bytesSent.addingClamped(request.requestBytesSent ?? 0)
       totalDuration += request.timings.totalDuration
       // Only completed requests are candidates. A timeout's duration is the client's timeout
       // setting, not a measurement of the server, so letting one win would make these fields report
@@ -174,7 +179,7 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// the same traffic.
   private static func throughput(of requests: [NetworkRequest]) -> Double? {
     let measurable = measurableReceiving(in: requests)
-    let bytes = measurable.reduce(Int64(0)) { $0 + ($1.responseBytesReceived ?? 0) }
+    let bytes = measurable.reduce(Int64(0)) { $0.addingClamped($1.responseBytesReceived ?? 0) }
     guard bytes > 0 else {
       return nil
     }
@@ -206,12 +211,27 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       guard (request.responseBytesReceived ?? 0) > 0 else {
         return false
       }
-      guard let start = request.timings.responseStart, let end = request.timings.responseEnd else {
+      guard let start = request.timings.responseStart,
+        let end = request.timings.measuredResponseEnd
+      else {
         return false
       }
-      return end > start
+      return end.timeIntervalSince(start) >= minimumTransferWindow
     }
   }
+
+  /// Shortest transfer window this ratio will divide by, in seconds.
+  ///
+  /// Android timestamps its phases with `Date()`, which advances in whole milliseconds, so a
+  /// transfer faster than that records as a zero-length window and drops out. iOS gets sub-
+  /// millisecond resolution from the transaction metrics and would otherwise keep those requests,
+  /// which is worse than it sounds: the platforms would disagree on whether the key is present at
+  /// all, and Android's surviving sample would skew slow while iOS's kept every fast transfer.
+  ///
+  /// Holding both to Android's floor costs the rate for transfers too quick to measure, which is
+  /// the honest outcome: dividing kilobytes by a duration the clock can't resolve produces a number
+  /// that says more about the timer than the network.
+  private static let minimumTransferWindow: TimeInterval = 0.001
 
   /// Total length of the union of the requests' transfer windows, in seconds, each running from the
   /// first response byte to the last.
@@ -222,10 +242,12 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// `measurableReceiving(in:)` so the same requests feed both sides of the ratio.
   private static func busyDuration(of requests: [NetworkRequest]) -> TimeInterval {
     let intervals = requests.compactMap { request -> (start: Date, end: Date)? in
-      guard let start = request.timings.responseStart, let end = request.timings.responseEnd else {
+      guard let start = request.timings.responseStart,
+        let end = request.timings.measuredResponseEnd
+      else {
         return nil
       }
-      return end > start ? (start, end) : nil
+      return end.timeIntervalSince(start) >= minimumTransferWindow ? (start, end) : nil
     }
     .sorted { $0.start < $1.start }
 
@@ -251,6 +273,18 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       total += spanEnd.timeIntervalSince(spanStart)
     }
     return total
+  }
+}
+
+extension Int64 {
+  /// Adds `other`, pinning at `Int64.max` instead of trapping.
+  ///
+  /// Byte counts come from the OS, and an observability library has no business aborting its host
+  /// app over one that doesn't make sense. Both operands are non-negative here, so only the upper
+  /// bound is reachable.
+  fileprivate func addingClamped(_ other: Int64) -> Int64 {
+    let (sum, overflowed) = addingReportingOverflow(other)
+    return overflowed ? Int64.max : sum
   }
 }
 

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -77,9 +77,13 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// Received bytes over the time those bytes were actually moving, in bytes per second, or `nil`
   /// when nothing was received or no receiving request reported a usable interval.
   ///
-  /// The denominator is the union of the intervals of the requests that received bytes. Three
-  /// choices are folded into that:
+  /// The denominator is the union of the transfer windows of the requests that received bytes, each
+  /// running from the first response byte to the last. Four choices are folded into that:
   ///
+  /// - The transfer window rather than the whole request, so time spent resolving DNS, connecting,
+  ///   and waiting on the server isn't charged to the connection. A request that waits four seconds
+  ///   on a backend and then delivers a kilobyte instantly describes a fast network, not a slow one;
+  ///   the wait belongs to `slowest.timeToFirstByte`.
   /// - A union rather than a sum of durations, so request concurrency doesn't inflate it. Four
   ///   parallel one-second requests would otherwise report a quarter of the real rate.
   /// - The busy span rather than the whole window, so idle time isn't charged to the network. A
@@ -87,6 +91,10 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// - Only requests that completed and received bytes, so neither a slow request returning nothing
   ///   nor one that stalled until the client gave up can stretch the denominator across time when
   ///   no payload was in flight. Their latency belongs to `slowest.timeToFirstByte` and `timedOut`.
+  ///
+  /// Requiring a first-byte timestamp also excludes cache hits for free: a response served from
+  /// disk never reports one, so the megabytes it contributes can't be divided by the milliseconds
+  /// it took to read them.
   ///
   /// This still can't see a stall between requests: if the radio dies while nothing is in flight,
   /// no interval covers it. `timedOut` is the signal for that case.
@@ -190,18 +198,19 @@ public struct NetworkRequestSummary: Sendable, Equatable {
     return Double(bytes) / busySeconds
   }
 
-  /// The requests that completed, received bytes, and reported a measurable span, which is the
-  /// subset the throughput ratio is computed over.
+  /// The requests that completed, received bytes, and reported a measurable transfer window, which
+  /// is the subset the throughput ratio is computed over.
   ///
   /// Deciding it once keeps the numerator and denominator describing the same traffic. Filtering
   /// inside the busy-time fold instead would let a request contribute its bytes while adding no
   /// time, which reads as a faster connection than actually happened. A cache hit is the case that
-  /// matters: it reports bytes from the task counters but is served from disk inside one clock tick.
+  /// matters: it reports bytes from the task counters but is served from disk, so it never gets a
+  /// first-byte timestamp and drops out here.
   ///
   /// Failures are excluded for the opposite reason. A request that received a few bytes and then
-  /// stalled until the client gave up reports a span covering the whole stall, so it would hold the
-  /// denominator open across time when nothing was moving and report a connection far slower than
-  /// the one that served the requests around it.
+  /// stalled until the client gave up reports a window covering the whole stall, so it would hold
+  /// the denominator open across time when nothing was moving and report a connection far slower
+  /// than the one that served the requests around it.
   private static func measurableReceiving(in requests: [NetworkRequest]) -> [NetworkRequest] {
     return requests.filter { request in
       guard !request.isFailed else {
@@ -210,22 +219,23 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       guard (request.responseBytesReceived ?? 0) > 0 else {
         return false
       }
-      guard let start = request.timings.fetchStart, let end = request.timings.responseEnd else {
+      guard let start = request.timings.responseStart, let end = request.timings.responseEnd else {
         return false
       }
       return end > start
     }
   }
 
-  /// Total length of the union of the requests' in-flight intervals, in seconds.
+  /// Total length of the union of the requests' transfer windows, in seconds, each running from the
+  /// first response byte to the last.
   ///
   /// Overlapping requests are merged so concurrency doesn't inflate the total, and gaps between
   /// requests are excluded so idle time isn't charged to the network. Requests without a measurable
-  /// span are skipped; callers computing a rate should pass a list already narrowed by
+  /// window are skipped; callers computing a rate should pass a list already narrowed by
   /// `measurableReceiving(in:)` so the same requests feed both sides of the ratio.
   private static func busyDuration(of requests: [NetworkRequest]) -> TimeInterval {
     let intervals = requests.compactMap { request -> (start: Date, end: Date)? in
-      guard let start = request.timings.fetchStart, let end = request.timings.responseEnd else {
+      guard let start = request.timings.responseStart, let end = request.timings.responseEnd else {
         return nil
       }
       return end > start ? (start, end) : nil

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -185,8 +185,9 @@ public struct NetworkRequestSummary: Sendable, Equatable {
         return false
       }
       // A cache hit reports bytes and timestamps like any other response, so nothing else here
-      // excludes it. Its window measures a disk read, not the connection.
-      guard request.cameFromNetwork != false else {
+      // excludes it. Requires a positive answer: an unclassified fetch may be a disk read, and its
+      // window would measure that rather than the connection.
+      guard request.cameFromNetwork == true else {
         return false
       }
       guard (request.responseBytesReceived ?? 0) > 0 else {

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -259,7 +259,7 @@ extension Int64 {
   /// Byte counts come from the OS, and an observability library has no business aborting its host
   /// app over one that doesn't make sense. Both operands are non-negative here, so only the upper
   /// bound is reachable.
-  fileprivate func addingClamped(_ other: Int64) -> Int64 {
+  func addingClamped(_ other: Int64) -> Int64 {
     let (sum, overflowed) = addingReportingOverflow(other)
     return overflowed ? Int64.max : sum
   }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -36,10 +36,10 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// against a large `bytesReceived` means the transfer itself was. `statusCode` explains a
   /// `bytesReceived` of 0, which is routine on a 304 and a problem on a 200.
   ///
-  /// Failed requests are deliberately not candidates. A timeout's duration is the client's timeout
-  /// setting rather than a measurement of the server, so letting one win would make these fields
-  /// report a config constant that barely varies with the network. `failed` carries that signal
-  /// instead.
+  /// A 4xx or 5xx that came back is a candidate: the app waited for it, and on a launch that felt
+  /// slow that wait is often the answer. Only requests that never produced a response are excluded,
+  /// because a timeout's duration is the client's own setting rather than a measurement of anything
+  /// the server did.
   public let slowest: SlowestRequest?
 
   /// Facts about the slowest completed request in a window. See `NetworkRequestSummary.slowest`.
@@ -72,8 +72,9 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   ///
   /// The denominator is the union of the transfer windows of the requests that received bytes, each
   /// running from the first response byte to the last. Measuring from the first byte keeps DNS,
-  /// connect and server think time out of the rate, and it excludes cache hits for free, since a
-  /// response served from disk never reports one. Taking the union rather than a sum keeps
+  /// connect and server think time out of the rate. Responses served from a cache are excluded by
+  /// fetch type, since they report bytes and timestamps like any other response but measure a disk
+  /// read. Taking the union rather than a sum keeps
   /// concurrency from deflating it, and gaps between requests are left out so idle time isn't
   /// charged to the network. Failures are excluded: a request that stalled until the client gave up
   /// would otherwise hold the window open while nothing moved.
@@ -122,11 +123,10 @@ public struct NetworkRequestSummary: Sendable, Equatable {
       bytesReceived = bytesReceived.addingClamped(request.responseBytesReceived ?? 0)
       bytesSent = bytesSent.addingClamped(request.requestBytesSent ?? 0)
       totalDuration += request.timings.totalDuration
-      // Only completed requests are candidates. A timeout's duration is the client's timeout
-      // setting, not a measurement of the server, so letting one win would make these fields report
-      // a config constant that barely varies with the network. Failures are already counted by
-      // `failed`.
-      if !request.isFailed {
+      // A 4xx or 5xx that came back is still a candidate: the app waited for it, and that wait is
+      // what this field exists to surface. Only requests that never produced a response are skipped,
+      // since a timeout's duration is the client's setting rather than the server's.
+      if !request.neverCompleted {
         if let current = slowest {
           if request.timings.totalDuration > current.timings.totalDuration {
             slowest = request
@@ -181,7 +181,12 @@ public struct NetworkRequestSummary: Sendable, Equatable {
   /// a request contribute bytes while adding no time.
   private static func measurableReceiving(in requests: [NetworkRequest]) -> [NetworkRequest] {
     return requests.filter { request in
-      guard !request.isFailed else {
+      guard !request.neverCompleted else {
+        return false
+      }
+      // A cache hit reports bytes and timestamps like any other response, so nothing else here
+      // excludes it. Its window measures a disk read, not the connection.
+      guard request.cameFromNetwork != false else {
         return false
       }
       guard (request.responseBytesReceived ?? 0) > 0 else {
@@ -261,6 +266,17 @@ extension Int64 {
 }
 
 extension NetworkRequest {
+  /// Whether the request never produced a response at all: it errored, or it died before headers
+  /// arrived. Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+  ///
+  /// This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
+  /// eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is
+  /// often the answer; a timeout's duration is the client's own setting and says nothing about the
+  /// network.
+  var neverCompleted: Bool {
+    return errorDescription != nil || statusCode == nil
+  }
+
   /// A request is treated as failed if it errored, or returned a 4xx (client error) or 5xx (server
   /// error) status. 1xx (informational), 2xx (success), and 3xx (redirection — usually followed
   /// transparently by URLSession, but the unfollowed case is still a successful response from the

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -266,15 +266,19 @@ extension Int64 {
 }
 
 extension NetworkRequest {
-  /// Whether the request never produced a response at all: it errored, or it died before headers
-  /// arrived. Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+  /// Whether the request never produced a response at all, so there is no status code to report.
+  /// Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+  ///
+  /// Keyed on the missing status rather than on `errorDescription`, because a response can carry
+  /// both: a transfer that breaks mid-body keeps the 200 its headers arrived with and gains an
+  /// error string. That request waited real seconds and belongs in `slowest`.
   ///
   /// This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
   /// eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is
   /// often the answer; a timeout's duration is the client's own setting and says nothing about the
   /// network.
   var neverCompleted: Bool {
-    return errorDescription != nil || statusCode == nil
+    return statusCode == nil
   }
 
   /// A request is treated as failed if it errored, or returned a 4xx (client error) or 5xx (server

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestSummary.swift
@@ -266,26 +266,20 @@ extension Int64 {
 }
 
 extension NetworkRequest {
-  /// Whether the request never produced a response at all, so there is no status code to report.
-  /// Distinct from `isFailed`, which also counts a 4xx or 5xx the server did return.
+  /// Whether the request never produced a response, so there is no status code to report. The
+  /// predicate for `slowest` and the throughput subset.
   ///
   /// Keyed on the missing status rather than on `errorDescription`, because a response can carry
   /// both: a transfer that breaks mid-body keeps the 200 its headers arrived with and gains an
-  /// error string. That request waited real seconds and belongs in `slowest`.
-  ///
-  /// This is the predicate for `slowest` and for the throughput subset. A 503 that came back after
-  /// eight seconds is a real measurement of a slow backend, and on a launch that felt slow it is
-  /// often the answer; a timeout's duration is the client's own setting and says nothing about the
-  /// network.
+  /// error string, and it waited real seconds. A 503 after eight seconds is likewise a measurement
+  /// worth surfacing, whereas a timeout's duration is the client's own setting.
   var neverCompleted: Bool {
     return statusCode == nil
   }
 
-  /// A request is treated as failed if it errored, or returned a 4xx (client error) or 5xx (server
-  /// error) status. 1xx (informational), 2xx (success), and 3xx (redirection — usually followed
-  /// transparently by URLSession, but the unfollowed case is still a successful response from the
-  /// origin's perspective) are not failures. A missing status code (the request failed before
-  /// headers arrived) counts as failed.
+  /// A request is treated as failed if it errored, or returned a 4xx or 5xx status. 1xx, 2xx and
+  /// 3xx are not failures: a redirect URLSession didn't follow is still a successful response from
+  /// the origin's perspective. A missing status code counts as failed.
   var isFailed: Bool {
     if errorDescription != nil {
       return true

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -117,7 +117,7 @@ struct MetricParamsBuilderTests {
   func `omits network request keys when summary is nil`() {
     let params = MetricParamsBuilder.build(userParams: ["tenant": "acme"])
     #expect(params["expo.network.requests.count"] == nil)
-    #expect(params["expo.network.requests.slowestHost"] == nil)
+    #expect(params["expo.network.requests.slowest.host"] == nil)
   }
 
   @Test
@@ -135,9 +135,12 @@ struct MetricParamsBuilderTests {
       bytesReceived: 12_000,
       bytesSent: 800,
       totalDuration: 1.4,
-      slowestDuration: 0.6,
-      slowestHost: "api.expo.dev",
-      slowestTimeToFirstByte: nil,
+      slowest: NetworkRequestSummary.SlowestRequest(
+        host: "api.expo.dev",
+        duration: 0.6,
+        timeToFirstByte: nil,
+        bytesReceived: nil
+      ),
       throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
@@ -146,8 +149,8 @@ struct MetricParamsBuilderTests {
     #expect(params["expo.network.requests.bytesReceived"] as? Int64 == 12_000)
     #expect(params["expo.network.requests.bytesSent"] as? Int64 == 800)
     #expect(params["expo.network.requests.totalDuration"] as? TimeInterval == 1.4)
-    #expect(params["expo.network.requests.slowestDuration"] as? TimeInterval == 0.6)
-    #expect(params["expo.network.requests.slowestHost"] as? String == "api.expo.dev")
+    #expect(params["expo.network.requests.slowest.duration"] as? TimeInterval == 0.6)
+    #expect(params["expo.network.requests.slowest.host"] as? String == "api.expo.dev")
   }
 
   @Test
@@ -192,9 +195,12 @@ struct MetricParamsBuilderTests {
       bytesReceived: 0,
       bytesSent: 0,
       totalDuration: 30.2,
-      slowestDuration: 30,
-      slowestHost: "slow.expo.dev",
-      slowestTimeToFirstByte: nil,
+      slowest: NetworkRequestSummary.SlowestRequest(
+        host: "slow.expo.dev",
+        duration: 30,
+        timeToFirstByte: nil,
+        bytesReceived: nil
+      ),
       throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
@@ -214,9 +220,12 @@ struct MetricParamsBuilderTests {
       bytesReceived: 10,
       bytesSent: 10,
       totalDuration: 0.1,
-      slowestDuration: 0.1,
-      slowestHost: "expo.dev",
-      slowestTimeToFirstByte: nil,
+      slowest: NetworkRequestSummary.SlowestRequest(
+        host: "expo.dev",
+        duration: 0.1,
+        timeToFirstByte: nil,
+        bytesReceived: nil
+      ),
       throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
@@ -232,13 +241,16 @@ struct MetricParamsBuilderTests {
       bytesReceived: 12_000,
       bytesSent: 800,
       totalDuration: 1.4,
-      slowestDuration: 0.6,
-      slowestHost: "api.expo.dev",
-      slowestTimeToFirstByte: 0.35,
+      slowest: NetworkRequestSummary.SlowestRequest(
+        host: "api.expo.dev",
+        duration: 0.6,
+        timeToFirstByte: 0.35,
+        bytesReceived: nil
+      ),
       throughputBytesPerSecond: 8571.4
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
-    #expect(params["expo.network.requests.slowestTimeToFirstByte"] as? TimeInterval == 0.35)
+    #expect(params["expo.network.requests.slowest.timeToFirstByte"] as? TimeInterval == 0.35)
     #expect(params["expo.network.requests.throughputBytesPerSecond"] as? Double == 8571.4)
   }
 
@@ -253,14 +265,17 @@ struct MetricParamsBuilderTests {
       bytesReceived: 0,
       bytesSent: 40,
       totalDuration: 0.2,
-      slowestDuration: 0.1,
-      slowestHost: "api.expo.dev",
-      slowestTimeToFirstByte: nil,
+      slowest: NetworkRequestSummary.SlowestRequest(
+        host: "api.expo.dev",
+        duration: 0.1,
+        timeToFirstByte: nil,
+        bytesReceived: nil
+      ),
       throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.count"] as? Int == 2)
-    #expect(params["expo.network.requests.slowestTimeToFirstByte"] == nil)
+    #expect(params["expo.network.requests.slowest.timeToFirstByte"] == nil)
     #expect(params["expo.network.requests.throughputBytesPerSecond"] == nil)
   }
 

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -138,8 +138,7 @@ struct MetricParamsBuilderTests {
       slowestDuration: 0.6,
       slowestHost: "api.expo.dev",
       slowestTimeToFirstByte: nil,
-      throughputBytesPerSecond: nil,
-      fastestTcpHandshake: nil
+      throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.count"] as? Int == 4)
@@ -185,8 +184,7 @@ struct MetricParamsBuilderTests {
       slowestDuration: 30,
       slowestHost: "slow.expo.dev",
       slowestTimeToFirstByte: nil,
-      throughputBytesPerSecond: nil,
-      fastestTcpHandshake: nil
+      throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.failed"] as? Int == 2)
@@ -208,8 +206,7 @@ struct MetricParamsBuilderTests {
       slowestDuration: 0.1,
       slowestHost: "expo.dev",
       slowestTimeToFirstByte: nil,
-      throughputBytesPerSecond: nil,
-      fastestTcpHandshake: nil
+      throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.timedOut"] as? Int == 0)
@@ -227,13 +224,11 @@ struct MetricParamsBuilderTests {
       slowestDuration: 0.6,
       slowestHost: "api.expo.dev",
       slowestTimeToFirstByte: 0.35,
-      throughputBytesPerSecond: 8571.4,
-      fastestTcpHandshake: 0.04
+      throughputBytesPerSecond: 8571.4
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.slowestTimeToFirstByte"] as? TimeInterval == 0.35)
     #expect(params["expo.network.requests.throughputBytesPerSecond"] as? Double == 8571.4)
-    #expect(params["expo.network.requests.fastestTcpHandshake"] as? TimeInterval == 0.04)
   }
 
   @Test
@@ -250,14 +245,12 @@ struct MetricParamsBuilderTests {
       slowestDuration: 0.1,
       slowestHost: "api.expo.dev",
       slowestTimeToFirstByte: nil,
-      throughputBytesPerSecond: nil,
-      fastestTcpHandshake: nil
+      throughputBytesPerSecond: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.count"] as? Int == 2)
     #expect(params["expo.network.requests.slowestTimeToFirstByte"] == nil)
     #expect(params["expo.network.requests.throughputBytesPerSecond"] == nil)
-    #expect(params["expo.network.requests.fastestTcpHandshake"] == nil)
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -131,11 +131,15 @@ struct MetricParamsBuilderTests {
     let summary = NetworkRequestSummary(
       count: 4,
       failed: 1,
+      timedOut: 0,
       bytesReceived: 12_000,
       bytesSent: 800,
       totalDuration: 1.4,
       slowestDuration: 0.6,
-      slowestHost: "api.expo.dev"
+      slowestHost: "api.expo.dev",
+      slowestTimeToFirstByte: nil,
+      throughputBytesPerSecond: nil,
+      fastestTcpHandshake: nil
     )
     let params = MetricParamsBuilder.build(networkRequests: summary)
     #expect(params["expo.network.requests.count"] as? Int == 4)
@@ -145,6 +149,115 @@ struct MetricParamsBuilderTests {
     #expect(params["expo.network.requests.totalDuration"] as? TimeInterval == 1.4)
     #expect(params["expo.network.requests.slowestDuration"] as? TimeInterval == 0.6)
     #expect(params["expo.network.requests.slowestHost"] as? String == "api.expo.dev")
+  }
+
+  @Test
+  func `emits path cost flags alongside the connection type`() {
+    let constrainedCellular = NetworkPath(
+      status: .satisfied,
+      interfaceType: .cellular,
+      isExpensive: true,
+      isConstrained: true,
+      unsatisfiedReason: nil,
+      timestamp: 0
+    )
+    let params = MetricParamsBuilder.build(networkPath: constrainedCellular)
+    #expect(params["expo.network.isExpensive"] as? Bool == true)
+    #expect(params["expo.network.isConstrained"] as? Bool == true)
+  }
+
+  @Test
+  func `emits path cost flags as false on an unmetered path`() {
+    let params = MetricParamsBuilder.build(networkPath: satisfiedWifi)
+    #expect(params["expo.network.isExpensive"] as? Bool == false)
+    #expect(params["expo.network.isConstrained"] as? Bool == false)
+  }
+
+  @Test
+  func `emits the timeout count alongside the failure count`() {
+    let summary = NetworkRequestSummary(
+      count: 3,
+      failed: 2,
+      timedOut: 1,
+      bytesReceived: 0,
+      bytesSent: 0,
+      totalDuration: 30.2,
+      slowestDuration: 30,
+      slowestHost: "slow.expo.dev",
+      slowestTimeToFirstByte: nil,
+      throughputBytesPerSecond: nil,
+      fastestTcpHandshake: nil
+    )
+    let params = MetricParamsBuilder.build(networkRequests: summary)
+    #expect(params["expo.network.requests.failed"] as? Int == 2)
+    #expect(params["expo.network.requests.timedOut"] as? Int == 1)
+  }
+
+  @Test
+  func `emits a zero timeout count so its absence is not ambiguous`() {
+    // Unlike the optional latency fields, a count of zero is a real measurement: we saw requests
+    // and none of them timed out. Omitting it would make "no timeouts" and "not measured" look
+    // the same.
+    let summary = NetworkRequestSummary(
+      count: 1,
+      failed: 0,
+      timedOut: 0,
+      bytesReceived: 10,
+      bytesSent: 10,
+      totalDuration: 0.1,
+      slowestDuration: 0.1,
+      slowestHost: "expo.dev",
+      slowestTimeToFirstByte: nil,
+      throughputBytesPerSecond: nil,
+      fastestTcpHandshake: nil
+    )
+    let params = MetricParamsBuilder.build(networkRequests: summary)
+    #expect(params["expo.network.requests.timedOut"] as? Int == 0)
+  }
+
+  @Test
+  func `emits the derived latency and throughput keys when the summary has them`() {
+    let summary = NetworkRequestSummary(
+      count: 4,
+      failed: 1,
+      timedOut: 0,
+      bytesReceived: 12_000,
+      bytesSent: 800,
+      totalDuration: 1.4,
+      slowestDuration: 0.6,
+      slowestHost: "api.expo.dev",
+      slowestTimeToFirstByte: 0.35,
+      throughputBytesPerSecond: 8571.4,
+      fastestTcpHandshake: 0.04
+    )
+    let params = MetricParamsBuilder.build(networkRequests: summary)
+    #expect(params["expo.network.requests.slowestTimeToFirstByte"] as? TimeInterval == 0.35)
+    #expect(params["expo.network.requests.throughputBytesPerSecond"] as? Double == 8571.4)
+    #expect(params["expo.network.requests.fastestTcpHandshake"] as? TimeInterval == 0.04)
+  }
+
+  @Test
+  func `omits the derived keys rather than emitting zero when they are unavailable`() {
+    // Every connection reused and nothing received: emitting 0 would read as "instant, no data"
+    // instead of "not measured" on a dashboard.
+    let summary = NetworkRequestSummary(
+      count: 2,
+      failed: 0,
+      timedOut: 0,
+      bytesReceived: 0,
+      bytesSent: 40,
+      totalDuration: 0.2,
+      slowestDuration: 0.1,
+      slowestHost: "api.expo.dev",
+      slowestTimeToFirstByte: nil,
+      throughputBytesPerSecond: nil,
+      fastestTcpHandshake: nil
+    )
+    let params = MetricParamsBuilder.build(networkRequests: summary)
+    #expect(params["expo.network.requests.count"] as? Int == 2)
+    #expect(params["expo.network.requests.slowestTimeToFirstByte"] == nil)
+    #expect(params["expo.network.requests.throughputBytesPerSecond"] == nil)
+    #expect(params["expo.network.requests.fastestTcpHandshake"] == nil)
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -166,6 +166,17 @@ struct MetricParamsBuilderTests {
   }
 
   @Test
+  func `omits path cost flags when there is no network to describe`() {
+    // `NWPath` reports both as `false` on an unsatisfied path. Emitting that would assert the
+    // connection wasn't metered, about a connection that doesn't exist, and Android withholds its
+    // equivalents in the same situation.
+    let params = MetricParamsBuilder.build(networkPath: unsatisfied)
+    #expect(params["expo.network.connected"] as? Bool == false)
+    #expect(params["expo.network.isExpensive"] == nil)
+    #expect(params["expo.network.isConstrained"] == nil)
+  }
+
+  @Test
   func `emits path cost flags as false on an unmetered path`() {
     let params = MetricParamsBuilder.build(networkPath: satisfiedWifi)
     #expect(params["expo.network.isExpensive"] as? Bool == false)

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -138,6 +138,7 @@ struct MetricParamsBuilderTests {
       slowest: NetworkRequestSummary.SlowestRequest(
         host: "api.expo.dev",
         duration: 0.6,
+        statusCode: 200,
         timeToFirstByte: nil,
         bytesReceived: nil
       ),
@@ -151,6 +152,7 @@ struct MetricParamsBuilderTests {
     #expect(params["expo.network.requests.totalDuration"] as? TimeInterval == 1.4)
     #expect(params["expo.network.requests.slowest.duration"] as? TimeInterval == 0.6)
     #expect(params["expo.network.requests.slowest.host"] as? String == "api.expo.dev")
+    #expect(params["expo.network.requests.slowest.statusCode"] as? Int == 200)
   }
 
   @Test
@@ -198,6 +200,7 @@ struct MetricParamsBuilderTests {
       slowest: NetworkRequestSummary.SlowestRequest(
         host: "slow.expo.dev",
         duration: 30,
+        statusCode: 200,
         timeToFirstByte: nil,
         bytesReceived: nil
       ),
@@ -223,6 +226,7 @@ struct MetricParamsBuilderTests {
       slowest: NetworkRequestSummary.SlowestRequest(
         host: "expo.dev",
         duration: 0.1,
+        statusCode: 200,
         timeToFirstByte: nil,
         bytesReceived: nil
       ),
@@ -244,6 +248,7 @@ struct MetricParamsBuilderTests {
       slowest: NetworkRequestSummary.SlowestRequest(
         host: "api.expo.dev",
         duration: 0.6,
+        statusCode: 200,
         timeToFirstByte: 0.35,
         bytesReceived: nil
       ),
@@ -268,6 +273,7 @@ struct MetricParamsBuilderTests {
       slowest: NetworkRequestSummary.SlowestRequest(
         host: "api.expo.dev",
         duration: 0.1,
+        statusCode: 200,
         timeToFirstByte: nil,
         bytesReceived: nil
       ),

--- a/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricParamsBuilderTests.swift
@@ -131,7 +131,6 @@ struct MetricParamsBuilderTests {
     let summary = NetworkRequestSummary(
       count: 4,
       failed: 1,
-      timedOut: 0,
       bytesReceived: 12_000,
       bytesSent: 800,
       totalDuration: 1.4,
@@ -189,59 +188,10 @@ struct MetricParamsBuilderTests {
   }
 
   @Test
-  func `emits the timeout count alongside the failure count`() {
-    let summary = NetworkRequestSummary(
-      count: 3,
-      failed: 2,
-      timedOut: 1,
-      bytesReceived: 0,
-      bytesSent: 0,
-      totalDuration: 30.2,
-      slowest: NetworkRequestSummary.SlowestRequest(
-        host: "slow.expo.dev",
-        duration: 30,
-        statusCode: 200,
-        timeToFirstByte: nil,
-        bytesReceived: nil
-      ),
-      throughputBytesPerSecond: nil
-    )
-    let params = MetricParamsBuilder.build(networkRequests: summary)
-    #expect(params["expo.network.requests.failed"] as? Int == 2)
-    #expect(params["expo.network.requests.timedOut"] as? Int == 1)
-  }
-
-  @Test
-  func `emits a zero timeout count so its absence is not ambiguous`() {
-    // Unlike the optional latency fields, a count of zero is a real measurement: we saw requests
-    // and none of them timed out. Omitting it would make "no timeouts" and "not measured" look
-    // the same.
-    let summary = NetworkRequestSummary(
-      count: 1,
-      failed: 0,
-      timedOut: 0,
-      bytesReceived: 10,
-      bytesSent: 10,
-      totalDuration: 0.1,
-      slowest: NetworkRequestSummary.SlowestRequest(
-        host: "expo.dev",
-        duration: 0.1,
-        statusCode: 200,
-        timeToFirstByte: nil,
-        bytesReceived: nil
-      ),
-      throughputBytesPerSecond: nil
-    )
-    let params = MetricParamsBuilder.build(networkRequests: summary)
-    #expect(params["expo.network.requests.timedOut"] as? Int == 0)
-  }
-
-  @Test
   func `emits the derived latency and throughput keys when the summary has them`() {
     let summary = NetworkRequestSummary(
       count: 4,
       failed: 1,
-      timedOut: 0,
       bytesReceived: 12_000,
       bytesSent: 800,
       totalDuration: 1.4,
@@ -266,7 +216,6 @@ struct MetricParamsBuilderTests {
     let summary = NetworkRequestSummary(
       count: 2,
       failed: 0,
-      timedOut: 0,
       bytesReceived: 0,
       bytesSent: 40,
       totalDuration: 0.2,

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -349,7 +349,7 @@ struct NetworkRequestSummaryTests {
     let summary = NetworkRequestSummary.from([])
     #expect(summary.isEmpty)
     #expect(summary.count == 0)
-    #expect(summary.slowestHost == nil)
+    #expect(summary.slowest?.host == nil)
   }
 
   @Test
@@ -386,8 +386,103 @@ struct NetworkRequestSummaryTests {
     #expect(summary.bytesSent == 180)
     #expect(summary.bytesReceived == 9240)
     #expect(abs(summary.totalDuration - 1.2) < 0.0001)
-    #expect(summary.slowestDuration == 0.8)
-    #expect(summary.slowestHost == "cdn.expo.dev")
+    #expect(summary.slowest?.duration == 0.8)
+    #expect(summary.slowest?.host == "cdn.expo.dev")
+  }
+
+  @Test
+  func `picks the slowest completed request rather than the slowest failure`() {
+    let now = Date()
+    // A timeout's duration is the client's timeout setting, not a measurement of the server, so
+    // letting it win would make this field report a config constant instead of the network.
+    let timedOut = makeRequest(
+      host: "192.168.0.104",
+      duration: 10.0,
+      status: nil,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      error: "timed out",
+      isTimeout: true
+    )
+    let slowSuccess = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 2.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 5000,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.4),
+      responseEnd: now.addingTimeInterval(2)
+    )
+    let quick = makeRequest(
+      host: "api.expo.dev",
+      duration: 0.2,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.05),
+      responseEnd: now.addingTimeInterval(0.2)
+    )
+    let summary = NetworkRequestSummary.from([timedOut, slowSuccess, quick])
+    #expect(summary.slowest?.duration == 2.0)
+    #expect(summary.slowest?.host == "cdn.expo.dev")
+    // All three `slowest` fields describe that one request.
+    #expect(abs((summary.slowest?.timeToFirstByte ?? 0) - 0.4) < 0.0001)
+    // The timeout is still counted, just not used to describe the slowest request.
+    #expect(summary.timedOut == 1)
+    #expect(summary.failed == 1)
+  }
+
+  @Test
+  func `leaves the slowest fields nil when every request failed`() {
+    let request = makeRequest(
+      host: "expo.dev",
+      duration: 10.0,
+      status: nil,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date(),
+      error: "timed out",
+      isTimeout: true
+    )
+    let summary = NetworkRequestSummary.from([request])
+    #expect(summary.slowest?.duration == nil)
+    #expect(summary.slowest?.host == nil)
+    #expect(summary.slowest?.timeToFirstByte == nil)
+    #expect(summary.count == 1)
+    #expect(summary.timedOut == 1)
+  }
+
+  @Test
+  func `reports the slowest request's own time to first byte, not the window maximum`() {
+    let now = Date()
+    // The quick request has the higher TTFB relative to its own duration; a window max would report
+    // 0.9 here. The slowest request's own TTFB is 0.3, which is what pairs with its duration.
+    let slowest = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 4.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 9000,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.3),
+      responseEnd: now.addingTimeInterval(4)
+    )
+    let slowServer = makeRequest(
+      host: "api.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.9),
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let summary = NetworkRequestSummary.from([slowest, slowServer])
+    #expect(summary.slowest?.duration == 4.0)
+    #expect(abs((summary.slowest?.timeToFirstByte ?? 0) - 0.3) < 0.0001)
   }
 
   @Test
@@ -473,7 +568,7 @@ struct NetworkRequestSummaryTests {
       error: "timed out"
     )
     let summary = NetworkRequestSummary.from([quick, stalled, headerless])
-    #expect(abs((summary.slowestTimeToFirstByte ?? 0) - 0.3) < 0.0001)
+    #expect(abs((summary.slowest?.timeToFirstByte ?? 0) - 0.3) < 0.0001)
   }
 
   @Test
@@ -487,7 +582,7 @@ struct NetworkRequestSummaryTests {
       fetchStart: Date()
     )
     let summary = NetworkRequestSummary.from([request])
-    #expect(summary.slowestTimeToFirstByte == nil)
+    #expect(summary.slowest?.timeToFirstByte == nil)
   }
 
   @Test
@@ -609,7 +704,7 @@ struct NetworkRequestSummaryTests {
     let now = Date()
     // A slow API call that returns nothing spends real time in flight, but no bytes could have been
     // flowing during it. Counting its span would describe time the payload wasn't moving and halve
-    // the reported rate; its latency is already covered by `slowestTimeToFirstByte`.
+    // the reported rate; its latency is already covered by `slowest.timeToFirstByte`.
     let download = makeRequest(
       host: "cdn.expo.dev",
       duration: 1.0,
@@ -706,7 +801,7 @@ struct NetworkRequestSummaryTests {
       responseStart: now.addingTimeInterval(-0.2)
     )
     let summary = NetworkRequestSummary.from([skewed])
-    #expect(summary.slowestTimeToFirstByte == nil)
+    #expect(summary.slowest?.timeToFirstByte == nil)
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -67,107 +67,7 @@ struct NetworkRequestTests {
   }
 
   @Test
-  func `flags a timed-out request as a timeout`() {
-    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
-    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
-    let now = Date()
-    let snapshot = NetworkRequest.from(
-      id: UUID(),
-      request: request,
-      response: nil,
-      taskBytesSent: nil,
-      taskBytesReceived: nil,
-      metrics: nil,
-      fallbackStart: now,
-      fallbackEnd: now,
-      error: error
-    )
-    #expect(snapshot.isTimeout)
-  }
-
-  @Test
-  func `flags a lost connection as a timeout`() {
-    // The radio dropping mid-request is the same "network went away" condition as a timeout, and
-    // is what an elevator actually produces.
-    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
-    let error = NSError(
-      domain: NSURLErrorDomain,
-      code: NSURLErrorNetworkConnectionLost,
-      userInfo: nil
-    )
-    let now = Date()
-    let snapshot = NetworkRequest.from(
-      id: UUID(),
-      request: request,
-      response: nil,
-      taskBytesSent: nil,
-      taskBytesReceived: nil,
-      metrics: nil,
-      fallbackStart: now,
-      fallbackEnd: now,
-      error: error
-    )
-    #expect(snapshot.isTimeout)
-  }
-
-  @Test
-  func `flags an unreachable network as a timeout`() {
-    // An offline device surfaces as any of these, depending on how far the request got before it
-    // gave up. Android reports the same conditions as UnknownHostException and counts them, so all
-    // four have to count here for the metric to mean one thing on both platforms.
-    let codes = [
-      NSURLErrorNotConnectedToInternet,
-      NSURLErrorCannotFindHost,
-      NSURLErrorDNSLookupFailed,
-      NSURLErrorCannotConnectToHost,
-    ]
-    for code in codes {
-      let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
-      let error = NSError(domain: NSURLErrorDomain, code: code, userInfo: nil)
-      let now = Date()
-      let snapshot = NetworkRequest.from(
-        id: UUID(),
-        request: request,
-        response: nil,
-        taskBytesSent: nil,
-        taskBytesReceived: nil,
-        metrics: nil,
-        fallbackStart: now,
-        fallbackEnd: now,
-        error: error
-      )
-      #expect(snapshot.isTimeout, "expected code \(code) to count as a timeout")
-    }
-  }
-
-  @Test
-  func `does not flag a TLS failure as a timeout`() {
-    // A failed handshake is a certificate or trust problem, not an absent network. Android leaves
-    // SSLException out of its set for the same reason.
-    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
-    let error = NSError(
-      domain: NSURLErrorDomain,
-      code: NSURLErrorSecureConnectionFailed,
-      userInfo: nil
-    )
-    let now = Date()
-    let snapshot = NetworkRequest.from(
-      id: UUID(),
-      request: request,
-      response: nil,
-      taskBytesSent: nil,
-      taskBytesReceived: nil,
-      metrics: nil,
-      fallbackStart: now,
-      fallbackEnd: now,
-      error: error
-    )
-    #expect(!snapshot.isTimeout)
-  }
-
-  @Test
-  func `does not flag a cancelled request as a timeout`() {
-    // The app abandoned the request; that says nothing about the network.
+  func `records a description for a cancelled request`() {
     let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
     let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil)
     let now = Date()
@@ -182,26 +82,9 @@ struct NetworkRequestTests {
       fallbackEnd: now,
       error: error
     )
-    #expect(!snapshot.isTimeout)
+    // A description is what makes the summary treat the request as failed, so an abandoned request
+    // still has to carry one rather than passing for a success.
     #expect(snapshot.errorDescription != nil)
-  }
-
-  @Test
-  func `does not flag a successful request as a timeout`() {
-    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
-    let now = Date()
-    let snapshot = NetworkRequest.from(
-      id: UUID(),
-      request: request,
-      response: nil,
-      taskBytesSent: nil,
-      taskBytesReceived: nil,
-      metrics: nil,
-      fallbackStart: now,
-      fallbackEnd: now,
-      error: nil
-    )
-    #expect(!snapshot.isTimeout)
   }
 }
 
@@ -450,15 +333,14 @@ struct NetworkRequestSummaryTests {
     let now = Date()
     // A timeout's duration is the client's timeout setting, not a measurement of the server, so
     // letting it win would make this field report a config constant instead of the network.
-    let timedOut = makeRequest(
+    let failure = makeRequest(
       host: "192.168.0.104",
       duration: 10.0,
       status: nil,
       bytesSent: 0,
       bytesReceived: 0,
       fetchStart: now,
-      error: "timed out",
-      isTimeout: true
+      error: "timed out"
     )
     let slowSuccess = makeRequest(
       host: "cdn.expo.dev",
@@ -480,13 +362,12 @@ struct NetworkRequestSummaryTests {
       responseStart: now.addingTimeInterval(0.05),
       responseEnd: now.addingTimeInterval(0.2)
     )
-    let summary = NetworkRequestSummary.from([timedOut, slowSuccess, quick])
+    let summary = NetworkRequestSummary.from([failure, slowSuccess, quick])
     #expect(summary.slowest?.duration == 2.0)
     #expect(summary.slowest?.host == "cdn.expo.dev")
     // All three `slowest` fields describe that one request.
     #expect(abs((summary.slowest?.timeToFirstByte ?? 0) - 0.4) < 0.0001)
     // The timeout is still counted, just not used to describe the slowest request.
-    #expect(summary.timedOut == 1)
     #expect(summary.failed == 1)
   }
 
@@ -530,15 +411,13 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 0,
       fetchStart: Date(),
-      error: "timed out",
-      isTimeout: true
+      error: "timed out"
     )
     let summary = NetworkRequestSummary.from([request])
     #expect(summary.slowest?.duration == nil)
     #expect(summary.slowest?.host == nil)
     #expect(summary.slowest?.timeToFirstByte == nil)
     #expect(summary.count == 1)
-    #expect(summary.timedOut == 1)
   }
 
   @Test
@@ -569,57 +448,6 @@ struct NetworkRequestSummaryTests {
     let summary = NetworkRequestSummary.from([slowest, slowServer])
     #expect(summary.slowest?.duration == 4.0)
     #expect(abs((summary.slowest?.timeToFirstByte ?? 0) - 0.3) < 0.0001)
-  }
-
-  @Test
-  func `counts timeouts separately from other failures`() {
-    let now = Date()
-    let timedOut = makeRequest(
-      host: "slow.expo.dev",
-      duration: 30,
-      status: nil,
-      bytesSent: 0,
-      bytesReceived: 0,
-      fetchStart: now,
-      error: "timed out",
-      isTimeout: true
-    )
-    // A 5xx is the backend failing, not the network.
-    let serverError = makeRequest(
-      host: "broken.expo.dev",
-      duration: 0.2,
-      status: 503,
-      bytesSent: 0,
-      bytesReceived: 0,
-      fetchStart: now
-    )
-    let ok = makeRequest(
-      host: "api.expo.dev",
-      duration: 0.1,
-      status: 200,
-      bytesSent: 0,
-      bytesReceived: 100,
-      fetchStart: now
-    )
-    let summary = NetworkRequestSummary.from([timedOut, serverError, ok])
-    #expect(summary.failed == 2)
-    #expect(summary.timedOut == 1)
-  }
-
-  @Test
-  func `reports no timeouts when every request reached the server`() {
-    let summary = NetworkRequestSummary.from([
-      makeRequest(
-        host: "expo.dev",
-        duration: 0.1,
-        status: 500,
-        bytesSent: 0,
-        bytesReceived: 0,
-        fetchStart: Date()
-      )
-    ])
-    #expect(summary.failed == 1)
-    #expect(summary.timedOut == 0)
   }
 
   @Test
@@ -745,7 +573,6 @@ struct NetworkRequestSummaryTests {
       bytesReceived: 2000,
       fetchStart: now,
       error: "The request timed out.",
-      isTimeout: true,
       responseStart: now,
       responseEnd: now.addingTimeInterval(30)
     )
@@ -1052,7 +879,6 @@ struct NetworkRequestSummaryTests {
     bytesReceived: Int64,
     fetchStart: Date?,
     error: String? = nil,
-    isTimeout: Bool = false,
     responseStart: Date? = nil,
     responseEnd: Date? = nil
   ) -> NetworkRequest {
@@ -1079,7 +905,6 @@ struct NetworkRequestSummaryTests {
         totalDuration: duration
       ),
       errorDescription: error,
-      isTimeout: isTimeout,
       redirects: []
     )
   }

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -436,6 +436,37 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `reports the slowest request's status code so an empty body can be explained`() {
+    let now = Date()
+    // A 304 revalidation is successful, so it's a `slowest` candidate, but carries no body. Without
+    // the status code a reader can't tell that from a 200 whose transfer broke.
+    let revalidation = makeRequest(
+      host: "192.168.0.104",
+      duration: 1.1,
+      status: 304,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(1.1)
+    )
+    let download = makeRequest(
+      host: "192.168.0.104",
+      duration: 0.5,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 7000,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.1),
+      responseEnd: now.addingTimeInterval(0.5)
+    )
+    let summary = NetworkRequestSummary.from([revalidation, download])
+    #expect(summary.slowest?.statusCode == 304)
+    #expect(summary.slowest?.bytesReceived == 0)
+    // Not filtered out: the status code explains the zero rather than hiding the request.
+    #expect(abs((summary.slowest?.duration ?? 0) - 1.1) < 0.0001)
+  }
+
+  @Test
   func `leaves the slowest fields nil when every request failed`() {
     let request = makeRequest(
       host: "expo.dev",

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -602,6 +602,47 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `excludes a request whose end was never measured from throughput`() {
+    let now = Date()
+    // Headers arrived and then the request died, so `responseEnd` is the wall-clock moment the
+    // snapshot was recorded rather than the last byte. Dividing by that window would describe the
+    // recording delay: 100 kB over the 550ms fallback reads as 186 kB/s for a 50ms transfer.
+    let unfinished = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.55,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 102_400,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(1.0),
+      responseEnd: now.addingTimeInterval(1.55),
+      endWasMeasured: false
+    )
+    let summary = NetworkRequestSummary.from([unfinished])
+    #expect(summary.throughputBytesPerSecond == nil)
+  }
+
+  @Test
+  func `excludes a transfer too fast for the clock to measure`() {
+    let now = Date()
+    // Android timestamps in whole milliseconds, so a sub-millisecond transfer records as a
+    // zero-length window there. iOS can resolve it but reports nothing either, so the two agree on
+    // when the rate is unknown rather than one of them dividing by a duration it barely measured.
+    let instant = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.01,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 8192,
+      fetchStart: now,
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(0.0004)
+    )
+    let summary = NetworkRequestSummary.from([instant])
+    #expect(summary.throughputBytesPerSecond == nil)
+  }
+
+  @Test
   func `excludes a cache hit from throughput`() {
     let now = Date()
     // A cached read reports its bytes from the task counters but never touches the network, so it
@@ -880,7 +921,11 @@ struct NetworkRequestSummaryTests {
     fetchStart: Date?,
     error: String? = nil,
     responseStart: Date? = nil,
-    responseEnd: Date? = nil
+    responseEnd: Date? = nil,
+    // Defaults to whatever `responseEnd` is so a test that doesn't care gets a transfer window
+    // matching the span it set up. Pass `false` to model a request whose last byte was never
+    // reported, which is what an unmeasured end looks like in production.
+    endWasMeasured: Bool = true
   ) -> NetworkRequest {
     return NetworkRequest(
       id: UUID(),
@@ -902,6 +947,7 @@ struct NetworkRequestSummaryTests {
         requestEnd: nil,
         responseStart: responseStart,
         responseEnd: responseEnd,
+        measuredResponseEnd: endWasMeasured ? responseEnd : nil,
         totalDuration: duration
       ),
       errorDescription: error,
@@ -951,6 +997,7 @@ struct NetworkRequestMonitorWindowingTests {
         requestEnd: nil,
         responseStart: nil,
         responseEnd: nil,
+        measuredResponseEnd: nil,
         totalDuration: 0.1
       ),
       errorDescription: nil,
@@ -1256,6 +1303,7 @@ struct NetworkRequestObserverTests {
         requestEnd: nil,
         responseStart: nil,
         responseEnd: responseEnd,
+        measuredResponseEnd: responseEnd,
         totalDuration: 0.5
       ),
       errorDescription: nil,
@@ -1314,6 +1362,7 @@ struct NetworkRequestObserverTests {
         requestEnd: nil,
         responseStart: nil,
         responseEnd: nil,
+        measuredResponseEnd: nil,
         totalDuration: 0.1
       ),
       errorDescription: "timed out",

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -287,7 +287,7 @@ struct NetworkRequestSummaryTests {
     let summary = NetworkRequestSummary.from([])
     #expect(summary.isEmpty)
     #expect(summary.count == 0)
-    #expect(summary.slowest?.host == nil)
+    #expect(summary.slowest == nil)
   }
 
   @Test
@@ -414,9 +414,9 @@ struct NetworkRequestSummaryTests {
       error: "timed out"
     )
     let summary = NetworkRequestSummary.from([request])
-    #expect(summary.slowest?.duration == nil)
-    #expect(summary.slowest?.host == nil)
-    #expect(summary.slowest?.timeToFirstByte == nil)
+    // The whole group is absent, not present with nil fields: asserting through `slowest?` would
+    // pass either way.
+    #expect(summary.slowest == nil)
     #expect(summary.count == 1)
   }
 

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -633,6 +633,51 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `ignores a byte-carrying request whose interval collapsed to nothing`() {
+    let now = Date()
+    // A cache hit reports its bytes (the task counters are wall-clock accurate even when no wire
+    // traffic occurred) but is served from disk inside one clock tick, so its interval collapses.
+    // Counting those bytes against someone else's span would roughly double the reported rate.
+    let cacheHit = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.001,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 10_000,
+      fetchStart: now,
+      responseEnd: now
+    )
+    let download = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 10_000,
+      fetchStart: now.addingTimeInterval(5),
+      responseEnd: now.addingTimeInterval(6)
+    )
+    let summary = NetworkRequestSummary.from([cacheHit, download])
+    // Only the download's 10 kB over its own 1s span; the cache hit contributes neither.
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 10_000) < 0.0001)
+  }
+
+  @Test
+  func `leaves throughput nil when the only receiving request had no measurable span`() {
+    let now = Date()
+    let cacheHit = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.001,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 10_000,
+      fetchStart: now,
+      responseEnd: now
+    )
+    let summary = NetworkRequestSummary.from([cacheHit])
+    #expect(summary.throughputBytesPerSecond == nil)
+  }
+
+  @Test
   func `leaves throughput nil when nothing was received`() {
     // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
     let cacheHit = makeRequest(

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -682,6 +682,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 8000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(1)
     )
     let second = makeRequest(
@@ -691,6 +692,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 2000,
       fetchStart: now.addingTimeInterval(1),
+      responseStart: now.addingTimeInterval(1),
       responseEnd: now.addingTimeInterval(2)
     )
     let summary = NetworkRequestSummary.from([first, second])
@@ -710,6 +712,7 @@ struct NetworkRequestSummaryTests {
         bytesSent: 0,
         bytesReceived: 10_000,
         fetchStart: now,
+        responseStart: now,
         responseEnd: now.addingTimeInterval(1)
       )
     }
@@ -731,6 +734,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 1_000_000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(1)
     )
     let stalled = makeRequest(
@@ -742,10 +746,62 @@ struct NetworkRequestSummaryTests {
       fetchStart: now,
       error: "The request timed out.",
       isTimeout: true,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(30)
     )
     let summary = NetworkRequestSummary.from([healthy, stalled])
     #expect(abs((summary.throughputBytesPerSecond ?? 0) - 1_000_000) < 0.0001)
+  }
+
+  @Test
+  func `measures throughput over the transfer window, not the whole request`() {
+    let now = Date()
+    // 4 seconds waiting on the backend, then 1 kB delivered in 10ms. Charging the wait to the
+    // network reports ~256 B/s for a connection that moved 1 kB in a hundredth of a second.
+    let slowServer = makeRequest(
+      host: "api.expo.dev",
+      duration: 4.01,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 1024,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(4.0),
+      responseEnd: now.addingTimeInterval(4.01)
+    )
+    let summary = NetworkRequestSummary.from([slowServer])
+    // `Date` arithmetic is base-2 floating point, so the 10ms window isn't exactly 0.01s. Compare
+    // against a relative tolerance rather than an absolute one that a rate this large can't meet.
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 102_400) < 1.0)
+  }
+
+  @Test
+  func `excludes a cache hit from throughput`() {
+    let now = Date()
+    // A cached read reports its bytes from the task counters but never touches the network, so it
+    // has no `responseStart`. Counting it would add megabytes to the numerator against the few
+    // milliseconds it took to read from disk.
+    let cached = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.02,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 5_000_000,
+      fetchStart: now,
+      responseStart: nil,
+      responseEnd: now.addingTimeInterval(0.02)
+    )
+    let real = makeRequest(
+      host: "api.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100_000,
+      fetchStart: now,
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(1.0)
+    )
+    let summary = NetworkRequestSummary.from([cached, real])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 100_000) < 0.0001)
   }
 
   @Test
@@ -760,6 +816,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 5000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(1)
     )
     let second = makeRequest(
@@ -769,6 +826,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 5000,
       fetchStart: now.addingTimeInterval(11),
+      responseStart: now.addingTimeInterval(11),
       responseEnd: now.addingTimeInterval(12)
     )
     let summary = NetworkRequestSummary.from([first, second])
@@ -786,6 +844,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 3000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(2)
     )
     let second = makeRequest(
@@ -795,6 +854,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 3000,
       fetchStart: now.addingTimeInterval(1),
+      responseStart: now.addingTimeInterval(1),
       responseEnd: now.addingTimeInterval(3)
     )
     let summary = NetworkRequestSummary.from([first, second])
@@ -829,6 +889,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 10_000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now.addingTimeInterval(1)
     )
     let slowEmptyResponse = makeRequest(
@@ -838,6 +899,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 0,
       fetchStart: now.addingTimeInterval(1),
+      responseStart: now.addingTimeInterval(1),
       responseEnd: now.addingTimeInterval(4)
     )
     let summary = NetworkRequestSummary.from([download, slowEmptyResponse])
@@ -857,6 +919,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 10_000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now
     )
     let download = makeRequest(
@@ -866,6 +929,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 10_000,
       fetchStart: now.addingTimeInterval(5),
+      responseStart: now.addingTimeInterval(5),
       responseEnd: now.addingTimeInterval(6)
     )
     let summary = NetworkRequestSummary.from([cacheHit, download])
@@ -883,6 +947,7 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 10_000,
       fetchStart: now,
+      responseStart: now,
       responseEnd: now
     )
     let summary = NetworkRequestSummary.from([cacheHit])

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -605,6 +605,34 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `ignores requests that received no bytes when timing throughput`() {
+    let now = Date()
+    // A slow API call that returns nothing spends real time in flight, but no bytes could have been
+    // flowing during it. Counting its span would describe time the payload wasn't moving and halve
+    // the reported rate; its latency is already covered by `slowestTimeToFirstByte`.
+    let download = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 10_000,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let slowEmptyResponse = makeRequest(
+      host: "httpbin.org",
+      duration: 3.0,
+      status: 204,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now.addingTimeInterval(1),
+      responseEnd: now.addingTimeInterval(4)
+    )
+    let summary = NetworkRequestSummary.from([download, slowEmptyResponse])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 10_000) < 0.0001)
+  }
+
+  @Test
   func `leaves throughput nil when nothing was received`() {
     // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
     let cacheHit = makeRequest(
@@ -620,53 +648,7 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
-  func `takes the fastest tcp handshake and excludes the tls portion`() {
-    let now = Date()
-    // TLS ran, so the handshake window ends at `secureConnectionStart`: 0.2s, not the 0.5s that
-    // `connectEnd` would report (it lands after the TLS exchange).
-    let secure = makeRequest(
-      host: "api.expo.dev",
-      duration: 1.0,
-      status: 200,
-      bytesSent: 0,
-      bytesReceived: 0,
-      fetchStart: now,
-      connectStart: now,
-      connectEnd: now.addingTimeInterval(0.5),
-      secureConnectionStart: now.addingTimeInterval(0.2)
-    )
-    // Cleartext, so it falls back to `connectEnd`: 0.3s.
-    let cleartext = makeRequest(
-      host: "plain.expo.dev",
-      duration: 1.0,
-      status: 200,
-      bytesSent: 0,
-      bytesReceived: 0,
-      fetchStart: now,
-      connectStart: now,
-      connectEnd: now.addingTimeInterval(0.3)
-    )
-    let summary = NetworkRequestSummary.from([secure, cleartext])
-    #expect(abs((summary.fastestTcpHandshake ?? 0) - 0.2) < 0.0001)
-  }
-
-  @Test
-  func `leaves fastest tcp handshake nil when every connection was reused`() {
-    // Under keep-alive `connectStart` is nil, which means "no new connection", not "zero latency".
-    let reused = makeRequest(
-      host: "api.expo.dev",
-      duration: 0.2,
-      status: 200,
-      bytesSent: 0,
-      bytesReceived: 0,
-      fetchStart: Date()
-    )
-    let summary = NetworkRequestSummary.from([reused, reused])
-    #expect(summary.fastestTcpHandshake == nil)
-  }
-
-  @Test
-  func `ignores negative handshake and first-byte durations`() {
+  func `ignores a negative first-byte duration`() {
     let now = Date()
     // A clock adjustment mid-request can invert these wall-clock dates.
     let skewed = makeRequest(
@@ -676,12 +658,9 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 0,
       fetchStart: now,
-      connectStart: now,
-      connectEnd: now.addingTimeInterval(-0.1),
       responseStart: now.addingTimeInterval(-0.2)
     )
     let summary = NetworkRequestSummary.from([skewed])
-    #expect(summary.fastestTcpHandshake == nil)
     #expect(summary.slowestTimeToFirstByte == nil)
   }
 
@@ -752,9 +731,6 @@ struct NetworkRequestSummaryTests {
     fetchStart: Date?,
     error: String? = nil,
     isTimeout: Bool = false,
-    connectStart: Date? = nil,
-    connectEnd: Date? = nil,
-    secureConnectionStart: Date? = nil,
     responseStart: Date? = nil,
     responseEnd: Date? = nil
   ) -> NetworkRequest {
@@ -770,9 +746,9 @@ struct NetworkRequestSummaryTests {
         fetchStart: fetchStart,
         domainLookupStart: nil,
         domainLookupEnd: nil,
-        connectStart: connectStart,
-        connectEnd: connectEnd,
-        secureConnectionStart: secureConnectionStart,
+        connectStart: nil,
+        connectEnd: nil,
+        secureConnectionStart: nil,
         secureConnectionEnd: nil,
         requestStart: nil,
         requestEnd: nil,

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -111,6 +111,61 @@ struct NetworkRequestTests {
   }
 
   @Test
+  func `flags an unreachable network as a timeout`() {
+    // An offline device surfaces as any of these, depending on how far the request got before it
+    // gave up. Android reports the same conditions as UnknownHostException and counts them, so all
+    // four have to count here for the metric to mean one thing on both platforms.
+    let codes = [
+      NSURLErrorNotConnectedToInternet,
+      NSURLErrorCannotFindHost,
+      NSURLErrorDNSLookupFailed,
+      NSURLErrorCannotConnectToHost,
+    ]
+    for code in codes {
+      let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+      let error = NSError(domain: NSURLErrorDomain, code: code, userInfo: nil)
+      let now = Date()
+      let snapshot = NetworkRequest.from(
+        id: UUID(),
+        request: request,
+        response: nil,
+        taskBytesSent: nil,
+        taskBytesReceived: nil,
+        metrics: nil,
+        fallbackStart: now,
+        fallbackEnd: now,
+        error: error
+      )
+      #expect(snapshot.isTimeout, "expected code \(code) to count as a timeout")
+    }
+  }
+
+  @Test
+  func `does not flag a TLS failure as a timeout`() {
+    // A failed handshake is a certificate or trust problem, not an absent network. Android leaves
+    // SSLException out of its set for the same reason.
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(
+      domain: NSURLErrorDomain,
+      code: NSURLErrorSecureConnectionFailed,
+      userInfo: nil
+    )
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(!snapshot.isTimeout)
+  }
+
+  @Test
   func `does not flag a cancelled request as a timeout`() {
     // The app abandoned the request; that says nothing about the network.
     let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
@@ -660,6 +715,37 @@ struct NetworkRequestSummaryTests {
     }
     let summary = NetworkRequestSummary.from(requests)
     #expect(abs((summary.throughputBytesPerSecond ?? 0) - 40_000) < 0.0001)
+  }
+
+  @Test
+  func `excludes a stalled failed request from throughput`() {
+    let now = Date()
+    // A healthy 1 MB download inside the span of a request that received a few bytes and then
+    // stalled until the client gave up. Counting the stall would merge the two spans and report
+    // the whole window as busy, which reads as a connection many times slower than the one that
+    // actually delivered the megabyte.
+    let healthy = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 1_000_000,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let stalled = makeRequest(
+      host: "slow.expo.dev",
+      duration: 30.0,
+      status: nil,
+      bytesSent: 0,
+      bytesReceived: 2000,
+      fetchStart: now,
+      error: "The request timed out.",
+      isTimeout: true,
+      responseEnd: now.addingTimeInterval(30)
+    )
+    let summary = NetworkRequestSummary.from([healthy, stalled])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 1_000_000) < 0.0001)
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -65,6 +65,89 @@ struct NetworkRequestTests {
     #expect(snapshot.statusCode == nil)
     #expect(snapshot.errorDescription != nil)
   }
+
+  @Test
+  func `flags a timed-out request as a timeout`() {
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(snapshot.isTimeout)
+  }
+
+  @Test
+  func `flags a lost connection as a timeout`() {
+    // The radio dropping mid-request is the same "network went away" condition as a timeout, and
+    // is what an elevator actually produces.
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(
+      domain: NSURLErrorDomain,
+      code: NSURLErrorNetworkConnectionLost,
+      userInfo: nil
+    )
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(snapshot.isTimeout)
+  }
+
+  @Test
+  func `does not flag a cancelled request as a timeout`() {
+    // The app abandoned the request; that says nothing about the network.
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(!snapshot.isTimeout)
+    #expect(snapshot.errorDescription != nil)
+  }
+
+  @Test
+  func `does not flag a successful request as a timeout`() {
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: nil
+    )
+    #expect(!snapshot.isTimeout)
+  }
 }
 
 @AppMetricsActor
@@ -308,6 +391,301 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `counts timeouts separately from other failures`() {
+    let now = Date()
+    let timedOut = makeRequest(
+      host: "slow.expo.dev",
+      duration: 30,
+      status: nil,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      error: "timed out",
+      isTimeout: true
+    )
+    // A 5xx is the backend failing, not the network.
+    let serverError = makeRequest(
+      host: "broken.expo.dev",
+      duration: 0.2,
+      status: 503,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now
+    )
+    let ok = makeRequest(
+      host: "api.expo.dev",
+      duration: 0.1,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100,
+      fetchStart: now
+    )
+    let summary = NetworkRequestSummary.from([timedOut, serverError, ok])
+    #expect(summary.failed == 2)
+    #expect(summary.timedOut == 1)
+  }
+
+  @Test
+  func `reports no timeouts when every request reached the server`() {
+    let summary = NetworkRequestSummary.from([
+      makeRequest(
+        host: "expo.dev",
+        duration: 0.1,
+        status: 500,
+        bytesSent: 0,
+        bytesReceived: 0,
+        fetchStart: Date()
+      )
+    ])
+    #expect(summary.failed == 1)
+    #expect(summary.timedOut == 0)
+  }
+
+  @Test
+  func `aggregates slowest time to first byte and ignores requests without one`() {
+    let now = Date()
+    let quick = makeRequest(
+      host: "api.expo.dev",
+      duration: 0.4,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.05)
+    )
+    let stalled = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.5,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.3)
+    )
+    // No `responseStart` at all (failed before headers arrived), so it contributes nothing.
+    let headerless = makeRequest(
+      host: "broken.expo.dev",
+      duration: 2.0,
+      status: nil,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      error: "timed out"
+    )
+    let summary = NetworkRequestSummary.from([quick, stalled, headerless])
+    #expect(abs((summary.slowestTimeToFirstByte ?? 0) - 0.3) < 0.0001)
+  }
+
+  @Test
+  func `leaves slowest time to first byte nil when no request reported one`() {
+    let request = makeRequest(
+      host: "expo.dev",
+      duration: 0.2,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
+    let summary = NetworkRequestSummary.from([request])
+    #expect(summary.slowestTimeToFirstByte == nil)
+  }
+
+  @Test
+  func `computes throughput over the time the network was actually busy`() {
+    let now = Date()
+    // Two requests running back to back: 1s each, no overlap, so 2s of busy time.
+    let first = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 8000,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let second = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 2000,
+      fetchStart: now.addingTimeInterval(1),
+      responseEnd: now.addingTimeInterval(2)
+    )
+    let summary = NetworkRequestSummary.from([first, second])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 5000) < 0.0001)
+  }
+
+  @Test
+  func `does not deflate throughput when requests run concurrently`() {
+    let now = Date()
+    // Four parallel requests, each 1s and 10 kB. Summed request-seconds would be 4s and report
+    // 10 kB/s; the network actually moved 40 kB in one second of wall-clock.
+    let requests = (0..<4).map { index in
+      makeRequest(
+        host: "cdn\(index).expo.dev",
+        duration: 1.0,
+        status: 200,
+        bytesSent: 0,
+        bytesReceived: 10_000,
+        fetchStart: now,
+        responseEnd: now.addingTimeInterval(1)
+      )
+    }
+    let summary = NetworkRequestSummary.from(requests)
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 40_000) < 0.0001)
+  }
+
+  @Test
+  func `excludes idle gaps between requests from throughput`() {
+    let now = Date()
+    // 1s of transfer, a 10s idle gap, then another 1s. Only the 2s of busy time counts, so the
+    // value reflects the connection rather than how long the app sat idle.
+    let first = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 5000,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let second = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 5000,
+      fetchStart: now.addingTimeInterval(11),
+      responseEnd: now.addingTimeInterval(12)
+    )
+    let summary = NetworkRequestSummary.from([first, second])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 5000) < 0.0001)
+  }
+
+  @Test
+  func `merges partially overlapping requests into one busy span`() {
+    let now = Date()
+    // 0-2s and 1-3s overlap, so busy time is 3s rather than the 4s of summed duration.
+    let first = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 2.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 3000,
+      fetchStart: now,
+      responseEnd: now.addingTimeInterval(2)
+    )
+    let second = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 2.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 3000,
+      fetchStart: now.addingTimeInterval(1),
+      responseEnd: now.addingTimeInterval(3)
+    )
+    let summary = NetworkRequestSummary.from([first, second])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 2000) < 0.0001)
+  }
+
+  @Test
+  func `leaves throughput nil when no request reported a usable interval`() {
+    // Without timestamps there's no busy span to divide by, so the rate is unknown rather than 0.
+    let request = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 5000,
+      fetchStart: nil
+    )
+    let summary = NetworkRequestSummary.from([request])
+    #expect(summary.throughputBytesPerSecond == nil)
+  }
+
+  @Test
+  func `leaves throughput nil when nothing was received`() {
+    // A cache hit moves no bytes; dividing would report a fake 0 B/s rather than "unknown".
+    let cacheHit = makeRequest(
+      host: "expo.dev",
+      duration: 0.01,
+      status: 304,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
+    let summary = NetworkRequestSummary.from([cacheHit])
+    #expect(summary.throughputBytesPerSecond == nil)
+  }
+
+  @Test
+  func `takes the fastest tcp handshake and excludes the tls portion`() {
+    let now = Date()
+    // TLS ran, so the handshake window ends at `secureConnectionStart`: 0.2s, not the 0.5s that
+    // `connectEnd` would report (it lands after the TLS exchange).
+    let secure = makeRequest(
+      host: "api.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      connectStart: now,
+      connectEnd: now.addingTimeInterval(0.5),
+      secureConnectionStart: now.addingTimeInterval(0.2)
+    )
+    // Cleartext, so it falls back to `connectEnd`: 0.3s.
+    let cleartext = makeRequest(
+      host: "plain.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      connectStart: now,
+      connectEnd: now.addingTimeInterval(0.3)
+    )
+    let summary = NetworkRequestSummary.from([secure, cleartext])
+    #expect(abs((summary.fastestTcpHandshake ?? 0) - 0.2) < 0.0001)
+  }
+
+  @Test
+  func `leaves fastest tcp handshake nil when every connection was reused`() {
+    // Under keep-alive `connectStart` is nil, which means "no new connection", not "zero latency".
+    let reused = makeRequest(
+      host: "api.expo.dev",
+      duration: 0.2,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: Date()
+    )
+    let summary = NetworkRequestSummary.from([reused, reused])
+    #expect(summary.fastestTcpHandshake == nil)
+  }
+
+  @Test
+  func `ignores negative handshake and first-byte durations`() {
+    let now = Date()
+    // A clock adjustment mid-request can invert these wall-clock dates.
+    let skewed = makeRequest(
+      host: "expo.dev",
+      duration: 0.2,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 0,
+      fetchStart: now,
+      connectStart: now,
+      connectEnd: now.addingTimeInterval(-0.1),
+      responseStart: now.addingTimeInterval(-0.2)
+    )
+    let summary = NetworkRequestSummary.from([skewed])
+    #expect(summary.fastestTcpHandshake == nil)
+    #expect(summary.slowestTimeToFirstByte == nil)
+  }
+
+  @Test
   func `counts errored requests without a status as failed`() {
     let request = makeRequest(
       host: "expo.dev",
@@ -371,8 +749,14 @@ struct NetworkRequestSummaryTests {
     status: Int?,
     bytesSent: Int64,
     bytesReceived: Int64,
-    fetchStart: Date,
-    error: String? = nil
+    fetchStart: Date?,
+    error: String? = nil,
+    isTimeout: Bool = false,
+    connectStart: Date? = nil,
+    connectEnd: Date? = nil,
+    secureConnectionStart: Date? = nil,
+    responseStart: Date? = nil,
+    responseEnd: Date? = nil
   ) -> NetworkRequest {
     return NetworkRequest(
       id: UUID(),
@@ -386,17 +770,18 @@ struct NetworkRequestSummaryTests {
         fetchStart: fetchStart,
         domainLookupStart: nil,
         domainLookupEnd: nil,
-        connectStart: nil,
-        connectEnd: nil,
-        secureConnectionStart: nil,
+        connectStart: connectStart,
+        connectEnd: connectEnd,
+        secureConnectionStart: secureConnectionStart,
         secureConnectionEnd: nil,
         requestStart: nil,
         requestEnd: nil,
-        responseStart: nil,
-        responseEnd: nil,
+        responseStart: responseStart,
+        responseEnd: responseEnd,
         totalDuration: duration
       ),
       errorDescription: error,
+      isTimeout: isTimeout,
       redirects: []
     )
   }

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -406,6 +406,38 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `keeps a slow response that broke mid-body as the slowest`() {
+    let now = Date()
+    // A truncated transfer keeps the 200 its headers arrived with and gains an error string. Keying
+    // "never completed" off that string would drop it, which is backwards: a 9s response that died
+    // partway is exactly what a bad-network launch looks like.
+    let broken = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 9.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 4000,
+      fetchStart: now,
+      error: "unexpected end of stream",
+      responseStart: now.addingTimeInterval(0.5),
+      responseEnd: now.addingTimeInterval(9.0)
+    )
+    let quick = makeRequest(
+      host: "api.expo.dev",
+      duration: 0.3,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.1),
+      responseEnd: now.addingTimeInterval(0.3)
+    )
+    let summary = NetworkRequestSummary.from([broken, quick])
+    #expect(summary.slowest?.duration == 9.0)
+    #expect(summary.slowest?.host == "cdn.expo.dev")
+  }
+
+  @Test
   func `reports the slowest request's status code so an empty body can be explained`() {
     let now = Date()
     // A 304 revalidation is successful, so it's a `slowest` candidate, but carries no body. Without

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -372,6 +372,40 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `picks a slow error response over a fast success`() {
+    let now = Date()
+    // A 503 that took 8 seconds is the answer to "why was this launch slow": the app really did
+    // wait that long. Only requests that never completed are excluded, because a timeout's duration
+    // is the client's own setting rather than anything the server did.
+    let slowError = makeRequest(
+      host: "api.expo.dev",
+      duration: 8.0,
+      status: 503,
+      bytesSent: 0,
+      bytesReceived: 900,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(7.8),
+      responseEnd: now.addingTimeInterval(8.0)
+    )
+    let fastSuccess = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 0.2,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100,
+      fetchStart: now,
+      responseStart: now.addingTimeInterval(0.1),
+      responseEnd: now.addingTimeInterval(0.2)
+    )
+    let summary = NetworkRequestSummary.from([slowError, fastSuccess])
+    #expect(summary.slowest?.duration == 8.0)
+    #expect(summary.slowest?.host == "api.expo.dev")
+    #expect(summary.slowest?.statusCode == 503)
+    // Still counted as a failure; the two fields answer different questions.
+    #expect(summary.failed == 1)
+  }
+
+  @Test
   func `reports the slowest request's status code so an empty body can be explained`() {
     let now = Date()
     // A 304 revalidation is successful, so it's a `slowest` candidate, but carries no body. Without
@@ -645,9 +679,8 @@ struct NetworkRequestSummaryTests {
   @Test
   func `excludes a cache hit from throughput`() {
     let now = Date()
-    // A cached read reports its bytes from the task counters but never touches the network, so it
-    // has no `responseStart`. Counting it would add megabytes to the numerator against the few
-    // milliseconds it took to read from disk.
+    // A cached read reports bytes AND timestamps just like a network response, so giving it a real
+    // window here is what actually happens on device. Only the fetch type distinguishes it.
     let cached = makeRequest(
       host: "cdn.expo.dev",
       duration: 0.02,
@@ -655,8 +688,9 @@ struct NetworkRequestSummaryTests {
       bytesSent: 0,
       bytesReceived: 5_000_000,
       fetchStart: now,
-      responseStart: nil,
-      responseEnd: now.addingTimeInterval(0.02)
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(0.02),
+      cameFromNetwork: false
     )
     let real = makeRequest(
       host: "api.expo.dev",
@@ -925,7 +959,8 @@ struct NetworkRequestSummaryTests {
     // Defaults to whatever `responseEnd` is so a test that doesn't care gets a transfer window
     // matching the span it set up. Pass `false` to model a request whose last byte was never
     // reported, which is what an unmeasured end looks like in production.
-    endWasMeasured: Bool = true
+    endWasMeasured: Bool = true,
+    cameFromNetwork: Bool? = true
   ) -> NetworkRequest {
     return NetworkRequest(
       id: UUID(),
@@ -935,6 +970,7 @@ struct NetworkRequestSummaryTests {
       networkProtocol: nil,
       requestBytesSent: bytesSent,
       responseBytesReceived: bytesReceived,
+      cameFromNetwork: cameFromNetwork,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -985,6 +1021,7 @@ struct NetworkRequestMonitorWindowingTests {
       networkProtocol: nil,
       requestBytesSent: 0,
       responseBytesReceived: 0,
+      cameFromNetwork: true,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1291,6 +1328,7 @@ struct NetworkRequestObserverTests {
       networkProtocol: "h2",
       requestBytesSent: 123,
       responseBytesReceived: 4567,
+      cameFromNetwork: true,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1350,6 +1388,7 @@ struct NetworkRequestObserverTests {
       networkProtocol: nil,
       requestBytesSent: nil,
       responseBytesReceived: nil,
+      cameFromNetwork: nil,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -730,24 +730,34 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
-  func `keeps a request the OS did not classify in the throughput ratio`() {
+  func `excludes a fetch the OS did not classify from throughput`() {
     let now = Date()
-    // `.unknown` means the fetch type wasn't reported, which a task intercepted by an
-    // NSURLProtocol subclass does routinely. Treating that as a cache read would drop real
-    // transfers for any app carrying such an SDK.
+    // A warm relaunch reads the bundle from `URLCache`, and the OS doesn't always say so: it
+    // reports the full byte count against a window of a few milliseconds. Counting that produced
+    // 2.6 GB/s on a device. Only a fetch identified as a network load feeds the ratio.
     let unclassified = makeRequest(
-      host: "cdn.expo.dev",
-      duration: 1.0,
+      host: "192.168.0.48",
+      duration: 0.003,
       status: 200,
       bytesSent: 0,
-      bytesReceived: 100_000,
+      bytesReceived: 7_584_879,
       fetchStart: now,
       responseStart: now,
-      responseEnd: now.addingTimeInterval(1),
-      cameFromNetwork: true
+      responseEnd: now.addingTimeInterval(0.00287),
+      cameFromNetwork: nil
     )
-    let summary = NetworkRequestSummary.from([unclassified])
-    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 100_000) < 1.0)
+    let real = makeRequest(
+      host: "192.168.0.48",
+      duration: 0.29,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 3652,
+      fetchStart: now,
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(0.29)
+    )
+    let summary = NetworkRequestSummary.from([unclassified, real])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 12_593) < 100)
   }
 
   @Test

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -709,6 +709,48 @@ struct NetworkRequestSummaryTests {
   }
 
   @Test
+  func `pins byte totals at the maximum instead of trapping`() {
+    let now = Date()
+    // Swift aborts the process on Int64 overflow, and these counts come from the OS. No honest
+    // response reaches the bound, but an observability library must not be able to take its host
+    // app down over a counter that doesn't make sense.
+    let huge = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: .max,
+      bytesReceived: .max,
+      fetchStart: now,
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(1)
+    )
+    let summary = NetworkRequestSummary.from([huge, huge])
+    #expect(summary.bytesReceived == Int64.max)
+    #expect(summary.bytesSent == Int64.max)
+  }
+
+  @Test
+  func `keeps a request the OS did not classify in the throughput ratio`() {
+    let now = Date()
+    // `.unknown` means the fetch type wasn't reported, which a task intercepted by an
+    // NSURLProtocol subclass does routinely. Treating that as a cache read would drop real
+    // transfers for any app carrying such an SDK.
+    let unclassified = makeRequest(
+      host: "cdn.expo.dev",
+      duration: 1.0,
+      status: 200,
+      bytesSent: 0,
+      bytesReceived: 100_000,
+      fetchStart: now,
+      responseStart: now,
+      responseEnd: now.addingTimeInterval(1),
+      cameFromNetwork: true
+    )
+    let summary = NetworkRequestSummary.from([unclassified])
+    #expect(abs((summary.throughputBytesPerSecond ?? 0) - 100_000) < 1.0)
+  }
+
+  @Test
   func `excludes a cache hit from throughput`() {
     let now = Date()
     // A cached read reports bytes AND timestamps just like a network response, so giving it a real

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -44,8 +44,13 @@ enum MetricParamsBuilder {
     if let networkPath {
       params["expo.network.connected"] = networkPath.status == .satisfied
       params["expo.network.type"] = networkTypeString(networkPath)
-      params["expo.network.isExpensive"] = networkPath.isExpensive
-      params["expo.network.isConstrained"] = networkPath.isConstrained
+      // Only when there's a network to describe. `NWPath` reports both as `false` on an unsatisfied
+      // path, which would assert the connection wasn't metered rather than admit there wasn't one.
+      // Android withholds its equivalents in the same situation.
+      if networkPath.status == .satisfied {
+        params["expo.network.isExpensive"] = networkPath.isExpensive
+        params["expo.network.isConstrained"] = networkPath.isConstrained
+      }
     }
     if let networkRequests, !networkRequests.isEmpty {
       params["expo.network.requests.count"] = networkRequests.count

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -66,6 +66,9 @@ enum MetricParamsBuilder {
         if let host = slowest.host {
           params["expo.network.requests.slowest.host"] = host
         }
+        if let statusCode = slowest.statusCode {
+          params["expo.network.requests.slowest.statusCode"] = statusCode
+        }
         if let timeToFirstByte = slowest.timeToFirstByte {
           params["expo.network.requests.slowest.timeToFirstByte"] = timeToFirstByte
         }

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -55,8 +55,6 @@ enum MetricParamsBuilder {
     if let networkRequests, !networkRequests.isEmpty {
       params["expo.network.requests.count"] = networkRequests.count
       params["expo.network.requests.failed"] = networkRequests.failed
-      // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
-      // them timed out, which is a real measurement rather than a missing one.
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -57,7 +57,6 @@ enum MetricParamsBuilder {
       params["expo.network.requests.failed"] = networkRequests.failed
       // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
       // them timed out, which is a real measurement rather than a missing one.
-      params["expo.network.requests.timedOut"] = networkRequests.timedOut
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -44,10 +44,15 @@ enum MetricParamsBuilder {
     if let networkPath {
       params["expo.network.connected"] = networkPath.status == .satisfied
       params["expo.network.type"] = networkTypeString(networkPath)
+      params["expo.network.isExpensive"] = networkPath.isExpensive
+      params["expo.network.isConstrained"] = networkPath.isConstrained
     }
     if let networkRequests, !networkRequests.isEmpty {
       params["expo.network.requests.count"] = networkRequests.count
       params["expo.network.requests.failed"] = networkRequests.failed
+      // Emitted even at zero, unlike the optional latency fields below: we saw requests and none of
+      // them timed out, which is a real measurement rather than a missing one.
+      params["expo.network.requests.timedOut"] = networkRequests.timedOut
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration
@@ -56,6 +61,17 @@ enum MetricParamsBuilder {
       }
       if let slowestHost = networkRequests.slowestHost {
         params["expo.network.requests.slowestHost"] = slowestHost
+      }
+      // Omitted rather than zeroed when unavailable: a reused connection or a window of cache hits
+      // never measured these, and a 0 would read as "instant" on a dashboard.
+      if let slowestTimeToFirstByte = networkRequests.slowestTimeToFirstByte {
+        params["expo.network.requests.slowestTimeToFirstByte"] = slowestTimeToFirstByte
+      }
+      if let throughputBytesPerSecond = networkRequests.throughputBytesPerSecond {
+        params["expo.network.requests.throughputBytesPerSecond"] = throughputBytesPerSecond
+      }
+      if let fastestTcpHandshake = networkRequests.fastestTcpHandshake {
+        params["expo.network.requests.fastestTcpHandshake"] = fastestTcpHandshake
       }
     }
     return params

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -70,9 +70,6 @@ enum MetricParamsBuilder {
       if let throughputBytesPerSecond = networkRequests.throughputBytesPerSecond {
         params["expo.network.requests.throughputBytesPerSecond"] = throughputBytesPerSecond
       }
-      if let fastestTcpHandshake = networkRequests.fastestTcpHandshake {
-        params["expo.network.requests.fastestTcpHandshake"] = fastestTcpHandshake
-      }
     }
     return params
   }

--- a/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
+++ b/packages/expo-app-metrics/ios/Utils/MetricParamsBuilder.swift
@@ -61,17 +61,20 @@ enum MetricParamsBuilder {
       params["expo.network.requests.bytesReceived"] = networkRequests.bytesReceived
       params["expo.network.requests.bytesSent"] = networkRequests.bytesSent
       params["expo.network.requests.totalDuration"] = networkRequests.totalDuration
-      if let slowestDuration = networkRequests.slowestDuration {
-        params["expo.network.requests.slowestDuration"] = slowestDuration
+      if let slowest = networkRequests.slowest {
+        params["expo.network.requests.slowest.duration"] = slowest.duration
+        if let host = slowest.host {
+          params["expo.network.requests.slowest.host"] = host
+        }
+        if let timeToFirstByte = slowest.timeToFirstByte {
+          params["expo.network.requests.slowest.timeToFirstByte"] = timeToFirstByte
+        }
+        if let bytesReceived = slowest.bytesReceived {
+          params["expo.network.requests.slowest.bytesReceived"] = bytesReceived
+        }
       }
-      if let slowestHost = networkRequests.slowestHost {
-        params["expo.network.requests.slowestHost"] = slowestHost
-      }
-      // Omitted rather than zeroed when unavailable: a reused connection or a window of cache hits
-      // never measured these, and a 0 would read as "instant" on a dashboard.
-      if let slowestTimeToFirstByte = networkRequests.slowestTimeToFirstByte {
-        params["expo.network.requests.slowestTimeToFirstByte"] = slowestTimeToFirstByte
-      }
+      // Omitted rather than zeroed when unavailable: a window of cache hits never measured this, and
+      // a 0 would read as "instant" on a dashboard.
       if let throughputBytesPerSecond = networkRequests.throughputBytesPerSecond {
         params["expo.network.requests.throughputBytesPerSecond"] = throughputBytesPerSecond
       }


### PR DESCRIPTION
# Why

We report which transport a session was on, but nothing about whether it actually worked. "cellular" doesn't tell you the user was in an elevator, and that's what you need to filter those sessions out.

Closes ENG-25647.

# How

Nine new attributes, all derived from data we already collect.

**Connection cost**

| Key | Type | Meaning |
| --- | --- | --- |
| `expo.network.isExpensive` | bool | Using this network may cost the user money: cellular, or a tethered hotspot. From `NWPath.isExpensive` on iOS, the inverse of `NET_CAPABILITY_NOT_METERED` on Android. Only emitted when there's a usable network, so `false` means "there was one and it wasn't metered" rather than "there was nothing". |
| `expo.network.isConstrained` | bool | iOS only. Low Data Mode is on for this path, so the user asked to conserve data on this network. |
| `expo.network.dataSaverEnabled` | bool | Android only. Data Saver is restricting this app's background traffic. Deliberately a separate key from `isConstrained`: Low Data Mode is per-path and changes as the user moves between networks, while Data Saver is process-wide. |

**Throughput**

| Key | Type | Meaning |
| --- | --- | --- |
| `expo.network.requests.throughputBytesPerSecond` | double | Received bytes over the time those bytes were actually moving. The denominator is the union of the transfer windows of the requests that received bytes, each running from the first response byte to the last, so server think time isn't charged to the connection, request concurrency can't inflate it, and idle time between requests is excluded. Cache hits drop out for free, since a response served from disk never reports a first byte. Transfers shorter than a millisecond are excluded on both platforms: Android's clock can't resolve them, and dividing by a duration the clock didn't measure says more about the timer than the network. |

**The slowest completed request**

One request described by five fields, so they can be read together: a `duration` mostly made up of `timeToFirstByte` means a slow server, while a small `timeToFirstByte` against a large `bytesReceived` means a slow transfer.

A request qualifies as long as it produced a response, so a 503 that took eight seconds and a transfer that broke mid-body both stay candidates: the app waited for them, and on a launch that felt slow that wait is usually the answer. Only requests that never got a status code are excluded, since a timeout's duration is the client's own setting rather than a measurement of the network.

| Key | Type | Meaning |
| --- | --- | --- |
| `expo.network.requests.slowest.host` | string | Host of the request. Absent if the URL had no resolvable host. |
| `expo.network.requests.slowest.duration` | seconds | Total wall-clock duration. |
| `expo.network.requests.slowest.statusCode` | int | What the server answered. Disambiguates an empty response: 0 bytes is routine on a 304, intentional on a 204, and a problem on a 200. |
| `expo.network.requests.slowest.timeToFirstByte` | seconds | Time until the first response byte. Includes server processing time, so it's a proxy for network quality rather than a measurement of it. Absent when the request never produced a first byte. |
| `expo.network.requests.slowest.bytesReceived` | int | Response bytes on the wire. Tells a request that was slow moving a lot of data from one that was slow while idle. Absent when nothing reported a size, which on Android means a caller abandoned the body of a response that declared no `Content-Length`. A 0 is a real measurement: an empty body, as on a 204 or a 304. |

Optional fields are omitted rather than zeroed, since a 0 would read as "instant" on a dashboard when nothing was measured.

The same distinction decides which requests form the throughput ratio. A request whose body size is unknown is left out of both sides of it, so it can't contribute duration to the denominator with no bytes to match.

# Test Plan

New unit tests across both platforms, including a chunked response the caller abandons and a body cut off mid-transfer, both driven through MockWebServer on Android.

```
$ et native-unit-tests -p ios --packages expo-app-metrics
Test Succeeded

$ et native-unit-tests -p android --packages expo-app-metrics
BUILD SUCCESSFUL
```

Swift lint, lint and format pass. Also verified against metric payloads captured from real launches on both platforms, which is where the throughput and byte-count problems turned up.






