### PR TITLE
[android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] Fix `UnsupportedOperationException` on Android 7.x
+- [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix `UnsupportedOperationException` on Android 7.x
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x
+- [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
@@ -30,9 +30,15 @@ internal object FrameRateMonitor {
 
   @Synchronized
   fun removeRecorder(recorder: FrameMetricsRecorder) {
-    // Use CopyOnWriteArrayList's atomic removeIf — Kotlin's removeAll { } extension
-    // uses an indexed iterator that is not safe against concurrent add().
-    recorders.removeIf { ref -> ref.get().let { it === recorder || it == null } }
+    // Don't use `removeIf`: on API 24-25 CopyOnWriteArrayList has no override, so it falls back to
+    // Collection.removeIf, whose iterator.remove() throws UnsupportedOperationException. The override
+    // only exists from API 26. `removeAll(Collection)` is a real synchronized implementation on both.
+    // API 24: https://android.googlesource.com/platform/libcore/+/refs/tags/android-7.0.0_r1/luni/src/main/java/java/util/concurrent/CopyOnWriteArrayList.java
+    //   (`removeAll` at line 362; no `removeIf`)
+    // API 26: https://android.googlesource.com/platform/libcore/+/refs/tags/android-8.0.0_r1/ojluni/src/main/java/java/util/concurrent/CopyOnWriteArrayList.java
+    //   (both implemented)
+    val matches = recorders.filter { ref -> ref.get().let { it === recorder || it == null } }
+    if (matches.isNotEmpty()) recorders.removeAll(matches)
     stopMonitoringIfEmpty()
   }
 
@@ -63,7 +69,8 @@ internal object FrameRateMonitor {
   }
 
   private fun removeReleasedRecorders() {
-    recorders.removeIf { it.get() == null }
+    val stale = recorders.filter { it.get() == null }
+    if (stale.isNotEmpty()) recorders.removeAll(stale)
   }
 
   internal fun dispatchFrame(frameDurationMs: Long) {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/TimeUtils.kt
@@ -45,21 +45,15 @@ object TimeUtils {
     )
 
   fun timestampToDateNS(timestamp: String): Long {
-    val date = sdf().parse(timestamp)
+    val date = millisFormatter.get()!!.parse(timestamp)
     if (date != null) {
       return date.time * 1_000_000L
     }
     return 0L
   }
 
-  private fun sdf(): SimpleDateFormat {
-    val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US)
-    sdf.timeZone = TimeZone.getTimeZone("UTC")
-    return sdf
-  }
-
   private fun dateToTimestamp(date: Date): String {
-    return sdf().format(date)
+    return millisFormatter.get()!!.format(date)
   }
 
   /**
@@ -70,12 +64,17 @@ object TimeUtils {
    */
   fun dateToIsoUtcSeconds(date: Date): String = secondsFormatter.get()!!.format(date)
 
-  // `SimpleDateFormat` isn't thread-safe; we stash one per thread. `java.time.DateTimeFormatter`
-  // would be cleaner but requires API 26+ without core-library desugaring (we avoid both, see
-  // `sdf()` below for the matching choice).
-  private val secondsFormatter = ThreadLocal.withInitial {
-    SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
+  // `SimpleDateFormat` isn't thread-safe, so we stash one per thread instead of sharing one
+  // instance. `java.time.DateTimeFormatter` and `ThreadLocal.withInitial` both need API 26+; we
+  // support API 24, so we use the `initialValue()` override, which has been available since API 1:
+  //   API 24 (no `withInitial`): https://android.googlesource.com/platform/libcore/+/refs/tags/android-7.0.0_r1/ojluni/src/main/java/java/lang/ThreadLocal.java
+  //   API 26 (has `withInitial`): https://android.googlesource.com/platform/libcore/+/refs/tags/android-8.0.0_r1/ojluni/src/main/java/java/lang/ThreadLocal.java#140
+  private fun utcFormatter(pattern: String) = object : ThreadLocal<SimpleDateFormat>() {
+    override fun initialValue() = SimpleDateFormat(pattern, Locale.US).apply {
       timeZone = TimeZone.getTimeZone("UTC")
     }
   }
+
+  private val millisFormatter = utcFormatter("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+  private val secondsFormatter = utcFormatter("yyyy-MM-dd'T'HH:mm:ss'Z'")
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/TimeUtilsTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/utils/TimeUtilsTest.kt
@@ -175,4 +175,41 @@ class TimeUtilsTest {
       parsedDate.time > tenYearsAgo
     )
   }
+
+  @Test
+  fun `dateToIsoUtcSeconds formats a fixed date as whole-second UTC`() {
+    // Given
+    val date = Date(1_700_000_000_000L)
+
+    // When
+    val timestamp = TimeUtils.dateToIsoUtcSeconds(date)
+
+    // Then
+    assertEquals("2023-11-14T22:13:20Z", timestamp)
+  }
+
+  @Test
+  fun `millisToTimestamp formats a fixed value as millisecond-precision UTC`() {
+    // Given
+    val millis = 1_700_000_000_123L
+
+    // When
+    val timestamp = TimeUtils.millisToTimestamp(millis)
+
+    // Then
+    assertEquals("2023-11-14T22:13:20.123Z", timestamp)
+  }
+
+  @Test
+  fun `timestampToDateNS round-trips a timestamp produced by millisToTimestamp`() {
+    // Given
+    val millis = 1_700_000_000_123L
+    val timestamp = TimeUtils.millisToTimestamp(millis)
+
+    // When
+    val nanos = TimeUtils.timestampToDateNS(timestamp)
+
+    // Then
+    assertEquals(millis * 1_000_000L, nanos)
+  }
 }


### PR DESCRIPTION
## Why

Apps with observe crashed on Android 7 (SDK 24 and 25). The main cause is using the unsupported functions:
- `CopyOnWriteArrayList.removeIf` 
- `ThreadLocal.withInitial`

## How

Replace these functions with code fully supported on SDK 24 

## Test

Run the app with and without these changes on Android 7 emulator (requires x86 architecture)