### PR TITLE
[ios][updates] Fix reload regression

### DIFF
--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/maestro-test-executor.sh
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/maestro-test-executor.sh
@@ -57,4 +57,5 @@ function beforeAll() {
 
 beforeAll
 
-maestro test $MAESTRO_TEST_SUITE
+# Without -p, maestro runs on any connected device and ignores the platform argument
+maestro -p "$MAESTRO_PLATFORM" test $MAESTRO_TEST_SUITE

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/reload_update.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/reload_update.yml
@@ -1,0 +1,44 @@
+appId: dev.expo.updatese2e
+onFlowStart:
+  - runFlow:
+      file: beforeEach.yml
+---
+# Download an update, then reload with the JS API and check that the running JS really is the new
+# bundle. `basic_reload.yml` reloads with no update available, so it passes whether or not the
+# bundle swaps. Asserting `updateString` matters too: the native update id changes on reload even
+# when the old bundle keeps running.
+#
+# The manifest is served only after the first launch, otherwise the app updates on startup and
+# never runs the embedded bundle.
+- launchApp
+- evalScript:
+    script: ${output.api.delay(3000)}
+    label: Delay for 3 seconds
+- copyTextFrom:
+    label: Copy text from update string
+    id: updateString
+- assertTrue:
+    condition: ${maestro.copiedText == "test"}
+    label: Assert update string is from embedded bundle
+- evalScript:
+    script:  ${output.api.serveManifest('test-update-basic', MAESTRO_PLATFORM)}
+    label: Setup updates server to serve a basic update
+    env:
+      MAESTRO_PLATFORM: ${MAESTRO_PLATFORM}
+- tapOn:
+    label: Tap on download update button
+    id: downloadUpdate
+- evalScript:
+    script: ${output.api.delay(5000)}
+    label: Delay for 5 seconds
+- tapOn: "reload"
+- evalScript:
+    script: ${output.api.delay(5000)}
+    label: Delay for 5 seconds
+- copyTextFrom:
+    label: Copy text from update string
+    id: updateString
+- assertTrue:
+    condition: ${maestro.copiedText == "test-update-1"}
+    label: Assert update string is from downloaded bundle
+- stopApp

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/updates-e2e-enabled.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/updates-e2e-enabled.yml
@@ -7,6 +7,8 @@ appId: dev.expo.updatese2e
 - runFlow:
     file: basic_reload.yml
 - runFlow:
+    file: reload_update.yml
+- runFlow:
     file: basic_runUpdate.yml
 - runFlow:
     file: basic_updateInvalidHash.yml

--- a/packages/expo/ios/AppDelegates/EXBundleConfiguration.mm
+++ b/packages/expo/ios/AppDelegates/EXBundleConfiguration.mm
@@ -23,6 +23,14 @@
 
 - (NSURL *)getBundleURL
 {
+  // A file URL is a snapshot of whichever bundle was current when this configuration was built,
+  // and `RCTBundleManager` prefers it over the live getter that `RCTHost` installs. Returning it
+  // would pin every reload to that bundle, so `Updates.reloadAsync` could never start a newly
+  // downloaded update.
+  if (_bundleURL.fileURL) {
+    return nil;
+  }
+
   return _bundleURL;
 }
 


### PR DESCRIPTION
# Why
Fixes a regression from #48010. `Updates.reloadAsync` on iOS restarts the app but keeps running the old JS bundle.

# How
`RCTBundleManager` has two sources for the bundle URL. The configuration holds a value fixed for the host's lifetime, and the getter installed by `RCTHost` holds one that can change. The configuration is always preferred, and the getter only read when it returns nil. This causes a problem with updates because the bundle url can change between reloads so the frozen url in the config causes you to be stuck on the same js bundle. 

Returning nil for file urls forces the bundle manager to check the host for the correct bundle url 

# Test Plan
Added a new test in updates e2e to catch this if it regresses again. 
CI passing
Everything seems correct in my testing but we should keep an eye on it

