### PR TITLE
[image-manipulator] Declare `Image` as the class it holds at runtime

### DIFF
--- a/apps/test-suite/tests/ImageManipulator.ts
+++ b/apps/test-suite/tests/ImageManipulator.ts
@@ -54,9 +54,6 @@ export async function test(t: JasmineInterface) {
         const image = await context.renderAsync();
 
         t.expect(image).toBeDefined();
-        // @ts-expect-error `ImageManipulator.Image` is declared as an `ImageRef` instance rather than
-        // `typeof ImageRef`, so TypeScript does not accept it on the right of `instanceof`,
-        // even though the runtime value is the class.
         t.expect(image instanceof ImageManipulator.Image).toBe(true);
         t.expect(image.width).toBe(100);
         t.expect(image.height).toBe(100);
@@ -70,9 +67,6 @@ export async function test(t: JasmineInterface) {
         const image = await context.renderAsync();
 
         t.expect(image).toBeDefined();
-        // @ts-expect-error `ImageManipulator.Image` is declared as an `ImageRef` instance rather than
-        // `typeof ImageRef`, so TypeScript does not accept it on the right of `instanceof`,
-        // even though the runtime value is the class.
         t.expect(image instanceof ImageManipulator.Image).toBe(true);
         t.expect(image.width).toBe(100);
         t.expect(image.height).toBe(100);

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `ImageManipulator.Image` being typed as an `ImageRef` instance rather than the class it holds at runtime, which rejected `instanceof` checks and made instance members appear to exist on it. ([#48613](https://github.com/expo/expo/pull/48613) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 57.0.7 - 2026-07-29

--- a/packages/expo-image-manipulator/src/ImageManipulator.types.ts
+++ b/packages/expo-image-manipulator/src/ImageManipulator.types.ts
@@ -152,7 +152,7 @@ export declare class ImageManipulator extends NativeModule {
   /**
    * @hidden
    */
-  Image: ImageRef;
+  Image: typeof ImageRef;
 
   /**
    * Loads an image from the given URI and creates a new image manipulation context.


### PR DESCRIPTION
# Why

`ImageManipulator.Image` is typed as an `ImageRef` **instance**, but the native module registers it as a **class** on both platforms — `Class("Image", ImageRef.self)` in `ios/ImageManipulatorModule.swift:61` and `Class<ImageRef>("Image")` in `ImageManipulatorModule.kt:117`. Its sibling `Context` is already declared correctly as `typeof ImageManipulatorContext`.

The wrong type fails in both directions:

```ts
const w: number = ImageManipulator.Image.width;  // ✅ type-checks — `undefined` at runtime
const c = new ImageManipulator.Image();          // ❌ TS2351: not constructable
```

`width` and `height` are registered as `Property(...)` on the class, so they exist on instances, not on the constructor. That makes the first line a silent lie rather than a harmless imprecision. The second is the case #48605 hit, where two `instanceof` assertions needed a `@ts-expect-error`.

# How

One word: `Image: ImageRef` → `Image: typeof ImageRef`. Removes the two directives this made necessary in the test-suite specs.

`Image` is marked `@hidden` and nothing else in the repo references it, so the blast radius is limited to code doing `instanceof` or reaching for `typeof ImageManipulator.Image`.

# Test Plan

```
pnpm typecheck   exit 0
pnpm build       exit 0 — emitted d.ts now reads `Image: typeof ImageRef`
pnpm test        5 suites pass (Node, Web, Android, iOS)
pnpm lint        0 warnings, 0 errors
pnpm format      26 files correctly formatted
```

`apps/test-suite` still reports 0 errors under `strict` with both directives gone.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
