### PR TITLE
[ci][test-runner][templates] Fix canary publishing under npm trusted publishing

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -21,7 +21,7 @@ jobs:
   publish-packages:
     if: github.repository == 'expo/expo'
     runs-on: macos-26
-    timeout-minutes: 120
+    timeout-minutes: 180
     permissions:
       # Lets the runner mint an OIDC token so npm can authenticate the publish
       # through trusted publishing instead of a long-lived token.

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -5,6 +5,11 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/log-box",
   "license": "MIT",
   "author": "Expo",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/@expo/log-box"
+  },
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "exports": {

--- a/packages/expo-test-runner/README.md
+++ b/packages/expo-test-runner/README.md
@@ -6,8 +6,8 @@
     <a href="https://www.npmjs.com/package/expo-test-runner">
       <img src="https://img.shields.io/npm/v/expo-test-runner?style=flat-square" alt="releases" />
     </a>
-    <a href="https://github.com/expo/expo-test-runner/blob/main/LICENSE.md">
-      <img src="https://img.shields.io/github/license/expo/expo-test-runner?style=flat-square" alt="license" />
+    <a href="https://github.com/expo/expo/blob/main/packages/expo-test-runner/LICENSE.md">
+      <img src="https://img.shields.io/github/license/expo/expo?style=flat-square" alt="license" />
     </a>
   </sup>
   <br />

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -2,15 +2,16 @@
   "name": "expo-test-runner",
   "version": "0.5.0",
   "description": "Script that enchants test experience.",
-  "homepage": "https://github.com/expo/expo-test-runner#readme",
+  "homepage": "https://github.com/expo/expo/tree/main/packages/expo-test-runner#readme",
   "bugs": {
-    "url": "https://github.com/expo/expo-test-runner/issues"
+    "url": "https://github.com/expo/expo/issues"
   },
   "license": "MIT",
   "author": "650 Industries, Inc.",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/expo/expo-test-runner.git"
+    "url": "https://github.com/expo/expo.git",
+    "directory": "packages/expo-test-runner"
   },
   "bin": {
     "expo-test-runner": "bin/expo-test-runner.js"

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -3,6 +3,11 @@
   "description": "This bare project template includes a minimal setup for using unimodules with React Native.",
   "license": "0BSD",
   "version": "57.0.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "templates/expo-template-bare-minimum"
+  },
   "main": "index.js",
   "scripts": {
     "start": "expo start --dev-client",

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -3,6 +3,11 @@
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
   "version": "57.0.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "templates/expo-template-blank-typescript"
+  },
   "main": "index.ts",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -3,6 +3,11 @@
   "description": "The Blank project template includes the minimum dependencies to run and an empty root component.",
   "license": "0BSD",
   "version": "57.0.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "templates/expo-template-blank"
+  },
   "main": "index.js",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -2,6 +2,11 @@
   "name": "expo-template-default",
   "version": "57.0.11",
   "license": "0BSD",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "templates/expo-template-default"
+  },
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -4,6 +4,11 @@
   "description": "The Tab Navigation project template includes several example screens.",
   "license": "0BSD",
   "version": "57.0.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/expo/expo.git",
+    "directory": "templates/expo-template-tabs"
+  },
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
# Why

The canary publish run on 2026-08-05 ([31046487402](https://github.com/expo/expo/actions/runs/31046487402)) published **17 of 144 packages** and then died:

```
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/expo-test-runner
  Error verifying sigstore provenance bundle: Failed to validate repository information:
  package.json: "repository.url" is "git+https://github.com/expo/expo-test-runner.git",
  expected to match "https://github.com/expo/expo" from provenance
```

`expo-test-runner/package.json` still pointed at the archived standalone `expo/expo-test-runner` repo. Since #48519 switched canaries to npm trusted publishing (OIDC), the registry cross-checks `repository.url` against the repo in the provenance statement and rejects a mismatch. The publish loop re-throws on the first failure, so the remaining 127 packages were skipped.

# How

Three commits:

1. **`expo-test-runner`** — point `repository`, `homepage`, and `bugs` at `expo/expo` with a `directory`, matching every sibling package. Also fixes two stale README badge links. This is the actual blocker.

2. **Six packages with no `repository` field at all** — `@expo/log-box` and the five `expo-template-*`. npm documents a matching public repository as a [prerequisite for provenance](https://docs.npmjs.com/generating-provenance-statements/). All 17 packages that did publish have one; these six were never reached, so their behaviour under OIDC is untested. Adding the field removes the unknown before the next run finds out the hard way.

   Safe for templates: `create-expo` already strips `repository` in `sanitizeTemplateAsync` (`packages/create-expo/src/Template.ts:396`), so scaffolded projects do not inherit it.

3. **Raise `timeout-minutes` 120 → 180.** Measured from the two most recent runs: ~56 min of build + iOS prebuilds before the publish loop starts, then ~14 s/package across ~144 packages (~34 min) — about 90 min on a warm Turbo cache. That 14 s/package figure comes from the 17 *small* packages that happened to publish first; `expo`, `expo-modules-core` and `expo-dev-menu` were never reached, so the real average is likely higher. A timeout part-way through the loop produces the same split-tag outcome as this failure.

# Test Plan

- Audited every package in the publish set against the provenance repo URL — 0 mismatches, 0 missing fields remain.
- Verified all 7 edited `package.json` files parse.
