### PR TITLE
[observe-tester] Pin pnpm version for EAS builds

### DIFF
--- a/apps/observe-tester/eas.json
+++ b/apps/observe-tester/eas.json
@@ -5,15 +5,18 @@
   },
   "build": {
     "development": {
+      "pnpm": "10.33.0",
       "developmentClient": true,
       "distribution": "internal",
       "channel": "development"
     },
     "preview": {
+      "pnpm": "10.33.0",
       "distribution": "internal",
       "channel": "preview"
     },
     "production": {
+      "pnpm": "10.33.0",
       "autoIncrement": true,
       "channel": "production"
     }


### PR DESCRIPTION
# Why

Pin `pnpm` version so that we can build observe-tester on eas

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)