### PR TITLE
[image-picker][iOS] Reject when a requested crop produces no image

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`. ([#48005](https://github.com/expo/expo/pull/48005) by [@barthap](https://github.com/barthap))
 - [iOS] Fixed crop square detection using the main screen's scale instead of the scale of the view being measured. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#PLACEHOLDER](https://github.com/expo/expo/pull/PLACEHOLDER) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Android] Fix `videoMaxDuration` option ([#47504](https://github.com/expo/expo/pull/47504) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix `base64` returning original (non-JPEG) image data when `allowsEditing` is `false`. ([#48005](https://github.com/expo/expo/pull/48005) by [@barthap](https://github.com/barthap))
 - [iOS] Fixed crop square detection using the main screen's scale instead of the scale of the view being measured. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#PLACEHOLDER](https://github.com/expo/expo/pull/PLACEHOLDER) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#48541](https://github.com/expo/expo/pull/48541) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/ExpoImagePicker.podspec
+++ b/packages/expo-image-picker/ios/ExpoImagePicker.podspec
@@ -30,5 +30,9 @@ Pod::Spec.new do |s|
     test_spec.dependency 'ExpoModulesTestCore'
 
     test_spec.source_files = 'Tests/**/*.{m,swift}'
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
   end
 end

--- a/packages/expo-image-picker/ios/ImageUtils.swift
+++ b/packages/expo-image-picker/ios/ImageUtils.swift
@@ -40,9 +40,11 @@ internal struct ImageUtils {
       return nil
     }
 
-    if shouldReadCroppedImage,
-      let cropRect = mediaInfo[.cropRect] as? CGRect,
-      let cropped = ImageUtils.crop(image: originalImage, to: cropRect) {
+    if shouldReadCroppedImage {
+      guard let cropRect = mediaInfo[.cropRect] as? CGRect,
+        let cropped = ImageUtils.crop(image: originalImage, to: cropRect) else {
+        return nil
+      }
       // Crop first (rect is defined in the original pixel space), then rotate.
       return cropped.fixOrientation()
     }

--- a/packages/expo-image-picker/ios/Tests/ImageUtilsReadImageTests.swift
+++ b/packages/expo-image-picker/ios/Tests/ImageUtilsReadImageTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+import UIKit
+
+@testable import ExpoImagePicker
+
+private func makeImage(width: Int, height: Int, orientation: UIImage.Orientation = .up) -> UIImage {
+  let format = UIGraphicsImageRendererFormat()
+  // Pin the scale so point and pixel dimensions match, keeping crop rects easy to reason about.
+  format.scale = 1
+  let size = CGSize(width: width, height: height)
+  let image = UIGraphicsImageRenderer(size: size, format: format).image { context in
+    UIColor.red.setFill()
+    context.fill(CGRect(origin: .zero, size: size))
+  }
+
+  guard orientation != .up, let cgImage = image.cgImage else {
+    return image
+  }
+  // `width`/`height` stay the pixel dimensions; the tag is what makes `size` differ from them.
+  return UIImage(cgImage: cgImage, scale: 1, orientation: orientation)
+}
+
+@Suite("ImageUtils.readImageFrom")
+struct ImageUtilsReadImageTests {
+  @Test
+  func `returns nil when editing was requested but cropping failed`() {
+    // A rect that does not intersect the image makes `CGImage.cropping(to:)` fail,
+    // standing in for any editor failure that leaves us without a cropped bitmap.
+    let mediaInfo: MediaInfo = [
+      .originalImage: makeImage(width: 10, height: 10),
+      .cropRect: CGRect(x: 100, y: 100, width: 6, height: 6)
+    ]
+
+    #expect(ImageUtils.readImageFrom(mediaInfo: mediaInfo, shouldReadCroppedImage: true) == nil)
+  }
+
+  @Test
+  func `returns nil when editing was requested but no crop information exists`() {
+    let mediaInfo: MediaInfo = [.originalImage: makeImage(width: 10, height: 10)]
+
+    #expect(ImageUtils.readImageFrom(mediaInfo: mediaInfo, shouldReadCroppedImage: true) == nil)
+  }
+
+  @Test
+  func `crops the original when cropRect is usable`() throws {
+    let mediaInfo: MediaInfo = [
+      .originalImage: makeImage(width: 10, height: 10),
+      .cropRect: CGRect(x: 0, y: 0, width: 6, height: 6)
+    ]
+
+    let image = try #require(ImageUtils.readImageFrom(mediaInfo: mediaInfo, shouldReadCroppedImage: true))
+
+    #expect(image.size == CGSize(width: 6, height: 6))
+  }
+
+  @Test
+  func `returns the original when editing was not requested`() throws {
+    let mediaInfo: MediaInfo = [.originalImage: makeImage(width: 10, height: 10)]
+
+    let image = try #require(ImageUtils.readImageFrom(mediaInfo: mediaInfo, shouldReadCroppedImage: false))
+
+    #expect(image.size == CGSize(width: 10, height: 10))
+  }
+
+  @Test
+  func `applies cropRect in the original pixel space before fixing orientation`() throws {
+    // 10x20 pixels tagged `.right`, so `size` reports the upright 20x10.
+    let original = makeImage(width: 10, height: 20, orientation: .right)
+    #expect(original.size == CGSize(width: 20, height: 10))
+
+    let mediaInfo: MediaInfo = [
+      .originalImage: original,
+      .cropRect: CGRect(x: 0, y: 0, width: 10, height: 5)
+    ]
+
+    let image = try #require(ImageUtils.readImageFrom(mediaInfo: mediaInfo, shouldReadCroppedImage: true))
+
+    // Cropping first gives 10x5 pixels, which uprights to 5x10. Fixing orientation
+    // first would upright to 20x10 and then crop to 10x5, misplacing the crop (#37810).
+    #expect(image.size == CGSize(width: 5, height: 10))
+  }
+}

--- a/packages/expo-image-picker/ios/Tests/MediaHandlerTests.swift
+++ b/packages/expo-image-picker/ios/Tests/MediaHandlerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+import UIKit
+import UniformTypeIdentifiers
+
+@testable import ExpoImagePicker
+
+private func makeSquareImage(side: Int) -> UIImage {
+  let format = UIGraphicsImageRendererFormat()
+  format.scale = 1
+  let size = CGSize(width: side, height: side)
+  return UIGraphicsImageRenderer(size: size, format: format).image { context in
+    UIColor.red.setFill()
+    context.fill(CGRect(origin: .zero, size: size))
+  }
+}
+
+@Suite("MediaHandler")
+struct MediaHandlerTests {
+  @Test
+  func `throws FailedToReadImageException when a requested crop produced no image`() async {
+    var options = ImagePickerOptions()
+    options.allowsEditing = true
+    let handler = MediaHandler(fileSystem: nil, options: options)
+
+    let mediaInfo: MediaInfo = [
+      .mediaType: UTType.image.identifier,
+      .originalImage: makeSquareImage(side: 10),
+      .cropRect: CGRect(x: 100, y: 100, width: 6, height: 6)
+    ]
+
+    await #expect(throws: FailedToReadImageException.self) {
+      try await handler.handleMedia(mediaInfo)
+    }
+  }
+}


### PR DESCRIPTION


# Why

Fixes - https://github.com/expo/expo/issues/48524

A failed crop was reported to JS as a successful pick carrying the full uncropped image, so apps could not tell that the crop was failed or user cancelled it.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Return `nil` when user requests cropped image but crop fails due to some reason. It will [throw](https://github.com/expo/expo/blob/2410cc1826d8950d3b9bbe38bf2a0aa8829c76ff/packages/expo-image-picker/ios/MediaHandler.swift#L62) `FailedToReadImageException`. 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added test cases to assert the exception and a few more cases to make sure it does not cause any regression in future.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
