### PR TITLE
[docs] update Maestro screenshot example

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1401,18 +1401,18 @@ jobs:
 
 <Collapsible summary="Saving screenshots and recordings">
 
-To save assets created by Maestro commands (such as [`takeScreenshot`](https://docs.maestro.dev/reference/commands-available/takescreenshot) or [`startRecording`](https://docs.maestro.dev/reference/commands-available/startrecording)) to use for debugging later, use the `MAESTRO_TESTS_DIR` environment variable.
+Maestro commands such as [`takeScreenshot`](https://docs.maestro.dev/reference/commands-available/takescreenshot) or [`startRecording`](https://docs.maestro.dev/reference/commands-available/startrecording) save assets that you can use for debugging later.
 
-In your Maestro flow file, specify the asset locations:
+In your Maestro flow file, give each asset a relative path:
 
 ```yaml maestro/flows/test-flow.yaml
 appId: com.myapp
 ---
 - launchApp
-- startRecording: ${MAESTRO_TESTS_DIR}/my_recording
-- takeScreenshot: ${MAESTRO_TESTS_DIR}/my_screenshot
+- startRecording: my_recording
+- takeScreenshot: my_screenshot
 - tapOn: 'Login Button'
-- takeScreenshot: ${MAESTRO_TESTS_DIR}/after_login_screenshot
+- takeScreenshot: after_login_screenshot
 - stopRecording
 ```
 


### PR DESCRIPTION
# Why

Our `takeScreenshot` and `startRecording` example told people to write `${MAESTRO_TESTS_DIR}/my_screenshot`. Maestro 2.8.0 added path validation to both commands and now rejects any path that resolves outside the current run's own output folder, so a flow copied from our docs fails.

# How

Switched the example to plain relative paths. Maestro writes those into the run's own bundle, which sits under the directory we upload as the "Maestro Test Results" artifact, so the assets still end up in that artifact. The two surrounding sentences pointed at `MAESTRO_TESTS_DIR`, so I reworded them to match.

The `after_maestro_tests` hook example further down still uses `$MAESTRO_TESTS_DIR`. That one is a shell environment variable and never reaches Maestro's path validation, so it stays as is.

# Test Plan

Docs-only change.

I traced the path resolution in the Maestro source at tags `cli-2.7.0` and `cli-2.8.0`. A relative path resolves to `$HOME/.maestro/tests/<session>/<flow>/takeScreenshot/<name>.png` on both, from identical code, so the example is correct for either version.

Vale and `oxfmt` are clean on the changed file. I also checked the new copy against the writing style guide for second person, present tense, active voice, and one thought per sentence.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
