### PR TITLE
[expo-symbols] Promote to stable

### DIFF
--- a/docs/pages/versions/unversioned/sdk/symbols.mdx
+++ b/docs/pages/versions/unversioned/sdk/symbols.mdx
@@ -5,14 +5,11 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-symbols'
 packageName: 'expo-symbols'
 iconUrl: '/static/images/packages/expo-symbols.png'
 platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
-isBeta: true
 ---
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
-
-> **important** This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.
 
 `expo-symbols` provides access to native symbol libraries across platforms. On iOS and tvOS, it uses [SF Symbols](https://developer.apple.com/sf-symbols/). On Android and web, it uses [Material Symbols](https://fonts.google.com/icons).
 

--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Promote Expo Symbols from beta to stable.
+- Promote Expo Symbols from beta to stable. ([#48537](https://github.com/expo/expo/pull/48537) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 57.0.1 - 2026-07-15
 

--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Promote Expo Symbols from beta to stable.
+
 ## 57.0.1 - 2026-07-15
 
 _This version does not introduce any user-facing changes._


### PR DESCRIPTION
# Why
Symbols has been is beta since release and is already a part of our template so it should be promoted

# How
Remove the beta tag and callout

# Test Plan
n/a

