### PR TITLE
[docs] EAS Workflows custom functions

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -477,6 +477,7 @@ export const eas = [
     makePage('eas/workflows/get-started.mdx'),
     makePage('eas/workflows/pre-packaged-jobs.mdx'),
     makePage('eas/workflows/syntax.mdx'),
+    makePage('eas/workflows/custom-functions.mdx'),
     makePage('eas/workflows/environment.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
     makePage('eas/workflows/rest-api.mdx'),

--- a/docs/pages/eas/workflows/custom-functions.mdx
+++ b/docs/pages/eas/workflows/custom-functions.mdx
@@ -32,7 +32,7 @@ You can use custom functions in:
 - Build job [`steps`](/eas/workflows/syntax/#jobsjob_idsteps)
 - Job [`hooks`](/eas/workflows/syntax/#jobsjob_idhooks) and [`defaults.hooks`](/eas/workflows/syntax/#defaultshooks)
 
-## Inputs, outputs, and scope
+## Inputs, outputs and scope
 
 Pass inputs at the call site with `with:`. Inside the function, read an input with `${{ inputs.<name> }}`.
 

--- a/docs/pages/eas/workflows/custom-functions.mdx
+++ b/docs/pages/eas/workflows/custom-functions.mdx
@@ -16,9 +16,9 @@ Create a directory for your custom function with a **function.yml** file inside 
 
 <FileTree
   files={[
-    ['my-app/.eas/workflows/publish-preview-update.yml', ''],
-    ['my-app/.eas/functions/setup/function.yml', ''],
-    ['my-app/eas.json', ''],
+    'my-app/.eas/workflows/publish-preview-update.yml',
+    'my-app/.eas/functions/setup/function.yml',
+    'my-app/eas.json',
   ]}
 />
 

--- a/docs/pages/eas/workflows/custom-functions.mdx
+++ b/docs/pages/eas/workflows/custom-functions.mdx
@@ -54,7 +54,7 @@ You can nest custom functions up to 10 levels deep. A custom function cannot cal
 
 ## Example
 
-**.eas/functions/greet/function.yml** defines a composite function with one input, one output, and one step:
+**.eas/functions/greet/function.yml** defines a custom function with one input, one output, and one step:
 
 ```yaml .eas/functions/greet/function.yml
 name: Greet

--- a/docs/pages/eas/workflows/custom-functions.mdx
+++ b/docs/pages/eas/workflows/custom-functions.mdx
@@ -1,0 +1,98 @@
+---
+title: Custom functions in EAS Workflows
+sidebar_title: Custom functions
+description: Learn how to define reusable step sequences with custom functions.
+---
+
+import { FileTree } from '~/ui/components/FileTree';
+
+Custom functions define reusable step sequences for custom jobs and hooks. Call them with a relative path using [`uses`](/eas/workflows/syntax/#jobsjob_idstepsstepuses), just like built-in functions. Each custom function defines its steps under `runs.steps` in a **function.yml** or **function.yaml** file. These steps use the same format as [custom job steps](/eas/workflows/syntax/#custom-jobs).
+
+For the **function.yml** schema, see [Custom functions](/eas/workflows/syntax/#custom-functions) in the syntax reference.
+
+## How it works
+
+Create a directory for your custom function with a **function.yml** file inside it. EAS Workflows also accepts **function.yaml**. EAS Workflows resolves the path you pass to `uses` relative to your EAS project directory:
+
+<FileTree
+  files={[
+    ['my-app/.eas/workflows/publish-preview-update.yml', ''],
+    ['my-app/.eas/functions/setup/function.yml', ''],
+    ['my-app/eas.json', ''],
+  ]}
+/>
+
+The **.eas/functions/&lt;name&gt;** path in the example above is only one option. The `uses` value must start with `./` or `../` and point to a directory containing a **function.yml** or **function.yaml** file. A path that starts with `../` can point outside the EAS project directory, but the custom function must remain within the repository.
+
+A relative `working_directory` on a step inside the custom function resolves from the job's default working directory, not the directory containing **function.yml**.
+
+You can use custom functions in:
+
+- Custom job [`steps`](/eas/workflows/syntax/#jobsjob_idsteps)
+- Build job [`steps`](/eas/workflows/syntax/#jobsjob_idsteps)
+- Job [`hooks`](/eas/workflows/syntax/#jobsjob_idhooks) and [`defaults.hooks`](/eas/workflows/syntax/#defaultshooks)
+
+## Inputs, outputs, and scope
+
+Pass inputs at the call site with `with:`. Inside the function, read an input with `${{ inputs.<name> }}`.
+
+Define function outputs with `outputs` in **function.yml**. EAS Workflows exposes each output as a string. Read outputs as `${{ steps.<call_id>.outputs.<name> }}`. Use the `id` from the call step. The caller cannot reference the function's internal step identifiers.
+
+Expressions use the following scopes:
+
+- Inside the function, `steps.*` references resolve against the function's own steps.
+- EAS Workflows evaluates the call step's `with`, `env`, and `if` values in the caller's scope.
+- Every step in the function inherits the call step's `env` values. In nested calls, inner values override outer values with the same name.
+- EAS Workflows evaluates input defaults and expressions inside the function in the function's scope.
+- The call step's `if` gates the whole function as a single unit.
+
+## Nesting
+
+A custom function can call other custom functions and built-in `eas/*` functions. Currently, custom functions cannot call `eas/build` or `eas/maestro_test`. EAS Workflows resolves every nested path relative to the EAS project directory, not the directory containing the calling function.
+
+You can nest custom functions up to 10 levels deep. A custom function cannot call itself, either directly or through other custom functions.
+
+## Example
+
+**.eas/functions/greet/function.yml** defines a composite function with one input, one output, and one step:
+
+```yaml .eas/functions/greet/function.yml
+name: Greet
+inputs:
+  - name: who
+    default_value: world
+outputs:
+  message:
+    value: '${{ steps.make.outputs.message }}'
+runs:
+  steps:
+    - id: make
+      run: set-output message "Hello, ${{ inputs.who }}!"
+```
+
+A workflow calls it with `uses: ./.eas/functions/greet`, passes an input with `with:`, and reads the output from `${{ steps.greet.outputs.message }}`:
+
+```yaml .eas/workflows/hello.yml
+name: Hello
+jobs:
+  greet:
+    steps:
+      - id: greet
+        uses: ./.eas/functions/greet
+        with:
+          who: Expo
+      - run: echo "${{ steps.greet.outputs.message }}"
+```
+
+You can also call a custom function from a [hook](/eas/workflows/syntax/#jobsjob_idhooks):
+
+```yaml .eas/workflows/build.yml
+jobs:
+  build_ios:
+    type: build
+    params:
+      platform: ios
+    hooks:
+      before_install_node_modules:
+        - uses: ./.eas/functions/setup
+```

--- a/docs/pages/eas/workflows/custom-functions.mdx
+++ b/docs/pages/eas/workflows/custom-functions.mdx
@@ -6,7 +6,7 @@ description: Learn how to define reusable step sequences with custom functions.
 
 import { FileTree } from '~/ui/components/FileTree';
 
-Custom functions define reusable step sequences for custom jobs and hooks. Call them with a relative path using [`uses`](/eas/workflows/syntax/#jobsjob_idstepsstepuses), just like built-in functions. Each custom function defines its steps under `runs.steps` in a **function.yml** or **function.yaml** file. These steps use the same format as [custom job steps](/eas/workflows/syntax/#custom-jobs).
+Custom functions define reusable step sequences for custom jobs and hooks. You can call them with a relative path using [`uses`](/eas/workflows/syntax/#jobsjob_idstepsstepuses), like built-in functions. Each custom function defines its steps under `runs.steps` in a **function.yml** or **function.yaml** file. These steps use the same format as [custom job steps](/eas/workflows/syntax/#custom-jobs).
 
 For the **function.yml** schema, see [Custom functions](/eas/workflows/syntax/#custom-functions) in the syntax reference.
 

--- a/docs/pages/eas/workflows/limitations.mdx
+++ b/docs/pages/eas/workflows/limitations.mdx
@@ -8,7 +8,7 @@ EAS Workflows is designed to help you automate your development and release proc
 
 ## No shared workflow configurations
 
-At this time, it's not possible to define shared workflow configurations. Each workflow needs to be defined independently, which may lead to some configuration duplication.
+You cannot currently share an entire job or workflow configuration across files. [Custom functions](/eas/workflows/custom-functions/) only let you reuse sequences of custom steps in jobs or hooks.
 
 ## No matrix support
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1823,7 +1823,7 @@ jobs:
       # @end #
 ```
 
-You can define reusable step sequences in your project and call them with a path that starts with `./` or `../`, such as `./.eas/functions/setup`. EAS Workflows resolves paths from the EAS project directory. A path that starts with `../` can point outside that directory, but the custom function must remain within the repository. The path must be a static, literal string. It cannot contain `${{ }}` interpolation or backslashes. Custom function calls accept the same fields as built-in function calls: `id`, `name`, `with`, `if`, and `env`. Do not set `working_directory` on the call step. Set it on the function's inner steps instead. A relative `working_directory` on an inner step resolves from the job's default working directory, not the directory containing **function.yml**. See the [custom function schema](#custom-functions) and the guide to [using custom functions in EAS Workflows](/eas/workflows/custom-functions/).
+You can define reusable step sequences in your project and call them with a path that starts with `./` or `../`, such as `./.eas/functions/setup`. See the [custom function schema](#custom-functions) and the guide to [using custom functions in EAS Workflows](/eas/workflows/custom-functions/).
 
 Below is a list of built-in functions you can use in your workflow steps.
 
@@ -2263,7 +2263,7 @@ jobs:
 
 ## Custom functions
 
-Define reusable step sequences in your project and call them with a relative path through [`uses`](#jobsjob_idstepsstepuses). Store each custom function in a directory that contains a **function.yml** or **function.yaml** file. Steps inside a custom function use the same format as [custom job steps](#jobsjob_idsteps). For details about organizing files, nesting functions, and calling functions from jobs or hooks, see [Custom functions in EAS Workflows](/eas/workflows/custom-functions/).
+Define reusable step sequences in your project and call them with a relative path through [`uses`](#jobsjob_idstepsstepuses). The path must be a static, literal string. It cannot contain `${{ }}` interpolation or backslashes. Custom function calls accept the same fields as built-in function calls: `id`, `name`, `with`, `if`, and `env`. Do not set `working_directory` on the call step. Set it on the function's inner steps instead. Store each custom function in a directory that contains a **function.yml** or **function.yaml** file. Steps inside a custom function use the same format as [custom job steps](#jobsjob_idsteps). For details about organizing files, nesting functions, and calling functions from jobs or hooks, see [Custom functions in EAS Workflows](/eas/workflows/custom-functions/).
 
 Your **function.yml** file supports the following top-level properties: `name`, `description`, `inputs`, `outputs`, and `runs`. EAS Workflows rejects unknown top-level properties.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -2333,7 +2333,7 @@ outputs:
     description: The rendered greeting.
 ```
 
-EAS Workflows exposes each output as a string. Read the output as `${{ steps.<call_id>.outputs.<name> }}`. Use the `id` from the call step. The caller cannot reference the function's internal step IDs.
+EAS Workflows exposes each output as a string. Read the output as `${{ steps.<call_id>.outputs.<name> }}`. Use the `id` from the call step. The caller cannot reference the function's internal step identifiers.
 
 ### `runs.steps`
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -2267,7 +2267,7 @@ Define reusable step sequences in your project and call them with a relative pat
 
 Your **function.yml** file supports the following top-level properties: `name`, `description`, `inputs`, `outputs`, and `runs`. EAS Workflows rejects unknown top-level properties.
 
-### `name`
+### Function `name`
 
 An optional display name for the custom function that appears in job logs.
 
@@ -2275,7 +2275,7 @@ An optional display name for the custom function that appears in job logs.
 name: Greet
 ```
 
-### `description`
+### Function `description`
 
 An optional description of what the custom function does.
 
@@ -2283,7 +2283,7 @@ An optional description of what the custom function does.
 description: Prints a greeting for the given name.
 ```
 
-### `inputs`
+### Function `inputs`
 
 Input values a caller can pass to the custom function with `with:`. You can declare inputs two ways.
 
@@ -2317,7 +2317,7 @@ inputs:
 
 Inside the custom function's steps, read an input with `${{ inputs.<name> }}`.
 
-### `outputs`
+### Function `outputs`
 
 Declare the output values that the custom function exposes to its caller as a map keyed by output name:
 
@@ -2335,7 +2335,7 @@ outputs:
 
 EAS Workflows exposes each output as a string. Read the output as `${{ steps.<call_id>.outputs.<name> }}`. Use the `id` from the call step. The caller cannot reference the function's internal step identifiers.
 
-### `runs.steps`
+### Function `runs.steps`
 
 `runs.steps` is required and must contain at least one step. Steps use the same format as [custom job steps](#jobsjob_idsteps), including `id`, `run`, `uses`, `if`, and `working_directory`. Currently, custom functions cannot call `eas/build` or `eas/maestro_test`.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -480,7 +480,7 @@ jobs:
 
 ### `jobs.<job_id>.hooks`
 
-The following pre-packaged jobs support hooks to run additional steps before or after the main job action: `build`, `deploy`, `fingerprint`, `maestro`, `maestro-cloud`, `repack`, `submit`, `testflight`, and `update`. Hook names are job-specific. See the job's documentation for the available hook keys. To set default hooks for all jobs in the workflow, use [`defaults.hooks`](#defaultshooks).
+The following pre-packaged jobs support hooks to run additional steps before or after the main job action: `build`, `deploy`, `fingerprint`, `maestro`, `maestro-cloud`, `repack`, `submit`, `testflight`, and `update`. Hook names are job-specific. See the job's documentation for the available hook keys. To set default hooks for all jobs in the workflow, use [`defaults.hooks`](#defaultshooks). Hook steps can call [custom functions](/eas/workflows/custom-functions/) just as job steps can.
 
 ```yaml
 jobs:
@@ -520,7 +520,7 @@ Parameters to use as defaults for all jobs defined in the workflow configuration
 
 ### `defaults.hooks`
 
-Default [hooks](#jobsjob_idhooks) for all jobs in the workflow. Each job runs the hook keys that apply to it and ignores the rest. A job-level hook key overrides the same key from `defaults.hooks`. To opt a single job out of a default hook, set the key to an empty array.
+Default [hooks](#jobsjob_idhooks) for all jobs in the workflow. Each job runs the hook keys that apply to it and ignores the rest. A job-level hook key overrides the same key from `defaults.hooks`. To opt a single job out of a default hook, set the key to an empty array. Default hook steps can also call [custom functions](/eas/workflows/custom-functions/).
 
 ```yaml
 defaults:
@@ -1823,6 +1823,8 @@ jobs:
       # @end #
 ```
 
+You can define reusable step sequences in your project and call them with a path that starts with `./` or `../`, such as `./.eas/functions/setup`. EAS Workflows resolves paths from the EAS project directory. A path that starts with `../` can point outside that directory, but the custom function must remain within the repository. The path must be a static, literal string. It cannot contain `${{ }}` interpolation or backslashes. Custom function calls accept the same fields as built-in function calls: `id`, `name`, `with`, `if`, and `env`. Do not set `working_directory` on the call step. Set it on the function's inner steps instead. A relative `working_directory` on an inner step resolves from the job's default working directory, not the directory containing **function.yml**. See the [custom function schema](#custom-functions) and the guide to [using custom functions in EAS Workflows](/eas/workflows/custom-functions/).
+
 Below is a list of built-in functions you can use in your workflow steps.
 
 #### `eas/checkout`
@@ -2258,6 +2260,91 @@ jobs:
 ##### Properties
 
 <EASFunctionDescription name="posthog_upload_sourcemaps" />
+
+## Custom functions
+
+Define reusable step sequences in your project and call them with a relative path through [`uses`](#jobsjob_idstepsstepuses). Store each custom function in a directory that contains a **function.yml** or **function.yaml** file. Steps inside a custom function use the same format as [custom job steps](#jobsjob_idsteps). For details about organizing files, nesting functions, and calling functions from jobs or hooks, see [Custom functions in EAS Workflows](/eas/workflows/custom-functions/).
+
+Your **function.yml** file supports the following top-level properties: `name`, `description`, `inputs`, `outputs`, and `runs`. EAS Workflows rejects unknown top-level properties.
+
+### `name`
+
+An optional display name for the custom function that appears in job logs.
+
+```yaml
+name: Greet
+```
+
+### `description`
+
+An optional description of what the custom function does.
+
+```yaml
+description: Prints a greeting for the given name.
+```
+
+### `inputs`
+
+Input values a caller can pass to the custom function with `with:`. You can declare inputs two ways.
+
+The shorthand form is a list of names. Each input becomes an optional string input with no default value:
+
+```yaml
+inputs:
+  - who
+```
+
+The full form is a list of objects with the following properties:
+
+| Property         | Type      | Required    | Description                                                                     |
+| ---------------- | --------- | ----------- | ------------------------------------------------------------------------------- |
+| `name`           | `string`  | <YesIcon /> | The input's name. Use it to access the input as `${{ inputs.<name> }}`.         |
+| `type`           | `string`  | <NoIcon />  | The input type: `string`, `boolean`, `number`, or `json`. Defaults to `string`. |
+| `default_value`  | varies    | <NoIcon />  | The value EAS Workflows uses when you do not provide one. Must match `type`.    |
+| `allowed_values` | array     | <NoIcon />  | The values you can pass for this input.                                         |
+| `required`       | `boolean` | <NoIcon />  | Whether you must provide this input. Defaults to `false`.                       |
+
+```yaml
+inputs:
+  - name: who
+    type: string
+    default_value: world
+  - name: platform
+    type: string
+    allowed_values: [android, ios]
+    required: true
+```
+
+Inside the custom function's steps, read an input with `${{ inputs.<name> }}`.
+
+### `outputs`
+
+Declare the output values that the custom function exposes to its caller as a map keyed by output name:
+
+| Property      | Required    | Description                                                                                    |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| `value`       | <YesIcon /> | An expression that resolves to the output's value, such as `${{ steps.<id>.outputs.<name> }}`. |
+| `description` | <NoIcon />  | A description of the output.                                                                   |
+
+```yaml
+outputs:
+  message:
+    value: '${{ steps.make.outputs.message }}'
+    description: The rendered greeting.
+```
+
+EAS Workflows exposes each output as a string. Read the output as `${{ steps.<call_id>.outputs.<name> }}`. Use the `id` from the call step. The caller cannot reference the function's internal step IDs.
+
+### `runs.steps`
+
+`runs.steps` is required and must contain at least one step. Steps use the same format as [custom job steps](#jobsjob_idsteps), including `id`, `run`, `uses`, `if`, and `working_directory`. Currently, custom functions cannot call `eas/build` or `eas/maestro_test`.
+
+```yaml
+runs:
+  steps:
+    - id: make
+      run: set-output message "Hello, ${{ inputs.who }}!"
+```
 
 ## Built-in shell functions
 

--- a/docs/pages/eas/workflows/troubleshooting.mdx
+++ b/docs/pages/eas/workflows/troubleshooting.mdx
@@ -14,6 +14,8 @@ Check a workflow file for YAML syntax and schema errors before running it:
 
 <Terminal cmd={['$ eas workflow:validate .eas/workflows/my-workflow.yml']} />
 
+The command also validates any [custom functions](/eas/workflows/custom-functions/) that the workflow calls from its steps or hooks.
+
 The [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) also provides descriptions and autocompletion for workflow files as you edit them.
 
 ## Workflow doesn't start on GitHub events


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added the "custom local composite functions" feature to EAS workflows. They are the the first form of reusable custom functions available in EAS workflows.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added a new documentation page "Custom functions in EAS workflows", which describes the behavior of custom composite functions. Added a navigation to this doc to the "EAS worfkflows" section in the sidebar.
- Added references to custom functions in the "Syntax" doc, added a "Custom functions" section focusing on the syntax of custom composite functions
- Updated the "Limitations" EAS workflows document, which previously stated that there are no reusability features in workflows
- Updated docs about `eas workflow:validate`, mentioning that they also validate custom functions.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Verified the documentation renders correctly.
- CI passes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
