### PR TITLE
[reviewer] Explain why `ai-review` does nothing on PRs from forks

### DIFF
--- a/.github/workflows/expo-code-review-fork-hint.yml
+++ b/.github/workflows/expo-code-review-fork-hint.yml
@@ -1,0 +1,65 @@
+name: AI code review (fork hint)
+
+# Explains, once, why the `ai-review` label did nothing on a PR from a fork.
+#
+# GitHub withholds secrets from `pull_request` runs on a forked PR and downgrades
+# GITHUB_TOKEN to read-only. The auto-review job in expo-code-review.yml therefore
+# cannot reach the model credential, and cannot post a comment to say so — it is the
+# one job that knows the label failed and the one job that cannot report it. Before
+# this workflow existed, labeling an external PR produced a red run and silence.
+#
+# SECURITY: `pull_request_target` normally deserves suspicion, because it hands secrets
+# and a write token to a run triggered by an untrusted PR. That danger comes from
+# checking out and EXECUTING the PR's code. This job does none of that: no checkout, no
+# dependency install, no build, no model, no model credential. It reads two fields off
+# the event payload and posts a fixed string with the default GITHUB_TOKEN. There is no
+# attacker-controlled input anywhere in it — the PR number is an integer from the event,
+# and the body is a literal. It also fires only on `labeled`, so an attacker cannot
+# re-trigger it by pushing.
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ai-code-review-fork-hint-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  hint:
+    # Only the exact `ai-review` label, and only on a PR from a fork. `github.event.label`
+    # is the label just added, so `ai-review:skip` and `ai-review:security` do not match.
+    if: >-
+      ${{ github.event.label.name == 'ai-review'
+      && github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Explain that the label cannot work here
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Post at most once per PR: re-adding the label should not stack up comments.
+          if gh api "repos/$REPO/issues/$PR/comments" --paginate \
+               --jq '.[].body' | grep -q '<!-- expo-ai-code-reviewer:fork-hint -->'; then
+            echo "Hint already posted on #$PR — nothing to do."
+            exit 0
+          fi
+          cat > /tmp/fork-hint.md <<'MARKDOWN'
+          <!-- expo-ai-code-reviewer:fork-hint -->
+          The `ai-review` label does not start a review on a pull request from a fork.
+
+          GitHub does not give secrets to workflow runs triggered by a forked pull
+          request, so the reviewer cannot reach its model credential there. This is a
+          platform rule, not a setting we can change.
+
+          **A maintainer can comment `/review` on this PR instead.** That path runs in
+          the base repository's context, so it has the credential and works normally.
+          MARKDOWN
+          gh pr comment "$PR" --repo "$REPO" --body-file /tmp/fork-hint.md
+          echo "Posted the fork hint on #$PR."

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -32,8 +32,19 @@ jobs:
     # `ai-review:security` are not confused with `ai-review`.
     # This must stay in agreement with config.jsonc `review.trigger: "label"`, which is
     # the real policy — `ecr ci` re-checks it and honors `ai-review:skip` regardless.
+    #
+    # FORKS ARE EXCLUDED, and this is a platform limit, not a preference. GitHub withholds
+    # secrets from `pull_request` runs on a forked PR and downgrades GITHUB_TOKEN to
+    # read-only, so this job cannot reach the model credential AND cannot post a comment —
+    # not even to explain itself. Without this guard, labeling an external PR produced a
+    # failed run and total silence. `expo-code-review-fork-hint.yml` now posts the "use
+    # /review" pointer for that case, and the `/review` command path (issue_comment) is
+    # what actually reviews a fork PR: it runs in base-repo context with full secrets.
     # @ref LLP 0009#guard-step-ordering-and-job-budgets [explains] — spin-up avoidance only; real policy is config.jsonc review.trigger
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ai-review') && !contains(github.event.pull_request.labels.*.name, 'ai-review:skip') }}
+    if: >-
+      ${{ !github.event.pull_request.head.repo.fork
+      && contains(github.event.pull_request.labels.*.name, 'ai-review')
+      && !contains(github.event.pull_request.labels.*.name, 'ai-review:skip') }}
     # Backstop so a stalled review fails fast instead of hanging. This is the ONE cap
     # with no soft landing (GitHub hard-kills the job and nothing is posted), so keep
     # margin over the worst-case internal chain: the passes budget


### PR DESCRIPTION
# Why

Labeling an external PR with `ai-review` starts a run that cannot work and cannot explain itself. Seen on #48556:

```
No Claude credential found: token env "CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN" is not set
CI reviewer: also failed to post the failure notice
gh: Resource not accessible by integration (HTTP 403)
```

You need to run `/review` instead.

# How

- `expo-code-review.yml` now skips forked PRs instead of starting a run that can't finish.
- `expo-code-review-fork-hint.yml` posts a short comment pointing at `/review`, which works on forks because `issue_comment` runs in base-repo context with secrets.

The hint uses `pull_request_target`, normally worth avoiding. That danger comes from checking out and executing PR code with secrets in scope. This job checks out nothing, installs nothing, runs no model, and needs no model credential — it reads two event fields and posts a literal string with the default `GITHUB_TOKEN`. It fires only on `labeled`, so a push can't re-trigger it, posts at most once per PR, and uses a marker distinct from the reviewer's so `ecr ci` never adopts it as its own comment.

# Test Plan

`/review` verified working on external PR #48556 — it posted a full review (Approve, with an accurate Android-only risk summary) where the label had failed minutes earlier.

# Checklist

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)