### PR TITLE
[android][core] Restore forced layout in ExpoView

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed Expo views using Android layout not completing system-forced layout passes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -2,7 +2,6 @@ package expo.modules.kotlin.views
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.res.Configuration
 import android.util.Log
 import android.view.View
 import android.view.ViewGroup
@@ -111,15 +110,6 @@ abstract class ExpoComposeView<T : ComposeProps>(
     super.onAttachedToWindow()
     if (!withHostingView) {
       validateHostingAncestor()
-    }
-  }
-
-  override fun dispatchConfigurationChanged(newConfig: Configuration) {
-    super.dispatchConfigurationChanged(newConfig)
-    // React Native owns this view's bounds and may not schedule another Android layout pass
-    // when a configuration change leaves its Yoga layout unchanged.
-    if (withHostingView && isAttachedToWindow && isLaidOut) {
-      requestLayout()
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ExpoView.kt
@@ -35,7 +35,8 @@ abstract class ExpoView(
 
   /**
    * Manually trigger measure and layout.
-   * If [shouldUseAndroidLayout] is set to `true`, this method will be called automatically after [requestLayout].
+   * If [shouldUseAndroidLayout] is set to `true`, this method will be called automatically after
+   * [requestLayout] or [forceLayout].
    */
   @UiThread
   fun measureAndLayout() {
@@ -51,6 +52,19 @@ abstract class ExpoView(
     if (shouldUseAndroidLayout) {
       // We need to force measure and layout, because React Native doesn't do it for us.
       post { measureAndLayout() }
+    }
+  }
+
+  override fun forceLayout() {
+    super.forceLayout()
+    if (shouldUseAndroidLayout && isAttachedToWindow && isLaidOut) {
+      // ViewRootImpl can force-layout the hierarchy without React Native laying out its
+      // managed children. Preserve the Android-layout contract at that boundary.
+      post {
+        if (isAttachedToWindow && isLayoutRequested) {
+          measureAndLayout()
+        }
+      }
     }
   }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This is a follow-up to #48407, which fixed #48370 for hosted Compose views that are reattached or receive `dispatchConfigurationChanged()`.

The fix released in `expo-modules-core` 57.0.10 still misses apps that pin their native appearance to light or dark. Changing the system appearance does not change the app's effective theme or Yoga geometry in that case, but the next `MenuView` popup is created without visible content.

On Android 16, a merged window configuration change causes `ViewRootImpl.handleResized()` to recursively call `forceLayout()` on the View hierarchy. This marks the Expo Compose Host and its internal Compose views as requiring layout, without going through the existing `ExpoView.requestLayout()` bridge.

React Native-managed parents do not measure and lay out their children during a normal Android traversal. Because the system appearance change does not change the React Native layout constraints, Fabric has no new geometric layout to commit. The hosted Compose subtree can therefore remain attached and previously laid out while still reporting `isLayoutRequested = true`.

When the menu is subsequently inserted, Compose cannot complete the measure and layout work needed to determine the popup anchor coordinates. The popup window is created and consumes input, but Compose keeps its content transparent because its position is unavailable.

This makes the system appearance change the trigger, but the underlying issue is an unfulfilled Android `forceLayout()` request crossing a React Native-managed layout boundary. The menu is only the observable symptom.

Minimal reproduction: https://github.com/lujjjh/expo-ui-menu-android-popup-repro/tree/52ca1b9826349997094778e986eebb1995a113fd

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Override `forceLayout()` in `ExpoView` and preserve the normal Android behavior by calling `super.forceLayout()`.
- For attached and previously laid-out views that opt into `shouldUseAndroidLayout`, post the existing `measureAndLayout()` recovery path.
- Recheck `isAttachedToWindow` and `isLayoutRequested` when the posted callback executes. This skips the recovery if the view was detached or if a normal Android or React Native traversal already completed the requested layout.
- Remove the configuration-specific `dispatchConfigurationChanged()` layout request from `ExpoComposeView`, so configuration changes are handled through the underlying `forceLayout()` path instead of a trigger-specific workaround.
- Keep the existing reattachment recovery because detach/reattach does not necessarily produce a `forceLayout()` call.
- Do not remount the Compose composition or change `MenuView`, `DropdownMenu`, or popup behavior.

Although the override is implemented in `ExpoView`, it is gated by `shouldUseAndroidLayout`, which defaults to `false`. Currently, hosted `ExpoComposeView` instances are the views that enable this behavior, so ordinary Expo views such as image, video, camera, and blur views are unaffected.

Placing the recovery in `ExpoView` completes the existing Android-layout contract: `requestLayout()` and `forceLayout()` now both bridge layouts that React Native does not perform for opted-in native views.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Source checks:

- Ran `node ./tools/bin/expotools.js check-packages expo-modules-core`.
- Ran `cd apps/bare-expo/android && ./gradlew :expo-modules-core:spotlessCheck :expo-modules-core:compileDebugKotlin --no-configuration-cache`.
- Both checks passed.

Unpatched reproduction:

- Checked out the minimal reproduction at commit `52ca1b9`.
- Confirmed the tracked worktree matched `origin/main`.
- Ran `npm ci` and confirmed it installed the published `expo-modules-core` 57.0.10.
- Confirmed the installed package contained the existing `dispatchConfigurationChanged()` handler and did not contain the new `forceLayout()` override.
- Ran a clean Android prebuild and rebuilt the APK.
- Tested on a Pixel 9 Pro Android emulator running Android 16 / API 36.
- Confirmed the app was pinned to light appearance.
- In system light mode, opened the menu and confirmed both actions were visible.
- Dismissed the menu, then ran `adb shell cmd uimode night yes`.
- Confirmed the app remained light and the process PID remained unchanged.
- Opened the menu again and observed:
  - `onOpenMenu` ran and the screen displayed `Menu opened`;
  - the popup content was invisible;
  - UI Automator exposed zero menu actions;
  - the first outside tap dismissed the invisible popup and changed the status to `Menu closed`;
  - opening the menu again still exposed zero actions.

Patched verification:

- Applied the candidate patch from the reproduction repository, including removal of the configuration-specific handler.
- Rebuilt and installed the app on the same Android 16 emulator.
- Verified six system appearance changes while the app was pinned to light. Both menu actions remained visible after every change, and the process PID remained stable.
- Verified four system appearance changes while the app followed the system appearance. Both menu actions remained visible after every change.
- Verified four portrait/landscape rotations. The menu remained visible and correctly anchored after every rotation.
- Verified three navigation cycles to another screen and back. The menu remained visible after every reattachment.
- Confirmed the configuration-specific `dispatchConfigurationChanged()` recovery was absent during the successful runs, so system appearance changes were recovered through the new `forceLayout()` bridge.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
