### PR TITLE
[test-suite] Enable strict and check types in CI

### DIFF
--- a/.github/workflows/test-suite-lint.yml
+++ b/.github/workflows/test-suite-lint.yml
@@ -42,6 +42,9 @@ jobs:
       - name: 💅 Check formatting
         run: pnpm format --check
         working-directory: apps/test-suite
+      - name: 🔍 Type check test-suite files
+        run: pnpm tsc
+        working-directory: apps/test-suite
       - name: 🧪 Run unit tests
         run: pnpm test
         working-directory: apps/test-suite

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    // `expo/tsconfig.base` does not set this, so it followed the compiler
-    // default and silently flipped on with TypeScript 6. Pin it so the setting
-    // does not change again underneath the app.
     "strict": true,
     // TypeScript 6 no longer picks up `@types` packages implicitly, so the
     // jasmine globals the test modules rely on and the jest globals used by

--- a/apps/test-suite/tsconfig.json
+++ b/apps/test-suite/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    // `expo/tsconfig.base` does not set this, so it followed the compiler
+    // default and silently flipped on with TypeScript 6. Pin it so the setting
+    // does not change again underneath the app.
+    "strict": true,
     // TypeScript 6 no longer picks up `@types` packages implicitly, so the
     // jasmine globals the test modules rely on and the jest globals used by
     // the `__tests__` unit tests have to be listed here.


### PR DESCRIPTION
## Why

`strict` was never set for this app, so it followed the compiler default and silently flipped on with TypeScript 6 — and nothing type-checked `apps/test-suite` to notice.

## How

Pin `"strict": true` for explicitness

## Test Plan

Top of the stack: `pnpm tsc` exits 0, down from 651 errors. `lint --max-warnings 0`, `format --check` (108 files) and `test` (9 passed) all pass.
