### PR TITLE
[ios][media-library] Include location in getAssetsAsync batch results

### DIFF
--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -209,6 +209,31 @@ export async function test(t) {
           const keys = Object.keys(value);
           GET_ASSETS_KEYS.forEach((key) => t.expect(keys).toContain(key));
         });
+
+        if (Platform.OS === 'ios') {
+          t.it(
+            'getAssetsAsync includes location even without resolveWithFullInfo',
+            async () => {
+              let exifAsset = null;
+              try {
+                const [exifImage] = await Asset.loadAsync(require('../assets/exif_data_image.jpg'));
+                exifAsset = await MediaLibrary.createAssetAsync(exifImage.localUri, album);
+                const { assets } = await MediaLibrary.getAssetsAsync({ album, first: 20 });
+                const batchAsset = assets.find((asset) => asset.id === exifAsset.id);
+                t.expect(typeof batchAsset.location.latitude).toBe('number');
+                t.expect(typeof batchAsset.location.longitude).toBe('number');
+              } finally {
+                // We delete the asset to ensure other tests that depend on there
+                // being specific numbers of assets won't fail even if this test
+                // fails.
+                if (exifAsset != null) {
+                  await MediaLibrary.deleteAssetsAsync(exifAsset);
+                }
+              }
+            },
+            TIMEOUT_WHEN_USER_NEEDS_TO_INTERACT
+          );
+        }
       });
 
       t.describe('Small tests', () => {
@@ -389,27 +414,28 @@ export async function test(t) {
           });
         });
 
-        t.it('supports sorting in ascending order', async () => {
+        t.it('supports sorting in ascending and descending order', async () => {
           // Get some assets with the largest height.
-          const { assets } = await MediaLibrary.getAssetsAsync({
+          const { assets: descendingAssets } = await MediaLibrary.getAssetsAsync({
             sortBy: [[MediaLibrary.SortBy.height, false]],
           });
 
-          // Set the first and last items in the list
-          const first = assets[0].height;
-          const last = assets[assets.length - 1].height;
+          for (let i = 1; i < descendingAssets.length; i++) {
+            t.expect(descendingAssets[i].height).toBeLessThanOrEqual(
+              descendingAssets[i - 1].height
+            );
+          }
 
           // Repeat assets request but reverse the order.
           const { assets: ascendingAssets } = await MediaLibrary.getAssetsAsync({
             sortBy: [[MediaLibrary.SortBy.height, true]],
           });
 
-          // Set the first and last items in the new list
-          const ascFirst = ascendingAssets[0].height;
-          const ascLast = ascendingAssets[assets.length - 1].height;
-
-          t.expect(ascFirst).toBe(last);
-          t.expect(ascLast).toBe(first);
+          for (let i = 1; i < ascendingAssets.length; i++) {
+            t.expect(ascendingAssets[i].height).toBeGreaterThanOrEqual(
+              ascendingAssets[i - 1].height
+            );
+          }
         });
 
         t.it('supports getting assets from specified time range', async () => {

--- a/docs/pages/versions/unversioned/sdk/media-library-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library-legacy.mdx
@@ -222,6 +222,10 @@ Therefore, when creating a new asset, instead of creating the asset and then mov
 
 On Android, when using `getAssetsAsync` without `resolveWithFullInfo: true`, image orientation may be incorrect because EXIF data (which includes orientation) is only read when that option is enabled.
 
+### Performance impact of `resolveWithFullInfo`
+
+On Android, enabling `resolveWithFullInfo: true` in `getAssetsAsync` significantly increases request time (~5×), because the library fetches EXIF and location data per image. The library resolves location and EXIF data for image assets only. iOS includes GPS location for all asset types in batch results, and this option does nothing.
+
 ## API
 
 ```js

--- a/docs/pages/versions/v57.0.0/sdk/media-library-legacy.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/media-library-legacy.mdx
@@ -222,6 +222,10 @@ Therefore, when creating a new asset, instead of creating the asset and then mov
 
 On Android, when using `getAssetsAsync` without `resolveWithFullInfo: true`, image orientation may be incorrect because EXIF data (which includes orientation) is only read when that option is enabled.
 
+### Performance impact of `resolveWithFullInfo`
+
+On Android, enabling `resolveWithFullInfo: true` in `getAssetsAsync` significantly increases request time (~5×), because the library fetches EXIF and location data per image. The library resolves location and EXIF data for image assets only. iOS includes GPS location for all asset types in batch results, and this option does nothing.
+
 ## API
 
 ```js

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Parallelize per-file EXIF and location reads in `getAssetsAsync` when `resolveWithFullInfo` is true, speeding up large library scans. ([#48637](https://github.com/expo/expo/pull/48637) by [@hsource](https://github.com/hsource) and [@robin-pham](https://github.com/robin-pham))
+- [iOS] Include GPS `location` in `getAssetsAsync` batch results and return numeric latitude/longitude from `exportLocation` (matching the documented `Location` type). ([#48630](https://github.com/expo/expo/pull/48630) by [@hsource](https://github.com/hsource) and [@fractalbeauty](https://github.com/fractalbeauty))
 - [Android] Fix transposed `width`/`height` for rotated assets (portrait photos and videos): `Asset.getInfo()`, `getWidth()`/`getHeight()`/`getShape()` and `Query.exeForMetadata()` now honor MediaStore `ORIENTATION`, matching the legacy API. ([#48150](https://github.com/expo/expo/pull/48150) by [@oeddyo](https://github.com/oeddyo))
 
 ### 💡 Others

--- a/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
+++ b/packages/expo-media-library/ios/ExpoMediaLibrary.podspec
@@ -35,5 +35,8 @@ Pod::Spec.new do |s|
     test_spec.dependency 'ExpoModulesTestCore'
 
     test_spec.source_files = 'Tests/**/*.{m,swift}'
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++',
+    }
   end
 end

--- a/packages/expo-media-library/ios/MediaLibraryUtilities.swift
+++ b/packages/expo-media-library/ios/MediaLibraryUtilities.swift
@@ -26,7 +26,6 @@ func stringifyAlbumType(type: PHAssetCollectionType) -> String {
 
 func exportAssetInfo(asset: PHAsset) -> [String: Any?] {
   var assetDict = exportAsset(asset: asset)
-  assetDict["location"] = exportLocation(location: asset.location)
   assetDict["isFavorite"] = asset.isFavorite
   assetDict["isHidden"] = asset.isHidden
   return assetDict
@@ -47,18 +46,21 @@ func exportAsset(asset: PHAsset) -> [String: Any?] {
     // Uses required reason API based on the following reason: 0A2A.1
     "modificationTime": exportDate(asset.modificationDate),
     "duration": asset.duration,
+    // `PHAsset.location` is already loaded; including it here avoids N calls to
+    // `getAssetInfoAsync` when batch-fetching assets that need GPS coordinates.
+    "location": exportLocation(location: asset.location),
     "pairedVideoAsset": nil
   ]
 }
 
-func exportLocation(location: CLLocation?) -> [String: String]? {
+func exportLocation(location: CLLocation?) -> [String: Double]? {
   guard let location else {
     return nil
   }
 
   return [
-    "latitude": "\(location.coordinate.latitude)",
-    "longitude": "\(location.coordinate.longitude)"
+    "latitude": location.coordinate.latitude,
+    "longitude": location.coordinate.longitude
   ]
 }
 

--- a/packages/expo-media-library/ios/TestSupport.swift
+++ b/packages/expo-media-library/ios/TestSupport.swift
@@ -1,15 +1,22 @@
 import Foundation
 import Photos
+import CoreLocation
 
 class MockPHAsset: PHAsset {
   private var id: Int
+  private var mockLocation: CLLocation?
 
-  init(id: Int) {
+  init(id: Int, location: CLLocation? = nil) {
     self.id = id
+    self.mockLocation = location
   }
 
   override var localIdentifier: String {
     return String(self.id)
+  }
+
+  override var location: CLLocation? {
+    return mockLocation
   }
 }
 

--- a/packages/expo-media-library/ios/Tests/MediaLibraryTests.swift
+++ b/packages/expo-media-library/ios/Tests/MediaLibraryTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Photos
+import CoreLocation
 
 @testable import ExpoMediaLibrary
 
@@ -120,5 +121,34 @@ struct MediaLibraryTests {
         #expect(response.hasNextPage == true)
       }
     }
+  }
+}
+
+@Suite("exportLocation")
+struct ExportLocationTests {
+  @Test
+  func `returns numeric latitude and longitude`() {
+    let location = CLLocation(latitude: 1.23, longitude: 4.56)
+    let exported = exportLocation(location: location)
+
+    #expect(exported?["latitude"] as? Double == 1.23)
+    #expect(exported?["longitude"] as? Double == 4.56)
+  }
+
+  @Test
+  func `returns nil when location is unavailable`() {
+    #expect(exportLocation(location: nil) == nil)
+  }
+}
+
+@Suite("exportAsset")
+struct ExportAssetTests {
+  @Test
+  func `includes location when asset has location metadata`() {
+    let location = CLLocation(latitude: 1.23, longitude: 4.56)
+    let asset = MockPHAsset(id: 0, location: location)
+
+    let exported = exportAsset(asset: asset)
+    #expect(exported["location"] as? [String: Double] == ["latitude": 1.23, "longitude": 4.56])
   }
 }

--- a/packages/expo-media-library/src/legacy/MediaLibrary.ts
+++ b/packages/expo-media-library/src/legacy/MediaLibrary.ts
@@ -122,7 +122,8 @@ export type Asset = {
    */
   albumId?: string;
   /**
-   * GPS location if available. On Android, `getAssetsAsync` includes this field for image
+   * GPS location if available. On iOS, `getAssetsAsync` includes this field for all asset types when
+   * the asset has location metadata. On Android, `getAssetsAsync` includes this field for image
    * assets only when you pass `resolveWithFullInfo: true`.
    */
   location?: Location;
@@ -329,6 +330,7 @@ export type AssetsOptions = {
   /**
    * Whether to resolve full EXIF metadata for image assets during the query.
    * When enabled, Android resolves EXIF data (including orientation) and GPS location for image assets.
+   * On iOS, `getAssetsAsync` includes GPS location for all asset types even when this option is disabled.
    *
    * > **Note:** On Android, enabling this option significantly increases request time (~5×),
    * > because the library fetches EXIF and location data per image.
@@ -862,6 +864,7 @@ export async function deleteAlbumsAsync(
  * Fetches a page of assets matching the provided criteria.
  * Returned assets may include a `location` field when GPS metadata is available.
  * On Android, pass `resolveWithFullInfo: true` to resolve location and full EXIF data for image assets only.
+ * On iOS, `getAssetsAsync` includes location for all asset types by default.
  *
  * > **Note:** On Android, `resolveWithFullInfo: true` significantly increases request time (~5×),
  * > because the library fetches EXIF and location data per image.


### PR DESCRIPTION
# Why

While working with photos with location, we realized iOS `getAssetsAsync` doesn't return location. On iOS, the location info is really cheap to get though, so we thought it'd be more efficient to have it be returned even if resolveWithFullInfo is not set on iOS.

**Credits:** this PR was created based on internal work at Wanderlog by @fractalbeauty

# How

- Include `PHAsset.location` in `exportAsset()` so `getAssetsAsync` returns GPS coordinates without calling `getAssetInfoAsync` per asset.
- Add `location?: Location` to the legacy `Asset` type when batch results include coordinates.
- **Side fix:** Fix `exportLocation()` to return numeric `latitude`/`longitude` values, matching the documented `Location` type (previously returned strings).
- **Side fix:** the MediaLibrary "supports sorting" test failed when there was a large number of images, as it only fetches one page. This fixes that test
- **Side fix:** add test flag for podxpec to fix `pnpm expotools native-unit-tests` for expo-media-library; without it, I get linker errors due to missing C++ basic library symbols

Wanderlog ([app link](https://apps.apple.com/us/app/wanderlog-travel-planner/id1476732439)) uses this for journal photo picker flows that scan large libraries (~10k assets). Internal context: GitLab !10315, !10800.

# Test Plan

- [x] Added Swift unit tests for `exportLocation` in `ios/Tests/MediaLibraryTests.swift`
- [x] `pnpm expotools native-unit-tests --platform ios --packages expo-media-library`
- [x] `cd apps/bare-expo && pnpm test:ios`
- [x] Manual in bare-expo: `cd apps/bare-expo && pnpm ios` → Test suite tab → run **MediaLibrary**, or APIs tab → **MediaLibrary** on a device/simulator with geotagged photos

| Test result | MediaLibrary API timing (before) | MediaLibrary API timing (after) |
| --- | --- | --- |
| <img width="591" height="1129" alt="image" src="https://github.com/user-attachments/assets/43d0430b-bf74-4589-8f9b-a1730f7ca6fa" /> | <img width="591" height="1129" alt="image" src="https://github.com/user-attachments/assets/52280b70-7a17-4dfa-93e3-af82985ff149" /> | <img width="591" height="1129" alt="image" src="https://github.com/user-attachments/assets/2d7afdb6-8621-4c4f-bad8-2ae1d334a621" /> |

### Performance info (before and after)

This only increases time by 15% in the MediaLibrary test app

- 10 runs without change location for 20k images: **average 954ms**
  - 952, 953, 1006, 951, 942, 946, 937, 929, 990, 936
- 10 runs with location data for 20k images: **average 1097ms**
  - 1198, 1090, 1074, 1118, 1092, 1093, 1065, 1102, 1077, 1056

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)