### PR TITLE
[router] Remove redundant `root` fallback in `useNavigation`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove `NavigationContainerRefContext` fallback in `useNavigation`. The hook now throws when called outside a navigator, including components rendered via `ExpoRoot`'s `wrapper` prop. ([#48638](https://github.com/expo/expo/pull/48638) by [@Ubax](https://github.com/Ubax))
 - Allow `key` to be `undefined` in the `Descriptor` type and in routes passed to screen `options`, navigator `screenOptions`, and `RouteGroupConfig.screenOptions` callbacks. ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
 - Make `href: null` hide JS tabs and make their routes unreachable, redirecting navigation to the initial tab. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
@@ -120,7 +120,7 @@ test("gets navigation's parent's parent from context", () => {
   );
 });
 
-test('throws if called outside a navigator', () => {
+test('throws when inside a container but outside any navigator', () => {
   expect.assertions(1);
 
   const TestNavigator = (props: any): any => {
@@ -136,7 +136,7 @@ test('throws if called outside a navigator', () => {
   const Test = () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     expect(() => useNavigation()).toThrow(
-      "Couldn't find a navigation object. This is most likely an issue in expo-router."
+      "Couldn't find a navigation object. Make sure the component is rendered inside your app's route tree. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues."
     );
 
     return null;
@@ -152,13 +152,13 @@ test('throws if called outside a navigator', () => {
   );
 });
 
-test('throws if called outside a navigation context', () => {
+test('throws when outside the navigation container', () => {
   expect.assertions(1);
 
   const Test = () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     expect(() => useNavigation()).toThrow(
-      "Couldn't find a navigation object. This is most likely an issue in expo-router."
+      "Couldn't find a navigation object. Make sure the component is rendered inside your app's route tree. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues."
     );
 
     return null;

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
@@ -120,7 +120,7 @@ test("gets navigation's parent's parent from context", () => {
   );
 });
 
-test('gets navigation from container from context', () => {
+test('throws if called outside a navigator', () => {
   expect.assertions(1);
 
   const TestNavigator = (props: any): any => {
@@ -134,9 +134,10 @@ test('gets navigation from container from context', () => {
   };
 
   const Test = () => {
-    const navigation = useNavigation();
-
-    expect(navigation.navigate).toBeDefined();
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    expect(() => useNavigation()).toThrow(
+      "Couldn't find a navigation object. This is most likely an issue in expo-router."
+    );
 
     return null;
   };
@@ -157,7 +158,7 @@ test('throws if called outside a navigation context', () => {
   const Test = () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     expect(() => useNavigation()).toThrow(
-      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+      "Couldn't find a navigation object. This is most likely an issue in expo-router."
     );
 
     return null;

--- a/packages/expo-router/src/react-navigation/core/useNavigation.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigation.tsx
@@ -19,10 +19,9 @@ export function useNavigation<
 
   if (navigation === undefined) {
     throw new Error(
-      "Couldn't find a navigation object. This is most likely an issue in expo-router."
+      "Couldn't find a navigation object. Make sure the component is rendered inside your app's route tree. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues."
     );
   }
 
-  // FIXME: Figure out a better way to do this
-  return navigation as unknown as T;
+  return navigation as T;
 }

--- a/packages/expo-router/src/react-navigation/core/useNavigation.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigation.tsx
@@ -2,7 +2,6 @@
 import { use } from 'react';
 
 import type { NavigationState } from '../routers';
-import { NavigationContainerRefContext } from './NavigationContainerRefContext';
 import { NavigationContext } from './NavigationContext';
 import type { NavigationProp } from './types';
 
@@ -16,15 +15,14 @@ export function useNavigation<
     getState(): NavigationState | undefined;
   },
 >(): T {
-  const root = use(NavigationContainerRefContext);
   const navigation = use(NavigationContext);
 
-  if (navigation === undefined && root === undefined) {
+  if (navigation === undefined) {
     throw new Error(
-      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
+      "Couldn't find a navigation object. This is most likely an issue in expo-router."
     );
   }
 
   // FIXME: Figure out a better way to do this
-  return (navigation ?? root) as unknown as T;
+  return navigation as unknown as T;
 }


### PR DESCRIPTION
# Why

In `react-navigation` apps, `useNavigation` can be called from outside a screen. In `expo-router` this is not possible since every app is wrapped in the root navigator. 

Therefore the `?? root` fallback in `useNavigation` is not needed and can mask real issues.

# How

1. Remove `?? root` fallback
2. Add tests

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>