### PR TITLE
[fetch] Type-check Fetch.ts under strict

### DIFF
--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -3,6 +3,7 @@ import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
 import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'Fetch';
 
@@ -57,13 +58,13 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     it('should process response in readablestream from late get reader call', async () => {
       const resp = await fetch('https://httpbin.io/get');
       expect(resp.ok).toBe(true);
-      expect(resp.body!).not.toBeNull();
+      expect(resp.body).not.toBeNull();
 
       // Delay 0.5s to ensure the response is completed before streaming started
       await delayAsync(500);
 
       const chunks = [];
-      const reader = resp.body!.getReader();
+      const reader = requireNotNull(resp.body).getReader();
       while (true) {
         const { done, value } = await reader.read();
         if (done) {
@@ -153,7 +154,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
 
     it('should throw a TypeError when cloning a response with a locked body', async () => {
       const resp = await fetch('https://httpbin.io/get');
-      resp.body!.getReader();
+      requireNotNull(resp.body).getReader();
       let error: TypeError | null = null;
       try {
         resp.clone();
@@ -410,7 +411,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
             Accept: 'text/event-stream',
           },
         });
-        const reader = resp.body!.getReader();
+        const reader = requireNotNull(resp.body).getReader();
         while (true) {
           const { done } = await reader.read();
           hasReceivedChunk = true;
@@ -441,7 +442,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
             Accept: 'text/event-stream',
           },
         });
-        const reader = resp.body!.getReader();
+        const reader = requireNotNull(resp.body).getReader();
         while (true) {
           const { done } = await reader.read();
           hasReceivedChunk = true;
@@ -455,7 +456,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
         }
       }
       expect(error).not.toBeNull();
-      expect(error!.message).toContain('Fetch request has been canceled');
+      expect(error?.message).toContain('Fetch request has been canceled');
       expect(hasReceivedChunk).toBe(false);
     });
   });
@@ -469,7 +470,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
           Accept: 'text/event-stream',
         },
       });
-      const reader = resp.body!.getReader();
+      const reader = requireNotNull(resp.body).getReader();
       const chunks = [];
       while (true) {
         const { done, value } = await reader.read();
@@ -490,10 +491,11 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
         },
       });
 
-      expect(resp.body![Symbol.asyncIterator]).not.toBeNull();
+      const body = requireNotNull(resp.body);
+      expect(body[Symbol.asyncIterator]).not.toBeNull();
 
       const chunks = [];
-      for await (const chunk of resp.body!) {
+      for await (const chunk of body) {
         chunks.push(chunk);
       }
       expect(chunks.length).toBeGreaterThan(3);
@@ -508,10 +510,11 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
         },
       });
 
-      expect(resp.body![Symbol.asyncIterator]).not.toBeNull();
+      const body = requireNotNull(resp.body);
+      expect(body[Symbol.asyncIterator]).not.toBeNull();
 
       const chunks = [];
-      for await (const chunk of resp.body!) {
+      for await (const chunk of body) {
         chunks.push(chunk);
         if (chunks.length === 2) {
           break;

--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -2,9 +2,11 @@ import * as FS from 'expo-file-system/legacy';
 import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'Fetch';
 
-export function test({ describe, expect, it, ...t }) {
+export function test({ describe, expect, it, ...t }: JasmineInterface) {
   describe('Response types', () => {
     setupTestTimeout(t);
 
@@ -55,13 +57,13 @@ export function test({ describe, expect, it, ...t }) {
     it('should process response in readablestream from late get reader call', async () => {
       const resp = await fetch('https://httpbin.io/get');
       expect(resp.ok).toBe(true);
-      expect(resp.body).not.toBeNull();
+      expect(resp.body!).not.toBeNull();
 
       // Delay 0.5s to ensure the response is completed before streaming started
       await delayAsync(500);
 
       const chunks = [];
-      const reader = resp.body.getReader();
+      const reader = resp.body!.getReader();
       while (true) {
         const { done, value } = await reader.read();
         if (done) {
@@ -408,7 +410,7 @@ export function test({ describe, expect, it, ...t }) {
             Accept: 'text/event-stream',
           },
         });
-        const reader = resp.body.getReader();
+        const reader = resp.body!.getReader();
         while (true) {
           const { done } = await reader.read();
           hasReceivedChunk = true;
@@ -439,7 +441,7 @@ export function test({ describe, expect, it, ...t }) {
             Accept: 'text/event-stream',
           },
         });
-        const reader = resp.body.getReader();
+        const reader = resp.body!.getReader();
         while (true) {
           const { done } = await reader.read();
           hasReceivedChunk = true;
@@ -453,7 +455,7 @@ export function test({ describe, expect, it, ...t }) {
         }
       }
       expect(error).not.toBeNull();
-      expect(error.message).toContain('Fetch request has been canceled');
+      expect(error!.message).toContain('Fetch request has been canceled');
       expect(hasReceivedChunk).toBe(false);
     });
   });
@@ -467,7 +469,7 @@ export function test({ describe, expect, it, ...t }) {
           Accept: 'text/event-stream',
         },
       });
-      const reader = resp.body.getReader();
+      const reader = resp.body!.getReader();
       const chunks = [];
       while (true) {
         const { done, value } = await reader.read();
@@ -488,10 +490,10 @@ export function test({ describe, expect, it, ...t }) {
         },
       });
 
-      expect(resp.body[Symbol.asyncIterator]).not.toBeNull();
+      expect(resp.body![Symbol.asyncIterator]).not.toBeNull();
 
       const chunks = [];
-      for await (const chunk of resp.body) {
+      for await (const chunk of resp.body!) {
         chunks.push(chunk);
       }
       expect(chunks.length).toBeGreaterThan(3);
@@ -506,10 +508,10 @@ export function test({ describe, expect, it, ...t }) {
         },
       });
 
-      expect(resp.body[Symbol.asyncIterator]).not.toBeNull();
+      expect(resp.body![Symbol.asyncIterator]).not.toBeNull();
 
       const chunks = [];
-      for await (const chunk of resp.body) {
+      for await (const chunk of resp.body!) {
         chunks.push(chunk);
         if (chunks.length === 2) {
           break;
@@ -556,7 +558,7 @@ export function test({ describe, expect, it, ...t }) {
   addLocalFileTestSuite({ describe, expect, it, ...t });
 }
 
-function addLocalFileTestSuite({ describe, expect, it, ...t }) {
+function addLocalFileTestSuite({ describe, expect, it, ...t }: JasmineInterface) {
   if (Platform.OS === 'web') {
     return;
   }
@@ -630,7 +632,7 @@ function addLocalFileTestSuite({ describe, expect, it, ...t }) {
 }
 
 function setupTestTimeout(t: Record<string, any>, timeout: number = 30000) {
-  let originalTimeout;
+  let originalTimeout: number;
 
   t.beforeAll(() => {
     // Increase the timeout in general because httpbin.test.k6.io can be slow.


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers `tests/Fetch.ts`.

# How

Harness types for both suites, and non-null on `resp.body` in the streaming specs.

# Test Plan

`pnpm tsc` drops 52 → 35 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)