### PR TITLE
[ci][reviewer] Post AI code review comments as expo-bot

### DIFF
--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Acknowledge
         if: steps.cmd.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         run: gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
 
       # SECURITY: `issue_comment` is NOT fork-restricted by GitHub — it always
@@ -140,7 +140,7 @@ jobs:
         if: steps.cmd.outputs.run == 'true'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           # Layer-1 auth lock: the CLI refuses to run when the tokenEnv it would honor
           # differs from this. Keep it in sync with the guard's EXPECTED.
           ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN' }}

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Acknowledge
         if: steps.cmd.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         run: gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
 
       # Base ref only (issue_comment runs with base-repo context). Dismiss just edits
@@ -99,11 +99,11 @@ jobs:
           # the post step doesn't error trying to save an empty cache.
           package-manager-cache: false
 
-      # @ref LLP 0009#guard-step-ordering-and-job-budgets [explains] — GH_TOKEN only, no OPENAI_API_KEY or model credential
+      # @ref LLP 0009#guard-step-ordering-and-job-budgets [explains] — GitHub token only, no OPENAI_API_KEY or model credential
       - name: Apply dismissal
         if: steps.cmd.outputs.run == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           SUB: ${{ steps.cmd.outputs.sub }}
           IDS: ${{ steps.cmd.outputs.ids }}
           REASON: ${{ steps.cmd.outputs.reason }}

--- a/.github/workflows/expo-code-review-fork-hint.yml
+++ b/.github/workflows/expo-code-review-fork-hint.yml
@@ -12,7 +12,7 @@ name: AI code review (fork hint)
 # and a write token to a run triggered by an untrusted PR. That danger comes from
 # checking out and EXECUTING the PR's code. This job does none of that: no checkout, no
 # dependency install, no build, no model, no model credential. It reads two fields off
-# the event payload and posts a fixed string with the default GITHUB_TOKEN. There is no
+# the event payload and posts a fixed string as expo-bot. There is no
 # attacker-controlled input anywhere in it — the PR number is an integer from the event,
 # and the body is a literal. It also fires only on `labeled`, so an attacker cannot
 # re-trigger it by pushing.
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Explain that the label cannot work here
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -117,7 +117,7 @@ jobs:
         run: npx --yes -p "@expo/code-review-cli@$ECR_VERSION" ecr ci
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           # Layer-1 auth lock: the CLI refuses to run when the tokenEnv it would
           # honor (root config.jsonc, or routing.jsonc defaults.auth) differs from
           # this — it catches what the guard step above can't. Keep it in sync


### PR DESCRIPTION
# Why

The new AI reviewer authenticates with the default `GITHUB_TOKEN`, so its comments are attributed to `github-actions`. Everything else we run against PRs and issues (`commentator`, `issue-triage`, `pr-contributor-labeler`, and the older `expotools code-review`) posts as expo-bot. On [#48559](https://github.com/expo/expo/pull/48559) you can see both bots commenting on the same PR under different names.

# How

Swapped `secrets.GITHUB_TOKEN` for `secrets.EXPO_BOT_GITHUB_TOKEN` in the six places the four reviewer workflows use it to talk to the API.

Dismiss had to move with it, not just the workflow that posts the review. `/dismiss` edits the reviewer's own comment, and GitHub only lets the authoring account do that, so leaving it on the default token would have broken the command the moment reviews started coming from expo-bot.

Forks are fine in all four. The auto-review job already gates on `!head.repo.fork`, so it never starts on a fork and never needs the secret. The other three run on `issue_comment` or `pull_request_target`, which execute in base-repo context and do get secrets.

# Test Plan

Nothing here is testable before merge, since workflow changes only take effect once they're on the default branch, and the token identity can't be exercised locally. All four files parse as valid YAML, and `EXPO_BOT_GITHUB_TOKEN` is present in the repo secrets.

Verification is labeling a PR `ai-review` after this lands and checking the comment is authored by expo-bot, then running `/dismiss` on that fresh comment.

One migration note: review comments already posted by `github-actions` can't be edited by expo-bot, so `/dismiss` won't work on them. It applies to any review posted before this merges, and resolves as soon as the reviewer reposts.
