### PR TITLE
[dev-launcher] Skip the manifest parser requests in app metrics

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [iOS] Stop triggering the Local Network permission prompt at launch by suppressing the React Native packager check until a development server is selected.
 - [iOS] Point at the Local Network setting when a local dev server URL can't be reached, and log instead of silently dropping discovered servers that fail to resolve. ([#48103](https://github.com/expo/expo/pull/48103) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Reload the recently opened apps list when the launcher appears so it no longer shows up empty or stale. ([#48103](https://github.com/expo/expo/pull/48103) by [@alanjhughes](https://github.com/alanjhughes))
+- Exclude the manifest parser requests from app metrics, so the bundler reachability check no longer skews the observed network summary. ([#48616](https://github.com/expo/expo/pull/48616) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -86,7 +86,11 @@ class DevLauncherManifestParser(
   private fun getHeaders(): Headers {
     val headersMap = mutableMapOf(
       "expo-platform" to "android",
-      "accept" to "application/expo+json,application/json"
+      "accept" to "application/expo+json,application/json",
+      // Dev-launcher infrastructure, not app traffic. Without this the reachability probe wins
+      // `slowest` on nearly every dev launch and skews the launch metrics summary. Mirrors
+      // `INTERNAL_HEADER_NAME` in expo-app-metrics, which strips the header before sending.
+      "Expo-AppMetrics-Skip" to "1"
     )
     headersMap.putAll(getForwardedHeaders(url))
     if (installationID != null) {

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -149,6 +149,47 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
+  fun `isManifestUrl opts out of network observation`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(server.url("/").toString()),
+      null
+    )
+
+    server.enqueue(MockResponse().setResponseCode(200))
+    manifestParser.isManifestUrl()
+
+    val request = server.takeRequest()
+    Truth.assertThat(request.getHeader("Expo-AppMetrics-Skip")).isEqualTo("1")
+  }
+
+  @Test
+  fun `parseManifest opts out of network observation`() = runBlocking {
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(server.url("/").toString()),
+      null
+    )
+
+    server.enqueue(
+      MockResponse().setBody(
+        """
+        {
+          "name": "testproject",
+          "slug": "testproject",
+          "sdkVersion": "UNVERSIONED",
+          "bundleUrl": "http://test.io/bundle.js"
+        }
+        """.trimIndent()
+      )
+    )
+    manifestParser.parseManifest()
+
+    val request = server.takeRequest()
+    Truth.assertThat(request.getHeader("Expo-AppMetrics-Skip")).isEqualTo("1")
+  }
+
+  @Test
   fun `isManifestUrl includes forwarding headers`() = runBlocking {
     val manifestParser = DevLauncherManifestParser(
       client,

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -104,6 +104,12 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
   [request setHTTPMethod:method];
   [request setValue:@"ios" forHTTPHeaderField:@"expo-platform"];
   [request setValue:@"application/expo+json,application/json" forHTTPHeaderField:@"accept"];
+  // Dev-launcher infrastructure, not app traffic. Without this the reachability probe wins
+  // `slowest` on nearly every dev launch and skews the launch metrics summary. Mirrors
+  // `NetworkRequestTaskSwizzling.internalHeaderName` in expo-app-metrics. Unlike Android, the
+  // iOS side can't strip the header once the task exists, so it reaches the server the user
+  // pointed the dev client at.
+  [request setValue:@"1" forHTTPHeaderField:@"Expo-AppMetrics-Skip"];
   [self _setForwardedHeadersOnRequest:request];
   [request setTimeoutInterval:self.requestTimeout];
   if (self.installationID) {

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -190,6 +190,62 @@
   [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
+- (void)testIsManifestURL_RequestOptsOutOfNetworkObservation
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/skip-metrics"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    XCTAssertEqualObjects(@"1", request.allHTTPHeaderFields[@"Expo-AppMetrics-Skip"]);
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:nil];
+  }];
+
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/skip-metrics"]
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"request should include the app-metrics opt-out header"];
+
+  [parser isManifestURLWithCompletion:^(BOOL isManifestURL) {
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
+- (void)testParseManifest_RequestOptsOutOfNetworkObservation
+{
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/skip-metrics"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    XCTAssertEqualObjects(@"1", request.allHTTPHeaderFields[@"Expo-AppMetrics-Skip"]);
+    NSString *manifestString = @"{\"name\":\"testproject\",\"slug\":\"testproject\",\"sdkVersion\":\"42.0.0\",\"bundleUrl\":\"http://test.io/bundle.js\"}";
+    NSData *jsonData = [manifestString dataUsingEncoding:NSUTF8StringEncoding];
+    return [HTTPStubsResponse responseWithData:jsonData statusCode:200 headers:nil];
+  }];
+
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:[NSURL URLWithString:@"http://ohhttpstubs/skip-metrics"]
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:@"manifest download should include the app-metrics opt-out header"];
+
+  [parser tryToParseManifest:^(EXManifestsManifest * _Nonnull manifest) {
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
+}
+
 - (void)testIsManifestURL_RequestIncludesForwardingHeaders
 {
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {


### PR DESCRIPTION
# Why

Closes ENG-25699.

The dev client probes the app URL with a pathless HEAD to work out whether it's pointing at a manifest server or a plain Metro server. That probe gets recorded as an observed network request, and since it outlasts the bundle download it wins `slowest` on basically every dev launch. In one clean three-request window it was a third of `count`, most of `totalDuration`, and the whole `slowest` group, so the 7.5 MB bundle download only showed up in the throughput and byte fields.

# How

Both parsers already send every request through a single helper, so setting `Expo-AppMetrics-Skip: 1` there covers the probe and the manifest download that follows it. Neither is app traffic. The header is the opt-out expo-app-metrics already recognizes on both platforms, so there's no new machinery and no host heuristic. Nothing set it before this, so the dev launcher is its first caller.

One wrinkle worth knowing about: Android's interceptor strips the header before the request goes out, but iOS can't. The swizzle only sees the task once `originalRequest` is fixed, so on iOS the header reaches whichever server the user pointed the dev client at, which may be a third party. That tradeoff is called out in the comment next to it.

# Test Plan

Added tests on both platforms covering the probe and the manifest download, written failing first. `et native-unit-tests -p ios --packages expo-dev-launcher` passes 13/13 in `EXDevLauncherManifestParserTests`, and the Android suite passes 11/11 via `:expo-dev-launcher:testDebugUnitTest`. `et check-packages expo-dev-launcher` is green.
