### PR TITLE
[ci] Send the Slack payload as JSON

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -126,14 +126,14 @@ runs:
           // [outputs] color and text based on status
           const status = process.env.JOB_STATUS.toLowerCase();
           let color = 'danger';
-          let text = ':no_entry: Failed GitHub Actions\n';
+          let text = ':no_entry: Failed GitHub Actions';
 
           if (status === 'success') {
             color = 'good';
-            text = ':white_check_mark: Succeeded GitHub Actions\n';
+            text = ':white_check_mark: Succeeded GitHub Actions';
           } else if (status === 'cancelled') {
             color = 'warning';
-            text = ':warning: Cancelled GitHub Actions\n';
+            text = ':warning: Cancelled GitHub Actions';
           }
 
           // [outputs] fields
@@ -180,19 +180,25 @@ runs:
             }
           }
 
-          core.setOutput('fields', JSON.stringify(slackFields));
-          core.setOutput('color', color);
-          core.setOutput('text', text);
-          core.setOutput('author_name', escape(process.env.AUTHOR_NAME));
+          // Emit the whole request body as JSON rather than as separate values
+          // interpolated into a YAML template. The action parses the payload input
+          // with js-yaml, which rejects a newline inside a quoted scalar
+          // ("deficient indentation"), so any value containing one would break the
+          // template. JSON.stringify escapes those characters instead.
+          core.setOutput('payload', JSON.stringify({
+            text,
+            attachments: [
+              {
+                color,
+                author_name: escape(process.env.AUTHOR_NAME),
+                fields: slackFields,
+              },
+            ],
+          }));
 
     - name: Send to Slack
       uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
       with:
         webhook: ${{ inputs.webhook }}
         webhook-type: incoming-webhook
-        payload: |
-          text: "${{ steps.details.outputs.text }}"
-          attachments:
-            - color: "${{ steps.details.outputs.color }}"
-              author_name: "${{ steps.details.outputs.author_name }}"
-              fields: ${{ steps.details.outputs.fields }}
+        payload: ${{ steps.details.outputs.payload }}


### PR DESCRIPTION
# Why

Slack notifications from `.github/actions/slack-notify` have been failing to send since Jul 31:

```
##[error]Invalid input! Failed to parse contents of the provided payload
YAMLException: deficient indentation (2:1)

 1 | text: ":no_entry: Failed GitHub  ...
 2 | "
-----^
 3 | attachments:
```

That's how [today's `publish-packages` failure](https://github.com/expo/expo/actions/runs/30967002878/job/92183028819) went unannounced: the Android publish step broke, and the notification meant to tell us crashed instead.

The action builds its request body by interpolating values into a YAML template, and `text` ended with a literal `\n`, which puts the closing quote at column 1. #47926 bumped the action to v4.0.0, whose [headline breaking change](https://github.com/slackapi/slack-github-action/releases/tag/v4.0.0) is stricter, spec-compliant YAML parsing via js-yaml v5. Multiline values now have to be indented, and their example is our exact shape. Our payload was never valid YAML; v4.0.0 is just the first version to reject it.

# How

Dropped the trailing `\n`, and replaced the YAML template with a single JSON body built in the `github-script` step.

Removing the newline is enough to unbreak it, but we'd still be hand-writing YAML around values we don't control (commit subjects, author names), where any newline or quote breaks it the same way. `JSON.stringify` escapes those, and the `payload` input takes JSON directly since JSON is a subset of YAML.

# Test Plan

Ran the real pinned action bundle against a local webhook server, comparing `main`'s payload with this one:

```
old: exit=1 parseError=true
new: exit=0 parseError=false

webhook deliveries: 1
delivered text  : ":no_entry: Failed GitHub Actions"
delivered color : danger
delivered fields: 3
```

The old payload delivers nothing; the new one delivers a correct message.

Only tested against a local HTTP server, so the first real notification will confirm rendering.
