### PR TITLE
[test-suite] Declare the jasmine and jest type packages

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -84,6 +84,7 @@
     "@types/getenv": "^1.0.0",
     "@types/invariant": "^2.2.35",
     "@types/jasmine": "^5.1.15",
+    "@types/jest": "^29.2.1",
     "@types/react": "~19.2.0",
     "@types/semver": "^7.7.1",
     "expo-module-scripts": "workspace:*"

--- a/apps/test-suite/screens/TestScreen.tsx
+++ b/apps/test-suite/screens/TestScreen.tsx
@@ -292,13 +292,16 @@ function useTestRunner() {
     // Wrap it/xit/fit so that test functions taking unused parameters
     // (e.g. `async (t) => {}`) aren't mistaken by jasmine 5.x as
     // callback-style tests expecting a `done` argument.
-    const wrapSpec = (fn: Function) => () => fn();
+    const wrapSpec = (fn: jasmine.ImplementationCallback) => () => (fn as () => unknown)();
     const origIt = jasmine.it;
-    jasmine.it = (desc: string, fn: Function, t?: number) => origIt(desc, wrapSpec(fn), t);
+    jasmine.it = (desc: string, fn?: jasmine.ImplementationCallback, t?: number) =>
+      origIt(desc, fn && wrapSpec(fn), t);
     const origXit = jasmine.xit;
-    jasmine.xit = (desc: string, fn: Function, t?: number) => origXit(desc, wrapSpec(fn), t);
+    jasmine.xit = (desc: string, fn?: jasmine.ImplementationCallback, t?: number) =>
+      origXit(desc, fn && wrapSpec(fn), t);
     const origFit = jasmine.fit;
-    jasmine.fit = (desc: string, fn: Function, t?: number) => origFit(desc, wrapSpec(fn), t);
+    jasmine.fit = (desc: string, fn?: jasmine.ImplementationCallback, t?: number) =>
+      origFit(desc, fn && wrapSpec(fn), t);
 
     const suiteModuleMap = suiteModuleMapRef.current;
     let topLevelSuiteIndex = 0;

--- a/apps/test-suite/screens/__tests__/getScreenIdForLinking.test.ts
+++ b/apps/test-suite/screens/__tests__/getScreenIdForLinking.test.ts
@@ -4,7 +4,7 @@ import {
   getSelectedTestNames,
 } from '../getScreenIdForLinking';
 
-describe(getScreenIdForLinking, () => {
+describe('getScreenIdForLinking', () => {
   it('should normalize derived routes to lowercase and trim', () => {
     expect(getScreenIdForLinking({ name: ' MyScreen ' })).toBe('myscreen');
   });
@@ -46,13 +46,13 @@ describe(getScreenIdForLinking, () => {
   });
 });
 
-describe(createQueryString, () => {
+describe('createQueryString', () => {
   it('should join normalized test names with commas', () => {
     expect(createQueryString([' Test1 ', 'TEST2', 'test1'])).toBe('test1,test2');
   });
 });
 
-describe(getSelectedTestNames, () => {
+describe('getSelectedTestNames', () => {
   it('should split and normalize query string', () => {
     expect(getSelectedTestNames(' Test1 , Test2 ')).toEqual(['test1', 'test2']);
   });

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    // TypeScript 6 no longer picks up `@types` packages implicitly, so the
+    // jasmine globals the test modules rely on and the jest globals used by
+    // the `__tests__` unit tests have to be listed here.
+    "types": ["jasmine", "jest"],
     "paths": {
       "ThemeProvider": ["../common/ThemeProvider"]
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1769,6 +1769,9 @@ importers:
       '@types/jasmine':
         specifier: ^5.1.15
         version: 5.1.15
+      '@types/jest':
+        specifier: ^29.2.1
+        version: 29.5.14
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers the jasmine and jest type packages.

# How

Declare both in `types` and add the missing `@types/jest` devDependency. With jasmine's types actually loading, `TestScreen`'s `it`/`xit`/`fit` wrappers and the three `describe(fn, ...)` calls in the unit test need fixing too.

# Test Plan

`pnpm tsc` drops 651 → 622 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)