### PR TITLE
fix(task-manager)[android]: fix NPE race between executeTask and notifyTaskFinished on sEvents

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix a `NullPointerException` crash in `TaskService.executeTask` when a task event is delivered concurrently with `notifyTaskFinished` removing the last in-flight event — the unsynchronized check-then-act on the static `sEvents` map could re-read a removed entry as `null`. Seen in production as fatal crashes during background location tracking. ([#48684](https://github.com/expo/expo/pull/48684) by [@pelayomartinez](https://github.com/pelayomartinez))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -69,6 +69,9 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   private static final Map<String, WeakReference<TaskManagerInterface>> sHeadlessTaskManagers = new HashMap<>();
 
   // { "<appScopeKey>": List(eventIds...) }
+  // Guarded by `synchronized (sEvents)`: entries are added from the JobScheduler
+  // thread (`executeTask`) and removed from the module's async queue
+  // (`notifyTaskFinished`), so compound accesses must hold the monitor.
   private static final Map<String, List<String>> sEvents = new HashMap<>();
 
   private TasksAndEventsRepository mTasksAndEventsRepository;
@@ -208,25 +211,38 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   @Override
   public void notifyTaskFinished(String taskName, final String appScopeKey, Map<String, Object> response) {
     String eventId = (String) response.get("eventId");
-    List<String> appEvents = sEvents.get(appScopeKey);
 
     Log.i(TAG, "Finished task '" + taskName + "' with eventId '" + eventId + "'.");
 
-    if (appEvents != null) {
-      appEvents.remove(eventId);
+    // Only the map/list mutations hold the lock — `maybeFinishHeadlessTask`
+    // and `invalidateAppRecord` stay outside it to keep the lock leaf-level.
+    boolean becameEmpty = false;
+    synchronized (sEvents) {
+      List<String> appEvents = sEvents.get(appScopeKey);
+      if (appEvents != null) {
+        appEvents.remove(eventId);
 
-      if (appEvents.isEmpty()) {
-        sEvents.remove(appScopeKey);
-        maybeFinishHeadlessTask(appScopeKey);
-
-        // Invalidate app record but after 2 seconds delay so we can still take batched events.
-        Handler handler = new Handler();
-        handler.postDelayed(() -> {
-          if (!sEvents.containsKey(appScopeKey)) {
-            invalidateAppRecord(appScopeKey);
-          }
-        }, 2000);
+        if (appEvents.isEmpty()) {
+          sEvents.remove(appScopeKey);
+          becameEmpty = true;
+        }
       }
+    }
+
+    if (becameEmpty) {
+      maybeFinishHeadlessTask(appScopeKey);
+
+      // Invalidate app record but after 2 seconds delay so we can still take batched events.
+      Handler handler = new Handler();
+      handler.postDelayed(() -> {
+        boolean stillEmpty;
+        synchronized (sEvents) {
+          stillEmpty = !sEvents.containsKey(appScopeKey);
+        }
+        if (stillEmpty) {
+          invalidateAppRecord(appScopeKey);
+        }
+      }, 2000);
     }
 
     // Invoke task callback
@@ -393,14 +409,16 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
       sTaskCallbacks.put(eventId, callback);
     }
 
-    boolean isFirstEvent = sEvents.get(appScopeKey) == null;
-    final List<String> appEvents;
-    if (isFirstEvent) {
-      appEvents = new ArrayList<>();
-      appEvents.add(eventId);
-      sEvents.put(appScopeKey, appEvents);
-    } else {
-      appEvents = sEvents.get(appScopeKey);
+    // Atomic check-then-act: `notifyTaskFinished` can remove the entry between
+    // an unsynchronized check and re-get, making the re-get return null.
+    boolean isFirstEvent;
+    synchronized (sEvents) {
+      List<String> appEvents = sEvents.get(appScopeKey);
+      isFirstEvent = appEvents == null;
+      if (isFirstEvent) {
+        appEvents = new ArrayList<>();
+        sEvents.put(appScopeKey, appEvents);
+      }
       appEvents.add(eventId);
     }
 
@@ -430,7 +448,9 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
       },
       success -> {
         if (!success) {
-          sEvents.remove(appScopeKey);
+          synchronized (sEvents) {
+            sEvents.remove(appScopeKey);
+          }
           mTasksAndEventsRepository.removeEvents(appScopeKey);
 
           // Host unreachable? Unregister all tasks for that app.


### PR DESCRIPTION
# Why

`TaskService` crashes the whole process with an uncaught `NullPointerException` when a task event is delivered at the same moment the JS side finishes the last in-flight event for that app. We hit this repeatedly in production (fatal, `com.yandv.skiapp`, background location tracking during ski session recording):

```
RuntimeException: java.lang.NullPointerException: Attempt to invoke interface method
'boolean java.util.List.add(java.lang.Object)' on a null object reference
  at expo.modules.taskManager.TaskService.executeTask(TaskService.java:403)
  at expo.modules.taskManager.Task.execute(Task.java:58)
  at expo.modules.location.taskConsumers.LocationTaskConsumer.executeTaskWithLocationBundles(LocationTaskConsumer.kt:333)
  at expo.modules.location.taskConsumers.LocationTaskConsumer.didExecuteJob(LocationTaskConsumer.kt:128)
  at expo.modules.taskManager.TaskService.handleJob(TaskService.java:344)
```

(Line numbers from `expo-task-manager@55.0.10`; the code is unchanged on `main`.)

This is the same crash reported in #41663 (~30k-user app, sporadic, production-only), which was closed for lacking a minimal repro — a repro is inherently hard to produce because the vulnerable window is a handful of instructions, as analyzed in detail by @TinyKitten in [this comment](https://github.com/expo/expo/issues/41663#issuecomment-4437301630) on that issue. This PR implements essentially the fix proposed there.

## Root cause

`sEvents` is a plain static `HashMap` mutated from two threads with no synchronization:

- `executeTask` runs on the main looper via `TaskJobService.onStartJob` → `handleJob`, and does a check-then-act: `sEvents.get(appScopeKey) == null`, then a *second* `sEvents.get(appScopeKey)` in the `else` branch.
- `notifyTaskFinished` runs on the module's async queue (`AsyncFunction("notifyTaskFinishedAsync")`) and calls `sEvents.remove(appScopeKey)` when the app's last in-flight event completes.

If the JS side finishes the last event between the first `get` and the second, the second `get` returns `null` and `appEvents.add(eventId)` throws. The NPE escapes onto the main looper and kills the process. Apps that drive sustained, frequent events through the task manager (background location) interleave these two threads constantly, which is why this bites location-tracking apps in particular.

# How

All compound accesses to `sEvents` (and to the `ArrayList`s stored in it, which were shared cross-thread the same way) now hold the `sEvents` monitor:

- `executeTask`: the check-then-act is one atomic block — single `get`, insert-if-absent, `add`.
- `notifyTaskFinished`: the remove/empty-check is atomic; `maybeFinishHeadlessTask` and the delayed `invalidateAppRecord` run outside the lock (the lock stays leaf-level, so no lock-ordering hazards), with the `containsKey` check inside the delayed lambda also guarded.
- the `loadApp` failure callback's `sEvents.remove(appScopeKey)` is guarded.

`ConcurrentHashMap` alone would not fix this: the bug is a compound operation (check-then-act spanning two `get`s, and remove-if-empty), so atomicity has to cover the compound, not the individual map calls.

# Test Plan

- The race has no deterministic repro (the window is a few instructions between two `get`s), which is why #41663 could not provide one. Evidence instead: production crashes on `expo-task-manager@55.0.10` with the exact stack above, always during background location delivery while the app is backgrounded — the interleaving the analysis in #41663 predicts.
- We are shipping this exact change via `patch-package` in a ski-tracking app that records multi-hour background location sessions (1 Hz updates plus deferred batches); happy to report back with production soak results on the fixed build.
- The change is confined to lock scoping in `TaskService.java` — no API change, and no behavior change on the success path: the same operations execute in the same order, only atomically with respect to each other.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — Android-only Java change, no TS sources to rebuild
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — no config-plugin changes
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — n/a, no docs changes
