### PR TITLE
[CI][font] Fix tests to use OS path separators

### DIFF
--- a/packages/expo-font/plugin/src/__tests__/withFontsAndroid-test.ts
+++ b/packages/expo-font/plugin/src/__tests__/withFontsAndroid-test.ts
@@ -81,8 +81,8 @@ describe('planFontCopies', () => {
     );
 
     expect([...copies]).toEqual([
-      ['/res/font/Inter[wght].ttf', '/p/Inter[wght].ttf'],
-      ['/res/font/Other.ttf', '/p/Other.ttf'],
+      [path.join(dir, 'Inter[wght].ttf'), '/p/Inter[wght].ttf'],
+      [path.join(dir, 'Other.ttf'), '/p/Other.ttf'],
     ]);
   });
 
@@ -97,13 +97,13 @@ describe('planFontCopies', () => {
   it('should apply the filename processor to the destination', () => {
     const copies = planFontCopies(['/p/SpaceMono-Regular.ttf'], dir, asResourceName);
 
-    expect([...copies.keys()]).toEqual(['/res/font/space_mono_regular.ttf']);
+    expect([...copies.keys()]).toEqual([path.join(dir, 'space_mono_regular.ttf')]);
   });
 
   it('should skip files that are not fonts', () => {
     const copies = planFontCopies(['/p/a.ttf', '/p/b.woff2', '/p/c.otf'], dir, (it) => it);
 
-    expect([...copies.keys()]).toEqual(['/res/font/a.ttf', '/res/font/c.otf']);
+    expect([...copies.keys()]).toEqual([path.join(dir, 'a.ttf'), path.join(dir, 'c.otf')]);
   });
 });
 


### PR DESCRIPTION


# Why

CI fails on check-packages-windows step - https://github.com/expo/expo/actions/runs/31112639858/job/92654107889

The tests hardcoded forward-slash expected paths instead of using `path.join`. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Use `path.join` 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

check-packages-windows CI passes
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
