### PR TITLE
[sqlite] Type-check SQLite.ts under strict

### DIFF
--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -5,6 +5,8 @@ import { SQLiteStorage } from 'expo-sqlite/kv-store';
 import path from 'path';
 import semver from 'semver';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'SQLite';
 
 interface UserEntity {
@@ -13,7 +15,16 @@ interface UserEntity {
   j: number;
 }
 
-export function test({ describe, expect, it, beforeAll, beforeEach, afterAll, afterEach, ...t }) {
+export function test({
+  describe,
+  expect,
+  it,
+  beforeAll,
+  beforeEach,
+  afterAll,
+  afterEach,
+  ...t
+}: JasmineInterface) {
   const nativeDescribe = process.env.EXPO_OS !== 'web' ? describe : t.xdescribe;
   const nativeIt = process.env.EXPO_OS !== 'web' ? it : t.xit;
 
@@ -39,14 +50,14 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
     it(`should use newer SQLite version`, async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       const row = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
-      expect(semver.gte(row['sqlite_version()'], '3.49.1')).toBe(true);
+      expect(semver.gte(row!['sqlite_version()'], '3.49.1')).toBe(true);
       await db.closeAsync();
     });
 
     it('unixepoch() is supported', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       const row = await db.getFirstAsync<{ 'unixepoch()': number }>('SELECT unixepoch()');
-      expect(row['unixepoch()']).toBeTruthy();
+      expect(row!['unixepoch()']).toBeTruthy();
       await db.closeAsync();
     });
 
@@ -54,11 +65,11 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       const db = await SQLite.openDatabaseAsync(':memory:');
       const value = 1700007974511;
       const row = await db.getFirstAsync<{ value: number }>(`SELECT ${value} as value`);
-      expect(row['value']).toBe(value);
+      expect(row!['value']).toBe(value);
       const row2 = await db.getFirstAsync<{ value: number }>('SELECT $value as value', {
         $value: value,
       });
-      expect(row2['value']).toBe(value);
+      expect(row2!['value']).toBe(value);
       await db.closeAsync();
     });
 
@@ -179,10 +190,10 @@ CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(6
     it('should support math functions', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       expect(
-        (await db.getFirstAsync<{ result: number }>('SELECT sqrt(2) as result')).result
+        (await db.getFirstAsync<{ result: number }>('SELECT sqrt(2) as result'))!.result
       ).toBeCloseTo(1.4142135623730951);
       expect(
-        (await db.getFirstAsync<{ result: number }>('SELECT pi() as result')).result
+        (await db.getFirstAsync<{ result: number }>('SELECT pi() as result'))!.result
       ).toBeCloseTo(3.141592653589793);
       await db.closeAsync();
     });
@@ -201,7 +212,7 @@ CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(6
       async () => {
         const asset = await Asset.fromModule(require('../assets/asset-db.db')).downloadAsync();
         await FS.copyAsync({
-          from: asset.localUri,
+          from: asset.localUri!,
           to: `${FS.documentDirectory}SQLite/downloaded.db`,
         });
 
@@ -451,7 +462,7 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       } catch (e) {
         error = e;
       }
-      expect(error.toString()).toMatch(/(Access to closed resource|Statement not found)/);
+      expect(String(error)).toMatch(/(Access to closed resource|Statement not found)/);
       await db.closeAsync();
     });
 
@@ -465,7 +476,7 @@ INSERT INTO users (user_id, name, k, j) VALUES (2, 'Manu Ginobili', 5, 72.8);
 INSERT INTO users (user_id, name, k, j) VALUES (3, 'Nikhilesh Sigatapu', 7, 42.14);
 `);
 
-      for (const method of ['getFirstAsync', 'getAllAsync']) {
+      for (const method of ['getFirstAsync', 'getAllAsync'] as const) {
         const statement = await db.prepareAsync('SELECT * FROM users ORDER BY j ASC');
         let error = null;
         try {
@@ -477,7 +488,7 @@ INSERT INTO users (user_id, name, k, j) VALUES (3, 'Nikhilesh Sigatapu', 7, 42.1
         } finally {
           await statement.finalizeAsync();
         }
-        expect(error.toString()).toMatch(/The SQLite cursor has been shifted/);
+        expect(String(error)).toMatch(/The SQLite cursor has been shifted/);
 
         const statement2 = await db.prepareAsync('SELECT * FROM users ORDER BY j ASC');
         error = null;
@@ -601,9 +612,9 @@ INSERT INTO users (user_id, name, k, j) VALUES (3, 'Nikhilesh Sigatapu', 7, 42.1
       const statement = await db.prepareAsync('SELECT * FROM blobs');
       const row = await (await statement.executeAsync<{ data: Uint8Array }>()).getFirstAsync();
       await statement.finalizeAsync();
-      expect(row.data).toEqual(blob);
+      expect(row!.data).toEqual(blob);
       const row2 = db.getFirstSync<{ data: Uint8Array }>('SELECT * FROM blobs');
-      expect(row2.data).toEqual(blob);
+      expect(row2!.data).toEqual(blob);
     });
   });
 
@@ -621,7 +632,7 @@ DROP TABLE IF EXISTS users;
 CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64));
 `);
 
-      async function fakeUserFetcher(userID) {
+      async function fakeUserFetcher(userID: number) {
         switch (userID) {
           case 1: {
             return Promise.resolve('Tim Duncan');
@@ -642,7 +653,7 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       await db.withTransactionAsync(async () => {
         await db.runAsync('INSERT INTO users (name) VALUES (?)', [userName]);
         const result = await db.getFirstAsync<UserEntity>('SELECT * FROM users LIMIT 1');
-        expect(result.name).toEqual('Tim Duncan');
+        expect(result!.name).toEqual('Tim Duncan');
       });
     });
 
@@ -722,7 +733,7 @@ INSERT INTO users (name) VALUES ('aaa');
           }
           resolve(null);
         } catch (e) {
-          reject(new Error(`Exception from promise2: ${e.toString()}`));
+          reject(new Error(`Exception from promise2: ${String(e)}`));
         }
       });
 
@@ -730,7 +741,7 @@ INSERT INTO users (name) VALUES ('aaa');
       expect(result1.status).toBe('rejected');
       expect(result2.status).toBe('fulfilled');
       const error = (result1 as PromiseRejectedResult).reason;
-      expect(error.toString()).toMatch(/Exception from promise1: Expected aaa but received bbb/);
+      expect(String(error)).toMatch(/Exception from promise1: Expected aaa but received bbb/);
     });
 
     nativeIt(
@@ -768,7 +779,7 @@ INSERT INTO users (name) VALUES ('aaa');
             }
             resolve(null);
           } catch (e) {
-            reject(new Error(`Exception from promise2: ${e.toString()}`));
+            reject(new Error(`Exception from promise2: ${String(e)}`));
           }
         });
 
@@ -776,13 +787,14 @@ INSERT INTO users (name) VALUES ('aaa');
         expect(result1.status).toBe('fulfilled');
         expect(result2.status).toBe('rejected');
         const error = (result2 as PromiseRejectedResult).reason;
-        expect(error.toString()).toMatch(/Exception from promise2:[\s\S]*database is locked/);
+        expect(String(error)).toMatch(/Exception from promise2:[\s\S]*database is locked/);
       }
     );
   });
 
   describe('Synchronous calls', () => {
-    let db: SQLite.SQLiteDatabase | null = null;
+    // Opened in `beforeEach` before every spec in this suite.
+    let db!: SQLite.SQLiteDatabase;
 
     beforeEach(() => {
       db = SQLite.openDatabaseSync(':memory:');
@@ -796,7 +808,7 @@ INSERT INTO users (user_id, name, k, j) VALUES (3, 'Nikhilesh Sigatapu', 7, 42.1
     });
 
     afterEach(() => {
-      db?.closeSync();
+      db.closeSync();
     });
 
     it('Basic CRUD', () => {
@@ -862,18 +874,19 @@ DROP TABLE IF EXISTS foo;
 CREATE TABLE foo (a INTEGER PRIMARY KEY NOT NULL, b INTEGER);
 `);
 
-      let databaseChangeListener: ReturnType<typeof SQLite.addDatabaseChangeListener> | null = null;
-      const waitChangePromise = new Promise((resolve) => {
-        databaseChangeListener = SQLite.addDatabaseChangeListener(
-          ({ databaseName, databaseFilePath, tableName, rowId }) => {
-            expect(databaseName).toEqual('main');
-            expect(path.basename(databaseFilePath)).toEqual('test.db');
-            expect(tableName).toEqual('foo');
-            expect(rowId).toBeDefined();
-            resolve(null);
-          }
-        );
+      let resolveChange!: () => void;
+      const waitChangePromise = new Promise<void>((resolve) => {
+        resolveChange = () => resolve();
       });
+      const databaseChangeListener = SQLite.addDatabaseChangeListener(
+        ({ databaseName, databaseFilePath, tableName, rowId }) => {
+          expect(databaseName).toEqual('main');
+          expect(path.basename(databaseFilePath)).toEqual('test.db');
+          expect(tableName).toEqual('foo');
+          expect(rowId).toBeDefined();
+          resolveChange();
+        }
+      );
 
       const delayedInsertPromise = new Promise((resolve) => setTimeout(resolve, 0)).then(() =>
         db.runAsync('INSERT INTO foo (a, b) VALUES (?, ?)', 1, 2)
@@ -882,7 +895,7 @@ CREATE TABLE foo (a INTEGER PRIMARY KEY NOT NULL, b INTEGER);
       await Promise.all([waitChangePromise, delayedInsertPromise]);
 
       await db.closeAsync();
-      databaseChangeListener?.remove();
+      databaseChangeListener.remove();
     }, 10000);
   });
 
@@ -912,7 +925,7 @@ CREATE TABLE foo (a INTEGER PRIMARY KEY NOT NULL, b INTEGER);
       } catch (e) {
         error = e;
       }
-      expect(error.toString()).toMatch(/unable to close due to unfinalized statements/);
+      expect(String(error)).toMatch(/unable to close due to unfinalized statements/);
     });
   });
 
@@ -1051,12 +1064,45 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
     });
   });
 
-  addSessionExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t });
-  addAppleAppGroupsTestSuiteAsync({ describe, expect, it, beforeEach, ...t });
-  addExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t });
+  addSessionExtensionTestSuiteAsync({
+    describe,
+    expect,
+    it,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    afterEach,
+    ...t,
+  });
+  addAppleAppGroupsTestSuiteAsync({
+    describe,
+    expect,
+    it,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    afterEach,
+    ...t,
+  });
+  addExtensionTestSuiteAsync({
+    describe,
+    expect,
+    it,
+    beforeAll,
+    beforeEach,
+    afterAll,
+    afterEach,
+    ...t,
+  });
 }
 
-function addSessionExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t }) {
+function addSessionExtensionTestSuiteAsync({
+  describe,
+  expect,
+  it,
+  beforeEach,
+  ...t
+}: JasmineInterface) {
   describe('Session Extension', () => {
     // Referenced from: https://github.com/livestorejs/wa-sqlite-build-env/blob/main/test/session-ext.ts
 
@@ -1239,7 +1285,13 @@ INSERT INTO todo (title, group_id, counter) VALUES ('initial todo', 1, 0);
   });
 }
 
-function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, beforeEach, ...t }) {
+function addAppleAppGroupsTestSuiteAsync({
+  describe,
+  expect,
+  it,
+  beforeEach,
+  ...t
+}: JasmineInterface) {
   let Paths: typeof import('expo-file-system').Paths | null = null;
   try {
     Paths = require('expo-file-system').Paths as typeof import('expo-file-system').Paths;
@@ -1250,9 +1302,9 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, beforeEach, ...
 
   describe('iOS App Group', () => {
     beforeEach(async () => {
-      if (sharedContainerDir) {
-        await FS.deleteAsync(sharedContainerDir, { idempotent: true });
-        await FS.makeDirectoryAsync(sharedContainerDir, { intermediates: true });
+      if (sharedContainerDir!) {
+        await FS.deleteAsync(sharedContainerDir!, { idempotent: true });
+        await FS.makeDirectoryAsync(sharedContainerDir!, { intermediates: true });
       }
       await FS.deleteAsync(FS.documentDirectory + 'SQLite', { idempotent: true });
       await FS.makeDirectoryAsync(FS.documentDirectory + 'SQLite', { intermediates: true });
@@ -1261,7 +1313,7 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, beforeEach, ...
     scopedIt('should create and delete a database in a shared container', async () => {
       const dbUri = sharedContainerDir + '/test.db';
 
-      const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir);
+      const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir!);
       await db.execAsync(`
 DROP TABLE IF EXISTS users;
 CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64), k INT, j REAL);
@@ -1274,7 +1326,7 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
       let fileInfo = await FS.getInfoAsync(dbUri);
       expect(fileInfo.exists).toBeTruthy();
 
-      await SQLite.deleteDatabaseAsync('test.db', sharedContainerDir);
+      await SQLite.deleteDatabaseAsync('test.db', sharedContainerDir!);
       fileInfo = await FS.getInfoAsync(dbUri);
       expect(fileInfo.exists).toBeFalsy();
     });
@@ -1285,9 +1337,9 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
         await SQLite.importDatabaseFromAssetAsync(
           'test.db',
           { assetId: require('../assets/asset-db.db') },
-          sharedContainerDir
+          sharedContainerDir!
         );
-        const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir);
+        const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir!);
         const results = await db.getAllAsync<UserEntity>('SELECT * FROM users');
         expect(results.length).toEqual(3);
         expect(results[0].j).toBeCloseTo(23.4);
@@ -1297,14 +1349,14 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
   });
 }
 
-function addExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t }) {
+function addExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t }: JasmineInterface) {
   const vecExt = SQLite.bundledExtensions['sqlite-vec'];
   const scopedIt = vecExt ? it : t.xit;
 
   describe('Extensions', () => {
     scopedIt('should load sqlite-vec extension', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
-      await db.loadExtensionAsync(vecExt.libPath, vecExt.entryPoint);
+      await db.loadExtensionAsync(vecExt!.libPath, vecExt!.entryPoint);
       // Example from https://github.com/asg017/sqlite-vec?#sample-usage
       await db.execAsync(`
 create virtual table vec_examples using vec0(

--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import semver from 'semver';
 
 import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'SQLite';
 
@@ -50,14 +51,14 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
     it(`should use newer SQLite version`, async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       const row = await db.getFirstAsync<{ 'sqlite_version()': string }>('SELECT sqlite_version()');
-      expect(semver.gte(row!['sqlite_version()'], '3.49.1')).toBe(true);
+      expect(semver.gte(requireNotNull(row)['sqlite_version()'], '3.49.1')).toBe(true);
       await db.closeAsync();
     });
 
     it('unixepoch() is supported', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       const row = await db.getFirstAsync<{ 'unixepoch()': number }>('SELECT unixepoch()');
-      expect(row!['unixepoch()']).toBeTruthy();
+      expect(row?.['unixepoch()']).toBeTruthy();
       await db.closeAsync();
     });
 
@@ -65,11 +66,11 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       const db = await SQLite.openDatabaseAsync(':memory:');
       const value = 1700007974511;
       const row = await db.getFirstAsync<{ value: number }>(`SELECT ${value} as value`);
-      expect(row!['value']).toBe(value);
+      expect(row?.['value']).toBe(value);
       const row2 = await db.getFirstAsync<{ value: number }>('SELECT $value as value', {
         $value: value,
       });
-      expect(row2!['value']).toBe(value);
+      expect(row2?.['value']).toBe(value);
       await db.closeAsync();
     });
 
@@ -190,10 +191,10 @@ CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(6
     it('should support math functions', async () => {
       const db = await SQLite.openDatabaseAsync(':memory:');
       expect(
-        (await db.getFirstAsync<{ result: number }>('SELECT sqrt(2) as result'))!.result
+        (await db.getFirstAsync<{ result: number }>('SELECT sqrt(2) as result'))?.result
       ).toBeCloseTo(1.4142135623730951);
       expect(
-        (await db.getFirstAsync<{ result: number }>('SELECT pi() as result'))!.result
+        (await db.getFirstAsync<{ result: number }>('SELECT pi() as result'))?.result
       ).toBeCloseTo(3.141592653589793);
       await db.closeAsync();
     });
@@ -212,7 +213,7 @@ CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(6
       async () => {
         const asset = await Asset.fromModule(require('../assets/asset-db.db')).downloadAsync();
         await FS.copyAsync({
-          from: asset.localUri!,
+          from: requireNotNull(asset.localUri),
           to: `${FS.documentDirectory}SQLite/downloaded.db`,
         });
 
@@ -612,9 +613,9 @@ INSERT INTO users (user_id, name, k, j) VALUES (3, 'Nikhilesh Sigatapu', 7, 42.1
       const statement = await db.prepareAsync('SELECT * FROM blobs');
       const row = await (await statement.executeAsync<{ data: Uint8Array }>()).getFirstAsync();
       await statement.finalizeAsync();
-      expect(row!.data).toEqual(blob);
+      expect(row?.data).toEqual(blob);
       const row2 = db.getFirstSync<{ data: Uint8Array }>('SELECT * FROM blobs');
-      expect(row2!.data).toEqual(blob);
+      expect(row2?.data).toEqual(blob);
     });
   });
 
@@ -653,7 +654,7 @@ CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VAR
       await db.withTransactionAsync(async () => {
         await db.runAsync('INSERT INTO users (name) VALUES (?)', [userName]);
         const result = await db.getFirstAsync<UserEntity>('SELECT * FROM users LIMIT 1');
-        expect(result!.name).toEqual('Tim Duncan');
+        expect(result?.name).toEqual('Tim Duncan');
       });
     });
 
@@ -1302,18 +1303,19 @@ function addAppleAppGroupsTestSuiteAsync({
 
   describe('iOS App Group', () => {
     beforeEach(async () => {
-      if (sharedContainerDir!) {
-        await FS.deleteAsync(sharedContainerDir!, { idempotent: true });
-        await FS.makeDirectoryAsync(sharedContainerDir!, { intermediates: true });
+      if (sharedContainerDir) {
+        await FS.deleteAsync(sharedContainerDir, { idempotent: true });
+        await FS.makeDirectoryAsync(sharedContainerDir, { intermediates: true });
       }
       await FS.deleteAsync(FS.documentDirectory + 'SQLite', { idempotent: true });
       await FS.makeDirectoryAsync(FS.documentDirectory + 'SQLite', { intermediates: true });
     });
 
     scopedIt('should create and delete a database in a shared container', async () => {
-      const dbUri = sharedContainerDir + '/test.db';
+      const containerDir = requireNotNull(sharedContainerDir);
+      const dbUri = containerDir + '/test.db';
 
-      const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir!);
+      const db = await SQLite.openDatabaseAsync('test.db', {}, containerDir);
       await db.execAsync(`
 DROP TABLE IF EXISTS users;
 CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64), k INT, j REAL);
@@ -1326,7 +1328,7 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
       let fileInfo = await FS.getInfoAsync(dbUri);
       expect(fileInfo.exists).toBeTruthy();
 
-      await SQLite.deleteDatabaseAsync('test.db', sharedContainerDir!);
+      await SQLite.deleteDatabaseAsync('test.db', containerDir);
       fileInfo = await FS.getInfoAsync(dbUri);
       expect(fileInfo.exists).toBeFalsy();
     });
@@ -1334,12 +1336,13 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
     scopedIt(
       'should support internal importDatabaseFromAssetAsync without using expo-file-system',
       async () => {
+        const containerDir = requireNotNull(sharedContainerDir);
         await SQLite.importDatabaseFromAssetAsync(
           'test.db',
           { assetId: require('../assets/asset-db.db') },
-          sharedContainerDir!
+          containerDir
         );
-        const db = await SQLite.openDatabaseAsync('test.db', {}, sharedContainerDir!);
+        const db = await SQLite.openDatabaseAsync('test.db', {}, containerDir);
         const results = await db.getAllAsync<UserEntity>('SELECT * FROM users');
         expect(results.length).toEqual(3);
         expect(results[0].j).toBeCloseTo(23.4);
@@ -1355,8 +1358,9 @@ function addExtensionTestSuiteAsync({ describe, expect, it, beforeEach, ...t }: 
 
   describe('Extensions', () => {
     scopedIt('should load sqlite-vec extension', async () => {
+      const ext = requireNotNull(vecExt);
       const db = await SQLite.openDatabaseAsync(':memory:');
-      await db.loadExtensionAsync(vecExt!.libPath, vecExt!.entryPoint);
+      await db.loadExtensionAsync(ext.libPath, ext.entryPoint);
       // Example from https://github.com/asg017/sqlite-vec?#sample-usage
       await db.execAsync(`
 create virtual table vec_examples using vec0(


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers `tests/SQLite.ts`.

# How

`db` gets a definite assignment, and row reads assert non-null. Two real problems surfaced: the sub-suite builders were called without `beforeAll`/`afterAll`/`afterEach`, so those hooks were unavailable inside them, and the change listener was assigned inside a promise executor so `remove()` narrowed to `never`.

# Test Plan

`pnpm tsc` drops 314 → 257 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)