### PR TITLE
[docs] Update EAS Observe language for user-defined events

### DIFF
--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -69,6 +69,7 @@ Traditional development-time profiling tools show how your app performs on your 
 - **Production performance data**: Track startup times, render performance, and bundle load times from real user sessions across a range of devices
 - **Release comparison**: See how metrics change between app versions and OTA updates to catch regressions early
 - **Session investigation**: Drill into individual user sessions to understand why certain devices or conditions lead to slower performance
+- **User-defined events**: Log custom signals from your app with `Observe.logEvent` and analyze them alongside performance data
 - **CLI and dashboard access**: Query metrics from the terminal with `eas observe:` commands or view them in the EAS dashboard
 
 ## When to use EAS Observe
@@ -79,15 +80,13 @@ Traditional development-time profiling tools show how your app performs on your 
 | Compare performance across releases and OTA updates | <YesIcon />    |
 | Investigate slow sessions on specific devices       | <YesIcon />    |
 | Query performance metrics from the CLI              | <YesIcon />    |
+| Track user-defined events from your app             | <YesIcon />    |
 | Development-time profiling and debugging            | <NoIcon />     |
 | Crash reporting and error tracking                  | <NoIcon />     |
-| Custom analytics and event tracking                 | <NoIcon />     |
 
 **Development-time profiling and debugging**: Use [React Native DevTools](/debugging/tools/#debugging-with-react-native-devtools) for debugging and [Expo Atlas](/guides/analyzing-bundles/) for bundle inspection.
 
 **Crash reporting and error tracking**: This is a planned addition for EAS Observe in the future. In the interim we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
-
-**Custom analytics and event tracking**: This is a planned addition for EAS Observe in the future. In the interim, choose an analytics provider from the [React Native analytics guide](/guides/using-analytics/), for example PostHog, Amplitude, or Firebase Analytics.
 
 ## Frequently asked questions (FAQ)
 
@@ -95,7 +94,7 @@ Traditional development-time profiling tools show how your app performs on your 
 
 <Collapsible summary="What metrics does EAS Observe track?">
 
-EAS Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric.
+EAS Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric. You can also log your own signals as [user-defined events](/eas/observe/events/).
 
 </Collapsible>
 
@@ -150,6 +149,13 @@ Metric data is retained for a minimum of 60 days.
   title="EAS Observe dashboard"
   description="View metrics, filter by platform or version, and investigate individual sessions."
   href="/eas/observe/dashboard"
+  Icon={ActivityIcon}
+/>
+
+<BoxLink
+  title="User-defined events"
+  description="Log named events from your app and view them in the dashboard or query them from the CLI."
+  href="/eas/observe/events"
   Icon={ActivityIcon}
 />
 

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -40,7 +40,7 @@ Get started with the following guide:
 
 ## EAS Observe
 
-[EAS Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
+[EAS Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions. It also records [user-defined events](/eas/observe/events/) that you log from your app, so you can track custom signals alongside performance data.
 
 <ContentSpotlight
   alt="Performance metrics on the EAS Observe dashboard."

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -154,7 +154,7 @@ A command-line tool for uploading and downloading Apple App Store metadata as JS
 
 ### EAS Observe
 
-[EAS Observe](/eas/observe/introduction/) is a performance monitoring service that tracks how an app performs in production, including cold and warm launch times, time to first render, and time to interactive. It uses the `expo-observe` library to collect metrics from production builds, which can then be viewed in the Observe dashboard.
+[EAS Observe](/eas/observe/introduction/) is a performance monitoring service that tracks how an app performs in production, including cold and warm launch times, time to first render, and time to interactive. It uses the `expo-observe` library to collect metrics from production builds, which can then be viewed in the Observe dashboard. It also records [user-defined events](/eas/observe/events/) logged from the app.
 
 ### EAS Update
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25683

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Replace the "Custom analytics and event tracking" No row with a "Track user-defined events from your app" Yes row in the "When to use EAS Observe" table and remove the "planned addition / interim analytics provider" paragraph in `eas/observe/introduction.mdx`.
- Add a "User-defined events" bullet under "Why EAS Observe", a FAQ mention, and a BoxLink to `/eas/observe/events/` on the same page.
- Mention user-defined events in the EAS Observe sections of `monitoring/services.mdx` and `more/glossary-of-terms.mdx`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
