### PR TITLE
[router] Allow descriptor without a `key`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Allow descriptor routes without a `key` in `expo-router/react-navigation` types.
+- Make `key` optional in `Descriptor` type ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Remove `getStateForRouteNamesChange` from the `Router` interface on `expo-router/react-navigation`. Custom routers must handle the `ROUTE_NAMES_CHANGED` action in `getStateForAction` instead. ([#48479](https://github.com/expo/expo/pull/48479) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Make `key` optional in `Descriptor` type ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
+- Allow `key` to be `undefined` in the `Descriptor` type and in routes passed to screen `options`, navigator `screenOptions`, and `RouteGroupConfig.screenOptions` callbacks. ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Remove `getStateForRouteNamesChange` from the `Router` interface on `expo-router/react-navigation`. Custom routers must handle the `ROUTE_NAMES_CHANGED` action in `getStateForAction` instead. ([#48479](https://github.com/expo/expo/pull/48479) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Allow descriptor routes without a `key` in `expo-router/react-navigation` types.
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Remove `getStateForRouteNamesChange` from the `Router` interface on `expo-router/react-navigation`. Custom routers must handle the `ROUTE_NAMES_CHANGED` action in `getStateForAction` instead. ([#48479](https://github.com/expo/expo/pull/48479) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/types.test.ts
+++ b/packages/expo-router/src/__tests__/types.test.ts
@@ -1,0 +1,16 @@
+import type { ScreenProps } from '../useScreens';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type CallbackArgument<T> = T extends (arg: infer P) => unknown ? P : never;
+
+export type _ScreenOptionsRouteKeyMayBeUndefined = Expect<
+  Equal<CallbackArgument<NonNullable<ScreenProps['options']>>['route']['key'], string | undefined>
+>;
+
+describe('public types', () => {
+  it('type-checks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/expo-router/src/layouts/StackClient.tsx
+++ b/packages/expo-router/src/layouts/StackClient.tsx
@@ -13,8 +13,8 @@ import {
   INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME,
 } from '../navigationParams';
 import {
+  type DescriptorRouteProp,
   type ParamListBase,
-  type RouteProp,
   StackActions,
   type StackNavigationState,
   type StackRouterOptions,
@@ -174,7 +174,7 @@ type NativeStackScreenOptions = ComponentProps<typeof RNStack>['screenOptions'];
 
 function disableAnimationInScreenOptions(
   options: NativeStackScreenOptions | undefined,
-  condition: (route: RouteProp<ParamListBase, string>) => boolean
+  condition: (route: DescriptorRouteProp<ParamListBase, string>) => boolean
 ): NativeStackScreenOptions {
   if (options && typeof options === 'function') {
     return (props) => {
@@ -199,7 +199,9 @@ function disableAnimationInScreenOptions(
   };
 }
 
-function shouldDisableAnimationBasedOnParams(route: RouteProp<ParamListBase, string>): boolean {
+function shouldDisableAnimationBasedOnParams(
+  route: DescriptorRouteProp<ParamListBase, string>
+): boolean {
   const expoParams = getInternalExpoRouterParams(route.params);
   return !!expoParams[INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME];
 }

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
@@ -1,7 +1,9 @@
 import type { ComponentProps } from 'react';
 
 import type { JSTabsProps, Tabs, TabsScreenOptions } from '../../../layouts/Tabs';
+import type { DescriptorRouteProp, ParamListBase, RouteProp } from '../../native';
 import type { BottomTabNavigatorContentProps } from '../navigators/createBottomTabNavigator';
+import type { BottomTabOptionsArgs } from '../types';
 
 type Expect<T extends true> = T;
 type Equal<A, B> =
@@ -9,6 +11,15 @@ type Equal<A, B> =
 
 type TabsProps = ComponentProps<typeof Tabs>;
 
+export type _OptionsRouteIsDescriptorRoute = Expect<
+  Equal<BottomTabOptionsArgs<ParamListBase>['route'], DescriptorRouteProp<ParamListBase>>
+>;
+export type _OptionsRouteKeyMayBeUndefined = Expect<
+  Equal<BottomTabOptionsArgs<ParamListBase>['route']['key'], string | undefined>
+>;
+export type _RoutePropIsDescriptorRoute = Expect<
+  RouteProp<ParamListBase> extends DescriptorRouteProp<ParamListBase> ? true : false
+>;
 export type _PublicPropsMatchTabs = Expect<Equal<JSTabsProps, TabsProps>>;
 
 // The props injected by `createProps` reach the content component but never the element.

--- a/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
@@ -13,6 +13,7 @@ import type { NavigatorArgs } from 'standard-navigation';
 import type { HeaderOptions, PlatformPressable } from '../elements';
 import type {
   Descriptor,
+  DescriptorRouteProp,
   NavigationProp,
   ParamListBase,
   RouteProp,
@@ -92,7 +93,8 @@ export type BottomTabOptionsArgs<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList,
   NavigatorID extends string | undefined = undefined,
-> = BottomTabScreenProps<ParamList, RouteName, NavigatorID> & {
+> = Omit<BottomTabScreenProps<ParamList, RouteName, NavigatorID>, 'route'> & {
+  route: DescriptorRouteProp<ParamList, RouteName>;
   theme: Theme;
 };
 

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabBar.tsx
@@ -333,7 +333,8 @@ export function BottomTabBar({ state, descriptors, emitter, navigateToTab, inset
       <View role="tablist" style={sidebar ? styles.sideContent : styles.bottomContent}>
         {routes.map((route, index) => {
           const focused = index === state.index;
-          const { options } = descriptors[route.key]!;
+          const descriptor = descriptors[route.key]!;
+          const { options } = descriptor;
 
           const onPress = () => {
             const event = emitter.emit({
@@ -367,14 +368,11 @@ export function BottomTabBar({ state, descriptors, emitter, navigateToTab, inset
                 : undefined;
 
           return (
-            <NavigationProvider
-              key={route.key}
-              route={route}
-              navigation={descriptors[route.key]!.navigation}>
+            <NavigationProvider key={route.name} route={route} navigation={descriptor.navigation}>
               <BottomTabItem
                 href={buildHref(route.name, route.params)}
                 route={route}
-                descriptor={descriptors[route.key]!}
+                descriptor={descriptor}
                 focused={focused}
                 horizontal={hasHorizontalLabels}
                 compact={compact}

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -231,8 +231,11 @@ export function BottomTabView(props: Props) {
           const isFocused = state.index === index;
           const isPreloaded = preloadedRouteKeys.includes(route.key);
 
-          if (lazy && !loaded.includes(route.key) && !isFocused && !isPreloaded) {
-            // Don't render a lazy screen if we've never navigated to it or it wasn't preloaded
+          if (
+            descriptor.route.key === undefined ||
+            (lazy && !loaded.includes(route.key) && !isFocused && !isPreloaded)
+          ) {
+            // Don't render placeholder or unloaded lazy screens.
             return null;
           }
 

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -281,14 +281,14 @@ export function BottomTabView(props: Props) {
                 value={tabBarPosition === 'bottom' ? tabBarHeight : 0}>
                 <Screen
                   focused={isFocused}
-                  route={descriptor.route}
+                  route={route}
                   navigation={descriptor.navigation}
                   headerShown={headerShown}
                   headerStatusBarHeight={headerStatusBarHeight}
                   headerTransparent={headerTransparent}
                   header={header({
                     layout: dimensions,
-                    route: descriptor.route,
+                    route,
                     navigation: descriptor.navigation as BottomTabNavigationProp<ParamListBase>,
                     options: descriptor.options,
                   })}

--- a/packages/expo-router/src/react-navigation/core/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/core/__tests__/types.test.ts
@@ -1,0 +1,41 @@
+import type {
+  DefaultNavigatorOptions,
+  EventMapBase,
+  NavigationState,
+  ParamListBase,
+  RouteGroupConfig,
+} from '../../native';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type CallbackArgument<T> = T extends (arg: infer P) => unknown ? P : never;
+
+type NavigatorOptions = DefaultNavigatorOptions<
+  ParamListBase,
+  undefined,
+  NavigationState,
+  Record<string, never>,
+  EventMapBase,
+  unknown
+>;
+type GroupOptions = RouteGroupConfig<ParamListBase, Record<string, never>, unknown>;
+
+export type _NavigatorScreenOptionsRouteKeyMayBeUndefined = Expect<
+  Equal<
+    CallbackArgument<NonNullable<NavigatorOptions['screenOptions']>>['route']['key'],
+    string | undefined
+  >
+>;
+export type _GroupScreenOptionsRouteKeyMayBeUndefined = Expect<
+  Equal<
+    CallbackArgument<NonNullable<GroupOptions['screenOptions']>>['route']['key'],
+    string | undefined
+  >
+>;
+
+describe('core types', () => {
+  it('type-checks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -81,7 +81,7 @@ export type DefaultNavigatorOptions<
   screenOptions?:
     | ScreenOptions
     | ((props: {
-        route: RouteProp<ParamList>;
+        route: DescriptorRouteProp<ParamList>;
         navigation: Navigation;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);
@@ -478,6 +478,11 @@ export type RouteProp<
   RouteName extends keyof ParamList = Keyof<ParamList>,
 > = Route<Extract<RouteName, string>, ParamList[RouteName]>;
 
+export type DescriptorRouteProp<
+  ParamList extends ParamListBase,
+  RouteName extends keyof ParamList = Keyof<ParamList>,
+> = DescriptorRoute<RouteProp<ParamList, RouteName>>;
+
 export type CompositeNavigationProp<
   A extends NavigationProp<ParamListBase, string, any, any, any>,
   B extends NavigationHelpersCommon<ParamListBase, any>,
@@ -554,9 +559,8 @@ export type RouteSource = 'layout' | 'filesystem';
  * describes a route name declared in a layout that has no live route
  * instance in navigation state.
  */
-export type DescriptorRoute<Route extends RouteProp<any, any>> = Route extends unknown
-  ? Omit<Route, 'key'> & Readonly<{ key: string | undefined }>
-  : never;
+export type DescriptorRoute<Route extends RouteProp<any, any>> = Omit<Route, 'key'> &
+  Readonly<{ key: string | undefined }>;
 
 export type Descriptor<
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -662,7 +666,7 @@ export type RouteConfigProps<
   options?:
     | ScreenOptions
     | ((props: {
-        route: RouteProp<ParamList, RouteName>;
+        route: DescriptorRouteProp<ParamList, RouteName>;
         navigation: Navigation;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);
@@ -729,7 +733,7 @@ export type RouteGroupConfig<
   screenOptions?:
     | ScreenOptions
     | ((props: {
-        route: RouteProp<ParamList, keyof ParamList>;
+        route: DescriptorRouteProp<ParamList, keyof ParamList>;
         navigation: Navigation;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -549,6 +549,15 @@ export type ScreenLayoutArgs<
  */
 export type RouteSource = 'layout' | 'filesystem';
 
+/**
+ * Route carried by a descriptor. `key` is `undefined` when the descriptor
+ * describes a route name declared in a layout that has no live route
+ * instance in navigation state.
+ */
+export type DescriptorRoute<Route extends RouteProp<any, any>> = Route extends unknown
+  ? Omit<Route, 'key'> & Readonly<{ key: string | undefined }>
+  : never;
+
 export type Descriptor<
   // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   ScreenOptions extends {},
@@ -568,7 +577,7 @@ export type Descriptor<
   /**
    * Route object for the screen
    */
-  route: Route;
+  route: DescriptorRoute<Route>;
 
   /**
    * Navigation object for the screen

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -19,6 +19,7 @@ import { SceneView } from './SceneView';
 import { ThemeContext } from './theming/ThemeContext';
 import type {
   Descriptor,
+  DescriptorRouteProp,
   EventMapBase,
   NavigationHelpers,
   NavigationProp,
@@ -53,7 +54,7 @@ type ScreenLayout<ScreenOptions extends {}> = (props: {
 type ScreenOptionsOrCallback<ScreenOptions extends {}> =
   | ScreenOptions
   | ((props: {
-      route: RouteProp<ParamListBase, string>;
+      route: DescriptorRouteProp<ParamListBase, string>;
       navigation: any;
       theme: ReactNavigation.Theme;
     }) => ScreenOptions);
@@ -152,7 +153,7 @@ export function useDescriptors<
   const cachedRoutes = useRouteCache(routes);
 
   const getOptions = (
-    route: RouteProp<ParamListBase, string>,
+    route: DescriptorRouteProp<ParamListBase, string>,
     navigation: NavigationProp<
       ParamListBase,
       string,

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/types.test.ts
@@ -1,9 +1,9 @@
 import type { ComponentProps } from 'react';
 
 import type { Drawer, DrawerNavigatorProps } from '../../../layouts/Drawer';
-import type { DrawerNavigationState, ParamListBase } from '../../native';
+import type { DescriptorRouteProp, DrawerNavigationState, ParamListBase } from '../../native';
 import type { DrawerNavigatorContentProps } from '../navigators/createDrawerNavigator';
-import type { DrawerNavigationHelpers } from '../types';
+import type { DrawerNavigationHelpers, DrawerOptionsArgs } from '../types';
 
 type Expect<T extends true> = T;
 type Equal<A, B> =
@@ -11,6 +11,12 @@ type Equal<A, B> =
 
 type DrawerProps = ComponentProps<typeof Drawer>;
 
+export type _OptionsRouteIsDescriptorRoute = Expect<
+  Equal<DrawerOptionsArgs<ParamListBase>['route'], DescriptorRouteProp<ParamListBase>>
+>;
+export type _OptionsRouteKeyMayBeUndefined = Expect<
+  Equal<DrawerOptionsArgs<ParamListBase>['route']['key'], string | undefined>
+>;
 export type _PublicPropsMatchDrawer = Expect<Equal<DrawerNavigatorProps, DrawerProps>>;
 export type _DrawerStateIsNotPublic = Expect<
   Equal<'drawerState' extends keyof DrawerProps ? true : false, false>

--- a/packages/expo-router/src/react-navigation/drawer/types.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/types.tsx
@@ -4,6 +4,7 @@ import type { PanGesture } from 'react-native-gesture-handler';
 import type { HeaderOptions } from '../elements';
 import type {
   Descriptor,
+  DescriptorRouteProp,
   DrawerActionHelpers,
   DrawerNavigationState,
   NavigationHelpers,
@@ -299,7 +300,8 @@ export type DrawerOptionsArgs<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList,
   NavigatorID extends string | undefined = undefined,
-> = DrawerScreenProps<ParamList, RouteName, NavigatorID> & {
+> = Omit<DrawerScreenProps<ParamList, RouteName, NavigatorID>, 'route'> & {
+  route: DescriptorRouteProp<ParamList, RouteName>;
   theme: Theme;
 };
 

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -250,14 +250,14 @@ function DrawerViewBase({
               shouldFreeze={!isFocused && !isPreloaded}>
               <Screen
                 focused={isFocused}
-                route={descriptor.route}
+                route={route}
                 navigation={descriptor.navigation}
                 headerShown={headerShown}
                 headerStatusBarHeight={headerStatusBarHeight}
                 headerTransparent={headerTransparent}
                 header={header({
                   layout: dimensions,
-                  route: descriptor.route,
+                  route,
                   navigation: descriptor.navigation as DrawerNavigationProp<ParamListBase>,
                   options: descriptor.options,
                 })}

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -210,8 +210,11 @@ function DrawerViewBase({
           const isFocused = state.index === index;
           const isPreloaded = state.preloadedRouteKeys.includes(route.key);
 
-          if (lazy && !loaded.includes(route.key) && !isFocused && !isPreloaded) {
-            // Don't render a lazy screen if we've never navigated to it or it wasn't preloaded
+          if (
+            descriptor.route.key === undefined ||
+            (lazy && !loaded.includes(route.key) && !isFocused && !isPreloaded)
+          ) {
+            // Don't render placeholder or unloaded lazy screens.
             return null;
           }
 

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
@@ -1,9 +1,11 @@
 import type { JSTopTabsProps } from '../../../layouts/TopTabs';
+import type { DescriptorRouteProp, ParamListBase } from '../../native';
 import type { MaterialTopTabNavigatorContentProps } from '../navigators/createMaterialTopTabNavigator';
 import type {
   MaterialTopTabBarProps,
   MaterialTopTabNavigationConfig,
   MaterialTopTabNavigationOptions,
+  MaterialTopTabOptionsArgs,
   MaterialTopTabViewState,
 } from '../types';
 
@@ -17,6 +19,12 @@ type IndicatorProps = Parameters<
 >[0];
 type TabBarCallbackProps = Parameters<NonNullable<MaterialTopTabNavigationConfig['tabBar']>>[0];
 
+export type _OptionsRouteIsDescriptorRoute = Expect<
+  Equal<MaterialTopTabOptionsArgs<ParamListBase>['route'], DescriptorRouteProp<ParamListBase>>
+>;
+export type _OptionsRouteKeyMayBeUndefined = Expect<
+  Equal<MaterialTopTabOptionsArgs<ParamListBase>['route']['key'], string | undefined>
+>;
 export type _PublicPropsIncludeTabBar = Expect<
   'tabBar' extends keyof JSTopTabsProps ? true : false
 >;

--- a/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/types.tsx
@@ -12,6 +12,7 @@ import type { NavigatorArgs } from 'standard-navigation';
 
 import type {
   Descriptor,
+  DescriptorRouteProp,
   NavigationProp,
   ParamListBase,
   RouteProp,
@@ -85,7 +86,8 @@ export type MaterialTopTabOptionsArgs<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList,
   NavigatorID extends string | undefined = undefined,
-> = MaterialTopTabScreenProps<ParamList, RouteName, NavigatorID> & {
+> = Omit<MaterialTopTabScreenProps<ParamList, RouteName, NavigatorID>, 'route'> & {
+  route: DescriptorRouteProp<ParamList, RouteName>;
   theme: Theme;
 };
 

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/types.test.ts
@@ -1,0 +1,19 @@
+import type { DescriptorRouteProp, ParamListBase } from '../../native';
+import type { NativeStackOptionsArgs } from '../types';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+export type _OptionsRouteIsDescriptorRoute = Expect<
+  Equal<NativeStackOptionsArgs<ParamListBase>['route'], DescriptorRouteProp<ParamListBase>>
+>;
+export type _OptionsRouteKeyMayBeUndefined = Expect<
+  Equal<NativeStackOptionsArgs<ParamListBase>['route']['key'], string | undefined>
+>;
+
+describe('native stack types', () => {
+  it('type-checks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/expo-router/src/react-navigation/native-stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/types.tsx
@@ -17,6 +17,7 @@ import type { SFSymbol } from 'sf-symbols-typescript';
 import type {
   DefaultNavigatorOptions,
   Descriptor,
+  DescriptorRouteProp,
   NavigationHelpers,
   NavigationProp,
   ParamListBase,
@@ -79,7 +80,8 @@ export type NativeStackOptionsArgs<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList,
   NavigatorID extends string | undefined = undefined,
-> = NativeStackScreenProps<ParamList, RouteName, NavigatorID> & {
+> = Omit<NativeStackScreenProps<ParamList, RouteName, NavigatorID>, 'route'> & {
+  route: DescriptorRouteProp<ParamList, RouteName>;
   theme: Theme;
 };
 

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -19,7 +19,7 @@ import {
   SafeAreaProviderCompat,
   useFrameSize,
 } from '../../elements';
-import { NavigationProvider, usePreventRemoveContext, useTheme } from '../../native';
+import { NavigationProvider, type Route, usePreventRemoveContext, useTheme } from '../../native';
 import type {
   NativeStackDescriptor,
   NativeStackDescriptorMap,
@@ -45,6 +45,7 @@ type SceneViewProps = {
   index: number;
   focused: boolean;
   shouldFreeze: boolean;
+  route: Route<string>;
   descriptor: NativeStackDescriptor;
   previousDescriptor?: NativeStackDescriptor;
   nextDescriptor?: NativeStackDescriptor;
@@ -67,6 +68,7 @@ const SceneView = ({
   index,
   focused,
   shouldFreeze,
+  route,
   descriptor,
   previousDescriptor,
   nextDescriptor,
@@ -82,7 +84,7 @@ const SceneView = ({
   onGestureCancel,
   onSheetDetentChanged,
 }: SceneViewProps) => {
-  const { route, navigation, options, render } = descriptor;
+  const { navigation, options, render } = descriptor;
 
   let {
     animation,
@@ -508,6 +510,7 @@ export function NativeStackView({ state, descriptors, emit, pop, unstable_native
               index={index}
               focused={isFocused}
               shouldFreeze={shouldFreeze}
+              route={route}
               descriptor={descriptor}
               previousDescriptor={previousDescriptor}
               nextDescriptor={nextDescriptor}

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
@@ -47,7 +47,7 @@ export function NativeStackView({ state, descriptors }: Props) {
         const nextKey = activeRoutes[i + 1]?.key;
         const previousDescriptor = previousKey ? descriptors[previousKey] : undefined;
         const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
-        const { options, navigation, render, route: descriptorRoute } = descriptors[route.key]!;
+        const { options, navigation, render } = descriptors[route.key]!;
 
         const headerBack = previousDescriptor
           ? {
@@ -79,7 +79,7 @@ export function NativeStackView({ state, descriptors }: Props) {
           <Screen
             key={route.key}
             focused={isFocused}
-            route={descriptorRoute}
+            route={route}
             navigation={navigation}
             headerShown={headerShown}
             headerTransparent={headerTransparent}
@@ -88,7 +88,7 @@ export function NativeStackView({ state, descriptors }: Props) {
                 header({
                   back: headerBack,
                   options,
-                  route: descriptorRoute,
+                  route,
                   navigation,
                 })
               ) : (

--- a/packages/expo-router/src/react-navigation/stack/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/stack/__tests__/types.test.ts
@@ -1,0 +1,19 @@
+import type { DescriptorRouteProp, ParamListBase } from '../../native';
+import type { StackOptionsArgs } from '../types';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+export type _OptionsRouteIsDescriptorRoute = Expect<
+  Equal<StackOptionsArgs<ParamListBase>['route'], DescriptorRouteProp<ParamListBase>>
+>;
+export type _OptionsRouteKeyMayBeUndefined = Expect<
+  Equal<StackOptionsArgs<ParamListBase>['route']['key'], string | undefined>
+>;
+
+describe('stack types', () => {
+  it('type-checks', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/expo-router/src/react-navigation/stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/stack/types.tsx
@@ -11,6 +11,7 @@ import type {
 import type {
   DefaultNavigatorOptions,
   Descriptor,
+  DescriptorRouteProp,
   LocaleDirection,
   NavigationHelpers,
   NavigationProp,
@@ -76,7 +77,8 @@ export type StackOptionsArgs<
   ParamList extends ParamListBase,
   RouteName extends keyof ParamList = keyof ParamList,
   NavigatorID extends string | undefined = undefined,
-> = StackScreenProps<ParamList, RouteName, NavigatorID> & {
+> = Omit<StackScreenProps<ParamList, RouteName, NavigatorID>, 'route'> & {
+  route: DescriptorRouteProp<ParamList, RouteName>;
   theme: Theme;
 };
 

--- a/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
@@ -71,7 +71,7 @@ export function HeaderContainer({
 
         const isFocused = focusedRoute.key === scene.descriptor.route.key;
         const previousScene = getPreviousScene({
-          route: scene.descriptor.route,
+          route: scene.route,
         });
 
         let headerBack = parentHeaderBack;
@@ -119,7 +119,7 @@ export function HeaderContainer({
           back: headerBack,
           progress: scene.progress,
           options: scene.descriptor.options,
-          route: scene.descriptor.route,
+          route: scene.route,
           navigation: scene.descriptor.navigation as StackNavigationProp<ParamListBase>,
           styleInterpolator:
             mode === 'float'
@@ -137,7 +137,7 @@ export function HeaderContainer({
         return (
           <NavigationProvider
             key={scene.descriptor.route.key}
-            route={scene.descriptor.route}
+            route={scene.route}
             navigation={scene.descriptor.navigation}>
             <View
               onLayout={
@@ -146,7 +146,7 @@ export function HeaderContainer({
                       const { height } = e.nativeEvent.layout;
 
                       onContentHeightChange({
-                        route: scene.descriptor.route,
+                        route: scene.route,
                         height,
                       });
                     }

--- a/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
@@ -69,7 +69,7 @@ export function HeaderContainer({
           return null;
         }
 
-        const isFocused = focusedRoute.key === scene.descriptor.route.key;
+        const isFocused = focusedRoute.key === scene.route.key;
         const previousScene = getPreviousScene({
           route: scene.route,
         });
@@ -136,7 +136,7 @@ export function HeaderContainer({
 
         return (
           <NavigationProvider
-            key={scene.descriptor.route.key}
+            key={scene.route.key}
             route={scene.route}
             navigation={scene.descriptor.navigation}>
             <View

--- a/packages/expo-router/src/react-navigation/stack/views/Stack/CardContainer.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Stack/CardContainer.tsx
@@ -102,35 +102,35 @@ function CardContainerInner({
   });
 
   const handleOpen = () => {
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onTransitionEnd({ route }, false);
     onOpenRoute({ route });
   };
 
   const handleClose = () => {
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onTransitionEnd({ route }, true);
     onCloseRoute({ route });
   };
 
   const handleGestureBegin = () => {
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onPageChangeStart();
     onGestureStart({ route });
   };
 
   const handleGestureCanceled = () => {
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onPageChangeCancel();
     onGestureCancel({ route });
   };
 
   const handleGestureEnd = () => {
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onGestureEnd({ route });
   };
@@ -138,7 +138,7 @@ function CardContainerInner({
   const handleTransition = ({ closing, gesture }: { closing: boolean; gesture: boolean }) => {
     wrapperRef.current?.setInert(closing);
 
-    const { route } = scene.descriptor;
+    const { route } = scene;
 
     onPageChangeConfirm?.({ gesture, active, closing });
 
@@ -184,7 +184,7 @@ function CardContainerInner({
   } = scene.descriptor.options;
 
   const { buildHref } = useLinkBuilder();
-  const previousScene = getPreviousScene({ route: scene.descriptor.route });
+  const previousScene = getPreviousScene({ route: scene.route });
 
   let backTitle: string | undefined;
   let href: string | undefined;

--- a/packages/expo-router/src/react-navigation/stack/views/Stack/CardStack.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Stack/CardStack.tsx
@@ -563,9 +563,7 @@ export class CardStack extends React.Component<Props, State> {
     const previousRoute = getPreviousRoute({ route });
 
     if (previousRoute) {
-      const previousScene = scenes.find(
-        (scene) => scene.descriptor.route.key === previousRoute.key
-      );
+      const previousScene = scenes.find((scene) => scene.route.key === previousRoute.key);
 
       return previousScene;
     }

--- a/packages/expo-router/src/standard-navigation/__tests__/useStandardState.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useStandardState.test.ios.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react-native';
 
-import type { NavigationRoute, NavigationState, ParamListBase } from '../../react-navigation/core';
+import type { NavigationState } from '../../react-navigation/core';
 import { useBuildHref } from '../useBuildHref';
 import { useStandardState } from '../useStandardState';
 
@@ -26,7 +26,7 @@ function makeBuilderState(
   } as unknown as NavigationState;
 }
 
-const byName: BuildHref = (route: NavigationRoute<ParamListBase, string>) => `/href/${route.name}`;
+const byName: BuildHref = (route) => `/href/${route.name}`;
 
 beforeEach(() => {
   mockedUseBuildHref.mockReturnValue(byName);

--- a/packages/expo-router/src/standard-navigation/useBuildHref.ts
+++ b/packages/expo-router/src/standard-navigation/useBuildHref.ts
@@ -8,12 +8,14 @@ import {
 } from '../react-navigation/core';
 import type { FocusedRouteState } from '../react-navigation/core/NavigationFocusedRouteStateContext';
 
+type HrefRoute = Pick<NavigationRoute<ParamListBase, string>, 'name' | 'params'>;
+
 // TODO(@ubax): move route info to state - https://linear.app/expo/issue/ENG-21483/refactor-state-to-include-all-route-info-information
 export function useBuildHref() {
   const currentState = useStateForPath();
   return useMemo(() => {
-    const cache = new WeakMap<NavigationRoute<ParamListBase, string>, string>();
-    return (route: NavigationRoute<ParamListBase, string>) => {
+    const cache = new WeakMap<HrefRoute, string>();
+    return (route: HrefRoute) => {
       const cached = cache.get(route);
       if (cached !== undefined) {
         return cached;

--- a/packages/expo-router/src/standard-navigation/useBuildHref.ts
+++ b/packages/expo-router/src/standard-navigation/useBuildHref.ts
@@ -14,6 +14,7 @@ type HrefRoute = Pick<NavigationRoute<ParamListBase, string>, 'name' | 'params'>
 export function useBuildHref() {
   const currentState = useStateForPath();
   return useMemo(() => {
+    // This cache uses object identity, so inline route objects never produce cache hits.
     const cache = new WeakMap<HrefRoute, string>();
     return (route: HrefRoute) => {
       const cached = cache.get(route);

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -23,6 +23,7 @@ import { Screen } from './primitives';
 import type { BottomTabNavigationEventMap } from './react-navigation/bottom-tabs';
 import {
   useStateForPath,
+  type DescriptorRouteProp,
   type EventConsumer,
   type EventMapBase,
   type NavigationProp,
@@ -57,7 +58,7 @@ export type ScreenProps<
   initialParams?: Record<string, any>;
   options?:
     | TOptions
-    | ((prop: { route: RouteProp<ParamListBase, string>; navigation: any }) => TOptions);
+    | ((prop: { route: DescriptorRouteProp<ParamListBase, string>; navigation: any }) => TOptions);
 
   listeners?:
     | ScreenListeners<TState, TEventMap>


### PR DESCRIPTION
# Why

Follow-up PR can add descriptors for placeholder routes (lazy loaded, which were not rendered yet). This PR is adjusting types for the coming change.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
