### PR TITLE
[observe-tester] Add worklet testing scenarios for Observe.logEvent

### DIFF
--- a/apps/observe-tester/app/(tabs)/debug/index.tsx
+++ b/apps/observe-tester/app/(tabs)/debug/index.tsx
@@ -13,6 +13,7 @@ import { LogEventsSection } from '@/components/LogEventsSection';
 import { NetworkRequestObserverSection } from '@/components/NetworkRequestObserverSection';
 import { RenderErrorSection } from '@/components/RenderErrorSection';
 import { ReportErrorSection } from '@/components/ReportErrorSection';
+import { WorkletAnimationSection } from '@/components/WorkletAnimationSection';
 import CrashTester from '@/modules/crash-tester';
 import { useTheme } from '@/utils/theme';
 
@@ -33,6 +34,8 @@ export default function Debug() {
       style={{ backgroundColor: theme.background.screen }}
       contentContainerStyle={styles.container}>
       <LogEventsSection />
+      <Divider />
+      <WorkletAnimationSection />
       <Divider />
       <NetworkRequestObserverSection />
       <Divider />

--- a/apps/observe-tester/components/WorkletAnimationSection.tsx
+++ b/apps/observe-tester/components/WorkletAnimationSection.tsx
@@ -1,0 +1,292 @@
+import { installOnUIRuntime } from 'expo-modules-core';
+import { Observe } from 'expo-observe';
+import { useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  runOnJS,
+  runOnUI,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
+import { getUIRuntimeHolder } from 'react-native-worklets';
+
+import { Button } from '@/components/Button';
+import { useTheme } from '@/utils/theme';
+
+const TRAVEL = 220;
+const CYCLE_MS = 700;
+
+// Expo modules are not on the worklet runtime until they are installed there, so
+// `globalThis.expo.modules` is empty in a worklet without this. Runs once per app start.
+let installState: string;
+try {
+  installOnUIRuntime(getUIRuntimeHolder());
+  installState = 'Expo modules installed on the UI runtime';
+} catch (error) {
+  installState = `installOnUIRuntime failed: ${String(error)}`;
+}
+
+/**
+ * The three ways a worklet can reach `logEvent`, from most to least direct:
+ * `proxy` captures the `expo-observe` JS proxy, `native` calls the module
+ * installed on the worklet runtime, and `runOnJS` hops back to the JS thread.
+ */
+type Strategy = 'proxy' | 'native' | 'runOnJS';
+
+const STRATEGIES: { strategy: Strategy; title: string; description: string }[] = [
+  {
+    strategy: 'proxy',
+    title: 'From worklet — Observe.logEvent',
+    description: 'Captures the expo-observe proxy in the animation callback',
+  },
+  {
+    strategy: 'native',
+    title: 'From worklet — native module',
+    description: 'Calls globalThis.expo.modules.ExpoAppMetrics.logEvent',
+  },
+  {
+    strategy: 'runOnJS',
+    title: 'From worklet — runOnJS hop',
+    description: 'Control: schedules the call back onto the JS thread',
+  },
+];
+
+export function WorkletAnimationSection() {
+  const theme = useTheme();
+  const [running, setRunning] = useState<Strategy | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [cycles, setCycles] = useState(0);
+
+  const offset = useSharedValue(0);
+
+  const report = (message: string) => setStatus(message);
+  const countCycle = () => setCycles((count) => count + 1);
+
+  const logFromJS = (cycle: number) => {
+    Observe.logEvent('debug.worklet_animation_cycle', {
+      severity: 'info',
+      body: 'Animation cycle finished, logged after hopping to the JS thread',
+      attributes: { strategy: 'runOnJS', cycle },
+    });
+  };
+
+  const onProxyCycle = (finished?: boolean) => {
+    'worklet';
+    if (!finished) return;
+    try {
+      Observe.logEvent('debug.worklet_animation_cycle', {
+        severity: 'info',
+        body: 'Animation cycle finished, logged from the UI runtime via the proxy',
+        attributes: { strategy: 'proxy' },
+      });
+      runOnJS(countCycle)();
+      runOnJS(report)('proxy: logEvent returned without throwing');
+    } catch (error) {
+      runOnJS(report)(`proxy: ${String(error)}`);
+    }
+  };
+
+  const onNativeCycle = (finished?: boolean) => {
+    'worklet';
+    if (!finished) return;
+    try {
+      const appMetrics = (globalThis as any).expo?.modules?.ExpoAppMetrics;
+      if (!appMetrics) {
+        runOnJS(report)('native: ExpoAppMetrics is not installed on the worklet runtime');
+        return;
+      }
+      appMetrics.logEvent('debug.worklet_animation_cycle', {
+        severity: 'info',
+        body: 'Animation cycle finished, logged from the UI runtime via the native module',
+        attributes: { strategy: 'native' },
+      });
+      runOnJS(countCycle)();
+      runOnJS(report)('native: logEvent returned without throwing');
+    } catch (error) {
+      runOnJS(report)(`native: ${String(error)}`);
+    }
+  };
+
+  const onRunOnJSCycle = (finished?: boolean) => {
+    'worklet';
+    if (!finished) return;
+    try {
+      runOnJS(countCycle)();
+      runOnJS(logFromJS)(0);
+      runOnJS(report)('runOnJS: scheduled the call on the JS thread');
+    } catch (error) {
+      runOnJS(report)(`runOnJS: ${String(error)}`);
+    }
+  };
+
+  const start = (strategy: Strategy) => {
+    const callback =
+      strategy === 'proxy' ? onProxyCycle : strategy === 'native' ? onNativeCycle : onRunOnJSCycle;
+
+    setRunning(strategy);
+    setStatus('running…');
+    setCycles(0);
+    cancelAnimation(offset);
+    offset.value = 0;
+    // A worklet failure can surface when the animation is built rather than when the
+    // callback runs, so keep the caller side guarded too.
+    try {
+      offset.value = withRepeat(withTiming(TRAVEL, { duration: CYCLE_MS }, callback), -1, true);
+    } catch (error) {
+      setStatus(`start: ${String(error)}`);
+    }
+  };
+
+  const inspectRuntime = () => {
+    try {
+      runOnUI(() => {
+        'worklet';
+        const expo = (globalThis as any).expo;
+        if (!expo) {
+          runOnJS(report)('globalThis.expo is missing on the UI runtime');
+          return;
+        }
+        const modules = expo.modules;
+        if (!modules) {
+          runOnJS(report)('globalThis.expo exists but has no `modules`');
+          return;
+        }
+        const appMetrics = modules.ExpoAppMetrics;
+        runOnJS(report)(
+          [
+            `typeof expo.modules: ${typeof modules}`,
+            `typeof ExpoAppMetrics: ${typeof appMetrics}`,
+            `typeof ExpoAppMetrics.logEvent: ${appMetrics ? typeof appMetrics.logEvent : 'n/a'}`,
+            `typeof ExpoObserve: ${typeof modules.ExpoObserve}`,
+          ].join('\n')
+        );
+      })();
+    } catch (error) {
+      setStatus(`inspect: ${String(error)}`);
+    }
+  };
+
+  const enumerateRuntime = () => {
+    try {
+      runOnUI(() => {
+        'worklet';
+        const modules = (globalThis as any).expo?.modules;
+        if (!modules) {
+          runOnJS(report)('no expo.modules on the UI runtime');
+          return;
+        }
+        runOnJS(report)(`module names: ${Object.keys(modules).join(', ') || '(none)'}`);
+      })();
+    } catch (error) {
+      setStatus(`enumerate: ${String(error)}`);
+    }
+  };
+
+  // Enumerating a module object on the worklet runtime takes the process down, so this
+  // probe is kept separate from the `typeof` checks above.
+  const enumerateModule = () => {
+    try {
+      runOnUI(() => {
+        'worklet';
+        const appMetrics = (globalThis as any).expo?.modules?.ExpoAppMetrics;
+        if (!appMetrics) {
+          runOnJS(report)('no ExpoAppMetrics on the UI runtime');
+          return;
+        }
+        runOnJS(report)(
+          `ExpoAppMetrics members: ${Object.keys(appMetrics).join(', ') || '(none)'}`
+        );
+      })();
+    } catch (error) {
+      setStatus(`enumerate module: ${String(error)}`);
+    }
+  };
+
+  const stop = () => {
+    cancelAnimation(offset);
+    offset.value = withTiming(0, { duration: 200 });
+    setRunning(null);
+  };
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: offset.value }],
+  }));
+
+  return (
+    <>
+      <Text style={[styles.sectionTitle, { color: theme.text.default }]}>Worklet animation</Text>
+      <Text style={[styles.sectionHint, { color: theme.text.secondary }]}>
+        Runs a Reanimated animation on the UI thread and calls `logEvent` from the worklet that
+        fires at the end of every cycle. Each strategy reaches the module a different way.
+      </Text>
+      <Text style={[styles.status, { color: theme.text.secondary }]}>{installState}</Text>
+      <View style={[styles.track, { backgroundColor: theme.background.element }]}>
+        <Animated.View style={[styles.box, animatedStyle]} />
+      </View>
+      <Text style={[styles.status, { color: theme.text.secondary }]}>
+        {running ? `${running} · ${cycles} cycles logged` : 'idle'}
+      </Text>
+      {status ? <Text style={[styles.status, { color: theme.text.default }]}>{status}</Text> : null}
+      {STRATEGIES.map(({ strategy, title, description }) => (
+        <Button
+          key={strategy}
+          title={title}
+          description={description}
+          onPress={() => start(strategy)}
+          theme="secondary"
+        />
+      ))}
+      <Button
+        title="Inspect worklet runtime"
+        description="Reports what the UI runtime can see, without enumerating"
+        onPress={inspectRuntime}
+        theme="secondary"
+      />
+      <Button
+        title="Enumerate worklet modules"
+        description="Object.keys on expo.modules"
+        onPress={enumerateRuntime}
+        theme="secondary"
+      />
+      <Button
+        title="Enumerate ExpoAppMetrics"
+        description="Object.keys on the module itself — crashes the app"
+        onPress={enumerateModule}
+        theme="secondary"
+      />
+      <Button title="Stop animation" onPress={stop} theme="secondary" disabled={!running} />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  sectionHint: {
+    fontSize: 13,
+    marginBottom: 16,
+  },
+  track: {
+    height: 64,
+    borderRadius: 6,
+    justifyContent: 'center',
+    paddingHorizontal: 8,
+    marginBottom: 8,
+  },
+  box: {
+    width: 48,
+    height: 48,
+    borderRadius: 6,
+    backgroundColor: '#4630eb',
+  },
+  status: {
+    fontSize: 13,
+    marginBottom: 8,
+  },
+});

--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -32,6 +32,7 @@
     "expo-haptics": "workspace:*",
     "expo-image": "workspace:*",
     "expo-linking": "workspace:*",
+    "expo-modules-core": "workspace:*",
     "expo-observe": "workspace:*",
     "expo-router": "workspace:*",
     "expo-splash-screen": "workspace:*",
@@ -43,8 +44,10 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
+    "react-native-reanimated": "4.5.1",
     "react-native-safe-area-context": "5.7.0",
-    "react-native-screens": "4.26.0"
+    "react-native-screens": "4.26.0",
+    "react-native-worklets": "0.10.1"
   },
   "devDependencies": {
     "@expo/config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1357,6 +1357,9 @@ importers:
       expo-linking:
         specifier: workspace:*
         version: link:../../packages/expo-linking
+      expo-modules-core:
+        specifier: workspace:*
+        version: link:../../packages/expo-modules-core
       expo-observe:
         specifier: workspace:*
         version: link:../../packages/expo-observe
@@ -1390,12 +1393,18 @@ importers:
       react-native:
         specifier: 0.86.0
         version: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+      react-native-reanimated:
+        specifier: 4.5.1
+        version: 4.5.1(patch_hash=f1adeb1c26dfb66311eb34b353a16b2ae27f5a95a65e9d52e683a60af0e8b18e)(react-native-worklets@0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context:
         specifier: 5.7.0
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-screens:
         specifier: 4.26.0
         version: 4.26.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-worklets:
+        specifier: 0.10.1
+        version: 0.10.1(patch_hash=b72ac0fc85273472ec4b8974adb8d4eba75672291aa7501270a7b08e58ba7dec)(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@expo/config':
         specifier: workspace:*


### PR DESCRIPTION
# Why

`observe-tester` had no way to exercise `Observe.logEvent` from a worklet, so we had no evidence about whether the API is reachable from the UI runtime. This adds the scenarios and, in doing so, surfaces three concrete gaps worth tracking.

The scenarios show that **`Observe.logEvent` cannot currently be called from a worklet at all**. Both direct routes fail, and only a `runOnJS` hop back to the JS thread works.

# How

Adds `apps/observe-tester/components/WorkletAnimationSection.tsx` to the Debug tab. It runs a Reanimated `withRepeat`/`withTiming` animation on the UI thread and calls `logEvent` from the worklet that fires at the end of every cycle, three different ways:

| Strategy | How it reaches `logEvent` | Result |
| --- | --- | --- |
| `proxy` | Captures the `expo-observe` `Observe` proxy in the worklet | ``Error: [Worklets] Cannot copy value of type `NativeModule`.`` |
| `native` | `globalThis.expo.modules.ExpoAppMetrics.logEvent` on the worklet runtime | `TypeError: undefined is not a function` |
| `runOnJS` | Schedules the call back onto the JS thread | Works |

Each strategy is wrapped in `try`/`catch` on both the worklet side and the caller side, and reports its outcome on screen. The `proxy` failure surfaces when the animation is *built*, not when the callback runs, hence the guard in `start`.

Three notes on what the scenarios revealed:

1. **`installOnUIRuntime` is required.** Expo modules are not on the worklet runtime until `installOnUIRuntime(getUIRuntimeHolder())` from `expo-modules-core` is called; before that, `globalThis.expo` is empty inside a worklet. The component calls it at module scope and reports whether it succeeded.

2. **`logEvent` is missing on the worklet runtime.** After installing, the module object is present but the function is not:
   ```
   typeof expo.modules:            object
   typeof ExpoAppMetrics:          object
   typeof ExpoAppMetrics.logEvent: undefined
   typeof ExpoObserve:             object
   ```
   `logEvent` is declared as a sync `Function` (not `AsyncFunction`) in both `AppMetricsModule.swift` and `AppMetricsModule.kt`, so it looks like it should have been eligible for the worklet runtime.

3. **Enumerating a module object in a worklet crashes the app.** `Object.keys(globalThis.expo.modules.ExpoAppMetrics)` inside a worklet takes the process down with no JS error. `Object.keys(globalThis.expo.modules)` is fine. Reproduced consistently, and kept behind its own clearly labelled button next to the existing crash triggers in this app.

Three probe buttons (`Inspect worklet runtime`, `Enumerate worklet modules`, `Enumerate ExpoAppMetrics`) report the above directly from the device, so the findings can be re-checked as the worklets integration changes.

Also adds `react-native-reanimated@4.5.1`, `react-native-worklets@0.10.1` (matching the versions the rest of the monorepo pins) and `expo-modules-core` to the app, since it now imports it directly.

# Test Plan

Built and ran on an iOS 26.5 simulator (iPhone 17 Pro), Debug tab → Worklet animation.

- **`From worklet — Observe.logEvent`** → animation does not start; screen reports ``start: Error: [Worklets] Cannot copy value of type `NativeModule`.``
- **`From worklet — native module`** → animation runs, worklet callback fires, screen reports `native: TypeError: undefined is not a function`
- **`From worklet — runOnJS hop`** → animation runs; 20 cycles logged. Confirmed the events actually land, not just that the call returns: Sessions tab → Main session → Logs shows 20 `debug.worklet_animation_cycle` entries at `INFO` with body `Animation cycle finished, logged after hopping to the JS thread` and attributes `{ "cycle": 0, "strategy": "runOnJS" }`.
- **`Inspect worklet runtime`** → reports the `typeof` table above.
- **`Enumerate worklet modules`** → lists all installed module names, no crash.
- **`Enumerate ExpoAppMetrics`** → app terminates immediately to the home screen, no JS error. Reproduced twice.

Types check with `tsc --noEmit` (the one remaining error is in `app.config.ts` and is pre-existing on `main`).

Not run: `expo lint` for this app. It fails with `Command "eslint" not found` — `observe-tester` has no eslint devDependency on `main` either, so this is pre-existing and not introduced here.

Android is not covered; everything above is iOS only.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — n/a, this only touches an app, no package sources
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). Verified via `pnpm prebuild` + `pod install` for this app.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
