### PR TITLE
[dev-launcher][updates][Android] Fix relative manifest URL resolution without base path

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix relative manifest URL resolution when the dev server URL has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle` in monorepo projects. (by [@hsource](https://github.com/hsource))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix relative manifest URL resolution when the dev server URL has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle` in monorepo projects. (by [@hsource](https://github.com/hsource))
+- [Android] Fix relative manifest URL resolution when the dev server URL has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle` in monorepo projects. ([#48636](https://github.com/expo/expo/pull/48636) by [@hsource](https://github.com/hsource))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Discover packagers across all connected networks on Android 33+. ([#46487](https://github.com/expo/expo/pull/46487) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParser.kt
@@ -6,11 +6,11 @@ import expo.modules.devlauncher.helpers.fetch
 import expo.modules.manifests.core.Manifest
 import okhttp3.Headers
 import okhttp3.Headers.Companion.toHeaders
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.Reader
-import java.net.URI
 
 class DevLauncherManifestParser(
   private val httpClient: OkHttpClient,
@@ -62,8 +62,20 @@ class DevLauncherManifestParser(
   }
 
   private fun resolveUrl(rawUrl: String): String {
+    // We use okhttp instead of java.net.URI because Android's URI
+    // implementation (Harmony-derived, RFC 2396) does not insert the missing
+    // `/` when the base has an empty path. This is unlike modern desktop
+    // JDKs and okhttp, which do insert the `/`.
+    //
+    // For example:
+    // - Inputs
+    //   - rawUrl: "apps/bare-expo/index.bundle?platform=android"
+    //   - url: "http://192.168.1.5:8081"
+    // - Outputs
+    //   - Using java.net.URI: "http://192.168.1.5:8081apps/bare-expo/index.bundle?platform=android"
+    //   - Using current code: "http://192.168.1.5:8081/apps/bare-expo/index.bundle?platform=android"
     return try {
-      URI(url.toString()).resolve(rawUrl).toString()
+      url.toString().toHttpUrl().resolve(rawUrl)?.toString() ?: rawUrl
     } catch (e: Exception) {
       rawUrl
     }

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/launcher/manifest/DevLauncherManifestParserTest.kt
@@ -216,7 +216,38 @@ internal class DevLauncherManifestParserTest {
     val manifest = manifestParser.parseManifest()
 
     Truth.assertThat(manifest.getBundleURL())
-      .isEqualTo(server.url("/dev/index.bundle?platform=android").toString())
+      .isEqualTo("http://${server.hostName}:${server.port}/dev/index.bundle?platform=android")
+  }
+
+  @Test
+  fun `parseManifest resolves relative bundle URL against base URL without a path`() = runBlocking {
+    // Regression test: the dev server URL passed to the dev client has no path
+    // (e.g. "http://192.168.1.5:8081"). Android's java.net.URI.resolve drops the "/"
+    // between authority and relative path in that case, producing invalid URLs like
+    // "http://192.168.1.5:8081apps/project/index.bundle".
+    val manifestParser = DevLauncherManifestParser(
+      client,
+      Uri.parse("http://${server.hostName}:${server.port}"),
+      null
+    )
+
+    server.enqueue(
+      MockResponse().setBody(
+        """
+        {
+          "name": "testproject",
+          "slug": "testproject",
+          "sdkVersion": "UNVERSIONED",
+          "bundleUrl": "apps/testproject/index.bundle?platform=android"
+        }
+        """.trimIndent()
+      )
+    )
+
+    val manifest = manifestParser.parseManifest()
+
+    Truth.assertThat(manifest.getBundleURL())
+      .isEqualTo("http://${server.hostName}:${server.port}/apps/testproject/index.bundle?platform=android")
   }
 
   @Test

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix relative manifest asset URL resolution when `updateUrl` has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle`. (by [@hsource](https://github.com/hsource))
 - [iOS] Set `always_out_of_date` on the `Generate updates resources for expo-updates` script_phase to silence the Xcode "run script phase will run on every build" dependency-analysis warning. ([#47622](https://github.com/expo/expo/pull/47622) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix relative manifest asset URL resolution when `updateUrl` has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle`. (by [@hsource](https://github.com/hsource))
+- [Android] Fix relative manifest asset URL resolution when `updateUrl` has no path, which caused invalid bundle URLs like `http://host:8081apps/project/index.bundle`. ([#48636](https://github.com/expo/expo/pull/48636) by [@hsource](https://github.com/hsource))
 - [iOS] Set `always_out_of_date` on the `Generate updates resources for expo-updates` script_phase to silence the Xcode "run script phase will run on every build" dependency-analysis warning. ([#47622](https://github.com/expo/expo/pull/47622) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ExpoUpdatesUpdateTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/manifest/ExpoUpdatesUpdateTest.kt
@@ -45,6 +45,28 @@ class ExpoUpdatesUpdateTest {
     )
   }
 
+  @Test
+  @Throws(JSONException::class)
+  fun testFromManifestJson_RelativeAssetUrls_BaseUrlWithoutPath() {
+    // Regression test: development servers are addressed without a path
+    // (e.g. "http://192.168.1.5:8081"). Android's java.net.URI.resolve drops the "/"
+    // between authority and relative path in that case, producing invalid URLs like
+    // "http://192.168.1.5:8081apps/project/index.bundle".
+    val manifestJson =
+      "{\"runtimeVersion\":\"1\",\"id\":\"0eef8214-4833-4089-9dff-b4138a14f196\",\"createdAt\":\"2020-11-11T00:17:54.797Z\",\"launchAsset\":{\"key\":\"bundle\",\"url\":\"apps/testproject/index.bundle?platform=android\",\"contentType\":\"application/javascript\"}}"
+    val manifest = ExpoUpdatesManifest(JSONObject(manifestJson))
+    val update = ExpoUpdatesUpdate.fromExpoUpdatesManifest(
+      manifest,
+      null,
+      createConfig(updateUrl = "http://192.168.1.5:8081")
+    )
+
+    Assert.assertEquals(
+      "http://192.168.1.5:8081/apps/testproject/index.bundle?platform=android",
+      update.manifest.getBundleURL()
+    )
+  }
+
   @Test(expected = JSONException::class)
   @Throws(JSONException::class)
   fun testFromManifestJson_NoId() {
@@ -81,9 +103,9 @@ class ExpoUpdatesUpdateTest {
     ExpoUpdatesUpdate.fromExpoUpdatesManifest(manifest, null, createConfig())
   }
 
-  private fun createConfig(): UpdatesConfiguration {
+  private fun createConfig(updateUrl: String = "https://exp.host/@test/test"): UpdatesConfiguration {
     val configMap = HashMap<String, Any>()
-    configMap["updateUrl"] = Uri.parse("https://exp.host/@test/test")
+    configMap["updateUrl"] = Uri.parse(updateUrl)
     return UpdatesConfiguration(null, configMap)
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
@@ -11,10 +11,10 @@ import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.loader.EmbeddedLoader
 import expo.modules.manifests.core.ExpoUpdatesManifest
 import expo.modules.updates.db.enums.UpdateStatus
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
-import java.net.URI
 import java.text.ParseException
 import java.util.*
 
@@ -140,8 +140,20 @@ class ExpoUpdatesUpdate private constructor(
     }
 
     private fun resolveUrl(url: String, baseUrl: Uri): String {
+      // We use okhttp instead of java.net.URI because Android's URI
+      // implementation (Harmony-derived, RFC 2396) does not insert the missing
+      // `/` when the base has an empty path. This is unlike modern desktop
+      // JDKs and okhttp, which do insert the `/`.
+      //
+      // For example:
+      // - Inputs
+      //   - url: "apps/bare-expo/index.bundle?platform=android"
+      //   - base: "http://192.168.1.5:8081"
+      // - Outputs
+      //   - Using java.net.URI: "http://192.168.1.5:8081apps/bare-expo/index.bundle?platform=android"
+      //   - Using current code: "http://192.168.1.5:8081/apps/bare-expo/index.bundle?platform=android"
       return try {
-        URI(baseUrl.toString()).resolve(url).toString()
+        baseUrl.toString().toHttpUrl().resolve(url)?.toString() ?: url
       } catch (e: Exception) {
         url
       }


### PR DESCRIPTION
# Why

Fixes a regression introduced by #47255 where Android development builds crash on launch with:

```
Invalid URL port: "8081apps:80"
```

This happens when loading a project served from a monorepo subpath (e.g. `apps/bare-expo` in this repo). The dev launcher sends `forwarded`/`x-forwarded-host` headers, so Expo CLI responds with a relative `launchAsset.url` like `apps/bare-expo/index.bundle?...`. That URL is then resolved against the path-less dev server URL (`http://<ip>:8081`).

Android's `java.net.URI.resolve()` (Harmony-derived, RFC 2396) does not insert the missing `/` between authority and path when the base URL has an empty path, producing invalid URLs like `http://192.168.1.5:8081apps/bare-expo/index.bundle?...`. Downstream, this malformed URL causes the packager websocket connection to fail.

Related: #47255

# How

Replaced `java.net.URI.resolve()` with `okhttp3.HttpUrl.resolve()` in both places that resolve relative manifest URLs on Android:

- `expo-dev-launcher`: `DevLauncherManifestParser.resolveUrl`
- `expo-updates`: `ExpoUpdatesUpdate.resolveUrl`

okhttp's URL resolution is RFC 3986 compliant and correctly inserts the `/`, matching modern desktop JDK behavior. okhttp is already a dependency in both packages.

Added regression tests covering the path-less base URL case.

# Test Plan

- [x] `./gradlew :expo-dev-launcher:testDebugUnitTest --tests "expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParserTest"` (from `apps/bare-expo/android`)
- [x] Manual: `cd apps/bare-expo && pnpm android --device` — app should launch without the `Invalid URL port: "8081apps:80"` crash

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)


Made with [Cursor](https://cursor.com)