### PR TITLE
[router] Isolate `LoaderSuspenseStore` from `LoaderClient`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Rewrite native tabs using standard-navigation ([#46457](https://github.com/expo/expo/pull/46457) by [@Ubax](https://github.com/Ubax))
 - [Internal] Split `useLoaderData()` into a document cache and a per-mount Suspense store ([#47365](https://github.com/expo/expo/pull/47365) by [@hassankhan](https://github.com/hassankhan))
 - [Internal] Read the development server URL from `expo/internal/bundle-origin` instead of duplicating its accessor ([#48278](https://github.com/expo/expo/pull/48278) by [@kitten](https://github.com/kitten))
+- [Internal] Isolate the loader's Suspense store from `LoaderClient` ([#48563](https://github.com/expo/expo/pull/48563) by [@hassankhan](https://github.com/hassankhan))
 
 ## 57.0.9 - 2026-07-29
 

--- a/packages/expo-router/oxlint.config.mjs
+++ b/packages/expo-router/oxlint.config.mjs
@@ -4,6 +4,17 @@ import { defineConfig } from 'oxlint';
 export default defineConfig({
   extends: [base],
   ignorePatterns: base.ignorePatterns,
+  overrides: [
+    {
+      files: ['src/loaders/LoaderClient.ts'],
+      rules: {
+        'no-restricted-imports': [
+          'error',
+          { patterns: ['./LoaderSuspenseStore', './LoaderSuspenseStore.*'] },
+        ],
+      },
+    },
+  ],
   rules: {
     'import/no-cycle': 'error',
     // expo-router passes `children` via props in a number of places (notably tests); accepted here.

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -5,7 +5,12 @@ import { Text } from 'react-native';
 
 import { router, Slot } from '../../exports';
 import Tabs from '../../layouts/Tabs';
-import { defaultLoaderClient, LoaderClient, LoaderClientContext } from '../../loaders/LoaderClient';
+import { LoaderClient } from '../../loaders/LoaderClient';
+import {
+  createLoaderContextValue,
+  defaultLoaderContextValue,
+  LoaderContext,
+} from '../../loaders/LoaderContext';
 import { ServerDataLoaderContext } from '../../loaders/ServerDataLoaderContext';
 import { fetchLoader } from '../../loaders/utils';
 import { renderRouter } from '../../testing-library';
@@ -32,20 +37,31 @@ describe(useLoaderData, () => {
   afterEach(() => {
     global.window = originalWindow;
     delete globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    defaultLoaderClient.clear();
+    defaultLoaderContextValue.client.clear();
+    defaultLoaderContextValue.store.reset();
   });
 
   it.each([
     { route: 'index', initialUrl: '/', expectedPath: '/index' },
-    { route: 'users/index', initialUrl: '/users', expectedPath: '/users/index' },
+    {
+      route: 'users/index',
+      initialUrl: '/users',
+      expectedPath: '/users/index',
+    },
     { route: '(group)/index', initialUrl: '/', expectedPath: '/(group)/index' },
-    { route: 'users/[id]', initialUrl: '/users/123', expectedPath: '/users/123' },
+    {
+      route: 'users/[id]',
+      initialUrl: '/users/123',
+      expectedPath: '/users/123',
+    },
   ])('resolves $route to $expectedPath', ({ route, initialUrl, expectedPath }) => {
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
       [expectedPath]: { correct: true },
     };
 
-    const { result } = renderHook(() => useLoaderData(), [route], { initialUrl });
+    const { result } = renderHook(() => useLoaderData(), [route], {
+      initialUrl,
+    });
 
     expect(result.current).toEqual({ correct: true });
   });
@@ -103,45 +119,33 @@ describe(useLoaderData, () => {
     expect(result.current).toEqual({ source: 'server' });
   });
 
-  it('consumes server-injected data from `globalThis.__EXPO_ROUTER_LOADER_DATA__` once', () => {
-    globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
-      '/index': { some: 'data' },
-    };
-
-    const { result } = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-    });
-
-    expect(result.current).toEqual({ some: 'data' });
-    expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).not.toHaveProperty('/index');
-  });
-
-  it('fetches on a later remount once the hydrated entry is gone', async () => {
+  it('consumes hydration once and fetches on a later remount after reclamation', async () => {
     const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
     fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
       '/index': { fromHydration: true },
     };
 
-    const client = new LoaderClient();
-    const ClientWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderClientContext value={client}>{children}</LoaderClientContext>
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
     );
 
     const firstMount = renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
-      wrapper: ClientWrapper,
+      wrapper: LoaderWrapper,
     });
     expect(firstMount.result.current).toEqual({ fromHydration: true });
+    expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).not.toHaveProperty('/index');
     expect(fetchLoaderMock).not.toHaveBeenCalled();
 
     firstMount.unmount();
     await act(async () => {});
-    expect(client.suspense.get('/index')).toBeUndefined();
+    expect(loaderContextValue.store.get('/index')).toBeUndefined();
 
     renderHook(() => useLoaderData(), ['index'], {
       initialUrl: '/',
-      wrapper: ClientWrapper,
+      wrapper: LoaderWrapper,
     });
     expect(fetchLoaderMock).toHaveBeenCalledTimes(1);
     expect(fetchLoaderMock).toHaveBeenCalledWith('/index');
@@ -155,15 +159,14 @@ describe(useLoaderData, () => {
       '/': { home: true },
     };
 
-    const client = new LoaderClient();
-
-    const ClientWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderClientContext value={client}>{children}</LoaderClientContext>
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
     );
 
     renderHook(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
-      wrapper: ClientWrapper,
+      wrapper: LoaderWrapper,
     });
 
     expect(fetchLoaderMock).toHaveBeenCalledWith('/users/123');
@@ -172,28 +175,167 @@ describe(useLoaderData, () => {
       await fetchLoaderMock.mock.results[0]!.value;
     });
 
-    expect(client.suspense.get('/users/123')).toEqual({ data: { fromFetch: true } });
+    expect(loaderContextValue.store.get('/users/123')).toEqual({
+      data: { fromFetch: true },
+    });
   });
 
   it('retrieves settled data from the Suspense store without fetching', () => {
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
-      '/': { home: true },
+      '/users/123': { fromHydration: true },
     };
 
-    const client = new LoaderClient();
-    client.suspense.set('/users/123', { data: { fromStore: true } });
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    loaderContextValue.store.set('/users/123', { data: { fromStore: true } });
 
-    const ClientWrapper = ({ children }: { children: React.ReactNode }) => (
-      <LoaderClientContext value={client}>{children}</LoaderClientContext>
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
     );
 
     const { result } = renderHook(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
-      wrapper: ClientWrapper,
+      wrapper: LoaderWrapper,
     });
 
     expect(result.current).toEqual({ fromStore: true });
+    expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).not.toHaveProperty('/users/123');
     expect(fetchLoader).not.toHaveBeenCalled();
+  });
+
+  it('keeps custom client/store pairs isolated for the same route', () => {
+    const firstValue = createLoaderContextValue(new LoaderClient());
+    const secondValue = createLoaderContextValue(new LoaderClient());
+    firstValue.store.set('/index', { data: { owner: 'first' } });
+    secondValue.store.set('/index', { data: { owner: 'second' } });
+
+    const FirstWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={firstValue}>{children}</LoaderContext>
+    );
+    const SecondWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={secondValue}>{children}</LoaderContext>
+    );
+
+    const first = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: FirstWrapper,
+    });
+    const second = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: SecondWrapper,
+    });
+
+    expect(first.result.current).toEqual({ owner: 'first' });
+    expect(second.result.current).toEqual({ owner: 'second' });
+  });
+
+  it('reuses a hydrated entry across a same-tick Strict Mode remount', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    loaderContextValue.store.seed('/index', { hydrated: true });
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
+    );
+
+    const first = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+    first.unmount();
+    const remount = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+    await act(async () => {});
+
+    expect(remount.result.current).toEqual({ hydrated: true });
+    expect(loaderContextValue.store.get('/index')).toEqual({
+      data: { hydrated: true },
+    });
+    expect(fetchLoaderMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps a shared entry while a sibling reader remains mounted', async () => {
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    loaderContextValue.store.seed('/index', { shared: true });
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
+    );
+
+    const first = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+    const second = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+
+    first.unmount();
+    await act(async () => {});
+    expect(second.result.current).toEqual({ shared: true });
+    expect(loaderContextValue.store.get('/index')).toEqual({
+      data: { shared: true },
+    });
+
+    second.unmount();
+    await act(async () => {});
+    expect(loaderContextValue.store.get('/index')).toBeUndefined();
+  });
+
+  it('refreshes a live entry in place during HMR coordination', async () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockResolvedValueOnce({ version: 2 });
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    loaderContextValue.store.seed('/index', { version: 1 });
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
+    );
+    const hook = renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+
+    act(() => {
+      const { client, store } = loaderContextValue;
+      store.retain(client.revalidate());
+      client.notify();
+    });
+
+    expect(hook.result.current).toEqual({ version: 1 });
+    await act(async () => {
+      await fetchLoaderMock.mock.results[0]!.value;
+    });
+    expect(hook.result.current).toEqual({ version: 2 });
+    expect(loaderContextValue.store.get('/index')).toEqual({
+      data: { version: 2 },
+    });
+  });
+
+  it('clears inactive entries while retaining live entries during HMR coordination', () => {
+    const fetchLoaderMock = fetchLoader as jest.MockedFunction<typeof fetchLoader>;
+    fetchLoaderMock.mockImplementation(() => new Promise(() => {}));
+    const loaderContextValue = createLoaderContextValue(new LoaderClient());
+    loaderContextValue.store.seed('/index', { live: true });
+    loaderContextValue.store.seed('/inactive', { stale: true });
+    const LoaderWrapper = ({ children }: { children: React.ReactNode }) => (
+      <LoaderContext value={loaderContextValue}>{children}</LoaderContext>
+    );
+    renderHook(() => useLoaderData(), ['index'], {
+      initialUrl: '/',
+      wrapper: LoaderWrapper,
+    });
+
+    act(() => {
+      const { client, store } = loaderContextValue;
+      store.retain(client.revalidate());
+      client.notify();
+    });
+
+    expect(loaderContextValue.store.get('/index')).toEqual({
+      data: { live: true },
+    });
+    expect(loaderContextValue.store.get('/inactive')).toBeUndefined();
   });
 
   it(`uses the loader function's return types`, () => {
@@ -250,7 +392,9 @@ describe(useLoaderData, () => {
 
     act(() => router.push('/profile'));
 
-    expect(profileResults[profileResults.length - 1]).toEqual({ tab: 'profile' });
+    expect(profileResults[profileResults.length - 1]).toEqual({
+      tab: 'profile',
+    });
     // Home screen should still be showing its own results
     expect(homeResults[homeResults.length - 1]).toEqual({ tab: 'home' });
   });

--- a/packages/expo-router/src/hooks/useLoaderData.ts
+++ b/packages/expo-router/src/hooks/useLoaderData.ts
@@ -5,7 +5,7 @@ import { use, useEffect, useMemo, useSyncExternalStore } from 'react';
 
 import { useContextKey } from '../Route';
 import { getRouteInfoFromState } from '../global-state/getRouteInfoFromState';
-import { LoaderClientContext } from '../loaders/LoaderClient';
+import { LoaderContext } from '../loaders/LoaderContext';
 import { ServerDataLoaderContext } from '../loaders/ServerDataLoaderContext';
 import { readLoaderData } from '../loaders/readLoaderData';
 import { fetchLoader } from '../loaders/utils';
@@ -34,14 +34,16 @@ type LoaderFunctionResult<T extends LoaderFunction<any>> =
  * }
  */
 export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunctionResult<T> {
+  const ctx = use(LoaderContext);
   const serverDataLoaderContext = use(ServerDataLoaderContext);
-  const loaderClient = use(LoaderClientContext);
+
+  const { client, store } = ctx;
 
   // Subscribe before any early returns so a later `loader-invalidate` re-renders this hook even
   // when the initial render was satisfied by `ServerDataLoaderContext` or `__EXPO_ROUTER_LOADER_DATA__`.
   // Returning early before subscribing would also change hook order on the next render once
   // invalidation deletes the injected global.
-  useSyncExternalStore(loaderClient.subscribe, loaderClient.getSnapshot, loaderClient.getSnapshot);
+  useSyncExternalStore(client.subscribe, client.getSnapshot, client.getSnapshot);
 
   const stateForPath = useStateForPath();
   const contextKey = useContextKey();
@@ -58,13 +60,17 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
   useEffect(() => {
     // Hydration-seeded routes never reach a read miss, so invalidation can't refetch them
     // without a registered fetcher.
-    loaderClient.registerFetcher(resolvedPath, fetchLoader);
-    const unsubscribe = loaderClient.subscribeLoader(resolvedPath);
+    client.registerFetcher(resolvedPath, fetchLoader);
+    const unsubscribe = client.subscribeLoader(resolvedPath, (result, isCurrentSource) => {
+      if (isCurrentSource) {
+        store.set(resolvedPath, result);
+      }
+    });
     return () => {
-      loaderClient.suspense.dispose(resolvedPath);
-      unsubscribe();
+      store.dispose(resolvedPath);
+      unsubscribe(() => store.teardown(resolvedPath));
     };
-  }, [loaderClient, resolvedPath]);
+  }, [client, resolvedPath, store]);
 
   // First invocation of this hook will happen server-side, so we look up the loaded data from context
   if (serverDataLoaderContext) {
@@ -73,8 +79,12 @@ export function useLoaderData<T extends LoaderFunction<any> = any>(): LoaderFunc
 
   // The second invocation happens after the client has hydrated, so we seed the suspense store
   // with the preloaded data from `globalThis.__EXPO_ROUTER_LOADER_DATA__`
-  loaderClient.consumeHydrationData(resolvedPath);
+  const hydrationData = globalThis.__EXPO_ROUTER_LOADER_DATA__;
+  if (hydrationData && resolvedPath in hydrationData) {
+    store.seed(resolvedPath, hydrationData[resolvedPath]);
+    delete hydrationData[resolvedPath];
+  }
 
-  const result = readLoaderData<LoaderFunctionResult<T>>(loaderClient, resolvedPath, fetchLoader);
+  const result = readLoaderData<LoaderFunctionResult<T>>(ctx, resolvedPath, fetchLoader);
   return result instanceof Promise ? use(result) : result;
 }

--- a/packages/expo-router/src/loaders/LoaderClient.ts
+++ b/packages/expo-router/src/loaders/LoaderClient.ts
@@ -1,25 +1,25 @@
-import { createContext } from 'react';
-
-import { LoaderSuspenseStore } from './LoaderSuspenseStore';
-import { bumpDevLoaderRevision } from './utils';
-
 type LoaderFetcher = (path: string) => Promise<unknown>;
-type LoaderResult = { data: unknown } | { error: unknown };
-type LoaderSubscriber = (result: LoaderResult) => void;
+export type LoaderResult = { data: unknown } | { error: unknown };
+type LoaderSubscriber = (result: LoaderResult, isCurrentSource: boolean) => void;
+export type LoaderUnsubscribe = (onSourceTeardown?: () => void) => void;
 
 interface LoaderSource {
   subscribers: Set<LoaderSubscriber>;
-  fetching: boolean;
-  ending: boolean;
+  isFetching: boolean;
+  onTeardown?: () => void;
 }
 
+/**
+ * Coordinates loader execution, deduplication, and source subscriptions.
+ *
+ * Suspense state belongs to the React integration layer; this client must not access or mutate
+ * `LoaderSuspenseStore`.
+ */
 export class LoaderClient {
   private active = new Map<string, LoaderSource>();
   private fetchers = new Map<string, LoaderFetcher>();
   private version = 0;
   private listeners = new Set<() => void>();
-
-  readonly suspense = new LoaderSuspenseStore();
 
   // Arrow-bound so `loaderClient.subscribe` returns a stable reference across renders,
   // which keeps `useSyncExternalStore()` from tearing down and re-attaching every render.
@@ -41,24 +41,24 @@ export class LoaderClient {
     }
   }
 
-  subscribeLoader(path: string, callback: LoaderSubscriber = () => {}): () => void {
+  subscribeLoader(path: string, callback: LoaderSubscriber = () => {}): LoaderUnsubscribe {
     let source = this.active.get(path);
     if (!source) {
-      source = { subscribers: new Set(), fetching: false, ending: false };
+      source = { subscribers: new Set(), isFetching: false };
       this.active.set(path, source);
     }
-    source.ending = false;
+    source.onTeardown = undefined;
     source.subscribers.add(callback);
 
     let subscribed = true;
-    return () => {
+    return (onSourceTeardown) => {
       if (!subscribed) {
         return;
       }
       subscribed = false;
       source.subscribers.delete(callback);
       if (source.subscribers.size === 0) {
-        this.scheduleTeardown(path, source);
+        this.scheduleTeardown(path, source, onSourceTeardown);
       }
     };
   }
@@ -73,87 +73,60 @@ export class LoaderClient {
     }
     const source = this.active.get(path);
     const fetcherFn = this.fetchers.get(path);
-    if (!source || !fetcherFn || source.fetching) {
+    if (!source || !fetcherFn || source.isFetching) {
       return;
     }
 
-    source.fetching = true;
+    source.isFetching = true;
     fetcherFn(path).then(
       (data) => this.settle(path, source, { data }),
       (error) =>
         this.settle(path, source, {
-          error: new Error(`Failed to load loader data for route: ${path}`, { cause: error }),
+          error: new Error(`Failed to load loader data for route: ${path}`, {
+            cause: error,
+          }),
         })
     );
   }
 
-  invalidateAll() {
+  revalidate(): ReadonlySet<string> {
+    const livePaths = new Set<string>();
     for (const [path, source] of this.active) {
       if (source.subscribers.size > 0) {
+        livePaths.add(path);
         this.execute(path);
       }
     }
-    for (const path of this.suspense.keys()) {
-      const source = this.active.get(path);
-      if (!source || source.subscribers.size === 0) {
-        this.suspense.clear(path);
-      }
-    }
-    this.notify();
-  }
-
-  consumeHydrationData(path: string) {
-    const hydrationData = globalThis.__EXPO_ROUTER_LOADER_DATA__;
-    if (!hydrationData || !(path in hydrationData)) {
-      return;
-    }
-
-    this.suspense.seed(path, hydrationData[path]);
-    delete hydrationData[path];
+    return livePaths;
   }
 
   clear() {
     this.active.clear();
     this.fetchers.clear();
-    this.suspense.reset();
   }
 
-  private scheduleTeardown(path: string, source: LoaderSource) {
-    source.ending = true;
-    queueMicrotask(() => {
-      if (source.ending && source.subscribers.size === 0 && this.active.get(path) === source) {
+  private scheduleTeardown(path: string, source: LoaderSource, onSourceTeardown?: () => void) {
+    const onTeardown = () => {
+      if (
+        source.onTeardown === onTeardown &&
+        source.subscribers.size === 0 &&
+        this.active.get(path) === source
+      ) {
         this.active.delete(path);
-        this.suspense.teardown(path);
+        source.onTeardown = undefined;
+        onSourceTeardown?.();
       }
-    });
+    };
+    source.onTeardown = onTeardown;
+    queueMicrotask(onTeardown);
   }
 
   private settle(path: string, source: LoaderSource, result: LoaderResult) {
-    source.fetching = false;
-    if (this.active.get(path) === source) {
-      this.suspense.set(path, result);
-    }
+    source.isFetching = false;
+    const isCurrentSource = this.active.get(path) === source;
     for (const subscriber of source.subscribers) {
-      subscriber(result);
+      subscriber(result, isCurrentSource);
     }
     this.notify();
-  }
-}
-
-export const defaultLoaderClient = new LoaderClient();
-export const LoaderClientContext = createContext<LoaderClient>(defaultLoaderClient);
-
-// On `loader-invalidate`, drop any unconsumed server-injected data, bump the dev revision so
-// refetches bypass the platform cache, and refresh live readers in place.
-if (__DEV__ && typeof window !== 'undefined') {
-  globalThis.__EXPO_LOADER_INVALIDATE_LISTENERS__ ??= [];
-
-  if (!globalThis.__EXPO_LOADER_INVALIDATE_LISTENER_REGISTERED__) {
-    globalThis.__EXPO_LOADER_INVALIDATE_LISTENER_REGISTERED__ = true;
-    globalThis.__EXPO_LOADER_INVALIDATE_LISTENERS__.push(() => {
-      delete globalThis.__EXPO_ROUTER_LOADER_DATA__;
-      bumpDevLoaderRevision();
-      defaultLoaderClient.invalidateAll();
-    });
   }
 }

--- a/packages/expo-router/src/loaders/LoaderContext.ts
+++ b/packages/expo-router/src/loaders/LoaderContext.ts
@@ -1,0 +1,35 @@
+import { createContext } from 'react';
+
+import { LoaderClient } from './LoaderClient';
+import { LoaderSuspenseStore } from './LoaderSuspenseStore';
+import { bumpDevLoaderRevision } from './utils';
+
+export interface LoaderContextValue {
+  client: LoaderClient;
+  store: LoaderSuspenseStore;
+}
+
+export function createLoaderContextValue(client: LoaderClient): LoaderContextValue {
+  return { client, store: new LoaderSuspenseStore() };
+}
+
+export const defaultLoaderContextValue = createLoaderContextValue(new LoaderClient());
+export const LoaderContext = createContext<LoaderContextValue>(defaultLoaderContextValue);
+
+// On `loader-invalidate`, drop any unconsumed server-injected data, bump the dev revision so
+// refetches bypass the platform cache, and refresh live readers in place.
+if (__DEV__ && typeof window !== 'undefined') {
+  globalThis.__EXPO_LOADER_INVALIDATE_LISTENERS__ ??= [];
+
+  if (!globalThis.__EXPO_LOADER_INVALIDATE_LISTENER_REGISTERED__) {
+    globalThis.__EXPO_LOADER_INVALIDATE_LISTENER_REGISTERED__ = true;
+    globalThis.__EXPO_LOADER_INVALIDATE_LISTENERS__.push(() => {
+      delete globalThis.__EXPO_ROUTER_LOADER_DATA__;
+      bumpDevLoaderRevision();
+
+      const { client, store } = defaultLoaderContextValue;
+      store.retain(client.revalidate());
+      client.notify();
+    });
+  }
+}

--- a/packages/expo-router/src/loaders/LoaderSuspenseStore.ts
+++ b/packages/expo-router/src/loaders/LoaderSuspenseStore.ts
@@ -1,5 +1,11 @@
 type SuspenseEntry = { data: unknown } | { error: unknown } | Promise<unknown>;
 
+/**
+ * Stores pending and settled loader reads for React Suspense.
+ *
+ * Disposal marks an entry reclaimable, teardown confirms its removal, and a replacement written
+ * between them cancels reclamation.
+ */
 export class LoaderSuspenseStore {
   private entries = new Map<string, SuspenseEntry>();
   private reclaim = new Set<string>();
@@ -34,8 +40,12 @@ export class LoaderSuspenseStore {
     }
   }
 
-  keys(): string[] {
-    return [...this.entries.keys()];
+  retain(livePaths: ReadonlySet<string>) {
+    for (const path of this.entries.keys()) {
+      if (!livePaths.has(path)) {
+        this.clear(path);
+      }
+    }
   }
 
   reset() {

--- a/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderClient.test.ts
@@ -3,10 +3,6 @@ import { LoaderClient } from '../LoaderClient';
 const tick = () => Promise.resolve();
 
 describe(LoaderClient, () => {
-  afterEach(() => {
-    delete globalThis.__EXPO_ROUTER_LOADER_DATA__;
-  });
-
   describe('notify', () => {
     it('bumps the version and wakes subscribers', () => {
       const client = new LoaderClient();
@@ -22,59 +18,42 @@ describe(LoaderClient, () => {
   });
 
   describe('subscribeLoader + execute', () => {
-    it('fetches once and settles the result into the store', async () => {
+    it('shares one in-flight fetch and delivers it to every subscriber before notifying', async () => {
       const client = new LoaderClient();
       const fetcher = jest.fn(async () => 'v1');
-      const results: unknown[] = [];
+      const events: unknown[] = [];
+      client.subscribeLoader('/p', (result, isCurrentSource) => {
+        events.push(['first', result, isCurrentSource]);
+      });
+      client.subscribeLoader('/p', (result, isCurrentSource) => {
+        events.push(['second', result, isCurrentSource]);
+      });
+      client.subscribe(() => events.push('notify'));
 
-      client.subscribeLoader('/p', (result) => results.push(result));
-      client.execute('/p', fetcher);
-      await tick();
-
-      expect(fetcher).toHaveBeenCalledTimes(1);
-      expect(results).toEqual([{ data: 'v1' }]);
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
-    });
-
-    it('shares one in-flight execution between concurrent execute calls', async () => {
-      const client = new LoaderClient();
-      const fetcher = jest.fn(async () => 'v1');
-
-      client.subscribeLoader('/p');
       client.execute('/p', fetcher);
       client.execute('/p', fetcher);
       await tick();
 
       expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(events).toEqual([
+        ['first', { data: 'v1' }, true],
+        ['second', { data: 'v1' }, true],
+        'notify',
+      ]);
     });
 
-    it('does not execute on subscribe alone', () => {
+    it('does not execute a fetcher for a path without a source', () => {
       const client = new LoaderClient();
       const fetcher = jest.fn(async () => 'v1');
 
-      client.subscribeLoader('/p');
-      client.execute('/other', fetcher);
+      client.execute('/p', fetcher);
 
       expect(fetcher).not.toHaveBeenCalled();
     });
 
-    it('pushes the result to every subscriber', async () => {
-      const client = new LoaderClient();
-      const first = jest.fn();
-      const second = jest.fn();
-
-      client.subscribeLoader('/p', first);
-      client.subscribeLoader('/p', second);
-      client.execute('/p', async () => 'v1');
-      await tick();
-
-      expect(first).toHaveBeenCalledWith({ data: 'v1' });
-      expect(second).toHaveBeenCalledWith({ data: 'v1' });
-    });
-
     it('wraps fetch rejections with the route path', async () => {
       const client = new LoaderClient();
-      const results: any[] = [];
+      const results: ({ data: unknown } | { error: unknown })[] = [];
 
       client.subscribeLoader('/err', (result) => results.push(result));
       client.execute('/err', async () => {
@@ -82,67 +61,19 @@ describe(LoaderClient, () => {
       });
       await tick();
 
-      expect(results[0].error.message).toBe('Failed to load loader data for route: /err');
-      expect(results[0].error.cause.message).toBe('boom');
-      expect(client.suspense.get('/err')).toEqual({ error: results[0].error });
-    });
-  });
-
-  describe('teardown', () => {
-    it('tears down a disposed entry after the last unsubscribe', async () => {
-      const client = new LoaderClient();
-      client.suspense.set('/p', { data: 'v1' });
-
-      const unsubscribe = client.subscribeLoader('/p');
-      client.suspense.dispose('/p');
-      unsubscribe();
-      await tick();
-
-      expect(client.suspense.get('/p')).toBeUndefined();
+      const result = results[0];
+      expect(result).toEqual({ error: expect.any(Error) });
+      const error = (result as { error: Error }).error;
+      expect(error.message).toBe('Failed to load loader data for route: /err');
+      expect(error.cause).toEqual(new Error('boom'));
     });
 
-    it('keeps an undisposed entry across teardown', async () => {
-      const client = new LoaderClient();
-      client.suspense.set('/p', { data: 'v1' });
-
-      const unsubscribe = client.subscribeLoader('/p');
-      unsubscribe();
-      await tick();
-
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
-    });
-
-    it('keeps the entry while another subscriber holds the source', async () => {
-      const client = new LoaderClient();
-      client.suspense.set('/p', { data: 'v1' });
-
-      const first = client.subscribeLoader('/p');
-      client.subscribeLoader('/p');
-      client.suspense.dispose('/p');
-      first();
-      await tick();
-
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
-    });
-
-    it('cancels the teardown when a subscriber returns within the same tick (Strict Mode safe)', async () => {
-      const client = new LoaderClient();
-      client.suspense.set('/p', { data: 'v1' });
-
-      const unsubscribe = client.subscribeLoader('/p');
-      client.suspense.dispose('/p');
-      unsubscribe();
-      client.subscribeLoader('/p');
-      await tick();
-
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
-    });
-
-    it('does not settle into the store after the source is torn down', async () => {
+    it('marks results from a cleared source as stale', async () => {
       const client = new LoaderClient();
       let resolveFetch!: (value: string) => void;
+      const subscriber = jest.fn();
 
-      const unsubscribe = client.subscribeLoader('/p');
+      client.subscribeLoader('/p', subscriber);
       client.execute(
         '/p',
         () =>
@@ -150,118 +81,160 @@ describe(LoaderClient, () => {
             resolveFetch = resolve;
           })
       );
-      client.suspense.dispose('/p');
+      client.clear();
+      resolveFetch('stale');
+      await tick();
+
+      expect(subscriber).toHaveBeenCalledWith({ data: 'stale' }, false);
+    });
+  });
+
+  describe('teardown', () => {
+    it('calls onTearDown after the last unsubscribe', async () => {
+      const client = new LoaderClient();
+      const onTearDown = jest.fn();
+      const unsubscribe = client.subscribeLoader('/p');
+
+      unsubscribe(onTearDown);
+      expect(onTearDown).not.toHaveBeenCalled();
+      await tick();
+
+      expect(onTearDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onTearDown while a sibling subscriber remains', async () => {
+      const client = new LoaderClient();
+      const onTearDown = jest.fn();
+      const first = client.subscribeLoader('/p');
+      client.subscribeLoader('/p');
+
+      first(onTearDown);
+      await tick();
+
+      expect(onTearDown).not.toHaveBeenCalled();
+    });
+
+    it('cancels a pending onTearDown on remount and does not retain it for later teardown', async () => {
+      const client = new LoaderClient();
+      const cancelledOnTearDown = jest.fn();
+      const laterOnTearDown = jest.fn();
+      const first = client.subscribeLoader('/p');
+
+      first(cancelledOnTearDown);
+      const second = client.subscribeLoader('/p');
+      await tick();
+
+      expect(cancelledOnTearDown).not.toHaveBeenCalled();
+      second(laterOnTearDown);
+      await tick();
+
+      expect(cancelledOnTearDown).not.toHaveBeenCalled();
+      expect(laterOnTearDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let a cancelled attempt run a later teardown with the same onTearDown', async () => {
+      const client = new LoaderClient();
+      const events: string[] = [];
+      const onTearDown = () => events.push('onTearDown');
+      const first = client.subscribeLoader('/p');
+
+      first(onTearDown);
+      const second = client.subscribeLoader('/p');
+      queueMicrotask(() => events.push('between'));
+      second(onTearDown);
+      await tick();
+
+      expect(events).toEqual(['between', 'onTearDown']);
+    });
+
+    it('does not deliver a result after the subscriber tears down', async () => {
+      const client = new LoaderClient();
+      let resolveFetch!: (value: string) => void;
+      const subscriber = jest.fn();
+
+      const unsubscribe = client.subscribeLoader('/p', subscriber);
+      client.execute(
+        '/p',
+        () =>
+          new Promise<string>((resolve) => {
+            resolveFetch = resolve;
+          })
+      );
       unsubscribe();
       await tick();
 
       resolveFetch('stale');
       await tick();
 
-      expect(client.suspense.get('/p')).toBeUndefined();
+      expect(subscriber).not.toHaveBeenCalled();
     });
   });
 
-  describe('invalidateAll', () => {
-    it('re-executes paths with live subscribers and replaces the entry in place', async () => {
+  describe('revalidate', () => {
+    it('re-executes paths with live subscribers and returns their paths', async () => {
       const client = new LoaderClient();
       const fetcher = jest
         .fn<Promise<string>, [string]>()
         .mockResolvedValueOnce('v1')
         .mockResolvedValueOnce('v2');
+      const results: unknown[] = [];
 
-      client.subscribeLoader('/p');
+      client.subscribeLoader('/p', (result) => results.push(result));
       client.execute('/p', fetcher);
       await tick();
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
 
-      client.invalidateAll();
-      expect(client.suspense.get('/p')).toEqual({ data: 'v1' });
-
+      const inactive = client.subscribeLoader('/inactive');
+      const inactiveFetcher = jest.fn(async () => 'unused');
+      client.registerFetcher('/inactive', inactiveFetcher);
+      inactive();
+      const livePaths = client.revalidate();
       await tick();
-      expect(client.suspense.get('/p')).toEqual({ data: 'v2' });
+
+      expect(livePaths).toEqual(new Set(['/p']));
+      expect(results).toEqual([{ data: 'v1' }, { data: 'v2' }]);
       expect(fetcher).toHaveBeenCalledTimes(2);
+      expect(inactiveFetcher).not.toHaveBeenCalled();
     });
 
-    it('re-executes a hydration-seeded live path via its registered fetcher', async () => {
+    it('re-executes a registered fetcher for a live hydration-seeded path', async () => {
       const client = new LoaderClient();
       const fetcher = jest.fn(async () => 'post-edit');
-      client.suspense.seed('/index', 'seeded');
+      const subscriber = jest.fn();
 
-      client.subscribeLoader('/index');
+      client.subscribeLoader('/index', subscriber);
       client.registerFetcher('/index', fetcher);
-      client.invalidateAll();
+      const livePaths = client.revalidate();
       await tick();
 
+      expect(livePaths).toEqual(new Set(['/index']));
       expect(fetcher).toHaveBeenCalledTimes(1);
-      expect(client.suspense.get('/index')).toEqual({ data: 'post-edit' });
-    });
-
-    it('clears entries without live subscribers', () => {
-      const client = new LoaderClient();
-      client.suspense.set('/p', { data: 'v1' });
-
-      client.invalidateAll();
-
-      expect(client.suspense.get('/p')).toBeUndefined();
-    });
-
-    it('wakes subscribers', () => {
-      const client = new LoaderClient();
-      const listener = jest.fn();
-      client.subscribe(listener);
-      const before = client.getSnapshot();
-
-      client.invalidateAll();
-
-      expect(client.getSnapshot()).toBe(before + 1);
-      expect(listener).toHaveBeenCalledTimes(1);
+      expect(subscriber).toHaveBeenCalledWith({ data: 'post-edit' }, true);
     });
   });
 
   describe('clear', () => {
-    it('drops sources and resets the Suspense store', () => {
+    it('drops sources and registered fetchers', () => {
       const client = new LoaderClient();
       const fetcher = jest.fn(async () => 'v1');
       client.subscribeLoader('/p');
-      client.suspense.set('/p', { data: 'v1' });
+      client.registerFetcher('/p', fetcher);
 
       client.clear();
-      client.execute('/p', fetcher);
+      client.execute('/p');
 
-      expect(client.suspense.get('/p')).toBeUndefined();
       expect(fetcher).not.toHaveBeenCalled();
     });
-  });
 
-  describe('consumeHydrationData', () => {
-    it('lifts the server-injected value into the Suspense store and deletes the global key', () => {
+    it('cancels a pending onTearDown', async () => {
       const client = new LoaderClient();
-      globalThis.__EXPO_ROUTER_LOADER_DATA__ = { '/index': { seeded: true } };
+      const onTearDown = jest.fn();
+      const unsubscribe = client.subscribeLoader('/p');
 
-      client.consumeHydrationData('/index');
+      unsubscribe(onTearDown);
+      client.clear();
+      await tick();
 
-      expect(client.suspense.get('/index')).toEqual({ data: { seeded: true } });
-      expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).not.toHaveProperty('/index');
-    });
-
-    it('does not replace an existing Suspense entry (set-if-absent)', () => {
-      const client = new LoaderClient();
-      client.suspense.set('/index', { data: 'existing' });
-      globalThis.__EXPO_ROUTER_LOADER_DATA__ = { '/index': 'seed' };
-
-      client.consumeHydrationData('/index');
-
-      expect(client.suspense.get('/index')).toEqual({ data: 'existing' });
-    });
-
-    it('is a no-op when no hydration data exists for the path', () => {
-      const client = new LoaderClient();
-      globalThis.__EXPO_ROUTER_LOADER_DATA__ = { '/other': 'value' };
-
-      client.consumeHydrationData('/index');
-
-      expect(client.suspense.get('/index')).toBeUndefined();
-      expect(globalThis.__EXPO_ROUTER_LOADER_DATA__).toHaveProperty('/other');
+      expect(onTearDown).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/LoaderSuspenseStore.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/LoaderSuspenseStore.test.ts
@@ -32,32 +32,20 @@ describe(LoaderSuspenseStore, () => {
     expect(store.get('/p')).toBeUndefined();
   });
 
-  it('does not remove an entry on dispose alone', () => {
+  it('removes entries only after both disposal and teardown', () => {
     const store = new LoaderSuspenseStore();
-    store.set('/p', { data: 'v1' });
+    store.set('/disposed', { data: 'disposed' });
+    store.set('/torn-down', { data: 'torn-down' });
+    store.set('/reclaimed', { data: 'reclaimed' });
 
-    store.dispose('/p');
+    store.dispose('/disposed');
+    store.teardown('/torn-down');
+    store.dispose('/reclaimed');
+    store.teardown('/reclaimed');
 
-    expect(store.get('/p')).toEqual({ data: 'v1' });
-  });
-
-  it('does not remove an entry on teardown alone', () => {
-    const store = new LoaderSuspenseStore();
-    store.set('/p', { data: 'v1' });
-
-    store.teardown('/p');
-
-    expect(store.get('/p')).toEqual({ data: 'v1' });
-  });
-
-  it('removes an entry on dispose followed by teardown', () => {
-    const store = new LoaderSuspenseStore();
-    store.set('/p', { data: 'v1' });
-
-    store.dispose('/p');
-    store.teardown('/p');
-
-    expect(store.get('/p')).toBeUndefined();
+    expect(store.get('/disposed')).toEqual({ data: 'disposed' });
+    expect(store.get('/torn-down')).toEqual({ data: 'torn-down' });
+    expect(store.get('/reclaimed')).toBeUndefined();
   });
 
   it('unmarks a disposed key when a new entry is set', () => {
@@ -71,12 +59,19 @@ describe(LoaderSuspenseStore, () => {
     expect(store.get('/p')).toEqual({ data: 'v2' });
   });
 
-  it('lists entry keys', () => {
+  it('retains live entries and clears inactive entries', () => {
     const store = new LoaderSuspenseStore();
-    store.set('/a', { data: 1 });
-    store.set('/b', { data: 2 });
+    store.set('/live', { data: 'fresh' });
+    store.set('/inactive', { data: 'stale' });
+    store.dispose('/inactive');
 
-    expect(store.keys()).toEqual(['/a', '/b']);
+    store.retain(new Set(['/live']));
+
+    expect(store.get('/live')).toEqual({ data: 'fresh' });
+    expect(store.get('/inactive')).toBeUndefined();
+    store.set('/inactive', { data: 'new' });
+    store.teardown('/inactive');
+    expect(store.get('/inactive')).toEqual({ data: 'new' });
   });
 
   it('drops all entries and marks on reset', () => {
@@ -89,6 +84,5 @@ describe(LoaderSuspenseStore, () => {
     store.teardown('/a');
 
     expect(store.get('/a')).toEqual({ data: 2 });
-    expect(store.keys()).toEqual(['/a']);
   });
 });

--- a/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
+++ b/packages/expo-router/src/loaders/__tests__/readLoaderData.test.ts
@@ -1,123 +1,231 @@
 import { LoaderClient } from '../LoaderClient';
+import { createLoaderContextValue, type LoaderContextValue } from '../LoaderContext';
 import { readLoaderData } from '../readLoaderData';
 
 const tick = () => Promise.resolve();
+const createLoaderContext = () => createLoaderContextValue(new LoaderClient());
+const read = <T>(ctx: LoaderContextValue, path: string, fetcher: (path: string) => Promise<T>) =>
+  readLoaderData(ctx, path, fetcher);
+const revalidate = ({ client, store }: LoaderContextValue) => {
+  store.retain(client.revalidate());
+  client.notify();
+};
 
 describe(readLoaderData, () => {
-  it('fetches once, then reuses the value across re-renders', async () => {
-    const client = new LoaderClient();
+  it('fetches once and reuses the settled value across reads', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest.fn(async () => 'v1');
 
-    const pending = readLoaderData(client, '/p', fetcher);
+    const pending = read(ctx, '/p', fetcher);
     expect(pending).toBeInstanceOf(Promise);
     await pending;
 
     for (let i = 0; i < 5; i++) {
-      expect(readLoaderData(client, '/p', fetcher)).toBe('v1');
+      expect(read(ctx, '/p', fetcher)).toBe('v1');
     }
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it('serves the settled value to a retry render that runs a task after settling', async () => {
-    const client = new LoaderClient();
+  it('shares one promise and one fetch between concurrent readers', () => {
+    const ctx = createLoaderContext();
     const fetcher = jest.fn(async () => 'v1');
 
-    await readLoaderData(client, '/p', fetcher);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(readLoaderData(client, '/p', fetcher)).toBe('v1');
-    expect(fetcher).toHaveBeenCalledTimes(1);
-  });
-
-  it('fetches exactly once when Suspense replays a cache-miss mount', () => {
-    const client = new LoaderClient();
-    const fetcher = jest.fn(async () => 'v1');
-
-    const first = readLoaderData(client, '/p', fetcher);
-    const second = readLoaderData(client, '/p', fetcher);
+    const first = read(ctx, '/p', fetcher);
+    const second = read(ctx, '/p', fetcher);
 
     expect(first).toBeInstanceOf(Promise);
     expect(second).toBe(first);
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it('fetches again on a fresh mount after the reader unmounts', async () => {
-    const client = new LoaderClient();
+  it('writes the settled result before resolving the Suspense promise', async () => {
+    const ctx = createLoaderContext();
+    const fetcher = jest.fn(async () => 'v1');
+    const pending = read(ctx, '/p', fetcher) as Promise<string>;
+
+    await pending.then((result) => {
+      expect(result).toBe('v1');
+      expect(ctx.store.get('/p')).toEqual({ data: 'v1' });
+    });
+  });
+
+  it('fetches again on a fresh mount after confirmed teardown', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest
       .fn<Promise<string>, [string]>()
       .mockResolvedValueOnce('v1')
       .mockResolvedValueOnce('v2');
 
-    await readLoaderData(client, '/p', fetcher);
-    expect(readLoaderData(client, '/p', fetcher)).toBe('v1');
-
-    const unsubscribe = client.subscribeLoader('/p');
-    client.suspense.dispose('/p');
-    unsubscribe();
+    await read(ctx, '/p', fetcher);
+    const unsubscribe = ctx.client.subscribeLoader('/p');
+    ctx.store.dispose('/p');
+    unsubscribe(() => ctx.store.teardown('/p'));
     await tick();
-    expect(client.suspense.get('/p')).toBeUndefined();
 
-    const revisit = readLoaderData(client, '/p', fetcher);
+    expect(ctx.store.get('/p')).toBeUndefined();
+    const revisit = read(ctx, '/p', fetcher);
     expect(revisit).toBeInstanceOf(Promise);
     await expect(revisit).resolves.toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it('does not refetch across a StrictMode unmount + remount within the same tick', async () => {
-    const client = new LoaderClient();
+  it('reuses the entry across a same-tick Strict Mode remount', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest.fn(async () => 'v1');
 
-    await readLoaderData(client, '/sm', fetcher);
-    const unsubscribe = client.subscribeLoader('/sm');
-    client.suspense.dispose('/sm');
-    unsubscribe();
-    client.subscribeLoader('/sm');
+    await read(ctx, '/sm', fetcher);
+    const unsubscribe = ctx.client.subscribeLoader('/sm');
+    ctx.store.dispose('/sm');
+    unsubscribe(() => ctx.store.teardown('/sm'));
+    ctx.client.subscribeLoader('/sm');
     await tick();
 
-    expect(readLoaderData(client, '/sm', fetcher)).toBe('v1');
+    expect(read(ctx, '/sm', fetcher)).toBe('v1');
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it('throws the settled error to replayed reads without refetching, then clears it so a retry refetches', async () => {
-    const client = new LoaderClient();
+  it('keeps a fresh result written between disposal and confirmed teardown', async () => {
+    const ctx = createLoaderContext();
+    ctx.store.set('/p', { data: 'old' });
+    const unsubscribe = ctx.client.subscribeLoader('/p');
+
+    ctx.store.dispose('/p');
+    unsubscribe(() => ctx.store.teardown('/p'));
+    ctx.store.set('/p', { data: 'fresh' });
+    await tick();
+
+    expect(ctx.store.get('/p')).toEqual({ data: 'fresh' });
+  });
+
+  it('throws a cached error once, then clears it so retry refetches', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest
       .fn<Promise<string>, [string]>()
       .mockRejectedValueOnce(new Error('boom'))
       .mockResolvedValueOnce('recovered');
 
-    await expect(readLoaderData(client, '/err', fetcher)).rejects.toThrow(
+    await expect(read(ctx, '/err', fetcher)).rejects.toThrow(
       'Failed to load loader data for route: /err'
     );
-    expect(() => readLoaderData(client, '/err', fetcher)).toThrow(
-      'Failed to load loader data for route: /err'
-    );
+    expect(() => read(ctx, '/err', fetcher)).toThrow('Failed to load loader data for route: /err');
     expect(fetcher).toHaveBeenCalledTimes(1);
 
     await tick();
-    expect(client.suspense.get('/err')).toBeUndefined();
+    expect(ctx.store.get('/err')).toBeUndefined();
 
-    const retry = readLoaderData(client, '/err', fetcher);
+    const retry = read(ctx, '/err', fetcher);
     expect(retry).toBeInstanceOf(Promise);
     await expect(retry).resolves.toBe('recovered');
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it('does not clear an entry that was replaced before the deferred error expiry runs', async () => {
-    const client = new LoaderClient();
+  it('does not clear an entry replaced before deferred error eviction', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest.fn<Promise<string>, [string]>().mockRejectedValueOnce(new Error('boom'));
 
-    await expect(readLoaderData(client, '/err', fetcher)).rejects.toThrow();
-    expect(() => readLoaderData(client, '/err', fetcher)).toThrow();
+    await expect(read(ctx, '/err', fetcher)).rejects.toThrow();
+    expect(() => read(ctx, '/err', fetcher)).toThrow();
 
-    client.suspense.set('/err', { data: 'fresh' });
+    ctx.store.set('/err', { data: 'fresh' });
     await tick();
 
-    expect(client.suspense.get('/err')).toEqual({ data: 'fresh' });
+    expect(ctx.store.get('/err')).toEqual({ data: 'fresh' });
   });
 
-  it('keeps a settled entry from an abandoned in-flight load for the next mount to adopt', async () => {
-    const client = new LoaderClient();
-    let resolveFetch!: (value: string) => void;
+  it('does not overwrite an entry replaced while its loader is in flight', async () => {
+    const ctx = createLoaderContext();
+    let resolveFetch!: (result: string) => void;
+    const pending = read(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFetch = resolve;
+        })
+    ) as Promise<string>;
+
+    ctx.store.set('/p', { data: 'fresh' });
+    resolveFetch('stale');
+    await expect(pending).resolves.toBe('stale');
+
+    expect(ctx.store.get('/p')).toEqual({ data: 'fresh' });
+  });
+
+  it('does not resurrect a cleared entry when its pending result settles', async () => {
+    const ctx = createLoaderContext();
+    let resolveFetch!: (result: string) => void;
+    const pending = read(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFetch = resolve;
+        })
+    ) as Promise<string>;
+
+    ctx.store.clear('/p');
+    resolveFetch('orphaned');
+    await expect(pending).resolves.toBe('orphaned');
+
+    expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('lets a detached source resolve its caller without restoring reset state', async () => {
+    const ctx = createLoaderContext();
+    let resolveFetch!: (result: string) => void;
+    const pending = read(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFetch = resolve;
+        })
+    ) as Promise<string>;
+
+    ctx.client.clear();
+    ctx.store.reset();
+    resolveFetch('detached');
+
+    await expect(pending).resolves.toBe('detached');
+    expect(ctx.store.get('/p')).toBeUndefined();
+  });
+
+  it('does not let a replaced source overwrite the newer pending entry', async () => {
+    const ctx = createLoaderContext();
+    let resolveOld!: (result: string) => void;
+    let resolveNew!: (result: string) => void;
+    const oldPending = read(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveOld = resolve;
+        })
+    ) as Promise<string>;
+
+    ctx.client.clear();
+    ctx.store.reset();
+    const newPending = read(
+      ctx,
+      '/p',
+      () =>
+        new Promise<string>((resolve) => {
+          resolveNew = resolve;
+        })
+    ) as Promise<string>;
+
+    resolveOld('old');
+    await expect(oldPending).resolves.toBe('old');
+    expect(ctx.store.get('/p')).toBe(newPending);
+
+    resolveNew('new');
+    await expect(newPending).resolves.toBe('new');
+    expect(ctx.store.get('/p')).toEqual({ data: 'new' });
+  });
+
+  it('keeps a settled result from an abandoned render for the next mount to adopt', async () => {
+    const ctx = createLoaderContext();
+    let resolveFetch!: (result: string) => void;
     const fetcher = jest.fn(
       () =>
         new Promise<string>((resolve) => {
@@ -125,70 +233,77 @@ describe(readLoaderData, () => {
         })
     );
 
-    const unsubscribe = client.subscribeLoader('/p');
-    const abandoned = readLoaderData(client, '/p', fetcher) as Promise<string>;
-    client.suspense.dispose('/p');
-    unsubscribe();
+    const mountedUnsubscribe = ctx.client.subscribeLoader('/p');
+    const abandoned = read(ctx, '/p', fetcher) as Promise<string>;
+    ctx.store.dispose('/p');
+    mountedUnsubscribe(() => ctx.store.teardown('/p'));
     await tick();
 
-    resolveFetch('stale');
-    await expect(abandoned).resolves.toBe('stale');
+    resolveFetch('adopted');
+    await expect(abandoned).resolves.toBe('adopted');
 
-    expect(readLoaderData(client, '/p', fetcher)).toBe('stale');
+    expect(read(ctx, '/p', fetcher)).toBe('adopted');
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
-  it('refreshes a live reader in place on invalidateAll without dropping the entry', async () => {
-    const client = new LoaderClient();
+  it('refreshes a live entry in place during invalidation', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest
       .fn<Promise<string>, [string]>()
       .mockResolvedValueOnce('v1')
       .mockResolvedValueOnce('v2');
 
-    await readLoaderData(client, '/p', fetcher);
-    client.subscribeLoader('/p');
+    await read(ctx, '/p', fetcher);
+    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+      if (isCurrentSource) {
+        ctx.store.set('/p', result);
+      }
+    });
 
-    client.invalidateAll();
-    expect(readLoaderData(client, '/p', fetcher)).toBe('v1');
+    revalidate(ctx);
+    expect(read(ctx, '/p', fetcher)).toBe('v1');
 
     await tick();
-    expect(readLoaderData(client, '/p', fetcher)).toBe('v2');
+    expect(read(ctx, '/p', fetcher)).toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it('keeps the entry for a surviving reader when a sibling unmounts after invalidateAll', async () => {
-    const client = new LoaderClient();
+  it('keeps the entry when a sibling subscriber remains', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest
       .fn<Promise<string>, [string]>()
       .mockResolvedValueOnce('v1')
       .mockResolvedValueOnce('v2');
 
-    await readLoaderData(client, '/p', fetcher);
-    const siblingReader = client.subscribeLoader('/p');
-    client.subscribeLoader('/p');
+    await read(ctx, '/p', fetcher);
+    const sibling = ctx.client.subscribeLoader('/p');
+    ctx.client.subscribeLoader('/p', (result, isCurrentSource) => {
+      if (isCurrentSource) {
+        ctx.store.set('/p', result);
+      }
+    });
 
-    client.invalidateAll();
-    client.suspense.dispose('/p');
-    siblingReader();
+    revalidate(ctx);
+    ctx.store.dispose('/p');
+    sibling(() => ctx.store.teardown('/p'));
     await tick();
 
-    expect(readLoaderData(client, '/p', fetcher)).toBe('v2');
+    expect(read(ctx, '/p', fetcher)).toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
-  it('clears an unwatched entry on invalidateAll so the next mount refetches', async () => {
-    const client = new LoaderClient();
+  it('clears an inactive entry during invalidation so the next mount refetches', async () => {
+    const ctx = createLoaderContext();
     const fetcher = jest
       .fn<Promise<string>, [string]>()
       .mockResolvedValueOnce('v1')
       .mockResolvedValueOnce('v2');
 
-    await readLoaderData(client, '/p', fetcher);
+    await read(ctx, '/p', fetcher);
     await tick();
+    revalidate(ctx);
 
-    client.invalidateAll();
-
-    const revisit = readLoaderData(client, '/p', fetcher);
+    const revisit = read(ctx, '/p', fetcher);
     expect(revisit).toBeInstanceOf(Promise);
     await expect(revisit).resolves.toBe('v2');
     expect(fetcher).toHaveBeenCalledTimes(2);

--- a/packages/expo-router/src/loaders/readLoaderData.ts
+++ b/packages/expo-router/src/loaders/readLoaderData.ts
@@ -1,21 +1,21 @@
-import type { LoaderClient } from './LoaderClient';
+import type { LoaderContextValue } from './LoaderContext';
 
 type LoaderFetcher<T> = (path: string) => Promise<T>;
 
 export function readLoaderData<T>(
-  client: LoaderClient,
+  { client, store }: LoaderContextValue,
   resolvedPath: string,
   fetcher: LoaderFetcher<T>
 ): T | Promise<T> {
-  const suspended = client.suspense.get<T>(resolvedPath);
+  const suspended = store.get<T>(resolvedPath);
   if (suspended instanceof Promise) {
     return suspended;
   }
   if (suspended) {
     if ('error' in suspended) {
       queueMicrotask(() => {
-        if (client.suspense.get(resolvedPath) === suspended) {
-          client.suspense.clear(resolvedPath);
+        if (store.get(resolvedPath) === suspended) {
+          store.clear(resolvedPath);
         }
       });
       throw suspended.error;
@@ -24,7 +24,10 @@ export function readLoaderData<T>(
   }
 
   const promise = new Promise<T>((resolve, reject) => {
-    const unsubscribe = client.subscribeLoader(resolvedPath, (result) => {
+    const unsubscribe = client.subscribeLoader(resolvedPath, (result, isCurrentSource) => {
+      if (isCurrentSource && store.get(resolvedPath) === promise) {
+        store.set(resolvedPath, result);
+      }
       unsubscribe();
       if ('error' in result) {
         reject(result.error);
@@ -34,6 +37,6 @@ export function readLoaderData<T>(
     });
     client.execute(resolvedPath, fetcher);
   });
-  client.suspense.set(resolvedPath, promise);
+  store.set(resolvedPath, promise);
   return promise;
 }

--- a/packages/expo-router/src/ts-declarations/expo-router-internal-globals.ts
+++ b/packages/expo-router/src/ts-declarations/expo-router-internal-globals.ts
@@ -15,9 +15,9 @@ declare global {
   var __EXPO_LOADER_INVALIDATE_LISTENERS__: undefined | (() => void)[];
   /**
    * Dev-only flag that ensures the default `loader-invalidate` listener is registered once
-   * across HMR re-evaluations of the `LoaderCache` module.
+   * across HMR re-evaluations of the `LoaderContext` module.
    *
-   * @see expo-router/src/loaders/LoaderCache.ts
+   * @see expo-router/src/loaders/LoaderContext.ts
    */
   var __EXPO_LOADER_INVALIDATE_LISTENER_REGISTERED__: undefined | true;
 }


### PR DESCRIPTION
# Why

`LoaderClient` previously owned a `LoaderSuspenseStore` instance and wrote to it directly. This coupling mixed two different concerns (transport vs Suspense state tracking) and made it harder to reason about behavior; store entries were written from multiple places inside the client, so Suspense state could change without any React-side involvement.

# How

- `LoaderClient` no longer imports or touches `LoaderSuspenseStore` (enforced by Oxlint too)
- `LoaderContext` now stores both `LoaderClient` and `LoaderSuspenseStore`
- `LoaderClient.invalidateAll()` is replaced by `revalidate()`, which now re-executes live sources and returns their paths; the HMR `loader-invalidate` listener calls `store.retain(client.revalidate())`
- `useLoaderData()` writes settled results through its subscriber, and its cleanup reclaims entries in two steps (`dispose()` and `teardown()`)

# Test Plan

- CI
- Manually testing

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
