### PR TITLE
fix(cli): Show Xcode build log path when run:ios fails

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 🐛 Bug fixes
 
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
-- Show the Xcode build log path when the final `run:ios` failure only reports an exit code.
+- Show the Xcode build log path when `run:ios` fails.
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Ignore simulators reported by `devicectl` and support json version 5 on Xcode 27 ([#48001](https://github.com/expo/expo/pull/48001) by [@crockalet](https://github.com/crockalet))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,7 +22,7 @@
 ### 🐛 Bug fixes
 
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
-- Show the Xcode build log path when `run:ios` fails.
+- Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Ignore simulators reported by `devicectl` and support json version 5 on Xcode 27 ([#48001](https://github.com/expo/expo/pull/48001) by [@crockalet](https://github.com/crockalet))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### 🐛 Bug fixes
 
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
+- Show the Xcode build log path when the final `run:ios` failure only reports an exit code.
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Ignore simulators reported by `devicectl` and support json version 5 on Xcode 27 ([#48001](https://github.com/expo/expo/pull/48001) by [@crockalet](https://github.com/crockalet))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -445,13 +445,12 @@ export function _assertXcodeBuildResults(
   xcodeProject: { name: string },
   logFilePath: string
 ): void {
-  const errorTitle = `Failed to build iOS project. "xcodebuild" exited with error code ${code}.`;
+  const errorHeader = _formatXcodeBuildFailure(code, logFilePath);
 
   const throwWithMessage = (message: string): never => {
     throw new CommandError(
-      `${errorTitle}\nTo view more error logs, try building the app with Xcode directly, by opening ${xcodeProject.name}.\n\n` +
-        message +
-        `Build logs written to ${chalk.underline(logFilePath)}`
+      `${errorHeader}\nTo view more error logs, try building the app with Xcode directly, by opening ${xcodeProject.name}.\n\n` +
+        message
     );
   };
 

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -484,8 +484,7 @@ export function _extractXcodeBuildErrorLines(output: string): string[] {
       errors.push(line);
     }
   }
-  const errorsWithDetails = errors.filter((error) => !isXcodeBuildNoOutputErrorLine(error));
-  return errorsWithDetails.length > 0 ? errorsWithDetails : errors;
+  return errors;
 }
 
 function isXcodeBuildNoOutputErrorLine(line: string): boolean {

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -23,7 +23,7 @@ const CONCURRENT_BUILD_ERROR_MESSAGE_1 = 'database is locked';
 const CONCURRENT_BUILD_ERROR_MESSAGE_2 = 'there are two concurrent builds running';
 // Xcode prints this after a command fails, but it does not show the cause.
 const XCODE_BUILD_NO_OUTPUT_ERROR_MESSAGE =
-  /^error: the following command failed with exit code \d+ but produced no further output$/;
+  /error: the following command failed with exit code \d+ but produced no further output/;
 
 /** Get the generic Xcode destination string for a given OS type.
  * Used when building without targeting a specific device (build-only workflow).
@@ -415,7 +415,7 @@ export async function buildAsync(props: BuildProps): Promise<string> {
   const logFilePath = writeBuildLogs(projectRoot, results, error);
 
   if (code !== 0) {
-    if (formatter.errors.length > 0) {
+    if (_hasXcodeBuildErrorDetails(formatter.errors)) {
       // The formatter can miss another error, so include the build log path.
       throw new CommandError(_formatXcodeBuildFailure(code, logFilePath));
     }
@@ -430,6 +430,11 @@ export function _formatXcodeBuildFailure(code: number | null, logFilePath: strin
   return `Failed to build iOS project. "xcodebuild" exited with error code ${code}.\nBuild logs written to ${chalk.underline(
     logFilePath
   )}`;
+}
+
+// Exposed for testing.
+export function _hasXcodeBuildErrorDetails(errors: string[]): boolean {
+  return errors.some((error) => !isXcodeBuildNoOutputErrorLine(error));
 }
 
 // Exposed for testing.
@@ -475,12 +480,13 @@ export function _extractXcodeBuildErrorLines(output: string): string[] {
   const errors: string[] = [];
   for (const raw of output.split(/\r?\n/)) {
     const line = raw.trim();
-    if (/(?:^|\s)error:\s/.test(line) && !isXcodeBuildNoOutputErrorLine(line) && !seen.has(line)) {
+    if (/(?:^|\s)error:\s/.test(line) && !seen.has(line)) {
       seen.add(line);
       errors.push(line);
     }
   }
-  return errors;
+  const errorsWithDetails = errors.filter((error) => !isXcodeBuildNoOutputErrorLine(error));
+  return errorsWithDetails.length > 0 ? errorsWithDetails : errors;
 }
 
 function isXcodeBuildNoOutputErrorLine(line: string): boolean {

--- a/packages/@expo/cli/src/run/ios/XcodeBuild.ts
+++ b/packages/@expo/cli/src/run/ios/XcodeBuild.ts
@@ -21,6 +21,9 @@ import { simulatorBuildRequiresCodeSigning } from './codeSigning/simulatorCodeSi
 // When multiple builds run simultaneously, Xcode's build database can become locked.
 const CONCURRENT_BUILD_ERROR_MESSAGE_1 = 'database is locked';
 const CONCURRENT_BUILD_ERROR_MESSAGE_2 = 'there are two concurrent builds running';
+// Xcode prints this after a command fails, but it does not show the cause.
+const XCODE_BUILD_NO_OUTPUT_ERROR_MESSAGE =
+  /^error: the following command failed with exit code \d+ but produced no further output$/;
 
 /** Get the generic Xcode destination string for a given OS type.
  * Used when building without targeting a specific device (build-only workflow).
@@ -412,21 +415,21 @@ export async function buildAsync(props: BuildProps): Promise<string> {
   const logFilePath = writeBuildLogs(projectRoot, results, error);
 
   if (code !== 0) {
-    // Determine if the logger found any errors;
-    const wasErrorPresented = !!formatter.errors.length;
-
-    if (wasErrorPresented) {
-      // This has a flaw, if the user is missing a file, and there is a script error, only the missing file error will be shown.
-      // They will only see the script error if they fix the missing file and rerun.
-      // The flaw can be fixed by catching script errors in the custom logger.
-      throw new CommandError(
-        `Failed to build iOS project. "xcodebuild" exited with error code ${code}.`
-      );
+    if (formatter.errors.length > 0) {
+      // The formatter can miss another error, so include the build log path.
+      throw new CommandError(_formatXcodeBuildFailure(code, logFilePath));
     }
 
     _assertXcodeBuildResults(code, results, error, xcodeProject, logFilePath);
   }
   return results;
+}
+
+// Exposed for testing.
+export function _formatXcodeBuildFailure(code: number | null, logFilePath: string): string {
+  return `Failed to build iOS project. "xcodebuild" exited with error code ${code}.\nBuild logs written to ${chalk.underline(
+    logFilePath
+  )}`;
 }
 
 // Exposed for testing.
@@ -453,10 +456,8 @@ export function _assertXcodeBuildResults(
     throwWithMessage(chalk.bold(localizedError) + '\n\n');
   }
 
-  // `@expo/xcpretty` can leave a real failure uncounted (its compile-error
-  // matching is stateful and anchored, and stderr never passes through it), so
-  // the build summary reads "0 error(s)" and in CI the full log below is
-  // truncated before the real error line.
+  // `@expo/xcpretty` only reads stdout and can miss some Xcode errors.
+  // Show useful error lines first so CI does not cut them off.
   const errorLines = _extractXcodeBuildErrorLines(results + '\n' + error);
   if (errorLines.length) {
     throwWithMessage(chalk.red(errorLines.join('\n')) + '\n\n' + results + '\n\n' + error);
@@ -474,12 +475,16 @@ export function _extractXcodeBuildErrorLines(output: string): string[] {
   const errors: string[] = [];
   for (const raw of output.split(/\r?\n/)) {
     const line = raw.trim();
-    if (/(?:^|\s)error:\s/.test(line) && !seen.has(line)) {
+    if (/(?:^|\s)error:\s/.test(line) && !isXcodeBuildNoOutputErrorLine(line) && !seen.has(line)) {
       seen.add(line);
       errors.push(line);
     }
   }
   return errors;
+}
+
+function isXcodeBuildNoOutputErrorLine(line: string): boolean {
+  return XCODE_BUILD_NO_OUTPUT_ERROR_MESSAGE.test(line);
 }
 
 function writeBuildLogs(projectRoot: string, buildOutput: string, errorOutput: string) {

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -224,7 +224,6 @@ describe(_assertXcodeBuildResults, () => {
     } catch (error: any) {
       message = error.message;
     }
-    // xcpretty only reads stdout, so check stderr too.
     expect(message).toContain('error: config generation failed');
   });
 });

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -232,7 +232,7 @@ describe(_assertXcodeBuildResults, () => {
 describe(_formatXcodeBuildFailure, () => {
   it(`includes the build log path`, () => {
     expect(_formatXcodeBuildFailure(65, '/app/.expo/xcodebuild.log')).toContain(
-      'Build logs written to /app/.expo/xcodebuild.log'
+      '/app/.expo/xcodebuild.log'
     );
   });
 });

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -192,7 +192,7 @@ describe(_assertXcodeBuildResults, () => {
     );
   });
 
-  it(`shows the log path and compile error before the raw log dump`, () => {
+  it(`shows the log path and compile error before the full build output`, () => {
     let message = '';
     try {
       _assertXcodeBuildResults(
@@ -286,7 +286,7 @@ describe(_extractXcodeBuildErrorLines, () => {
     expect(_extractXcodeBuildErrorLines(message)).toEqual([message]);
   });
 
-  it(`skips Xcode's no-output message when another error is present`, () => {
+  it(`keeps Xcode's no-output message with another error`, () => {
     const output = [
       'script.sh: error: config generation failed',
       'error: the following command failed with exit code 1 but produced no further output',
@@ -294,6 +294,7 @@ describe(_extractXcodeBuildErrorLines, () => {
 
     expect(_extractXcodeBuildErrorLines(output)).toEqual([
       'script.sh: error: config generation failed',
+      'error: the following command failed with exit code 1 but produced no further output',
     ]);
   });
 });

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -192,7 +192,7 @@ describe(_assertXcodeBuildResults, () => {
     );
   });
 
-  it(`surfaces the compile error before the raw log dump so it survives truncation`, () => {
+  it(`shows the log path and compile error before the raw log dump`, () => {
     let message = '';
     try {
       _assertXcodeBuildResults(
@@ -207,6 +207,10 @@ describe(_assertXcodeBuildResults, () => {
     }
     expect(message).toContain(
       "call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'"
+    );
+    expect(message).toContain('./output.log');
+    expect(message.indexOf('./output.log')).toBeLessThan(
+      message.indexOf('ComputeTargetDependencyGraph')
     );
     expect(message.indexOf('call to undeclared function')).toBeLessThan(
       message.indexOf('ComputeTargetDependencyGraph')

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -1,3 +1,4 @@
+import { ExpoRunFormatter } from '@expo/xcpretty';
 import path from 'path';
 
 import {
@@ -7,6 +8,7 @@ import {
   _assertXcodeBuildResults,
   _extractXcodeBuildErrorLines,
   _formatXcodeBuildFailure,
+  _hasXcodeBuildErrorDetails,
   matchEstimatedBinaryPath,
   getAppBinaryPath,
 } from '../XcodeBuild';
@@ -236,6 +238,25 @@ describe(_formatXcodeBuildFailure, () => {
   });
 });
 
+describe(_hasXcodeBuildErrorDetails, () => {
+  it(`returns false for Xcode's no-output message`, () => {
+    const formatter = ExpoRunFormatter.create('/', {
+      xcodeProject: { name: 'BareExpo' },
+      isDebug: false,
+    });
+    formatter.pipe(
+      'error: the following command failed with exit code 1 but produced no further output\n'
+    );
+
+    expect(formatter.errors).toHaveLength(1);
+    expect(_hasXcodeBuildErrorDetails(formatter.errors)).toBe(false);
+  });
+
+  it(`returns true for other errors`, () => {
+    expect(_hasXcodeBuildErrorDetails(['error: config generation failed'])).toBe(true);
+  });
+});
+
 describe(_extractXcodeBuildErrorLines, () => {
   it(`extracts and dedupes compiler error lines`, () => {
     const output = [
@@ -252,6 +273,13 @@ describe(_extractXcodeBuildErrorLines, () => {
 
   it(`returns nothing when no error lines are present`, () => {
     expect(_extractXcodeBuildErrorLines('** BUILD SUCCEEDED **\n› 0 error(s)')).toEqual([]);
+  });
+
+  it(`keeps Xcode's no-output message when it is the only error`, () => {
+    const message =
+      'error: the following command failed with exit code 1 but produced no further output';
+
+    expect(_extractXcodeBuildErrorLines(message)).toEqual([message]);
   });
 
   it(`skips Xcode's no-output message when another error is present`, () => {

--- a/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/XcodeBuild-test.ts
@@ -1,4 +1,3 @@
-import { ExpoRunFormatter } from '@expo/xcpretty';
 import path from 'path';
 
 import {
@@ -7,6 +6,7 @@ import {
   getXcodeBuildArgsAsync,
   _assertXcodeBuildResults,
   _extractXcodeBuildErrorLines,
+  _formatXcodeBuildFailure,
   matchEstimatedBinaryPath,
   getAppBinaryPath,
 } from '../XcodeBuild';
@@ -206,8 +206,6 @@ describe(_assertXcodeBuildResults, () => {
     expect(message).toContain(
       "call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'"
     );
-    // The extracted error is shown before the raw dependency-graph dump, so it
-    // survives CI log truncation. The full log is still there below for context.
     expect(message.indexOf('call to undeclared function')).toBeLessThan(
       message.indexOf('ComputeTargetDependencyGraph')
     );
@@ -226,52 +224,16 @@ describe(_assertXcodeBuildResults, () => {
     } catch (error: any) {
       message = error.message;
     }
-    // stderr never passes through the formatter, so the extractor scans it too.
+    // xcpretty only reads stdout, so check stderr too.
     expect(message).toContain('error: config generation failed');
   });
+});
 
-  it(`extracts an error line the formatter left uncounted`, () => {
-    // The compile-error matching is stateful: a bare `error:` line with no
-    // source and caret following it is never counted, so the summary reads
-    // "0 error(s)". Intentionally coupled to the formatter's current gap: if
-    // an upgrade counts this, revisit the fallback's precondition.
-    const formatter = ExpoRunFormatter.create('/', {
-      xcodeProject: { name: 'BareExpo' },
-      isDebug: false,
-    });
-    const line =
-      "/path/EXDevLauncherController.m:185:3: error: call to undeclared function 'RCTBundleURLProviderAllowPackagerServerAccess'";
-    for (const _ of formatter.pipe(line + '\n')) {
-      // drain
-    }
-    expect(formatter.errors).toHaveLength(0);
-    expect(_extractXcodeBuildErrorLines(line)).toEqual([line]);
-  });
-
-  it(`extracts an error the formatter downgraded to a warning`, () => {
-    // A project-level `ld: warning:` line latches the compile-warning matcher,
-    // so the parser emits the next complete compile error as a warning. The
-    // duplicate `-lc++` warning is routine in CocoaPods projects. Same
-    // intentional coupling as the previous test.
-    const formatter = ExpoRunFormatter.create('/', {
-      xcodeProject: { name: 'BareExpo' },
-      isDebug: false,
-    });
-    const errorLine =
-      "/path/Broken.m:4:3: error: call to undeclared function 'thisFunctionDoesNotExist'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]";
-    const log = [
-      "/path/BareExpo.xcodeproj: BareExpo: ld: warning: ignoring duplicate libraries: '-lc++'",
-      errorLine,
-      '    4 |   thisFunctionDoesNotExist();',
-      '      |   ^',
-      '1 error generated.',
-    ].join('\n');
-    for (const _ of formatter.pipe(log + '\n')) {
-      // drain
-    }
-    // Lost despite the complete error block (source line and caret included).
-    expect(formatter.errors).toHaveLength(0);
-    expect(_extractXcodeBuildErrorLines(log)).toEqual([errorLine]);
+describe(_formatXcodeBuildFailure, () => {
+  it(`includes the build log path`, () => {
+    expect(_formatXcodeBuildFailure(65, '/app/.expo/xcodebuild.log')).toContain(
+      'Build logs written to /app/.expo/xcodebuild.log'
+    );
   });
 });
 
@@ -291,6 +253,17 @@ describe(_extractXcodeBuildErrorLines, () => {
 
   it(`returns nothing when no error lines are present`, () => {
     expect(_extractXcodeBuildErrorLines('** BUILD SUCCEEDED **\n› 0 error(s)')).toEqual([]);
+  });
+
+  it(`skips Xcode's no-output message when another error is present`, () => {
+    const output = [
+      'script.sh: error: config generation failed',
+      'error: the following command failed with exit code 1 but produced no further output',
+    ].join('\n');
+
+    expect(_extractXcodeBuildErrorLines(output)).toEqual([
+      'script.sh: error: config generation failed',
+    ]);
   });
 });
 


### PR DESCRIPTION
Follow-up to [#47748](https://github.com/expo/expo/pull/47748)
Related to [#162](https://github.com/expo/third-party/pull/162)

# Why

`expo run:ios` can sometimes end with this message: `error: the following command failed with exit code 1 but produced no further output`.

This does not explain why the build failed. The full log is saved, but the CLI does not show the log path.

# How

We keep this message as an error, but still check the full log for another error that explains the failure. We also show the build log path before the full Xcode output so it is easier to find.

# Test Plan

- Ran `corepack pnpm --filter @expo/cli exec jest --runInBand --watchman=false`
- Ran `et check-packages @expo/cli --no-test`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
