### PR TITLE
[docs] Remove alpha status from expo-sqlite web, patch-project, and DOM components

### DIFF
--- a/docs/pages/config-plugins/patch-project.mdx
+++ b/docs/pages/config-plugins/patch-project.mdx
@@ -7,8 +7,6 @@ description: Learn about how to use patch-project to create generate, apply, and
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **Note**: `patch-project` is an [alpha](/more/release-statuses/#alpha) feature.
-
 `patch-project` is an Expo config plugin and command-line interface (CLI) tool that generates and applies patches to preserve native changes after running `npx expo prebuild`. This tool is useful for native app developers who want to preserve customizations without needing to know how to write a config plugin, effectively generating an automatic solution that works with [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/).
 
 This guide explains how to use `patch-project`, when to use it, and its limitations.

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -235,8 +235,6 @@ Think of these functions like React Server Functions, but instead of residing on
 
 ## Passing refs
 
-> **important** This is in [alpha](/more/release-statuses/#alpha) and may change in the future.
-
 You can use the `useDOMImperativeHandle` hook inside a DOM component to accept ref calls from the native side. This hook is similar to React's [`useImperativeHandle`](https://react.dev/reference/react/useImperativeHandle) hook, but it does not need a ref object to be passed to it.
 
 ```tsx App.tsx (native)
@@ -349,7 +347,7 @@ While `process.env.EXPO_OS` will always be web in a DOM component, you can detec
 
 ## Public assets
 
-> **important** **Warning:** This is in [alpha](/more/release-statuses/#alpha) and may change in the future. Public assets are not supported in EAS Update. Use `require()` to load local assets instead.
+> **warning** Public assets are not supported in EAS Update. Use `require()` to load local assets instead.
 
 The contents of the root **public** directory are copied to the native app's binary to support the use of public assets in DOM components. Since these public assets will be served from the local filesystem, use the `process.env.EXPO_BASE_URL` prefix to reference the correct path. For example:
 

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -91,8 +91,6 @@ You can configure `expo-sqlite` for advanced configurations using its built-in [
 
 ## Web setup
 
-> **important** Web support is in [alpha](/more/release-statuses/#alpha) and may be unstable. [Create an issue on GitHub](https://github.com/expo/expo/issues) if you encounter any issues.
-
 To use `expo-sqlite` on web, you need to configure Metro bundler to support **wasm** files and add HTTP headers to allow [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) usage.
 
 Add the following configuration to your **metro.config.js**. If you don't have the **metro.config.js** yet, you can run `npx expo customize metro.config.js`. [Learn more about customizing Metro](/guides/customizing-metro/).


### PR DESCRIPTION
# Why

remove outdated alpha tag

# How

remove alpha or experiment tag for expo-sqlite web, patch-project and some features in dom components

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
