### PR TITLE
fix(metro-config): Support packed source maps outside Expo CLI

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
+- Install packed source map support from `getDefaultConfig` so Metro drivers other than `@expo/cli` no longer fail with `Unexpected module with full source map found`. ([#48593](https://github.com/expo/expo/pull/48593) by [@jakubstec](https://github.com/jakubstec))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/ExpoMetroConfig.ts
+++ b/packages/@expo/metro-config/src/ExpoMetroConfig.ts
@@ -24,7 +24,9 @@ import { getModulesPaths } from './getModulesPaths';
 import { getWatchFolders } from './getWatchFolders';
 import { getRewriteRequestUrl } from './rewriteRequestUrl';
 import type { JSModule } from './serializer/getCssDeps';
+import { patchBundlerPrototypeForPackedMaps } from './serializer/packedMap';
 import { isVirtualModule } from './serializer/sideEffects';
+import { patchMetroSourceMapStringForPackedMaps } from './serializer/sourceMap';
 import { withExpoSerializers } from './serializer/withExpoSerializers';
 import { getPostcssConfigHash } from './transform-worker/postcss';
 import { toPosixPath } from './utils/filePath';
@@ -216,6 +218,13 @@ export function getDefaultConfig(
   if (isCSSEnabled) {
     patchMetroGraphToSupportUncachedModules();
   }
+
+  // The transformer below emits packed source maps, so non-CLI Metro drivers
+  // need the unpack side too, not just
+  // `@expo/cli`. Both patches are idempotent, so it's fine that the CLI installs
+  // them again on its own `Bundler`.
+  patchBundlerPrototypeForPackedMaps();
+  patchMetroSourceMapStringForPackedMaps();
 
   const reactNativePath = path.dirname(
     resolveFrom.silent(projectRoot, 'react-native/package.json') ?? 'react-native/package.json'

--- a/packages/@expo/metro-config/src/serializer/__tests__/packedMap.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/packedMap.test.ts
@@ -689,4 +689,55 @@ describe('patchTransformFileForPackedMaps', () => {
     expect(r.output[0].data.__packedMap).toBeInstanceOf(PackedMap);
     expect(r.output[0].data.map.length).toBe(1);
   });
+
+  // The patch has to work on `Bundler.prototype` since third-party drivers never
+  // hand out an instance — which only works if it forwards `this` instead of
+  // binding, otherwise it'd run against the prototype, not the real bundler.
+  it('forwards the receiver so it can be installed on a shared prototype', async () => {
+    const receivers: unknown[] = [];
+    class FakeBundler {
+      async transformFile(this: FakeBundler) {
+        receivers.push(this);
+        return {
+          output: [
+            {
+              type: 'js/module',
+              data: {
+                map: wire({ segments: [[1, 0, 1, 0]] }),
+                code: '',
+                lineCount: 1,
+                functionMap: null,
+              },
+            },
+          ],
+        };
+      }
+    }
+    patchTransformFileForPackedMaps(FakeBundler.prototype as any);
+
+    const a = new FakeBundler();
+    const b = new FakeBundler();
+    const ra: any = await a.transformFile();
+    await b.transformFile();
+
+    // toBe, not toEqual — these bare instances have no properties, so they'd
+    // compare equal structurally even though they're different objects.
+    expect(receivers).toHaveLength(2);
+    expect(receivers[0]).toBe(a);
+    expect(receivers[1]).toBe(b);
+    expect(ra.output[0].data.__packedMap).toBeInstanceOf(PackedMap);
+  });
+
+  it('leaves an instance alone when its prototype is already patched', async () => {
+    class FakeBundler {
+      async transformFile() {
+        return { output: [] };
+      }
+    }
+    patchTransformFileForPackedMaps(FakeBundler.prototype as any);
+    const instance = new FakeBundler();
+    patchTransformFileForPackedMaps(instance as any);
+
+    expect(Object.prototype.hasOwnProperty.call(instance, 'transformFile')).toBe(false);
+  });
 });

--- a/packages/@expo/metro-config/src/serializer/packedMap.ts
+++ b/packages/@expo/metro-config/src/serializer/packedMap.ts
@@ -191,15 +191,37 @@ export function wrapTransformResultMaps<T extends { output?: readonly unknown[] 
   return result;
 }
 
-// Idempotent: chaining is safe because `installPackedMap` only fires
-// when `data.map` is still a `SerializableSourceMap`.
+// An instance inherits this from a patched prototype, so patching the prototype
+// first makes a later instance-level call a no-op instead of double-wrapping.
+const PATCHED_FLAG = '__expoPackedSourceMapsPatched';
+
+// Idempotent, and works whether `bundler` is an instance or `Bundler.prototype`.
+// The receiver is forwarded, not bound, so a prototype patch still runs against
+// whichever bundler actually calls `transformFile`.
 export function patchTransformFileForPackedMaps(bundler: {
   transformFile: (...args: any[]) => Promise<unknown>;
 }): void {
-  const originalTransformFile = bundler.transformFile.bind(bundler);
-  bundler.transformFile = async (...args: any[]) => {
-    return wrapTransformResultMaps((await originalTransformFile(...args)) as any);
+  if ((bundler as Record<string, unknown>)[PATCHED_FLAG]) return;
+  const originalTransformFile = bundler.transformFile;
+  bundler.transformFile = async function (this: unknown, ...args: any[]) {
+    return wrapTransformResultMaps((await originalTransformFile.apply(this, args)) as any);
   };
+  Object.defineProperty(bundler, PATCHED_FLAG, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+// `@expo/cli` patches its own `Bundler` instance, but other Metro drivers
+// build their own and never expose it.
+// Patching the prototype covers those too — otherwise their `data.map` stays
+// packed and Metro's `fromRawMappings` throws "Unexpected module with full
+// source map found".
+export function patchBundlerPrototypeForPackedMaps(): void {
+  const mod = require('@expo/metro/metro/Bundler');
+  const Bundler = mod.default ?? mod;
+  patchTransformFileForPackedMaps(Bundler.prototype);
 }
 
 // Materialize any `data.map` shape (serialized, Proxy, or plain tuples) into a


### PR DESCRIPTION
# Why

Fixes #48594.

`@expo/metro-config` emits packed source maps, but only `@expo/cli` knows how to read them. Anything else that drives Metro with Expo's config crashes as soon as it needs a source map.

#45594 changed `module.output[0].data.map` from `MetroSourceMapSegmentTuple[]` to a packed `{ __packed, __names, __count, __version }` object. The producing side is installed **declaratively** — `getDefaultConfig` sets `transformerPath`, so it travels with the config to every consumer. The consuming side is installed **imperatively**, and only inside `@expo/cli` (`instantiateMetro.ts`, `exportEmbedAsync.ts`), so it stays behind.

Everyone else therefore hits [`metro-source-map/src/source-map.js#L140`](https://github.com/react/metro/blob/v0.84.4/packages/metro-source-map/src/source-map.js#L140):

```js
if (Array.isArray(map)) {
  addMappingsForFile(generator, map, mod, carryOver);
} else if (map != null) {
  throw new Error(`Unexpected module with full source map found: ${mod.path}`);
}
```

The packed object matches `map != null && !Array.isArray(map)` exactly. `fromRawMappings` declares `+map: ?ReadonlyArray<MetroSourceMapSegmentTuple>`, so this breaks a documented contract rather than a private assumption.

This is happening in the wild:

- [react/metro#1779](https://github.com/react/metro/issues/1779) — the same crash from plain `react-native bundle --sourcemap-output` on SDK 56. Fails in Xcode builds but not via `npx expo run:ios`, which matches the patch being CLI-only. Filed against Metro because the reporter had no way to know the format came from Expo.
- [Expensify/App@e6632bd](https://github.com/Expensify/App/commit/e6632bd3c57ddb6e29cdcac827617f5480683481) — we hit it upgrading to RN 0.85 / SDK 56 with [Rock](https://github.com/callstackincubator/rock). Rock never exposes a `Bundler` instance, so we patch `Bundler.prototype.transformFile` from our own `metro.config.js`, deep-importing `@expo/metro-config/build/serializer/packedMap` and `metro/private/Bundler`. This PR is that workaround upstreamed so nobody has to reach into internals.

Worth noting there's no way to discover any of this — the format isn't documented and nothing is re-exported from the package root.

# How

Install the reader side from `getDefaultConfig`, right next to the `transformerPath` that causes the packing, so producer and consumer can't drift apart:

```ts
patchBundlerPrototypeForPackedMaps();
patchMetroSourceMapStringForPackedMaps();
```

Patching a Metro internal from config load already has precedent a few lines up in the same function — `patchMetroGraphToSupportUncachedModules` does the same thing to `Graph.prototype.traverseDependencies`, with a lazy `require` and an idempotency flag.

Two supporting changes in `serializer/packedMap.ts`:

1. **`patchTransformFileForPackedMaps` forwards its receiver.** It used `bundler.transformFile.bind(bundler)`, which is fine on an instance but wrong on a prototype — `this` would be the prototype instead of the live bundler. It now uses a `function` and `originalTransformFile.apply(this, args)`, so it works on both.
2. **It's idempotent** via a non-enumerable `__expoPackedSourceMapsPatched` flag. An instance inherits it from a patched prototype, so the existing `@expo/cli` calls become no-ops rather than stacking a second wrapper. I left those calls in place as a safety net for configs that set Expo's `transformerPath` without going through `getDefaultConfig` — happy to drop them if you'd rather have one source of truth.
3. New `patchBundlerPrototypeForPackedMaps()` lazily requires `@expo/metro/metro/Bundler` and patches the prototype.

Only the `transformFile` patch matters for correctness — `installPackedMap` puts an `Array.isArray`-true Proxy on `data.map`, which `fromRawMappings` accepts. `patchMetroSourceMapStringForPackedMaps` is just the encoder fast path, so third-party drivers were quietly losing that win too; installing it here gives them the same performance as the CLI.

### Alternative considered

Gate the packed format behind a transformer flag (e.g. `transformer.unstable_packedSourceMaps`), off by default in `getDefaultConfig` and switched on by `@expo/cli`. That's semantically stronger — producer and consumer can't desync by construction, and no prototype patching. I didn't go that way because it silently denies the #45594 memory win to exactly the people who are currently broken, and it changes the transform cache key. Glad to switch if you prefer that tradeoff.

# Test Plan

Two unit tests added to `packages/@expo/metro-config/src/serializer/__tests__/packedMap.test.ts`, covering prototype installation and the idempotency guard. Both fail before this change:

```
$ pnpm exec jest src/serializer/__tests__/packedMap.test.ts -t patchTransformFileForPackedMaps   # before
  ✓ wraps every result returned by the patched bundler
  ✓ chains cleanly with a pre-existing patch (no double-wrap on the second pass)
  ✕ forwards the receiver so it can be installed on a shared prototype
  ✕ leaves an instance alone when its prototype is already patched
```

```
$ pnpm exec jest                                                                                  # after
Test Suites: 47 passed, 47 total
Tests:       4 skipped, 866 passed, 870 total
Snapshots:   374 passed, 374 total
```

```
$ et check-packages @expo/metro-config @expo/cli
 Tasks:    48 successful, 48 total     # build, typecheck, depscheck, test, lint
 Tasks:     4 successful, 4 total      # format
🏁 All checks passed.
```

Manual reproduction, in a project whose `metro.config.js` uses `getDefaultConfig` but bundles without Expo CLI:

```bash
npx react-native bundle --entry-file index.js --platform ios --dev true \
  --bundle-output /tmp/main.jsbundle --sourcemap-output /tmp/main.jsbundle.map
```

Before: `Error: Unexpected module with full source map found: <path>`. After: bundle and map are written, and the map symbolicates correctly.

Also worth confirming no regression on the CLI paths that already installed these patches and now hit the idempotency guard — `npx expo start` (fetch a `.map` from the dev server) and `npx expo export`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
