### PR TITLE
[router] Make `navigation` optional in `Descriptor` type

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Allow descriptors without a `navigation` object in `expo-router/react-navigation` types.
 - Remove `NavigationContainerRefContext` fallback in `useNavigation`. The hook now throws when called outside a navigator, including components rendered via `ExpoRoot`'s `wrapper` prop. ([#48638](https://github.com/expo/expo/pull/48638) by [@Ubax](https://github.com/Ubax))
 - Make `key` optional in `Descriptor` type ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Allow descriptors without a `navigation` object in `expo-router/react-navigation` types.
+- Make `navigation` optional in `Descriptor` type ([#48619](https://github.com/expo/expo/pull/48619) by [@Ubax](https://github.com/Ubax))
 - Remove `NavigationContainerRefContext` fallback in `useNavigation`. The hook now throws when called outside a navigator, including components rendered via `ExpoRoot`'s `wrapper` prop. ([#48638](https://github.com/expo/expo/pull/48638) by [@Ubax](https://github.com/Ubax))
 - Make `key` optional in `Descriptor` type ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
@@ -425,7 +425,7 @@ export type BottomTabHeaderProps = {
   /**
    * Navigation prop for the header.
    */
-  navigation: BottomTabNavigationProp<ParamListBase>;
+  navigation: BottomTabNavigationProp<ParamListBase> | undefined;
 };
 
 // TODO(@ubax): update docs — https://linear.app/expo/issue/ENG-25579/update-documentation-after-the-refactor

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -292,7 +292,9 @@ export function BottomTabView(props: Props) {
                   header={header({
                     layout: dimensions,
                     route,
-                    navigation: descriptor.navigation as BottomTabNavigationProp<ParamListBase>,
+                    navigation: descriptor.navigation as
+                      | BottomTabNavigationProp<ParamListBase>
+                      | undefined,
                     options: descriptor.options,
                   })}
                   style={[customSceneStyle, animationEnabled && sceneStyle]}>

--- a/packages/expo-router/src/react-navigation/core/NavigationProvider.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigationProvider.tsx
@@ -14,7 +14,7 @@ export const NavigationRouteContext = React.createContext<Route<string> | undefi
 
 type Props = {
   route: Route<string>;
-  navigation: NavigationProp<ParamListBase>;
+  navigation: NavigationProp<ParamListBase> | undefined;
   children: React.ReactNode;
 };
 

--- a/packages/expo-router/src/react-navigation/core/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/core/__tests__/types.test.ts
@@ -1,0 +1,75 @@
+import type { NavigationState } from '../../routers';
+import type {
+  DefaultNavigatorOptions,
+  Descriptor,
+  NavigationProp,
+  RouteConfigProps,
+  RouteGroupConfig,
+  RouteProp,
+  ScreenLayoutArgs,
+} from '../types';
+
+type Expect<T extends true> = T;
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type CallbackNavigation<T> = Parameters<Extract<T, (...args: any[]) => any>>[0] extends {
+  navigation: infer Navigation;
+}
+  ? Navigation
+  : never;
+
+type ParamList = { index: undefined };
+type State = NavigationState<ParamList>;
+type Navigation = NavigationProp<ParamList>;
+type Options = { title?: string };
+type EventMap = { focus: { data: undefined } };
+
+type NavigatorOptions = DefaultNavigatorOptions<
+  ParamList,
+  undefined,
+  State,
+  Options,
+  EventMap,
+  Navigation
+>;
+type ScreenProps = RouteConfigProps<ParamList, 'index', State, Options, EventMap, Navigation>;
+type GroupProps = RouteGroupConfig<ParamList, Options, Navigation>;
+type ScreenDescriptor = Descriptor<Options, Navigation, RouteProp<ParamList>>;
+
+export type _NavigatorScreenOptionsNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<NavigatorOptions['screenOptions']>, Navigation | undefined>
+>;
+export type _NavigatorScreenListenersNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<NavigatorOptions['screenListeners']>, Navigation | undefined>
+>;
+export type _NavigatorScreenLayoutNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<NavigatorOptions['screenLayout']>, Navigation | undefined>
+>;
+export type _ScreenOptionsNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<ScreenProps['options']>, Navigation | undefined>
+>;
+export type _ScreenListenersNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<ScreenProps['listeners']>, Navigation | undefined>
+>;
+export type _ScreenLayoutNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<ScreenProps['layout']>, Navigation | undefined>
+>;
+export type _GroupScreenOptionsNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<GroupProps['screenOptions']>, Navigation | undefined>
+>;
+export type _GroupScreenLayoutNavigationCanBeUndefined = Expect<
+  Equal<CallbackNavigation<GroupProps['screenLayout']>, Navigation | undefined>
+>;
+export type _ScreenLayoutArgsNavigationCanBeUndefined = Expect<
+  Equal<
+    ScreenLayoutArgs<ParamList, 'index', Options, Navigation>['navigation'],
+    Navigation | undefined
+  >
+>;
+export type _DescriptorNavigationIsRequired = Expect<
+  Equal<Record<never, never> extends Pick<ScreenDescriptor, 'navigation'> ? true : false, false>
+>;
+
+describe('react-navigation core types', () => {
+  it('is type-checked by tsc', () => {});
+});

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -584,9 +584,11 @@ export type Descriptor<
   route: DescriptorRoute<Route>;
 
   /**
-   * Navigation object for the screen
+   * Navigation object for the screen. `undefined` when the descriptor
+   * describes a route name declared in a layout that has no live route
+   * instance in navigation state.
    */
-  navigation: Navigation;
+  navigation: Navigation | undefined;
 
   /**
    * Whether this screen was declared in the layout (`<Screen>`/`<NativeTabs.Trigger>`)
@@ -678,7 +680,7 @@ export type RouteConfigProps<
     | ScreenListeners<State, EventMap>
     | ((props: {
         route: RouteProp<ParamList, RouteName>;
-        navigation: Navigation;
+        navigation: Navigation | undefined;
       }) => ScreenListeners<State, EventMap>);
 
   /**

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -72,7 +72,7 @@ export type DefaultNavigatorOptions<
     | ScreenListeners<State, EventMap>
     | ((props: {
         route: RouteProp<ParamList>;
-        navigation: Navigation;
+        navigation: Navigation | undefined;
       }) => ScreenListeners<State, EventMap>);
 
   /**
@@ -82,7 +82,7 @@ export type DefaultNavigatorOptions<
     | ScreenOptions
     | ((props: {
         route: DescriptorRouteProp<ParamList>;
-        navigation: Navigation;
+        navigation: Navigation | undefined;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);
 
@@ -543,7 +543,7 @@ export type ScreenLayoutArgs<
 > = {
   route: RouteProp<ParamList, RouteName>;
   options: ScreenOptions;
-  navigation: Navigation;
+  navigation: Navigation | undefined;
   theme: ReactNavigation.Theme;
   children: React.ReactElement;
 };
@@ -586,7 +586,8 @@ export type Descriptor<
   /**
    * Navigation object for the screen. `undefined` when the descriptor
    * describes a route name declared in a layout that has no live route
-   * instance in navigation state.
+   * instance in navigation state. The property is intentionally required so
+   * descriptor producers must set `navigation: undefined` explicitly.
    */
   navigation: Navigation | undefined;
 
@@ -669,7 +670,7 @@ export type RouteConfigProps<
     | ScreenOptions
     | ((props: {
         route: DescriptorRouteProp<ParamList, RouteName>;
-        navigation: Navigation;
+        navigation: Navigation | undefined;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);
 
@@ -736,7 +737,7 @@ export type RouteGroupConfig<
     | ScreenOptions
     | ((props: {
         route: DescriptorRouteProp<ParamList, keyof ParamList>;
-        navigation: Navigation;
+        navigation: Navigation | undefined;
         theme: ReactNavigation.Theme;
       }) => ScreenOptions);
 

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -45,7 +45,7 @@ export type ScreenConfigWithParent<
 type ScreenLayout<ScreenOptions extends {}> = (props: {
   route: RouteProp<ParamListBase, string>;
   options: ScreenOptions;
-  navigation: any;
+  navigation: any | undefined;
   theme: ReactNavigation.Theme;
   children: React.ReactElement;
 }) => React.ReactElement;
@@ -55,7 +55,7 @@ type ScreenOptionsOrCallback<ScreenOptions extends {}> =
   | ScreenOptions
   | ((props: {
       route: DescriptorRouteProp<ParamListBase, string>;
-      navigation: any;
+      navigation: any | undefined;
       theme: ReactNavigation.Theme;
     }) => ScreenOptions);
 
@@ -154,14 +154,9 @@ export function useDescriptors<
 
   const getOptions = (
     route: DescriptorRouteProp<ParamListBase, string>,
-    navigation: NavigationProp<
-      ParamListBase,
-      string,
-      string | undefined,
-      State,
-      ScreenOptions,
-      EventMap
-    >,
+    navigation:
+      | NavigationProp<ParamListBase, string, string | undefined, State, ScreenOptions, EventMap>
+      | undefined,
     overrides: Record<string, ScreenOptions>
   ) => {
     const config = screens[route.name]!;

--- a/packages/expo-router/src/react-navigation/drawer/types.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/types.tsx
@@ -239,7 +239,7 @@ export type DrawerHeaderProps = {
   /**
    * Navigation prop for the header.
    */
-  navigation: DrawerNavigationProp<ParamListBase>;
+  navigation: DrawerNavigationProp<ParamListBase> | undefined;
 };
 
 export type DrawerNavigationEventMap = {

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -261,7 +261,9 @@ function DrawerViewBase({
                 header={header({
                   layout: dimensions,
                   route,
-                  navigation: descriptor.navigation as DrawerNavigationProp<ParamListBase>,
+                  navigation: descriptor.navigation as
+                    | DrawerNavigationProp<ParamListBase>
+                    | undefined,
                   options: descriptor.options,
                 })}
                 style={sceneStyle}>

--- a/packages/expo-router/src/react-navigation/elements/Screen.tsx
+++ b/packages/expo-router/src/react-navigation/elements/Screen.tsx
@@ -19,7 +19,7 @@ import { useFrameSize } from './useFrameSize';
 type Props = {
   focused: boolean;
   modal?: boolean;
-  navigation: NavigationProp<ParamListBase>;
+  navigation: NavigationProp<ParamListBase> | undefined;
   route: RouteProp<ParamListBase>;
   header: React.ReactNode;
   headerShown?: boolean;

--- a/packages/expo-router/src/react-navigation/native-stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/types.tsx
@@ -137,7 +137,7 @@ export type NativeStackHeaderProps = {
   /**
    * Navigation prop for the header.
    */
-  navigation: NativeStackNavigationProp<ParamListBase>;
+  navigation: NativeStackNavigationProp<ParamListBase> | undefined;
 };
 
 export type NativeStackHeaderItemProps = {

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.tsx
@@ -121,7 +121,7 @@ export function NativeStackView({ state, descriptors }: Props) {
                                     )
                                   : undefined
                               }
-                              onPress={navigation.goBack}
+                              onPress={navigation?.goBack}
                             />
                           )
                         : headerLeft

--- a/packages/expo-router/src/react-navigation/stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/stack/types.tsx
@@ -246,7 +246,7 @@ export type StackHeaderProps = {
   /**
    * Navigation prop for the header.
    */
-  navigation: StackNavigationProp<ParamListBase>;
+  navigation: StackNavigationProp<ParamListBase> | undefined;
   /**
    * Interpolated styles for various elements in the header.
    */

--- a/packages/expo-router/src/react-navigation/stack/views/Header/Header.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Header/Header.tsx
@@ -34,7 +34,7 @@ export const Header = React.memo(function Header({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const goBack = React.useCallback(
     throttle(() => {
-      if (navigation.isFocused() && navigation.canGoBack()) {
+      if (navigation?.isFocused() && navigation.canGoBack()) {
         navigation.dispatch({
           ...StackActions.pop(),
           source: route.key,

--- a/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Header/HeaderContainer.tsx
@@ -120,7 +120,7 @@ export function HeaderContainer({
           progress: scene.progress,
           options: scene.descriptor.options,
           route: scene.route,
-          navigation: scene.descriptor.navigation as StackNavigationProp<ParamListBase>,
+          navigation: scene.descriptor.navigation as StackNavigationProp<ParamListBase> | undefined,
           styleInterpolator:
             mode === 'float'
               ? isHeaderStatic

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -86,7 +86,7 @@ type ListenersFn = Extract<Props['screenListeners'], (...args: any) => any>;
 type OptionsFn = Extract<Props['screenOptions'], (...args: any) => any>;
 
 export const _listeners: ListenersFn = ({ route, navigation }) => {
-  navigation.navigate();
+  navigation?.navigate();
   // @ts-expect-error the route passed to screenListeners must not expose `href`.
   route.href;
   return { focus: () => route.name };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
