### PR TITLE
[docs][audio] Fix AudioPlayer.seekTo JSDoc

### DIFF
--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -184,8 +184,8 @@ export declare class AudioPlayer extends SharedObject<AudioEvents> {
   replace(source: AudioSource): void;
 
   /**
-   * Seeks the playback by the given number of seconds.
-   * @param seconds The number of seconds to seek by.
+   * Seeks the playback to a specific position in seconds.
+   * @param seconds The position to seek to.
    * @param toleranceMillisBefore The tolerance allowed before the requested seek time, in milliseconds. iOS only.
    * @param toleranceMillisAfter The tolerance allowed after the requested seek time, in milliseconds. iOS only.
    */


### PR DESCRIPTION
# Why

Docs before change sound like `AudioPlayer.seekTo` is `currentTime += seconds`, but it's actually `currentTime = seconds`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Changed to same wording as `AudioPlaylist.seekTo`.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

N/A

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
