### PR TITLE
docs: remove copy link comment about Expo Go

### DIFF
--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -40,7 +40,7 @@ Once the Developer menu is open, it will appear as below:
 
 The Developer menu provides the following options:
 
-- **Copy link**: To copy the dev server address in dev client or [`exp://`](/linking/into-your-app/#test-a-link-using-expo-go) link in Expo of your app.
+- **Copy link**: To copy the dev server address of your app.
 - **Reload**: To reload you app. Usually, not necessary since Fast Refresh is enabled by default.
 - **Go Home**: To leave your app and navigate back to the dev client's or Expo Go app's Home screen.
 - **Toggle performance monitor**: To view the performance information about your app.


### PR DESCRIPTION
# Why

* Check `showHostUrl: Bool = false` in [apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift](https://github.com/expo/expo/blob/main/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift#L16) and NOT changed at all

# How



# Test Plan

* run a any example app and check it's NOT AVAILABLE in Expo Go

<img width="434" height="966" alt="image" src="https://github.com/user-attachments/assets/d580b150-3eb2-49d3-9409-43b48ba2bf47" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
