### PR TITLE
[tools] Publish canaries via npm trusted publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,8 +22,11 @@ jobs:
     if: github.repository == 'expo/expo'
     runs-on: macos-26
     timeout-minutes: 120
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
+    permissions:
+      # Lets the runner mint an OIDC token so npm can authenticate the publish
+      # through trusted publishing instead of a long-lived token.
+      id-token: write
+      contents: read
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.test.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isTrustedPublishingEnvironment } from './checkEnvironmentTask';
+
+describe('isTrustedPublishingEnvironment', () => {
+  it('is true when the Actions OIDC endpoint is available', () => {
+    assert.equal(
+      isTrustedPublishingEnvironment({
+        ACTIONS_ID_TOKEN_REQUEST_URL: 'https://pipelines.actions.githubusercontent.com/abc',
+      }),
+      true
+    );
+  });
+
+  it('is false without the OIDC endpoint, even on CI', () => {
+    assert.equal(isTrustedPublishingEnvironment({ CI: 'true' }), false);
+  });
+
+  it('is false locally', () => {
+    assert.equal(isTrustedPublishingEnvironment({}), false);
+  });
+
+  // The runner only sets this variable when the job requests `id-token: write`,
+  // so an empty value means the permission was not granted.
+  it('is false when the variable is set but empty', () => {
+    assert.equal(isTrustedPublishingEnvironment({ ACTIONS_ID_TOKEN_REQUEST_URL: '' }), false);
+  });
+});

--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -7,6 +7,18 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
 const { cyan } = chalk;
 
 /**
+ * Whether the process can authenticate to npm through trusted publishing (OIDC)
+ * instead of a long-lived token.
+ *
+ * GitHub Actions only sets `ACTIONS_ID_TOKEN_REQUEST_URL` for jobs that request
+ * the `id-token: write` permission, which makes it an accurate signal for "an
+ * OIDC token can be minted here".
+ */
+export function isTrustedPublishingEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !!env.ACTIONS_ID_TOKEN_REQUEST_URL;
+}
+
+/**
  * Checks whether the environment allows to proceed with any further tasks.
  */
 export const checkEnvironmentTask = new Task<TaskArgs>(
@@ -19,6 +31,14 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
     // the login check so dry runs work without a token (e.g. on Dependabot
     // pull requests and forks, which don't have access to repository secrets).
     if (options.dry) {
+      return;
+    }
+
+    // Under trusted publishing there is no token to authenticate `npm whoami`,
+    // so both checks below would fail. Skipping them loses nothing: the registry
+    // authorizes the publish against the package's trusted-publisher config,
+    // which is a stronger guarantee than comparing a username to a team roster.
+    if (isTrustedPublishingEnvironment()) {
       return;
     }
 


### PR DESCRIPTION
# Why

Canary publishing authenticates with `EXPO_BOT_NPM_TOKEN`, a long-lived npm token in the repository secrets. Trusted publishing replaces it with an OIDC token minted per run, so there is no durable credential to leak or rotate.

All 145 publishable packages already have `expo/expo` + `publish-packages.yml` registered as their trusted publisher on npm.

# How

`NODE_AUTH_TOKEN` becomes `id-token: write`, plus `contents: read` since declaring a `permissions` block drops the default read scope.

`checkEnvironmentTask` calls `npm whoami` and checks `expo:developers` membership, both of which need a token. Skipped when the runner can mint an OIDC token: the registry authorizes against the package's trusted-publisher config instead. Note the team check no longer runs on CI.

`registry-url` stays on `setup-node` even though the `.npmrc` it writes references the now-unset `NODE_AUTH_TOKEN`. npm overwrites that entry with the exchanged token.

Provenance needs no flag; npm enables it for OIDC publishes from public repos.

# Test Plan

`pnpm build`, `node --test` (380 pass) and `pnpm lint` clean in `tools/`.

CI here proves nothing: `pull_request` and `schedule` runs pass `--dry`, which returns before the OIDC branch. Verification is a manual `workflow_dispatch` after merge, then checking published versions carry `_npmUser.trustedPublisher`. A successful publish alone doesn't prove OIDC was used.

Reverting is restoring the `env:` block.

<!-- disable:changelog-checks -->
