### PR TITLE
[android][web][symbols] Fixed style prop being ignored on SymbolView

### DIFF
--- a/packages/expo-symbols/CHANGELOG.md
+++ b/packages/expo-symbols/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `style` prop being ignored on `SymbolView`'s non-native fallback. ([#48553](https://github.com/expo/expo/pull/48553) by [@fallmo](https://github.com/fallmo))
+
 ### 💡 Others
 
 - Promote Expo Symbols from beta to stable. ([#48537](https://github.com/expo/expo/pull/48537) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-symbols/src/SymbolView.tsx
+++ b/packages/expo-symbols/src/SymbolView.tsx
@@ -32,17 +32,19 @@ export function SymbolView(props: SymbolViewProps): JSX.Element {
   if (!name) {
     return <>{props.fallback}</>;
   }
+  const size = props.size ?? 24;
+  const style = [{ width: size, height: size }, props.style];
   if (!loaded) {
-    return <View style={{ width: props.size ?? 24, height: props.size ?? 24 }} />;
+    return <View style={style} />;
   }
   return (
-    <View style={{ width: props.size ?? 24, height: props.size ?? 24 }}>
+    <View style={style}>
       <Text
         style={{
           fontFamily: font.name,
           color: props.tintColor ?? DEFAULT_SYMBOL_COLOR,
-          fontSize: props.size ?? 24,
-          lineHeight: props.size ?? 24,
+          fontSize: size,
+          lineHeight: size,
         }}>
         {androidSymbolToString(name)}
       </Text>


### PR DESCRIPTION
# Why

`SymbolView`'s non-native fallback (used on Android and web) hardcodes its wrapper `View`'s
style to `{ width: props.size ?? 24, height: props.size ?? 24 }` and never merges in
`props.style`. Any style override — margin, padding, position, or even an explicit
`width`/`height` — is silently dropped on Android/web, while the identical code works
correctly on iOS (`SymbolView.ios.tsx` already merges `props.style`). This makes it
impossible to lay out a `SymbolView` next to other content (e.g. spacing an icon from a
label) without the layout breaking on Android.

Fixes #48552

# How

Computed `size`/`style` once and merged `props.style` over the default `{ width, height }`,
matching the merge order already used in `SymbolView.ios.tsx`'s `getNativeProps`. Both the
"font not loaded yet" placeholder `View` and the fully rendered `View` now use this same
merged style, so a caller's overrides win consistently in every render path.

# Test Plan

Rendered a `SymbolView` next to a `Text` with `style={{ marginRight: 8 }}`:
- **Before:** margin applied on iOS, ignored on Android (see `android_symbol_bug.jpg`).
- **After:** margin applied identically on both platforms.

Also verified passing an explicit `style={{ width: 40, height: 40 }}` (no `size` prop) now
resizes the icon on Android the same way it already did on iOS.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
