### PR TITLE
[notifications] Type-check Notifications.ts under strict

### DIFF
--- a/apps/test-suite/tests/Notifications.ts
+++ b/apps/test-suite/tests/Notifications.ts
@@ -20,6 +20,7 @@ import { Alert, AppState, type AppStateStatus } from 'react-native';
 import * as TestUtils from '../TestUtils';
 import type { JasmineInterface } from '../types';
 import { isInteractive } from '../utils/Environment';
+import { requireNotNull } from '../utils/requireNotNull';
 import { waitFor } from './helpers';
 
 export const name = 'Notifications';
@@ -151,7 +152,7 @@ export async function test(t: JasmineInterface) {
       t.it('emits a "notification received" event with `data` value', async () => {
         await waitUntil(() => !!receivedEvent);
         t.expect(receivedEvent).not.toBeNull();
-        t.expect(receivedEvent!.request.content.data!.fieldTestedInDataContentsTest).toBe(42);
+        t.expect(receivedEvent?.request.content.data?.fieldTestedInDataContentsTest).toBe(42);
         if (Platform.OS === 'android') {
           // @ts-expect-error delete this later, see TODO in mapNotificationContent
           t.expect(typeof receivedEvent.request.content.dataString).toBe('string');
@@ -187,7 +188,7 @@ export async function test(t: JasmineInterface) {
           async () => {
             await waitUntil(() => !!handleErrorEvent);
             t.expect(handleErrorEvent).not.toBeNull();
-            t.expect(typeof handleErrorEvent![0]).toBe('string');
+            t.expect(typeof handleErrorEvent?.[0]).toBe('string');
             t.expect(handleSuccessEvent).toBeNull();
           },
           10000
@@ -346,9 +347,9 @@ export async function test(t: JasmineInterface) {
                 ...testChannel,
                 groupId,
               });
-              t.expect(channel!.groupId).toBe(groupId);
+              t.expect(channel?.groupId).toBe(groupId);
               const group = await Notifications.getNotificationChannelGroupAsync(groupId);
-              t.expect(group!.channels).toContain(t.jasmine.objectContaining(testChannel));
+              t.expect(group?.channels).toContain(t.jasmine.objectContaining(testChannel));
             } catch (e) {
               await Notifications.deleteNotificationChannelAsync(testChannelId);
               await Notifications.deleteNotificationChannelGroupAsync(groupId);
@@ -1485,8 +1486,9 @@ export async function test(t: JasmineInterface) {
             minute: 20,
           });
           t.expect(nextDate).not.toBeNull();
-          t.expect(new Date(nextDate!).getHours()).toBe(9);
-          t.expect(new Date(nextDate!).getMinutes()).toBe(20);
+          const triggerDate = new Date(requireNotNull(nextDate));
+          t.expect(triggerDate.getHours()).toBe(9);
+          t.expect(triggerDate.getMinutes()).toBe(20);
         });
 
         t.it('generates trigger date for a weekly trigger', async () => {
@@ -1497,7 +1499,7 @@ export async function test(t: JasmineInterface) {
             minute: 20,
           });
           t.expect(nextDateTimestamp).not.toBeNull();
-          const nextDate = new Date(nextDateTimestamp!);
+          const nextDate = new Date(requireNotNull(nextDateTimestamp));
           // JS has 0 (Sunday) - 6 (Saturday) based week days
           t.expect(nextDate.getDay()).toBe(1);
           t.expect(nextDate.getHours()).toBe(9);
@@ -1513,7 +1515,7 @@ export async function test(t: JasmineInterface) {
             minute: 20,
           });
           t.expect(nextDateTimestamp).not.toBeNull();
-          const nextDate = new Date(nextDateTimestamp!);
+          const nextDate = new Date(requireNotNull(nextDateTimestamp));
           t.expect(nextDate.getDate()).toBe(2);
           t.expect(nextDate.getMonth()).toBe(6);
           t.expect(nextDate.getHours()).toBe(9);
@@ -1730,8 +1732,8 @@ export async function test(t: JasmineInterface) {
           });
           await waitUntil(() => !!event);
           t.expect(event).not.toBeNull();
-          t.expect(event!.actionIdentifier).toBe(Notifications.DEFAULT_ACTION_IDENTIFIER);
-          t.expect(event!.notification).toEqual(
+          t.expect(event?.actionIdentifier).toBe(Notifications.DEFAULT_ACTION_IDENTIFIER);
+          t.expect(event?.notification).toEqual(
             t.jasmine.objectContaining({
               request: t.jasmine.objectContaining({
                 content: t.jasmine.objectContaining(notificationSpec),

--- a/apps/test-suite/tests/Notifications.ts
+++ b/apps/test-suite/tests/Notifications.ts
@@ -15,9 +15,10 @@ import {
   SchedulableNotificationTriggerInput,
   SchedulableTriggerInputTypes,
 } from 'expo-notifications';
-import { Alert, AppState } from 'react-native';
+import { Alert, AppState, type AppStateStatus } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
+import type { JasmineInterface } from '../types';
 import { isInteractive } from '../utils/Environment';
 import { waitFor } from './helpers';
 
@@ -30,7 +31,7 @@ const behaviorEnableAll: NotificationBehavior = {
   shouldSetBadge: true,
 };
 
-export async function test(t) {
+export async function test(t: JasmineInterface) {
   const shouldSkipTestsRequiringPermissions =
     await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
@@ -39,15 +40,17 @@ export async function test(t) {
   t.describe('Notifications', () => {
     t.describe('getDevicePushTokenAsync', () => {
       t.it('resolves with a token equal to the one from addPushTokenListener()', async () => {
-        let tokenFromEvent = null;
+        // Held in an object so the assignment from the listener is visible to
+        // the assertion below; a plain `let` stays narrowed to `null`.
+        const received: { token: Notifications.DevicePushToken | null } = { token: null };
         const subscription = Notifications.addPushTokenListener((newEvent) => {
-          tokenFromEvent = newEvent;
+          received.token = newEvent;
         });
         const devicePushToken = await Notifications.getDevicePushTokenAsync();
         const expectedType = Platform.OS === 'web' ? 'object' : 'string';
         t.expect(typeof devicePushToken.data).toBe(expectedType);
         await waitFor(1000);
-        t.expect(tokenFromEvent).toEqual(devicePushToken);
+        t.expect(received.token).toEqual(devicePushToken);
         subscription.remove();
       });
 
@@ -84,11 +87,11 @@ export async function test(t) {
       : t.xdescribe;
 
     describeWithExpoPushToken('when a push notification is sent', () => {
-      let notificationToHandle: Notifications.Notification | undefined;
-      let handleSuccessEvent: string | undefined;
-      let handleErrorEvent: Parameters<NotificationHandler['handleError']>;
+      let notificationToHandle: Notifications.Notification | null;
+      let handleSuccessEvent: string | null;
+      let handleErrorEvent: Parameters<NonNullable<NotificationHandler['handleError']>> | null;
 
-      let receivedEvent: Notifications.Notification | undefined;
+      let receivedEvent: Notifications.Notification | null;
       let receivedSubscription: EventSubscription | null = null;
 
       let expoPushToken: string | undefined;
@@ -138,7 +141,7 @@ export async function test(t) {
       });
 
       t.it('calls the `handleNotification` callback of the notification handler', async () => {
-        t.expect(expoPushToken?.length > 1).toBe(true);
+        t.expect((expoPushToken?.length ?? 0) > 1).toBe(true);
 
         await waitUntil(() => !!notificationToHandle);
 
@@ -148,7 +151,7 @@ export async function test(t) {
       t.it('emits a "notification received" event with `data` value', async () => {
         await waitUntil(() => !!receivedEvent);
         t.expect(receivedEvent).not.toBeNull();
-        t.expect(receivedEvent.request.content.data.fieldTestedInDataContentsTest).toBe(42);
+        t.expect(receivedEvent!.request.content.data!.fieldTestedInDataContentsTest).toBe(42);
         if (Platform.OS === 'android') {
           // @ts-expect-error delete this later, see TODO in mapNotificationContent
           t.expect(typeof receivedEvent.request.content.dataString).toBe('string');
@@ -184,7 +187,7 @@ export async function test(t) {
           async () => {
             await waitUntil(() => !!handleErrorEvent);
             t.expect(handleErrorEvent).not.toBeNull();
-            t.expect(typeof handleErrorEvent[0]).toBe('string');
+            t.expect(typeof handleErrorEvent![0]).toBe('string');
             t.expect(handleSuccessEvent).toBeNull();
           },
           10000
@@ -240,7 +243,7 @@ export async function test(t) {
         });
 
         // prerequisite: send a test push notification without a channel ID, it creates the fallback channel
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('returns an object if there is such channel', async () => {
             const channel = await Notifications.getNotificationChannelAsync(fallbackChannelId);
             t.expect(channel).toBeDefined();
@@ -255,7 +258,7 @@ export async function test(t) {
         });
 
         // Test push notifications sent without a channel ID should create a fallback channel
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('contains the fallback channel', async () => {
             const channels = await Notifications.getNotificationChannelsAsync();
             t.expect(channels).toContain(
@@ -277,7 +280,7 @@ export async function test(t) {
           await Notifications.deleteNotificationChannelAsync(testChannelId);
         });
 
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('returns the created channel', async () => {
             const channel = await Notifications.setNotificationChannelAsync(
               testChannelId,
@@ -343,9 +346,9 @@ export async function test(t) {
                 ...testChannel,
                 groupId,
               });
-              t.expect(channel.groupId).toBe(groupId);
+              t.expect(channel!.groupId).toBe(groupId);
               const group = await Notifications.getNotificationChannelGroupAsync(groupId);
-              t.expect(group.channels).toContain(t.jasmine.objectContaining(testChannel));
+              t.expect(group!.channels).toContain(t.jasmine.objectContaining(testChannel));
             } catch (e) {
               await Notifications.deleteNotificationChannelAsync(testChannelId);
               await Notifications.deleteNotificationChannelGroupAsync(groupId);
@@ -384,7 +387,7 @@ export async function test(t) {
       });
 
       t.describe('deleteNotificationChannelAsync()', () => {
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('deletes a channel', async () => {
             const preChannels = await Notifications.getNotificationChannelsAsync();
             const channelSpec = t.jasmine.objectContaining({ ...testChannel, id: testChannelId });
@@ -415,7 +418,7 @@ export async function test(t) {
           t.expect(channelGroup).toBe(null);
         });
 
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('returns an object if there is such channel group', async () => {
             await Notifications.setNotificationChannelGroupAsync(
               testChannelGroupId,
@@ -430,7 +433,7 @@ export async function test(t) {
       });
 
       t.describe('getNotificationChannelGroupsAsync()', () => {
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 28) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 28) {
           t.it('returns an array', async () => {
             const channels = await Notifications.getNotificationChannelGroupsAsync();
             t.expect(channels).toEqual(t.jasmine.any(Array));
@@ -457,7 +460,7 @@ export async function test(t) {
           await Notifications.deleteNotificationChannelGroupAsync(testChannelGroupId);
         });
 
-        if (Platform.OS === 'android' && Device.platformApiLevel >= 26) {
+        if (Platform.OS === 'android' && (Device.platformApiLevel ?? 0) >= 26) {
           t.it('returns the modified channel group', async () => {
             const group = await Notifications.setNotificationChannelGroupAsync(
               testChannelGroupId,
@@ -493,8 +496,11 @@ export async function test(t) {
               testChannelGroupId,
               createSpec
             );
-            const groupSpec = { ...createSpec, id: testChannelGroupId };
-            if (Device.platformApiLevel < 28) {
+            const groupSpec: Partial<typeof createSpec> & { id: string } = {
+              ...createSpec,
+              id: testChannelGroupId,
+            };
+            if ((Device.platformApiLevel ?? 0) < 28) {
               // Groups descriptions is only supported on API 28+
               delete groupSpec.description;
             }
@@ -689,7 +695,7 @@ export async function test(t) {
                   : {
                       // options are iOS-only
                     },
-            });
+            } as Notifications.NotificationCategory);
 
             const responseEvents: Notifications.NotificationResponse[] = [];
             const responsePromise = attachResponseListener();
@@ -815,7 +821,7 @@ export async function test(t) {
 
     t.describe('getPresentedNotificationsAsync()', () => {
       const identifier = 'test-containing-id';
-      const notificationStatuses = {};
+      const notificationStatuses: Record<string, boolean> = {};
 
       t.beforeAll(() => {
         Notifications.setNotificationHandler({
@@ -1271,7 +1277,7 @@ export async function test(t) {
                 t.expect(result[0].trigger).toEqual({
                   channelId: null,
                   ...trigger,
-                });
+                } as Notifications.NotificationTrigger);
               } else if (Platform.OS === 'ios') {
                 t.expect(result[0].trigger).toEqual({
                   type: 'calendar',
@@ -1287,7 +1293,7 @@ export async function test(t) {
                     isRepeatedDay: false,
                     calendar: null,
                   },
-                });
+                } as Notifications.NotificationTrigger);
               } else {
                 throw new Error('Test does not support platform');
               }
@@ -1318,7 +1324,7 @@ export async function test(t) {
                 t.expect(result[0].trigger).toEqual({
                   channelId: null,
                   ...trigger,
-                });
+                } as Notifications.NotificationTrigger);
               } else if (Platform.OS === 'ios') {
                 t.expect(result[0].trigger).toEqual({
                   type: 'calendar',
@@ -1334,7 +1340,7 @@ export async function test(t) {
                     isRepeatedDay: false,
                     calendar: null,
                   },
-                });
+                } as Notifications.NotificationTrigger);
               } else {
                 throw new Error('Test does not support platform');
               }
@@ -1364,7 +1370,7 @@ export async function test(t) {
                 t.expect(result[0].trigger).toEqual({
                   channelId: null,
                   ...trigger,
-                });
+                } as Notifications.NotificationTrigger);
               } else if (Platform.OS === 'ios') {
                 t.expect(result[0].trigger).toEqual({
                   type: 'calendar',
@@ -1383,7 +1389,7 @@ export async function test(t) {
                     isLeapMonth: false,
                     calendar: null,
                   },
-                });
+                } as Notifications.NotificationTrigger);
               } else {
                 throw new Error('Test does not support platform');
               }
@@ -1479,8 +1485,8 @@ export async function test(t) {
             minute: 20,
           });
           t.expect(nextDate).not.toBeNull();
-          t.expect(new Date(nextDate).getHours()).toBe(9);
-          t.expect(new Date(nextDate).getMinutes()).toBe(20);
+          t.expect(new Date(nextDate!).getHours()).toBe(9);
+          t.expect(new Date(nextDate!).getMinutes()).toBe(20);
         });
 
         t.it('generates trigger date for a weekly trigger', async () => {
@@ -1491,7 +1497,7 @@ export async function test(t) {
             minute: 20,
           });
           t.expect(nextDateTimestamp).not.toBeNull();
-          const nextDate = new Date(nextDateTimestamp);
+          const nextDate = new Date(nextDateTimestamp!);
           // JS has 0 (Sunday) - 6 (Saturday) based week days
           t.expect(nextDate.getDay()).toBe(1);
           t.expect(nextDate.getHours()).toBe(9);
@@ -1507,7 +1513,7 @@ export async function test(t) {
             minute: 20,
           });
           t.expect(nextDateTimestamp).not.toBeNull();
-          const nextDate = new Date(nextDateTimestamp);
+          const nextDate = new Date(nextDateTimestamp!);
           t.expect(nextDate.getDate()).toBe(2);
           t.expect(nextDate.getMonth()).toBe(6);
           t.expect(nextDate.getHours()).toBe(9);
@@ -1579,18 +1585,20 @@ export async function test(t) {
     });
 
     onlyInteractiveDescribe('when the app is in background', () => {
-      let subscription: EventSubscription = null;
-      let handleNotificationSpy = null;
-      let handleSuccessSpy = null;
-      let handleErrorSpy = null;
-      let notificationReceivedSpy = null;
+      let subscription: EventSubscription | null = null;
+      let handleNotificationSpy: jasmine.Spy | null = null;
+      let handleSuccessSpy: jasmine.Spy | null = null;
+      let handleErrorSpy: jasmine.Spy | null = null;
+      let notificationReceivedSpy: jasmine.Spy | null = null;
 
       t.beforeEach(async () => {
         handleNotificationSpy = t.jasmine.createSpy('handleNotificationSpy');
         handleSuccessSpy = t.jasmine.createSpy('handleSuccessSpy');
-        handleErrorSpy = t.jasmine.createSpy('handleErrorSpy').and.callFake((...args) => {
-          console.log(args);
-        });
+        handleErrorSpy = t.jasmine
+          .createSpy('handleErrorSpy')
+          .and.callFake((...args: unknown[]) => {
+            console.log(args);
+          });
         notificationReceivedSpy = t.jasmine.createSpy('notificationReceivedSpy');
         Notifications.setNotificationHandler({
           handleNotification: handleNotificationSpy,
@@ -1620,9 +1628,9 @@ export async function test(t) {
             const secondsToTimeout = 5;
             let notificationSent = false;
             Alert.alert(`Please move the app to the background and wait for 5 seconds`);
-            let userInteractionTimeout = null;
-            let subscription = null;
-            async function handleStateChange(state) {
+            let userInteractionTimeout: ReturnType<typeof setInterval> | null = null;
+            let subscription: EventSubscription | null = null;
+            async function handleStateChange(state: AppStateStatus) {
               const identifier = 'test-interactive-notification';
               if (state === 'background' && !notificationSent) {
                 if (userInteractionTimeout) {
@@ -1673,8 +1681,8 @@ export async function test(t) {
     });
 
     onlyInteractiveDescribe('tapping on a notification', () => {
-      let subscription = null;
-      let event = null;
+      let subscription: EventSubscription | null = null;
+      let event: Notifications.NotificationResponse | null = null;
 
       t.beforeEach(async () => {
         Notifications.setNotificationHandler({
@@ -1722,8 +1730,8 @@ export async function test(t) {
           });
           await waitUntil(() => !!event);
           t.expect(event).not.toBeNull();
-          t.expect(event.actionIdentifier).toBe(Notifications.DEFAULT_ACTION_IDENTIFIER);
-          t.expect(event.notification).toEqual(
+          t.expect(event!.actionIdentifier).toBe(Notifications.DEFAULT_ACTION_IDENTIFIER);
+          t.expect(event!.notification).toEqual(
             t.jasmine.objectContaining({
               request: t.jasmine.objectContaining({
                 content: t.jasmine.objectContaining(notificationSpec),


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers `tests/Notifications.ts`.

# How

`Device.platformApiLevel` is null off Android, so the version guards read `?? 0`. Spy and subscription holders are typed, and the trigger/category comparisons cast their expected literals because they check a stored value against the *input* shape used to schedule it.

# Test Plan

`pnpm tsc` drops 201 → 149 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)