### PR TITLE
[ios][audio] Fix blocking calls on JS thread

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Create a fresh recording file each time `prepareToRecordAsync` is called, matching Android — repeated takes no longer overwrite the previous recording at the same URL. ([#48002](https://github.com/expo/expo/pull/48002) by [@idoyana](https://github.com/idoyana))
 - Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types. ([#48219](https://github.com/expo/expo/pull/48219) by [@zoontek](https://github.com/zoontek))
-- [iOS] Activate the audio session once and keep it active instead of toggling.
+- [iOS] Activate the audio session once and keep it active instead of toggling. ([#48588](https://github.com/expo/expo/pull/48588) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [Android] Don't start playback when the system denies audio focus, and log a warning explaining that background playback needs an active media playback foreground service. ([#46957](https://github.com/expo/expo/pull/46957) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Create a fresh recording file each time `prepareToRecordAsync` is called, matching Android — repeated takes no longer overwrite the previous recording at the same URL. ([#48002](https://github.com/expo/expo/pull/48002) by [@idoyana](https://github.com/idoyana))
 - Fix `player.replace(null)` throwing due to a mismatch between native and TypeScript types. ([#48219](https://github.com/expo/expo/pull/48219) by [@zoontek](https://github.com/zoontek))
+- [iOS] Activate the audio session once and keep it active instead of toggling.
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -1,8 +1,12 @@
 import ExpoModulesCore
+import os
 
 public class AudioModule: Module {
-  private var sessionIsActive = true
   private let registry = AudioComponentRegistry()
+
+  private let sessionQueue = DispatchQueue(label: "expo.modules.audio.session", qos: .userInitiated)
+  private var sessionIsActive = false
+  private let audioEnabled = OSAllocatedUnfairLock(initialState: true)
 
   // MARK: Properties
   private var recordingSettings = [String: Any]()
@@ -32,7 +36,7 @@ public class AudioModule: Module {
       try setAudioMode(mode: mode)
     }
 
-    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool)  in
+    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool) in
       try setIsAudioActive(isActive)
     }
 
@@ -211,9 +215,12 @@ public class AudioModule: Module {
       }
 
       Function("play") { player in
-        try activateSession()
+        guard self.canStartPlayback() else {
+          return
+        }
         let rate = player.currentRate > 0 ? player.currentRate : 1.0
         player.play(at: rate)
+        self.activateSession()
       }
 
       Function("setPlaybackRate") { (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
@@ -245,7 +252,7 @@ public class AudioModule: Module {
       Function("pause") { player in
         player.ref.pause()
         if !player.keepAudioSessionActive {
-          deactivateSession()
+          self.deactivateSession()
         }
       }
 
@@ -364,8 +371,11 @@ public class AudioModule: Module {
       }
 
       Function("play") { playlist in
-        try activateSession()
+        guard self.canStartPlayback() else {
+          return
+        }
         playlist.play(at: playlist.currentRate)
+        self.activateSession()
       }
 
       Function("pause") { playlist in
@@ -552,10 +562,12 @@ public class AudioModule: Module {
       AsyncFunction("start") { (stream: AudioStream) in
         try checkPermissions()
         try stream.start()
+        self.recordSessionActive(true)
       }
 
       Function("stop") { (stream: AudioStream) in
         stream.stop()
+        self.deactivateSession()
       }
 
       AsyncFunction("startFileRecordingAsync") { (stream: AudioStream, options: AudioStreamFileRecordingOptions?) throws -> AudioStreamFileRecordingStartResult in
@@ -660,16 +672,18 @@ public class AudioModule: Module {
       }
     }
 #endif
+
+    recordSessionActive(false)
   }
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
-    do {
-      try AVAudioSession.sharedInstance().setActive(true)
-      if options.contains(.shouldResume) {
-        resumeInterruptedPlayers()
+    sessionQueue.async { [weak self] in
+      guard let self, self.audioEnabled.withLock({ $0 }), self.applySessionActive(true) else {
+        return
       }
-    } catch {
-      print("Failed to reactivate audio session: \(error)")
+      if options.contains(.shouldResume) {
+        self.resumeInterruptedPlayers()
+      }
     }
   }
 
@@ -705,13 +719,23 @@ public class AudioModule: Module {
   }
 
   private func reconfigureAudioSession() {
-    do {
-      if let mode = lastConfiguredMode {
-        try setAudioMode(mode: mode)
+    sessionQueue.async { [weak self] in
+      guard let self else {
+        return
       }
-      try AVAudioSession.sharedInstance().setActive(true)
-    } catch {
-      print("Failed to reconfigure audio session after media services reset: \(error)")
+      do {
+        if let mode = self.lastConfiguredMode {
+          try self.setAudioMode(mode: mode)
+        }
+      } catch {
+        log.warn("[expo-audio] Failed to reconfigure the audio session after a media services reset: \(error.localizedDescription)")
+        return
+      }
+      guard self.audioEnabled.withLock({ $0 }) else {
+        self.sessionIsActive = false
+        return
+      }
+      self.applySessionActive(true)
     }
   }
   #endif
@@ -789,13 +813,16 @@ public class AudioModule: Module {
   }
 
   private func setIsAudioActive(_ isActive: Bool) throws {
+    audioEnabled.withLock { $0 = isActive }
     if !isActive {
       pauseAllPlayers()
     }
 
     do {
-      try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
-      sessionIsActive = isActive
+      try sessionQueue.sync {
+        try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
+        self.sessionIsActive = isActive
+      }
     } catch {
       throw AudioStateException(error.localizedDescription)
     }
@@ -871,23 +898,58 @@ public class AudioModule: Module {
     }
   }
 
-  private func activateSession() throws {
-    try AVAudioSession.sharedInstance().setActive(true)
+  private func canStartPlayback() -> Bool {
+    guard audioEnabled.withLock({ $0 }) else {
+      log.warn("[expo-audio] Ignoring play() because audio is disabled. Call setIsAudioActiveAsync(true) to re-enable playback.")
+      return false
+    }
+    return true
+  }
+
+  private func activateSession() {
+    sessionQueue.async { [weak self] in
+      guard let self, self.audioEnabled.withLock({ $0 }), !self.sessionIsActive else {
+        return
+      }
+      self.applySessionActive(true)
+    }
   }
 
   private func deactivateSession() {
-    Task {
-      // Give isPlaying time to update before deciding whether to deactivate.
-      try? await Task.sleep(for: .milliseconds(100))
-      let hasActivePlayables = registry.allPlayables.contains { $0.isPlaying }
-      guard !hasActivePlayables else {
+    sessionQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
+      guard let self, self.sessionIsActive, !self.isSessionInUse else {
         return
       }
-      do {
-        try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
-      } catch {
-        print("Failed to deactivate audio session: \(error)")
-      }
+      self.applySessionActive(false)
+    }
+  }
+
+  @discardableResult
+  private func applySessionActive(_ isActive: Bool) -> Bool {
+    do {
+      try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
+      sessionIsActive = isActive
+      return true
+    } catch {
+      log.warn("[expo-audio] Failed to \(isActive ? "activate" : "deactivate") the audio session: \(error.localizedDescription)")
+      return false
+    }
+  }
+
+  private var isSessionInUse: Bool {
+    if registry.allPlayables.contains(where: { $0.isPlaying }) {
+      return true
+    }
+    #if os(iOS)
+    return registry.allRecorders.values.contains { $0.isRecording }
+    #else
+    return false
+    #endif
+  }
+
+  private func recordSessionActive(_ isActive: Bool) {
+    sessionQueue.async { [weak self] in
+      self?.sessionIsActive = isActive
     }
   }
 

--- a/packages/expo-audio/ios/AudioStream.swift
+++ b/packages/expo-audio/ios/AudioStream.swift
@@ -117,12 +117,10 @@ class AudioStream: SharedObject {
     // removeTap above ensures no more data is dispatched to fileWriterQueue;
     // syncing on the queue drains any appends already in flight before closing the writer.
     fileWriterQueue.sync {
-      try? self.fileWriter?.finish()
+      _ = try? self.fileWriter?.finish()
       self.fileWriter = nil
       self.fileWriterError = nil
     }
-
-    try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
   }
 
   func startFileRecording(url: URL, format: AudioStreamFileFormat) throws -> String {
@@ -250,16 +248,15 @@ class AudioStream: SharedObject {
 
     let timestamp = timestampSinceStart(when)
     let channelCount = Int(buffer.format.channelCount)
-    let data: NativeArrayBuffer
+    let data: ArrayBuffer
+    let sampleCount = frameLength * channelCount
 
     if encoding == .int16, let int16Data = buffer.int16ChannelData {
-      let sampleCount = frameLength * channelCount
       let byteCount = sampleCount * MemoryLayout<Int16>.size
-      data = NativeArrayBuffer.copy(of: int16Data[0], count: byteCount)
+      data = ArrayBuffer.copy(of: int16Data[0], count: byteCount)
     } else if let floatData = buffer.floatChannelData {
-      let sampleCount = frameLength * channelCount
       let byteCount = sampleCount * MemoryLayout<Float32>.size
-      data = NativeArrayBuffer.copy(of: floatData[0], count: byteCount)
+      data = ArrayBuffer.copy(of: floatData[0], count: byteCount)
     } else {
       return
     }


### PR DESCRIPTION
# Why
Closes #48531

# How
Interacting with the audio session can be blocking on ios so calls to things like setActive can block the JS thread.  The main change is that the session is activated once and kept active, rather than toggled. `sessionIsActive` tracks the state and is only touched on the session queue, so `activateSession()` is a no-op when the session is already active. 

# Test Plan
Bare expo

