### PR TITLE
[audio] Type-check Recording.ts and Audio.ts under strict

### DIFF
--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -81,10 +81,12 @@
     "semver": "^7.7.4"
   },
   "devDependencies": {
+    "@types/async-retry": "^1.4.5",
     "@types/getenv": "^1.0.0",
     "@types/invariant": "^2.2.35",
     "@types/jasmine": "^5.1.15",
     "@types/jest": "^29.2.1",
+    "@types/lodash": "^4.14.184",
     "@types/react": "~19.2.0",
     "@types/semver": "^7.7.1",
     "expo-module-scripts": "workspace:*"

--- a/apps/test-suite/tests/Audio.ts
+++ b/apps/test-suite/tests/Audio.ts
@@ -68,7 +68,8 @@ export function test({ describe, expect, it, ...t }: any) {
   });
 
   describe('Player instance', () => {
-    let player: AudioPlayer = null;
+    // Assigned by each spec before the `afterEach` below releases and clears it.
+    let player: AudioPlayer = null!;
 
     t.beforeAll(async () => {
       await setIsAudioActiveAsync(true);
@@ -81,7 +82,7 @@ export function test({ describe, expect, it, ...t }: any) {
         } catch (error: any) {
           console.warn('Player release error:', error.message);
         }
-        player = null;
+        player = null!;
       }
     });
 

--- a/apps/test-suite/tests/Audio.ts
+++ b/apps/test-suite/tests/Audio.ts
@@ -68,7 +68,6 @@ export function test({ describe, expect, it, ...t }: any) {
   });
 
   describe('Player instance', () => {
-    // Assigned by each spec before the `afterEach` below releases and clears it.
     let player: AudioPlayer = null!;
 
     t.beforeAll(async () => {

--- a/apps/test-suite/tests/Recording.ts
+++ b/apps/test-suite/tests/Recording.ts
@@ -256,7 +256,7 @@ export async function test(t: JasmineInterface) {
           options: RecordingOptions,
           expectedRootUri: string
         ) => {
-          const currentRecorder = recorder!;
+          const currentRecorder = recorder;
           let recordingUri: string | null = null;
 
           try {

--- a/apps/test-suite/tests/Recording.ts
+++ b/apps/test-suite/tests/Recording.ts
@@ -77,7 +77,6 @@ export async function test(t: JasmineInterface) {
     // According to the documentation pausing should be supported on Android API >= 24,
     // unfortunately such test fails on Android v24.
     const pausingIsSupported = Platform.OS !== 'android' || Platform.Version >= 25;
-    // Recreated in `beforeEach` before each spec runs, and cleared in `afterEach`.
     let recorder: AudioRecorder = null!;
 
     t.beforeEach(async () => {

--- a/apps/test-suite/tests/Recording.ts
+++ b/apps/test-suite/tests/Recording.ts
@@ -12,10 +12,12 @@ import {
   RecordingOptions,
 } from 'expo-audio';
 import { File, Paths } from 'expo-file-system';
+import { PermissionStatus } from 'expo-modules-core';
 import { isMatch } from 'lodash';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
+import type { JasmineInterface } from '../types';
 import { waitFor } from './helpers';
 
 export const name = 'Recording';
@@ -51,7 +53,7 @@ const retryForStatus = (recorder: AudioRecorder, status: Partial<RecorderState>)
     { retries: 5, minTimeout: 100 }
   );
 
-export async function test(t) {
+export async function test(t: JasmineInterface) {
   const shouldSkipTestsRequiringPermissions =
     await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
@@ -75,16 +77,17 @@ export async function test(t) {
     // According to the documentation pausing should be supported on Android API >= 24,
     // unfortunately such test fails on Android v24.
     const pausingIsSupported = Platform.OS !== 'android' || Platform.Version >= 25;
-    let recorder: AudioRecorder | null = null;
+    // Recreated in `beforeEach` before each spec runs, and cleared in `afterEach`.
+    let recorder: AudioRecorder = null!;
 
     t.beforeEach(async () => {
       const { status } = await getRecordingPermissionsAsync();
-      t.expect(status).toEqual('granted');
+      t.expect(status).toEqual(PermissionStatus.GRANTED);
       recorder = new AudioModule.AudioRecorder({});
     });
 
     t.afterEach(() => {
-      recorder = null;
+      recorder = null!;
     });
 
     t.describe('Recorder.prepareToRecordAsync(preset)', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1760,6 +1760,9 @@ importers:
         specifier: ^7.7.4
         version: 7.8.5
     devDependencies:
+      '@types/async-retry':
+        specifier: ^1.4.5
+        version: 1.4.9
       '@types/getenv':
         specifier: ^1.0.0
         version: 1.0.3
@@ -1772,6 +1775,9 @@ importers:
       '@types/jest':
         specifier: ^29.2.1
         version: 29.5.14
+      '@types/lodash':
+        specifier: ^4.14.184
+        version: 4.17.24
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14
@@ -9167,6 +9173,9 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/async-retry@1.4.9':
+    resolution: {integrity: sha512-s1ciZQJzRh3708X/m3vPExr5KJlzlZJvXsKpbtE2luqNcbROr64qU+3KpJsYHqWMeaxI839OvXf9PrUSw1Xtyg==}
+
   '@types/babel__code-frame@7.27.0':
     resolution: {integrity: sha512-Dwlo+LrxDx/0SpfmJ/BKveHf7QXWvLBLc+x03l5sbzykj3oB9nHygCpSECF1a+s+QIxbghe+KHqC90vGtxLRAA==}
 
@@ -9447,6 +9456,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/rtl-detect@1.0.3':
     resolution: {integrity: sha512-qpstuHivwg/HoXxRrBo5/r/OVx5M2SkqJpVu2haasdLctt+jMGHWjqdbI0LL7Rk2wRmN/UHdHK4JZg9RUMcvKA==}
@@ -17830,6 +17842,10 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
+  '@types/async-retry@1.4.9':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/babel__code-frame@7.27.0': {}
 
   '@types/babel__core@7.20.5':
@@ -18147,6 +18163,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.20.1
+
+  '@types/retry@0.12.5': {}
 
   '@types/rtl-detect@1.0.3': {}
 


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers `tests/Recording.ts` and `tests/Audio.ts`.

# How

`recorder` and `player` were nullable but assigned before every spec that reads them. Also adds the missing `@types/async-retry` and `@types/lodash` devDependencies.

# Test Plan

`pnpm tsc` drops 365 → 314 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)