### PR TITLE
[router] replace `useSyncExternalStore()` in `useLoaderData()`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [android][ios] Fix `expo-router/head` and `expo-router/stack` resolution on native platforms. ([#47870](https://github.com/expo/expo/pull/47870) by [@hassankhan](https://github.com/hassankhan))
 - Fix missing subpath warning from Metro when importing from `expo-router/server` ([#48045](https://github.com/expo/expo/pull/48045) by [@hassankhan](https://github.com/hassankhan))
 - Fix `replace` navigation in tabs leaving the replaced route in history. ([#48256](https://github.com/expo/expo/pull/48256) by [@Ubax](https://github.com/Ubax))
+- Prevent `useLoaderData()` from re-rendering readers of unrelated loader paths ([#48523](https://github.com/expo/expo/pull/48523) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -99,26 +99,6 @@ describe(useLoaderData, () => {
     expect(result.current).toEqual({ correct: true });
   });
 
-  it('retrieves server-side data from `ServerDataLoaderContext`', () => {
-    // Added to ensure that data is not fetched from global scope
-    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
-      '/index': { source: 'global' },
-    };
-
-    const ServerWrapper = ({ children }: { children: ReactNode }) => (
-      <ServerDataLoaderContext value={{ '/index': { source: 'server' } }}>
-        {children}
-      </ServerDataLoaderContext>
-    );
-
-    const { result } = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-      wrapper: ServerWrapper,
-    });
-
-    expect(result.current).toEqual({ source: 'server' });
-  });
-
   it('consumes hydration once and fetches on a later remount after reclamation', async () => {
     const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
     fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
@@ -190,32 +170,6 @@ describe(useLoaderData, () => {
     expect(result.current).toEqual({ fromStore: true });
     expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).not.toHaveProperty('/users/123');
     expect(fetchLoader).not.toHaveBeenCalled();
-  });
-
-  it('keeps custom client/store pairs isolated for the same route', () => {
-    const firstValue = createLoaderContextValue(new LoaderClient());
-    const secondValue = createLoaderContextValue(new LoaderClient());
-    firstValue.store.set('/index', { data: { owner: 'first' } });
-    secondValue.store.set('/index', { data: { owner: 'second' } });
-
-    const FirstWrapper = ({ children }: { children: ReactNode }) => (
-      <LoaderContext value={firstValue}>{children}</LoaderContext>
-    );
-    const SecondWrapper = ({ children }: { children: ReactNode }) => (
-      <LoaderContext value={secondValue}>{children}</LoaderContext>
-    );
-
-    const first = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-      wrapper: FirstWrapper,
-    });
-    const second = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-      wrapper: SecondWrapper,
-    });
-
-    expect(first.result.current).toEqual({ owner: 'first' });
-    expect(second.result.current).toEqual({ owner: 'second' });
   });
 
   it('reuses a hydrated entry across a same-tick Strict Mode remount', async () => {
@@ -304,10 +258,10 @@ describe(useLoaderData, () => {
     let serverData: Record<string, unknown> | null = {
       '/index': { source: 'server' },
     };
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>
-        <ServerDataLoaderContext value={serverData}>{children}</ServerDataLoaderContext>
-      </LoaderContext>
+    const LoaderWrapper = ({ children }: { children: ReactNode }) => (
+      <ServerDataLoaderContext value={serverData}>
+        <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
+      </ServerDataLoaderContext>
     );
     const hook = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
@@ -547,48 +501,6 @@ describe(useLoaderData, () => {
       user: { id: number; name: string };
       timestamp: number;
     }>();
-  });
-
-  it('resolves loader data for non-focused tab route', () => {
-    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
-      '/index': { tab: 'home' },
-      '/profile': { tab: 'profile' },
-    };
-
-    const homeResults: any[] = [];
-    const profileResults: any[] = [];
-
-    renderRouter(
-      {
-        _layout: () => (
-          <Tabs>
-            <Tabs.Screen name="index" />
-            <Tabs.Screen name="profile" />
-          </Tabs>
-        ),
-        index: function Home() {
-          homeResults.push(useLoaderData());
-          return <Text>Home</Text>;
-        },
-        profile: function Profile() {
-          profileResults.push(useLoaderData());
-          return <Text>Profile</Text>;
-        },
-      },
-      {
-        initialUrl: '/',
-      }
-    );
-
-    expect(homeResults[homeResults.length - 1]).toEqual({ tab: 'home' });
-
-    act(() => router.push('/profile'));
-
-    expect(profileResults[profileResults.length - 1]).toEqual({
-      tab: 'profile',
-    });
-    // Home screen should still be showing its own results
-    expect(homeResults[homeResults.length - 1]).toEqual({ tab: 'home' });
   });
 });
 

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -1,6 +1,6 @@
 import { act } from '@testing-library/react-native';
 import { expectTypeOf } from 'expect-type';
-import React from 'react';
+import { type ReactNode, useLayoutEffect } from 'react';
 import { Text } from 'react-native';
 
 import { router, Slot } from '../../exports';
@@ -105,7 +105,7 @@ describe(useLoaderData, () => {
       '/index': { source: 'global' },
     };
 
-    const ServerWrapper = ({ children }: { children: React.ReactNode }) => (
+    const ServerWrapper = ({ children }: { children: ReactNode }) => (
       <ServerDataLoaderContext value={{ '/index': { source: 'server' } }}>
         {children}
       </ServerDataLoaderContext>
@@ -126,10 +126,7 @@ describe(useLoaderData, () => {
       '/index': { fromHydration: true },
     };
 
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
 
     const firstMount = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
@@ -141,7 +138,7 @@ describe(useLoaderData, () => {
 
     firstMount.unmount();
     await act(async () => {});
-    expect(loaderContextValue.store.get('/index')).toBeUndefined();
+    expect(ctx.store.get('/index')).toBeUndefined();
 
     renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
@@ -159,10 +156,7 @@ describe(useLoaderData, () => {
       '/': { home: true },
     };
 
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
 
     renderHook(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
@@ -175,7 +169,7 @@ describe(useLoaderData, () => {
       await fetchLoaderMock.mock.results[0]!.value;
     });
 
-    expect(loaderContextValue.store.get('/users/123')).toEqual({
+    expect(ctx.store.get('/users/123')).toEqual({
       data: { fromFetch: true },
     });
   });
@@ -185,12 +179,8 @@ describe(useLoaderData, () => {
       '/users/123': { fromHydration: true },
     };
 
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    loaderContextValue.store.set('/users/123', { data: { fromStore: true } });
-
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.set('/users/123', { data: { fromStore: true } });
 
     const { result } = renderHook(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
@@ -208,10 +198,10 @@ describe(useLoaderData, () => {
     firstValue.store.set('/index', { data: { owner: 'first' } });
     secondValue.store.set('/index', { data: { owner: 'second' } });
 
-    const FirstWrapper = ({ children }: { children: React.ReactNode }) => (
+    const FirstWrapper = ({ children }: { children: ReactNode }) => (
       <LoaderContext value={firstValue}>{children}</LoaderContext>
     );
-    const SecondWrapper = ({ children }: { children: React.ReactNode }) => (
+    const SecondWrapper = ({ children }: { children: ReactNode }) => (
       <LoaderContext value={secondValue}>{children}</LoaderContext>
     );
 
@@ -231,11 +221,8 @@ describe(useLoaderData, () => {
   it('reuses a hydrated entry across a same-tick Strict Mode remount', async () => {
     const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
     fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    loaderContextValue.store.seed('/index', { hydrated: true });
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.seed('/index', { hydrated: true });
 
     const first = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
@@ -249,18 +236,15 @@ describe(useLoaderData, () => {
     await act(async () => {});
 
     expect(remount.result.current).toEqual({ hydrated: true });
-    expect(loaderContextValue.store.get('/index')).toEqual({
+    expect(ctx.store.get('/index')).toEqual({
       data: { hydrated: true },
     });
     expect(fetchLoaderMock).not.toHaveBeenCalled();
   });
 
   it('keeps a shared entry while a sibling reader remains mounted', async () => {
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    loaderContextValue.store.seed('/index', { shared: true });
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.seed('/index', { shared: true });
 
     const first = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
@@ -274,32 +258,30 @@ describe(useLoaderData, () => {
     first.unmount();
     await act(async () => {});
     expect(second.result.current).toEqual({ shared: true });
-    expect(loaderContextValue.store.get('/index')).toEqual({
+    expect(ctx.store.get('/index')).toEqual({
       data: { shared: true },
     });
 
     second.unmount();
     await act(async () => {});
-    expect(loaderContextValue.store.get('/index')).toBeUndefined();
+    expect(ctx.store.get('/index')).toBeUndefined();
   });
 
   it('refreshes a live entry in place during HMR coordination', async () => {
     const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
     fetchLoaderMock.mockResolvedValueOnce({ version: 2 });
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    loaderContextValue.store.seed('/index', { version: 1 });
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
+      '/index': { version: 1 },
+    };
     const hook = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
       wrapper: LoaderWrapper,
     });
 
     act(() => {
-      const { client, store } = loaderContextValue;
+      const { client, store } = ctx;
       store.retain(client.revalidate());
-      client.notify();
     });
 
     expect(hook.result.current).toEqual({ version: 1 });
@@ -307,35 +289,245 @@ describe(useLoaderData, () => {
       await fetchLoaderMock.mock.results[0]!.value;
     });
     expect(hook.result.current).toEqual({ version: 2 });
-    expect(loaderContextValue.store.get('/index')).toEqual({
+    expect(ctx.store.get('/index')).toEqual({
       data: { version: 2 },
     });
+  });
+
+  it('moves from server-provided data to normal store reads and refreshes in place', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockResolvedValueOnce({ version: 2 });
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
+      '/index': { version: 1 },
+    };
+    let serverData: Record<string, unknown> | null = {
+      '/index': { source: 'server' },
+    };
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>
+        <ServerDataLoaderContext value={serverData}>{children}</ServerDataLoaderContext>
+      </LoaderContext>
+    );
+    const hook = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+
+    expect(hook.result.current).toEqual({ source: 'server' });
+
+    serverData = null;
+    hook.rerender(undefined);
+    expect(hook.result.current).toEqual({ version: 1 });
+
+    act(() => {
+      const { client, store } = loaderContextValue;
+      store.retain(client.revalidate());
+    });
+    await act(async () => {
+      await fetchLoaderMock.mock.results[0]!.value;
+    });
+
+    expect(hook.result.current).toEqual({ version: 2 });
   });
 
   it('clears inactive entries while retaining live entries during HMR coordination', () => {
     const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
     fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
-    const loaderContextValue = createLoaderContextValue(new LoaderClient());
-    loaderContextValue.store.seed('/index', { live: true });
-    loaderContextValue.store.seed('/inactive', { stale: true });
-    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
-    );
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.seed('/index', { live: true });
+    ctx.store.seed('/inactive', { stale: true });
     renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
       wrapper: LoaderWrapper,
     });
 
     act(() => {
-      const { client, store } = loaderContextValue;
+      const { client, store } = ctx;
       store.retain(client.revalidate());
-      client.notify();
     });
 
-    expect(loaderContextValue.store.get('/index')).toEqual({
+    expect(ctx.store.get('/index')).toEqual({
       data: { live: true },
     });
-    expect(loaderContextValue.store.get('/inactive')).toBeUndefined();
+    expect(ctx.store.get('/inactive')).toBeUndefined();
+  });
+
+  it('updates the settled path without re-rendering a non-focused reader', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockResolvedValue({ tab: 'home', fresh: true });
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
+      '/index': { tab: 'home' },
+      '/profile': { tab: 'profile' },
+    };
+
+    let indexRenders = 0;
+    let profileRenders = 0;
+    let indexResult: unknown;
+    let profileResult: unknown;
+    renderRouter(
+      {
+        _layout: () => (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="profile" />
+          </Tabs>
+        ),
+        index: function Home() {
+          indexRenders++;
+          indexResult = useLoaderData();
+          return <Text>Home</Text>;
+        },
+        profile: function Profile() {
+          profileRenders++;
+          profileResult = useLoaderData();
+          return <Text>Profile</Text>;
+        },
+      },
+      { initialUrl: '/' }
+    );
+    jest.useRealTimers();
+
+    expect(indexResult).toEqual({ tab: 'home' });
+    act(() => router.push('/profile'));
+    expect(profileResult).toEqual({ tab: 'profile' });
+    expect(indexResult).toEqual({ tab: 'home' });
+    const indexBefore = indexRenders;
+    const profileBefore = profileRenders;
+
+    await act(async () => {
+      defaultLoaderContextValue.client.execute('/index');
+    });
+
+    expect(indexResult).toEqual({ tab: 'home', fresh: true });
+    expect(profileResult).toEqual({ tab: 'profile' });
+    expect(indexRenders).toBeGreaterThan(indexBefore);
+    expect(profileRenders).toBe(profileBefore);
+  });
+
+  it('re-renders every same-path sibling reader when its loader settles', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockResolvedValue({ version: 2 });
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
+      '/index': { version: 1 },
+    };
+
+    const renders: [number, number] = [0, 0];
+    function Reader({ index }: { index: 0 | 1 }) {
+      renders[index]++;
+      useLoaderData();
+      return null;
+    }
+
+    renderRouter({
+      index: () => (
+        <>
+          <Reader index={0} />
+          <Reader index={1} />
+        </>
+      ),
+    });
+    jest.useRealTimers();
+    const rendersBefore: [number, number] = [...renders];
+
+    await act(async () => {
+      defaultLoaderContextValue.client.execute('/index');
+    });
+
+    expect(renders[0]).toBeGreaterThan(rendersBefore[0]);
+    expect(renders[1]).toBeGreaterThan(rendersBefore[1]);
+  });
+
+  it('catches a store update between render and effect subscription', () => {
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.seed('/index', { version: 1 });
+
+    const { result } = renderHook(
+      () => {
+        const data = useLoaderData();
+        useLayoutEffect(() => {
+          ctx.store.set('/index', { data: { version: 2 } });
+        }, []);
+        return data;
+      },
+      ['index'],
+      { initialUrl: '/', wrapper: LoaderWrapper }
+    );
+
+    expect(result.current).toEqual({ version: 2 });
+  });
+
+  it('does not wake or update a reader when a replaced source settles', async () => {
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    ctx.store.seed('/index', { version: 1 });
+    const oldFetch = createDeferred<{ version: number }>();
+    let renders = 0;
+    const hook = renderHook(
+      () => {
+        renders++;
+        return useLoaderData();
+      },
+      ['index'],
+      { initialUrl: '/', wrapper: LoaderWrapper }
+    );
+
+    ctx.client.execute('/index', () => oldFetch.promise);
+    ctx.client.clear();
+    const replacementUnsubscribe = ctx.client.subscribeLoader('/index');
+    ctx.store.set('/index', { data: { version: 2 } });
+    hook.rerender(undefined);
+    const rendersBeforeOldSettle = renders;
+
+    await act(async () => {
+      oldFetch.resolve({ version: 3 });
+    });
+
+    expect(hook.result.current).toEqual({ version: 2 });
+    expect(ctx.store.get('/index')).toEqual({ data: { version: 2 } });
+    expect(renders).toBe(rendersBeforeOldSettle);
+    replacementUnsubscribe();
+  });
+
+  it('unsubscribes from the old resolved path and subscribes to the new path', async () => {
+    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
+      '/users/1': { id: 1 },
+      '/users/2': { id: 2 },
+    };
+    const { ctx, LoaderWrapper } = createLoaderTestContext();
+    const subscribeLoaderSpy = jest.spyOn(ctx.client, 'subscribeLoader');
+    const oldFetch = createDeferred<{ id: number }>();
+    let renders = 0;
+    let latestData: unknown;
+
+    renderRouter(
+      {
+        'users/[id]': function User() {
+          const data = useLoaderData() as { id: number };
+          renders++;
+          latestData = data;
+          return <Text>User: {data.id}</Text>;
+        },
+      },
+      { initialUrl: '/users/1', wrapper: LoaderWrapper }
+    );
+    jest.useRealTimers();
+
+    expect(subscribeLoaderSpy.mock.calls.map(([path]) => path)).toEqual(['/users/1']);
+
+    ctx.client.execute('/users/1', () => oldFetch.promise);
+
+    act(() => router.replace('/users/2'));
+
+    expect(subscribeLoaderSpy.mock.calls.map(([path]) => path)).toEqual(['/users/1', '/users/2']);
+    expect(latestData).toEqual({ id: 2 });
+    const rendersBeforeOldSettle = renders;
+
+    await act(async () => {
+      oldFetch.resolve({ id: 3 });
+    });
+
+    expect(latestData).toEqual({ id: 2 });
+    expect(renders).toBe(rendersBeforeOldSettle);
   });
 
   it(`uses the loader function's return types`, () => {
@@ -399,3 +591,19 @@ describe(useLoaderData, () => {
     expect(homeResults[homeResults.length - 1]).toEqual({ tab: 'home' });
   });
 });
+
+function createLoaderTestContext() {
+  const ctx = createLoaderContextValue(new LoaderClient());
+  const LoaderWrapper = ({ children }: { children: ReactNode }) => (
+    <LoaderContext value={ctx}>{children}</LoaderContext>
+  );
+  return { ctx, LoaderWrapper };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+}

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import type { LoaderFunction } from 'expo-server';
-import { use, useEffect, useMemo, useSyncExternalStore } from 'react';
+import { use, useEffect, useMemo, useState } from 'react';
 
 import { useContextKey } from '../Route';
 import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
@@ -39,12 +39,6 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
 
   const { client, store } = ctx;
 
-  // Subscribe before any early returns so a later `loader-invalidate` re-renders this hook even
-  // when the initial render was satisfied by `ServerDataLoaderContext` or `__EXPO_ROUTER_LOADER_DATA__`.
-  // Returning early before subscribing would also change hook order on the next render once
-  // invalidation deletes the injected global.
-  useSyncExternalStore(client.subscribe, client.getSnapshot, client.getSnapshot);
-
   const stateForPath = useStateForPath();
   const contextKey = useContextKey();
 
@@ -57,32 +51,46 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
     return searchString ? `${resolvedPathname}?${searchString}` : resolvedPathname;
   }, [contextKey, stateForPath]);
 
+  // Loader data stays in the shared Suspense store; local state only invalidates this reader.
+  const [, setVersion] = useState(0);
+
+  // Seed first so hydration is not mistaken for an update missed before subscription.
+  if (!serverDataLoaderContext) {
+    const hydrationData = globalThis.__EXPO_ROUTER_LOADER_DATA__;
+    if (hydrationData && resolvedPath in hydrationData) {
+      store.seed(resolvedPath, hydrationData[resolvedPath]);
+      delete hydrationData[resolvedPath];
+    }
+  }
+
+  // Keep this render-scoped rather than in a ref: only the committed render's effect should
+  // compare the entry it rendered with the entry present when the subscription attaches.
+  const entryAtRender = store.get(resolvedPath);
+
   useEffect(() => {
-    // Hydration-seeded routes never reach a read miss, so invalidation can't refetch them
-    // without a registered fetcher.
+    // Seeded routes do not reach a read miss, so register their fetcher explicitly for HMR.
     client.registerFetcher(resolvedPath, fetchLoader);
     const unsubscribe = client.subscribeLoader(resolvedPath, (result, isCurrentSource) => {
       if (isCurrentSource) {
         store.set(resolvedPath, result);
+        setVersion((version) => version + 1);
       }
     });
+    if (store.get(resolvedPath) !== entryAtRender) {
+      setVersion((version) => version + 1);
+    }
     return () => {
       store.dispose(resolvedPath);
       unsubscribe(() => store.teardown(resolvedPath));
     };
+    // NOTE(@hassankhan): `entryAtRender` is intentionally omitted: including it would recreate
+    // the persistent subscription whenever the store entry changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, resolvedPath, store]);
 
-  // First invocation of this hook will happen server-side, so we look up the loaded data from context
+  // Server renders read request-injected loader data directly.
   if (serverDataLoaderContext) {
     return serverDataLoaderContext[resolvedPath];
-  }
-
-  // The second invocation happens after the client has hydrated, so we seed the suspense store
-  // with the preloaded data from `globalThis.__EXPO_ROUTER_LOADER_DATA__`
-  const hydrationData = globalThis.__EXPO_ROUTER_LOADER_DATA__;
-  if (hydrationData && resolvedPath in hydrationData) {
-    store.seed(resolvedPath, hydrationData[resolvedPath]);
-    delete hydrationData[resolvedPath];
   }
 
   const result = readLoaderData<LoaderFunctionResult<T>>(ctx, resolvedPath, fetchLoader);

--- a/packages/expo-router/src/loaders/LoaderClient.ts
+++ b/packages/expo-router/src/loaders/LoaderClient.ts
@@ -18,28 +18,6 @@ interface LoaderSource {
 export class LoaderClient {
   private active = new Map<string, LoaderSource>();
   private fetchers = new Map<string, LoaderFetcher>();
-  private version = 0;
-  private listeners = new Set<() => void>();
-
-  // Arrow-bound so `loaderClient.subscribe` returns a stable reference across renders,
-  // which keeps `useSyncExternalStore()` from tearing down and re-attaching every render.
-  subscribe = (listener: () => void): (() => void) => {
-    this.listeners.add(listener);
-    return () => {
-      this.listeners.delete(listener);
-    };
-  };
-
-  getSnapshot = (): number => {
-    return this.version;
-  };
-
-  notify() {
-    this.version++;
-    for (const listener of this.listeners) {
-      listener();
-    }
-  }
 
   subscribeLoader(path: string, callback: LoaderSubscriber = () => {}): LoaderUnsubscribe {
     let source = this.active.get(path);
@@ -127,6 +105,5 @@ export class LoaderClient {
     for (const subscriber of source.subscribers) {
       subscriber(result, isCurrentSource);
     }
-    this.notify();
   }
 }

--- a/packages/expo-router/src/loaders/LoaderContext.ts
+++ b/packages/expo-router/src/loaders/LoaderContext.ts
@@ -29,7 +29,6 @@ if (__DEV__ && typeof window !== 'undefined') {
 
       const { client, store } = defaultLoaderContextValue;
       store.retain(client.revalidate());
-      client.notify();
     });
   }
 }

--- a/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
@@ -3,22 +3,8 @@ import { LoaderClient } from '../LoaderClient';
 const tick = () => Promise.resolve();
 
 describe(LoaderClient, () => {
-  describe('notify', () => {
-    it('bumps the version and wakes subscribers', () => {
-      const client = new LoaderClient();
-      const listener = jest.fn();
-      client.subscribe(listener);
-
-      const before = client.getSnapshot();
-      client.notify();
-
-      expect(client.getSnapshot()).toBe(before + 1);
-      expect(listener).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('subscribeLoader + execute', () => {
-    it('shares one in-flight fetch and delivers it to every subscriber before notifying', async () => {
+    it('shares one in-flight fetch and delivers it to every subscriber', async () => {
       const client = new LoaderClient();
       const fetcher = jest.fn(async () => 'v1');
       const events: unknown[] = [];
@@ -28,7 +14,6 @@ describe(LoaderClient, () => {
       client.subscribeLoader('/p', (result, isCurrentSource) => {
         events.push(['second', result, isCurrentSource]);
       });
-      client.subscribe(() => events.push('notify'));
 
       client.execute('/p', fetcher);
       client.execute('/p', fetcher);
@@ -38,7 +23,6 @@ describe(LoaderClient, () => {
       expect(events).toEqual([
         ['first', { data: 'v1' }, true],
         ['second', { data: 'v1' }, true],
-        'notify',
       ]);
     });
 

--- a/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
@@ -195,30 +195,4 @@ describe(LoaderClient, () => {
       expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
     });
   });
-
-  describe('clear', () => {
-    it('drops sources and registered fetchers', () => {
-      const client = new LoaderClient();
-      const fetcher = jest.fn(async () => 'v1');
-      client.subscribeLoader('/p');
-      client.registerFetcher('/p', fetcher);
-
-      client.clear();
-      client.execute('/p');
-
-      expect(fetcher).not.toHaveBeenCalled();
-    });
-
-    it('cancels a pending onTearDown', async () => {
-      const client = new LoaderClient();
-      const onTearDown = jest.fn();
-      const unsubscribe = client.subscribeLoader('/p');
-
-      unsubscribe(onTearDown);
-      client.clear();
-      await tick();
-
-      expect(onTearDown).not.toHaveBeenCalled();
-    });
-  });
 });

--- a/packages/expo-router/src/loaders/__tests__/LoaderSuspenseStore.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderSuspenseStore.test.ts
@@ -73,16 +73,4 @@ describe(LoaderSuspenseStore, () => {
     store.teardown('/inactive');
     expect(store.get('/inactive')).toEqual({ data: 'new' });
   });
-
-  it('drops all entries and marks on reset', () => {
-    const store = new LoaderSuspenseStore();
-    store.set('/a', { data: 1 });
-    store.dispose('/a');
-
-    store.reset();
-    store.set('/a', { data: 2 });
-    store.teardown('/a');
-
-    expect(store.get('/a')).toEqual({ data: 2 });
-  });
 });

--- a/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
@@ -8,7 +8,6 @@ const read = <T>(ctx: LoaderContextValue, path: string, fetcher: (path: string) 
   readLoaderData(ctx, path, fetcher);
 const revalidate = ({ client, store }: LoaderContextValue) => {
   store.retain(client.revalidate());
-  client.notify();
 };
 
 describe(readLoaderData, () => {


### PR DESCRIPTION
# Why

`useLoaderData()` currently subscribes every reader to a global version counter on `LoaderClient` using [`useSyncExternalStore()`](https://react.dev/reference/react/useSyncExternalStore). Any loader promise that settles bumps the counter, causing **all** mounted readers to re-render, including readers of unrelated paths.

# How

- Each reader now holds a local version counter using `useState`. An effect subscribes to the reader's resolved path via `client.subscribeLoader()`. On settle, the subscriber writes the result to the Suspense store and bumps only that reader.
- The effect compares the store entry against the entry captured during render, and an identity mismatch bumps the version.
- Removed `subscribe()`/`getSnapshot()`/`notify()` from `LoaderClient` since the client no longer needs machinery for `useSyncExternalStore()`.
- The dev `loader-invalidate` listener no longer calls `client.notify()`. When a refetch finishes, each reader re-renders through its own subscription instead.

# Test Plan

- CI, no user-visible change expected beyond fewer re-renders.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
