### PR TITLE
[feedback-cli] support custom local API base URL

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -323,6 +323,7 @@ describe('feedback submission', () => {
       EXPO_LOCAL: '1',
     };
     delete env.EXPO_STAGING;
+    delete env.EXPO_FEEDBACK_API_BASE_URL;
     delete env.EXPO_TOKEN;
     delete env.DO_NOT_TRACK;
     delete env.EXPO_NO_TELEMETRY;
@@ -399,6 +400,35 @@ describe('feedback submission', () => {
         username: 'expo-user',
       },
     });
+  });
+
+  it('uses the feedback API base URL override in local mode', async () => {
+    process.env.EXPO_FEEDBACK_API_BASE_URL = 'http://127.0.0.1:43210';
+
+    await sendFeedbackAsync({
+      feedback: 'please make errors clearer',
+      metadata: await createFeedbackMetadataAsync(projectRoot),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:43210/v2/feedback/cli-send',
+      expect.any(Object)
+    );
+  });
+
+  it('ignores the feedback API base URL override outside local mode', async () => {
+    delete process.env.EXPO_LOCAL;
+    process.env.EXPO_FEEDBACK_API_BASE_URL = 'http://127.0.0.1:43210';
+
+    await sendFeedbackAsync({
+      feedback: 'please make errors clearer',
+      metadata: await createFeedbackMetadataAsync(projectRoot),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.expo.dev/v2/feedback/cli-send',
+      expect.any(Object)
+    );
   });
 
   it('does not submit feedback over the maximum length', async () => {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -455,7 +455,9 @@ export function getExpoHomeDirectory(): string {
 }
 
 function getExpoApiBaseUrl(): string {
-  if (process.env.EXPO_STAGING) {
+  if (process.env.EXPO_LOCAL && process.env.EXPO_FEEDBACK_API_BASE_URL) {
+    return process.env.EXPO_FEEDBACK_API_BASE_URL;
+  } else if (process.env.EXPO_STAGING) {
     return 'https://staging-api.expo.dev';
   } else if (process.env.EXPO_LOCAL) {
     return 'http://127.0.0.1:3000';


### PR DESCRIPTION
## Why

Universe integration tests run the API server on a random port and need to exercise `submit-expo-feedback@latest` against that server.

## How

Adds `EXPO_FEEDBACK_API_BASE_URL` as a feedback-specific API base URL override. The override is only honored when `EXPO_LOCAL=1`, preventing normal CLI usage from accidentally sending authentication or user metadata to an arbitrary URL.

Tests both the enabled and guarded behavior.

## Test Plan

- `pnpm --dir packages/submit-expo-feedback lint`
- `pnpm --dir packages/submit-expo-feedback typecheck`
- `pnpm --dir packages/submit-expo-feedback exec jest --runInBand`
- `pnpm --dir packages/submit-expo-feedback build`
