### PR TITLE
[feedback-cli] define submit feedback interface and adds validation

### DIFF
--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -20,6 +20,7 @@
     "build"
   ],
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "build": "ncc build ./src/index.ts -o build/ -e typescript",
     "build:prod": "ncc build ./src/index.ts -o build/ -e typescript --minify --no-cache --no-source-map-register",

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -75,10 +75,12 @@ describe('help output', () => {
       expect(helpOutput).toContain(
         '| evals      | Expo package, command, or capability the task involves'
       );
+      expect(helpOutput).toContain('| simulator  | EAS Simulator feature or workflow involved');
       expect(helpOutput).toContain(
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
       expect(helpOutput).toContain('--resume <feedbackId>');
+      expect(helpOutput).toContain('Feedback messages can be up to 5,000 characters.');
       expect(helpOutput).toContain(
         'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected'
       );
@@ -119,10 +121,27 @@ describe('feedback message resolution', () => {
   });
 
   it('uses a category supplied on the command line', async () => {
-    await expect(resolveFeedbackAsync(['improve', 'the', 'server'], 'mcp')).resolves.toEqual({
-      category: 'mcp',
-      feedback: 'improve the server',
+    await expect(
+      resolveFeedbackAsync(['improve', 'the', 'controls'], 'simulator')
+    ).resolves.toEqual({
+      category: 'simulator',
+      feedback: 'improve the controls',
     });
+  });
+
+  it('accepts feedback at the maximum length', async () => {
+    const feedback = 'a'.repeat(5_000);
+
+    await expect(resolveFeedbackAsync([feedback])).resolves.toEqual({
+      category: 'unknown',
+      feedback,
+    });
+  });
+
+  it('rejects feedback over the maximum length', async () => {
+    await expect(resolveFeedbackAsync(['a'.repeat(5_001)])).rejects.toThrow(
+      'Feedback cannot exceed 5,000 characters.'
+    );
   });
 
   it('rejects invalid categories', async () => {
@@ -379,6 +398,17 @@ describe('feedback submission', () => {
         username: 'expo-user',
       },
     });
+  });
+
+  it('does not submit feedback over the maximum length', async () => {
+    await expect(
+      sendFeedbackAsync({
+        feedback: 'a'.repeat(5_001),
+        metadata: await createFeedbackMetadataAsync(projectRoot),
+      })
+    ).rejects.toThrow('Feedback cannot exceed 5,000 characters.');
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('resumes a feedback session and prints instructions using the provided ID', async () => {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -11,23 +11,23 @@ import path from 'path';
 import prompts from 'prompts';
 import { detectSandbox } from 'sandbox-cli-detector';
 
+import {
+  CLI_FEEDBACK_CATEGORIES,
+  CLI_FEEDBACK_MAX_LENGTH,
+  type CliFeedbackCategory,
+  type CliFeedbackContextMetadata,
+  type CliFeedbackMetadata,
+  type CliFeedbackProjectMetadata,
+  type CliFeedbackRequest,
+  type CliFeedbackTelemetryMetadata,
+} from './types';
+
 const CLI_NAME = 'submit-expo-feedback';
 const FEEDBACK_TIMEOUT_MS = 15_000;
 const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
-const FEEDBACK_CATEGORIES = [
-  'skills',
-  'expo-cli',
-  'eas-cli',
-  'mcp',
-  'docs',
-  'evals',
-  'unknown',
-] as const;
-
-type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
 
 type UserSession = {
   sessionSecret?: string;
@@ -45,51 +45,6 @@ type ConfigFilePaths = {
   staticConfigPath: string | null;
   dynamicConfigPath: string | null;
 };
-
-type FeedbackContextMetadata = {
-  category: FeedbackCategory;
-  feedbackId: string;
-  subject?: string;
-};
-
-type FeedbackTelemetryMetadata = {
-  cli: {
-    name: typeof CLI_NAME;
-    version: string;
-  };
-  agentEnvironment: ReturnType<typeof getAgentEnvironment>;
-  sandboxEnvironment: ReturnType<typeof getSandboxEnvironment>;
-  ci?: {
-    name: string | null;
-    isPr: boolean | null;
-  };
-  device: {
-    arch: string;
-    platform: NodeJS.Platform;
-  };
-  node: {
-    version: string;
-  };
-  packageManager: string | null;
-  project: {
-    isExpoProject: boolean;
-    name?: string;
-    slug?: string;
-    sdkVersion?: string;
-    platforms?: string[];
-    expoPackageVersion?: string;
-    reactNativePackageVersion?: string;
-    expoRouterPackageVersion?: string;
-  };
-  user?: {
-    id?: string;
-    username?: string;
-    authType: 'token' | 'session';
-  };
-};
-
-type FeedbackMetadata = FeedbackContextMetadata & FeedbackTelemetryMetadata;
-type FeedbackPayloadMetadata = FeedbackContextMetadata | FeedbackMetadata;
 
 export async function runExpoFeedbackAsync(): Promise<void> {
   await runAsync();
@@ -176,10 +131,11 @@ async function runAsync(): Promise<void> {
 export async function resolveFeedbackAsync(
   messageParts: string[],
   categoryValue?: string
-): Promise<{ category: FeedbackCategory; feedback: string }> {
+): Promise<{ category: CliFeedbackCategory; feedback: string }> {
   const category = resolveFeedbackCategory(categoryValue);
   const feedback = messageParts.join(' ').trim();
   if (feedback) {
+    validateFeedback(feedback);
     return { category, feedback };
   }
 
@@ -193,7 +149,7 @@ export async function resolveFeedbackAsync(
         type: categoryValue ? null : 'select',
         name: 'category',
         message: 'What is your feedback about?',
-        choices: FEEDBACK_CATEGORIES.map((value) => ({
+        choices: CLI_FEEDBACK_CATEGORIES.map((value) => ({
           title:
             value === 'unknown'
               ? 'Other / unknown'
@@ -207,7 +163,7 @@ export async function resolveFeedbackAsync(
         type: 'text',
         name: 'feedback',
         message: 'Share feedback with Expo',
-        validate: (value) => (value.trim() ? true : 'Feedback cannot be empty.'),
+        validate: (value) => getFeedbackValidationError(value.trim()) ?? true,
       },
     ],
     {
@@ -221,6 +177,7 @@ export async function resolveFeedbackAsync(
   if (!promptedFeedback) {
     throw new CommandError('Feedback message cannot be empty.');
   }
+  validateFeedback(promptedFeedback);
   return {
     category: response.category ?? category,
     feedback: promptedFeedback,
@@ -230,13 +187,13 @@ export async function resolveFeedbackAsync(
 export async function createFeedbackMetadataAsync(
   projectRoot: string,
   session?: UserSession | null,
-  category: FeedbackCategory = 'unknown',
+  category: CliFeedbackCategory = 'unknown',
   subjectValue?: string,
   feedbackIdValue?: string
-): Promise<FeedbackPayloadMetadata> {
+): Promise<CliFeedbackMetadata> {
   const subject = normalizeSubject(subjectValue);
   const feedbackId = resolveFeedbackId(feedbackIdValue);
-  const context: FeedbackContextMetadata = {
+  const context: CliFeedbackContextMetadata = {
     category,
     feedbackId,
     ...(subject ? { subject } : {}),
@@ -274,27 +231,31 @@ export async function createFeedbackMetadataAsync(
   };
 }
 
-function getAgentEnvironment() {
+function getAgentEnvironment(): CliFeedbackTelemetryMetadata['agentEnvironment'] {
   const result = detectAgent();
 
-  return {
-    detected: result.detected,
-    agent: result.agent,
-  };
+  return result.detected && result.agent
+    ? {
+        detected: true,
+        agent: result.agent,
+      }
+    : { detected: false };
 }
 
-function getSandboxEnvironment() {
+function getSandboxEnvironment(): CliFeedbackTelemetryMetadata['sandboxEnvironment'] {
   const result = detectSandbox();
 
-  return {
-    detected: result.detected,
-    sandbox: result.sandbox,
-  };
+  return result.detected && result.sandbox
+    ? {
+        detected: true,
+        sandbox: result.sandbox,
+      }
+    : { detected: false };
 }
 
 export async function getUserMetadataAsync(
   session: UserSession | null
-): Promise<FeedbackTelemetryMetadata['user']> {
+): Promise<CliFeedbackTelemetryMetadata['user']> {
   const authType = process.env.EXPO_TOKEN ? 'token' : session?.sessionSecret ? 'session' : null;
   if (!authType) {
     return undefined;
@@ -315,7 +276,7 @@ export async function getUserMetadataAsync(
   };
 }
 
-export function getProjectMetadata(projectRoot: string): FeedbackTelemetryMetadata['project'] {
+export function getProjectMetadata(projectRoot: string): CliFeedbackProjectMetadata {
   const pkg = getPackageJson(projectRoot);
   const paths = getConfigFilePaths(projectRoot);
 
@@ -412,12 +373,12 @@ export async function sendFeedbackAsync({
   feedback,
   metadata,
   session,
-}: {
-  feedback: string;
-  metadata: FeedbackPayloadMetadata;
+}: CliFeedbackRequest & {
   session?: UserSession | null;
 }): Promise<void> {
+  validateFeedback(feedback);
   const telemetryDisabled = isTelemetryDisabled();
+  const request: CliFeedbackRequest = { feedback, metadata };
   const response = await fetch(new URL('/v2/feedback/cli-send', getExpoApiBaseUrl()).toString(), {
     method: 'POST',
     signal: AbortSignal.timeout(FEEDBACK_TIMEOUT_MS),
@@ -430,10 +391,7 @@ export async function sendFeedbackAsync({
             'User-Agent': `${CLI_NAME}/${getPackageVersion()}`,
           }),
     },
-    body: JSON.stringify({
-      feedback,
-      metadata,
-    }),
+    body: JSON.stringify(request),
   });
 
   if (!response.ok) {
@@ -512,6 +470,7 @@ function printHelp(): void {
 
   {bold Info}
     Send feedback to the Expo team. If no message is provided, you will be prompted.
+    Feedback messages can be up to ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.
 
   {bold Data collection}
     Feedback includes available agent/session identifiers, sandbox and environment
@@ -520,7 +479,7 @@ function printHelp(): void {
     metadata and authentication.
 
   {bold Options}
-    --category, -c <category>  Feedback category (${FEEDBACK_CATEGORIES.join(', ')})
+    --category, -c <category>  Feedback category (${CLI_FEEDBACK_CATEGORIES.join(', ')})
     --subject, -s <subject>    Exact item the feedback is about, based on the category
     --resume <feedbackId>      Continue a feedback session using its ID
     --version, -v              Version number
@@ -535,23 +494,41 @@ function printHelp(): void {
     | expo-cli   | Full Expo CLI command, such as npx expo install                   |
     | eas-cli    | Full EAS CLI command, such as eas build                           |
     | evals      | Expo package, command, or capability the task involves            |
+    | simulator  | EAS Simulator feature or workflow involved                       |
     | unknown    | Concise Expo product, package, feature, or topic, or leave empty  |
 `);
 }
 
-function resolveFeedbackCategory(value?: string): FeedbackCategory {
+function resolveFeedbackCategory(value?: string): CliFeedbackCategory {
   const category = value?.trim().toLowerCase() || 'unknown';
-  if (FEEDBACK_CATEGORIES.includes(category as FeedbackCategory)) {
-    return category as FeedbackCategory;
+  if (CLI_FEEDBACK_CATEGORIES.includes(category as CliFeedbackCategory)) {
+    return category as CliFeedbackCategory;
   }
   throw new CommandError(
-    `Invalid feedback category "${value}". Expected one of: ${FEEDBACK_CATEGORIES.join(', ')}.`
+    `Invalid feedback category "${value}". Expected one of: ${CLI_FEEDBACK_CATEGORIES.join(', ')}.`
   );
 }
 
 function normalizeSubject(value?: string): string | undefined {
   const subject = value?.trim();
   return subject || undefined;
+}
+
+function validateFeedback(feedback: string): void {
+  const error = getFeedbackValidationError(feedback);
+  if (error) {
+    throw new CommandError(error);
+  }
+}
+
+function getFeedbackValidationError(feedback: string): string | null {
+  if (!feedback) {
+    return 'Feedback cannot be empty.';
+  }
+  if (feedback.length > CLI_FEEDBACK_MAX_LENGTH) {
+    return `Feedback cannot exceed ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.`;
+  }
+  return null;
 }
 
 function isTelemetryDisabled(): boolean {

--- a/packages/submit-expo-feedback/src/index.ts
+++ b/packages/submit-expo-feedback/src/index.ts
@@ -1,4 +1,16 @@
 #!/usr/bin/env node
 import { logErrorAndExit, runExpoFeedbackAsync } from './cli';
 
+export type {
+  CliFeedbackAgentEnvironment,
+  CliFeedbackCategory,
+  CliFeedbackContextMetadata,
+  CliFeedbackMetadata,
+  CliFeedbackProjectMetadata,
+  CliFeedbackRequest,
+  CliFeedbackSandboxEnvironment,
+  CliFeedbackTelemetryMetadata,
+  CliFeedbackUserMetadata,
+} from './types';
+
 runExpoFeedbackAsync().catch(logErrorAndExit);

--- a/packages/submit-expo-feedback/src/types.ts
+++ b/packages/submit-expo-feedback/src/types.ts
@@ -1,0 +1,95 @@
+export const CLI_FEEDBACK_MAX_LENGTH = 5_000;
+export const CLI_FEEDBACK_CATEGORIES = [
+  'skills',
+  'expo-cli',
+  'eas-cli',
+  'mcp',
+  'docs',
+  'evals',
+  'simulator',
+  'unknown',
+] as const;
+
+export type CliFeedbackCategory = (typeof CLI_FEEDBACK_CATEGORIES)[number];
+
+export type CliFeedbackContextMetadata = {
+  category: CliFeedbackCategory;
+  feedbackId: string;
+  subject?: string;
+};
+
+export type CliFeedbackAgentEnvironment =
+  | { detected: false }
+  | {
+      detected: true;
+      agent: {
+        id: string;
+        name: string;
+        sessionId?: string;
+      };
+    };
+
+export type CliFeedbackSandboxEnvironment =
+  | { detected: false }
+  | {
+      detected: true;
+      sandbox: {
+        id: string;
+        name: string;
+      };
+    };
+
+export type CliFeedbackProjectMetadata =
+  | { isExpoProject: false }
+  | {
+      isExpoProject: true;
+      name?: string;
+      slug?: string;
+      sdkVersion?: string;
+      platforms?: string[];
+      expoPackageVersion?: string;
+      reactNativePackageVersion?: string;
+      expoRouterPackageVersion?: string;
+    };
+
+/**
+ * Expo account identifiers. Consumers must treat these fields as personal data and remove them
+ * before storing metadata with external processors.
+ */
+export type CliFeedbackUserMetadata = {
+  id?: string;
+  username?: string;
+  authType: 'token' | 'session';
+};
+
+export type CliFeedbackTelemetryMetadata = {
+  cli: {
+    name: 'submit-expo-feedback';
+    version: string;
+  };
+  agentEnvironment: CliFeedbackAgentEnvironment;
+  sandboxEnvironment: CliFeedbackSandboxEnvironment;
+  ci?: {
+    name: string | null;
+    isPr: boolean | null;
+  };
+  device: {
+    arch: string;
+    platform: NodeJS.Platform;
+  };
+  node: {
+    version: string;
+  };
+  packageManager: string | null;
+  project: CliFeedbackProjectMetadata;
+  user?: CliFeedbackUserMetadata;
+};
+
+export type CliFeedbackMetadata =
+  | CliFeedbackContextMetadata
+  | (CliFeedbackContextMetadata & CliFeedbackTelemetryMetadata);
+
+export type CliFeedbackRequest = {
+  feedback: string;
+  metadata: CliFeedbackMetadata;
+};


### PR DESCRIPTION
Few changes to the submit-expo-cli command:
1. makes the metadata model explicit so we can rely on it in the endpoint implementation
2. adds simulator category
3. sets a max feedback length of 5000 chars
