### PR TITLE
[updates][dev-launcher][expo-go][Android] Give an empty-path base URL a root path before resolving

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/kernel/ExponentUrls.kt
@@ -34,10 +34,24 @@ object ExponentUrls {
   @JvmStatic fun resolveManifestUrl(rawUrl: String, manifestUrl: String): String {
     val baseUrl = ExponentManifest.httpManifestUrl(manifestUrl).toString()
     return try {
-      URI(baseUrl).resolve(rawUrl).toString()
+      URI(baseUrl).withRootPath().resolve(rawUrl).toString()
     } catch (e: Exception) {
       rawUrl
     }
+  }
+
+  /**
+   * Works around Android's [URI.resolve] dropping the separator between the authority and a
+   * path-relative reference when the base path is empty, which splices the reference's first
+   * segment onto the port. A manifest URL without a path reaches this in the normal case, since
+   * building the HTTP manifest URL normalizes a missing path to an empty one.
+   */
+  private fun URI.withRootPath(): URI {
+    if (rawAuthority == null || !rawPath.isNullOrEmpty()) {
+      return this
+    }
+    // A base query or fragment is dropped during resolution anyway, so it doesn't need carrying.
+    return URI("$scheme://$rawAuthority/")
   }
 
   /**

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix SIGABRT when loading a development server URL that has no path (e.g. `http://192.168.1.2:8081`): Android's `URI.resolve` omits the path separator for an empty-path base, so the first segment of a relative `bundleUrl` was spliced onto the port and the resulting authority failed to parse. ([#48625](https://github.com/expo/expo/pull/48625) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -63,10 +63,24 @@ class DevLauncherManifestParser(
 
   private fun resolveUrl(rawUrl: String): String {
     return try {
-      URI(url.toString()).resolve(rawUrl).toString()
+      URI(url.toString()).withRootPath().resolve(rawUrl).toString()
     } catch (e: Exception) {
       rawUrl
     }
+  }
+
+  /**
+   * Works around Android's [URI.resolve] dropping the separator between the authority and a
+   * path-relative reference when the base path is empty, which splices the reference's first
+   * segment onto the port. Only the base is adjusted, so non-HTTP bases such as `exp://` still
+   * resolve.
+   */
+  private fun URI.withRootPath(): URI {
+    if (rawAuthority == null || !rawPath.isNullOrEmpty()) {
+      return this
+    }
+    // A base query or fragment is dropped during resolution anyway, so it doesn't need carrying.
+    return URI("$scheme://$rawAuthority/")
   }
 
   private fun getHeaders(): Headers {

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -220,6 +220,35 @@ internal class DevLauncherManifestParserTest {
   }
 
   @Test
+  fun `parseManifest resolves relative bundle URL against a base URL without a path`() = runBlocking {
+    // A dev server URL typed without a trailing slash, e.g. `http://10.0.2.2:8081`, has an empty
+    // path. Resolving a path-relative bundle URL against it must still insert the `/` separator,
+    // otherwise the first path segment is glued onto the port and the authority becomes unparseable.
+    val baseUrl = "http://${server.hostName}:${server.port}"
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse(baseUrl),
+      null
+    )
+    server.enqueue(
+      MockResponse().setBody(
+        """
+        {
+          "name": "testproject",
+          "slug": "testproject",
+          "sdkVersion": "UNVERSIONED",
+          "bundleUrl": "apps/testproject/node_modules/expo-router/entry.bundle?platform=android"
+        }
+        """.trimIndent()
+      )
+    )
+    val manifest = manifestParser.parseManifest()
+    Truth.assertThat(manifest.getBundleURL())
+      .isEqualTo("$baseUrl/apps/testproject/node_modules/expo-router/entry.bundle?platform=android")
+    Truth.assertThat(Uri.parse(manifest.getBundleURL()).port).isEqualTo(server.port)
+  }
+
+  @Test
   fun `checks if parseManifest fails on unsuccessful response`() {
     val manifestParser = DevLauncherManifestParser(
       client,

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [iOS] Fix SIGABRT during log purge when the persistent log contains a truncated line: `UpdatesLogReader` guarded on UTF-8 byte length but advanced the string index by Characters, so a line holding only the multi-byte emoji log prefix trapped with "String index is out of bounds". ([#48222](https://github.com/expo/expo/pull/48222) by [@valinagacevschi](https://github.com/valinagacevschi))
+- [Android] Fix SIGABRT when loading a development server URL that has no path (e.g. `http://192.168.1.2:8081`): Android's `URI.resolve` omits the path separator for an empty-path base, so the first segment of a relative asset URL was spliced onto the port and the resulting authority failed to parse. ([#48625](https://github.com/expo/expo/pull/48625) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
@@ -141,10 +141,24 @@ class ExpoUpdatesUpdate private constructor(
 
     private fun resolveUrl(url: String, baseUrl: Uri): String {
       return try {
-        URI(baseUrl.toString()).resolve(url).toString()
+        URI(baseUrl.toString()).withRootPath().resolve(url).toString()
       } catch (e: Exception) {
         url
       }
+    }
+
+    /**
+     * Works around Android's [URI.resolve] dropping the separator between the authority and a
+     * path-relative reference when the base path is empty, which splices the reference's first
+     * segment onto the port. Only the base is adjusted, so non-HTTP bases such as `exp://` still
+     * resolve.
+     */
+    private fun URI.withRootPath(): URI {
+      if (rawAuthority == null || !rawPath.isNullOrEmpty()) {
+        return this
+      }
+      // A base query or fragment is dropped during resolution anyway, so it doesn't need carrying.
+      return URI("$scheme://$rawAuthority/")
     }
   }
 }

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -62,6 +62,96 @@ class FileDownloaderManifestParsingTest {
   }
 
   @Test
+  fun testManifestParsing_RelativeUrlsAgainstBaseWithoutPath() = runTest {
+    // A development server URL typed without a trailing slash has an empty path. Resolving a
+    // path-relative asset URL against it must still insert the `/` separator, otherwise the first
+    // path segment is spliced onto the port and the resulting authority fails to parse.
+    val manifestBody = """
+      {
+        "id": "0754dad0-d200-d634-113c-ef1f26106028",
+        "createdAt": "2021-11-23T00:57:14.437Z",
+        "runtimeVersion": "1",
+        "assets": [{
+          "hash": "cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d",
+          "key": "489ea2f19fa850b65653ab445637a181.jpg",
+          "contentType": "image/jpeg",
+          "url": "assets/node_modules/expo-asset/image.jpg?platform=android",
+          "fileExtension": ".jpg"
+        }],
+        "launchAsset": {
+          "hash": "323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8",
+          "key": "696a70cf7035664c20ea86f67dae822b.bundle",
+          "contentType": "application/javascript",
+          "url": "apps/testproject/node_modules/expo-router/entry.bundle?platform=android",
+          "fileExtension": ".bundle"
+        },
+        "extra": { "scopeKey": "@test/app" }
+      }
+    """.trimIndent()
+    val response = manifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("http://192.168.1.2:8081")
+      )
+    )
+    val fileDownloader = createFileDownloader(configuration)
+    val updateResponse = fileDownloader.parseRemoteUpdateResponse(response)
+    val resultUpdate = updateResponse.manifestUpdateResponsePart?.update
+    Assert.assertNotNull(resultUpdate)
+    val launchAsset = resultUpdate!!.assetEntityList.first { it.isLaunchAsset }
+    Assert.assertEquals(
+      "http://192.168.1.2:8081/apps/testproject/node_modules/expo-router/entry.bundle?platform=android",
+      launchAsset.url.toString()
+    )
+    // The authority must stay parseable: a spliced path segment yields port -1 instead of 8081.
+    Assert.assertEquals("192.168.1.2", launchAsset.url!!.host)
+    Assert.assertEquals(8081, launchAsset.url!!.port)
+    val imageAsset = resultUpdate.assetEntityList.first { !it.isLaunchAsset }
+    Assert.assertEquals(
+      "http://192.168.1.2:8081/assets/node_modules/expo-asset/image.jpg?platform=android",
+      imageAsset.url.toString()
+    )
+  }
+
+  @Test
+  fun testManifestParsing_RelativeUrlsAgainstNonHttpBase() = runTest {
+    // Normalizing the base must not narrow which schemes resolve: `exp://` URLs still reach here.
+    val manifestBody = """
+      {
+        "id": "0754dad0-d200-d634-113c-ef1f26106028",
+        "createdAt": "2021-11-23T00:57:14.437Z",
+        "runtimeVersion": "1",
+        "assets": [],
+        "launchAsset": {
+          "hash": "323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8",
+          "key": "696a70cf7035664c20ea86f67dae822b.bundle",
+          "contentType": "application/javascript",
+          "url": "apps/testproject/node_modules/expo-router/entry.bundle?platform=android",
+          "fileExtension": ".bundle"
+        },
+        "extra": { "scopeKey": "@test/app" }
+      }
+    """.trimIndent()
+    val response = manifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
+    val configuration = UpdatesConfiguration(
+      null,
+      mapOf(
+        UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("exp://192.168.1.2:8081")
+      )
+    )
+    val fileDownloader = createFileDownloader(configuration)
+    val updateResponse = fileDownloader.parseRemoteUpdateResponse(response)
+    val resultUpdate = updateResponse.manifestUpdateResponsePart?.update
+    Assert.assertNotNull(resultUpdate)
+    val launchAsset = resultUpdate!!.assetEntityList.first { it.isLaunchAsset }
+    Assert.assertEquals(
+      "exp://192.168.1.2:8081/apps/testproject/node_modules/expo-router/entry.bundle?platform=android",
+      launchAsset.url.toString()
+    )
+  }
+
+  @Test
   fun testManifestParsing_MultipartBody() = runTest {
     val filesDirectory = temporaryFolder.newFolder()
     val logDirectory = temporaryFolder.newFolder()


### PR DESCRIPTION
## Why

Opening a dev server URL without a trailing slash (`http://192.168.1.2:8081`) kills a development build with SIGABRT before any JS runs. Android's `URI.resolve` skips the separator for an empty-path base, so the first segment of the relative bundle URL lands on the port. `192.168.1.2:8081apps` parses with no port, we append the default 80, and OkHttp rejects the packager and inspector WebSocket URLs. That throws on a JNI thread, so ART kills the process instead of showing a red box. Any project hits it, not just monorepos.

## How

Give the base an explicit `/` path when it has an authority and no path, then resolve as before. Only the base changes, so `exp://` and `file://` bases keep resolving.

Expo Go resolves manifest URLs the same way in `ExponentUrls`, and its `setDevServer` builds `debugServerHost` from the same mangled authority, so it gets the same fix.

## Test Plan

Emulator on Android 16: with and without the trailing slash, plus `exp://` with no slash, all load. Unit tests cover both bases, though they can't catch a revert since Robolectric runs the desktop JDK, where an empty-path base resolves correctly.

The Expo Go path is fixed by inspection. I didn't build it, and no test covers it.

This fixes the trigger, not the failure mode. A bad dev server URL from anywhere else still aborts the process instead of surfacing an error, worth hardening separately.
