### PR TITLE
[ci] Declare explicit workflow permissions for stale and sdk-cutoff

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -8,6 +8,15 @@ jobs:
   close-issues:
     if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
+    # actions/stale labels and closes issues with the default GITHUB_TOKEN, so it needs
+    # `issues: write` stated explicitly. It worked until now only because the repository
+    # default was "read and write", which we are moving to read-only.
+    #
+    # `pull-requests: write` is deliberately NOT granted: days-before-pr-stale and
+    # days-before-pr-close are both -1 below, which disables PR handling entirely. Grant
+    # it if those ever change.
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:

--- a/.github/workflows/sdk-cutoff.yml
+++ b/.github/workflows/sdk-cutoff.yml
@@ -10,6 +10,14 @@ on:
 jobs:
   cut-release:
     runs-on: ubuntu-24.04
+    # Stated explicitly because the repository default is moving to read-only. This job
+    # needs both: `contents: write` to push the new sdk-* branch (that push authenticates
+    # with the credentials actions/checkout stores), and `issues: write` for
+    # `gh label create`, which goes through the issues API even though the labels are
+    # applied to pull requests.
+    permissions:
+      contents: write
+      issues: write
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
# Why

`issue-stale.yml` and `sdk-cutoff.yml` write with the default `GITHUB_TOKEN` but declare no `permissions:` block, so they work only because the repo default is "read and write". We changed default org permissions to read.

# Checklist

- [ ] `changelog.md` entry — n/a, CI only
- [ ] Works for `npx expo prebuild` & EAS Build — n/a
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)