### PR TITLE
[android][ios][router] Add NativeTabs color scheme control

### DIFF
--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -1551,6 +1551,12 @@ export default function TabLayout() {
 
 ## Known limitations
 
+<Collapsible summary="Limited tab bar background customization on iOS 26 and later">
+
+On iOS 26 and later, Liquid Glass controls the native tab bar background and shadow. The `backgroundColor`, `blurEffect`, and `shadowColor` props do not affect its appearance. You can still use `tintColor` to customize the selected tab item and selection glow. Use [JavaScript tabs](/router/advanced/tabs/) if your app requires full control over the tab bar background.
+
+</Collapsible>
+
 <Collapsible summary="A limit of 5 tabs on Android">
 
 On Android, there is a limitation of having a maximum of 5 tabs in the tab bar. This restriction comes from the platform's Material Tabs component.

--- a/docs/pages/router/advanced/native-tabs.mdx
+++ b/docs/pages/router/advanced/native-tabs.mdx
@@ -225,6 +225,12 @@ export default function TabLayout() {
 
 Liquid glass on iOS automatically changes colors based on if the background color is light or dark. There is no callback for this, so you need to use a `PlatformColor` or `DynamicColorIOS` to set the color of the icon.
 
+Use the `colorScheme` prop to set a light or dark appearance for the native tabs host and its child containers. On iOS 26 and later, this also controls the Liquid Glass tab bar appearance. The default value, `inherit`, follows the app's color scheme.
+
+```tsx
+<NativeTabs colorScheme="dark">{/* ... */}</NativeTabs>
+```
+
 <Tabs>
 
 <Tab label="SDK 55 and later">
@@ -1553,7 +1559,7 @@ export default function TabLayout() {
 
 <Collapsible summary="Limited tab bar background customization on iOS 26 and later">
 
-On iOS 26 and later, Liquid Glass controls the native tab bar background and shadow. The `backgroundColor`, `blurEffect`, and `shadowColor` props do not affect its appearance. You can still use `tintColor` to customize the selected tab item and selection glow. Use [JavaScript tabs](/router/advanced/tabs/) if your app requires full control over the tab bar background.
+On iOS 26 and later, Liquid Glass controls the native tab bar background and shadow. Use `colorScheme` to select a light or dark Liquid Glass appearance. The `backgroundColor`, `blurEffect`, and `shadowColor` props do not affect its appearance, but you can still use `tintColor` to customize the selected tab item and selection glow. Use [JavaScript tabs](/router/advanced/tabs/) if your app requires full control over the tab bar background.
 
 </Collapsible>
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🎉 New features
 
+- [native-tabs] Add the `colorScheme` prop to `NativeTabs`. ([#48673](https://github.com/expo/expo/pull/48673) by [@slavaluka](https://github.com/slavaluka))
 - Improve withLayoutContext types ([#48356](https://github.com/expo/expo/pull/48356) by [@Ubax](https://github.com/Ubax))
 - Expose `unstable_nativeProps` props from Stack component ([#48152](https://github.com/expo/expo/pull/48152) by [@Ubax](https://github.com/Ubax))
 - Expose route provenance to custom navigators through descriptor `routeSource`. ([#47827](https://github.com/expo/expo/pull/47827) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/native-tabs/NativeTabsView.android.tsx
+++ b/packages/expo-router/src/native-tabs/NativeTabsView.android.tsx
@@ -57,6 +57,7 @@ export function NativeTabsView(props: NativeTabsViewProps) {
         tabBarRespectsIMEInsets: !!tabBarRespectsIMEInsets,
         ...rawAndroidProps,
       }}
+      colorScheme={props.colorScheme}
       tabBarHidden={props.hidden}
       {...rawHostRestProps}
       navStateRequest={{ selectedScreenKey, baseProvenance: provenance }}

--- a/packages/expo-router/src/native-tabs/NativeTabsView.ios.tsx
+++ b/packages/expo-router/src/native-tabs/NativeTabsView.ios.tsx
@@ -87,6 +87,7 @@ export function NativeTabsView(props: NativeTabsViewProps) {
         bottomAccessory: bottomAccessoryFn,
         ...rawIosProps,
       }}
+      colorScheme={props.colorScheme}
       tabBarHidden={props.hidden}
       {...rawHostRestProps}
       navStateRequest={{ selectedScreenKey, baseProvenance: provenance }}

--- a/packages/expo-router/src/native-tabs/NativeTabsView.ios.tsx
+++ b/packages/expo-router/src/native-tabs/NativeTabsView.ios.tsx
@@ -30,6 +30,8 @@ export function NativeTabsView(props: NativeTabsViewProps) {
     android: _ignoredRawAndroidProps,
     ...rawHostRestProps
   } = unstable_nativeProps ?? {};
+  const colorScheme =
+    'colorScheme' in rawHostRestProps ? rawHostRestProps.colorScheme : props.colorScheme;
 
   const { selectedScreenKey, provenance } = useSelectedScreenKey(props);
   const onTabSelected = useOnTabSelectedHandler(props.onTabChange);
@@ -67,6 +69,7 @@ export function NativeTabsView(props: NativeTabsViewProps) {
       isFocused={selectedScreenKey === tab.name}
       standardAppearance={iosAppearances[index]!.standardAppearance}
       scrollEdgeAppearance={iosAppearances[index]!.scrollEdgeAppearance}
+      colorScheme={colorScheme}
       contentRenderer={tab.contentRenderer}
     />
   ));
@@ -87,7 +90,7 @@ export function NativeTabsView(props: NativeTabsViewProps) {
         bottomAccessory: bottomAccessoryFn,
         ...rawIosProps,
       }}
-      colorScheme={props.colorScheme}
+      colorScheme={colorScheme}
       tabBarHidden={props.hidden}
       {...rawHostRestProps}
       navStateRequest={{ selectedScreenKey, baseProvenance: provenance }}
@@ -101,6 +104,7 @@ export function NativeTabsView(props: NativeTabsViewProps) {
 interface InternalTabScreenProps extends SharedInternalTabScreenProps {
   standardAppearance: TabsScreenAppearanceIOS;
   scrollEdgeAppearance: TabsScreenAppearanceIOS;
+  colorScheme?: NativeTabsViewProps['colorScheme'];
 }
 
 function Screen(props: InternalTabScreenProps) {
@@ -129,6 +133,10 @@ function Screen(props: InternalTabScreenProps) {
         selectedIcon: iosSelectedIcon,
         standardAppearance,
         scrollEdgeAppearance,
+        // On iOS 26, react-native-screens reapplies the selected screen's interface style to the
+        // tab bar ancestor. Keep it aligned with the host so the appearance persists after selection.
+        experimental_userInterfaceStyle:
+          props.colorScheme === 'inherit' ? 'unspecified' : props.colorScheme,
         systemItem: options.role,
         overrideScrollViewContentInsetAdjustmentBehavior: !options.disableAutomaticContentInsets,
         ...shared.nativeIosOverrides,

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx
@@ -25,6 +25,24 @@ jest.mock('react-native-screens', () => {
 const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
 
+it.each(['inherit', 'light', 'dark'] as const)(
+  'forwards colorScheme=%s to Tabs.Host',
+  (colorScheme) => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs colorScheme={colorScheme}>
+          <NativeTabs.Trigger name="index" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+    });
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(TabsHost).toHaveBeenCalledTimes(1);
+    expect(TabsHost.mock.calls[0][0].colorScheme).toBe(colorScheme);
+  }
+);
+
 it.each([
   { value: undefined, expected: false },
   { value: true, expected: true },

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.ios.tsx
@@ -25,9 +25,13 @@ jest.mock('react-native-screens', () => {
 const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
 
-it.each(['inherit', 'light', 'dark'] as const)(
-  'forwards colorScheme=%s to Tabs.Host',
-  (colorScheme) => {
+it.each([
+  { colorScheme: 'inherit', expectedScreenStyle: 'unspecified' },
+  { colorScheme: 'light', expectedScreenStyle: 'light' },
+  { colorScheme: 'dark', expectedScreenStyle: 'dark' },
+] as const)(
+  'forwards colorScheme=$colorScheme to Tabs.Host and Tabs.Screen',
+  ({ colorScheme, expectedScreenStyle }) => {
     renderRouter({
       _layout: () => (
         <NativeTabs colorScheme={colorScheme}>
@@ -40,6 +44,10 @@ it.each(['inherit', 'light', 'dark'] as const)(
     expect(screen.getByTestId('index')).toBeVisible();
     expect(TabsHost).toHaveBeenCalledTimes(1);
     expect(TabsHost.mock.calls[0][0].colorScheme).toBe(colorScheme);
+    expect(TabsScreen).toHaveBeenCalledTimes(1);
+    expect(TabsScreen.mock.calls[0][0].ios?.experimental_userInterfaceStyle).toBe(
+      expectedScreenStyle
+    );
   }
 );
 
@@ -114,6 +122,23 @@ describe('unstable_nativeProps', () => {
     expect(TabsHost).toHaveBeenCalledTimes(1);
     expect(TabsHost.mock.calls[0][0].colorScheme).toBe('dark');
     expect(TabsHost.mock.calls[0][0].direction).toBe('rtl');
+    expect(TabsScreen.mock.calls[0][0].ios?.experimental_userInterfaceStyle).toBe('dark');
+  });
+
+  it('uses the raw host color scheme for Tabs.Screen when it overrides the stable prop', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs colorScheme="light" unstable_nativeProps={{ colorScheme: 'dark' }}>
+          <NativeTabs.Trigger name="index" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+    });
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(TabsHost).toHaveBeenCalledTimes(1);
+    expect(TabsHost.mock.calls[0][0].colorScheme).toBe('dark');
+    expect(TabsScreen.mock.calls[0][0].ios?.experimental_userInterfaceStyle).toBe('dark');
   });
 
   it('merges ios raw props with expo-router-managed ios props', () => {

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.ios.tsx
@@ -25,6 +25,24 @@ jest.mock('react-native-screens', () => {
 const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
 
+it.each(['inherit', 'light', 'dark'] as const)(
+  'forwards colorScheme=%s to Tabs.Host',
+  (colorScheme) => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs colorScheme={colorScheme}>
+          <NativeTabs.Trigger name="index" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+    });
+
+    expect(screen.getByTestId('index')).toBeVisible();
+    expect(TabsHost).toHaveBeenCalledTimes(1);
+    expect(TabsHost.mock.calls[0][0].colorScheme).toBe(colorScheme);
+  }
+);
+
 it.each([
   { value: undefined, expected: 'automatic' },
   { value: true, expected: 'tabSidebar' },

--- a/packages/expo-router/src/native-tabs/index.ts
+++ b/packages/expo-router/src/native-tabs/index.ts
@@ -17,6 +17,7 @@ export type {
   SymbolOrImageSource,
   NativeTabsTabBarItemLabelVisibilityMode,
   NativeTabsBlurEffect,
+  NativeTabsColorScheme,
   NativeTabsTabBarMinimizeBehavior,
   NativeTabsTabBarItemRole,
 } from './types';

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -106,7 +106,7 @@ export interface NativeTabOptions extends DefaultRouterOptions {
   badgeTextColor?: ColorValue;
   /**
    * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
-   * effect.
+   * effect. Use the `colorScheme` prop on `NativeTabs` to select a light or dark appearance.
    *
    * @platform android
    * @platform iOS
@@ -115,13 +115,14 @@ export interface NativeTabOptions extends DefaultRouterOptions {
   backgroundColor?: ColorValue;
   /**
    * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
-   * effect.
+   * effect. Use the `colorScheme` prop on `NativeTabs` to select a light or dark appearance.
    *
    * @platform iOS
    */
   blurEffect?: NativeTabsBlurEffect;
   /**
    * On iOS 26 and later, Liquid Glass controls the tab bar shadow, so this prop has no effect.
+   * Use the `colorScheme` prop on `NativeTabs` to select a light or dark appearance.
    *
    * @platform iOS
    */
@@ -302,6 +303,11 @@ export const SUPPORTED_BLUR_EFFECTS = [
  */
 export type NativeTabsBlurEffect = (typeof SUPPORTED_BLUR_EFFECTS)[number];
 
+/**
+ * The color scheme used by the native tab host.
+ */
+export type NativeTabsColorScheme = 'inherit' | 'light' | 'dark';
+
 export interface NativeTabsProps extends PropsWithChildren {
   // #region common props
   /**
@@ -324,10 +330,20 @@ export interface NativeTabsProps extends PropsWithChildren {
    */
   tintColor?: ColorValue;
   /**
+   * The color scheme used by the native tab bar and its child containers.
+   *
+   * On iOS 26 and later, this controls the Liquid Glass appearance.
+   *
+   * @default inherit
+   * @platform android
+   * @platform iOS
+   */
+  colorScheme?: NativeTabsColorScheme;
+  /**
    * The background color of the tab bar.
    *
    * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
-   * effect.
+   * effect. Use `colorScheme` to select a light or dark appearance.
    */
   backgroundColor?: ColorValue;
   /**
@@ -367,7 +383,7 @@ export interface NativeTabsProps extends PropsWithChildren {
    * The blur effect applied to the tab bar.
    *
    * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
-   * effect.
+   * effect. Use `colorScheme` to select a light or dark appearance.
    *
    * @platform iOS
    */
@@ -376,6 +392,7 @@ export interface NativeTabsProps extends PropsWithChildren {
    * The color of the shadow.
    *
    * On iOS 26 and later, Liquid Glass controls the tab bar shadow, so this prop has no effect.
+   * Use `colorScheme` to select a light or dark appearance.
    *
    * @see [Apple documentation](https://developer.apple.com/documentation/uikit/uibarappearance/shadowcolor)
    *

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -105,16 +105,24 @@ export interface NativeTabOptions extends DefaultRouterOptions {
    */
   badgeTextColor?: ColorValue;
   /**
+   * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
+   * effect.
+   *
    * @platform android
    * @platform iOS
    * @platform web
    */
   backgroundColor?: ColorValue;
   /**
+   * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
+   * effect.
+   *
    * @platform iOS
    */
   blurEffect?: NativeTabsBlurEffect;
   /**
+   * On iOS 26 and later, Liquid Glass controls the tab bar shadow, so this prop has no effect.
+   *
    * @platform iOS
    */
   shadowColor?: ColorValue;
@@ -317,6 +325,9 @@ export interface NativeTabsProps extends PropsWithChildren {
   tintColor?: ColorValue;
   /**
    * The background color of the tab bar.
+   *
+   * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
+   * effect.
    */
   backgroundColor?: ColorValue;
   /**
@@ -355,11 +366,16 @@ export interface NativeTabsProps extends PropsWithChildren {
   /**
    * The blur effect applied to the tab bar.
    *
+   * On iOS 26 and later, Liquid Glass controls the tab bar background, so this prop has no
+   * effect.
+   *
    * @platform iOS
    */
   blurEffect?: NativeTabsBlurEffect;
   /**
    * The color of the shadow.
+   *
+   * On iOS 26 and later, Liquid Glass controls the tab bar shadow, so this prop has no effect.
    *
    * @see [Apple documentation](https://developer.apple.com/documentation/uikit/uibarappearance/shadowcolor)
    *


### PR DESCRIPTION
# Why

On iOS 26 and later, Liquid Glass ignores the Native Tabs `backgroundColor`, `blurEffect`, and `shadowColor` appearance props. This makes material changes appear to do nothing.

`react-native-screens` exposes a `Tabs.Host.colorScheme` control, but Expo Router users can currently reach it only through `unstable_nativeProps`. On iOS 26, the selected tab screen's interface style is also reapplied to the tab bar ancestor during selection. Forwarding only the host value therefore causes the requested scheme to appear briefly and then reset.

A stable Expo Router prop can handle both native layers and provide a persistent light or dark appearance.

# How

- Add a typed `colorScheme` prop to `NativeTabs` with `inherit`, `light`, and `dark` values.
- Forward the effective value to the native tabs host on iOS and Android.
- On iOS, mirror the effective host scheme to every native tab screen so it persists after tab selection.
- Preserve `unstable_nativeProps` host and per-screen override precedence.
- Add iOS and Android forwarding tests, including raw-only and conflicting stable/raw cases.
- Document the effect on the native host, child containers, and iOS 26 Liquid Glass.
- Clarify the remaining iOS 26 background customization limitations and add a changelog entry.

# Test Plan

- Rebuilt Raena's iOS development client with `react-native-screens` 4.26.2 and tested on an iPhone 17 simulator running iOS 26.5.
- Verified `colorScheme="dark"` remains dark after switching from Home to Calendar; verified `colorScheme="light"` returns to and remains light.
- `bun run typecheck` in the consuming app.
- `bun run ios -- --no-bundler` completed successfully.
- `pnpm dlx oxfmt@0.55.0 --check packages/expo-router/src/native-tabs/types.ts packages/expo-router/src/native-tabs/index.ts packages/expo-router/src/native-tabs/NativeTabsView.ios.tsx packages/expo-router/src/native-tabs/NativeTabsView.android.tsx packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.ios.tsx packages/expo-router/src/native-tabs/__tests__/NativeTabsView.test.android.tsx packages/expo-router/CHANGELOG.md docs/pages/router/advanced/native-tabs.mdx`
- `git diff --check`
- Added targeted iOS and Android regression tests. The suites could not start in this sparse checkout because the Expo monorepo workspace dependencies are not installed; the fallback dependency tree stopped in Jest setup before running tests.

# Checklist

- [x] I added a `CHANGELOG.md` entry and updated the package sources.
- [x] This diff will work correctly for `npx expo prebuild` and EAS Build.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
