### PR TITLE
[router] Fix testing-library compatibility with @testing-library/react-native v14

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -45,6 +45,7 @@
 ### 🐛 Bug fixes
 
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
+- Fix `expo-router/testing-library` compatibility with `@testing-library/react-native` v14, where `render` and `act` are asynchronous and `screen.getPathname is not a function` was thrown. ([#48587](https://github.com/expo/expo/pull/48587) by [@henriquepe](https://github.com/henriquepe))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
 - Redirect fully guarded navigators to parent ([#47984](https://github.com/expo/expo/pull/47984) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/testing-library-async.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/testing-library-async.test.ios.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react-native';
+
+import { renderRouter, testRouter } from '../testing-library';
+
+/*
+ * Simulates `@testing-library/react-native` v14, where `render` and `act` are asynchronous
+ * (https://github.com/expo/expo/issues/47444). Like v14, the mocked `render` resolves with the
+ * same object it registers as `screen`.
+ */
+jest.mock('@testing-library/react-native', () => {
+  const actual = jest.requireActual('@testing-library/react-native');
+  const mocked = {
+    ...actual,
+    render: (...args: Parameters<typeof actual.render>) => Promise.resolve(actual.render(...args)),
+    act: (callback: () => unknown) => Promise.resolve(actual.act(callback)),
+  };
+  Object.defineProperty(mocked, 'screen', {
+    get: () => actual.screen,
+  });
+  return mocked;
+});
+
+describe('renderRouter with an asynchronous render', () => {
+  it('returns a promise and decorates the resolved result', async () => {
+    const pending = renderRouter(['[slug]'], { initialUrl: '/home?test=true' });
+    expect(typeof (pending as unknown as PromiseLike<unknown>).then).toBe('function');
+
+    const result = await pending;
+    expect(result.getPathname()).toBe('/home');
+    expect(result.getSegments()).toEqual(['[slug]']);
+    expect(result.getSearchParams()).toEqual({ slug: 'home', test: 'true' });
+  });
+
+  it('decorates the `screen` object so the matchers work', async () => {
+    await renderRouter(['[slug]'], { initialUrl: '/home?test=true' });
+    expect(screen).toHavePathname('/home');
+    expect(screen).toHavePathnameWithParams('/home?test=true');
+    expect(screen).toHaveSegments(['[slug]']);
+  });
+
+  it('supports the `testRouter` helpers with an asynchronous `act`', async () => {
+    await renderRouter(['[slug]'], { initialUrl: '/home' });
+    await testRouter.navigate('/other');
+    expect(screen).toHavePathname('/other');
+    await testRouter.back('/home');
+  });
+
+  it('fails with an actionable message when the render result is not awaited', async () => {
+    const pending = renderRouter(['[slug]'], { initialUrl: '/home' });
+    expect(() => expect(pending).toHavePathname('/home')).toThrow(
+      'await it when using @testing-library/react-native v14'
+    );
+    await pending;
+  });
+});

--- a/packages/expo-router/src/testing-library/expect.ts
+++ b/packages/expo-router/src/testing-library/expect.ts
@@ -34,9 +34,29 @@ function printMatcherValues(
   );
 }
 
+function readRouterScreen(
+  screen: unknown,
+  method:
+    | 'getPathname'
+    | 'getPathnameWithParams'
+    | 'getSegments'
+    | 'getSearchParams'
+    | 'getRouterState',
+  matcherName: string
+) {
+  const fn = (screen as Record<string, unknown> | null | undefined)?.[method];
+  if (typeof fn !== 'function') {
+    throw new TypeError(
+      `expect(received).${matcherName}: received value is not an expo-router render result. ` +
+        `Call \`renderRouter()\` before asserting — and await it when using @testing-library/react-native v14: \`await renderRouter(...)\`.`
+    );
+  }
+  return fn.call(screen);
+}
+
 expect.extend({
   toHavePathname(screen, expected) {
-    const received = screen.getPathname();
+    const received = readRouterScreen(screen, 'getPathname', 'toHavePathname');
     const pass = this.equals(received, expected);
     return {
       pass,
@@ -48,7 +68,7 @@ expect.extend({
     };
   },
   toHavePathnameWithParams(screen, expected) {
-    const received = screen.getPathnameWithParams();
+    const received = readRouterScreen(screen, 'getPathnameWithParams', 'toHavePathnameWithParams');
     const pass = this.equals(received, expected);
     return {
       pass,
@@ -60,7 +80,7 @@ expect.extend({
     };
   },
   toHaveSegments(screen, expected) {
-    const received = screen.getSegments();
+    const received = readRouterScreen(screen, 'getSegments', 'toHaveSegments');
     const pass = this.equals(received, expected);
     return {
       pass,
@@ -71,7 +91,7 @@ expect.extend({
     };
   },
   toHaveSearchParams(screen, expected) {
-    const received = screen.getSearchParams();
+    const received = readRouterScreen(screen, 'getSearchParams', 'toHaveSearchParams');
     const pass = this.equals(received, expected);
     return {
       pass,
@@ -82,7 +102,7 @@ expect.extend({
     };
   },
   toHaveRouterState(screen, expected) {
-    const received = screen.getRouterState();
+    const received = readRouterScreen(screen, 'getRouterState', 'toHaveRouterState');
     const pass = this.equals(received, expected);
     return {
       pass,

--- a/packages/expo-router/src/testing-library/index.tsx
+++ b/packages/expo-router/src/testing-library/index.tsx
@@ -60,7 +60,9 @@ export type RenderRouterOptions = Parameters<typeof rnTestingLibrary.render>[1] 
   linking?: Partial<ExpoLinkingOptions>;
 };
 
-type Result = ReturnType<typeof rnTestingLibrary.render> & {
+type NativeRenderResult = Awaited<ReturnType<typeof rnTestingLibrary.render>>;
+
+type RouterRenderResult = NativeRenderResult & {
   getPathname(): string;
   getPathnameWithParams(): string;
   getSegments(): string[];
@@ -68,29 +70,22 @@ type Result = ReturnType<typeof rnTestingLibrary.render> & {
   getRouterState(): ReactNavigationState | undefined;
 };
 
-export function renderRouter(
-  context: MockContextConfig = './app',
-  { initialUrl = '/', linking, ...options }: RenderRouterOptions = {}
-): Result {
-  // See https://github.com/expo/expo/issues/46864 and https://github.com/expo/expo/pull/27648
-  const systemTime = Date.now();
-  jest.useFakeTimers();
-  try {
-    jest.setSystemTime(systemTime);
-  } catch {
-    // Legacy fake timers don't support `setSystemTime` (and don't mock the clock), so there's nothing to restore.
-  }
+// `render` is synchronous in `@testing-library/react-native` v13 and asynchronous in v14, so
+// `renderRouter` mirrors whichever version is installed.
+type Result =
+  ReturnType<typeof rnTestingLibrary.render> extends PromiseLike<any>
+    ? Promise<RouterRenderResult>
+    : RouterRenderResult;
 
-  const mockContext = getMockContext(context);
+function isThenable<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as PromiseLike<T> | null | undefined)?.then === 'function';
+}
 
-  // Force the render to be synchronous
-  process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
+// Whether the last `render` returned a promise (v14). `act` returns a thenable in both versions,
+// so the `testRouter` helpers use this to decide when its result must be chained.
+let renderedAsynchronously = false;
 
-  const result = rnTestingLibrary.render(
-    <ExpoRoot context={mockContext} location={initialUrl} linking={linking} />,
-    options
-  );
-
+function decorateRenderResult(result: NativeRenderResult): RouterRenderResult {
   /**
    * This is a hack to ensure that React Navigation's state updates are processed before we run assertions.
    * Some updates are async and we need to wait for them to complete, otherwise will we get a false positive.
@@ -115,29 +110,85 @@ export function renderRouter(
   });
 }
 
+export function renderRouter(
+  context: MockContextConfig = './app',
+  { initialUrl = '/', linking, ...options }: RenderRouterOptions = {}
+): Result {
+  // See https://github.com/expo/expo/issues/46864 and https://github.com/expo/expo/pull/27648
+  const systemTime = Date.now();
+  jest.useFakeTimers();
+  try {
+    jest.setSystemTime(systemTime);
+  } catch {
+    // Legacy fake timers don't support `setSystemTime` (and don't mock the clock), so there's nothing to restore.
+  }
+
+  const mockContext = getMockContext(context);
+
+  // Force the render to be synchronous
+  process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
+
+  const result: NativeRenderResult | PromiseLike<NativeRenderResult> = rnTestingLibrary.render(
+    <ExpoRoot context={mockContext} location={initialUrl} linking={linking} />,
+    options
+  );
+
+  // On v14 `render` resolves with the same object it registers as `screen`, so the route helpers
+  // must be assigned after it settles — assigning them to the promise would leave `screen`
+  // without them (see https://github.com/expo/expo/issues/47444).
+  renderedAsynchronously = isThenable(result);
+  if (isThenable(result)) {
+    return Promise.resolve(result).then(decorateRenderResult) as unknown as Result;
+  }
+  return decorateRenderResult(result) as Result;
+}
+
+// `act` only settles asynchronously on v14, so the `testRouter` helpers mirror `render`: they
+// stay synchronous on v13 and return a promise that must be awaited on v14.
+type MaybeAsync<T> =
+  ReturnType<typeof rnTestingLibrary.render> extends PromiseLike<any> ? Promise<T> : T;
+
+function afterAct(actResult: void | PromiseLike<void>, assertion: () => void): MaybeAsync<void> {
+  if (renderedAsynchronously && isThenable(actResult)) {
+    return Promise.resolve(actResult).then(assertion) as unknown as MaybeAsync<void>;
+  }
+  assertion();
+  return undefined as unknown as MaybeAsync<void>;
+}
+
 export const testRouter = {
   /** Navigate to the provided pathname and assert the pathname */
-  navigate(path: string) {
-    rnTestingLibrary.act(() => router.navigate(path));
-    expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
+  navigate(path: string): MaybeAsync<void> {
+    return afterAct(
+      rnTestingLibrary.act(() => router.navigate(path)),
+      () => expect(rnTestingLibrary.screen).toHavePathnameWithParams(path)
+    );
   },
   /** Push the provided pathname and assert the pathname */
-  push(path: string) {
-    rnTestingLibrary.act(() => router.push(path));
-    expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
+  push(path: string): MaybeAsync<void> {
+    return afterAct(
+      rnTestingLibrary.act(() => router.push(path)),
+      () => expect(rnTestingLibrary.screen).toHavePathnameWithParams(path)
+    );
   },
   /** Replace with provided pathname and assert the pathname */
-  replace(path: string) {
-    rnTestingLibrary.act(() => router.replace(path));
-    expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
+  replace(path: string): MaybeAsync<void> {
+    return afterAct(
+      rnTestingLibrary.act(() => router.replace(path)),
+      () => expect(rnTestingLibrary.screen).toHavePathnameWithParams(path)
+    );
   },
   /** Go back in history and assert the new pathname */
-  back(path?: string) {
+  back(path?: string): MaybeAsync<void> {
     expect(router.canGoBack()).toBe(true);
-    rnTestingLibrary.act(() => router.back());
-    if (path) {
-      expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
-    }
+    return afterAct(
+      rnTestingLibrary.act(() => router.back()),
+      () => {
+        if (path) {
+          expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
+        }
+      }
+    );
   },
   /** If there's history that supports invoking the `back` function. */
   canGoBack() {
@@ -147,11 +198,14 @@ export const testRouter = {
   setParams(params: Record<string, string>, path?: string) {
     router.setParams(params);
     if (path) {
-      expect(screen).toHavePathnameWithParams(path);
+      expect(rnTestingLibrary.screen).toHavePathnameWithParams(path);
     }
   },
   /** If there's history that supports invoking the `back` function. */
-  dismissAll() {
-    rnTestingLibrary.act(() => router.dismissAll());
+  dismissAll(): MaybeAsync<void> {
+    return afterAct(
+      rnTestingLibrary.act(() => router.dismissAll()),
+      () => {}
+    );
   },
 };


### PR DESCRIPTION
# Why

Fixes #47444 — `expo-router/testing-library` is broken with `@testing-library/react-native` (RNTL) v14: `expect(screen).toHavePathname(...)` throws `TypeError: screen.getPathname is not a function`.

Root cause: RNTL v14 made `render()` asynchronous. `renderRouter` called it without awaiting and `Object.assign`ed the route helpers (`getPathname`, `getSegments`, …) onto the returned value — on v14 that decorates the **promise**, while the actual `RenderResult` (the same object RNTL registers as `screen`) never receives them. The custom matchers then fail on `screen.getPathname()`. (Confirmed from the RNTL side in callstack/react-native-testing-library#1924.)

# How

- `renderRouter` now detects whether `render()` returned a thenable:
  - **v13**: unchanged — fully synchronous, decorates and returns the result directly.
  - **v14**: returns a promise that decorates the **resolved** result, restoring the `result === screen` identity the helpers and matchers rely on. The return type mirrors the installed RNTL version (`ReturnType<typeof render> extends PromiseLike<any> ? Promise<RouterRenderResult> : RouterRenderResult`), so v14 users get correct `await renderRouter(...)` types.
- `testRouter` helpers (`navigate`, `push`, `replace`, `back`, `dismissAll`) chain their assertion after `act` settles on v14, and stay synchronous on v13. Since `act` returns a thenable on both versions, the discriminator is the observed `render` behavior (module flag set by `renderRouter`), not the `act` return value.
- The custom matchers now throw an actionable error (`Call \`renderRouter()\` before asserting — and await it when using @testing-library/react-native v14`) instead of a raw `TypeError` when the received value is not a decorated render result.
- Drive-by: `testRouter.setParams` asserted against a bare `screen` identifier that resolved to the global instead of RNTL's `screen`; it now uses `rnTestingLibrary.screen` like the other helpers.

No dependency changes: the monorepo stays on RNTL v13 (`^13.3.0` devDependency, shared by 21 other packages), and the peer range (`>= 13.2.0`) already allowed v14.

# Test Plan

- **v13 (no regression):** full `expo-router` suite on RNTL 13.3.3 — 347 suites / 4664 tests, 0 failures. All existing testing-library consumers (`smoke`, navigator suites, matcher snapshots) untouched and green.
- **v14 (unit):** new `src/__tests__/testing-library-async.test.ios.tsx` mocks RNTL with async `render`/`act` (resolving with the same object registered as `screen`, matching the v14 implementation) and covers: promise-returning `renderRouter` with decorated resolved result, decorated `screen` + matchers, `testRouter` helpers with async `act`, and the actionable matcher error for un-awaited results.
- **v14 (end-to-end):** ran the issue's minimal reproduction (https://github.com/kovbe21/jest-reproductions, `path-name.test.tsx`) against real RNTL **14.0.1**: reproduces the exact `TypeError` before the fix, passes with the patched build output.
- `pnpm build`, `pnpm typecheck`, `pnpm lint`, `pnpm format --check` all clean.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
