### PR TITLE
[font][Android] Support variation axes in the config plugin

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -8,7 +8,8 @@
 
 ### 🎉 New features
 
-- [android] Support variable fonts in the config plugin ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
+- [android] Added an `axes` field to the config plugin's font definitions, so one variable font file can also back a slanted or condensed face through its `slnt`, `wdth` and other variation axes. ([#48621](https://github.com/expo/expo/pull/48621) by [@vonovak](https://github.com/vonovak))
+- [android] Support variable weight fonts in the config plugin ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
 - [ios] Apply `fontWeight` to variable fonts loaded with `useFonts`. ([#48432](https://github.com/expo/expo/pull/48432) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes

--- a/packages/expo-font/plugin/src/__tests__/withFontsAndroid-test.ts
+++ b/packages/expo-font/plugin/src/__tests__/withFontsAndroid-test.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 
 import { toValidAndroidResourceName } from '../utils';
-import type { FontObject } from '../withFonts';
+import type { FontObject, FontVariationAxes } from '../withFonts';
 import {
   groupByFamily,
   planFontCopies,
@@ -9,6 +9,10 @@ import {
   generateFontManagerCalls,
   assertNoConflictingDefinitions,
   assertAndroidCanLoadFonts,
+  assertValidWeights,
+  assertValidAxes,
+  warnAboutUnknownAxisTags,
+  warnAboutUnslantedItalics,
 } from '../withFontsAndroid';
 
 const input = [
@@ -37,9 +41,33 @@ const input = [
     fontDefinitions: [
       { path: './assets/fonts/Inter[wght].ttf', weight: 400 },
       { path: './assets/fonts/Inter[wght].ttf', weight: 700 },
+      // The same file slanted by its `slnt` axis, so one variable font also backs the oblique.
+      { path: './assets/fonts/Inter[wght].ttf', weight: 400, style: 'italic', axes: { slnt: -10 } },
+    ],
+  },
+  {
+    fontFamily: 'Roboto Flex',
+    // One variable file backs every definition, so the family names it once instead of each
+    // definition repeating it.
+    path: './assets/fonts/RobotoFlex.ttf',
+    fontDefinitions: [
+      { weight: 400 },
+      // A registered axis and one the font declares for itself. `slnt` is left undefined, the
+      // shape a conditional in app.config.ts writes for the axis it omits.
+      { weight: 700, axes: { wght: 650, slnt: undefined, wdth: 75, GRAD: -50 } },
+      // A definition may still name a file of its own.
+      { path: './assets/fonts/RobotoSerif_italic.ttf', weight: 400, style: 'italic' },
     ],
   },
 ] as const satisfies FontObject[];
+
+const declaring = (axes: FontVariationAxes) =>
+  groupByFamily([
+    {
+      fontFamily: 'Roboto Flex',
+      fontDefinitions: [{ path: './RobotoFlex.ttf', weight: 400, axes }],
+    },
+  ]);
 
 describe('groupByFamily', () => {
   it('should group font definitions by font family', () => {
@@ -54,6 +82,22 @@ describe('groupByFamily', () => {
       Inter: [
         { path: './assets/fonts/Inter[wght].ttf', weight: 400 },
         { path: './assets/fonts/Inter[wght].ttf', weight: 700 },
+        {
+          path: './assets/fonts/Inter[wght].ttf',
+          weight: 400,
+          style: 'italic',
+          axes: { slnt: -10 },
+        },
+      ],
+      // The family's `path` fills in every definition that declares none of its own.
+      'Roboto Flex': [
+        { path: './assets/fonts/RobotoFlex.ttf', weight: 400 },
+        {
+          path: './assets/fonts/RobotoFlex.ttf',
+          weight: 700,
+          axes: { slnt: undefined, wght: 650, wdth: 75, GRAD: -50 },
+        },
+        { path: './assets/fonts/RobotoSerif_italic.ttf', weight: 400, style: 'italic' },
       ],
     };
 
@@ -64,6 +108,12 @@ describe('groupByFamily', () => {
   it('should handle empty input', () => {
     const result = groupByFamily([]);
     expect(result).toEqual({});
+  });
+
+  it('should name the missing field when neither the family nor the definition holds a path', () => {
+    expect(() =>
+      groupByFamily([{ fontFamily: 'Roboto Flex', fontDefinitions: [{ weight: 700 }] }])
+    ).toThrow(/declares no "path"/);
   });
 });
 
@@ -130,6 +180,34 @@ describe('assertAndroidCanLoadFonts', () => {
       /"Inter".+Inter\[wght\]\.woff2.+\.ttf.+\.otf/s
     );
     expect(() => assertAndroidCanLoadFonts(declaring('./Inter[wght].woff'))).toThrow(/\.woff/);
+  });
+});
+
+describe('assertValidWeights', () => {
+  const declaring = (weight: unknown) =>
+    groupByFamily([
+      {
+        fontFamily: 'Inter',
+        fontDefinitions: [{ path: './Inter[wght].ttf', weight: weight as number }],
+      },
+    ]);
+
+  it('should accept the weights Android resolves a family by', () => {
+    expect(() => assertValidWeights(groupByFamily(input))).not.toThrow();
+    expect(() => assertValidWeights(declaring(1))).not.toThrow();
+    expect(() => assertValidWeights(declaring(1000))).not.toThrow();
+  });
+
+  it('should reject a weight outside the range Android reads', () => {
+    expect(() => assertValidWeights(declaring(0))).toThrow(/1 to 1000/);
+    expect(() => assertValidWeights(declaring(1001))).toThrow(/1 to 1000/);
+    expect(() => assertValidWeights(declaring(400.5))).toThrow(/1 to 1000/);
+    expect(() => assertValidWeights(declaring('400'))).toThrow(/1 to 1000/);
+  });
+
+  it('should name the missing field when a definition carries no weight', () => {
+    expect(() => assertValidWeights(declaring(undefined))).toThrow(/declares no weight/);
+    expect(() => assertValidWeights(declaring(null))).toThrow(/declares no weight/);
   });
 });
 
@@ -269,6 +347,50 @@ describe('getXmlSpecs', () => {
                   'app:fontVariationSettings': `'wght' 700`,
                 },
               },
+              {
+                $: {
+                  'app:font': '@font/inter_wght_',
+                  'app:fontStyle': 'italic',
+                  'app:fontWeight': '400',
+                  'app:fontVariationSettings': `'wght' 400, 'slnt' -10`,
+                },
+              },
+            ],
+          },
+        },
+      },
+      {
+        // the family's `path` backing two weights, and one definition naming a file of its own
+        path: path.join(fontsDir, `xml_roboto_flex.xml`),
+        xml: {
+          'font-family': {
+            $: { 'xmlns:app': 'http://schemas.android.com/apk/res-auto' },
+            font: [
+              {
+                $: {
+                  'app:font': '@font/roboto_flex',
+                  'app:fontStyle': 'normal',
+                  'app:fontWeight': '400',
+                  'app:fontVariationSettings': `'wght' 400`,
+                },
+              },
+              {
+                $: {
+                  'app:font': '@font/roboto_flex',
+                  'app:fontStyle': 'normal',
+                  'app:fontWeight': '700',
+                  // `slnt` is undefined, so it is left out entirely.
+                  'app:fontVariationSettings': `'wght' 650, 'wdth' 75, 'GRAD' -50`,
+                },
+              },
+              {
+                $: {
+                  'app:font': '@font/roboto_serif_italic',
+                  'app:fontStyle': 'italic',
+                  'app:fontWeight': '400',
+                  'app:fontVariationSettings': `'wght' 400`,
+                },
+              },
             ],
           },
         },
@@ -285,6 +407,130 @@ describe('getXmlSpecs', () => {
   });
 });
 
+describe('assertValidAxes', () => {
+  it('should accept registered and custom axis tags', () => {
+    // `input` holds `slnt` left undefined, the registered `wdth`, and the font's own `GRAD`.
+    expect(() => assertValidAxes(groupByFamily(input))).not.toThrow();
+  });
+
+  it('should accept a tag padded to four characters', () => {
+    // The registry pads a tag holding fewer than four letters or digits with trailing spaces.
+    expect(() => assertValidAxes(declaring({ 'AB  ': 1 }))).not.toThrow();
+  });
+
+  it('should reject an axis it cannot emit', () => {
+    expect(() => assertValidAxes(declaring({ slant: -10 }))).toThrow(/"slant".+four/s);
+    expect(() => assertValidAxes(declaring({ "a'b'": -10 }))).toThrow(/begins with a letter/);
+    expect(() => assertValidAxes(declaring({ '    ': -10 }))).toThrow(/begins with a letter/);
+    // A tag begins with a letter, so this one names no axis however the font is built.
+    expect(() => assertValidAxes(declaring({ '1abc': -10 }))).toThrow(/begins with a letter/);
+    // @ts-expect-error an axis takes a number
+    expect(() => assertValidAxes(declaring({ slnt: 'left' }))).toThrow();
+  });
+
+  it('should accept a registered tag spelled in the foundry namespace', () => {
+    // Uppercase names an axis a font declares for itself, so `SLNT` is not a misspelt `slnt`.
+    expect(() => assertValidAxes(declaring({ SLNT: -10, WDTH: 75 }))).not.toThrow();
+    expect(() => assertValidAxes(declaring({ WGHT: 650 }))).not.toThrow();
+  });
+
+  it('should reject a registered axis tag in a case that names no axis', () => {
+    expect(() => assertValidAxes(declaring({ Slnt: -10 }))).toThrow(/"Slnt".+"slnt"/s);
+    expect(() => assertValidAxes(declaring({ Wdth: 75 }))).toThrow(/"Wdth".+"wdth"/s);
+    expect(() => assertValidAxes(declaring({ Wght: 650 }))).toThrow(/"Wght".+"wght"/s);
+  });
+
+  it('should reject a§xes that hold no entries to read', () => {
+    expect(() => assertValidAxes(declaring('slnt' as unknown as FontVariationAxes))).toThrow(
+      /not an object/
+    );
+    expect(() => assertValidAxes(declaring([-10] as unknown as FontVariationAxes))).toThrow(
+      /not an object/
+    );
+  });
+});
+
+describe('warnAboutUnknownAxisTags', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('should warn about a foundry tag written in lowercase', () => {
+    // Roboto Flex declares `GRAD`, so `grad` names no axis and Android applies nothing.
+    warnAboutUnknownAxisTags(declaring({ grad: -50 }));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/"grad".+"GRAD"/s));
+  });
+
+  it('should warn about a registered tag written in the foundry namespace', () => {
+    // Legal, so `assertValidAxes` lets it through — but far more often `slnt` in the wrong case,
+    // and Android then applies nothing. Without this the mistake is silent.
+    warnAboutUnknownAxisTags(declaring({ SLNT: -10 }));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/"SLNT".+"slnt"/s));
+  });
+
+  it('should point at the registered tag for a foundry WGHT', () => {
+    warnAboutUnknownAxisTags(declaring({ WGHT: 650 }));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/"WGHT".+"wght"/s));
+  });
+
+  it('should stay quiet about tags a font can declare', () => {
+    warnAboutUnknownAxisTags(declaring({ slnt: -10, GRAD: -50, XTR2: 1, 'AB  ': 1 }));
+    warnAboutUnknownAxisTags(groupByFamily(input));
+    // A tag that would warn stays quiet while it holds no value, so an axis left out of an
+    // app.config.ts conditional never reports.
+    warnAboutUnknownAxisTags(declaring({ grad: undefined }));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('warnAboutUnslantedItalics', () => {
+  let warn: jest.SpyInstance;
+
+  // One file backing both an upright and an italic face, the shape a variable font takes.
+  const backedBy = (italic: Partial<FontObject['fontDefinitions'][number]>) =>
+    groupByFamily([
+      {
+        fontFamily: 'Inter',
+        path: './Inter[wght].ttf',
+        fontDefinitions: [{ weight: 400 }, { weight: 400, style: 'italic', ...italic }],
+      },
+    ]);
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('should warn when the file backing an italic face also backs an upright one without declaring slnt / ital', () => {
+    warnAboutUnslantedItalics(backedBy({}));
+
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/"Inter".+will render upright/s));
+  });
+
+  it('should stay quiet when the italic definition slants the file or has own file path', () => {
+    warnAboutUnslantedItalics(backedBy({ axes: { slnt: -10 } }));
+    warnAboutUnslantedItalics(backedBy({ axes: { ital: 1 } }));
+    // A font may declare the slant as its own axis, which slants it just the same.
+    warnAboutUnslantedItalics(backedBy({ axes: { SLNT: -10 } }));
+    warnAboutUnslantedItalics(backedBy({ path: './Inter-Italic.ttf' }));
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
 describe('generateFontManagerCalls', () => {
   it('supports kotlin and java', () => {
     const resultKt = generateFontManagerCalls(groupByFamily(input), 'kt');
@@ -294,6 +540,7 @@ describe('generateFontManagerCalls', () => {
         "    ReactFontManager.getInstance().addCustomFont(this, "Source Serif 4", R.font.xml_source_serif_4)",
         "    ReactFontManager.getInstance().addCustomFont(this, "SpaceMono", R.font.xml_space_mono)",
         "    ReactFontManager.getInstance().addCustomFont(this, "Inter", R.font.xml_inter)",
+        "    ReactFontManager.getInstance().addCustomFont(this, "Roboto Flex", R.font.xml_roboto_flex)",
       ]
     `);
 
@@ -304,6 +551,7 @@ describe('generateFontManagerCalls', () => {
         "    ReactFontManager.getInstance().addCustomFont(this, "Source Serif 4", R.font.xml_source_serif_4);",
         "    ReactFontManager.getInstance().addCustomFont(this, "SpaceMono", R.font.xml_space_mono);",
         "    ReactFontManager.getInstance().addCustomFont(this, "Inter", R.font.xml_inter);",
+        "    ReactFontManager.getInstance().addCustomFont(this, "Roboto Flex", R.font.xml_roboto_flex);",
       ]
     `);
   });

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -5,13 +5,45 @@ import { withFontsIos } from './withFontsIos';
 
 const pkg = require('../../package.json');
 
+/**
+ * The five axes the OpenType registry names, or any other four-character tag
+ * (a font may declare custom axes of its own, such as `GRAD`).
+ */
+export type FontVariationAxisTag = 'ital' | 'opsz' | 'slnt' | 'wdth' | 'wght' | (string & {});
+
+export type FontVariationAxes = Partial<Record<FontVariationAxisTag, number>>;
+
+export type FontDefinition = {
+  /**
+   * For static fonts, each definition can point to a different font file.
+   */
+  path?: string | undefined;
+  weight: number;
+  style?: 'normal' | 'italic' | undefined;
+  /**
+   * The axes to instance a variable font at, such as `{ slnt: -10 }` for an oblique.
+   *
+   * `weight` and `style` pick which face the `fontWeight` and `fontStyle` JS props match; the axes
+   * here draw it. You may set them apart: `weight: 700` with `{ wght: 650 }`
+   * matches a request for bold and draws the file at 650. `wght` defaults to `weight`.
+   *
+   * `style` alone does not slant the glyphs, so an upright file declared `style: "italic"` renders
+   * upright until `slnt` or `ital` is set here.
+   *
+   * @platform android
+   */
+  axes?: FontVariationAxes | undefined;
+};
+
 export type FontObject = {
   fontFamily: string;
-  fontDefinitions: {
-    path: string;
-    weight: number;
-    style?: 'normal' | 'italic' | undefined;
-  }[];
+  /**
+   * One variable font file can back several definitions; provide the file path once instead of repeating it per-definition.
+   *
+   * @platform android
+   */
+  path?: string | undefined;
+  fontDefinitions: FontDefinition[];
 };
 
 export type Font = string | FontObject;

--- a/packages/expo-font/plugin/src/withFontsAndroid.ts
+++ b/packages/expo-font/plugin/src/withFontsAndroid.ts
@@ -6,13 +6,14 @@ import {
   XML,
   CodeGenerator,
   AndroidConfig,
+  WarningAggregator,
 } from 'expo/config-plugins';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
 import { resolveFontPaths, toValidAndroidResourceName } from './utils';
-import type { Font, FontObject } from './withFonts';
+import type { Font, FontDefinition, FontObject } from './withFonts';
 
 const assetsFontsFir = 'app/src/main/assets/fonts';
 const resourcesFontsDir = 'app/src/main/res/font';
@@ -30,15 +31,37 @@ export const withFontsAndroid: ConfigPlugin<Font[]> = (config, fonts) => {
   return config;
 };
 
-type GroupedFontObject = Record<string, FontObject['fontDefinitions']>;
+/** A definition once the family's `path` has filled in the file it reads. */
+export type ResolvedFontDefinition = FontDefinition & { path: string };
+
+type GroupedFontObject = Record<string, ResolvedFontDefinition[]>;
 
 export function groupByFamily(array: FontObject[]): GroupedFontObject {
   return array.reduce<GroupedFontObject>((result, item) => {
     const keyValue = item['fontFamily'];
     result[keyValue] ||= [];
-    result[keyValue].push(...item.fontDefinitions);
+    result[keyValue].push(
+      ...item.fontDefinitions.map((it, index) => resolveFontFile(item, it, index))
+    );
     return result;
   }, {});
+}
+
+function resolveFontFile(
+  family: FontObject,
+  definition: FontDefinition,
+  index: number
+): ResolvedFontDefinition {
+  const resolvedPath = definition.path ?? family.path;
+
+  if (!resolvedPath) {
+    throw new Error(
+      `Font family ${JSON.stringify(family.fontFamily)} declares no "path" at index ${index}. ` +
+        `Add "path" to the font definition, or next to the family.`
+    );
+  }
+
+  return { ...definition, path: resolvedPath };
 }
 
 export function assertAndroidCanLoadFonts(fontsByFamily: GroupedFontObject) {
@@ -51,6 +74,37 @@ export function assertAndroidCanLoadFonts(fontsByFamily: GroupedFontObject) {
       throw new Error(
         `Font family ${JSON.stringify(fontFamily)} declares ${definition.path}, which Android cannot load. ` +
           `Android reads TrueType (.ttf) and OpenType (.otf) files only. To convert a web font such as WOFF or WOFF2, use a utility such as fontTools: https://fonttools.readthedocs.io/`
+      );
+    }
+  }
+}
+
+const MIN_FONT_WEIGHT = 1;
+const MAX_FONT_WEIGHT = 1000;
+
+export function assertValidWeights(fontsByFamily: GroupedFontObject) {
+  for (const [fontFamily, definitions] of Object.entries(fontsByFamily)) {
+    for (const definition of definitions) {
+      const { weight } = definition;
+
+      if (weight === undefined || weight === null) {
+        throw new Error(
+          `Font family ${JSON.stringify(fontFamily)} declares no weight for ${definition.path}. ` +
+            `A weight is a whole number from ${MIN_FONT_WEIGHT} to ${MAX_FONT_WEIGHT}, such as 400 for regular or 700 for bold.`
+        );
+      }
+
+      if (
+        typeof weight === 'number' &&
+        Number.isInteger(weight) &&
+        weight >= MIN_FONT_WEIGHT &&
+        weight <= MAX_FONT_WEIGHT
+      ) {
+        continue;
+      }
+
+      throw new Error(
+        `Font family ${JSON.stringify(fontFamily)} declares weight ${JSON.stringify(weight)} for ${definition.path}. A weight is a whole number from ${MIN_FONT_WEIGHT} to ${MAX_FONT_WEIGHT}.`
       );
     }
   }
@@ -73,9 +127,9 @@ export function assertNoConflictingDefinitions(fontsByFamily: GroupedFontObject)
 
       if (alreadyDeclaredBy) {
         throw new Error(
-          `Font family ${JSON.stringify(fontFamily)} declares more than one font for weight ${definition.weight} and style ${JSON.stringify(style)}: ${alreadyDeclaredBy} and ${definition.path}. ` +
-            `Android resolves a font family by weight and style, so it cannot hold two fonts with the same pair — the app would crash on startup while registering the family. ` +
-            `Remove the duplicate, or give each definition a weight or style of its own. One variable font file can back several weights, but each definition needs a different weight.`
+          `Font family ${JSON.stringify(fontFamily)} declares two fonts for weight ${definition.weight} and style ${JSON.stringify(style)}: ${alreadyDeclaredBy} and ${definition.path}. ` +
+            `Android matches a family on weight and style alone, so the app would crash on startup while registering it. ` +
+            `Give each definition a weight or style of its own — "axes" cannot tell them apart.`
         );
       }
 
@@ -84,10 +138,171 @@ export function assertNoConflictingDefinitions(fontsByFamily: GroupedFontObject)
   }
 }
 
+// https://learn.microsoft.com/en-us/typography/opentype/spec/dvaraxisreg
+const AXIS_TAG_LENGTH = 4;
+const AXIS_TAG_PATTERN = /^[A-Za-z][A-Za-z0-9]* *$/;
+
+// Case splits the namespace: registered axes are lowercase, a font's own axes are uppercase, and a
+// tag in any other case names nothing. So `SLNT` is a font's own axis, not a misspelt `slnt`.
+const registeredAxisTags = ['ital', 'opsz', 'slnt', 'wdth', 'wght'];
+const FOUNDRY_AXIS_TAG_PATTERN = /^[A-Z][A-Z0-9]* *$/;
+
+function isFoundryAxisTag(tag: string) {
+  return FOUNDRY_AXIS_TAG_PATTERN.test(tag);
+}
+
+type DeclaredAxis = { tag: string; value: unknown; declares: string };
+
+/** Throws when a definition holds `axes` that cannot be read one axis at a time. */
+function collectDeclaredAxes(fontsByFamily: GroupedFontObject): DeclaredAxis[] {
+  return Object.entries(fontsByFamily).flatMap(([fontFamily, definitions]) =>
+    definitions.flatMap((definition) => {
+      const axes = definition.axes ?? {};
+
+      if (typeof axes !== 'object' || Array.isArray(axes)) {
+        throw new Error(
+          `Font family ${JSON.stringify(fontFamily)} declares "axes" for ${definition.path} as ${JSON.stringify(axes)}, which is not an object. ` +
+            `"axes" holds one entry per axis, such as { "slnt": -10 }.`
+        );
+      }
+
+      return Object.entries<unknown>(axes).map(([tag, value]) => ({
+        tag,
+        value,
+        declares: `Font family ${JSON.stringify(fontFamily)} declares axis ${JSON.stringify(tag)} for ${definition.path}`,
+      }));
+    })
+  );
+}
+
+export function assertValidAxes(fontsByFamily: GroupedFontObject) {
+  for (const { tag, value, declares } of collectDeclaredAxes(fontsByFamily)) {
+    // On Android 15, `'wght' 900, 'sl t' -10` rendered at weight 900 with no slant: the bad
+    // entry is dropped, the rest still applies.
+    const consequence = `Android may drop a setting it cannot parse.`;
+    const lowercaseTag = tag.toLowerCase();
+
+    // An `app.config.ts` conditional writes `undefined` for the axis it leaves out.
+    if (value === undefined) {
+      continue;
+    }
+
+    if (tag.length !== AXIS_TAG_LENGTH) {
+      throw new Error(
+        `${declares}, which is not four characters. An axis tag is exactly four, such as "slnt". ` +
+          `List the axes a font declares with a utility such as fontTools: https://fonttools.readthedocs.io/`
+      );
+    }
+
+    if (!AXIS_TAG_PATTERN.test(tag)) {
+      throw new Error(
+        `${declares}, which holds characters no axis tag uses. A tag begins with a letter, then letters, digits, or the trailing spaces that pad a shorter tag. ${consequence}`
+      );
+    }
+
+    if (
+      registeredAxisTags.includes(lowercaseTag) &&
+      lowercaseTag !== tag &&
+      !isFoundryAxisTag(tag)
+    ) {
+      throw new Error(
+        `${declares}, which names no axis: tags are case sensitive. Write it as ${JSON.stringify(lowercaseTag)}. ${consequence}`
+      );
+    }
+
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw new Error(
+        `${declares}, which is set to ${JSON.stringify(value)} — not a finite number. ` +
+          `An axis takes a number in the range the font declares, such as -10 for "slnt".`
+      );
+    }
+  }
+}
+
+export function warnAboutUnknownAxisTags(fontsByFamily: GroupedFontObject) {
+  for (const { tag, value, declares } of collectDeclaredAxes(fontsByFamily)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    const lowercaseTag = tag.toLowerCase();
+
+    // A font may declare `SLNT`, so this stays legal — but it is far more often `slnt` in the
+    // wrong case, and Android then applies nothing.
+    if (isFoundryAxisTag(tag) && registeredAxisTags.includes(lowercaseTag)) {
+      WarningAggregator.addWarningAndroid(
+        'expo-font',
+        `${declares}, which is an axis the font declares for itself, not the registered ${JSON.stringify(lowercaseTag)}. ` +
+          `Write it as ${JSON.stringify(lowercaseTag)} instead if you meant the registered axis.`
+      );
+    } else if (!registeredAxisTags.includes(tag) && !isFoundryAxisTag(tag)) {
+      WarningAggregator.addWarningAndroid(
+        'expo-font',
+        `${declares}, which names no axis: registered axes are lowercase, such as "slnt", and a font's own are uppercase, such as "GRAD". ` +
+          `Write it in the case the font uses, or Android applies nothing for it.`
+      );
+    }
+  }
+}
+
+// Either axis draws a slant: `slnt` by an angle, `ital` by the upright-to-italic switch.
+const slantAxisTags = ['ital', 'slnt'];
+
+function hasSlantAxis(definition: ResolvedFontDefinition) {
+  return Object.entries(definition.axes ?? {}).some(
+    ([tag, value]) => value !== undefined && slantAxisTags.includes(tag.toLowerCase())
+  );
+}
+
+/**
+ * Warns when one file backs both an upright and an italic face while the italic one sets no slant.
+ */
+export function warnAboutUnslantedItalics(fontsByFamily: GroupedFontObject) {
+  for (const [fontFamily, definitions] of Object.entries(fontsByFamily)) {
+    const uprightPaths = new Set(
+      definitions.filter((it) => (it.style || 'normal') === 'normal').map((it) => it.path)
+    );
+
+    for (const definition of definitions) {
+      // A font definition that has a file of its own may hold a static italic, which needs no axis.
+      const rendersUpright =
+        definition.style === 'italic' &&
+        uprightPaths.has(definition.path) &&
+        !hasSlantAxis(definition);
+
+      if (rendersUpright) {
+        WarningAggregator.addWarningAndroid(
+          'expo-font',
+          `Font family ${JSON.stringify(fontFamily)} reads ${definition.path} for style "italic", and the same file also backs an upright face. ` +
+            `"style" by itself does not slant the glyphs, so the text will render upright. ` +
+            `Add a slant to "axes" for that definition, such as { "slnt": -10 }, or point it at an italic font file using "path".`
+        );
+      }
+    }
+  }
+}
+
+function formatVariationSettings(definition: FontDefinition) {
+  const { wght, ...rest } = definition.axes ?? {};
+  const axes = {
+    wght: wght ?? definition.weight,
+    ...rest,
+  };
+
+  return Object.entries(axes)
+    .filter(([, value]) => value !== undefined)
+    .map(([tag, value]) => `'${tag}' ${value}`)
+    .join(', ');
+}
+
 function addXmlFonts(config: ExpoConfig, xmlFontObjects: FontObject[]) {
   const fontsByFamily = groupByFamily(xmlFontObjects);
   assertAndroidCanLoadFonts(fontsByFamily);
+  assertValidWeights(fontsByFamily);
   assertNoConflictingDefinitions(fontsByFamily);
+  assertValidAxes(fontsByFamily);
+  warnAboutUnknownAxisTags(fontsByFamily);
+  warnAboutUnslantedItalics(fontsByFamily);
   const fontPaths = Object.values(fontsByFamily).flatMap((definitions) =>
     definitions.map((it) => it.path)
   );
@@ -140,9 +355,9 @@ export function getXmlSpecs(fontsDir: string, xmlFontObjects: GroupedFontObject)
                 'app:font': `@font/${toValidAndroidResourceName(definition.path)}`,
                 'app:fontStyle': definition.style || 'normal',
                 'app:fontWeight': String(definition.weight),
-                // Instances a variable font at the declared weight, so that one file can back
-                // several definitions. Static fonts have no `wght` axis and ignore it.
-                'app:fontVariationSettings': `'wght' ${definition.weight}`,
+                // Instances a variable font at the declared weight and axes, so that one file can
+                // back several definitions. Static fonts declare no axes and ignore this.
+                'app:fontVariationSettings': formatVariationSettings(definition),
               },
             };
           }),


### PR DESCRIPTION
# Why

we previously specified only `wght` axis to allow variable fonts to specify at what weight to render; there are other axes that users may want to specify and this PR does that

# How

added new `axes` field in the android section of the config plugin that allow custom `slnt` and other, potentially font-custom axes.

docs in https://github.com/expo/expo/pull/48776


# Test Plan

- tested manually with defining the following config plugin option and verifying the slant has an effect

```
              {
                "fontFamily": "FlexSlant10",
                "path": "./assets/fonts/RobotoFlex.ttf",
                "fontDefinitions": [
                  { "weight": 400 },
                  {
                    "weight": 400,
                    "style": "italic",
                    "axes": { "slnt": -10 }
                  }
                ]
              }
```
- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)