### PR TITLE
[audio] Expose read-only isActiveForLockScreen for AudioPlayer and AudioPlaylist

### DIFF
--- a/apps/test-suite/tests/Audio.ts
+++ b/apps/test-suite/tests/Audio.ts
@@ -281,6 +281,7 @@ export function test({ describe, expect, it, ...t }: any) {
         expect(player.shouldCorrectPitch).toBe(true);
         expect(player.currentTime).toBe(0);
         expect(player.duration).toBeGreaterThan(0);
+        expect(player.isActiveForLockScreen).toBe(false);
       });
 
       it('has valid currentStatus object', async () => {

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added a `fileSize` field to `RecorderState` reporting the current size of the recording file in bytes. ([#46808](https://github.com/expo/expo/pull/46808) by [@behenate](https://github.com/behenate))
 - Added `startFileRecordingAsync` and `stopFileRecordingAsync` methods to `AudioStream` for continuous WAV and PCM file recording alongside buffer streaming. ([#46771](https://github.com/expo/expo/pull/46771) by [@behenate](https://github.com/behenate))
 - [iOS] Added `allowsExternalPlayback` option to `AudioPlayerOptions`. Set to `false` to keep the local player in control during AirPlay, fixing `player.loop` not firing. ([#48366](https://github.com/expo/expo/pull/48366) by [@zoontek](https://github.com/zoontek))
+- Added a read-only `isActiveForLockScreen` property to `AudioPlayer` and `AudioPlaylist` reporting whether the player is currently active for lock screen controls. ([#48657](https://github.com/expo/expo/pull/48657) by [@RasmusKard](https://github.com/RasmusKard))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -487,6 +487,12 @@ class AudioModule : Module() {
         ref.setVolume(volume)
       }
 
+      Property("isActiveForLockScreen") { player ->
+        runOnMain {
+          player.isActiveForLockScreen
+        }
+      }
+
       Function("play") { player: AudioPlayer ->
         if (!audioEnabled) {
           Log.e(TAG, "Audio has been disabled. Re-enable to start playing")
@@ -837,6 +843,12 @@ class AudioModule : Module() {
       Property("currentStatus") { playlist ->
         runOnMain {
           playlist.currentStatus()
+        }
+      }
+
+      Property("isActiveForLockScreen") { playlist ->
+        runOnMain {
+          playlist.isActiveForLockScreen
         }
       }
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -214,6 +214,10 @@ public class AudioModule: Module {
         player.currentStatus()
       }
 
+      Property("isActiveForLockScreen") { player in
+        player.isActiveForLockScreen
+      }
+
       Function("play") { player in
         guard self.canStartPlayback() else {
           return
@@ -368,6 +372,10 @@ public class AudioModule: Module {
 
       Property("currentStatus") { playlist in
         playlist.currentStatus()
+      }
+
+      Property("isActiveForLockScreen") { playlist in
+        playlist.isActiveForLockScreen
       }
 
       Function("play") { playlist in

--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -169,6 +169,11 @@ export declare class AudioPlayer extends SharedObject<AudioEvents> {
   currentStatus: AudioStatus;
 
   /**
+   * A boolean describing whether the player is active for lock screen controls. See [`setActiveForLockScreen()`](#setactiveforlockscreenactive-metadata-options).
+   */
+  readonly isActiveForLockScreen: boolean;
+
+  /**
    * Start playing audio.
    */
   play(): void;
@@ -471,6 +476,11 @@ export declare class AudioPlaylist extends SharedObject<AudioPlaylistEvents> {
    * @hidden
    */
   currentStatus: AudioPlaylistStatus;
+
+  /**
+   * A boolean describing whether the player is active for lock screen controls. See [`setActiveForLockScreen()`](#setactiveforlockscreenactive-metadata-options-1).
+   */
+  readonly isActiveForLockScreen: boolean;
 
   /**
    * Start playing the current track in the playlist.

--- a/packages/expo-audio/src/AudioPlayer.web.ts
+++ b/packages/expo-audio/src/AudioPlayer.web.ts
@@ -120,6 +120,10 @@ export class AudioPlayerWeb
     return getStatusFromMedia(this.media, this.id);
   }
 
+  get isActiveForLockScreen(): boolean {
+    return mediaSessionController.isActive(this);
+  }
+
   play(): void {
     if (!isAudioActive) {
       return;

--- a/packages/expo-audio/src/AudioPlaylist.web.ts
+++ b/packages/expo-audio/src/AudioPlaylist.web.ts
@@ -148,6 +148,10 @@ export class AudioPlaylistWeb
     return this._getStatus();
   }
 
+  get isActiveForLockScreen(): boolean {
+    return mediaSessionController.isActive(this);
+  }
+
   play(): void {
     if (!this._currentMedia || this._sources.length === 0) {
       return;


### PR DESCRIPTION


# Why

Can be relevant state for some decisions, like choosing whether to call `setActiveForLockScreen()` or `updateLockScreenMetadata()` for example.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Exposed `isActiveForLockScreen` as a read-only property for both `AudioPlayer` and `AudioPlaylist`
- Added `isActiveForLockScreen` to default property test of `AudioPlayer`

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Ran `bare-expo` test-suite on iOS and Android - passed.
Tested manually on web with `native-component-list` - seemed good.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
