### PR TITLE
[test-suite] Type-check the remaining eight test modules under strict

### DIFF
--- a/apps/test-suite/tests/AppMetrics.ts
+++ b/apps/test-suite/tests/AppMetrics.ts
@@ -8,7 +8,18 @@ import AppMetrics, {
 } from 'expo-app-metrics';
 import { fetch } from 'expo/fetch';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'AppMetrics';
+
+/**
+ * `LogAttributeValue` is recursive, which jasmine's `Expected<T>` cannot
+ * instantiate. Reading attributes through a shallow record keeps the
+ * comparisons below cheap for the type checker.
+ */
+function readAttributes(log: { attributes?: Record<string, unknown> | null }) {
+  return log.attributes ?? {};
+}
 
 const TEST_HOST = 'https://httpbin.io';
 const TEST_HOSTNAME = 'httpbin.io';
@@ -115,7 +126,7 @@ function uniqueLabel(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 }
 
-export function test({ describe, expect, it, afterEach }) {
+export function test({ describe, expect, it, afterEach }: JasmineInterface) {
   describe('getMainSession', () => {
     it('returns a non-null main session with the documented shape', () => {
       const session = AppMetrics.getMainSession();
@@ -213,9 +224,10 @@ export function test({ describe, expect, it, afterEach }) {
       expect(log.severity).toBe('warn');
       expect(typeof log.timestamp).toBe('string');
       expect(log.attributes).toBeDefined();
-      expect(log.attributes!.feature).toBe('app-metrics');
-      expect(log.attributes!.retries).toBe(2);
-      expect(log.attributes!.enabled).toBe(true);
+      const attributes = readAttributes(log);
+      expect(attributes.feature).toBe('app-metrics');
+      expect(attributes.retries).toBe(2);
+      expect(attributes.enabled).toBe(true);
     });
 
     it('defaults severity to "info" when none is provided', async () => {
@@ -250,10 +262,11 @@ export function test({ describe, expect, it, afterEach }) {
 
       const log = await readBackLog(name);
       expect(log.attributes).toBeDefined();
-      expect(log.attributes!.subscription_tier).toBe('pro');
-      expect(log.attributes!.experiment_variant).toBe('B');
+      const attributes = readAttributes(log);
+      expect(attributes.subscription_tier).toBe('pro');
+      expect(attributes.experiment_variant).toBe('B');
       // Per-record attributes coexist with the globals.
-      expect(log.attributes!.local_key).toBe('local_value');
+      expect(attributes.local_key).toBe('local_value');
     });
 
     it('lets a per-record attribute win over a global with the same key', async () => {
@@ -262,7 +275,7 @@ export function test({ describe, expect, it, afterEach }) {
       AppMetrics.logEvent(name, { attributes: { source: 'local' } });
 
       const log = await readBackLog(name);
-      expect(log.attributes!.source).toBe('local');
+      expect(readAttributes(log).source).toBe('local');
     });
 
     it('stops applying globals after they are cleared', async () => {
@@ -273,7 +286,7 @@ export function test({ describe, expect, it, afterEach }) {
       AppMetrics.logEvent(name);
 
       const log = await readBackLog(name);
-      expect(log.attributes?.cleared_key).toBeUndefined();
+      expect(readAttributes(log).cleared_key).toBeUndefined();
     });
   });
 
@@ -559,7 +572,7 @@ export function test({ describe, expect, it, afterEach }) {
       );
       expect(log.severity).toBe('error');
 
-      const attributes = log.attributes ?? {};
+      const attributes = readAttributes(log);
       expect(attributes['exception.type']).toBe('TypeError');
       expect(attributes['exception.message']).toBe(message);
       expect(attributes['exception.stacktrace']).toBe('onPress@index.bundle:42:7');

--- a/apps/test-suite/tests/AppMetrics.ts
+++ b/apps/test-suite/tests/AppMetrics.ts
@@ -193,8 +193,8 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
       const recorded = metrics.find((metric) => metric.name === name) as Metric;
       expect(recorded).toBeDefined();
       expect(recorded.params).toBeDefined();
-      expect(recorded.params!.screen).toBe('home');
-      expect(recorded.params!.count).toBe(3);
+      expect(recorded.params?.screen).toBe('home');
+      expect(recorded.params?.count).toBe(3);
     });
   });
 
@@ -356,12 +356,12 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
         // One logical fetch → one completion event observed at the caller-supplied URL.
         const completed = capture.completed.find((event) => event.url === url);
         expect(completed).toBeDefined();
-        expect(completed!.statusCode).toBe(200);
-        expect(completed!.redirects.length).toBe(1);
-        expect(completed!.redirects[0].fromUrl).toBe(url);
-        expect(completed!.redirects[0].toUrl).toBe(target);
-        expect(completed!.redirects[0].statusCode).toBeGreaterThanOrEqual(300);
-        expect(completed!.redirects[0].statusCode).toBeLessThan(400);
+        expect(completed?.statusCode).toBe(200);
+        expect(completed?.redirects.length).toBe(1);
+        expect(completed?.redirects[0].fromUrl).toBe(url);
+        expect(completed?.redirects[0].toUrl).toBe(target);
+        expect(completed?.redirects[0].statusCode).toBeGreaterThanOrEqual(300);
+        expect(completed?.redirects[0].statusCode).toBeLessThan(400);
       } finally {
         release();
       }

--- a/apps/test-suite/tests/Asset.ts
+++ b/apps/test-suite/tests/Asset.ts
@@ -2,6 +2,8 @@ import { Asset } from 'expo-asset';
 import * as FileSystem from 'expo-file-system/legacy';
 import invariant from 'invariant';
 
+import { requireNotNull } from '../utils/requireNotNull';
+
 export const name = 'Asset';
 
 export function test(t: any) {
@@ -38,7 +40,8 @@ export function test(t: any) {
 
         await asset.downloadAsync();
 
-        const fileInfo = await FileSystem.getInfoAsync(asset.localUri!);
+        const localUri = requireNotNull(asset.localUri);
+        const fileInfo = await FileSystem.getInfoAsync(localUri);
         invariant(fileInfo.exists, 'File should exist');
         t.expect(fileInfo.size > 0).toBeTruthy();
 
@@ -47,16 +50,17 @@ export function test(t: any) {
           name: asset.name + 'another',
           type: asset.type,
           hash: asset.hash,
-          uri: asset.localUri!,
+          uri: localUri,
         });
         anotherAsset.downloaded = false;
         await anotherAsset.downloadAsync();
 
-        const fileInfo2 = await FileSystem.getInfoAsync(anotherAsset.localUri!);
+        const anotherLocalUri = requireNotNull(anotherAsset.localUri);
+        const fileInfo2 = await FileSystem.getInfoAsync(anotherLocalUri);
         invariant(fileInfo2.exists, 'File should exist');
 
         t.expect(fileInfo2.size).toBe(fileInfo.size);
-        t.expect(anotherAsset.localUri!).toBe(asset.localUri!);
+        t.expect(anotherAsset.localUri).toBe(asset.localUri);
       }
     );
 
@@ -74,7 +78,7 @@ export function test(t: any) {
         t.it("when downloaded, has a 'file://' localUri", async () => {
           const asset = Asset.fromModule(module);
           await asset.downloadAsync();
-          t.expect(asset.localUri!).toMatch(new RegExp(`^file:\/\/.*\.${type}`));
+          t.expect(asset.localUri).toMatch(new RegExp(`^file:\/\/.*\.${type}`));
         });
 
         t.it(
@@ -84,7 +88,8 @@ export function test(t: any) {
             const asset = Asset.fromModule(module);
             await asset.downloadAsync();
 
-            const fileInfo = await FileSystem.getInfoAsync(asset.localUri!, {
+            const localUri = requireNotNull(asset.localUri);
+            const fileInfo = await FileSystem.getInfoAsync(localUri, {
               md5: true,
             });
             invariant(fileInfo.exists, 'File should exist');
@@ -93,9 +98,9 @@ export function test(t: any) {
 
             t.expect(size > 0).toBeTruthy();
             more['hash'] && t.expect(md5).toBe(asset.hash);
-            t.expect(cacheUri).toBe(asset.localUri!);
+            t.expect(cacheUri).toBe(asset.localUri);
             await asset.downloadAsync();
-            t.expect(asset.localUri!).toBe(cacheUri);
+            t.expect(asset.localUri).toBe(cacheUri);
           }
         );
       })

--- a/apps/test-suite/tests/Asset.ts
+++ b/apps/test-suite/tests/Asset.ts
@@ -38,7 +38,7 @@ export function test(t: any) {
 
         await asset.downloadAsync();
 
-        const fileInfo = await FileSystem.getInfoAsync(asset.localUri);
+        const fileInfo = await FileSystem.getInfoAsync(asset.localUri!);
         invariant(fileInfo.exists, 'File should exist');
         t.expect(fileInfo.size > 0).toBeTruthy();
 
@@ -47,16 +47,16 @@ export function test(t: any) {
           name: asset.name + 'another',
           type: asset.type,
           hash: asset.hash,
-          uri: asset.localUri,
+          uri: asset.localUri!,
         });
         anotherAsset.downloaded = false;
         await anotherAsset.downloadAsync();
 
-        const fileInfo2 = await FileSystem.getInfoAsync(anotherAsset.localUri);
+        const fileInfo2 = await FileSystem.getInfoAsync(anotherAsset.localUri!);
         invariant(fileInfo2.exists, 'File should exist');
 
         t.expect(fileInfo2.size).toBe(fileInfo.size);
-        t.expect(anotherAsset.localUri).toBe(asset.localUri);
+        t.expect(anotherAsset.localUri!).toBe(asset.localUri!);
       }
     );
 
@@ -74,7 +74,7 @@ export function test(t: any) {
         t.it("when downloaded, has a 'file://' localUri", async () => {
           const asset = Asset.fromModule(module);
           await asset.downloadAsync();
-          t.expect(asset.localUri).toMatch(new RegExp(`^file:\/\/.*\.${type}`));
+          t.expect(asset.localUri!).toMatch(new RegExp(`^file:\/\/.*\.${type}`));
         });
 
         t.it(
@@ -84,7 +84,7 @@ export function test(t: any) {
             const asset = Asset.fromModule(module);
             await asset.downloadAsync();
 
-            const fileInfo = await FileSystem.getInfoAsync(asset.localUri, {
+            const fileInfo = await FileSystem.getInfoAsync(asset.localUri!, {
               md5: true,
             });
             invariant(fileInfo.exists, 'File should exist');
@@ -93,9 +93,9 @@ export function test(t: any) {
 
             t.expect(size > 0).toBeTruthy();
             more['hash'] && t.expect(md5).toBe(asset.hash);
-            t.expect(cacheUri).toBe(asset.localUri);
+            t.expect(cacheUri).toBe(asset.localUri!);
             await asset.downloadAsync();
-            t.expect(asset.localUri).toBe(cacheUri);
+            t.expect(asset.localUri!).toBe(cacheUri);
           }
         );
       })

--- a/apps/test-suite/tests/Asset.web.ts
+++ b/apps/test-suite/tests/Asset.web.ts
@@ -1,8 +1,10 @@
 import { Asset } from 'expo-asset';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'Asset';
 
-export async function test(t) {
+export async function test(t: JasmineInterface) {
   t.describe(name, () => {
     [
       {
@@ -25,7 +27,9 @@ export async function test(t) {
           t.expect(asset.name).toMatch(new RegExp(`${name}.*\.${type}`));
           t.expect(asset.type).toBe(type);
           console.log(asset);
-          Object.keys(more).forEach((member) => t.expect(asset[member]).toBe(more[member]));
+          Object.keys(more).forEach((member) =>
+            t.expect(asset[member as keyof typeof asset]).toBe(more[member as keyof typeof more]!)
+          );
         });
 
         t.it("when downloaded, has a 'file://' localUri", async () => {

--- a/apps/test-suite/tests/Brightness.ts
+++ b/apps/test-suite/tests/Brightness.ts
@@ -2,6 +2,7 @@ import * as Brightness from 'expo-brightness';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
+import type { JasmineInterface } from '../types';
 
 export const name = 'Brightness (device-only)';
 
@@ -22,7 +23,7 @@ function timeoutWrapper(fn: () => void | Promise<void>, time: number): Promise<v
   });
 }
 
-export async function test(t) {
+export async function test(t: JasmineInterface) {
   const shouldSkipTestsRequiringPermissions =
     await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;

--- a/apps/test-suite/tests/Cellular.ts
+++ b/apps/test-suite/tests/Cellular.ts
@@ -2,6 +2,7 @@ import * as Cellular from 'expo-cellular';
 import Constants from 'expo-constants';
 
 import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'Cellular (device-only)';
 
@@ -58,7 +59,8 @@ export async function test({ describe, it, expect, jasmine }: JasmineInterface) 
 
         expect(hasError).toBe(false);
         expect(cellularGeneration).toEqual(jasmine.any(Number));
-        expect(CellularGenerationEnumValues.includes(cellularGeneration!)).toBe(true);
+        const generation = requireNotNull(cellularGeneration);
+        expect(CellularGenerationEnumValues.includes(generation)).toBe(true);
       });
     });
   });

--- a/apps/test-suite/tests/Cellular.ts
+++ b/apps/test-suite/tests/Cellular.ts
@@ -1,9 +1,11 @@
 import * as Cellular from 'expo-cellular';
 import Constants from 'expo-constants';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'Cellular (device-only)';
 
-export async function test({ describe, it, expect, jasmine }) {
+export async function test({ describe, it, expect, jasmine }: JasmineInterface) {
   const isNullOrString = (value: any) => {
     if (Constants.isDevice) {
       return typeof value === 'string';
@@ -45,7 +47,7 @@ export async function test({ describe, it, expect, jasmine }) {
       it('returns an enum value of Cellular.Cellular Generation', async () => {
         let hasError = false;
         let cellularGeneration: Cellular.CellularGeneration | undefined;
-        const CellularGenerationEnumValues = [0, 1, 2, 3, 4];
+        const CellularGenerationEnumValues: Cellular.CellularGeneration[] = [0, 1, 2, 3, 4];
 
         try {
           cellularGeneration = await Cellular.getCellularGenerationAsync();
@@ -56,7 +58,7 @@ export async function test({ describe, it, expect, jasmine }) {
 
         expect(hasError).toBe(false);
         expect(cellularGeneration).toEqual(jasmine.any(Number));
-        expect(CellularGenerationEnumValues.includes(cellularGeneration)).toBe(true);
+        expect(CellularGenerationEnumValues.includes(cellularGeneration!)).toBe(true);
       });
     });
   });

--- a/apps/test-suite/tests/CryptoAES.ts
+++ b/apps/test-suite/tests/CryptoAES.ts
@@ -7,6 +7,8 @@ import {
 } from 'expo-crypto';
 import { Platform } from 'react-native';
 
+import type { JasmineInterface } from '../types';
+
 const DEFAULT_IV_LENGTH = 12;
 const DEFAULT_TAG_LENGTH = 16;
 
@@ -28,7 +30,7 @@ function uint8ArrayToBase64(uint8Array: Uint8Array) {
 
 export const name = 'CryptoAES';
 
-export async function test({ describe, it, expect, beforeAll }) {
+export async function test({ describe, it, expect, beforeAll }: JasmineInterface) {
   describe('AES Crypto', () => {
     describe('EncryptionKey', () => {
       it('generates a 256-bit key by default', async () => {

--- a/apps/test-suite/tests/DevToolsPluginClient.ts
+++ b/apps/test-suite/tests/DevToolsPluginClient.ts
@@ -8,6 +8,8 @@ import {
   type DevToolsPluginClientOptions,
 } from 'expo/devtools';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'DevToolsPluginClient';
 
 const PLUGIN_NAME = 'test-suite';
@@ -15,12 +17,12 @@ const METHOD_PING = 'ping';
 const METHOD_PONG = 'pong';
 
 interface TestSuiteContext {
-  browserEchoClient: DevToolsPluginClient;
-  client: DevToolsPluginClient;
-  responsePromise: Promise<any>;
+  browserEchoClient: DevToolsPluginClient | null;
+  client: DevToolsPluginClient | null;
+  responsePromise: Promise<any> | null;
 }
 
-export function test({ describe, expect, it, ...t }) {
+export function test({ describe, expect, it, ...t }: JasmineInterface) {
   describe('Transportation tests', () => {
     const context: TestSuiteContext = {
       browserEchoClient: null,
@@ -31,7 +33,7 @@ export function test({ describe, expect, it, ...t }) {
 
     it('should support plaintext messages', async () => {
       const message = 'Test message';
-      context.client.sendMessage(METHOD_PING, message);
+      context.client!.sendMessage(METHOD_PING, message);
       const response = await context.responsePromise;
       expect(response).toEqual(message);
     });
@@ -41,14 +43,14 @@ export function test({ describe, expect, it, ...t }) {
         foo: 'foo',
         bar: 'bar',
       };
-      context.client.sendMessage(METHOD_PING, json);
+      context.client!.sendMessage(METHOD_PING, json);
       const response = await context.responsePromise;
       expect(response).toEqual(json);
     });
 
     it('should support binary payload', async () => {
       const payload = new Uint8Array([0x01, 0x02, 0x03]);
-      context.client.sendMessage(METHOD_PING, payload);
+      context.client!.sendMessage(METHOD_PING, payload);
       const response = await context.responsePromise;
       expect(response).toEqual(payload);
     });
@@ -63,10 +65,10 @@ export function test({ describe, expect, it, ...t }) {
     setupContext(context, t, { websocketBinaryType: 'arraybuffer' });
 
     it('should terminate duplicated browser clients for the same plugin', async () => {
-      expect(context.browserEchoClient.isConnected()).toBe(true);
+      expect(context.browserEchoClient!.isConnected()).toBe(true);
       const newBrowserClient = await createBrowserEchoClientAsync({ pluginName: PLUGIN_NAME });
       await delayAsync(200);
-      expect(context.browserEchoClient.isConnected()).toBe(false);
+      expect(context.browserEchoClient!.isConnected()).toBe(false);
       expect(newBrowserClient.isConnected()).toBe(true);
       await newBrowserClient.closeAsync();
     });
@@ -103,15 +105,15 @@ function setupContext(
 
   t.beforeEach(async () => {
     context.responsePromise = new Promise((resolve) => {
-      context.client.addMessageListenerOnce(METHOD_PONG, (message) => {
+      context.client!.addMessageListenerOnce(METHOD_PONG, (message) => {
         resolve(message);
       });
     });
   });
 
   t.afterAll(async () => {
-    await context.browserEchoClient.closeAsync();
-    await context.client.closeAsync();
+    await context.browserEchoClient!.closeAsync();
+    await context.client!.closeAsync();
   });
 }
 
@@ -128,7 +130,7 @@ async function createBrowserEchoClientAsync({
   protocolVersion,
   options,
 }: {
-  pluginName;
+  pluginName: string;
   protocolVersion?: number;
   options?: DevToolsPluginClientOptions;
 }): Promise<DevToolsPluginClient> {
@@ -146,7 +148,6 @@ async function createBrowserEchoClientAsync({
     client.sendMessage(METHOD_PONG, message);
   });
 
-  // @ts-expect-error: return type of `createDevToolsPluginClient` is internal but compatible with `DevToolsPluginClient`.
   return client;
 }
 

--- a/apps/test-suite/tests/DevToolsPluginClient.ts
+++ b/apps/test-suite/tests/DevToolsPluginClient.ts
@@ -9,6 +9,7 @@ import {
 } from 'expo/devtools';
 
 import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'DevToolsPluginClient';
 
@@ -33,7 +34,8 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
 
     it('should support plaintext messages', async () => {
       const message = 'Test message';
-      context.client!.sendMessage(METHOD_PING, message);
+      const client = requireNotNull(context.client);
+      client.sendMessage(METHOD_PING, message);
       const response = await context.responsePromise;
       expect(response).toEqual(message);
     });
@@ -43,14 +45,16 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
         foo: 'foo',
         bar: 'bar',
       };
-      context.client!.sendMessage(METHOD_PING, json);
+      const client = requireNotNull(context.client);
+      client.sendMessage(METHOD_PING, json);
       const response = await context.responsePromise;
       expect(response).toEqual(json);
     });
 
     it('should support binary payload', async () => {
       const payload = new Uint8Array([0x01, 0x02, 0x03]);
-      context.client!.sendMessage(METHOD_PING, payload);
+      const client = requireNotNull(context.client);
+      client.sendMessage(METHOD_PING, payload);
       const response = await context.responsePromise;
       expect(response).toEqual(payload);
     });
@@ -65,10 +69,10 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     setupContext(context, t, { websocketBinaryType: 'arraybuffer' });
 
     it('should terminate duplicated browser clients for the same plugin', async () => {
-      expect(context.browserEchoClient!.isConnected()).toBe(true);
+      expect(context.browserEchoClient?.isConnected()).toBe(true);
       const newBrowserClient = await createBrowserEchoClientAsync({ pluginName: PLUGIN_NAME });
       await delayAsync(200);
-      expect(context.browserEchoClient!.isConnected()).toBe(false);
+      expect(context.browserEchoClient?.isConnected()).toBe(false);
       expect(newBrowserClient.isConnected()).toBe(true);
       await newBrowserClient.closeAsync();
     });
@@ -104,16 +108,17 @@ function setupContext(
   });
 
   t.beforeEach(async () => {
+    const client = requireNotNull(context.client);
     context.responsePromise = new Promise((resolve) => {
-      context.client!.addMessageListenerOnce(METHOD_PONG, (message) => {
+      client.addMessageListenerOnce(METHOD_PONG, (message) => {
         resolve(message);
       });
     });
   });
 
   t.afterAll(async () => {
-    await context.browserEchoClient!.closeAsync();
-    await context.client!.closeAsync();
+    await requireNotNull(context.browserEchoClient).closeAsync();
+    await requireNotNull(context.client).closeAsync();
   });
 }
 

--- a/apps/test-suite/tests/ModulesCore.ts
+++ b/apps/test-suite/tests/ModulesCore.ts
@@ -1,8 +1,10 @@
 import { EventEmitter, requireNativeModule } from 'expo';
 
+import type { JasmineInterface } from '../types';
+
 export const name = 'ModulesCore';
 
-export function test({ describe, expect, it }) {
+export function test({ describe, expect, it }: JasmineInterface) {
   describe('EventEmitter', () => {
     it('does not propagate errors from listeners', () => {
       expect(() => {


### PR DESCRIPTION
# Why

Part of the stack in #48597, which explains why `apps/test-suite` accumulated 651 errors under `strict` and how the work is split up. This PR covers the remaining eight test modules.

# How

devtools, cellular, crypto, asset, app-metrics, modules-core and brightness. `TestSuiteContext` declared three non-nullable fields that every instance initialised to `null`, one stale `@ts-expect-error` is gone, and a `readAttributes` helper avoids jasmine's `Expected<T>` blowing up on the recursive `LogAttributeValue`.

# Test Plan

`pnpm tsc` drops 35 → 0 on this branch. `pnpm lint --max-warnings 0`, `pnpm format --check` and `pnpm test` all pass, verified on this branch rather than only on the tip of the stack.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)