### PR TITLE
[jest] Add missing `getIntegrations` to the ExpoObserve module mock

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing `getIntegrations` method to the `ExpoObserve` module mock, which crashed every test importing `expo-image` since `expo-image@57.0.2`. ([#48632](https://github.com/expo/expo/pull/48632) by [@radko93](https://github.com/radko93))
+
 ### 💡 Others
 
 ## 57.0.3 — 2026-07-29

--- a/packages/jest-expo/src/preset/moduleMocks/expoModules.js
+++ b/packages/jest-expo/src/preset/moduleMocks/expoModules.js
@@ -632,6 +632,11 @@ module.exports = {
         ExpoObserve: [
           { name: 'configure', argumentsCount: 1, key: 'configure' },
           { name: 'dispatchEvents', argumentsCount: 0, key: 'dispatchEvents' },
+          {
+            name: 'getIntegrations',
+            argumentsCount: 0,
+            key: 'getIntegrations',
+          },
           { name: 'setBundleDefaults', argumentsCount: 1, key: 'setBundleDefaults' },
         ],
         ExpoPrint: [
@@ -1369,6 +1374,7 @@ module.exports = {
           addListener: { type: 'function' },
           configure: { type: 'function' },
           dispatchEvents: { type: 'function' },
+          getIntegrations: { type: 'function' },
           removeListeners: { type: 'function' },
           setBundleDefaults: { type: 'function' },
         },


### PR DESCRIPTION
# Why

`jest-expo@57.0.3`'s generated module mocks predate the `expo-observe` sync to SDK 57 (#48328). Since `expo-image@57.0.2` wires up its observe integration at import time (`observe.getIntegrations()` in `src/observe.ts`), every Jest suite that imports `expo-image` under the `jest-expo` preset now crashes with:

```
TypeError: observe.getIntegrations is not a function
```

Fixes #48617 for the SDK 57 release line. `main` already has the fix via the mock regeneration in #47496 — this backports just the missing `ExpoObserve` entries so a `jest-expo@57.0.4` patch release can ship it.

# How

Adds `getIntegrations` to both `ExpoObserve` sections of `src/preset/moduleMocks/expoModules.js` (`exportedMethods` and `modulesConstants`), copied verbatim from the regenerated mocks on `main`. Hand-applied rather than a full mock regeneration to keep the sdk-57 diff minimal.

Behavior note: the mocked module resolves through the `NativeModulesProxy` adapter, whose methods `jest-expo` mocks as `jest.fn(async () => {})`, so `getIntegrations()` returns a truthy thenable; `activate()` then reads `integrations['expo-image']` → `undefined` and the integration stays disabled — the same end state as a runtime app without `expo-observe` installed.

# Test Plan

Verified against a production SDK 57 app (RN 0.86.2, `jest-expo@57.0.3`, `expo-image@57.0.2`, jsdom-free `react-native` preset environment):

- Before: 13 of 45 suites fail at import time with `TypeError: observe.getIntegrations is not a function`.
- After applying exactly this diff to `node_modules/jest-expo`: **45/45 suites, 301/301 tests pass**, with no app-level `jest.mock` workaround.

Reproduction for a reviewer: in any SDK 57 app using the `jest-expo` preset, add a test containing `import { Image } from 'expo-image';` and run Jest — it fails on 57.0.3 and passes with this patch.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (the module mocks are plain `.js` sources shipped as-is — no build step applies)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — N/A, test-preset-only change
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — N/A, no docs changes
