### PR TITLE
[widgets][iOS] Remove availability checks for iOS 16

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### 💡 Others
 
-- [iOS] Remove availability check for iOS 16.
+- [iOS] Remove availability check for iOS 16. ([#48651](https://github.com/expo/expo/pull/48651) by [@jakex7](https://github.com/jakex7))
 
 ## 57.0.7 - 2026-07-29
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove availability check for iOS 16.
+
 ## 57.0.7 - 2026-07-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -33,6 +33,8 @@
 
 ### 💡 Others
 
+- [iOS] Remove availability check for iOS 16.
+
 ## 57.0.7 - 2026-07-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-widgets/ios/LiveActivity.swift
+++ b/packages/expo-widgets/ios/LiveActivity.swift
@@ -13,8 +13,6 @@ final class LiveActivity: SharedObject {
   }
 
   func update(props: String?, staleDate: Date?) async throws {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
-
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
       throw LiveActivityNotFoundException(id)
     }
@@ -24,8 +22,6 @@ final class LiveActivity: SharedObject {
   }
 
   func end(dismissalPolicy: LiveActivityDismissalPolicy?, afterDate: Date?, props: String?, contentDate: Date?) async throws {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
-
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
       throw LiveActivityNotFoundException(id)
     }
@@ -45,8 +41,6 @@ final class LiveActivity: SharedObject {
   }
 
   func getPushToken() throws -> String? {
-    guard #available(iOS 16.1, *) else { throw LiveActivitiesNotSupportedException() }
-
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
       throw LiveActivityNotFoundException(id)
     }
@@ -56,7 +50,6 @@ final class LiveActivity: SharedObject {
     return tokenData.reduce("") { $0 + String(format: "%02x", $1) }
   }
 
-  @available(iOS 16.1, *)
   func observePushTokenUpdates(for activity: Activity<LiveActivityAttributes>, pushNotificationsEnabled: Bool) {
     guard pushNotificationsEnabled else {
       return

--- a/packages/expo-widgets/ios/LiveActivityFactory.swift
+++ b/packages/expo-widgets/ios/LiveActivityFactory.swift
@@ -15,7 +15,6 @@ final class LiveActivityFactory: SharedObject {
   }
 
   func start(props: String?, url: URL?, staleDate: Date?) throws -> LiveActivity {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
     guard ActivityAuthorizationInfo().areActivitiesEnabled else {
       throw LiveActivitiesNotSupportedException()
     }
@@ -38,8 +37,6 @@ final class LiveActivityFactory: SharedObject {
   }
 
   func getInstances() throws -> [LiveActivity] {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
-
     let activities = Activity<LiveActivityAttributes>.activities
       // Filter LiveActivity instances for activities that don't match the factory's name.
       .filter { $0.content.state.name == name }

--- a/packages/expo-widgets/ios/LiveActivityFactory.swift
+++ b/packages/expo-widgets/ios/LiveActivityFactory.swift
@@ -14,7 +14,6 @@ final class LiveActivityFactory: SharedObject {
   }
 
   func start(props: String?, url: URL?, staleDate: Date?) throws -> LiveActivity {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
     guard ActivityAuthorizationInfo().areActivitiesEnabled else {
       throw LiveActivitiesNotSupportedException()
     }
@@ -36,8 +35,6 @@ final class LiveActivityFactory: SharedObject {
   }
 
   func getInstances() throws -> [LiveActivity] {
-    guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
-
     return Activity<LiveActivityAttributes>.activities
       .filter { $0.content.state.name == name }
       // A stale activity is still visible and updatable; only ended/dismissed ones are gone.

--- a/packages/expo-widgets/ios/Widgets/AppIntent.swift
+++ b/packages/expo-widgets/ios/Widgets/AppIntent.swift
@@ -23,7 +23,6 @@ struct WidgetReload: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
 struct WidgetUserInteraction: AppIntent {
   // title is not used for non-discoverable intents, but it is required
   static var title: LocalizedStringResource = "User Interaction"
@@ -102,7 +101,6 @@ struct WidgetUserInteraction: AppIntent {
   }
 }
 
-@available(iOS 16.0, *)
 struct LiveActivityUserInteraction: LiveActivityIntent {
   // title is not used for non-discoverable intents, but it is required
   static var title: LocalizedStringResource = "User Interaction"

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -97,14 +97,12 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
   var env: [String: Any] = [
     "showsContainerBackground": environment.showsWidgetContainerBackground,
     "widgetFamily": environment.widgetFamily.description,
-    "colorScheme": "\(environment.colorScheme)"
+    "colorScheme": "\(environment.colorScheme)",
+    "isLuminanceReduced": environment.isLuminanceReduced,
+    "widgetRenderingMode": environment.widgetRenderingMode.description,
+    "showsWidgetLabel": environment.showsWidgetLabel
   ]
 
-  if #available(iOS 16.0, *) {
-    env["isLuminanceReduced"] = environment.isLuminanceReduced
-    env["widgetRenderingMode"] = environment.widgetRenderingMode.description
-    env["showsWidgetLabel"] = environment.showsWidgetLabel
-  }
   if #available(iOS 17.0, *) {
     env["widgetContentMargins"] = [
       "top": environment.widgetContentMargins.top,
@@ -121,15 +119,11 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
 
 func getLiveActivityEnvironment(environment: EnvironmentValues) -> [String: Any] {
   var env: [String: Any] = [
-    "colorScheme": "\(environment.colorScheme)"
+    "colorScheme": "\(environment.colorScheme)",
+    "isLuminanceReduced": environment.isLuminanceReduced,
+    "isActivityFullscreen": environment.isActivityFullscreen
   ]
 
-  if #available(iOS 16.0, *) {
-    env["isLuminanceReduced"] = environment.isLuminanceReduced
-  }
-  if #available(iOS 16.1, *) {
-    env["isActivityFullscreen"] = environment.isActivityFullscreen
-  }
   if #available(iOS 18.0, *) {
     env["isActivityUpdateReduced"] = environment.isActivityUpdateReduced
     env["activityFamily"] = "\(environment.activityFamily)"

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -97,14 +97,12 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
   var env: [String: Any] = [
     "showsContainerBackground": environment.showsWidgetContainerBackground,
     "widgetFamily": environment.widgetFamily.description,
-    "colorScheme": "\(environment.colorScheme)"
+    "colorScheme": "\(environment.colorScheme)",
+    "isLuminanceReduced": environment.isLuminanceReduced,
+    "widgetRenderingMode": environment.widgetRenderingMode.description,
+    "showsWidgetLabel": environment.showsWidgetLabel
   ]
 
-  if #available(iOS 16.0, *) {
-    env["isLuminanceReduced"] = environment.isLuminanceReduced
-    env["widgetRenderingMode"] = environment.widgetRenderingMode.description
-    env["showsWidgetLabel"] = environment.showsWidgetLabel
-  }
   if #available(iOS 17.0, *) {
     env["widgetContentMargins"] = [
       "top": environment.widgetContentMargins.top,
@@ -119,20 +117,14 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
   return env
 }
 
-// ActivityViewContext requires iOS 16.1. Without the availability attribute, precompiling
-// this package fails: the SwiftPM prebuild targets iOS 16.0 (spm.config.json), unlike the
-// podspec (16.4). Both callers live in @available(iOS 16.1, *) views.
-@available(iOS 16.1, *)
 func getLiveActivityEnvironment(for environment: EnvironmentValues, in context: ActivityViewContext<LiveActivityAttributes>) -> [String: Any] {
   var env: [String: Any] = [
-    "colorScheme": "\(environment.colorScheme)"
+    "colorScheme": "\(environment.colorScheme)",
+    "isLuminanceReduced": environment.isLuminanceReduced,
+    "isActivityFullscreen": environment.isActivityFullscreen,
+    "isStale": context.isStale
   ]
 
-  env["isLuminanceReduced"] = environment.isLuminanceReduced
-  env["isActivityFullscreen"] = environment.isActivityFullscreen
-  if #available(iOS 16.2, *) {
-    env["isStale"] = context.isStale
-  }
   if #available(iOS 18.0, *) {
     env["isActivityUpdateReduced"] = environment.isActivityUpdateReduced
     env["activityFamily"] = "\(environment.activityFamily)"

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -18,7 +18,6 @@ struct LiveActivityAttributes: ActivityAttributes {
   }
 }
 
-@available(iOS 16.1, *)
 public struct WidgetLiveActivity: Widget {
   @Environment(\.self) var env
   
@@ -81,7 +80,6 @@ public struct WidgetLiveActivity: Widget {
   }
 }
 
-@available(iOS 16.1, *)
 private struct LiveActivitySectionView: View {
   let context: ActivityViewContext<LiveActivityAttributes>
   let nodes: [String: Any]
@@ -96,7 +94,6 @@ private struct LiveActivitySectionView: View {
   }
 }
 
-@available(iOS 16.1, *)
 private struct LiveActivityBannerView: View {
   var context: ActivityViewContext<LiveActivityAttributes>
   let nodes: [String: Any]

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -18,7 +18,6 @@ struct LiveActivityAttributes: ActivityAttributes {
   }
 }
 
-@available(iOS 16.1, *)
 public struct WidgetLiveActivity: Widget {
   @Environment(\.self) var env
   
@@ -77,7 +76,6 @@ public struct WidgetLiveActivity: Widget {
   }
 }
 
-@available(iOS 16.1, *)
 private struct LiveActivitySectionView: View {
   let context: ActivityViewContext<LiveActivityAttributes>
   let nodes: [String: Any]
@@ -92,7 +90,6 @@ private struct LiveActivitySectionView: View {
   }
 }
 
-@available(iOS 16.1, *)
 private struct LiveActivityBannerView: View {
   var context: ActivityViewContext<LiveActivityAttributes>
   let nodes: [String: Any]

--- a/packages/expo-widgets/ios/WidgetsRecords.swift
+++ b/packages/expo-widgets/ios/WidgetsRecords.swift
@@ -28,7 +28,6 @@ internal enum LiveActivityDismissalPolicy: String, Enumerable {
   case immediate
   case after
 
-  @available(iOS 16.1, *)
   internal func toDismissalPolicy(date: Date?) -> ActivityUIDismissalPolicy {
     return switch self {
     case .default: .default


### PR DESCRIPTION
# Why

Min iOS version is `16.4` anyway.

# How

Removed `available(iOS 16, *)` checks.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
