### PR TITLE
[cli] Fix oxfmt formatting in codesigning-test.ts

### DIFF
--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -228,7 +228,11 @@ describe(getCodeSigningInfoAsync, () => {
 
     it('throws when private key path is specified without codeSigningCertificate', async () => {
       await expect(
-        getCodeSigningInfoAsync({} as any, 'keyid="test", alg="rsa-v1_5-sha256"', 'keys/private-key.pem')
+        getCodeSigningInfoAsync(
+          {} as any,
+          'keyid="test", alg="rsa-v1_5-sha256"',
+          'keys/private-key.pem'
+        )
       ).rejects.toThrow(
         '--private-key-path was specified, but updates.codeSigningCertificate is not set in the resolved app config'
       );


### PR DESCRIPTION
# Why

The `check-packages` CI job on `main` is red: https://github.com/expo/expo/actions/runs/31144954926/job/92762372870

#48631 added a test assertion whose line is longer than `oxfmt`'s print width. `oxfmt --check` fails the `format` task in `@expo/cli`, so every subsequent CI run on `main` reports the same failure until this is fixed.

# How

Ran `pnpm run format` in `packages/@expo/cli`, which reformatted the one offending call in `src/utils/__tests__/codesigning-test.ts` (wrapped its arguments across multiple lines). No behavior change; test file only.

# Test Plan

- `pnpm turbo run depscheck lint format --filter="@expo/cli"` — all 3 tasks pass.
- `pnpm oxfmt --check .` in `packages/@expo/cli` — reports "All matched files use the correct format."

# Checklist

- [x] Docs not applicable (test-only formatting fix)
- [x] Verified `check-packages` equivalent locally passes
- [x] No CHANGELOG.md entry (no user-facing change)