### PR TITLE
fix(expo): Change async `import()` return value to carry full promise shape again

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Mark `ExpoAppSceneDelegate` as unavailable in `iOSApplicationExtension` for widgets. ([#47894](https://github.com/expo/expo/pull/47894) by [@jakex7](https://github.com/jakex7))
 - [iOS] Add ExpoBundleConfiguration to derive RCTBundleConfiguration from the normalized bundle URL instead of default shared settings singleton ([#48010](https://github.com/expo/expo/pull/48010) by [@kitten](https://github.com/kitten))
 - [iOS] Resolve the dev server port from the `RCTMetroPort` Info.plist key at runtime so bare projects without expo-dev-client connect to their own Metro instance instead of defaulting to 8081. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix async imports (`import(...)`) via `asyncRequireModule` not a thenable instead of a full promise shape ([#48550](https://github.com/expo/expo/pull/48550) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
+++ b/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
@@ -90,20 +90,9 @@ describe('asyncRequireModule', () => {
 
       function asyncRequire(moduleID, paths, moduleName) {
         var ret = asyncRequireImpl(moduleID, paths, moduleName);
-        if (!(ret instanceof Promise)) {
-          return {
-            _result: ret,
-            then: function(resolve, reject) {
-              return Promise.resolve(ret).then(resolve, reject);
-            },
-          };
-        }
-        return {
-          _result: ret,
-          then: function(resolve, reject) {
-            return ret.then(resolve, reject);
-          },
-        };
+        var promise = Promise.resolve(ret);
+        promise._result = ret;
+        return promise;
       }
 
       asyncRequire.unstable_importMaybeSync = function(moduleID, paths) {
@@ -225,14 +214,20 @@ describe('asyncRequireModule', () => {
   });
 
   describe('thenable return value', () => {
-    it('exposes a synchronous _result when no bundle load was needed', () => {
+    it('returns a Promise with a synchronous _result when no bundle load was needed', async () => {
       const ret = asyncRequire(42, null, 'my-module');
 
-      expect(typeof ret.then).toBe('function');
+      const onFinally = jest.fn();
+
+      expect(ret).toBeInstanceOf(Promise);
+      expect(typeof ret.catch).toBe('function');
+      expect(typeof ret.finally).toBe('function');
       expect(ret._result).toEqual({ default: 'module-42' });
+      await expect(ret.finally(onFinally)).resolves.toEqual({ default: 'module-42' });
+      expect(onFinally).toHaveBeenCalledTimes(1);
     });
 
-    it('exposes a Promise _result when a bundle load was needed', async () => {
+    it('returns a Promise with a Promise _result when a bundle load was needed', async () => {
       process.env.EXPO_OS = 'web';
       mockImportAll
         .mockImplementationOnce(() => {
@@ -244,9 +239,21 @@ describe('asyncRequireModule', () => {
 
       const ret = asyncRequire(42, { '42': '/bundles/my-module.bundle' }, 'my-module');
 
-      expect(typeof ret.then).toBe('function');
+      expect(ret).toBeInstanceOf(Promise);
+      expect(typeof ret.catch).toBe('function');
+      expect(typeof ret.finally).toBe('function');
       expect(ret._result).toBeInstanceOf(Promise);
       await expect(ret._result).resolves.toEqual({ default: 'module-42' });
+    });
+
+    it('supports catching a rejected bundle load', async () => {
+      process.env.EXPO_OS = 'ios';
+      const error = new Error('Bundle load failed');
+      (globalThis as any).__loadBundleAsync = jest.fn(() => Promise.reject(error));
+
+      const ret = asyncRequire(42, { '42': '/bundles/my-module.bundle' }, 'my-module');
+
+      await expect(ret.catch((caughtError: Error) => caughtError)).resolves.toBe(error);
     });
   });
 

--- a/packages/expo/src/async-require/asyncRequireModule.ts
+++ b/packages/expo/src/async-require/asyncRequireModule.ts
@@ -94,30 +94,22 @@ function asyncRequireImpl<T>(
   return importAll();
 }
 
+type PromiseWithResult<T> = Promise<T> & {
+  _result?: T | Promise<T>;
+};
+
 function asyncRequire<T>(
   moduleID: number,
   paths: DependencyMapPaths,
   moduleName?: string
-): PromiseLike<T> & { _result?: T | Promise<T> } {
+): PromiseWithResult<T> {
   const ret = asyncRequireImpl<T>(moduleID, paths, moduleName);
-  if (!(ret instanceof Promise)) {
-    // We return a thenable with an added `unstable_importMaybeSync`-like
-    // `_result` property to bypass this being force-converted to a promise
-    // for rehydration
-    return {
-      _result: ret,
-      then(resolve, reject) {
-        return Promise.resolve(ret).then(resolve, reject);
-      },
-    };
-  } else {
-    return {
-      _result: ret,
-      then(resolve, reject) {
-        return ret.then(resolve, reject);
-      },
-    };
-  }
+  // We return a Promise with an added `unstable_importMaybeSync`-like
+  // `_result` property to bypass this being force-converted to a promise
+  // for rehydration
+  const promise: PromiseWithResult<T> = Promise.resolve(ret);
+  promise._result = ret;
+  return promise;
 }
 
 // Synchronous version of asyncRequire, which can still return a promise


### PR DESCRIPTION
# Why

Regressed in #46539
Resolves #47591

We accidentally provided a thenable for `asyncRequireModule.ts`' return value on `asyncRequire`, which fulfills the requirements we had for `asyncRoutes` and `React.lazy`, but narrowed the shape of plain `import()`s accidentally.

Instead, we should ensure we have the plain `Promise<T> & { _result: T | Promise<T> }` shape, not just `PromiseLike<T>` i.e. a thenable.

# How

- Return plain `Promise.resolve` with `_result` property providing a maybe sync value
- Update tests to assert full Promise shape

# Test Plan

- Manually tested via unit tests; integration/E2E covered via CLI tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
