### PR TITLE
[tools] Remove bundled frameworks with prune

### DIFF
--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -33,6 +33,7 @@ async function main(packageNames: string[], options: PrebuildCliOptions) {
       includeExternal: options.includeExternal,
       externalOnly: options.externalOnly,
       dryRun: options.dryRun,
+      bundled: options.bundled,
     });
     process.exit(exitCode);
   }
@@ -46,7 +47,7 @@ export default (program: Command) => {
     .command('prebuild-packages [packageNames...]')
     .description(
       'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, builds the default distributed set; pass --all-packages to build every package with an spm.config.json.\n' +
-        'Run `et prebuild prune [packageNames...]` to delete the intermediate build files (Xcode DerivedData, ~2GB/package) while keeping the composed xcframeworks. With no names (or `all`) it cleans every build cache found on disk; pass package names to prune only those. Add --dry-run to preview what would be removed.'
+        "Run `et prebuild prune [packageNames...]` to delete the intermediate build files (Xcode DerivedData, ~2GB/package) while keeping the composed xcframeworks. With no names (or `all`) it cleans every build cache found on disk; pass package names to prune only those. Add --dry-run to preview what would be removed, or --bundled to also drop each package's bundled `prebuilds/` directory."
     )
     .alias('prebuild')
     .option(
@@ -88,6 +89,11 @@ export default (program: Command) => {
     .option(
       '--dry-run',
       'Only applies to `prebuild prune`: list the build files that would be removed (with sizes) without deleting anything.',
+      false
+    )
+    .option(
+      '--bundled',
+      "Only applies to `prebuild prune`: also remove each package's bundled `prebuilds/` directory. That directory is publish staging output; in a monorepo checkout CocoaPods falls back to it whenever the build cache is missing, which silently links stale binaries against current source.",
       false
     )
     .option('--skip-generate', 'Skip the generate step.', false)

--- a/tools/src/prebuilds/Prune.test.ts
+++ b/tools/src/prebuilds/Prune.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import { describe, it } from 'node:test';
 import path from 'path';
 
-import { findDerivedDataDirsAsync } from './Prune';
+import { findBundledPrebuildDirsAsync, findDerivedDataDirsAsync } from './Prune';
 
 describe('findDerivedDataDirsAsync', () => {
   it('targets frameworks/ (DerivedData) and never the xcframeworks/ deliverables', async () => {
@@ -63,6 +63,41 @@ describe('findDerivedDataDirsAsync', () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-prune-'));
     try {
       assert.deepEqual(await findDerivedDataDirsAsync(tmp), []);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+});
+
+describe('findBundledPrebuildDirsAsync', () => {
+  it('finds bundled prebuilds/ for scoped and unscoped packages, and nothing else', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-bundled-'));
+    try {
+      await fs.outputFile(
+        path.join(tmp, 'expo-modules-core', 'prebuilds', 'output', 'release', 'x.tar.gz'),
+        'tar'
+      );
+      await fs.ensureDir(path.join(tmp, '@expo', 'ui', 'prebuilds', 'output'));
+      // A package with no bundled prebuilds must not be selected.
+      await fs.ensureDir(path.join(tmp, 'expo-image', 'ios'));
+      // `prebuilds` nested inside a package's node_modules is not a bundled deliverable.
+      await fs.ensureDir(path.join(tmp, 'expo-image', 'node_modules', 'dep', 'prebuilds'));
+
+      const dirs = (await findBundledPrebuildDirsAsync(tmp)).sort();
+
+      assert.deepEqual(dirs, [
+        path.join(tmp, '@expo', 'ui', 'prebuilds'),
+        path.join(tmp, 'expo-modules-core', 'prebuilds'),
+      ]);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+
+  it('returns nothing when the packages root does not exist', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'prebuild-bundled-'));
+    try {
+      assert.deepEqual(await findBundledPrebuildDirsAsync(path.join(tmp, 'nope')), []);
     } finally {
       await fs.remove(tmp);
     }

--- a/tools/src/prebuilds/Prune.ts
+++ b/tools/src/prebuilds/Prune.ts
@@ -14,6 +14,12 @@
  * With no names (or `all`) it scans the entire `.build` directory and cleans every cache on
  * disk — independent of package discovery, so it also catches packages that aren't part of
  * the default distributed set (e.g. `@expo/ui`). With explicit names it prunes just those.
+ *
+ * `--bundled` additionally removes each package's `prebuilds/` directory. Those are publish
+ * staging output, written by `bundleIOSPrebuilds` so `npm pack` ships them to consumers who
+ * have no `.build/`. In a monorepo checkout they are leftovers, and because the CocoaPods
+ * integration falls back to them whenever `.build/` is missing — without any staleness check
+ * — a stale one silently links month-old binaries against current source.
  */
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
@@ -21,7 +27,7 @@ import fs from 'fs-extra';
 import { glob } from 'glob';
 import path from 'path';
 
-import { getPrecompileDir } from '../Directories';
+import { getPackagesDir, getPrecompileDir } from '../Directories';
 import logger from '../Logger';
 import { verifyAllPackagesAsync } from './Utils';
 
@@ -32,6 +38,8 @@ export type PruneOptions = {
   externalOnly?: boolean;
   /** Report what would be removed and how much it would free, without deleting anything. */
   dryRun?: boolean;
+  /** Also remove each package's bundled `prebuilds/` directory. Defaults to false. */
+  bundled?: boolean;
 };
 
 export type PruneResult = {
@@ -83,6 +91,25 @@ export async function findAllDerivedDataDirsAsync(): Promise<string[]> {
   return matches.filter(isDerivedDataDir);
 }
 
+export async function findBundledPrebuildDirsAsync(packagesRoot: string): Promise<string[]> {
+  if (!(await fs.pathExists(packagesRoot))) {
+    return [];
+  }
+
+  const matches = await glob(['*/prebuilds', '@*/*/prebuilds'], {
+    cwd: packagesRoot,
+    absolute: true,
+  });
+  const dirs = await Promise.all(
+    matches.map(async (dir) => ((await fs.stat(dir)).isDirectory() ? dir : null))
+  );
+  return dirs.filter((dir): dir is string => dir !== null);
+}
+
+function labelForBundledPrebuildDir(dir: string): string {
+  return path.relative(getPackagesDir(), path.dirname(dir));
+}
+
 /** Returns the size of a directory in kilobytes via `du -sk`, or 0 if it can't be measured. */
 async function getDirSizeKbAsync(dir: string): Promise<number> {
   try {
@@ -127,13 +154,25 @@ export async function prunePrebuildBuildFilesAsync(
 ): Promise<PruneResult> {
   const pruneEverything = selector.length === 0 || (selector.length === 1 && selector[0] === 'all');
 
-  // Map each DerivedData dir to a display label (package name).
-  const targets: { label: string; dir: string }[] = [];
+  const bundled = options.bundled ?? false;
+
+  const targets: { label: string; dir: string; display: string }[] = [];
+  const relativeToBuildCache = (dir: string) => path.relative(getBuildCacheRoot(), dir);
+  const relativeToPackages = (dir: string) => path.relative(getPackagesDir(), dir);
 
   if (pruneEverything) {
     logger.info('🔎 Scanning the prebuild cache for build files to prune...');
     for (const dir of await findAllDerivedDataDirsAsync()) {
-      targets.push({ label: labelForDerivedDataDir(dir), dir });
+      targets.push({ label: labelForDerivedDataDir(dir), dir, display: relativeToBuildCache(dir) });
+    }
+    if (bundled) {
+      for (const dir of await findBundledPrebuildDirsAsync(getPackagesDir())) {
+        targets.push({
+          label: labelForBundledPrebuildDir(dir),
+          dir,
+          display: relativeToPackages(dir),
+        });
+      }
     }
   } else {
     const packages = await verifyAllPackagesAsync(
@@ -144,7 +183,17 @@ export async function prunePrebuildBuildFilesAsync(
     );
     for (const pkg of packages) {
       for (const dir of await findDerivedDataDirsAsync(pkg.buildPath)) {
-        targets.push({ label: pkg.packageName, dir });
+        targets.push({ label: pkg.packageName, dir, display: relativeToBuildCache(dir) });
+      }
+      if (bundled) {
+        const bundledDir = path.join(pkg.path, 'prebuilds');
+        if (await fs.pathExists(bundledDir)) {
+          targets.push({
+            label: pkg.packageName,
+            dir: bundledDir,
+            display: relativeToPackages(bundledDir),
+          });
+        }
       }
     }
   }
@@ -153,20 +202,20 @@ export async function prunePrebuildBuildFilesAsync(
   let freedKb = 0;
   const prunedPackages = new Set<string>();
 
-  for (const { label, dir } of targets) {
+  for (const { label, dir, display } of targets) {
     const kb = await getDirSizeKbAsync(dir);
     freedKb += kb;
     prunedPackages.add(label);
     const action = dryRun ? 'would remove' : 'removing';
-    logger.info(
-      `🧹 ${chalk.green(label)}: ${action} ${chalk.gray(
-        path.relative(getBuildCacheRoot(), dir)
-      )} (${formatSize(kb)})`
-    );
+    logger.info(`🧹 ${chalk.green(label)}: ${action} ${chalk.gray(display)} (${formatSize(kb)})`);
     if (!dryRun) {
       await fs.remove(dir);
     }
   }
+
+  const kept = bundled
+    ? 'Build-cache XCFrameworks kept, bundled prebuilds removed.'
+    : 'XCFrameworks kept.';
 
   if (targets.length === 0) {
     logger.info('✨ Nothing to prune — no build files found. XCFrameworks are untouched.');
@@ -180,7 +229,7 @@ export async function prunePrebuildBuildFilesAsync(
     logger.info(
       `\n✅ Pruned ${chalk.cyan(targets.length)} build folder(s) across ${chalk.cyan(
         prunedPackages.size
-      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. XCFrameworks kept.`
+      )} package(s), freeing ${chalk.green(formatSize(freedKb))}. ${kept}`
     );
   }
 

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -44,6 +44,8 @@ export type PrebuildCliOptions = {
   bundleSharedDeps?: boolean;
   /** Used only by `prebuild prune`: report what would be removed without deleting. */
   dryRun?: boolean;
+  /** Used only by `prebuild prune`: also remove each package's bundled `prebuilds/`. */
+  bundled?: boolean;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# Why
When running the updates e2e tests locally, we can get stale bundled xcframeworks added to the test project. These are artifacts from the most recent publish and could be incompatible with other changes on main. 

# How
Add a `--bundled` option to prune that removes these artifacts from the packages. 

# Test Plan
Test run on the monorepo. Works as expected
