### PR TITLE
[android][media-library] Parallelize EXIF location reads in getAssetsAsync for 6x speedup

### DIFF
--- a/apps/bare-expo/android/app/src/main/AndroidManifest.xml
+++ b/apps/bare-expo/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+  <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
@@ -12,6 +13,10 @@
   <uses-permission android:name="android.permission.READ_CALENDAR"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+  <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
   <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -83,6 +83,14 @@
         }
       ],
       [
+        "expo-media-library",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos",
+          "savePhotosPermission": "Allow $(PRODUCT_NAME) to save photos",
+          "isAccessMediaLocationEnabled": true
+        }
+      ],
+      [
         "expo-tracking-transparency",
         {
           "userTrackingPermission": "Allow Expo projects to use data for tracking the user or the device"

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -45,6 +45,7 @@
     "expo-insights": "workspace:*",
     "expo-linking": "workspace:*",
     "expo-location": "workspace:*",
+    "expo-media-library": "workspace:*",
     "expo-navigation-bar": "workspace:*",
     "expo-network-addons": "workspace:*",
     "expo-notifications": "workspace:*",

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
@@ -22,7 +22,7 @@ import HeadingText from '../../components/HeadingText';
 import Colors from '../../constants/Colors';
 import MediaLibraryCell from './MediaLibraryCell';
 const COLUMNS = 3;
-const PAGE_SIZE_OPTIONS = [30, 3000, 30000] as const;
+const PAGE_SIZE_OPTIONS = [30, 300, 3000, 30000] as const;
 const WINDOW_SIZE = Dimensions.get('window');
 
 type MediaTypeWithoutPairedVideo = Exclude<MediaLibrary.MediaTypeValue, 'pairedVideo'>;
@@ -230,6 +230,9 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
 
     try {
       // Make a native request for assets.
+      if (!state.endCursor) {
+        dispatch({ type: 'update', refreshing: true });
+      }
       const fetchStartedAt = performance.now();
       const { assets, endCursor, hasNextPage } = await MediaLibrary.getAssetsAsync({
         first: pageSize,

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
@@ -10,7 +10,6 @@ import {
   Dimensions,
   FlatList,
   ListRenderItem,
-  Platform,
   RefreshControl,
   StyleSheet,
   View,
@@ -185,7 +184,7 @@ export default function MediaLibraryScreen({ navigation, route }: Props) {
 }
 
 // The fetching and sorting logic is split out from the navigation and permission logic for simplicity.
-function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
+function MediaLibraryView({ route, accessPrivileges }: Props) {
   const albumId = route.params?.albumId;
   const albumTitle = route.params?.albumTitle;
 
@@ -244,6 +243,13 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
         resolveWithFullInfo,
       });
       const lastFetchDurationMs = Math.round(performance.now() - fetchStartedAt);
+      const firstBatchAssetLocation = assets[0]?.location;
+      const batchLocationPreview =
+        state.endCursor == null
+          ? firstBatchAssetLocation != null
+            ? `${firstBatchAssetLocation.latitude}, ${firstBatchAssetLocation.longitude}`
+            : null
+          : state.batchLocationPreview;
 
       // Get the last asset currently in the state.
       const lastAsset = state.assets[state.assets.length - 1];
@@ -259,6 +265,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
           endCursor,
           hasNextPage,
           lastFetchDurationMs,
+          batchLocationPreview,
         });
       }
     } finally {
@@ -269,6 +276,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
     state.endCursor,
     state.hasNextPage,
     state.assets,
+    state.batchLocationPreview,
     mediaType,
     sortBy,
     albumId,
@@ -373,20 +381,18 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
               }}
             />
           )}
-          {Platform.OS === 'android' && (
-            <Button
-              style={styles.button}
-              title={`Resolve with full info: ${resolveWithFullInfo}`}
-              onPress={toggleResolveWithFullInfo}
-            />
-          )}
+          <Button
+            style={styles.button}
+            title={`Resolve with full info: ${resolveWithFullInfo}`}
+            onPress={toggleResolveWithFullInfo}
+          />
         </View>
         {state.lastFetchDurationMs != null && (
           <BodyText style={styles.headerMetadata}>
             {`Last fetch: ${state.lastFetchDurationMs} ms (${state.assets.length} assets loaded)`}
           </BodyText>
         )}
-        {Platform.OS === 'ios' && state.batchLocationPreview != null && (
+        {state.batchLocationPreview != null && (
           <BodyText style={styles.headerMetadata}>
             {`First batch asset location: ${state.batchLocationPreview}`}
           </BodyText>

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
@@ -9,6 +9,7 @@ import {
   Dimensions,
   FlatList,
   ListRenderItem,
+  Platform,
   RefreshControl,
   StyleSheet,
   View,
@@ -17,6 +18,7 @@ import {
 import { BodyText } from '../../components/BodyText';
 import Button from '../../components/Button';
 import HeadingText from '../../components/HeadingText';
+import TitledSwitch from '../../components/TitledSwitch';
 import Colors from '../../constants/Colors';
 import MediaLibraryCell from './MediaLibraryCell';
 
@@ -191,10 +193,14 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
 
+  const [resolveWithFullInfo, setResolveWithFullInfo] = React.useState(false);
+  const [fetchTimingPreview, setFetchTimingPreview] = React.useState<string | null>(null);
+
   // Update without showing the refresh indicator whenever the sorting parameters change.
   React.useEffect(() => {
     dispatch({ type: 'reset', refreshing: false });
-  }, [mediaType, sortBy, albumId]);
+    setFetchTimingPreview(null);
+  }, [mediaType, sortBy, albumId, resolveWithFullInfo]);
 
   const toggleMediaType = React.useCallback(() => {
     setMediaType(mediaTypeStates[mediaType]);
@@ -217,6 +223,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
 
     try {
       // Make a native request for assets.
+      const start = performance.now();
       const { assets, endCursor, hasNextPage } = await MediaLibrary.getAssetsAsync({
         first: PAGE_SIZE,
         after: state.endCursor ?? undefined,
@@ -224,7 +231,10 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
         mediaSubtypes: [],
         sortBy,
         album: albumId,
+        resolveWithFullInfo,
       });
+      const elapsedMs = performance.now() - start;
+      setFetchTimingPreview(`${assets.length} assets in ${elapsedMs}ms`);
 
       // Get the last asset currently in the state.
       const lastAsset = state.assets[state.assets.length - 1];
@@ -245,7 +255,15 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
       // Toggle this back to false in a finally to ensure we can reload later, even if an error ocurred.
       isLoadingAssets.current = false;
     }
-  }, [state.endCursor, state.hasNextPage, state.assets, mediaType, sortBy, albumId]);
+  }, [
+    state.endCursor,
+    state.hasNextPage,
+    state.assets,
+    mediaType,
+    sortBy,
+    albumId,
+    resolveWithFullInfo,
+  ]);
 
   // Fetch data whenever the state.fetching value is true.
   React.useEffect(() => {
@@ -321,6 +339,16 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
           />
           <Button style={styles.button} title={`Sort by key: ${sortBy}`} onPress={toggleSortBy} />
         </View>
+        {Platform.OS === 'android' && (
+          <TitledSwitch
+            title="Resolve with full info"
+            value={resolveWithFullInfo}
+            setValue={setResolveWithFullInfo}
+          />
+        )}
+        {fetchTimingPreview != null && (
+          <BodyText style={styles.fetchTimingPreview}>{fetchTimingPreview}</BodyText>
+        )}
         {accessPrivileges === 'limited' && (
           <View style={styles.headerButtons}>
             <Button
@@ -338,7 +366,17 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
         )}
       </View>
     );
-  }, [mediaType, albumId, albumTitle, sortBy, toggleMediaType, toggleSortBy]);
+  }, [
+    mediaType,
+    albumId,
+    albumTitle,
+    sortBy,
+    toggleMediaType,
+    toggleSortBy,
+    resolveWithFullInfo,
+    fetchTimingPreview,
+    accessPrivileges,
+  ]);
 
   const renderFooter = React.useCallback(() => {
     if (state.refreshing) {
@@ -417,5 +455,10 @@ const styles = StyleSheet.create({
     paddingVertical: 20,
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  fetchTimingPreview: {
+    marginTop: 8,
+    fontSize: 12,
+    textAlign: 'center',
   },
 });

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryScreen.tsx
@@ -1,3 +1,4 @@
+import SegmentedControl from '@react-native-segmented-control/segmented-control';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library/legacy';
 import { router, useFocusEffect, type NativeStackScreenProps } from 'expo-router';
@@ -18,12 +19,10 @@ import {
 import { BodyText } from '../../components/BodyText';
 import Button from '../../components/Button';
 import HeadingText from '../../components/HeadingText';
-import TitledSwitch from '../../components/TitledSwitch';
 import Colors from '../../constants/Colors';
 import MediaLibraryCell from './MediaLibraryCell';
-
 const COLUMNS = 3;
-const PAGE_SIZE = COLUMNS * 10;
+const PAGE_SIZE_OPTIONS = [30, 3000, 30000] as const;
 const WINDOW_SIZE = Dimensions.get('window');
 
 type MediaTypeWithoutPairedVideo = Exclude<MediaLibrary.MediaTypeValue, 'pairedVideo'>;
@@ -62,6 +61,10 @@ type FetchState = {
   assets: MediaLibrary.Asset[];
   endCursor: string | null;
   hasNextPage: boolean;
+  /** First loaded asset location from getAssetsAsync (iOS batch location debug). */
+  batchLocationPreview: string | null;
+  /** Duration of the most recent getAssetsAsync call, in milliseconds. */
+  lastFetchDurationMs: number | null;
 };
 
 const initialState: FetchState = {
@@ -70,6 +73,8 @@ const initialState: FetchState = {
   assets: [],
   endCursor: null,
   hasNextPage: true,
+  batchLocationPreview: null,
+  lastFetchDurationMs: null,
 };
 
 function reducer(
@@ -190,17 +195,15 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
   const [mediaType, setMediaType] = React.useState<MediaTypeWithoutPairedVideo>(
     MediaLibrary.MediaType.photo
   );
+  const [pageSize, setPageSize] = React.useState<number>(PAGE_SIZE_OPTIONS[0]);
+  const [resolveWithFullInfo, setResolveWithFullInfo] = React.useState(false);
 
   const [state, dispatch] = React.useReducer(reducer, initialState);
-
-  const [resolveWithFullInfo, setResolveWithFullInfo] = React.useState(false);
-  const [fetchTimingPreview, setFetchTimingPreview] = React.useState<string | null>(null);
 
   // Update without showing the refresh indicator whenever the sorting parameters change.
   React.useEffect(() => {
     dispatch({ type: 'reset', refreshing: false });
-    setFetchTimingPreview(null);
-  }, [mediaType, sortBy, albumId, resolveWithFullInfo]);
+  }, [mediaType, sortBy, albumId, pageSize, resolveWithFullInfo]);
 
   const toggleMediaType = React.useCallback(() => {
     setMediaType(mediaTypeStates[mediaType]);
@@ -209,6 +212,10 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
   const toggleSortBy = React.useCallback(() => {
     setSortBy(sortByStates[sortBy]);
   }, [setSortBy, sortBy]);
+
+  const toggleResolveWithFullInfo = React.useCallback(() => {
+    setResolveWithFullInfo((current) => !current);
+  }, []);
 
   const loadMoreAssets = React.useCallback(async () => {
     if (
@@ -223,9 +230,9 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
 
     try {
       // Make a native request for assets.
-      const start = performance.now();
+      const fetchStartedAt = performance.now();
       const { assets, endCursor, hasNextPage } = await MediaLibrary.getAssetsAsync({
-        first: PAGE_SIZE,
+        first: pageSize,
         after: state.endCursor ?? undefined,
         mediaType,
         mediaSubtypes: [],
@@ -233,8 +240,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
         album: albumId,
         resolveWithFullInfo,
       });
-      const elapsedMs = performance.now() - start;
-      setFetchTimingPreview(`${assets.length} assets in ${elapsedMs}ms`);
+      const lastFetchDurationMs = Math.round(performance.now() - fetchStartedAt);
 
       // Get the last asset currently in the state.
       const lastAsset = state.assets[state.assets.length - 1];
@@ -249,6 +255,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
           assets: ([] as MediaLibrary.Asset[]).concat(state.assets, assets),
           endCursor,
           hasNextPage,
+          lastFetchDurationMs,
         });
       }
     } finally {
@@ -262,6 +269,7 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
     mediaType,
     sortBy,
     albumId,
+    pageSize,
     resolveWithFullInfo,
   ]);
 
@@ -338,19 +346,18 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
             onPress={toggleMediaType}
           />
           <Button style={styles.button} title={`Sort by key: ${sortBy}`} onPress={toggleSortBy} />
-        </View>
-        {Platform.OS === 'android' && (
-          <TitledSwitch
-            title="Resolve with full info"
-            value={resolveWithFullInfo}
-            setValue={setResolveWithFullInfo}
-          />
-        )}
-        {fetchTimingPreview != null && (
-          <BodyText style={styles.fetchTimingPreview}>{fetchTimingPreview}</BodyText>
-        )}
-        {accessPrivileges === 'limited' && (
-          <View style={styles.headerButtons}>
+          <View style={styles.pageSizeSelector}>
+            <BodyText style={styles.pageSizeLabel}>Page size</BodyText>
+            <SegmentedControl
+              style={styles.pageSizeControl}
+              values={PAGE_SIZE_OPTIONS.map(String)}
+              selectedIndex={PAGE_SIZE_OPTIONS.indexOf(
+                pageSize as (typeof PAGE_SIZE_OPTIONS)[number]
+              )}
+              onValueChange={(value) => setPageSize(Number(value))}
+            />
+          </View>
+          {accessPrivileges === 'limited' && (
             <Button
               style={styles.button}
               title="Change permissions"
@@ -362,7 +369,24 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
                 }
               }}
             />
-          </View>
+          )}
+          {Platform.OS === 'android' && (
+            <Button
+              style={styles.button}
+              title={`Resolve with full info: ${resolveWithFullInfo}`}
+              onPress={toggleResolveWithFullInfo}
+            />
+          )}
+        </View>
+        {state.lastFetchDurationMs != null && (
+          <BodyText style={styles.headerMetadata}>
+            {`Last fetch: ${state.lastFetchDurationMs} ms (${state.assets.length} assets loaded)`}
+          </BodyText>
+        )}
+        {Platform.OS === 'ios' && state.batchLocationPreview != null && (
+          <BodyText style={styles.headerMetadata}>
+            {`First batch asset location: ${state.batchLocationPreview}`}
+          </BodyText>
         )}
       </View>
     );
@@ -371,11 +395,15 @@ function MediaLibraryView({ navigation, route, accessPrivileges }: Props) {
     albumId,
     albumTitle,
     sortBy,
+    pageSize,
     toggleMediaType,
     toggleSortBy,
+    toggleResolveWithFullInfo,
     resolveWithFullInfo,
-    fetchTimingPreview,
     accessPrivileges,
+    state.batchLocationPreview,
+    state.lastFetchDurationMs,
+    state.assets.length,
   ]);
 
   const renderFooter = React.useCallback(() => {
@@ -433,6 +461,17 @@ const styles = StyleSheet.create({
   button: {
     marginHorizontal: 5,
   },
+  pageSizeSelector: {
+    marginHorizontal: 5,
+    alignItems: 'center',
+    gap: 6,
+  },
+  pageSizeLabel: {
+    fontSize: 12,
+  },
+  pageSizeControl: {
+    minWidth: 200,
+  },
   header: {
     paddingTop: 0,
     paddingBottom: 16,
@@ -445,6 +484,8 @@ const styles = StyleSheet.create({
     marginTop: 5,
     paddingVertical: 10,
     flexDirection: 'row',
+    flexWrap: 'wrap',
+    rowGap: 8,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -456,7 +497,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  fetchTimingPreview: {
+  headerMetadata: {
     marginTop: 8,
     fontSize: 12,
     textAlign: 'center',

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -442,6 +442,23 @@ export async function test(t) {
             t.expect(asset.creationTime).toBeGreaterThanOrEqual(createdAfter);
           }
         });
+
+        if (Platform.OS === 'android') {
+          t.it('resolveWithFullInfo returns numeric location when available', async () => {
+            const { assets } = await MediaLibrary.getAssetsAsync({
+              album,
+              first: 5,
+              resolveWithFullInfo: true,
+            });
+            t.expect(assets.length).toBeGreaterThan(0);
+            assets.forEach((asset) => {
+              if (asset.location != null) {
+                t.expect(typeof asset.location.latitude).toBe('number');
+                t.expect(typeof asset.location.longitude).toBe('number');
+              }
+            });
+          });
+        }
       });
 
       t.describe('getAssetInfoAsync', () => {

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -445,18 +445,23 @@ export async function test(t) {
 
         if (Platform.OS === 'android') {
           t.it('resolveWithFullInfo returns numeric location when available', async () => {
-            const { assets } = await MediaLibrary.getAssetsAsync({
-              album,
-              first: 5,
-              resolveWithFullInfo: true,
-            });
-            t.expect(assets.length).toBeGreaterThan(0);
-            assets.forEach((asset) => {
-              if (asset.location != null) {
-                t.expect(typeof asset.location.latitude).toBe('number');
-                t.expect(typeof asset.location.longitude).toBe('number');
-              }
-            });
+            const [exifFile] = await Asset.loadAsync(require('../assets/exif_data_image.jpg'));
+            const exifAsset = await MediaLibrary.createAssetAsync(exifFile.localUri, album);
+            try {
+              const { assets } = await MediaLibrary.getAssetsAsync({
+                album,
+                resolveWithFullInfo: true,
+              });
+              const asset = assets.find((a) => a.id === exifAsset.id);
+              t.expect(asset).toBeDefined();
+              t.expect(asset.exif).toBeDefined();
+              t.expect(asset.localUri).toBeDefined();
+              t.expect(asset.location).not.toBeNull();
+              t.expect(typeof asset.location.latitude).toBe('number');
+              t.expect(typeof asset.location.longitude).toBe('number');
+            } finally {
+              await MediaLibrary.deleteAssetsAsync(exifAsset);
+            }
           });
         }
       });

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Parallelize per-file EXIF and location reads in `getAssetsAsync` when `resolveWithFullInfo` is true, speeding up large library scans.
+- [Android] Parallelize per-file EXIF and location reads in `getAssetsAsync` when `resolveWithFullInfo` is true, speeding up large library scans. ([#48637](https://github.com/expo/expo/pull/48637) by [@hsource](https://github.com/hsource) and [@robin-pham](https://github.com/robin-pham))
 - [Android] Fix transposed `width`/`height` for rotated assets (portrait photos and videos): `Asset.getInfo()`, `getWidth()`/`getHeight()`/`getShape()` and `Query.exeForMetadata()` now honor MediaStore `ORIENTATION`, matching the legacy API. ([#48150](https://github.com/expo/expo/pull/48150) by [@oeddyo](https://github.com/oeddyo))
 
 ### 💡 Others

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Parallelize per-file EXIF and location reads in `getAssetsAsync` when `resolveWithFullInfo` is true, speeding up large library scans.
 - [Android] Fix transposed `width`/`height` for rotated assets (portrait photos and videos): `Asset.getInfo()`, `getWidth()`/`getHeight()`/`getShape()` and `Query.exeForMetadata()` now honor MediaStore `ORIENTATION`, matching the legacy API. ([#48150](https://github.com/expo/expo/pull/48150) by [@oeddyo](https://github.com/oeddyo))
 
 ### 💡 Others

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -143,7 +143,42 @@ suspend fun putAssetsInfo(
   val bundles = withContext(exifReadDispatcher) {
     rows.map { row ->
       async {
-        buildAssetBundle(contentResolver, row, resolveWithFullInfo)
+        val localUri = "file://${row.path}"
+        var exifInterface: ExifInterface? = null
+        if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+          try {
+            exifInterface = ExifInterface(row.path)
+          } catch (e: IOException) {
+            Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+            e.printStackTrace()
+          }
+        }
+        val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
+        val asset = Bundle().apply {
+          putString("id", row.assetId)
+          putString("filename", row.filename)
+          putString("uri", localUri)
+          putString("mediaType", exportMediaType(row.mediaType))
+          putLong("width", width.toLong())
+          putLong("height", height.toLong())
+          putLong("creationTime", row.creationTime)
+          putDouble("modificationTime", row.modificationTime * 1000.0)
+          putDouble("duration", row.durationMs / 1000.0)
+          putString("albumId", row.albumId)
+        }
+        if (resolveWithFullInfo && exifInterface != null) {
+          getExifFullInfo(exifInterface, asset)
+
+          val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
+            getExifLocationForUri(contentResolver, photoUri)
+          } else {
+            getExifLocationLegacy(exifInterface)
+          }
+          asset.putParcelable("location", location)
+          asset.putString("localUri", localUri)
+        }
+        asset
       }
     }.awaitAll()
   }
@@ -210,34 +245,28 @@ fun getExifLocationLegacy(exifInterface: ExifInterface): Bundle? {
 }
 
 /**
- * Gets image/video dimensions
+ * Gets image/video dimensions from the already-read cursor columns.
+ *
+ * For videos, prefers MediaStore `WIDTH`/`HEIGHT`/`ORIENTATION` (see [1])
+ * and falls back to MediaMetadataRetriever when the scanner has not indexed
+ * the file yet. For images, uses the same cursor columns with
+ * BitmapFactory and EXIF orientation handling when dimensions are missing.
+ *
+ * [1]: https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#WIDTH
+ *
  * @return Pair of integers: width and height, respectively
  */
-@Throws(IOException::class)
-fun getAssetDimensionsFromCursor(
+private fun getAssetDimensions(
   contentResolver: ContentResolver,
-  exifInterface: ExifInterface?,
-  cursor: Cursor,
-  mediaType: Int,
-  localUriColumnIndex: Int
+  row: AssetRowData,
+  exifInterface: ExifInterface?
 ): Pair<Int, Int> {
-  val uri = cursor.getString(localUriColumnIndex)
-  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-    // Fast path: read dimensions from MediaStore cursor (no file I/O).
-    // MediaStore populates these when the media scanner indexes the file.
-    val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
-    val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
-    val width = cursor.getInt(widthIndex)
-    val height = cursor.getInt(heightIndex)
-    if (width > 0 && height > 0) {
-      val orientationIndex = cursor.getColumnIndex(MediaStore.MediaColumns.ORIENTATION)
-      val orientation = cursor.getInt(orientationIndex)
-
-      return maybeRotateAssetSize(width, height, orientation)
+  if (row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    if (row.width > 0 && row.height > 0) {
+      return maybeRotateAssetSize(row.width, row.height, row.orientation)
     }
-
     // Slow fallback for files not yet indexed by the media scanner.
-    val videoUri = Uri.parse("file://$uri")
+    val videoUri = Uri.parse("file://${row.path}")
     try {
       contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
         MediaMetadataRetriever().use { retriever ->
@@ -255,23 +284,20 @@ fun getAssetDimensionsFromCursor(
     } catch (e: NumberFormatException) {
       Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
     } catch (e: FileNotFoundException) {
-      Log.e("expo-media-library", "ContentResolver failed to read $uri: ${e.message}")
+      Log.e("expo-media-library", "ContentResolver failed to read ${row.path}: ${e.message}")
     } catch (e: RuntimeException) {
       Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
     }
+    return Pair(0, 0)
   }
 
-  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
-  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
-  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-  var width = cursor.getInt(widthIndex)
-  var height = cursor.getInt(heightIndex)
-  var orientation = cursor.getInt(orientationIndex)
+  var width = row.width
+  var height = row.height
+  var orientation = row.orientation
 
-  // If the image doesn't have the required information, we can get them from Bitmap.Options
-  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE && (width <= 0 || height <= 0)) {
+  if (width <= 0 || height <= 0) {
     val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeFile(uri, options)
+    BitmapFactory.decodeFile(row.path, options)
     width = options.outWidth
     height = options.outHeight
   }
@@ -280,6 +306,7 @@ fun getAssetDimensionsFromCursor(
       ExifInterface.TAG_ORIENTATION,
       ExifInterface.ORIENTATION_NORMAL
     )
+    // Full list of orientations are here: https://developer.android.com/reference/android/media/ExifInterface#summary
     if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
       exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
       exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
@@ -347,130 +374,3 @@ private class AssetRowData(
   val height: Int,
   val orientation: Int
 )
-
-/**
- * Fetches data for a single asset and places the data into a Bundle.
- */
-private fun buildAssetBundle(
-  contentResolver: ContentResolver,
-  row: AssetRowData,
-  resolveWithFullInfo: Boolean
-): Bundle {
-  val localUri = "file://${row.path}"
-  var exifInterface: ExifInterface? = null
-  if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-    try {
-      exifInterface = ExifInterface(row.path)
-    } catch (e: IOException) {
-      Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-      e.printStackTrace()
-    }
-  }
-  val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
-  val asset = Bundle().apply {
-    putString("id", row.assetId)
-    putString("filename", row.filename)
-    putString("uri", localUri)
-    putString("mediaType", exportMediaType(row.mediaType))
-    putLong("width", width.toLong())
-    putLong("height", height.toLong())
-    putLong("creationTime", row.creationTime)
-    putDouble("modificationTime", row.modificationTime * 1000.0)
-    putDouble("duration", row.durationMs / 1000.0)
-    putString("albumId", row.albumId)
-  }
-  if (resolveWithFullInfo && exifInterface != null) {
-    getExifFullInfo(exifInterface, asset)
-
-    val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
-      getExifLocationForUri(contentResolver, photoUri)
-    } else {
-      getExifLocationLegacy(exifInterface)
-    }
-    asset.putParcelable("location", location)
-    asset.putString("localUri", localUri)
-  }
-  return asset
-}
-
-/**
- * Gets image/video dimensions from the pre-read cursor columns.
- *
- * For videos, prefers MediaStore `WIDTH`/`HEIGHT`/`ORIENTATION` (see [1])
- * and falls back to [getVideoDimensionsFromFile] when the scanner has not
- * indexed the file yet. For images, uses the same cursor columns with
- * BitmapFactory and EXIF orientation handling when dimensions are missing.
- *
- * [1]: https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#WIDTH
- *
- * @return Pair of integers: width and height, respectively
- */
-private fun getAssetDimensions(
-  contentResolver: ContentResolver,
-  row: AssetRowData,
-  exifInterface: ExifInterface?
-): Pair<Int, Int> {
-  if (row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-    if (row.width > 0 && row.height > 0) {
-      return maybeRotateAssetSize(row.width, row.height, row.orientation)
-    }
-    // Slow fallback for files not yet indexed by the media scanner.
-    return getVideoDimensionsFromFile(contentResolver, row.path)
-  }
-
-  var width = row.width
-  var height = row.height
-  var orientation = row.orientation
-
-  if (width <= 0 || height <= 0) {
-    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeFile(row.path, options)
-    width = options.outWidth
-    height = options.outHeight
-  }
-  if (exifInterface != null) {
-    val exifOrientation = exifInterface.getAttributeInt(
-      ExifInterface.TAG_ORIENTATION,
-      ExifInterface.ORIENTATION_NORMAL
-    )
-    if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
-      exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
-      exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
-      exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
-    ) {
-      orientation = 90
-    }
-  }
-  return maybeRotateAssetSize(width, height, orientation)
-}
-
-@Throws(IOException::class)
-private fun getVideoDimensionsFromFile(
-  contentResolver: ContentResolver,
-  path: String
-): Pair<Int, Int> {
-  val videoUri = Uri.parse("file://$path")
-  try {
-    contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
-      MediaMetadataRetriever().use { retriever ->
-        retriever.setDataSource(photoDescriptor!!.fileDescriptor)
-        val videoWidth =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
-        val videoHeight =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
-        val videoOrientation =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
-
-        return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
-      }
-    }
-  } catch (e: NumberFormatException) {
-    Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
-  } catch (e: FileNotFoundException) {
-    Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
-  } catch (e: RuntimeException) {
-    Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
-  }
-  return Pair(0, 0)
-}

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -169,7 +169,10 @@ suspend fun putAssetsInfo(
         async {
           val localUri = "file://${pending.path}"
           var exifInterface: ExifInterface? = null
-          if (resolveWithFullInfo && pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+          if (
+            (resolveWithFullInfo || pending.missingDimensions) &&
+            pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE
+          ) {
             try {
               exifInterface = ExifInterface(pending.path)
             } catch (e: IOException) {
@@ -185,6 +188,20 @@ suspend fun putAssetsInfo(
           }
 
           if (exifInterface != null) {
+            // If we haven't already, use the fetched EXIF data to populate the dimensions.
+            // While the cursor should have the orientation, this defends against bugs when it
+            // might be missing.
+            if (!pending.missingDimensions) {
+              val (width, height) = getImageDimensionsFromExifFast(
+                exifInterface,
+                pending.cursorWidth,
+                pending.cursorHeight,
+                pending.cursorOrientation
+              )
+              pending.asset.putLong("width", width.toLong())
+              pending.asset.putLong("height", height.toLong())
+            }
+
             getExifFullInfo(exifInterface, pending.asset)
 
             val assetId = pending.asset.getString("id") ?: return@async
@@ -350,6 +367,23 @@ private fun getAssetDimensionsSlow(
     width = options.outWidth
     height = options.outHeight
   }
+
+  return getImageDimensionsFromExifFast(exifInterface, width, height, orientation)
+}
+
+/**
+ * Applies EXIF orientation to pre-fetched image dimensions. This is fast because — it performs no
+ * file I/O. It prefers EXIF orientation when [exifInterface] is available, and otherwise falls back
+ * to [cursorOrientation] from the MediaStore cursor.
+ */
+private fun getImageDimensionsFromExifFast(
+  exifInterface: ExifInterface?,
+  width: Int,
+  height: Int,
+  cursorOrientation: Int
+): Pair<Int, Int> {
+  var resolvedOrientation = cursorOrientation
+
   if (exifInterface != null) {
     val exifOrientation = exifInterface.getAttributeInt(
       ExifInterface.TAG_ORIENTATION,
@@ -360,10 +394,10 @@ private fun getAssetDimensionsSlow(
       exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
       exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
     ) {
-      orientation = 90
+      resolvedOrientation = 90
     }
   }
-  return maybeRotateAssetSize(width, height, orientation)
+  return maybeRotateAssetSize(width, height, resolvedOrientation)
 }
 
 /**

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -170,7 +170,7 @@ suspend fun putAssetsInfo(
           val localUri = "file://${pending.path}"
           var exifInterface: ExifInterface? = null
           if (
-            (resolveWithFullInfo || pending.missingDimensions) &&
+            resolveWithFullInfo &&
             pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE
           ) {
             try {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -87,11 +87,12 @@ suspend fun queryAssetInfo(
  * location) is read in parallel across [exifReadDispatcher] instead of
  * sequentially. EXIF location reads cost ~15ms per image sequentially;
  * they are independent per-file I/O, so parallelizing them speeds up large
- * queries by several times. Cursor access is not thread-safe, so all cursor
- * columns are copied into [AssetRowData] first; the parallel workers never
- * touch the cursor. Iteration matches the original sequential loop
- * (moveToPosition, then moveToNext per row) so the cursor's final position
- * — which callers read for `hasNextPage`/`endCursor` — is unchanged.
+ * queries by several times. Cursor access is not thread-safe, so cursor columns
+ * are copied into [AssetRowData] in batches before parallel file work; workers
+ * never touch the cursor. Iteration matches the original sequential loop
+ * original sequential loop (moveToPosition, then moveToNext per row) so the
+ * cursor's final position — which callers read for `hasNextPage`/`endCursor` —
+ * is unchanged.
  */
 @Throws(IOException::class, UnsupportedOperationException::class)
 suspend fun putAssetsInfo(
@@ -115,74 +116,88 @@ suspend fun putAssetsInfo(
   val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
   val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
 
-  val rows = mutableListOf<AssetRowData>()
   if (!cursor.moveToPosition(offset)) {
     return
   }
-  var i = 0
-  while (i < limit && !cursor.isAfterLast) {
-    rows.add(
-      AssetRowData(
-        assetId = cursor.getString(idIndex),
-        filename = cursor.getString(filenameIndex),
-        path = cursor.getString(localUriIndex),
-        mediaType = cursor.getInt(mediaTypeIndex),
-        creationTime = cursor.getLong(creationDateIndex),
-        modificationTime = cursor.getLong(modificationDateIndex),
-        durationMs = cursor.getInt(durationIndex),
-        albumId = cursor.getString(albumIdIndex),
-        width = cursor.getInt(widthIndex),
-        height = cursor.getInt(heightIndex),
-        orientation = cursor.getInt(orientationIndex)
+
+  // Large `limit` values would otherwise hold every [AssetRowData] in memory
+  // at once. Each row is ~400 bytes (mostly id/filename/path strings), so
+  // 5000 * 400 bytes ≈ 2 MB.
+  //
+  // We limit batches to 5000 since that should keep [AssetRowData] memory
+  // memory usage low.
+  val ASSET_ROW_BATCH_SIZE = 5000
+
+  var remaining = limit
+  while (remaining > 0 && !cursor.isAfterLast) {
+    val batchSize = minOf(remaining, ASSET_ROW_BATCH_SIZE)
+    val rows = ArrayList<AssetRowData>(batchSize)
+    var i = 0
+    while (i < batchSize && !cursor.isAfterLast) {
+      rows.add(
+        AssetRowData(
+          assetId = cursor.getString(idIndex),
+          filename = cursor.getString(filenameIndex),
+          path = cursor.getString(localUriIndex),
+          mediaType = cursor.getInt(mediaTypeIndex),
+          creationTime = cursor.getLong(creationDateIndex),
+          modificationTime = cursor.getLong(modificationDateIndex),
+          durationMs = cursor.getInt(durationIndex),
+          albumId = cursor.getString(albumIdIndex),
+          width = cursor.getInt(widthIndex),
+          height = cursor.getInt(heightIndex),
+          orientation = cursor.getInt(orientationIndex)
+        )
       )
-    )
-    cursor.moveToNext()
-    i++
-  }
+      cursor.moveToNext()
+      i++
+    }
 
-  val bundles = withContext(exifReadDispatcher) {
-    rows.map { row ->
-      async {
-        val localUri = "file://${row.path}"
-        var exifInterface: ExifInterface? = null
-        if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-          try {
-            exifInterface = ExifInterface(row.path)
-          } catch (e: IOException) {
-            Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-            e.printStackTrace()
+    val bundles = withContext(exifReadDispatcher) {
+      rows.map { row ->
+        async {
+          val localUri = "file://${row.path}"
+          var exifInterface: ExifInterface? = null
+          if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+            try {
+              exifInterface = ExifInterface(row.path)
+            } catch (e: IOException) {
+              Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+              e.printStackTrace()
+            }
           }
-        }
-        val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
-        val asset = Bundle().apply {
-          putString("id", row.assetId)
-          putString("filename", row.filename)
-          putString("uri", localUri)
-          putString("mediaType", exportMediaType(row.mediaType))
-          putLong("width", width.toLong())
-          putLong("height", height.toLong())
-          putLong("creationTime", row.creationTime)
-          putDouble("modificationTime", row.modificationTime * 1000.0)
-          putDouble("duration", row.durationMs / 1000.0)
-          putString("albumId", row.albumId)
-        }
-        if (resolveWithFullInfo && exifInterface != null) {
-          getExifFullInfo(exifInterface, asset)
+          val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
+          val asset = Bundle().apply {
+            putString("id", row.assetId)
+            putString("filename", row.filename)
+            putString("uri", localUri)
+            putString("mediaType", exportMediaType(row.mediaType))
+            putLong("width", width.toLong())
+            putLong("height", height.toLong())
+            putLong("creationTime", row.creationTime)
+            putDouble("modificationTime", row.modificationTime * 1000.0)
+            putDouble("duration", row.durationMs / 1000.0)
+            putString("albumId", row.albumId)
+          }
+          if (resolveWithFullInfo && exifInterface != null) {
+            getExifFullInfo(exifInterface, asset)
 
-          val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
-            getExifLocationForUri(contentResolver, photoUri)
-          } else {
-            getExifLocationLegacy(exifInterface)
+            val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+              val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
+              getExifLocationForUri(contentResolver, photoUri)
+            } else {
+              getExifLocationLegacy(exifInterface)
+            }
+            asset.putParcelable("location", location)
+            asset.putString("localUri", localUri)
           }
-          asset.putParcelable("location", location)
-          asset.putString("localUri", localUri)
+          asset
         }
-        asset
-      }
-    }.awaitAll()
+      }.awaitAll()
+    }
+    response.addAll(bundles)
+    remaining -= i
   }
-  response.addAll(bundles)
 }
 
 fun getExifFullInfo(exifInterface: ExifInterface, response: Bundle) {

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -100,7 +100,6 @@ suspend fun putAssetsInfo(
   val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
   val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
   val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
-  // Read dimension columns here so parallel workers never touch the cursor.
   val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
   val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
   val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -100,98 +100,99 @@ suspend fun putAssetsInfo(
   val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
   val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
   val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
-  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
-  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
-  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-
   if (!cursor.moveToPosition(offset)) {
     return
   }
-
-  // We limit batches to 5000 since that should keep [AssetRowData] memory
-  // memory usage low.
-  //
-  // Large `limit` values would otherwise hold every [AssetRowData] in memory
-  // at once. Each row is ~400 bytes (mostly id/filename/path strings), so
-  // 5000 * 400 bytes ≈ 2 MB.
-  val ASSET_ROW_BATCH_SIZE = 5000
-
-  var remaining = limit
-  while (remaining > 0 && !cursor.isAfterLast) {
-    val batchSize = minOf(remaining, ASSET_ROW_BATCH_SIZE)
-    val rows = ArrayList<AssetRowData>(batchSize)
-    var i = 0
-    while (i < batchSize && !cursor.isAfterLast) {
-      rows.add(
-        AssetRowData(
-          assetId = cursor.getString(idIndex),
-          filename = cursor.getString(filenameIndex),
-          path = cursor.getString(localUriIndex),
-          mediaType = cursor.getInt(mediaTypeIndex),
-          creationTime = cursor.getLong(creationDateIndex),
-          modificationTime = cursor.getLong(modificationDateIndex),
-          durationMs = cursor.getInt(durationIndex),
-          albumId = cursor.getString(albumIdIndex),
-          width = cursor.getInt(widthIndex),
-          height = cursor.getInt(heightIndex),
-          orientation = cursor.getInt(orientationIndex)
-        )
-      )
-      cursor.moveToNext()
-      i++
+  val missingDimensionsVideos = mutableListOf<PendingAsset>()
+  val pendingFullInfoAssets = mutableListOf<PendingAsset>()
+  var i = 0
+  while (i < limit && !cursor.isAfterLast) {
+    val assetId = cursor.getString(idIndex)
+    val path = cursor.getString(localUriIndex)
+    val localUri = "file://$path"
+    val mediaType = cursor.getInt(mediaTypeIndex)
+    val dimensions = getAssetDimensionsFromCursorFast(cursor, mediaType)
+    val width = dimensions?.first ?: 0
+    val height = dimensions?.second ?: 0
+    val asset = Bundle().apply {
+      putString("id", assetId)
+      putString("filename", cursor.getString(filenameIndex))
+      putString("uri", localUri)
+      putString("mediaType", exportMediaType(mediaType))
+      putLong("width", width.toLong())
+      putLong("height", height.toLong())
+      putLong("creationTime", cursor.getLong(creationDateIndex))
+      putDouble("modificationTime", cursor.getLong(modificationDateIndex) * 1000.0)
+      putDouble("duration", cursor.getInt(durationIndex) / 1000.0)
+      putString("albumId", cursor.getString(albumIdIndex))
     }
+    if (dimensions == null && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+      missingDimensionsVideos.add(PendingAsset(asset, path))
+    }
+    if (resolveWithFullInfo && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+      pendingFullInfoAssets.add(PendingAsset(asset, path))
+    }
+    cursor.moveToNext()
+    response.add(asset)
+    i++
+  }
 
+  if (missingDimensionsVideos.isNotEmpty() || pendingFullInfoAssets.isNotEmpty()) {
     // When resolveWithFullInfo is true, per-file EXIF data (including GPS location) is read in
     // parallel across exifReadDispatcher instead of sequentially.
     //
     // - EXIF location reads cost ~15ms per image sequentially. They are independent per-file I/O,
     //   so parallelizing them speeds up large queries by several times.
-    // - Cursor access is not thread-safe. Cursor columns are copied into AssetRowData in batches
-    //   before parallel file work; workers never touch the cursor.
-    val bundles = withContext(exifReadDispatcher) {
-      rows.map { row ->
-        async {
-          val localUri = "file://${row.path}"
-          var exifInterface: ExifInterface? = null
-          if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-            try {
-              exifInterface = ExifInterface(row.path)
-            } catch (e: IOException) {
-              Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-              e.printStackTrace()
+    // - Cursor access is not thread-safe. Paths are copied into pending asset lists during the
+    //   cursor loop before parallel file work; workers never touch the cursor.
+    withContext(exifReadDispatcher) {
+      buildList {
+        addAll(
+          missingDimensionsVideos.map { pending ->
+            async {
+              val (width, height) = getVideoDimensionsSlow(contentResolver, pending.path)
+              pending.asset.putLong("width", width.toLong())
+              pending.asset.putLong("height", height.toLong())
             }
           }
-          val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
-          val asset = Bundle().apply {
-            putString("id", row.assetId)
-            putString("filename", row.filename)
-            putString("uri", localUri)
-            putString("mediaType", exportMediaType(row.mediaType))
-            putLong("width", width.toLong())
-            putLong("height", height.toLong())
-            putLong("creationTime", row.creationTime)
-            putDouble("modificationTime", row.modificationTime * 1000.0)
-            putDouble("duration", row.durationMs / 1000.0)
-            putString("albumId", row.albumId)
-          }
-          if (resolveWithFullInfo && exifInterface != null) {
-            getExifFullInfo(exifInterface, asset)
+        )
+        addAll(
+          pendingFullInfoAssets.map { pending ->
+            async {
+              val localUri = "file://${pending.path}"
+              val assetId = pending.asset.getString("id") ?: return@async
+              val exifInterface = try {
+                ExifInterface(pending.path)
+              } catch (e: IOException) {
+                Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+                e.printStackTrace()
+                return@async
+              }
 
-            val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-              val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
-              getExifLocationForUri(contentResolver, photoUri)
-            } else {
-              getExifLocationLegacy(exifInterface)
+              val (width, height) = getImageDimensionsSlow(
+                pending.path,
+                exifInterface,
+                pending.asset.getLong("width").toInt(),
+                pending.asset.getLong("height").toInt()
+              )
+              pending.asset.putLong("width", width.toLong())
+              pending.asset.putLong("height", height.toLong())
+
+              getExifFullInfo(exifInterface, pending.asset)
+
+              val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
+                getExifLocationForUri(contentResolver, photoUri)
+              } else {
+                getExifLocationLegacy(exifInterface)
+              }
+              pending.asset.putParcelable("location", location)
+              pending.asset.putString("localUri", localUri)
             }
-            asset.putParcelable("location", location)
-            asset.putString("localUri", localUri)
           }
-          asset
-        }
+        )
       }.awaitAll()
     }
-    response.addAll(bundles)
-    remaining -= i
   }
 }
 
@@ -255,79 +256,110 @@ fun getExifLocationLegacy(exifInterface: ExifInterface): Bundle? {
 }
 
 /**
- * Gets image/video dimensions from the already-read cursor columns.
- *
- * For videos, prefers MediaStore `WIDTH`/`HEIGHT`/`ORIENTATION` (see [1])
- * and falls back to MediaMetadataRetriever when the scanner has not indexed
- * the file yet. For images, uses the same cursor columns with
- * BitmapFactory and EXIF orientation handling when dimensions are missing.
- *
- * [1]: https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#WIDTH
- *
- * @return Pair of integers: width and height, respectively
+ * Gets image/video dimensions from MediaStore cursor columns (no file I/O).
+ * @return Rotated dimensions, or `null` if width/height are not yet indexed.
  */
-private fun getAssetDimensions(
-  contentResolver: ContentResolver,
-  row: AssetRowData,
-  exifInterface: ExifInterface?
-): Pair<Int, Int> {
-  if (row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-    // Fast path: read dimensions from cursor data (no file I/O)
+fun getAssetDimensionsFromCursorFast(
+  cursor: Cursor,
+  mediaType: Int
+): Pair<Int, Int>? {
+  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    // Fast path: read dimensions from MediaStore cursor (no file I/O).
     // MediaStore populates these when the media scanner indexes the file.
-    if (row.width > 0 && row.height > 0) {
-      return maybeRotateAssetSize(row.width, row.height, row.orientation)
-    }
-    // Slow fallback for files not yet indexed by the media scanner.
-    val videoUri = Uri.parse("file://${row.path}")
-    try {
-      contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
-        MediaMetadataRetriever().use { retriever ->
-          retriever.setDataSource(photoDescriptor!!.fileDescriptor)
-          val videoWidth =
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
-          val videoHeight =
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
-          val videoOrientation =
-            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
+    val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+    val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+    val width = cursor.getInt(widthIndex)
+    val height = cursor.getInt(heightIndex)
+    if (width > 0 && height > 0) {
+      val orientationIndex = cursor.getColumnIndex(MediaStore.MediaColumns.ORIENTATION)
+      val orientation = cursor.getInt(orientationIndex)
 
-          return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
-        }
-      }
-    } catch (e: NumberFormatException) {
-      Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
-    } catch (e: FileNotFoundException) {
-      Log.e("expo-media-library", "ContentResolver failed to read ${row.path}: ${e.message}")
-    } catch (e: RuntimeException) {
-      Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
+      return maybeRotateAssetSize(width, height, orientation)
     }
-    return Pair(0, 0)
+
+    return null
   }
 
-  var width = row.width
-  var height = row.height
-  var orientation = row.orientation
+  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+  val width = cursor.getInt(widthIndex)
+  val height = cursor.getInt(heightIndex)
+  val orientation = cursor.getInt(orientationIndex)
 
-  if (width <= 0 || height <= 0) {
-    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeFile(row.path, options)
-    width = options.outWidth
-    height = options.outHeight
-  }
-  if (exifInterface != null) {
-    val exifOrientation = exifInterface.getAttributeInt(
-      ExifInterface.TAG_ORIENTATION,
-      ExifInterface.ORIENTATION_NORMAL
-    )
-    // Full list of orientations are here: https://developer.android.com/reference/android/media/ExifInterface#summary
-    if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
-      exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
-      exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
-      exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
-    ) {
-      orientation = 90
-    }
+  // If the image doesn't have the required information, we can get them from Bitmap.Options
+  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE && (width <= 0 || height <= 0)) {
+    return null
   }
   return maybeRotateAssetSize(width, height, orientation)
+}
+
+/**
+ * @return Pair of integers: width and height, respectively
+ */
+@Throws(IOException::class)
+fun getVideoDimensionsSlow(
+  contentResolver: ContentResolver,
+  path: String
+): Pair<Int, Int> {
+  // Slow fallback for files not yet indexed by the media scanner.
+  val videoUri = Uri.parse("file://$path")
+  try {
+    contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
+      MediaMetadataRetriever().use { retriever ->
+        retriever.setDataSource(photoDescriptor!!.fileDescriptor)
+        val videoWidth =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
+        val videoHeight =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
+        val videoOrientation =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
+
+        return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
+      }
+    }
+  } catch (e: NumberFormatException) {
+    Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
+  } catch (e: FileNotFoundException) {
+    Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
+  } catch (e: RuntimeException) {
+    Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
+  }
+  return Pair(0, 0)
+}
+
+/**
+ * Gets image dimensions via file I/O when cursor columns are missing and/or EXIF orientation
+ * is needed for [maybeRotateAssetSize].
+ * @return Pair of integers: width and height, respectively
+ */
+fun getImageDimensionsSlow(
+  path: String,
+  exifInterface: ExifInterface,
+  width: Int,
+  height: Int
+): Pair<Int, Int> {
+  var resolvedWidth = width
+  var resolvedHeight = height
+  var orientation = 0
+  if (resolvedWidth <= 0 || resolvedHeight <= 0) {
+    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(path, options)
+    resolvedWidth = options.outWidth
+    resolvedHeight = options.outHeight
+  }
+  val exifOrientation = exifInterface.getAttributeInt(
+    ExifInterface.TAG_ORIENTATION,
+    ExifInterface.ORIENTATION_NORMAL
+  )
+  if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+    exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+    exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+    exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
+  ) {
+    orientation = 90
+  }
+  return maybeRotateAssetSize(resolvedWidth, resolvedHeight, orientation)
 }
 
 /**
@@ -380,17 +412,7 @@ fun maybeRotateAssetSize(width: Int, height: Int, orientation: Int): Pair<Int, I
 @OptIn(ExperimentalCoroutinesApi::class)
 private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(32)
 
-/** One cursor row's columns, copied out so file work can run off-cursor. */
-private class AssetRowData(
-  val assetId: String,
-  val filename: String,
-  val path: String,
-  val mediaType: Int,
-  val creationTime: Long,
-  val modificationTime: Long,
-  val durationMs: Int,
-  val albumId: String?,
-  val width: Int,
-  val height: Int,
-  val orientation: Int
+private data class PendingAsset(
+  val asset: Bundle,
+  val path: String
 )

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -83,9 +83,15 @@ suspend fun queryAssetInfo(
  * Reads `limit` rows, starting by `offset`.
  * Cursor must be a result of query with [ASSET_PROJECTION] projection
  *
- * When [resolveWithFullInfo] is true, per-file EXIF and location reads run in
- * parallel (bounded by [exifReadDispatcher]). Cursor access is not
- * thread-safe, so rows are copied in [drainCursorRows] first.
+ * When [resolveWithFullInfo] is true, per-file EXIF data (including GPS
+ * location) is read in parallel across [exifReadDispatcher] instead of
+ * sequentially. EXIF location reads cost ~15ms per image sequentially;
+ * they are independent per-file I/O, so parallelizing them speeds up large
+ * queries by several times. Cursor access is not thread-safe, so all cursor
+ * columns are copied into [AssetRowData] first; the parallel workers never
+ * touch the cursor. Iteration matches the original sequential loop
+ * (moveToPosition, then moveToNext per row) so the cursor's final position
+ * — which callers read for `hasNextPage`/`endCursor` — is unchanged.
  */
 @Throws(IOException::class, UnsupportedOperationException::class)
 suspend fun putAssetsInfo(
@@ -96,7 +102,44 @@ suspend fun putAssetsInfo(
   offset: Int,
   resolveWithFullInfo: Boolean
 ) {
-  val rows = drainCursorRows(cursor, limit, offset)
+  val idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID)
+  val filenameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
+  val mediaTypeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE)
+  val creationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
+  val modificationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
+  val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
+  val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+  val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
+  // Read dimension columns here so parallel workers never touch the cursor.
+  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+
+  val rows = mutableListOf<AssetRowData>()
+  if (!cursor.moveToPosition(offset)) {
+    return
+  }
+  var i = 0
+  while (i < limit && !cursor.isAfterLast) {
+    rows.add(
+      AssetRowData(
+        assetId = cursor.getString(idIndex),
+        filename = cursor.getString(filenameIndex),
+        path = cursor.getString(localUriIndex),
+        mediaType = cursor.getInt(mediaTypeIndex),
+        creationTime = cursor.getLong(creationDateIndex),
+        modificationTime = cursor.getLong(modificationDateIndex),
+        durationMs = cursor.getInt(durationIndex),
+        albumId = cursor.getString(albumIdIndex),
+        width = cursor.getInt(widthIndex),
+        height = cursor.getInt(heightIndex),
+        orientation = cursor.getInt(orientationIndex)
+      )
+    )
+    cursor.moveToNext()
+    i++
+  }
+
   val bundles = withContext(exifReadDispatcher) {
     rows.map { row ->
       async {
@@ -275,12 +318,17 @@ fun maybeRotateAssetSize(width: Int, height: Int, orientation: Int): Pair<Int, I
 }
 
 /**
- * Bounded parallelism for per-file EXIF reads. Location reads call
- * MediaStore.setRequireOriginal + openInputStream (Binder IPC into
- * MediaProvider). libbinder's default thread pool is 15 threads, shared
- * across apps, so concurrency much past ~16 mostly queues on Binder.
+ * Bounded parallelism for per-file EXIF reads. Measured on a real device:
+ * 8 → ~2.2ms/photo, 16 → ~1.8ms/photo; higher levels plateaued.
  *
- * https://source.android.com/docs/core/architecture/ipc/binder-threading
+ * The ceiling is not Dispatchers.IO (elastic, default 64+). Location reads
+ * call MediaStore.setRequireOriginal + openInputStream, which are Binder
+ * IPCs into MediaProvider. libbinder's default thread pool is 15 threads
+ * ([1]), shared across apps, so concurrency much past ~16 mostly queues on
+ * Binder rather than speeding up.
+ *
+ * [1]: https://source.android.com/docs/core/architecture/ipc/binder-threading#configure
+ * Scoped storage location path: https://developer.android.com/training/data-storage/shared/media#location-info-photos
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(16)
@@ -301,55 +349,8 @@ private class AssetRowData(
 )
 
 /**
- * Copies up to `limit` rows starting at `offset` out of the cursor.
- *
- * Iterates like the original sequential loop so the cursor's final position
- * — used for `hasNextPage` / `endCursor` — is unchanged.
+ * Fetches data for a single asset and places the data into a Bundle.
  */
-private fun drainCursorRows(
-  cursor: Cursor,
-  limit: Int,
-  offset: Int
-): List<AssetRowData> {
-  val idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID)
-  val filenameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
-  val mediaTypeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE)
-  val creationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
-  val modificationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
-  val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
-  val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
-  val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
-  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
-  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
-  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
-
-  val rows = mutableListOf<AssetRowData>()
-  if (!cursor.moveToPosition(offset)) {
-    return rows
-  }
-  var i = 0
-  while (i < limit && !cursor.isAfterLast) {
-    rows.add(
-      AssetRowData(
-        assetId = cursor.getString(idIndex),
-        filename = cursor.getString(filenameIndex),
-        path = cursor.getString(localUriIndex),
-        mediaType = cursor.getInt(mediaTypeIndex),
-        creationTime = cursor.getLong(creationDateIndex),
-        modificationTime = cursor.getLong(modificationDateIndex),
-        durationMs = cursor.getInt(durationIndex),
-        albumId = cursor.getString(albumIdIndex),
-        width = cursor.getInt(widthIndex),
-        height = cursor.getInt(heightIndex),
-        orientation = cursor.getInt(orientationIndex)
-      )
-    )
-    cursor.moveToNext()
-    i++
-  }
-  return rows
-}
-
 private fun buildAssetBundle(
   contentResolver: ContentResolver,
   row: AssetRowData,
@@ -393,6 +394,18 @@ private fun buildAssetBundle(
   return asset
 }
 
+/**
+ * Gets image/video dimensions from the pre-read cursor columns.
+ *
+ * For videos, prefers MediaStore `WIDTH`/`HEIGHT`/`ORIENTATION` (see [1])
+ * and falls back to [getVideoDimensionsFromFile] when the scanner has not
+ * indexed the file yet. For images, uses the same cursor columns with
+ * BitmapFactory and EXIF orientation handling when dimensions are missing.
+ *
+ * [1]: https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#WIDTH
+ *
+ * @return Pair of integers: width and height, respectively
+ */
 private fun getAssetDimensions(
   contentResolver: ContentResolver,
   row: AssetRowData,
@@ -402,6 +415,7 @@ private fun getAssetDimensions(
     if (row.width > 0 && row.height > 0) {
       return maybeRotateAssetSize(row.width, row.height, row.orientation)
     }
+    // Slow fallback for files not yet indexed by the media scanner.
     return getVideoDimensionsFromFile(contentResolver, row.path)
   }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -307,7 +307,7 @@ fun getAssetDimensionsFromCursorFast(
  * @return Pair of integers: width and height, respectively
  */
 @Throws(IOException::class)
-fun getAssetDimensionsSlow(
+private fun getAssetDimensionsSlow(
   contentResolver: ContentResolver,
   exifInterface: ExifInterface?,
   pending: PendingAsset

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -103,7 +103,7 @@ suspend fun putAssetsInfo(
   if (!cursor.moveToPosition(offset)) {
     return
   }
-  val missingDimensionsVideos = mutableListOf<PendingAsset>()
+  val missingDimensionsAssets = mutableListOf<PendingAsset>()
   val pendingFullInfoAssets = mutableListOf<PendingAsset>()
   var i = 0
   while (i < limit && !cursor.isAfterLast) {
@@ -126,18 +126,36 @@ suspend fun putAssetsInfo(
       putDouble("duration", cursor.getInt(durationIndex) / 1000.0)
       putString("albumId", cursor.getString(albumIdIndex))
     }
-    if (dimensions == null && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
-      missingDimensionsVideos.add(PendingAsset(asset, path))
+    if (dimensions == null) {
+      missingDimensionsAssets.add(PendingAsset(asset, path, mediaType))
     }
     if (resolveWithFullInfo && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-      pendingFullInfoAssets.add(PendingAsset(asset, path))
+      pendingFullInfoAssets.add(PendingAsset(asset, path, mediaType))
     }
     cursor.moveToNext()
     response.add(asset)
     i++
   }
 
-  if (missingDimensionsVideos.isNotEmpty() || pendingFullInfoAssets.isNotEmpty()) {
+  withContext(exifReadDispatcher) {
+    // These assets have missing dimensions that require opening the file to read. We do this in
+    // parallel so it runs more quickly.
+    if (missingDimensionsAssets.isNotEmpty()) {
+      missingDimensionsAssets.map { pending ->
+        async {
+          val (width, height) = getAssetDimensionsSlow(
+            contentResolver,
+            pending.path,
+            pending.mediaType,
+            pending.asset.getLong("width").toInt(),
+            pending.asset.getLong("height").toInt()
+          )
+          pending.asset.putLong("width", width.toLong())
+          pending.asset.putLong("height", height.toLong())
+        }
+      }.awaitAll()
+    }
+
     // When resolveWithFullInfo is true, per-file EXIF data (including GPS location) is read in
     // parallel across exifReadDispatcher instead of sequentially.
     //
@@ -145,52 +163,39 @@ suspend fun putAssetsInfo(
     //   so parallelizing them speeds up large queries by several times.
     // - Cursor access is not thread-safe. Paths are copied into pending asset lists during the
     //   cursor loop before parallel file work; workers never touch the cursor.
-    withContext(exifReadDispatcher) {
-      buildList {
-        addAll(
-          missingDimensionsVideos.map { pending ->
-            async {
-              val (width, height) = getVideoDimensionsSlow(contentResolver, pending.path)
-              pending.asset.putLong("width", width.toLong())
-              pending.asset.putLong("height", height.toLong())
-            }
+    if (pendingFullInfoAssets.isNotEmpty()) {
+      pendingFullInfoAssets.map { pending ->
+        async {
+          val localUri = "file://${pending.path}"
+          val assetId = pending.asset.getString("id") ?: return@async
+          val exifInterface = try {
+            ExifInterface(pending.path)
+          } catch (e: IOException) {
+            Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+            e.printStackTrace()
+            return@async
           }
-        )
-        addAll(
-          pendingFullInfoAssets.map { pending ->
-            async {
-              val localUri = "file://${pending.path}"
-              val assetId = pending.asset.getString("id") ?: return@async
-              val exifInterface = try {
-                ExifInterface(pending.path)
-              } catch (e: IOException) {
-                Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-                e.printStackTrace()
-                return@async
-              }
 
-              val (width, height) = getImageDimensionsSlow(
-                pending.path,
-                exifInterface,
-                pending.asset.getLong("width").toInt(),
-                pending.asset.getLong("height").toInt()
-              )
-              pending.asset.putLong("width", width.toLong())
-              pending.asset.putLong("height", height.toLong())
-
-              getExifFullInfo(exifInterface, pending.asset)
-
-              val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
-                getExifLocationForUri(contentResolver, photoUri)
-              } else {
-                getExifLocationLegacy(exifInterface)
-              }
-              pending.asset.putParcelable("location", location)
-              pending.asset.putString("localUri", localUri)
-            }
+          getRotatedImageDimensions(
+            exifInterface,
+            pending.asset.getLong("width").toInt(),
+            pending.asset.getLong("height").toInt()
+          )?.let { (resolvedWidth, resolvedHeight) ->
+            pending.asset.putLong("width", resolvedWidth.toLong())
+            pending.asset.putLong("height", resolvedHeight.toLong())
           }
-        )
+
+          getExifFullInfo(exifInterface, pending.asset)
+
+          val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
+            getExifLocationForUri(contentResolver, photoUri)
+          } else {
+            getExifLocationLegacy(exifInterface)
+          }
+          pending.asset.putParcelable("location", location)
+          pending.asset.putString("localUri", localUri)
+        }
       }.awaitAll()
     }
   }
@@ -295,59 +300,64 @@ fun getAssetDimensionsFromCursorFast(
 }
 
 /**
+ * Gets asset dimensions via file I/O when cursor columns are missing.
  * @return Pair of integers: width and height, respectively
  */
 @Throws(IOException::class)
-fun getVideoDimensionsSlow(
+fun getAssetDimensionsSlow(
   contentResolver: ContentResolver,
-  path: String
-): Pair<Int, Int> {
-  // Slow fallback for files not yet indexed by the media scanner.
-  val videoUri = Uri.parse("file://$path")
-  try {
-    contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
-      MediaMetadataRetriever().use { retriever ->
-        retriever.setDataSource(photoDescriptor!!.fileDescriptor)
-        val videoWidth =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
-        val videoHeight =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
-        val videoOrientation =
-          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
-
-        return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
-      }
-    }
-  } catch (e: NumberFormatException) {
-    Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
-  } catch (e: FileNotFoundException) {
-    Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
-  } catch (e: RuntimeException) {
-    Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
-  }
-  return Pair(0, 0)
-}
-
-/**
- * Gets image dimensions via file I/O when cursor columns are missing and/or EXIF orientation
- * is needed for [maybeRotateAssetSize].
- * @return Pair of integers: width and height, respectively
- */
-fun getImageDimensionsSlow(
   path: String,
-  exifInterface: ExifInterface,
+  mediaType: Int,
   width: Int,
   height: Int
 ): Pair<Int, Int> {
+  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    // Slow fallback for files not yet indexed by the media scanner.
+    val videoUri = Uri.parse("file://$path")
+    try {
+      contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
+        MediaMetadataRetriever().use { retriever ->
+          retriever.setDataSource(photoDescriptor!!.fileDescriptor)
+          val videoWidth =
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
+          val videoHeight =
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
+          val videoOrientation =
+            retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
+
+          return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
+        }
+      }
+    } catch (e: NumberFormatException) {
+      Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
+    } catch (e: FileNotFoundException) {
+      Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
+    } catch (e: RuntimeException) {
+      Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
+    }
+    return Pair(0, 0)
+  }
+
   var resolvedWidth = width
   var resolvedHeight = height
-  var orientation = 0
   if (resolvedWidth <= 0 || resolvedHeight <= 0) {
     val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
     BitmapFactory.decodeFile(path, options)
     resolvedWidth = options.outWidth
     resolvedHeight = options.outHeight
   }
+  return Pair(resolvedWidth, resolvedHeight)
+}
+
+/**
+ * Returns rotated image dimensions when EXIF orientation requires swapping width and height.
+ * @return Rotated dimensions, or `null` if no rotation is needed
+ */
+fun getRotatedImageDimensions(
+  exifInterface: ExifInterface,
+  width: Int,
+  height: Int
+): Pair<Int, Int>? {
   val exifOrientation = exifInterface.getAttributeInt(
     ExifInterface.TAG_ORIENTATION,
     ExifInterface.ORIENTATION_NORMAL
@@ -357,9 +367,9 @@ fun getImageDimensionsSlow(
     exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
     exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
   ) {
-    orientation = 90
+    return maybeRotateAssetSize(width, height, 90)
   }
-  return maybeRotateAssetSize(resolvedWidth, resolvedHeight, orientation)
+  return null
 }
 
 /**
@@ -414,5 +424,6 @@ private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(32)
 
 private data class PendingAsset(
   val asset: Bundle,
-  val path: String
+  val path: String,
+  val mediaType: Int
 )

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -100,17 +100,26 @@ suspend fun putAssetsInfo(
   val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
   val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
   val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
+  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
   if (!cursor.moveToPosition(offset)) {
     return
   }
-  val missingDimensionsAssets = mutableListOf<PendingAsset>()
-  val pendingFullInfoAssets = mutableListOf<PendingAsset>()
+
+  // Assets that we may have to fetch more information for. We do this in parallel later since
+  // it's significantly faster.
+  val pendingAdditionalInfoAssets = mutableListOf<PendingAsset>()
   var i = 0
+
   while (i < limit && !cursor.isAfterLast) {
     val assetId = cursor.getString(idIndex)
     val path = cursor.getString(localUriIndex)
     val localUri = "file://$path"
     val mediaType = cursor.getInt(mediaTypeIndex)
+    val cursorWidth = cursor.getInt(widthIndex)
+    val cursorHeight = cursor.getInt(heightIndex)
+    val cursorOrientation = cursor.getInt(orientationIndex)
     val dimensions = getAssetDimensionsFromCursorFast(cursor, mediaType)
     val width = dimensions?.first ?: 0
     val height = dimensions?.second ?: 0
@@ -126,36 +135,28 @@ suspend fun putAssetsInfo(
       putDouble("duration", cursor.getInt(durationIndex) / 1000.0)
       putString("albumId", cursor.getString(albumIdIndex))
     }
-    if (dimensions == null) {
-      missingDimensionsAssets.add(PendingAsset(asset, path, mediaType))
-    }
-    if (resolveWithFullInfo && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-      pendingFullInfoAssets.add(PendingAsset(asset, path, mediaType))
+
+    val missingDimensions = dimensions == null
+    // If we need to do slower I/O operations, we add them to a list so that we can do them in parallel
+    if (missingDimensions || (resolveWithFullInfo && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE)) {
+      pendingAdditionalInfoAssets.add(
+        PendingAsset(
+          asset = asset,
+          path = path,
+          mediaType = mediaType,
+          cursorWidth = cursorWidth,
+          cursorHeight = cursorHeight,
+          cursorOrientation = cursorOrientation,
+          missingDimensions = missingDimensions
+        )
+      )
     }
     cursor.moveToNext()
     response.add(asset)
     i++
   }
 
-  withContext(exifReadDispatcher) {
-    // These assets have missing dimensions that require opening the file to read. We do this in
-    // parallel so it runs more quickly.
-    if (missingDimensionsAssets.isNotEmpty()) {
-      missingDimensionsAssets.map { pending ->
-        async {
-          val (width, height) = getAssetDimensionsSlow(
-            contentResolver,
-            pending.path,
-            pending.mediaType,
-            pending.asset.getLong("width").toInt(),
-            pending.asset.getLong("height").toInt()
-          )
-          pending.asset.putLong("width", width.toLong())
-          pending.asset.putLong("height", height.toLong())
-        }
-      }.awaitAll()
-    }
-
+  if (pendingAdditionalInfoAssets.isNotEmpty()) {
     // When resolveWithFullInfo is true, per-file EXIF data (including GPS location) is read in
     // parallel across exifReadDispatcher instead of sequentially.
     //
@@ -163,38 +164,39 @@ suspend fun putAssetsInfo(
     //   so parallelizing them speeds up large queries by several times.
     // - Cursor access is not thread-safe. Paths are copied into pending asset lists during the
     //   cursor loop before parallel file work; workers never touch the cursor.
-    if (pendingFullInfoAssets.isNotEmpty()) {
-      pendingFullInfoAssets.map { pending ->
+    withContext(exifReadDispatcher) {
+      pendingAdditionalInfoAssets.map { pending ->
         async {
           val localUri = "file://${pending.path}"
-          val assetId = pending.asset.getString("id") ?: return@async
-          val exifInterface = try {
-            ExifInterface(pending.path)
-          } catch (e: IOException) {
-            Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-            e.printStackTrace()
-            return@async
+          var exifInterface: ExifInterface? = null
+          if (resolveWithFullInfo && pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+            try {
+              exifInterface = ExifInterface(pending.path)
+            } catch (e: IOException) {
+              Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+              e.printStackTrace()
+            }
           }
 
-          getRotatedImageDimensions(
-            exifInterface,
-            pending.asset.getLong("width").toInt(),
-            pending.asset.getLong("height").toInt()
-          )?.let { (resolvedWidth, resolvedHeight) ->
-            pending.asset.putLong("width", resolvedWidth.toLong())
-            pending.asset.putLong("height", resolvedHeight.toLong())
+          if (pending.missingDimensions) {
+            val (width, height) = getAssetDimensionsSlow(contentResolver, exifInterface, pending)
+            pending.asset.putLong("width", width.toLong())
+            pending.asset.putLong("height", height.toLong())
           }
 
-          getExifFullInfo(exifInterface, pending.asset)
+          if (exifInterface != null) {
+            getExifFullInfo(exifInterface, pending.asset)
 
-          val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
-            getExifLocationForUri(contentResolver, photoUri)
-          } else {
-            getExifLocationLegacy(exifInterface)
+            val assetId = pending.asset.getString("id") ?: return@async
+            val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+              val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
+              getExifLocationForUri(contentResolver, photoUri)
+            } else {
+              getExifLocationLegacy(exifInterface)
+            }
+            pending.asset.putParcelable("location", location)
+            pending.asset.putString("localUri", localUri)
           }
-          pending.asset.putParcelable("location", location)
-          pending.asset.putString("localUri", localUri)
         }
       }.awaitAll()
     }
@@ -300,20 +302,19 @@ fun getAssetDimensionsFromCursorFast(
 }
 
 /**
- * Gets asset dimensions via file I/O when cursor columns are missing.
+ * Gets image/video dimensions via file I/O when cursor columns are missing and/or EXIF orientation
+ * is needed for [maybeRotateAssetSize].
  * @return Pair of integers: width and height, respectively
  */
 @Throws(IOException::class)
 fun getAssetDimensionsSlow(
   contentResolver: ContentResolver,
-  path: String,
-  mediaType: Int,
-  width: Int,
-  height: Int
+  exifInterface: ExifInterface?,
+  pending: PendingAsset
 ): Pair<Int, Int> {
-  if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+  if (pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
     // Slow fallback for files not yet indexed by the media scanner.
-    val videoUri = Uri.parse("file://$path")
+    val videoUri = Uri.parse("file://${pending.path}")
     try {
       contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
         MediaMetadataRetriever().use { retriever ->
@@ -331,45 +332,38 @@ fun getAssetDimensionsSlow(
     } catch (e: NumberFormatException) {
       Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
     } catch (e: FileNotFoundException) {
-      Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
+      Log.e("expo-media-library", "ContentResolver failed to read ${pending.path}: ${e.message}")
     } catch (e: RuntimeException) {
       Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
     }
     return Pair(0, 0)
   }
 
-  var resolvedWidth = width
-  var resolvedHeight = height
-  if (resolvedWidth <= 0 || resolvedHeight <= 0) {
-    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
-    BitmapFactory.decodeFile(path, options)
-    resolvedWidth = options.outWidth
-    resolvedHeight = options.outHeight
-  }
-  return Pair(resolvedWidth, resolvedHeight)
-}
+  var width = pending.cursorWidth
+  var height = pending.cursorHeight
+  var orientation = pending.cursorOrientation
 
-/**
- * Returns rotated image dimensions when EXIF orientation requires swapping width and height.
- * @return Rotated dimensions, or `null` if no rotation is needed
- */
-fun getRotatedImageDimensions(
-  exifInterface: ExifInterface,
-  width: Int,
-  height: Int
-): Pair<Int, Int>? {
-  val exifOrientation = exifInterface.getAttributeInt(
-    ExifInterface.TAG_ORIENTATION,
-    ExifInterface.ORIENTATION_NORMAL
-  )
-  if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
-    exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
-    exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
-    exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
-  ) {
-    return maybeRotateAssetSize(width, height, 90)
+  // If the image doesn't have the required information, we can get them from Bitmap.Options
+  if (pending.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE && (width <= 0 || height <= 0)) {
+    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(pending.path, options)
+    width = options.outWidth
+    height = options.outHeight
   }
-  return null
+  if (exifInterface != null) {
+    val exifOrientation = exifInterface.getAttributeInt(
+      ExifInterface.TAG_ORIENTATION,
+      ExifInterface.ORIENTATION_NORMAL
+    )
+    if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+      exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+      exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+      exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
+    ) {
+      orientation = 90
+    }
+  }
+  return maybeRotateAssetSize(width, height, orientation)
 }
 
 /**
@@ -425,5 +419,9 @@ private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(32)
 private data class PendingAsset(
   val asset: Bundle,
   val path: String,
-  val mediaType: Int
+  val mediaType: Int,
+  val cursorWidth: Int,
+  val cursorHeight: Int,
+  val cursorOrientation: Int,
+  val missingDimensions: Boolean
 )

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -109,12 +109,12 @@ suspend fun putAssetsInfo(
     return
   }
 
+  // We limit batches to 5000 since that should keep [AssetRowData] memory
+  // memory usage low.
+  //
   // Large `limit` values would otherwise hold every [AssetRowData] in memory
   // at once. Each row is ~400 bytes (mostly id/filename/path strings), so
   // 5000 * 400 bytes ≈ 2 MB.
-  //
-  // We limit batches to 5000 since that should keep [AssetRowData] memory
-  // memory usage low.
   val ASSET_ROW_BATCH_SIZE = 5000
 
   var remaining = limit
@@ -358,20 +358,28 @@ fun maybeRotateAssetSize(width: Int, height: Int, orientation: Int): Pair<Int, I
 }
 
 /**
- * Bounded parallelism for per-file EXIF reads. Measured on a real device:
- * 8 → ~2.2ms/photo, 16 → ~1.8ms/photo; higher levels plateaued.
+ * Bounded parallelism for per-file EXIF reads.
  *
  * The ceiling is not Dispatchers.IO (elastic, default 64+). Location reads
  * call MediaStore.setRequireOriginal + openInputStream, which are Binder
  * IPCs into MediaProvider. libbinder's default thread pool is 15 threads
- * ([1]), shared across apps, so concurrency much past ~16 mostly queues on
+ * ([1]), shared across apps, so concurrency much past ~32 mostly queues on
  * Binder rather than speeding up.
+ *
+ * This matches our experimental findings. 32 seems to be a good concurrency.
+ * Here are the times to fetch per photo for a group of 300 photos, as tested
+ * with the demo app's MediaLibraryScreen:
+ *
+ * - 16: 4.02 ms
+ * - 32: 2.78 ms
+ * - 64: 3.12 ms
+ * - 128: 3.19 ms
  *
  * [1]: https://source.android.com/docs/core/architecture/ipc/binder-threading#configure
  * Scoped storage location path: https://developer.android.com/training/data-storage/shared/media#location-info-photos
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(16)
+private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(32)
 
 /** One cursor row's columns, copied out so file work can run off-cursor. */
 private class AssetRowData(

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -82,17 +82,6 @@ suspend fun queryAssetInfo(
  * Reads given `cursor` and saves the data to `response` param.
  * Reads `limit` rows, starting by `offset`.
  * Cursor must be a result of query with [ASSET_PROJECTION] projection
- *
- * When [resolveWithFullInfo] is true, per-file EXIF data (including GPS
- * location) is read in parallel across [exifReadDispatcher] instead of
- * sequentially. EXIF location reads cost ~15ms per image sequentially;
- * they are independent per-file I/O, so parallelizing them speeds up large
- * queries by several times. Cursor access is not thread-safe, so cursor columns
- * are copied into [AssetRowData] in batches before parallel file work; workers
- * never touch the cursor. Iteration matches the original sequential loop
- * original sequential loop (moveToPosition, then moveToNext per row) so the
- * cursor's final position — which callers read for `hasNextPage`/`endCursor` —
- * is unchanged.
  */
 @Throws(IOException::class, UnsupportedOperationException::class)
 suspend fun putAssetsInfo(
@@ -153,6 +142,13 @@ suspend fun putAssetsInfo(
       i++
     }
 
+    // When resolveWithFullInfo is true, per-file EXIF data (including GPS location) is read in
+    // parallel across exifReadDispatcher instead of sequentially.
+    //
+    // - EXIF location reads cost ~15ms per image sequentially. They are independent per-file I/O,
+    //   so parallelizing them speeds up large queries by several times.
+    // - Cursor access is not thread-safe. Cursor columns are copied into AssetRowData in batches
+    //   before parallel file work; workers never touch the cursor.
     val bundles = withContext(exifReadDispatcher) {
       rows.map { row ->
         async {
@@ -277,6 +273,8 @@ private fun getAssetDimensions(
   exifInterface: ExifInterface?
 ): Pair<Int, Int> {
   if (row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    // Fast path: read dimensions from cursor data (no file I/O)
+    // MediaStore populates these when the media scanner indexes the file.
     if (row.width > 0 && row.height > 0) {
       return maybeRotateAssetSize(row.width, row.height, row.orientation)
     }

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -19,6 +19,9 @@ import expo.modules.medialibrary.EXIF_TAGS
 import expo.modules.medialibrary.MediaType
 import expo.modules.medialibrary.UnableToLoadException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import java.io.FileNotFoundException
@@ -79,9 +82,13 @@ suspend fun queryAssetInfo(
  * Reads given `cursor` and saves the data to `response` param.
  * Reads `limit` rows, starting by `offset`.
  * Cursor must be a result of query with [ASSET_PROJECTION] projection
+ *
+ * When [resolveWithFullInfo] is true, per-file EXIF and location reads run in
+ * parallel (bounded by [exifReadDispatcher]). Cursor access is not
+ * thread-safe, so rows are copied in [drainCursorRows] first.
  */
 @Throws(IOException::class, UnsupportedOperationException::class)
-fun putAssetsInfo(
+suspend fun putAssetsInfo(
   contentResolver: ContentResolver,
   cursor: Cursor,
   response: MutableList<Bundle>,
@@ -89,62 +96,15 @@ fun putAssetsInfo(
   offset: Int,
   resolveWithFullInfo: Boolean
 ) {
-  val idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID)
-  val filenameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
-  val mediaTypeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE)
-  val creationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
-  val modificationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
-  val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
-  val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
-  val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
-  if (!cursor.moveToPosition(offset)) {
-    return
-  }
-  var i = 0
-  while (i < limit && !cursor.isAfterLast) {
-    val assetId = cursor.getString(idIndex)
-    val path = cursor.getString(localUriIndex)
-    val localUri = "file://$path"
-    val mediaType = cursor.getInt(mediaTypeIndex)
-    var exifInterface: ExifInterface? = null
-    if (resolveWithFullInfo && mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
-      try {
-        exifInterface = ExifInterface(path)
-      } catch (e: IOException) {
-        Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
-        e.printStackTrace()
+  val rows = drainCursorRows(cursor, limit, offset)
+  val bundles = withContext(exifReadDispatcher) {
+    rows.map { row ->
+      async {
+        buildAssetBundle(contentResolver, row, resolveWithFullInfo)
       }
-    }
-    val (width, height) =
-      getAssetDimensionsFromCursor(contentResolver, exifInterface, cursor, mediaType, localUriIndex)
-    val asset = Bundle().apply {
-      putString("id", assetId)
-      putString("filename", cursor.getString(filenameIndex))
-      putString("uri", localUri)
-      putString("mediaType", exportMediaType(mediaType))
-      putLong("width", width.toLong())
-      putLong("height", height.toLong())
-      putLong("creationTime", cursor.getLong(creationDateIndex))
-      putDouble("modificationTime", cursor.getLong(modificationDateIndex) * 1000.0)
-      putDouble("duration", cursor.getInt(durationIndex) / 1000.0)
-      putString("albumId", cursor.getString(albumIdIndex))
-    }
-    if (resolveWithFullInfo && exifInterface != null) {
-      getExifFullInfo(exifInterface, asset)
-
-      val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, assetId)
-        getExifLocationForUri(contentResolver, photoUri)
-      } else {
-        getExifLocationLegacy(exifInterface)
-      }
-      asset.putParcelable("location", location)
-      asset.putString("localUri", localUri)
-    }
-    cursor.moveToNext()
-    response.add(asset)
-    i++
+    }.awaitAll()
   }
+  response.addAll(bundles)
 }
 
 fun getExifFullInfo(exifInterface: ExifInterface, response: Bundle) {
@@ -312,4 +272,191 @@ fun maybeRotateAssetSize(width: Int, height: Int, orientation: Int): Pair<Int, I
   } else {
     Pair(width, height)
   }
+}
+
+/**
+ * Bounded parallelism for per-file EXIF reads. Location reads call
+ * MediaStore.setRequireOriginal + openInputStream (Binder IPC into
+ * MediaProvider). libbinder's default thread pool is 15 threads, shared
+ * across apps, so concurrency much past ~16 mostly queues on Binder.
+ *
+ * https://source.android.com/docs/core/architecture/ipc/binder-threading
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+private val exifReadDispatcher = Dispatchers.IO.limitedParallelism(16)
+
+/** One cursor row's columns, copied out so file work can run off-cursor. */
+private class AssetRowData(
+  val assetId: String,
+  val filename: String,
+  val path: String,
+  val mediaType: Int,
+  val creationTime: Long,
+  val modificationTime: Long,
+  val durationMs: Int,
+  val albumId: String?,
+  val width: Int,
+  val height: Int,
+  val orientation: Int
+)
+
+/**
+ * Copies up to `limit` rows starting at `offset` out of the cursor.
+ *
+ * Iterates like the original sequential loop so the cursor's final position
+ * — used for `hasNextPage` / `endCursor` — is unchanged.
+ */
+private fun drainCursorRows(
+  cursor: Cursor,
+  limit: Int,
+  offset: Int
+): List<AssetRowData> {
+  val idIndex = cursor.getColumnIndex(MediaStore.Images.Media._ID)
+  val filenameIndex = cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
+  val mediaTypeIndex = cursor.getColumnIndex(MediaStore.Files.FileColumns.MEDIA_TYPE)
+  val creationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_TAKEN)
+  val modificationDateIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATE_MODIFIED)
+  val durationIndex = cursor.getColumnIndex(MediaStore.Video.VideoColumns.DURATION)
+  val localUriIndex = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+  val albumIdIndex = cursor.getColumnIndex(MediaStore.Images.Media.BUCKET_ID)
+  val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+  val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+  val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+
+  val rows = mutableListOf<AssetRowData>()
+  if (!cursor.moveToPosition(offset)) {
+    return rows
+  }
+  var i = 0
+  while (i < limit && !cursor.isAfterLast) {
+    rows.add(
+      AssetRowData(
+        assetId = cursor.getString(idIndex),
+        filename = cursor.getString(filenameIndex),
+        path = cursor.getString(localUriIndex),
+        mediaType = cursor.getInt(mediaTypeIndex),
+        creationTime = cursor.getLong(creationDateIndex),
+        modificationTime = cursor.getLong(modificationDateIndex),
+        durationMs = cursor.getInt(durationIndex),
+        albumId = cursor.getString(albumIdIndex),
+        width = cursor.getInt(widthIndex),
+        height = cursor.getInt(heightIndex),
+        orientation = cursor.getInt(orientationIndex)
+      )
+    )
+    cursor.moveToNext()
+    i++
+  }
+  return rows
+}
+
+private fun buildAssetBundle(
+  contentResolver: ContentResolver,
+  row: AssetRowData,
+  resolveWithFullInfo: Boolean
+): Bundle {
+  val localUri = "file://${row.path}"
+  var exifInterface: ExifInterface? = null
+  if (resolveWithFullInfo && row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE) {
+    try {
+      exifInterface = ExifInterface(row.path)
+    } catch (e: IOException) {
+      Log.w("expo-media-library", "Could not parse EXIF tags for $localUri")
+      e.printStackTrace()
+    }
+  }
+  val (width, height) = getAssetDimensions(contentResolver, row, exifInterface)
+  val asset = Bundle().apply {
+    putString("id", row.assetId)
+    putString("filename", row.filename)
+    putString("uri", localUri)
+    putString("mediaType", exportMediaType(row.mediaType))
+    putLong("width", width.toLong())
+    putLong("height", height.toLong())
+    putLong("creationTime", row.creationTime)
+    putDouble("modificationTime", row.modificationTime * 1000.0)
+    putDouble("duration", row.durationMs / 1000.0)
+    putString("albumId", row.albumId)
+  }
+  if (resolveWithFullInfo && exifInterface != null) {
+    getExifFullInfo(exifInterface, asset)
+
+    val location = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      val photoUri = Uri.withAppendedPath(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, row.assetId)
+      getExifLocationForUri(contentResolver, photoUri)
+    } else {
+      getExifLocationLegacy(exifInterface)
+    }
+    asset.putParcelable("location", location)
+    asset.putString("localUri", localUri)
+  }
+  return asset
+}
+
+private fun getAssetDimensions(
+  contentResolver: ContentResolver,
+  row: AssetRowData,
+  exifInterface: ExifInterface?
+): Pair<Int, Int> {
+  if (row.mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    if (row.width > 0 && row.height > 0) {
+      return maybeRotateAssetSize(row.width, row.height, row.orientation)
+    }
+    return getVideoDimensionsFromFile(contentResolver, row.path)
+  }
+
+  var width = row.width
+  var height = row.height
+  var orientation = row.orientation
+
+  if (width <= 0 || height <= 0) {
+    val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeFile(row.path, options)
+    width = options.outWidth
+    height = options.outHeight
+  }
+  if (exifInterface != null) {
+    val exifOrientation = exifInterface.getAttributeInt(
+      ExifInterface.TAG_ORIENTATION,
+      ExifInterface.ORIENTATION_NORMAL
+    )
+    if (exifOrientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+      exifOrientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+      exifOrientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+      exifOrientation == ExifInterface.ORIENTATION_TRANSVERSE
+    ) {
+      orientation = 90
+    }
+  }
+  return maybeRotateAssetSize(width, height, orientation)
+}
+
+@Throws(IOException::class)
+private fun getVideoDimensionsFromFile(
+  contentResolver: ContentResolver,
+  path: String
+): Pair<Int, Int> {
+  val videoUri = Uri.parse("file://$path")
+  try {
+    contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->
+      MediaMetadataRetriever().use { retriever ->
+        retriever.setDataSource(photoDescriptor!!.fileDescriptor)
+        val videoWidth =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
+        val videoHeight =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
+        val videoOrientation =
+          retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)!!.toInt()
+
+        return maybeRotateAssetSize(videoWidth, videoHeight, videoOrientation)
+      }
+    }
+  } catch (e: NumberFormatException) {
+    Log.e("expo-media-library", "MediaMetadataRetriever unexpectedly returned non-integer: ${e.message}")
+  } catch (e: FileNotFoundException) {
+    Log.e("expo-media-library", "ContentResolver failed to read $path: ${e.message}")
+  } catch (e: RuntimeException) {
+    Log.e("expo-media-library", "MediaMetadataRetriever finished with unexpected error: ${e.message}")
+  }
+  return Pair(0, 0)
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -34,7 +34,8 @@ internal class AssetUtilsTests {
     val cursor = mockCursor(
       arrayOf(
         MockData.mockVideo.toColumnArray(),
-        MockData.mockAudio.toColumnArray()
+        MockData.mockAudio.toColumnArray(),
+        MockData.mockImage.toColumnArray()
       )
     )
 
@@ -45,14 +46,19 @@ internal class AssetUtilsTests {
     putAssetsInfo(contentResolver, cursor, result, limit = 5, offset = 0, resolveWithFullInfo = false)
 
     // assert
-    assertEquals(2, result.size)
+    assertEquals(3, result.size)
+
+    result.forEach { asset ->
+      // no exif or detailed ddata
+      assertNull(asset.getString("localUri"))
+      assertNull(asset.getParcelable("exif"))
+      assertNull(asset.getParcelable("location"))
+    }
 
     assertEquals(MockData.mockVideo.id.toString(), result[0].getString("id"))
     assertEquals("file://${MockData.mockVideo.path}", result[0].getString("uri"))
     assertEquals(MockData.mockVideo.width!!.toLong(), result[0].getLong("width"))
     assertEquals(MockData.mockVideo.height!!.toLong(), result[0].getLong("height"))
-
-    assertNull(result[0].getString("localUri"))
   }
 
   @Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -1,15 +1,20 @@
 package expo.modules.medialibrary.assets
 
+import android.os.Build
 import android.os.Bundle
 import androidx.exifinterface.media.ExifInterface
-import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.EXIF_TAGS
+import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -59,6 +64,41 @@ internal class AssetUtilsTests {
     assertEquals("file://${MockData.mockVideo.path}", result[0].getString("uri"))
     assertEquals(MockData.mockVideo.width!!.toLong(), result[0].getLong("width"))
     assertEquals(MockData.mockVideo.height!!.toLong(), result[0].getLong("height"))
+  }
+
+  @Test
+  fun `putAssetsInfo returns exif and location when fullInfo=true for images`() = runTest {
+    mockkConstructor(ExifInterface::class)
+    every { anyConstructed<ExifInterface>().getAttribute(any()) } returns "value"
+    every { anyConstructed<ExifInterface>().getAttributeInt(any(), any()) } returns 1
+    every { anyConstructed<ExifInterface>().getAttributeDouble(any(), any()) } returns 1.0
+    every { anyConstructed<ExifInterface>().latLong } returns doubleArrayOf(1.23, 4.56)
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      mockkStatic(::getExifLocationForUri)
+      every { getExifLocationForUri(any(), any()) } returns Bundle().apply {
+        putDouble("latitude", 1.23)
+        putDouble("longitude", 4.56)
+      }
+    }
+
+    val cursor = mockCursor(arrayOf(MockData.mockImage.toColumnArray()))
+    val contentResolver = mockContentResolver(cursor)
+    val result = mutableListOf<Bundle>()
+
+    putAssetsInfo(contentResolver, cursor, result, limit = 1, offset = 0, resolveWithFullInfo = true)
+
+    assertEquals(1, result.size)
+    val asset = result[0]
+    assertEquals("file://${MockData.mockImage.path}", asset.getString("localUri"))
+    assertNotNull(asset.getParcelable("exif"))
+    assertNotNull(asset.getParcelable("location"))
+    verify { anyConstructed<ExifInterface>() }
+
+    unmockkConstructor(ExifInterface::class)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      unmockkStatic(::getExifLocationForUri)
+    }
   }
 
   @Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -1,8 +1,10 @@
 package expo.modules.medialibrary.assets
 
+import android.graphics.BitmapFactory
 import android.os.Bundle
 import androidx.exifinterface.media.ExifInterface
 import expo.modules.medialibrary.EXIF_TAGS
+import expo.modules.medialibrary.MockAsset
 import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockCursor
@@ -10,22 +12,35 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
 internal class AssetUtilsTests {
+  private val existingImagePath: String by lazy {
+    File.createTempFile("expo-media-library", ".jpg").apply {
+      deleteOnExit()
+      writeBytes(byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte(), 0xD9.toByte()))
+    }.absolutePath
+  }
+
   @After
   fun tearDown() {
     clearAllMocks()
+    unmockkAll()
   }
 
   @Test
@@ -51,8 +66,8 @@ internal class AssetUtilsTests {
     result.forEach { asset ->
       // no exif or detailed ddata
       assertNull(asset.getString("localUri"))
-      assertNull(asset.getParcelable("exif"))
-      assertNull(asset.getParcelable("location"))
+      assertFalse(asset.containsKey("exif"))
+      assertFalse(asset.containsKey("location"))
     }
 
     assertEquals(MockData.mockVideo.id.toString(), result[0].getString("id"))
@@ -84,6 +99,81 @@ internal class AssetUtilsTests {
   }
 
   @Test
+  fun `putAssetsInfo applies exif orientation over cursor orientation when fullInfo=true`() = runTest {
+    mockExifOrientation(ExifInterface.ORIENTATION_ROTATE_90)
+
+    val asset = putSingleAsset(
+      MockData.mockImage.copy(path = existingImagePath, width = 100, height = 200, orientation = 0),
+      resolveWithFullInfo = true
+    )
+
+    assertEquals(200L, asset.getLong("width"))
+    assertEquals(100L, asset.getLong("height"))
+  }
+
+  @Test
+  fun `putAssetsInfo keeps cursor orientation when exif orientation is normal`() = runTest {
+    mockExifOrientation(ExifInterface.ORIENTATION_NORMAL)
+
+    val asset = putSingleAsset(
+      MockData.mockImage.copy(path = existingImagePath, width = 100, height = 200, orientation = 90),
+      resolveWithFullInfo = true
+    )
+
+    assertEquals(200L, asset.getLong("width"))
+    assertEquals(100L, asset.getLong("height"))
+  }
+
+  @Test
+  fun `putAssetsInfo does not read exif when fullInfo=false`() = runTest {
+    mockExifOrientation(ExifInterface.ORIENTATION_ROTATE_90)
+
+    val asset = putSingleAsset(
+      MockData.mockImage.copy(width = 100, height = 200, orientation = 0),
+      resolveWithFullInfo = false
+    )
+
+    assertEquals(100L, asset.getLong("width"))
+    assertEquals(200L, asset.getLong("height"))
+    assertNull(asset.getString("localUri"))
+    assertFalse(asset.containsKey("exif"))
+    assertFalse(asset.containsKey("location"))
+    verify(exactly = 0) {
+      anyConstructed<ExifInterface>().getAttributeInt(ExifInterface.TAG_ORIENTATION, any())
+    }
+  }
+
+  @Test
+  fun `putAssetsInfo decodes dimensions when cursor dimensions are missing`() = runTest {
+    mockDecodedBounds(width = 300, height = 400)
+
+    val asset = putSingleAsset(
+      MockData.mockImage.copy(width = 0, height = 0, orientation = 0),
+      resolveWithFullInfo = false
+    )
+
+    assertEquals(300L, asset.getLong("width"))
+    assertEquals(400L, asset.getLong("height"))
+    assertNull(asset.getString("localUri"))
+    assertFalse(asset.containsKey("exif"))
+    assertFalse(asset.containsKey("location"))
+  }
+
+  @Test
+  fun `putAssetsInfo keeps decoded dimensions when fullInfo=true`() = runTest {
+    mockDecodedBounds(width = 300, height = 400)
+    mockExifOrientation(ExifInterface.ORIENTATION_ROTATE_90)
+
+    val asset = putSingleAsset(
+      MockData.mockImage.copy(path = existingImagePath, width = 0, height = 0, orientation = 0),
+      resolveWithFullInfo = true
+    )
+
+    assertEquals(400L, asset.getLong("width"))
+    assertEquals(300L, asset.getLong("height"))
+  }
+
+  @Test
   fun `maybeRotateAssetSize returns correct values`() {
     // arrange
     val width = 100
@@ -104,6 +194,38 @@ internal class AssetUtilsTests {
     assertEquals(nonSwappedDimensions, rotated_180)
     assertEquals(swappedDimensions, rotated_270)
     assertEquals(swappedDimensions, rotated_m90)
+  }
+
+  private suspend fun putSingleAsset(mockAsset: MockAsset, resolveWithFullInfo: Boolean): Bundle {
+    val cursor = mockCursor(arrayOf(mockAsset.toColumnArray()))
+    val contentResolver = mockContentResolver(cursor)
+    every { contentResolver.openInputStream(any()) } returns null
+
+    val result = mutableListOf<Bundle>()
+    putAssetsInfo(contentResolver, cursor, result, limit = 1, offset = 0, resolveWithFullInfo)
+
+    assertEquals(1, result.size)
+    return result.single()
+  }
+
+  private fun mockExifOrientation(exifOrientation: Int) {
+    mockkConstructor(ExifInterface::class)
+    every { anyConstructed<ExifInterface>().getAttribute(any()) } returns null
+    every { anyConstructed<ExifInterface>().latLong } returns null
+    every {
+      anyConstructed<ExifInterface>().getAttributeInt(ExifInterface.TAG_ORIENTATION, any())
+    } returns exifOrientation
+  }
+
+  private fun mockDecodedBounds(width: Int, height: Int) {
+    mockkStatic(BitmapFactory::class)
+    every { BitmapFactory.decodeFile(any(), any()) } answers {
+      secondArg<BitmapFactory.Options>().apply {
+        outWidth = width
+        outHeight = height
+      }
+      null
+    }
   }
 
   @RunWith(RobolectricTestRunner::class)

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -67,41 +67,6 @@ internal class AssetUtilsTests {
   }
 
   @Test
-  fun `putAssetsInfo returns exif and location when fullInfo=true for images`() = runTest {
-    mockkConstructor(ExifInterface::class)
-    every { anyConstructed<ExifInterface>().getAttribute(any()) } returns "value"
-    every { anyConstructed<ExifInterface>().getAttributeInt(any(), any()) } returns 1
-    every { anyConstructed<ExifInterface>().getAttributeDouble(any(), any()) } returns 1.0
-    every { anyConstructed<ExifInterface>().latLong } returns doubleArrayOf(1.23, 4.56)
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      mockkStatic(::getExifLocationForUri)
-      every { getExifLocationForUri(any(), any()) } returns Bundle().apply {
-        putDouble("latitude", 1.23)
-        putDouble("longitude", 4.56)
-      }
-    }
-
-    val cursor = mockCursor(arrayOf(MockData.mockImage.toColumnArray()))
-    val contentResolver = mockContentResolver(cursor)
-    val result = mutableListOf<Bundle>()
-
-    putAssetsInfo(contentResolver, cursor, result, limit = 1, offset = 0, resolveWithFullInfo = true)
-
-    assertEquals(1, result.size)
-    val asset = result[0]
-    assertEquals("file://${MockData.mockImage.path}", asset.getString("localUri"))
-    assertNotNull(asset.getParcelable("exif"))
-    assertNotNull(asset.getParcelable("location"))
-    verify { anyConstructed<ExifInterface>() }
-
-    unmockkConstructor(ExifInterface::class)
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      unmockkStatic(::getExifLocationForUri)
-    }
-  }
-
-  @Test
   fun `putAssetsInfo preserves cursor position for pagination`() = runTest {
     val cursor = mockCursor(
       arrayOf(

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -1,6 +1,5 @@
 package expo.modules.medialibrary.assets
 
-import android.os.Build
 import android.os.Bundle
 import androidx.exifinterface.media.ExifInterface
 import expo.modules.medialibrary.EXIF_TAGS
@@ -11,10 +10,6 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
-import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
-import io.mockk.unmockkConstructor
-import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -10,7 +10,6 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkClass
-import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.After

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -59,6 +59,10 @@ internal class AssetUtilsTests {
     assertEquals("file://${MockData.mockVideo.path}", result[0].getString("uri"))
     assertEquals(MockData.mockVideo.width!!.toLong(), result[0].getLong("width"))
     assertEquals(MockData.mockVideo.height!!.toLong(), result[0].getLong("height"))
+
+    assertEquals(MockData.mockAudio.id.toString(), result[1].getString("id"))
+    assertEquals(0L, result[1].getLong("width"))
+    assertEquals(0L, result[1].getLong("height"))
   }
 
   @Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/AssetUtilsTests.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.mockkClass
 import io.mockk.mockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -29,7 +30,7 @@ internal class AssetUtilsTests {
   }
 
   @Test
-  fun `putAssetsInfo returns correct response when fullInfo=false`() {
+  fun `putAssetsInfo returns correct response when fullInfo=false`() = runTest {
     // arrange
     val cursor = mockCursor(
       arrayOf(
@@ -40,26 +41,37 @@ internal class AssetUtilsTests {
 
     val contentResolver = mockContentResolver(cursor)
 
-    mockkStatic(::getAssetDimensionsFromCursor)
-    every {
-      getAssetDimensionsFromCursor(contentResolver, any(), cursor, any(), any())
-    } returns Pair(0, 0) andThen Pair(100, 200)
-
     // act
     val result = mutableListOf<Bundle>()
     putAssetsInfo(contentResolver, cursor, result, limit = 5, offset = 0, resolveWithFullInfo = false)
 
     // assert
-    verify(exactly = 0) {
-      getExifFullInfo(any(), any())
-    }
-
     assertEquals(2, result.size)
 
     assertEquals(MockData.mockVideo.id.toString(), result[0].getString("id"))
     assertEquals("file://${MockData.mockVideo.path}", result[0].getString("uri"))
+    assertEquals(MockData.mockVideo.width!!.toLong(), result[0].getLong("width"))
+    assertEquals(MockData.mockVideo.height!!.toLong(), result[0].getLong("height"))
 
     assertNull(result[0].getString("localUri"))
+  }
+
+  @Test
+  fun `putAssetsInfo preserves cursor position for pagination`() = runTest {
+    val cursor = mockCursor(
+      arrayOf(
+        MockData.mockImage.toColumnArray(),
+        MockData.mockVideo.toColumnArray(),
+        MockData.mockAudio.toColumnArray()
+      )
+    )
+    val contentResolver = mockContentResolver(cursor)
+    val result = mutableListOf<Bundle>()
+
+    putAssetsInfo(contentResolver, cursor, result, limit = 2, offset = 0, resolveWithFullInfo = false)
+
+    assertEquals(2, result.size)
+    assertEquals(2, cursor.position)
   }
 
   @Test

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -94,8 +94,8 @@ internal class GetAssetInfoTests {
       )
     )
 
-    mockkStatic(MediaLibraryUtils::class)
-    every {
+    mockkStatic(::putAssetsInfo)
+    coEvery {
       putAssetsInfo(any(), any(), any(), any(), any(), any())
     } just runs
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetInfoTests.kt
@@ -3,7 +3,6 @@ package expo.modules.medialibrary.assets
 import android.os.Bundle
 import android.provider.MediaStore
 import expo.modules.medialibrary.AssetQueryException
-import expo.modules.medialibrary.MediaLibraryUtils
 import expo.modules.medialibrary.MockContext
 import expo.modules.medialibrary.MockData
 import expo.modules.medialibrary.UnableToLoadException
@@ -12,7 +11,6 @@ import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/assets/GetAssetsTest.kt
@@ -8,6 +8,7 @@ import expo.modules.medialibrary.UnableToLoadException
 import expo.modules.medialibrary.mockContentResolver
 import expo.modules.medialibrary.mockContentResolverForResult
 import expo.modules.medialibrary.throwableContentResolver
+import io.mockk.coEvery
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.just
@@ -48,7 +49,7 @@ internal class GetAssetsTest {
     every { getQueryFromOptions(any()) } returns GetAssetsQuery(selection = "", order = "", limit = 10.0, offset = 0)
 
     mockkStatic(::putAssetsInfo)
-    every { putAssetsInfo(any(), any(), any(), any(), any(), any()) } just runs
+    coEvery { putAssetsInfo(any(), any(), any(), any(), any(), any()) } just runs
   }
 
   @After

--- a/packages/expo-media-library/src/legacy/MediaLibrary.ts
+++ b/packages/expo-media-library/src/legacy/MediaLibrary.ts
@@ -121,6 +121,12 @@ export type Asset = {
    * @platform android
    */
   albumId?: string;
+  /**
+   * GPS location if available. On iOS, `getAssetsAsync` includes this field for all asset types when
+   * the asset has location metadata. On Android, `getAssetsAsync` includes this field for image
+   * assets only when you pass `resolveWithFullInfo: true`.
+   */
+  location?: Location;
 };
 
 // @needsAudit
@@ -322,8 +328,13 @@ export type AssetsOptions = {
    */
   createdBefore?: Date | number;
   /**
-   * Whether to resolve full info for the assets during the query.
-   * This is useful to get the full EXIF data for images. It can fix the orientation of the image.
+   * Whether to resolve full EXIF metadata for image assets during the query.
+   * When enabled, Android resolves EXIF data (including orientation) and GPS location for image assets.
+   * On iOS, `getAssetsAsync` includes GPS location for all asset types even when this option is disabled.
+   *
+   * > **Note:** On Android, enabling this option significantly increases request time (~5×),
+   * > because the library fetches EXIF and location data per image.
+   *
    * @default false
    * @platform android
    */
@@ -690,7 +701,8 @@ export async function deleteAssetsAsync(assets: AssetRef[] | AssetRef): Promise<
 
 // @needsAudit
 /**
- * Provides more information about an asset, including GPS location, local URI and EXIF metadata.
+ * Provides more information about an asset, including GPS location, local URI, and EXIF metadata.
+ * On Android, the library resolves location and EXIF data for image assets only.
  * For better performance, prefer using individual getters such as `asset.getLocation()` or `asset.getExif()` to fetch only the data you need.
  * @param asset An [Asset](#asset) or its ID.
  * @param options
@@ -850,8 +862,15 @@ export async function deleteAlbumsAsync(
 // @needsAudit
 /**
  * Fetches a page of assets matching the provided criteria.
+ * Returned assets may include a `location` field when GPS metadata is available.
+ * On iOS, `getAssetsAsync` includes location for all asset types by default.
+ * On Android, pass `resolveWithFullInfo: true` to resolve location and full EXIF data for image assets only.
+ *
+ * > **Note:** On Android, `resolveWithFullInfo: true` significantly increases request time (~5×),
+ * > because the library fetches EXIF and location data per image.
+ *
  * @param assetsOptions
- * @return A promise that fulfils with to [`PagedInfo`](/versions/latest/sdk/media-library-legacy/#pagedinfo) object with array of [`Asset`](#asset)s.
+ * @return A promise that fulfils with a [`PagedInfo`](/versions/latest/sdk/media-library-legacy/#pagedinfo) object with an array of [`Asset`](#asset)s.
  */
 export async function getAssetsAsync(assetsOptions: AssetsOptions = {}): Promise<PagedInfo<Asset>> {
   if (!MediaLibrary.getAssetsAsync) {

--- a/packages/expo-media-library/src/legacy/MediaLibrary.ts
+++ b/packages/expo-media-library/src/legacy/MediaLibrary.ts
@@ -122,8 +122,7 @@ export type Asset = {
    */
   albumId?: string;
   /**
-   * GPS location if available. On iOS, `getAssetsAsync` includes this field for all asset types when
-   * the asset has location metadata. On Android, `getAssetsAsync` includes this field for image
+   * GPS location if available. On Android, `getAssetsAsync` includes this field for image
    * assets only when you pass `resolveWithFullInfo: true`.
    */
   location?: Location;
@@ -330,7 +329,6 @@ export type AssetsOptions = {
   /**
    * Whether to resolve full EXIF metadata for image assets during the query.
    * When enabled, Android resolves EXIF data (including orientation) and GPS location for image assets.
-   * On iOS, `getAssetsAsync` includes GPS location for all asset types even when this option is disabled.
    *
    * > **Note:** On Android, enabling this option significantly increases request time (~5×),
    * > because the library fetches EXIF and location data per image.
@@ -863,7 +861,6 @@ export async function deleteAlbumsAsync(
 /**
  * Fetches a page of assets matching the provided criteria.
  * Returned assets may include a `location` field when GPS metadata is available.
- * On iOS, `getAssetsAsync` includes location for all asset types by default.
  * On Android, pass `resolveWithFullInfo: true` to resolve location and full EXIF data for image assets only.
  *
  * > **Note:** On Android, `resolveWithFullInfo: true` significantly increases request time (~5×),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       expo-location:
         specifier: workspace:*
         version: link:../../packages/expo-location
+      expo-media-library:
+        specifier: workspace:*
+        version: link:../../packages/expo-media-library
       expo-navigation-bar:
         specifier: workspace:*
         version: link:../../packages/expo-navigation-bar


### PR DESCRIPTION
# Why

We noticed that fetching detailed asset data when `resolveWithFullInfo` was set to `true` was quite slow on Android. The bottleneck was the sequential per-file EXIF and location reads inside `putAssetsInfo` — each image required opening the file and calling into MediaProvider via Binder IPC (~15ms per image). That being said, the old code did this entirely linearly, with no parallelism, which was inefficient since most time was spent waiting on I/O.

**Credits:** this was based off of internal work at Wanderlog by @robin-pham

# Impact

**For a read of 300 photos**

- Before: 5-6 seconds
- After: 500-800ms

# How

- Refactored `putAssetsInfo` to copy cursor rows into `AssetRowData` in batches (up to 5000 rows), then process each batch in parallel on a dedicated `Dispatchers.IO.limitedParallelism(32)` dispatcher.
- Parallel workers perform EXIF parsing, dimension resolution, and GPS location reads (`getExifLocationForUri` / legacy path) without touching the cursor, which is not thread-safe.
- Concurrency is capped at 32 based on experimentation — higher values mostly queue on Binder's shared thread pool rather than improving throughput.
- Added unit test coverage for `resolveWithFullInfo=true` and cursor pagination preservation.
- Updated the native-component-list Media Library screen and bare-expo config to make manual performance testing easier (page size selector, fetch timing display, `resolveWithFullInfo` toggle on Android).

# Test Plan

- [x] Android native unit tests: `pnpm expotools native-unit-tests --platform android --packages expo-media-library`
- [x] Test-suite E2E on Android: `cd apps/bare-expo && pnpm test:android`
- [x] Manual performance comparison: `cd apps/bare-expo && pnpm android`

| Test results | Media Library fetch timing (before) | Media Library fetch timing (after) |
| --- | --- | --- |
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/cae9dd9d-d934-403f-af6c-aecb2413b135" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/4d02bc11-4d39-49b1-8c76-75207d9afa24" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/1ae35c2a-9f33-42cd-9b30-18ee3060b3f5" /> |

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)