### PR TITLE
[ui][ios] Add kind to contentShape modifier

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### 🎉 New features
 
 - [iOS] Added `presentationBackground` SwiftUI modifier and applied it in `community/bottom-sheet`. ([#46285](https://github.com/expo/expo/pull/46285) by [@duyanhv](https://github.com/duyanhv))
+- [iOS] Added an optional `kind` argument to the `contentShape` modifier, so a shape can be applied to drag previews, context menu previews, hover effects, or accessibility instead of only hit-testing. ([#48540](https://github.com/expo/expo/issues/48540) by [@sinhong2011](https://github.com/sinhong2011)) ([#48564](https://github.com/expo/expo/pull/48564) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift
@@ -3,27 +3,60 @@
 import ExpoModulesCore
 import SwiftUI
 
+internal enum ContentShapeKind: String, Enumerable {
+  case interaction
+  case dragPreview
+  case contextMenuPreview
+  case hoverEffect
+  case accessibility
+
+  func toContentShapeKinds() -> ContentShapeKinds {
+    switch self {
+    case .interaction:
+      return .interaction
+    case .dragPreview:
+      return .dragPreview
+    case .contextMenuPreview:
+      return .contextMenuPreview
+    case .hoverEffect:
+      return .hoverEffect
+    case .accessibility:
+      return .accessibility
+    }
+  }
+}
+
 internal struct ContentShapeModifier: ViewModifier, Record {
   @Field var shape: ShapeType = .rectangle
   @Field var cornerRadius: CGFloat = 0
   @Field var roundedCornerStyle: RoundedCornerStyle?
   @Field var cornerSize: CornerSize?
+  @Field var kind: [ContentShapeKind]?
 
   @ViewBuilder
   func body(content: Content) -> some View {
     switch shape {
     case .capsule:
-      content.contentShape(makeCapsule(style: roundedCornerStyle))
+      applyContentShape(content, makeCapsule(style: roundedCornerStyle))
     case .circle:
-      content.contentShape(Circle())
+      applyContentShape(content, Circle())
     case .containerRelativeShape:
-      content.contentShape(ContainerRelativeShape())
+      applyContentShape(content, ContainerRelativeShape())
     case .ellipse:
-      content.contentShape(Ellipse())
+      applyContentShape(content, Ellipse())
     case .rectangle:
-      content.contentShape(Rectangle())
+      applyContentShape(content, Rectangle())
     case .roundedRectangle:
-      content.contentShape(makeRoundedRectangle(cornerRadius: cornerRadius, cornerSize: cornerSize, style: roundedCornerStyle))
+      applyContentShape(content, makeRoundedRectangle(cornerRadius: cornerRadius, cornerSize: cornerSize, style: roundedCornerStyle))
+    }
+  }
+
+  @ViewBuilder
+  private func applyContentShape(_ content: Content, _ shape: some Shape) -> some View {
+    if let kind, !kind.isEmpty {
+      content.contentShape(ContentShapeKinds(kind.map { $0.toContentShapeKinds() }), shape)
+    } else {
+      content.contentShape(shape)
     }
   }
 }

--- a/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift
+++ b/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift
@@ -15,13 +15,26 @@ internal enum ContentShapeKind: String, Enumerable {
     case .interaction:
       return .interaction
     case .dragPreview:
+      #if os(tvOS)
+      return .interaction
+      #else
       return .dragPreview
+      #endif
     case .contextMenuPreview:
-      return .contextMenuPreview
+      if #available(iOS 15.0, tvOS 17.0, *) {
+        return .contextMenuPreview
+      }
+      return .interaction
     case .hoverEffect:
-      return .hoverEffect
+      if #available(iOS 15.0, tvOS 18.0, *) {
+        return .hoverEffect
+      }
+      return .interaction
     case .accessibility:
-      return .accessibility
+      if #available(iOS 17.0, tvOS 17.0, macOS 14.0, *) {
+        return .accessibility
+      }
+      return .interaction
     }
   }
 }

--- a/packages/expo-ui/src/swift-ui/modifiers/contentShape.ts
+++ b/packages/expo-ui/src/swift-ui/modifiers/contentShape.ts
@@ -2,12 +2,32 @@ import { createModifier } from './createModifier';
 import type { Shape } from './shapes/index';
 
 /**
+ * The kinds of interaction a content shape applies to.
+ *
+ * - `interaction` - The kind for hit-testing and accessibility.
+ * - `dragPreview` - The kind for drag and drop previews.
+ * - `contextMenuPreview` - The kind for context menu previews.
+ * - `hoverEffect` - The kind for hover effects.
+ * - `accessibility` - The kind for accessibility.
+ */
+export type ContentShapeKind =
+  | 'interaction'
+  | 'dragPreview'
+  | 'contextMenuPreview'
+  | 'hoverEffect'
+  | 'accessibility';
+
+/**
  * Defines the content shape for hit-testing purposes.
  *
  * This modifier is essential for making entire view areas (including `Spacer` or empty space)
  * interactive. Without it, only visible elements like `Text` or `Image` respond to tap gestures.
  *
+ * Pass `kind` to shape something other than the default `interaction` (hit-testing), such as
+ * the preview used while a `List.ForEach` row is dragged to reorder it.
+ *
  * @param shape - A shape configuration from the shapes API (rectangle, circle, capsule, ellipse, roundedRectangle).
+ * @param kind - The kinds to apply the shape to. Defaults to `interaction` when not provided.
  *
  * @example
  * ```tsx
@@ -35,6 +55,19 @@ import type { Shape } from './shapes/index';
  * }
  * ```
  *
- * @see Official [SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/contentshape(_:eofill:)).
+ * @example
+ * ```tsx
+ * // Round the preview shown while a row is dragged, so its corners are not filled in.
+ * <Label
+ *   title={item.title}
+ *   modifiers={[contentShape(shapes.roundedRectangle({ cornerRadius: 10 }), 'dragPreview')]}
+ * />
+ * ```
+ *
+ * @see Official [SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/contentshape(_:_:eofill:)).
  */
-export const contentShape = (shape: Shape) => createModifier('contentShape', shape);
+export const contentShape = (shape: Shape, kind?: ContentShapeKind | ContentShapeKind[]) =>
+  createModifier('contentShape', {
+    ...shape,
+    kind: kind === undefined ? undefined : [kind].flat(),
+  });


### PR DESCRIPTION
## Why


Fixes - https://github.com/expo/expo/issues/48540

Adds `kind` argument to contentShape modifier to allow configuring the drag preview content shape in List.

## How

Added an optional `kind` argument to `contentShape`. It can be one value or an array of values.

## Test Plan
Tested in NCL

## Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Verified the change builds, type-checks, lints via `et check-packages`.
- [ ] Confirmed the change works with `npx expo prebuild` & EAS Build.
- [x] Follows the documentation style guide.