### PR TITLE
[audio][ios] Run AVAudioSession.setActive on a serial queue off the calling thread

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Run `AVAudioSession.setActive` calls on a serial queue instead of the calling thread. The synchronous `play()` performed the blocking activation XPC on the JS thread, so an audio-daemon stall froze all JS execution (timers, state updates) while the rest of the app appeared alive; deactivation had the same hazard on its calling thread. A monotonic activation token drops stale deactivations so rapid back-to-back playback isn't torn down, and a per-playable play generation prevents a queued play from audibly starting audio that `pause()`/`replace()` already cancelled. Behavior change: `play()` no longer throws when session activation fails — playback is still attempted and the failure is reported through the `playbackStatusUpdate` event's `error` field. ([#48532](https://github.com/expo/expo/pull/48532) by [@sbs44](https://github.com/sbs44))
 - [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48151](https://github.com/expo/expo/pull/48151) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -1,7 +1,6 @@
 import ExpoModulesCore
 
 public class AudioModule: Module {
-  private var sessionIsActive = true
   private let registry = AudioComponentRegistry()
 
   // MARK: Properties
@@ -14,6 +13,20 @@ public class AudioModule: Module {
   private var allowsBackgroundRecording = false
   private var sessionOptions: AVAudioSession.CategoryOptions = []
   private var lastConfiguredMode: AudioMode?
+
+  // AVAudioSession.setActive(_:) is a synchronous XPC round-trip to the audio
+  // daemon that can stall for seconds (or indefinitely) under system contention.
+  // This module's session transitions run on this serial queue so a stall can
+  // never block the calling thread — for the sync `play` Functions that caller
+  // is the JS thread, and a blocked JS thread freezes every JS timer and state
+  // update in the app. The interruption bookkeeping (interruptedPlayers /
+  // playerVolumes) also lives on this queue. sessionActivation lets a later
+  // activation supersede a pending deactivation so back-to-back playback isn't
+  // torn down by a stale setActive(false). (AudioRecorder/AudioStream still
+  // activate the session inline outside this queue — a known gap, tracked for
+  // a follow-up.)
+  private let sessionQueue = DispatchQueue(label: "expo.modules.audio.session")
+  private let sessionActivation = MonotonicGeneration()
 
   public func definition() -> ModuleDefinition {
     Name("ExpoAudio")
@@ -32,8 +45,8 @@ public class AudioModule: Module {
       try setAudioMode(mode: mode)
     }
 
-    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool)  in
-      try setIsAudioActive(isActive)
+    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool, promise: Promise) in
+      setIsAudioActive(isActive, promise: promise)
     }
 
     AsyncFunction("requestRecordingPermissionsAsync") { (promise: Promise) in
@@ -211,9 +224,23 @@ public class AudioModule: Module {
       }
 
       Function("play") { player in
-        try activateSession()
+        // Sync Functions execute inline on the JS thread, so the blocking
+        // setActive(true) must not happen here. Observer registration runs now
+        // (on the JS thread, where the player's other mutations happen); only
+        // the AVPlayer start is deferred behind activation on sessionQueue,
+        // and the generation guard skips it if pause()/replace()/teardown
+        // superseded this play while it was queued.
         let rate = player.currentRate > 0 ? player.currentRate : 1.0
-        player.play(at: rate)
+        player.prepareToPlay()
+        let generation = player.playGeneration.current
+        withSessionActivatedOnQueue({
+          guard player.playGeneration.current == generation else {
+            return
+          }
+          player.startPlayback(at: rate)
+        }, onActivationError: { error in
+          player.updateStatus(with: ["error": "Audio session activation failed: \(error.localizedDescription)"])
+        })
       }
 
       Function("setPlaybackRate") { (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
@@ -233,6 +260,8 @@ public class AudioModule: Module {
       }
 
       Function("replace") { (player, source: AudioSource?) in
+        // Generation bumps live inside the player's replace/pause/teardown
+        // methods so every superseding path invalidates a queued play.
         if let uri = source?.uri?.absoluteString, let cachedPlayer = self.registry.removePreloadedPlayer(forKey: uri) {
           let cachedItem = cachedPlayer.currentItem
           cachedPlayer.replaceCurrentItem(with: nil)
@@ -243,13 +272,16 @@ public class AudioModule: Module {
       }
 
       Function("pause") { player in
-        player.ref.pause()
+        player.pause()
         if !player.keepAudioSessionActive {
           deactivateSession()
         }
       }
 
       Function("remove") { player in
+        // The player object may outlive registry removal; make sure a play
+        // still queued behind a slow activation doesn't start it afterwards.
+        player.playGeneration.bump()
         self.registry.remove(player)
       }
 
@@ -364,8 +396,18 @@ public class AudioModule: Module {
       }
 
       Function("play") { playlist in
-        try activateSession()
-        playlist.play(at: playlist.currentRate)
+        // Same JS-thread hazard and same split as AudioPlayer's play above.
+        let rate = playlist.currentRate
+        playlist.prepareToPlay()
+        let generation = playlist.playGeneration.current
+        withSessionActivatedOnQueue({
+          guard playlist.playGeneration.current == generation else {
+            return
+          }
+          playlist.startPlayback(at: rate)
+        }, onActivationError: { error in
+          playlist.updateStatus(with: ["error": "Audio session activation failed: \(error.localizedDescription)"])
+        })
       }
 
       Function("pause") { playlist in
@@ -637,6 +679,17 @@ public class AudioModule: Module {
   }
 
   private func handleInterruptionBegan() {
+    // Runs on sessionQueue: interruptedPlayers/playerVolumes are also read and
+    // mutated by resumeInterruptedPlayers, which executes there (queued behind
+    // the reactivation). Back-to-back interruptions would otherwise mutate
+    // these collections from the notification thread while a queued resume
+    // iterates them.
+    sessionQueue.async {
+      self.handleInterruptionBeganOnSessionQueue()
+    }
+  }
+
+  private func handleInterruptionBeganOnSessionQueue() {
     interruptedPlayers.removeAll()
     playerVolumes.removeAll()
 
@@ -663,13 +716,13 @@ public class AudioModule: Module {
   }
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
-    do {
-      try AVAudioSession.sharedInstance().setActive(true)
+    // Activation ordered on sessionQueue with resume kept after it. Resume is
+    // attempted even if activation throws — activation failures are frequently
+    // transient and dropping the resume silently is worse.
+    withSessionActivatedOnQueue { [weak self] in
       if options.contains(.shouldResume) {
-        resumeInterruptedPlayers()
+        self?.resumeInterruptedPlayers()
       }
-    } catch {
-      print("Failed to reactivate audio session: \(error)")
     }
   }
 
@@ -682,7 +735,11 @@ public class AudioModule: Module {
 
     switch reason {
     case .oldDeviceUnavailable:
-      pauseAllPlayers()
+      // On sessionQueue for ordering with queued plays/resumes; pause() bumps
+      // each player's generation so a queued play can't undo this pause.
+      sessionQueue.async {
+        self.pauseAllPlayers()
+      }
     default:
       break
     }
@@ -709,10 +766,10 @@ public class AudioModule: Module {
       if let mode = lastConfiguredMode {
         try setAudioMode(mode: mode)
       }
-      try AVAudioSession.sharedInstance().setActive(true)
     } catch {
       print("Failed to reconfigure audio session after media services reset: \(error)")
     }
+    withSessionActivatedOnQueue()
   }
   #endif
 
@@ -788,16 +845,25 @@ public class AudioModule: Module {
     return URL(fileURLWithPath: path)
   }
 
-  private func setIsAudioActive(_ isActive: Bool) throws {
-    if !isActive {
-      pauseAllPlayers()
+  private func setIsAudioActive(_ isActive: Bool, promise: Promise) {
+    // Bump on activation so a pending deactivateSession() doesn't tear down
+    // the session being explicitly activated here. The transition itself runs
+    // async on sessionQueue and settles the promise from there — a stalled
+    // setActive keeps the promise pending instead of blocking the process-wide
+    // AsyncFunction queue that all Expo modules share.
+    if isActive {
+      sessionActivation.bump()
     }
-
-    do {
-      try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
-      sessionIsActive = isActive
-    } catch {
-      throw AudioStateException(error.localizedDescription)
+    sessionQueue.async {
+      if !isActive {
+        self.pauseAllPlayers()
+      }
+      do {
+        try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
+        promise.resolve()
+      } catch {
+        promise.reject(AudioStateException(error.localizedDescription))
+      }
     }
   }
 
@@ -871,11 +937,36 @@ public class AudioModule: Module {
     }
   }
 
-  private func activateSession() throws {
-    try AVAudioSession.sharedInstance().setActive(true)
+  private func withSessionActivatedOnQueue(
+    _ then: @escaping () -> Void = {},
+    onActivationError: ((Error) -> Void)? = nil
+  ) {
+    // AudioModule's activation path: session transitions are ordered against
+    // deactivateSession on sessionQueue, and a stall can never wedge the
+    // calling thread. The bump happens at call time so this activation
+    // supersedes any pending deactivation.
+    sessionActivation.bump()
+    sessionQueue.async {
+      do {
+        try AVAudioSession.sharedInstance().setActive(true)
+      } catch {
+        // Run the continuation anyway: activation failures are frequently
+        // transient, and for playback this keeps the player advancing to
+        // didJustFinish so JS-side callers aren't left waiting forever on a
+        // completion event that can no longer arrive. The play paths surface
+        // the failure through the playbackStatusUpdate `error` field via
+        // onActivationError.
+        print("Failed to activate audio session: \(error)")
+        onActivationError?(error)
+      }
+      then()
+    }
   }
 
   private func deactivateSession() {
+    // Capture the token now so a session reactivated before the deferred
+    // deactivation runs skips this stale setActive(false).
+    let requestedToken = sessionActivation.current
     Task {
       // Give isPlaying time to update before deciding whether to deactivate.
       try? await Task.sleep(for: .milliseconds(100))
@@ -883,10 +974,17 @@ public class AudioModule: Module {
       guard !hasActivePlayables else {
         return
       }
-      do {
-        try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-      } catch {
-        print("Failed to deactivate audio session: \(error)")
+      sessionQueue.async {
+        // The token re-check and setActive(false) aren't atomic, leaving a
+        // narrow TOCTOU window that iOS's session `isBusy` handling covers.
+        guard self.sessionActivation.current == requestedToken else {
+          return
+        }
+        do {
+          try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        } catch {
+          print("Failed to deactivate audio session: \(error)")
+        }
       }
     }
   }

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -26,6 +26,12 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   var samplingEnabled = false
   var keepAudioSessionActive = false
 
+  // Supersedes a play deferred to AudioModule's sessionQueue: bumped inside
+  // pause()/replace/teardown so EVERY pausing path (module pause,
+  // pauseAllPlayers, interruptions) invalidates a queued play — the queued
+  // closure re-checks before starting cancelled audio.
+  let playGeneration = MonotonicGeneration()
+
   var isLooping = false {
     didSet {
       guard isLooping != oldValue else {
@@ -105,12 +111,27 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   func play(at rate: Float) {
+    prepareToPlay()
+    startPlayback(at: rate)
+  }
+
+  /// The calling-thread half of play(at:): observer registration and loop
+  /// bookkeeping mutate the player's internal state, so they stay on the
+  /// thread the rest of the player's mutations (pause/replace/teardown) run
+  /// on instead of racing them from the session queue.
+  func prepareToPlay() {
     ref.actionAtItemEnd = isLooping ? .advance : .pause
     if isLooping {
       enqueueNextLoopItem()
     }
     addPlaybackEndNotification()
     registerTimeObserver()
+  }
+
+  /// The queue-safe half of play(at:): touches only the AVPlayer ref and
+  /// MediaController, so AudioModule may defer it behind the blocking session
+  /// activation on sessionQueue.
+  func startPlayback(at rate: Float) {
     ref.playImmediately(atRate: rate)
 
     if isActiveForLockScreen {
@@ -247,6 +268,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   func replaceWithPreloadedItem(_ item: AVPlayerItem?) {
+    playGeneration.bump()
     let wasPlaying = ref.timeControlStatus == .playing
     let wasSamplingEnabled = samplingEnabled
     removeQueuedLoopItems()
@@ -267,6 +289,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   func replaceCurrentSource(source: AudioSource?) {
+    playGeneration.bump()
     self.source = source
     let wasPlaying = ref.timeControlStatus == .playing
     let wasSamplingEnabled = samplingEnabled
@@ -502,6 +525,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   func pause() {
+    playGeneration.bump()
     ref.pause()
   }
 
@@ -510,6 +534,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   public override func sharedObjectWillRelease() {
+    playGeneration.bump()
     ref.currentItem?.cancelPendingSeeks()
     owningRegistry?.remove(self)
 

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -18,6 +18,11 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   var loopMode: LoopMode = .none
   var wasPlaying = false
 
+  // Supersedes a play deferred to AudioModule's sessionQueue — same contract
+  // as AudioPlayer.playGeneration: bumped in pause/clear/skipTo/teardown so a
+  // queued play can detect it was cancelled while waiting on activation.
+  let playGeneration = MonotonicGeneration()
+
   private(set) var sources: [AudioSource] = []
 
   private var playerItems: [AVPlayerItem?] = []
@@ -95,7 +100,17 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   func play(at rate: Float) {
+    prepareToPlay()
+    startPlayback(at: rate)
+  }
+
+  /// Calling-thread half of play(at:) — see AudioPlayer.prepareToPlay().
+  func prepareToPlay() {
     registerTimeObserver()
+  }
+
+  /// Queue-safe half of play(at:) — see AudioPlayer.startPlayback(at:).
+  func startPlayback(at rate: Float) {
     ref.playImmediately(atRate: rate)
 
     if isActiveForLockScreen {
@@ -104,6 +119,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   func pause() {
+    playGeneration.bump()
     ref.pause()
 
     if isActiveForLockScreen {
@@ -144,6 +160,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
       return
     }
 
+    playGeneration.bump()
     let wasPlaying = isPlaying
     rebuildPlaylist(startingAt: index)
 
@@ -230,6 +247,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   func clear() {
+    playGeneration.bump()
     ref.pause()
     ref.removeAllItems()
     sources.removeAll()
@@ -413,6 +431,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayab
   }
 
   public override func sharedObjectWillRelease() {
+    playGeneration.bump()
     ref.currentItem?.cancelPendingSeeks()
     owningRegistry?.remove(self)
     cancellables.removeAll()

--- a/packages/expo-audio/ios/MonotonicGeneration.swift
+++ b/packages/expo-audio/ios/MonotonicGeneration.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/**
+ A lock-guarded, monotonically increasing counter for detecting superseded
+ deferred work: capture `current` when enqueueing an operation, `bump()` in
+ every path that invalidates it, and compare captured vs. `current` before
+ executing. Shared by the module-level session activation token (a later
+ activation supersedes a pending deactivation) and the per-playable play
+ generation (pause/replace/teardown supersede a play still queued behind a
+ slow session activation).
+ */
+final class MonotonicGeneration {
+  private let lock = NSLock()
+  private var value = 0
+
+  var current: Int {
+    lock.lock()
+    defer {
+      lock.unlock()
+    }
+    return value
+  }
+
+  @discardableResult
+  func bump() -> Int {
+    lock.lock()
+    defer {
+      lock.unlock()
+    }
+    value += 1
+    return value
+  }
+}

--- a/packages/expo-audio/ios/Tests/MonotonicGenerationTests.swift
+++ b/packages/expo-audio/ios/Tests/MonotonicGenerationTests.swift
@@ -1,0 +1,46 @@
+import Testing
+import Dispatch
+
+@testable import ExpoAudio
+
+@Suite("MonotonicGeneration")
+struct MonotonicGenerationTests {
+  @Test
+  func capturedValueStaysCurrentUntilBumped() {
+    let generation = MonotonicGeneration()
+    let captured = generation.current
+    // A queued operation whose generation is still current must run.
+    #expect(captured == generation.current)
+  }
+
+  @Test
+  func bumpSupersedesCapturedValue() {
+    let generation = MonotonicGeneration()
+    let captured = generation.current
+    generation.bump()
+    // A queued operation captured before the bump must detect it is stale:
+    // this is the play-then-pause ordering (queued play must not start), and
+    // equally the deactivate-then-activate ordering (stale deactivation must
+    // not tear down the reactivated session).
+    #expect(captured != generation.current)
+  }
+
+  @Test
+  func laterCaptureIsUnaffectedByEarlierBumps() {
+    let generation = MonotonicGeneration()
+    generation.bump()
+    let captured = generation.current
+    // pause-then-play: the later play's capture must still be current.
+    #expect(captured == generation.current)
+  }
+
+  @Test
+  func concurrentBumpsAreLossless() {
+    let generation = MonotonicGeneration()
+    let iterations = 1_000
+    DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+      generation.bump()
+    }
+    #expect(generation.current == iterations)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #48531 – the activation counterpart to #47045/#47066.

`AVAudioSession.setActive` is a synchronous XPC round-trip to the audio daemon that can stall for seconds, or indefinitely, under system contention. Both sync `Function("play")` definitions performed the activation inline... and expo-modules sync Functions execute on the JS runtime thread (`SyncFunctionDefinition` is `@JavaScriptActor`)... so a stalled activation froze **all JS execution**: every timer, state update, and event handler, while natively driven UI kept running and the app looked alive. No crash, no JS error, and no app-hang report (watchdogs monitor the main thread, which is idle). #47066 fixed the deactivation half of this; the activation half remained on the JS thread.

Production evidence and a measurable repro (sync `play()` means the call's wall-clock duration *is* the JS-thread block time) are in #48531.

# How

- **All of AudioModule's session transitions run on one serial `sessionQueue`.** `play()` splits into `prepareToPlay()` (observer registration and loop bookkeeping... kept on the calling thread, where the player's other mutations run) and `startPlayback()` (AVPlayer-only, deferred behind the activation on the queue).
- **A `MonotonicGeneration` token supersedes stale deactivations** so back-to-back playback isn't torn down by a deferred `setActive(false)` (same token idea as #47079, now shared by one small type).
- **A per-playable play generation keeps a queued play from starting cancelled audio.** Bumps live inside the playables' own `pause()`/replace/`skipTo`/`clear`/teardown methods, so every superseding path (module Functions, `pauseAllPlayers` on backgrounding, interruptions, `remove`) is covered by construction. `AudioPlaylist` gets the same protection as `AudioPlayer`.
- **Interruption bookkeeping moves onto `sessionQueue`.** `interruptedPlayers`/`playerVolumes` were mutated on the notification thread while the (now queued) resume path iterated them... a Swift collection race.
- **`setIsAudioActiveAsync` becomes promise-based** and settles from the queue, so a stalled transition no longer blocks the process-wide AsyncFunction queue that all Expo modules share. JS API unchanged.
- **Behavior change:** `play()` no longer throws when activation fails... playback is still attempted (failures are frequently transient) and the failure is surfaced through the `playbackStatusUpdate` event's existing `error` field. Noted in the changelog.
- Write-only `sessionIsActive` removed.

Known gap, deliberately out of scope: `AudioRecorder`/`AudioStream` still call `setActive(true)` inline outside the queue; noted in-code for a follow-up.

# Test Plan

- `ios/Tests/MonotonicGenerationTests.swift` (Swift Testing) covers the supersession orderings... play-then-pause must skip the queued play, deactivate-then-activate must skip the stale deactivation, pause-then-play must still play... plus lossless concurrent bumps.
- Behavioral verification is on-device with the repro in #48531 (https://github.com/sbs44/expo-audio-test): the sync `play()` call duration displays the JS-thread block per play; with the repro's simulated-stall patch, stock expo-audio freezes the JS tick counter for 4 s per clip while a native animation keeps running... with this branch, the JS tick never stops and audio starts when the (simulated) daemon recovers. Pause during the stall window and the queued play stays silent.
- A backport of this change to expo-audio 57.0.3 compiles clean (pod install + xcodebuild of the ExpoAudio target) and is shipping in a production navigation app via patch-package.
- Swift-only diff... no JS/TS or committed `build/` changes. Package lint and native tests run in CI (no local expo monorepo toolchain was available for `expo-module lint`/`test`).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)