### PR TITLE
[cli] Fail when --private-key-path is set without codeSigningCertificate

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - [Internal] Fix `LogStream.destroy()` racing a pending write and dropping log data ([#47181](https://github.com/expo/expo/pull/47181) by [@kitten](https://github.com/kitten))
 - Ignore simulators reported by `devicectl` and support json version 5 on Xcode 27 ([#48001](https://github.com/expo/expo/pull/48001) by [@crockalet](https://github.com/crockalet))
 - In non-interactive shells, automatically roll over to the next available port when default is busy, unless a specific port is specified with `--port` or `RCT_METRO_PORT` ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -220,6 +220,20 @@ describe(getCodeSigningInfoAsync, () => {
   });
 
   describe('non expo-root certificate keyid requested', () => {
+    it('returns null when codeSigningCertificate and private key path are not specified', async () => {
+      await expect(
+        getCodeSigningInfoAsync({} as any, 'keyid="test", alg="rsa-v1_5-sha256"', undefined)
+      ).resolves.toBeNull();
+    });
+
+    it('throws when private key path is specified without codeSigningCertificate', async () => {
+      await expect(
+        getCodeSigningInfoAsync({} as any, 'keyid="test", alg="rsa-v1_5-sha256"', 'keys/private-key.pem')
+      ).rejects.toThrow(
+        '--private-key-path was specified, but updates.codeSigningCertificate is not set in the resolved app config'
+      );
+    });
+
     it('normal case gets the configured certificate', async () => {
       vol.fromJSON({
         'certs/cert.pem': mockSelfSigned.certificate,

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -254,6 +254,11 @@ async function getProjectCodeSigningCertificateAsync(
 ): Promise<CodeSigningInfo | null> {
   const codeSigningCertificatePath = exp.updates?.codeSigningCertificate;
   if (!codeSigningCertificatePath) {
+    if (privateKeyPath) {
+      throw new CommandError(
+        '--private-key-path was specified, but updates.codeSigningCertificate is not set in the resolved app config. Code signing requires both the certificate in app config and the private key. Ensure codeSigningCertificate (and codeSigningMetadata) are present, or omit --private-key-path if you do not intend to sign.\nLearn more: https://docs.expo.dev/eas-update/code-signing/'
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
# Why

When `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config: that implies an intent to sign, but `@expo/cli` previously ignored the flag and continued without signing the development manifest.

# How

- In `getProjectCodeSigningCertificateAsync`, throw if a private key path is provided without a certificate path
- Leave the unsigned path alone when neither is set

# Test Plan

- Unit tests for no-cert/no-key → `null`, and no-cert/with-key → throw
- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)