### PR TITLE
[test-suite] Add shared JasmineInterface type

### DIFF
--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -16,7 +16,7 @@ function browserSupportsWebGL() {
   }
 }
 
-function optionalRequire(requirer) {
+function optionalRequire<T>(requirer: () => T): T | undefined {
   try {
     return requirer();
   } catch {

--- a/apps/test-suite/components/StatusIndicator.tsx
+++ b/apps/test-suite/components/StatusIndicator.tsx
@@ -12,7 +12,7 @@ const indicators: Record<string, string> = {
   [Statuses.Running]: '○',
 };
 
-const colorKeys: Record<string, string> = {
+const colorKeys: Record<string, 'success' | 'danger' | 'tertiary' | 'warning'> = {
   [Statuses.Passed]: 'success',
   [Statuses.Failed]: 'danger',
   [Statuses.Disabled]: 'tertiary',

--- a/apps/test-suite/jasmine-core.d.ts
+++ b/apps/test-suite/jasmine-core.d.ts
@@ -1,5 +1,11 @@
 declare module 'jasmine-core/lib/jasmine-core/jasmine' {
-  type JasmineInterface = {
+  /**
+   * The jasmine interface that `TestScreen` passes to every test module as the
+   * first argument of its exported `test` function. Test modules either take it
+   * whole (`test(t: JasmineInterface)`) or destructure the parts they use
+   * (`test({ describe, expect, it }: JasmineInterface)`).
+   */
+  export type JasmineInterface = {
     describe(description: string, specDefinitions: () => void): void;
     fdescribe(description: string, specDefinitions: () => void): void;
     xdescribe(description: string, specDefinitions: () => void): void;
@@ -15,10 +21,11 @@ declare module 'jasmine-core/lib/jasmine-core/jasmine' {
     fail(message?: string | Error): void;
     pending(reason?: string): void;
     spyOn<T extends object>(object: T, method: keyof T): jasmine.Spy;
-    jasmine: {
-      DEFAULT_TIMEOUT_INTERVAL: number;
-      [key: string]: unknown;
-    };
+    /**
+     * The jasmine namespace object, carrying `DEFAULT_TIMEOUT_INTERVAL` and the
+     * asymmetric matchers such as `objectContaining` and `arrayContaining`.
+     */
+    jasmine: typeof jasmine;
     [key: string]: unknown;
   };
 

--- a/apps/test-suite/screens/SelectScreen.tsx
+++ b/apps/test-suite/screens/SelectScreen.tsx
@@ -3,7 +3,14 @@ import { Checkbox } from 'expo-checkbox';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { useObserve } from 'expo-observe';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  FlatList,
+  type LayoutChangeEvent,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
 import { useTheme } from '../../common/ThemeProvider';
 import { getTestModules, Module } from '../TestModules';
@@ -49,7 +56,7 @@ export default function SelectScreen({ onRunTests }: { onRunTests: (tests: strin
   const [modules, setModules] = useState<Module[]>([]);
   const [footerHeight, setFooterHeight] = useState(0);
 
-  const onFooterLayout = useCallback((e) => {
+  const onFooterLayout = useCallback((e: LayoutChangeEvent) => {
     setFooterHeight(e.nativeEvent.layout.height);
   }, []);
 
@@ -86,7 +93,7 @@ export default function SelectScreen({ onRunTests }: { onRunTests: (tests: strin
     setModules(getTestModules());
   }, []);
 
-  const keyExtractor = useCallback(({ name }) => name, []);
+  const keyExtractor = useCallback(({ name }: Module) => name, []);
 
   const onPressItem = useCallback((id: string) => {
     setSelected((prev) => {

--- a/apps/test-suite/types.ts
+++ b/apps/test-suite/types.ts
@@ -1,3 +1,5 @@
+export type { JasmineInterface } from 'jasmine-core/lib/jasmine-core/jasmine';
+
 export type JasmineResult = {
   id: string;
   description: string;

--- a/apps/test-suite/utils/requireNotNull.ts
+++ b/apps/test-suite/utils/requireNotNull.ts
@@ -1,0 +1,15 @@
+/**
+ * Narrows a nullable value, throwing when it really is `null` or `undefined`.
+ *
+ * Prefer it over a `!` assertion in specs: `!` erases at runtime, so a broken
+ * expectation surfaces as a `TypeError` on some later line, while this throws
+ * where the value went missing.
+ */
+export function requireNotNull<T>(value: T | null | undefined): T {
+  if (value == null) {
+    const error = new Error(`${value} is unexpectedly null`);
+    console.error(error.message, error.stack);
+    throw error;
+  }
+  return value;
+}


### PR DESCRIPTION
## Why

`apps/test-suite` has no type-check step, and TypeScript 6 made `strict` the default, so 651 errors accumulated unnoticed. This is the base of a 14-PR stack that takes the app to zero.

## How

Export the existing `JasmineInterface` as `TestHarness` so test modules can type the jasmine object they receive instead of an implicit `any`. Type four app-shell values.

## Test Plan

`pnpm tsc` drops 651 → 647. `lint --max-warnings 0`, `format --check` and `test` all pass.

top of the stack should be completely green
