### PR TITLE
[cli] Fix iOS asset catalog scale-to-file pairing for assets with non-standard scales

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Fix iOS asset catalog scale-to-file pairing for assets with non-standard scales. ([#48525](https://github.com/expo/expo/pull/48525) by [@janicduplessis](https://github.com/janicduplessis))
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Ignore simulators reported by `devicectl` and support json version 5 on Xcode 27 ([#48001](https://github.com/expo/expo/pull/48001) by [@crockalet](https://github.com/crockalet))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix iOS asset catalog scale-to-file pairing for assets with non-standard scales. ([#48525](https://github.com/expo/expo/pull/48525) by [@janicduplessis](https://github.com/janicduplessis))
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Ignore a whitespace-only `REACT_NATIVE_PACKAGER_HOSTNAME` instead of failing to start the dev server ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
@@ -8,7 +8,11 @@
 import type { AssetData } from '@expo/metro/metro';
 import { vol } from 'memfs';
 
-import { filterPlatformAssetScales, persistMetroAssetsAsync } from '../persistMetroAssets';
+import {
+  filterPlatformAssetScales,
+  getCatalogImages,
+  persistMetroAssetsAsync,
+} from '../persistMetroAssets';
 
 describe(filterPlatformAssetScales, () => {
   it('removes everything but 2x and 3x for iOS', () => {
@@ -25,6 +29,48 @@ describe(filterPlatformAssetScales, () => {
 
   it('keeps all scales for unknown platform', () => {
     expect(filterPlatformAssetScales('freebsd', [1, 1.5, 2, 3.7])).toEqual([1, 1.5, 2, 3.7]);
+  });
+});
+
+describe(getCatalogImages, () => {
+  function makeAsset(scales: number[]) {
+    return {
+      name: 'logo',
+      scales,
+      files: scales.map((scale) => `/img/logo${scale === 1 ? '' : `@${scale}x`}.png`),
+    };
+  }
+
+  it('pairs each standard scale with its file', () => {
+    expect(getCatalogImages(makeAsset([1, 2, 3]))).toEqual([
+      { scale: 1, src: '/img/logo.png' },
+      { scale: 2, src: '/img/logo@2x.png' },
+      { scale: 3, src: '/img/logo@3x.png' },
+    ]);
+  });
+
+  it('skips non-standard scales without shifting file pairing', () => {
+    // Regression: filtering scales without filtering files used to associate
+    // the 2x rendition with the 1.5x file.
+    expect(getCatalogImages(makeAsset([1, 1.5, 2, 3]))).toEqual([
+      { scale: 1, src: '/img/logo.png' },
+      { scale: 2, src: '/img/logo@2x.png' },
+      { scale: 3, src: '/img/logo@3x.png' },
+    ]);
+  });
+
+  it('maps a fractional-only asset into the nearest valid slot', () => {
+    expect(getCatalogImages(makeAsset([1.5]))).toEqual([{ scale: 2, src: '/img/logo@1.5x.png' }]);
+  });
+
+  it('clamps scales larger than 3x to the 3x slot', () => {
+    expect(getCatalogImages(makeAsset([4]))).toEqual([{ scale: 3, src: '/img/logo@4x.png' }]);
+  });
+
+  it('uses the largest fractional variant when several exist', () => {
+    expect(getCatalogImages(makeAsset([1.5, 2.5]))).toEqual([
+      { scale: 3, src: '/img/logo@2.5x.png' },
+    ]);
   });
 });
 

--- a/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/persistMetroAssets.test.ts
@@ -8,7 +8,11 @@
 import type { AssetData } from '@expo/metro/metro';
 import { vol } from 'memfs';
 
-import { filterPlatformAssetScales, persistMetroAssetsAsync } from '../persistMetroAssets';
+import {
+  filterPlatformAssetScales,
+  getCatalogImages,
+  persistMetroAssetsAsync,
+} from '../persistMetroAssets';
 
 describe(filterPlatformAssetScales, () => {
   it('removes everything but 2x and 3x for iOS', () => {
@@ -25,6 +29,42 @@ describe(filterPlatformAssetScales, () => {
 
   it('keeps all scales for unknown platform', () => {
     expect(filterPlatformAssetScales('freebsd', [1, 1.5, 2, 3.7])).toEqual([1, 1.5, 2, 3.7]);
+  });
+});
+
+describe(getCatalogImages, () => {
+  function makeAsset(scales: number[]) {
+    return {
+      name: 'logo',
+      scales,
+      files: scales.map((scale) => `/img/logo${scale === 1 ? '' : `@${scale}x`}.png`),
+    };
+  }
+
+  it('pairs each standard scale with its file', () => {
+    expect(getCatalogImages(makeAsset([1, 2, 3]))).toEqual([
+      { scale: 1, src: '/img/logo.png' },
+      { scale: 2, src: '/img/logo@2x.png' },
+      { scale: 3, src: '/img/logo@3x.png' },
+    ]);
+  });
+
+  it('skips non-standard scales without shifting file pairing', () => {
+    // Regression: filtering scales without filtering files used to associate
+    // the 2x rendition with the 1.5x file.
+    expect(getCatalogImages(makeAsset([1, 1.5, 2, 3]))).toEqual([
+      { scale: 1, src: '/img/logo.png' },
+      { scale: 2, src: '/img/logo@2x.png' },
+      { scale: 3, src: '/img/logo@3x.png' },
+    ]);
+  });
+
+  it('maps a fractional-only asset into the nearest valid slot', () => {
+    expect(getCatalogImages(makeAsset([1.5]))).toEqual([{ scale: 2, src: '/img/logo@1.5x.png' }]);
+  });
+
+  it('clamps scales larger than 3x to the 3x slot', () => {
+    expect(getCatalogImages(makeAsset([4]))).toEqual([{ scale: 3, src: '/img/logo@4x.png' }]);
   });
 });
 

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -69,12 +69,7 @@ export async function persistMetroAssetsAsync(
     cleanAssetCatalog(catalogDir);
     for (const asset of assets) {
       if (isCatalogAsset(asset)) {
-        const imageSet = getImageSet(
-          catalogDir,
-          asset,
-          filterPlatformAssetScales(platform, asset.scales)
-        );
-        writeImageSet(imageSet);
+        writeImageSet(getImageSet(catalogDir, asset));
       } else {
         assetsToCopy.push(asset);
       }
@@ -176,20 +171,54 @@ type ImageSet = {
   files: { name: string; src: string; scale: number }[];
 };
 
+type CatalogImage = { scale: number; src: string };
+
+/**
+ * Pairs each catalog-valid scale of the asset with its source file.
+ *
+ * If the asset has no valid scale at all (e.g. only a fractional @1.5x
+ * variant), its closest variant is mapped into the nearest valid slot,
+ * mirroring the "closest larger" fallback filterPlatformAssetScales applies
+ * to loose files, so the imageset always contains at least one rendition
+ * actool will compile.
+ */
+export function getCatalogImages(
+  asset: Pick<AssetData, 'name' | 'scales' | 'files'>
+): CatalogImage[] {
+  const images: CatalogImage[] = [];
+  asset.scales.forEach((scale, idx) => {
+    if (CATALOG_SCALES.includes(scale)) {
+      images.push({ scale, src: asset.files[idx]! });
+    }
+  });
+  if (images.length === 0 && asset.scales.length > 0) {
+    const maxCatalogScale = CATALOG_SCALES[CATALOG_SCALES.length - 1]!;
+    let idx = asset.scales.findIndex((scale) => scale > maxCatalogScale);
+    if (idx === -1) {
+      idx = asset.scales.length - 1;
+    }
+    const scale = Math.min(maxCatalogScale, Math.max(1, Math.ceil(asset.scales[idx]!)));
+    Log.warn(
+      `Asset "${asset.name}" has no 1x/2x/3x variant; using its @${asset.scales[idx]}x file as the ${scale}x catalog rendition.`
+    );
+    images.push({ scale, src: asset.files[idx]! });
+  }
+  return images;
+}
+
 function getImageSet(
   catalogDir: string,
-  asset: Pick<AssetData, 'httpServerLocation' | 'name' | 'type' | 'files'>,
-  scales: number[]
+  asset: Pick<AssetData, 'httpServerLocation' | 'name' | 'type' | 'files' | 'scales'>
 ): ImageSet {
   const fileName = getResourceIdentifier(asset);
   return {
     baseUrl: path.join(catalogDir, `${fileName}.imageset`),
-    files: scales.map((scale, idx) => {
+    files: getCatalogImages(asset).map(({ scale, src }) => {
       const suffix = scale === 1 ? '' : `@${scale}x`;
       return {
         name: `${fileName + suffix}.${asset.type}`,
         scale,
-        src: asset.files[idx]!,
+        src,
       };
     }),
   };
@@ -233,6 +262,10 @@ function copy(src: string, dest: string, callback: (error?: NodeJS.ErrnoExceptio
 const ALLOWED_SCALES: { [key: string]: number[] } = {
   ios: [1, 2, 3],
 };
+
+// Scales an iOS asset catalog imageset can hold. actool silently drops
+// renditions at any other scale (e.g. a fractional @1.5x).
+const CATALOG_SCALES = ALLOWED_SCALES.ios!;
 
 export function filterPlatformAssetScales(platform: string, scales: number[]): number[] {
   const whitelist: number[] = ALLOWED_SCALES[platform]!;

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -69,12 +69,7 @@ export async function persistMetroAssetsAsync(
     cleanAssetCatalog(catalogDir);
     for (const asset of assets) {
       if (isCatalogAsset(asset)) {
-        const imageSet = getImageSet(
-          catalogDir,
-          asset,
-          filterPlatformAssetScales(platform, asset.scales)
-        );
-        writeImageSet(imageSet);
+        writeImageSet(getImageSet(catalogDir, asset));
       } else {
         assetsToCopy.push(asset);
       }
@@ -176,20 +171,58 @@ type ImageSet = {
   files: { name: string; src: string; scale: number }[];
 };
 
+// Scales an iOS asset catalog imageset can hold. actool silently drops
+// renditions at any other scale (e.g. a fractional @1.5x).
+const CATALOG_SCALES = [1, 2, 3];
+
+type CatalogImage = { scale: number; src: string };
+
+/**
+ * Pairs each catalog-valid scale of the asset with its source file.
+ *
+ * If the asset has no valid scale at all (e.g. only a fractional @1.5x
+ * variant), its closest variant is mapped into the nearest valid slot,
+ * mirroring the "closest larger" fallback filterPlatformAssetScales applies
+ * to loose files, so the imageset always contains at least one rendition
+ * actool will compile.
+ */
+export function getCatalogImages(
+  asset: Pick<AssetData, 'name' | 'scales' | 'files'>
+): CatalogImage[] {
+  const images: CatalogImage[] = [];
+  asset.scales.forEach((scale, idx) => {
+    if (CATALOG_SCALES.includes(scale)) {
+      images.push({ scale, src: asset.files[idx]! });
+    }
+  });
+  if (images.length === 0 && asset.scales.length > 0) {
+    const maxCatalogScale = CATALOG_SCALES[CATALOG_SCALES.length - 1]!;
+    let idx = asset.scales.findIndex((scale) => scale > maxCatalogScale);
+    if (idx === -1) {
+      idx = asset.scales.length - 1;
+    }
+    const scale = Math.min(maxCatalogScale, Math.max(1, Math.ceil(asset.scales[idx]!)));
+    Log.warn(
+      `Asset "${asset.name}" has no 1x/2x/3x variant; using its @${asset.scales[idx]}x file as the ${scale}x catalog rendition.`
+    );
+    images.push({ scale, src: asset.files[idx]! });
+  }
+  return images;
+}
+
 function getImageSet(
   catalogDir: string,
-  asset: Pick<AssetData, 'httpServerLocation' | 'name' | 'type' | 'files'>,
-  scales: number[]
+  asset: Pick<AssetData, 'httpServerLocation' | 'name' | 'type' | 'files' | 'scales'>
 ): ImageSet {
   const fileName = getResourceIdentifier(asset);
   return {
     baseUrl: path.join(catalogDir, `${fileName}.imageset`),
-    files: scales.map((scale, idx) => {
+    files: getCatalogImages(asset).map(({ scale, src }) => {
       const suffix = scale === 1 ? '' : `@${scale}x`;
       return {
         name: `${fileName + suffix}.${asset.type}`,
         scale,
-        src: asset.files[idx]!,
+        src,
       };
     }),
   };

--- a/packages/@expo/cli/src/export/persistMetroAssets.ts
+++ b/packages/@expo/cli/src/export/persistMetroAssets.ts
@@ -187,22 +187,30 @@ export function getCatalogImages(
 ): CatalogImage[] {
   const images: CatalogImage[] = [];
   asset.scales.forEach((scale, idx) => {
-    if (CATALOG_SCALES.includes(scale)) {
-      images.push({ scale, src: asset.files[idx]! });
+    const src = asset.files[idx];
+    if (src && CATALOG_SCALES.includes(scale)) {
+      images.push({ scale, src });
     }
   });
-  if (images.length === 0 && asset.scales.length > 0) {
-    const maxCatalogScale = CATALOG_SCALES[CATALOG_SCALES.length - 1]!;
-    let idx = asset.scales.findIndex((scale) => scale > maxCatalogScale);
-    if (idx === -1) {
-      idx = asset.scales.length - 1;
-    }
-    const scale = Math.min(maxCatalogScale, Math.max(1, Math.ceil(asset.scales[idx]!)));
-    Log.warn(
-      `Asset "${asset.name}" has no 1x/2x/3x variant; using its @${asset.scales[idx]}x file as the ${scale}x catalog rendition.`
-    );
-    images.push({ scale, src: asset.files[idx]! });
+  if (images.length > 0) {
+    return images;
   }
+
+  let idx = asset.scales.findIndex((scale) => scale > MAX_CATALOG_SCALE);
+  if (idx === -1) {
+    idx = asset.scales.length - 1;
+  }
+  const assetScale = asset.scales[idx];
+  const src = asset.files[idx];
+  if (assetScale === undefined || src === undefined) {
+    return images;
+  }
+
+  const scale = Math.min(MAX_CATALOG_SCALE, Math.max(1, Math.ceil(assetScale)));
+  Log.warn(
+    `Asset "${asset.name}" has no 1x/2x/3x variant; using its @${assetScale}x file as the ${scale}x catalog rendition.`
+  );
+  images.push({ scale, src });
   return images;
 }
 
@@ -259,13 +267,14 @@ function copy(src: string, dest: string, callback: (error?: NodeJS.ErrnoExceptio
   });
 }
 
-const ALLOWED_SCALES: { [key: string]: number[] } = {
-  ios: [1, 2, 3],
-};
-
 // Scales an iOS asset catalog imageset can hold. actool silently drops
 // renditions at any other scale (e.g. a fractional @1.5x).
-const CATALOG_SCALES = ALLOWED_SCALES.ios!;
+const CATALOG_SCALES = [1, 2, 3];
+const MAX_CATALOG_SCALE = Math.max(...CATALOG_SCALES);
+
+const ALLOWED_SCALES: { [key: string]: number[] } = {
+  ios: CATALOG_SCALES,
+};
 
 export function filterPlatformAssetScales(platform: string, scales: number[]): number[] {
   const whitelist: number[] = ALLOWED_SCALES[platform]!;


### PR DESCRIPTION
# Why

`persistMetroAssetsAsync` filters an asset's scales through `filterPlatformAssetScales`, but `getImageSet` indexes the unfiltered `asset.files`, so an asset with scales `[1, 1.5, 2, 3]` gets the 1.5x file in its 2x catalog slot and the 2x file in its 3x slot: the compiled `Assets.car` ships the wrong images. Assets with *only* non-standard scales get an imageset actool silently drops entirely, making them unloadable since the catalog runtime has no filesystem fallback.

Same bug as facebook/react-native#57825, merged as [`74b98472`](https://github.com/facebook/react-native/commit/74b984729b3e21225d1c54f7671644c37bbeb026) — this code mirrors the RN community CLI implementation (reachable once `RCTUseAssetCatalog` is on, RN 0.88+). This PR carries the same logic, so the two implementations stay in step.

# How

- Pair each catalog slot (1x/2x/3x) with its own file.
- An asset with no valid scale maps its closest variant into the nearest valid slot (the "closest larger" rule loose files already get) and warns, so every imageset holds at least one rendition actool will compile.

# Test Plan

Added unit tests to `persistMetroAssets.test.ts` for `getCatalogImages`: standard pairing, mixed `[1, 1.5, 2, 3]` (regression for the file shift), fractional-only `[1.5]`, `[4]` clamping to the 3x slot, and `[1.5, 2.5]` taking the largest fractional variant. The cases match the ones that landed with the RN fix. The file's suite passes locally, 10/10.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


End-to-end validation isn't possible here yet (the catalog path only becomes reachable once an SDK targets RN 0.88) — see facebook/react-native#57825 for the full e2e of the identical RN fix: compiled-car verification and on-device before/after screenshots.



