### PR TITLE
[file-system] Type-check FileSystem.ts under strict

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -7,6 +7,7 @@ import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
 import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'FileSystem';
 const shouldSkipTestsRequiringPermissions = true;
@@ -2296,11 +2297,11 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
       expect((await reader.read(array1)).done).toBe(false);
       const result = await reader.read(array2);
       expect(result.done).toBe(false);
-      expect(result.value![4999]).toBe(alphabet.charCodeAt(9999));
+      expect(result.value?.[4999]).toBe(alphabet.charCodeAt(9999));
 
       const result2 = await reader.read(array3);
       expect(result2.done).toBe(true);
-      expect(result2.value!.length).toBe(0);
+      expect(result2.value?.length).toBe(0);
     });
 
     it('Provides a WriteableStream', async () => {
@@ -2316,7 +2317,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
 
     it('Returns correct file type', async () => {
       const asset = await Asset.fromModule(require('../assets/qrcode_expo.jpg')).downloadAsync();
-      const src = new File(asset.localUri!);
+      const src = new File(requireNotNull(asset.localUri));
       expect(src.type).toBe('image/jpeg');
       const src2 = new File(testDirectory, 'file.txt');
       src2.writeSync('abcde');
@@ -2397,14 +2398,16 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }: Jasmine
     });
 
     scopedIt('Writes a string to a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir!, 'file.txt');
+      const containerDir = requireNotNull(sharedContainerTestDir);
+      const outputFile = new File(containerDir, 'file.txt');
       expect(outputFile.exists).toBe(false);
       outputFile.writeSync('Hello world');
       expect(outputFile.exists).toBe(true);
     });
 
     scopedIt('Deletes a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir!, 'file3.txt');
+      const containerDir = requireNotNull(sharedContainerTestDir);
+      const outputFile = new File(containerDir, 'file3.txt');
       outputFile.writeSync('Hello world');
       expect(outputFile.exists).toBe(true);
 
@@ -2413,13 +2416,15 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }: Jasmine
     });
 
     scopedIt('Creates a folder', () => {
-      const folder = new Directory(sharedContainerTestDir!, 'newFolder');
+      const containerDir = requireNotNull(sharedContainerTestDir);
+      const folder = new Directory(containerDir, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
     });
 
     scopedIt('Deletes a folder', () => {
-      const folder = new Directory(sharedContainerTestDir!, 'newFolder');
+      const containerDir = requireNotNull(sharedContainerTestDir);
+      const folder = new Directory(containerDir, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
 

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -6,6 +6,8 @@ import * as FS from 'expo-file-system/legacy';
 import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'FileSystem';
 const shouldSkipTestsRequiringPermissions = true;
 
@@ -13,7 +15,7 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export async function test({ describe, expect, it, ...t }) {
+export async function test({ describe, expect, it, ...t }: JasmineInterface) {
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : describe;
 
   const testDirectory = FS.documentDirectory + 'tests/';
@@ -52,7 +54,7 @@ export async function test({ describe, expect, it, ...t }) {
     }
 
     describeWithPermissions('picker operations', () => {
-      let originalTimeout;
+      let originalTimeout: number;
       t.beforeAll(async () => {
         originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;
         t.jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout * 10;
@@ -225,7 +227,7 @@ export async function test({ describe, expect, it, ...t }) {
     });
 
     describe('watching files and directories', () => {
-      let originalTimeout;
+      let originalTimeout: number;
 
       t.beforeAll(() => {
         originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;
@@ -1574,13 +1576,13 @@ export async function test({ describe, expect, it, ...t }) {
         const url = 'https://picsum.photos/id/237/200/300';
         const file = new File(testDirectory, 'image.jpeg');
         file.create();
-        let error;
+        let error: unknown;
         try {
           await File.downloadFileAsync(url, file);
         } catch (e) {
           error = e;
         }
-        expect(error.message.includes('Destination already exists')).toBe(true);
+        expect((error as Error).message.includes('Destination already exists')).toBe(true);
       });
 
       it('downloads file when headers are set', async () => {
@@ -1802,7 +1804,7 @@ export async function test({ describe, expect, it, ...t }) {
         file.writeSync('Hello world');
         expect(file.creationTime).not.toBeNull();
         expect(file.modificationTime).not.toBeNull();
-        expect(file.creationTime).toBeLessThanOrEqual(file.modificationTime);
+        expect(file.creationTime).toBeLessThanOrEqual(file.modificationTime!);
       });
 
       it('computes md5', async () => {
@@ -1870,6 +1872,8 @@ export async function test({ describe, expect, it, ...t }) {
 
       it('returns null size and md5 for nonexistent files', async () => {
         const file = new File(testDirectory, 'file2.txt');
+        // @ts-expect-error `size` is typed `number`, but a nonexistent file reports
+        // `null`, which is what this spec checks.
         expect(file.size).toBe(null);
         expect(file.md5).toBe(null);
       });
@@ -1980,11 +1984,11 @@ export async function test({ describe, expect, it, ...t }) {
     describe('Exposes common app directories', () => {
       it('exposes cache directory', () => {
         expect(Paths.cache instanceof Directory).toBe(true);
-        expect(Paths.cache.uri).toBe(FS.cacheDirectory);
+        expect(Paths.cache.uri).toBe(FS.cacheDirectory!);
       });
       it('exposes document directory', () => {
         expect(Paths.document instanceof Directory).toBe(true);
-        expect(Paths.document.uri).toBe(FS.documentDirectory);
+        expect(Paths.document.uri).toBe(FS.documentDirectory!);
       });
       it('can be easily used with joining paths', () => {
         const file = new File(Paths.document, 'file.txt');
@@ -2292,11 +2296,11 @@ export async function test({ describe, expect, it, ...t }) {
       expect((await reader.read(array1)).done).toBe(false);
       const result = await reader.read(array2);
       expect(result.done).toBe(false);
-      expect(result.value[4999]).toBe(alphabet.charCodeAt(9999));
+      expect(result.value![4999]).toBe(alphabet.charCodeAt(9999));
 
       const result2 = await reader.read(array3);
       expect(result2.done).toBe(true);
-      expect(result2.value.length).toBe(0);
+      expect(result2.value!.length).toBe(0);
     });
 
     it('Provides a WriteableStream', async () => {
@@ -2312,7 +2316,7 @@ export async function test({ describe, expect, it, ...t }) {
 
     it('Returns correct file type', async () => {
       const asset = await Asset.fromModule(require('../assets/qrcode_expo.jpg')).downloadAsync();
-      const src = new File(asset.localUri);
+      const src = new File(asset.localUri!);
       expect(src.type).toBe('image/jpeg');
       const src2 = new File(testDirectory, 'file.txt');
       src2.writeSync('abcde');
@@ -2374,7 +2378,7 @@ export async function test({ describe, expect, it, ...t }) {
   addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t });
 }
 
-function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }) {
+function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }: JasmineInterface) {
   const firstContainer = Object.values(Paths.appleSharedContainers)?.[0];
   const sharedContainerTestDir = firstContainer ? firstContainer.uri + 'test/' : null;
   const scopedIt = sharedContainerTestDir ? it : t.xit;
@@ -2393,14 +2397,14 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }) {
     });
 
     scopedIt('Writes a string to a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir, 'file.txt');
+      const outputFile = new File(sharedContainerTestDir!, 'file.txt');
       expect(outputFile.exists).toBe(false);
       outputFile.writeSync('Hello world');
       expect(outputFile.exists).toBe(true);
     });
 
     scopedIt('Deletes a file reference', () => {
-      const outputFile = new File(sharedContainerTestDir, 'file3.txt');
+      const outputFile = new File(sharedContainerTestDir!, 'file3.txt');
       outputFile.writeSync('Hello world');
       expect(outputFile.exists).toBe(true);
 
@@ -2409,13 +2413,13 @@ function addAppleAppGroupsTestSuiteAsync({ describe, expect, it, ...t }) {
     });
 
     scopedIt('Creates a folder', () => {
-      const folder = new Directory(sharedContainerTestDir, 'newFolder');
+      const folder = new Directory(sharedContainerTestDir!, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
     });
 
     scopedIt('Deletes a folder', () => {
-      const folder = new Directory(sharedContainerTestDir, 'newFolder');
+      const folder = new Directory(sharedContainerTestDir!, 'newFolder');
       folder.create();
       expect(folder.exists).toBe(true);
 


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers `tests/FileSystem.ts`.

# How

Harness types, the `originalTimeout` holders and `error` catch bindings, plus non-null on the legacy `cacheDirectory`/`documentDirectory`.

Follow-up for expo-file-system maintainers: one site here carries a `@ts-expect-error` because `size` is typed `number` while a nonexistent file reports `null`.

# Test Plan

`pnpm tsc` drops 70 → 52 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
