### PR TITLE
[media-library][android][ios] Add native unit tests for the class-based API

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 💡 Others
 
 - Re-organize TS code ([#45953](https://github.com/expo/expo/pull/45953) by [@Wenszel](https://github.com/Wenszel))
+- [Android][iOS] Add native unit tests for the class-based API mapping layer: `AssetMapper` unit conversions, `MediaStoreQueryFormatter`, `MediaType`, `MimeType`, `RelativePath`, `AssetField`, `SortDescriptor`, `buildUniqueDisplayName`, `extractAssetContentUri`, `AssetDimensionsResolver`, `AssetFieldPredicateBuilder` and the legacy `assetType`/`exportDate` helpers.
 
 ## 57.0.3 - 2026-07-17
 

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/extensions/resolver/ExtractAssetContentUriTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/extensions/resolver/ExtractAssetContentUriTests.kt
@@ -1,0 +1,88 @@
+package expo.modules.medialibrary.next.extensions.resolver
+
+import android.os.Build
+import android.provider.MediaStore
+import expo.modules.medialibrary.next.objects.wrappers.MediaType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `Asset.id` is the content uri produced here, so its shape is public API: it is what JS stores
+ * and later passes back to `new Asset(id)`. It also has to round-trip through
+ * [MediaType.fromContentUri], which reads the collection path segment.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class ExtractAssetContentUriTests {
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+  fun `builds a per-collection uri`() {
+    // then
+    assertEquals(
+      "${MediaStore.Images.Media.EXTERNAL_CONTENT_URI}/42",
+      extractAssetContentUri(42L, MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE).toString()
+    )
+    assertEquals(
+      "${MediaStore.Video.Media.EXTERNAL_CONTENT_URI}/42",
+      extractAssetContentUri(42L, MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO).toString()
+    )
+    assertEquals(
+      "${MediaStore.Audio.Media.EXTERNAL_CONTENT_URI}/42",
+      extractAssetContentUri(42L, MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO).toString()
+    )
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+  fun `falls back to the files collection for non-media rows`() {
+    // given MediaStore.Files also indexes documents and downloads
+    // then
+    assertEquals(
+      "$EXTERNAL_CONTENT_URI/42",
+      extractAssetContentUri(42L, MediaStore.Files.FileColumns.MEDIA_TYPE_NONE).toString()
+    )
+    assertEquals("$EXTERNAL_CONTENT_URI/42", extractAssetContentUri(42L, null).toString())
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
+  fun `produces uris that resolve back to the same media type`() {
+    // then
+    assertEquals(
+      MediaType.IMAGE,
+      MediaType.fromContentUri(
+        extractAssetContentUri(1L, MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE)
+      )
+    )
+    assertEquals(
+      MediaType.VIDEO,
+      MediaType.fromContentUri(
+        extractAssetContentUri(1L, MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO)
+      )
+    )
+    assertEquals(
+      MediaType.AUDIO,
+      MediaType.fromContentUri(
+        extractAssetContentUri(1L, MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO)
+      )
+    )
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.Q])
+  fun `pins the uri to the primary external volume on Android 10`() {
+    // given on exactly API 29 the volume-less collection uris are not writable, so the
+    // implementation switches to the explicit `external_primary` volume
+    // then
+    assertEquals(
+      "${MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)}/42",
+      extractAssetContentUri(42L, MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE).toString()
+    )
+    assertEquals(
+      "${MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)}/42",
+      extractAssetContentUri(42L, null).toString()
+    )
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/album/factories/AlbumFactoryEmptyInputTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/album/factories/AlbumFactoryEmptyInputTests.kt
@@ -1,0 +1,53 @@
+package expo.modules.medialibrary.next.objects.album.factories
+
+import android.content.Context
+import android.os.Build
+import expo.modules.kotlin.exception.CodedException
+import expo.modules.medialibrary.next.objects.asset.deleters.AssetDeleter
+import expo.modules.medialibrary.next.objects.asset.factories.AssetFactory
+import expo.modules.medialibrary.next.objects.asset.movers.AssetMover
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * `Album.create(name, refs)` accepts an array, and the JS layer forwards an empty one unchanged
+ * (`AssetAlbum.ts` treats a zero-length array as `string[]`). Both factories must therefore reject
+ * an empty list with a `CodedException` that JS can surface, rather than letting an
+ * `IndexOutOfBoundsException` escape.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class AlbumFactoryEmptyInputTests {
+  private val context = mockk<Context>(relaxed = true)
+  private val assetFactory = mockk<AssetFactory>(relaxed = true)
+  private val assetDeleter = mockk<AssetDeleter>(relaxed = true)
+  private val assetMover = mockk<AssetMover>(relaxed = true)
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.P])
+  fun `legacy factory rejects an empty asset list`() {
+    // given
+    val factory = AlbumLegacyFactory(assetFactory, assetDeleter, assetMover, context)
+
+    // then
+    assertThrows(CodedException::class.java) {
+      runBlocking { factory.createFromAssets("My Album", emptyList(), false) }
+    }
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.P])
+  fun `legacy factory rejects an empty file path list`() {
+    // given
+    val factory = AlbumLegacyFactory(assetFactory, assetDeleter, assetMover, context)
+
+    // then
+    assertThrows(CodedException::class.java) {
+      runBlocking { factory.createFromFilePaths("My Album", emptyList()) }
+    }
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/AssetDimensionsResolverTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/AssetDimensionsResolverTests.kt
@@ -1,0 +1,107 @@
+package expo.modules.medialibrary.next.objects.asset
+
+import expo.modules.medialibrary.next.objects.asset.domain.AssetMediaStoreItem
+import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreAudio
+import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreImage
+import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreVideo
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Decoding a file just to read its bounds is expensive, so the resolver must only fall back to
+ * `BitmapFactory` when MediaStore has no usable dimensions, and only for images.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class AssetDimensionsResolverTests {
+  private val resolver = AssetDimensionsResolver()
+
+  private fun image(width: Int?, height: Int?, data: String? = "/storage/DCIM/a.jpg") =
+    MediaStoreImage(
+      id = 1L,
+      displayName = "a.jpg",
+      dateTaken = 0L,
+      dateModified = 0L,
+      width = width,
+      height = height,
+      orientation = 0,
+      data = data,
+      isFavorite = 0
+    )
+
+  @Test
+  fun `leaves an image untouched when MediaStore already has both dimensions`() = runTest {
+    // given
+    val item = AssetMediaStoreItem.Image(image(width = 4000, height = 3000))
+
+    // when
+    val resolved = resolver.resolveDimensions(item)
+
+    // then
+    assertEquals(4000, (resolved as AssetMediaStoreItem.Image).asset.width)
+    assertEquals(3000, resolved.asset.height)
+  }
+
+  @Test
+  fun `leaves an image untouched when there is no file path to decode`() = runTest {
+    // given a MediaStore row with neither dimensions nor a DATA path
+    val item = AssetMediaStoreItem.Image(image(width = null, height = null, data = null))
+
+    // when
+    val resolved = resolver.resolveDimensions(item)
+
+    // then the wrapper is rebuilt for images, so compare by value rather than by identity
+    assertEquals(item, resolved)
+  }
+
+  @Test
+  fun `never decodes a video`() = runTest {
+    // given MediaStore always populates video dimensions, and decoding a video with
+    // BitmapFactory would fail anyway
+    val item = AssetMediaStoreItem.Video(
+      MediaStoreVideo(
+        id = 2L,
+        displayName = "a.mp4",
+        dateTaken = 0L,
+        dateModified = 0L,
+        width = null,
+        height = null,
+        orientation = 0,
+        duration = 1000L,
+        data = "/storage/DCIM/a.mp4",
+        isFavorite = 0
+      )
+    )
+
+    // when
+    val resolved = resolver.resolveDimensions(item)
+
+    // then
+    assertSame(item, resolved)
+  }
+
+  @Test
+  fun `never decodes an audio file`() = runTest {
+    // given
+    val item = AssetMediaStoreItem.Audio(
+      MediaStoreAudio(
+        id = 3L,
+        displayName = "a.mp3",
+        dateTaken = 0L,
+        dateModified = 0L,
+        duration = 1000L,
+        data = "/storage/Music/a.mp3",
+        isFavorite = 0
+      )
+    )
+
+    // when
+    val resolved = resolver.resolveDimensions(item)
+
+    // then
+    assertSame(item, resolved)
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/AssetMapperTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/AssetMapperTests.kt
@@ -1,13 +1,17 @@
 package expo.modules.medialibrary.next.objects.asset
 
 import android.provider.MediaStore
+import expo.modules.medialibrary.next.exceptions.AssetPropertyNotFoundException
 import expo.modules.medialibrary.next.objects.asset.domain.AssetMediaStoreItem
+import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreAudio
 import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreFile
 import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreImage
 import expo.modules.medialibrary.next.objects.asset.domain.MediaStoreVideo
+import expo.modules.medialibrary.next.objects.wrappers.MediaType
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -38,6 +42,16 @@ internal class AssetMapperTests {
     orientation = orientation,
     duration = 1000L,
     data = "/storage/emulated/0/DCIM/portrait.mp4",
+    isFavorite = 0
+  )
+
+  private fun mediaStoreAudio() = MediaStoreAudio(
+    id = 4L,
+    displayName = "song.mp3",
+    dateTaken = 0L,
+    dateModified = 0L,
+    duration = 30_000L,
+    data = "/storage/emulated/0/Music/song.mp3",
     isFavorite = 0
   )
 
@@ -122,5 +136,158 @@ internal class AssetMapperTests {
     // assert
     assertNull(metadata.width)
     assertNull(metadata.height)
+  }
+
+  @Test
+  fun `toDto keeps image dimensions when orientation is a half turn`() {
+    // given a 180 degree rotation does not change the display aspect ratio
+    // act
+    val info = mapper.toDto(AssetMediaStoreItem.Image(mediaStoreImage(orientation = 180)))
+
+    // assert
+    assertEquals(4000, info.width)
+    assertEquals(3000, info.height)
+  }
+
+  @Test
+  fun `toDto swaps image dimensions when orientation is negative`() {
+    // given MediaStore should only ever store 0/90/180/270, but the column does not enforce it
+    // act
+    val info = mapper.toDto(AssetMediaStoreItem.Image(mediaStoreImage(orientation = -90)))
+
+    // assert
+    assertEquals(3000, info.width)
+    assertEquals(4000, info.height)
+  }
+
+  @Test
+  fun `mapCreationTime keeps DATE_TAKEN in milliseconds`() {
+    // given MediaStore stores DATE_TAKEN in milliseconds since the epoch
+    // act & assert
+    assertEquals(1_767_225_600_000L, mapper.mapCreationTime(1_767_225_600_000L))
+  }
+
+  @Test
+  fun `mapCreationTime treats zero and null as unavailable`() {
+    // given MediaStore leaves DATE_TAKEN at 0 for assets that never had one, such as downloads
+    // act & assert
+    assertNull(mapper.mapCreationTime(0L))
+    assertNull(mapper.mapCreationTime(null))
+  }
+
+  @Test
+  fun `mapModificationTime converts DATE_MODIFIED from seconds to milliseconds`() {
+    // given MediaStore stores DATE_MODIFIED in seconds, unlike DATE_TAKEN
+    // act & assert
+    assertEquals(1_767_225_600_000L, mapper.mapModificationTime(1_767_225_600L))
+  }
+
+  @Test
+  fun `mapModificationTime treats zero and null as unavailable`() {
+    // act & assert
+    assertNull(mapper.mapModificationTime(0L))
+    assertNull(mapper.mapModificationTime(null))
+  }
+
+  @Test
+  fun `mapDuration keeps DURATION in milliseconds`() {
+    // given MediaStore stores DURATION in milliseconds
+    // act & assert
+    assertEquals(4_200L, mapper.mapDuration(4_200L))
+  }
+
+  @Test
+  fun `mapDuration treats zero and null as unavailable`() {
+    // act & assert
+    assertNull(mapper.mapDuration(0L))
+    assertNull(mapper.mapDuration(null))
+  }
+
+  @Test
+  fun `mapIsFavorite reads the IS_FAVORITE flag`() {
+    // given the column is an integer flag and is absent below Android 10
+    // act & assert
+    assertEquals(true, mapper.mapIsFavorite(1))
+    assertEquals(false, mapper.mapIsFavorite(0))
+    assertEquals(false, mapper.mapIsFavorite(null))
+  }
+
+  @Test
+  fun `mapUri builds a file uri from the DATA column`() {
+    // act
+    val uri = mapper.mapUri("/storage/emulated/0/DCIM/portrait.jpg")
+
+    // assert
+    assertEquals("file:///storage/emulated/0/DCIM/portrait.jpg", uri.toString())
+  }
+
+  @Test
+  fun `mapUri returns null when the DATA column is absent`() {
+    // act & assert
+    assertNull(mapper.mapUri(null))
+  }
+
+  @Test
+  fun `toDto reports audio assets as zero-sized with a duration`() {
+    // given audio has no dimensions, so AssetInfo reports 0 rather than failing
+    // act
+    val info = mapper.toDto(AssetMediaStoreItem.Audio(mediaStoreAudio()))
+
+    // assert
+    assertEquals(0, info.width)
+    assertEquals(0, info.height)
+    assertEquals(30_000L, info.duration!!)
+    assertEquals(MediaType.AUDIO, info.mediaType)
+  }
+
+  @Test
+  fun `mapShape returns null for audio assets`() {
+    // act & assert
+    assertNull(mapper.mapShape(AssetMediaStoreItem.Audio(mediaStoreAudio())))
+  }
+
+  @Test
+  fun `mapShape returns null when a dimension is missing`() {
+    // act & assert
+    assertNull(
+      mapper.mapShape(
+        AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(width = null))
+      )
+    )
+    assertNull(
+      mapper.mapShape(
+        AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(height = 0))
+      )
+    )
+  }
+
+  @Test
+  fun `toDto fails with a coded exception when the filename is missing`() {
+    // given MediaStore rows can be incomplete while a file is still being written
+    // act & assert
+    assertThrows(AssetPropertyNotFoundException::class.java) {
+      mapper.toDto(
+        AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(displayName = null))
+      )
+    }
+  }
+
+  @Test
+  fun `toDto fails with a coded exception when a dimension is missing`() {
+    // act & assert
+    assertThrows(AssetPropertyNotFoundException::class.java) {
+      mapper.toDto(AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(width = null)))
+    }
+    assertThrows(AssetPropertyNotFoundException::class.java) {
+      mapper.toDto(AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(height = 0)))
+    }
+  }
+
+  @Test
+  fun `toDto fails with a coded exception when the DATA path is missing`() {
+    // act & assert
+    assertThrows(AssetPropertyNotFoundException::class.java) {
+      mapper.toDto(AssetMediaStoreItem.Image(mediaStoreImage(orientation = 0).copy(data = null)))
+    }
   }
 }

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/factories/BuildUniqueDisplayNameTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/asset/factories/BuildUniqueDisplayNameTests.kt
@@ -1,0 +1,63 @@
+package expo.modules.medialibrary.next.objects.asset.factories
+
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * The content resolver gives up de-duplicating a file name after ~32 collisions, at which point
+ * asset creation retries with a name built here. The name has to stay a valid MediaStore
+ * `DISPLAY_NAME`: a bare file name, with the original extension preserved.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class BuildUniqueDisplayNameTests {
+  @Test
+  fun `keeps the base name and the extension`() {
+    // when
+    val displayName = buildUniqueDisplayName(Uri.parse("file:///storage/DCIM/IMG_0001.jpg"))
+
+    // then
+    assertTrue(displayName, displayName.matches(Regex("""IMG_0001_[0-9a-f]{8}\.jpg""")))
+  }
+
+  @Test
+  fun `omits the separator when the file has no extension`() {
+    // when
+    val displayName = buildUniqueDisplayName(Uri.parse("file:///storage/DCIM/screenshot"))
+
+    // then
+    assertTrue(displayName, displayName.matches(Regex("""screenshot_[0-9a-f]{8}""")))
+  }
+
+  @Test
+  fun `keeps only the last extension of a multi-dot name`() {
+    // when
+    val displayName = buildUniqueDisplayName(Uri.parse("file:///storage/DCIM/my.holiday.photo.jpeg"))
+
+    // then
+    assertTrue(displayName, displayName.matches(Regex("""my\.holiday\.photo_[0-9a-f]{8}\.jpeg""")))
+  }
+
+  @Test
+  fun `never produces a path separator`() {
+    // given DISPLAY_NAME must be a bare file name, not a path
+    // when
+    val displayName = buildUniqueDisplayName(Uri.parse("file:///storage/DCIM/Album/IMG_1.jpg"))
+
+    // then
+    assertEquals(-1, displayName.indexOf('/'))
+  }
+
+  @Test
+  fun `produces a different name on every call`() {
+    // given
+    val uri = Uri.parse("file:///storage/DCIM/IMG_0001.jpg")
+
+    // then
+    assertNotEquals(buildUniqueDisplayName(uri), buildUniqueDisplayName(uri))
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatterTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/query/MediaStoreQueryFormatterTests.kt
@@ -1,0 +1,76 @@
+package expo.modules.medialibrary.next.objects.query
+
+import expo.modules.medialibrary.next.objects.wrappers.MediaType
+import expo.modules.medialibrary.next.records.AssetField
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * `Query` values cross the bridge in the same units the `Asset` getters return: timestamps and
+ * durations in milliseconds. MediaStore is not consistent — `DATE_TAKEN` and `DURATION` are stored
+ * in milliseconds, `DATE_MODIFIED` in seconds — so the formatter has to convert exactly one field.
+ * These tests pin that asymmetry, because getting it wrong silently returns the wrong rows instead
+ * of raising an error.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class MediaStoreQueryFormatterTests {
+  @Test
+  fun `converts modification time from milliseconds to seconds`() {
+    // given DATE_MODIFIED is stored in seconds
+    val millis = 1_767_225_600_000L
+
+    // when
+    val formatted = MediaStoreQueryFormatter.parse(AssetField.MODIFICATION_TIME, millis)
+
+    // then
+    assertEquals("1767225600", formatted)
+  }
+
+  @Test
+  fun `truncates sub-second precision when converting modification time`() {
+    // when
+    val formatted = MediaStoreQueryFormatter.parse(AssetField.MODIFICATION_TIME, 1_999L)
+
+    // then
+    assertEquals("1", formatted)
+  }
+
+  @Test
+  fun `keeps creation time in milliseconds`() {
+    // given DATE_TAKEN is already stored in milliseconds
+    val millis = 1_767_225_600_000L
+
+    // when
+    val formatted = MediaStoreQueryFormatter.parse(AssetField.CREATION_TIME, millis)
+
+    // then
+    assertEquals("1767225600000", formatted)
+  }
+
+  @Test
+  fun `keeps duration in milliseconds`() {
+    // when
+    val formatted = MediaStoreQueryFormatter.parse(AssetField.DURATION, 4_200L)
+
+    // then
+    assertEquals("4200", formatted)
+  }
+
+  @Test
+  fun `passes dimensions through unchanged`() {
+    // then
+    assertEquals("1080", MediaStoreQueryFormatter.parse(AssetField.WIDTH, 1_080L))
+    assertEquals("1920", MediaStoreQueryFormatter.parse(AssetField.HEIGHT, 1_920L))
+  }
+
+  @Test
+  fun `formats media types as their MediaStore column values`() {
+    // then
+    assertEquals("1", MediaStoreQueryFormatter.parse(MediaType.IMAGE))
+    assertEquals("2", MediaStoreQueryFormatter.parse(MediaType.AUDIO))
+    assertEquals("3", MediaStoreQueryFormatter.parse(MediaType.VIDEO))
+    assertEquals("0", MediaStoreQueryFormatter.parse(MediaType.UNKNOWN))
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/MediaTypeTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/MediaTypeTests.kt
@@ -1,0 +1,82 @@
+package expo.modules.medialibrary.next.objects.wrappers
+
+import android.net.Uri
+import android.provider.MediaStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class MediaTypeTests {
+  @Test
+  fun `parses api names case-insensitively`() {
+    // then
+    assertEquals(MediaType.IMAGE, MediaType.fromString("image"))
+    assertEquals(MediaType.IMAGE, MediaType.fromString("IMAGE"))
+    assertEquals(MediaType.VIDEO, MediaType.fromString("Video"))
+    assertEquals(MediaType.AUDIO, MediaType.fromString("audio"))
+  }
+
+  @Test
+  fun `falls back to unknown for unrecognised api names`() {
+    // then
+    assertEquals(MediaType.UNKNOWN, MediaType.fromString("unknown"))
+    assertEquals(MediaType.UNKNOWN, MediaType.fromString("photo"))
+    assertEquals(MediaType.UNKNOWN, MediaType.fromString(""))
+  }
+
+  @Test
+  fun `round-trips through MediaStore column values`() {
+    // then
+    for (mediaType in MediaType.entries) {
+      assertEquals(mediaType, MediaType.fromMediaStoreValue(mediaType.toMediaStoreValue()))
+    }
+  }
+
+  @Test
+  fun `maps to the MediaStore file column constants`() {
+    // then
+    assertEquals(MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE, MediaType.IMAGE.toMediaStoreValue())
+    assertEquals(MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO, MediaType.VIDEO.toMediaStoreValue())
+    assertEquals(MediaStore.Files.FileColumns.MEDIA_TYPE_AUDIO, MediaType.AUDIO.toMediaStoreValue())
+    assertEquals(MediaStore.Files.FileColumns.MEDIA_TYPE_NONE, MediaType.UNKNOWN.toMediaStoreValue())
+  }
+
+  @Test
+  fun `falls back to unknown for unmapped MediaStore column values`() {
+    // given MEDIA_TYPE_PLAYLIST and MEDIA_TYPE_SUBTITLE have no equivalent in the new API
+    // then
+    assertEquals(
+      MediaType.UNKNOWN,
+      MediaType.fromMediaStoreValue(MediaStore.Files.FileColumns.MEDIA_TYPE_SUBTITLE)
+    )
+  }
+
+  @Test
+  fun `derives the media type from a content uri collection segment`() {
+    // then
+    assertEquals(
+      MediaType.IMAGE,
+      MediaType.fromContentUri(Uri.parse("content://media/external/images/media/42"))
+    )
+    assertEquals(
+      MediaType.VIDEO,
+      MediaType.fromContentUri(Uri.parse("content://media/external/video/media/42"))
+    )
+    assertEquals(
+      MediaType.AUDIO,
+      MediaType.fromContentUri(Uri.parse("content://media/external/audio/media/42"))
+    )
+  }
+
+  @Test
+  fun `treats the generic files collection as unknown`() {
+    // given `Query` builds this uri for rows whose MEDIA_TYPE is NONE
+    // then
+    assertEquals(
+      MediaType.UNKNOWN,
+      MediaType.fromContentUri(Uri.parse("content://media/external/file/42"))
+    )
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/MimeTypeTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/MimeTypeTests.kt
@@ -1,0 +1,101 @@
+package expo.modules.medialibrary.next.objects.wrappers
+
+import android.os.Environment
+import android.provider.MediaStore
+import expo.modules.medialibrary.next.extensions.resolver.EXTERNAL_CONTENT_URI
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class MimeTypeTests {
+  @Test
+  fun `splits a mime type into its type and subtype`() {
+    // given
+    val mimeType = MimeType("image/jpeg")
+
+    // then
+    assertEquals("image", mimeType.type)
+    assertEquals("jpeg", mimeType.subType)
+  }
+
+  @Test
+  fun `exposes null halves for an absent mime type`() {
+    // given the content resolver could not determine the type
+    val mimeType = MimeType(null)
+
+    // then
+    assertNull(mimeType.type)
+    assertNull(mimeType.subType)
+    assertFalse(mimeType.isImage())
+    assertFalse(mimeType.isVideo())
+    assertFalse(mimeType.isAudio())
+  }
+
+  @Test
+  fun `classifies the top-level type`() {
+    // then
+    assertTrue(MimeType("image/png").isImage())
+    assertTrue(MimeType("video/mp4").isVideo())
+    assertTrue(MimeType("audio/mpeg").isAudio())
+    assertFalse(MimeType("video/mp4").isImage())
+  }
+
+  @Test
+  fun `routes visual media to DCIM and audio to Music when creating an asset`() {
+    // then
+    assertEquals(Environment.DIRECTORY_DCIM, MimeType("image/png").assetRootDirectory())
+    assertEquals(Environment.DIRECTORY_DCIM, MimeType("video/mp4").assetRootDirectory())
+    assertEquals(Environment.DIRECTORY_MUSIC, MimeType("audio/mpeg").assetRootDirectory())
+    assertEquals(Environment.DIRECTORY_DCIM, MimeType(null).assetRootDirectory())
+  }
+
+  @Test
+  fun `routes visual media to Pictures and audio to Music when creating an album`() {
+    // then
+    assertEquals(Environment.DIRECTORY_PICTURES, MimeType("image/png").albumRootDirectory())
+    assertEquals(Environment.DIRECTORY_PICTURES, MimeType("video/mp4").albumRootDirectory())
+    assertEquals(Environment.DIRECTORY_MUSIC, MimeType("audio/mpeg").albumRootDirectory())
+    assertEquals(Environment.DIRECTORY_PICTURES, MimeType(null).albumRootDirectory())
+  }
+
+  @Test
+  fun `maps to the matching MediaStore collection uri`() {
+    // then
+    assertEquals(
+      MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+      MimeType("image/png").mediaCollectionUri()
+    )
+    assertEquals(
+      MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
+      MimeType("video/mp4").mediaCollectionUri()
+    )
+    assertEquals(
+      MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+      MimeType("audio/mpeg").mediaCollectionUri()
+    )
+    assertEquals(EXTERNAL_CONTENT_URI, MimeType(null).mediaCollectionUri())
+  }
+
+  @Test
+  fun `accepts a subtype containing a dash`() {
+    // given AAC audio recorded on Android reports this type
+    // then
+    assertEquals("audio/mp4a-latm", MimeType("audio/mp4a-latm").value)
+    assertEquals("mp4a-latm", MimeType("audio/mp4a-latm").subType)
+  }
+
+  @Test
+  fun `rejects strings that are not a type-subtype pair`() {
+    // then
+    assertThrows(IllegalArgumentException::class.java) { MimeType("image") }
+    assertThrows(IllegalArgumentException::class.java) { MimeType("") }
+    assertThrows(IllegalArgumentException::class.java) { MimeType("image/png/extra") }
+    assertThrows(IllegalArgumentException::class.java) { MimeType("image /png") }
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/RelativePathTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/objects/wrappers/RelativePathTests.kt
@@ -1,0 +1,99 @@
+package expo.modules.medialibrary.next.objects.wrappers
+
+import android.os.Environment
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class RelativePathTests {
+  @Test
+  fun `accepts a single directory segment`() {
+    // then
+    assertEquals("DCIM/", RelativePath("DCIM/").value)
+  }
+
+  @Test
+  fun `accepts nested directory segments`() {
+    // then
+    assertEquals("Pictures/Holiday/", RelativePath("Pictures/Holiday/").value)
+  }
+
+  @Test
+  fun `accepts spaces, digits and underscores inside a segment`() {
+    // then
+    assertEquals("Pictures/Trip 2026/", RelativePath("Pictures/Trip 2026/").value)
+    assertEquals("Pictures/my_album/", RelativePath("Pictures/my_album/").value)
+  }
+
+  @Test
+  fun `requires a trailing separator`() {
+    // given MediaStore RELATIVE_PATH values always end with a separator
+    // then
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("Pictures/Holiday") }
+  }
+
+  @Test
+  fun `rejects a leading separator`() {
+    // then
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("/Pictures/") }
+  }
+
+  @Test
+  fun `rejects an empty path`() {
+    // then
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("") }
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("/") }
+  }
+
+  @Test
+  fun `rejects empty segments`() {
+    // then
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("Pictures//Holiday/") }
+  }
+
+  @Test
+  fun `rejects parent directory traversal`() {
+    // given `toFilePath` concatenates the value onto the external storage root, so a segment that
+    // walks upwards would escape the media directories entirely
+    // then
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("../") }
+    assertThrows(IllegalArgumentException::class.java) { RelativePath("Pictures/../../etc/") }
+  }
+
+  @Test
+  fun `creates an asset path rooted at the media type directory`() {
+    // when
+    val imagePath = RelativePath.create(MimeType("image/png"))
+    val audioPath = RelativePath.create(MimeType("audio/mpeg"))
+
+    // then
+    assertEquals("${Environment.DIRECTORY_DCIM}/", imagePath.value)
+    assertEquals("${Environment.DIRECTORY_MUSIC}/", audioPath.value)
+  }
+
+  @Test
+  fun `creates an album path underneath the album root directory`() {
+    // when
+    val imageAlbum = RelativePath.create(MimeType("image/png"), "Holiday")
+    val audioAlbum = RelativePath.create(MimeType("audio/mpeg"), "Podcasts")
+
+    // then
+    assertEquals("${Environment.DIRECTORY_PICTURES}/Holiday/", imageAlbum.value)
+    assertEquals("${Environment.DIRECTORY_MUSIC}/Podcasts/", audioAlbum.value)
+  }
+
+  @Test
+  fun `builds an absolute file path underneath external storage`() {
+    // given
+    val externalRoot = Environment.getExternalStorageDirectory().absolutePath
+
+    // when
+    val filePath = RelativePath("Pictures/Holiday/").toFilePath()
+
+    // then
+    assertEquals("$externalRoot/Pictures/Holiday//", filePath)
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/records/AssetFieldTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/records/AssetFieldTests.kt
@@ -1,0 +1,63 @@
+package expo.modules.medialibrary.next.records
+
+import android.provider.MediaStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * `AssetField` is the only place that ties the public JS field names to MediaStore columns.
+ * A wrong column name surfaces as an opaque `IllegalArgumentException: Invalid column` from the
+ * content resolver at query time, so it is worth pinning here.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class AssetFieldTests {
+  @Test
+  fun `exposes the api names used by the JS AssetField enum`() {
+    // then
+    assertEquals("creationTime", AssetField.CREATION_TIME.key)
+    assertEquals("modificationTime", AssetField.MODIFICATION_TIME.key)
+    assertEquals("mediaType", AssetField.MEDIA_TYPE.key)
+    assertEquals("width", AssetField.WIDTH.key)
+    assertEquals("height", AssetField.HEIGHT.key)
+    assertEquals("duration", AssetField.DURATION.key)
+    assertEquals("isFavorite", AssetField.IS_FAVORITE.key)
+  }
+
+  @Test
+  fun `maps every field to a MediaStore column`() {
+    // then
+    assertEquals(
+      MediaStore.Images.Media.DATE_TAKEN,
+      AssetField.CREATION_TIME.toMediaStoreColumn()
+    )
+    assertEquals(
+      MediaStore.Images.Media.DATE_MODIFIED,
+      AssetField.MODIFICATION_TIME.toMediaStoreColumn()
+    )
+    assertEquals(
+      MediaStore.Files.FileColumns.MEDIA_TYPE,
+      AssetField.MEDIA_TYPE.toMediaStoreColumn()
+    )
+    assertEquals(MediaStore.MediaColumns.WIDTH, AssetField.WIDTH.toMediaStoreColumn())
+    assertEquals(MediaStore.MediaColumns.HEIGHT, AssetField.HEIGHT.toMediaStoreColumn())
+    assertEquals(
+      MediaStore.Video.VideoColumns.DURATION,
+      AssetField.DURATION.toMediaStoreColumn()
+    )
+    assertEquals(
+      MediaStore.MediaColumns.IS_FAVORITE,
+      AssetField.IS_FAVORITE.toMediaStoreColumn()
+    )
+  }
+
+  @Test
+  fun `resolves a column for every declared field`() {
+    // given a new field must not be added without a column mapping
+    // then
+    for (field in AssetField.entries) {
+      assertEquals(true, field.toMediaStoreColumn().isNotEmpty())
+    }
+  }
+}

--- a/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/records/SortDescriptorTests.kt
+++ b/packages/expo-media-library/android/src/test/java/expo/modules/medialibrary/next/records/SortDescriptorTests.kt
@@ -1,0 +1,52 @@
+package expo.modules.medialibrary.next.records
+
+import android.provider.MediaStore
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class SortDescriptorTests {
+  @Test
+  fun `sorts ascending by default`() {
+    // given `ascending` is optional in the JS SortDescriptor
+    val descriptor = SortDescriptor(key = AssetField.CREATION_TIME)
+
+    // then
+    assertEquals(
+      "${MediaStore.Images.Media.DATE_TAKEN} ASC",
+      descriptor.toMediaStoreQueryString()
+    )
+  }
+
+  @Test
+  fun `sorts ascending when ascending is explicitly null`() {
+    // given the JS caller passed `{ key }` without `ascending`
+    val descriptor = SortDescriptor(key = AssetField.HEIGHT, ascending = null)
+
+    // then
+    assertEquals("${MediaStore.MediaColumns.HEIGHT} ASC", descriptor.toMediaStoreQueryString())
+  }
+
+  @Test
+  fun `sorts descending when ascending is false`() {
+    // given
+    val descriptor = SortDescriptor(key = AssetField.MODIFICATION_TIME, ascending = false)
+
+    // then
+    assertEquals(
+      "${MediaStore.Images.Media.DATE_MODIFIED} DESC",
+      descriptor.toMediaStoreQueryString()
+    )
+  }
+
+  @Test
+  fun `builds a query string for every field`() {
+    // then
+    for (field in AssetField.entries) {
+      val descriptor = SortDescriptor(key = field, ascending = true)
+      assertEquals("${field.toMediaStoreColumn()} ASC", descriptor.toMediaStoreQueryString())
+    }
+  }
+}

--- a/packages/expo-media-library/ios/Tests/MediaLibraryNextMappingTests.swift
+++ b/packages/expo-media-library/ios/Tests/MediaLibraryNextMappingTests.swift
@@ -1,0 +1,213 @@
+import Photos
+import Testing
+
+@testable import ExpoMediaLibrary
+
+/// Unit coverage for the pure mapping layer of the class-based ("next") API. Everything here is a
+/// value transformation with no PhotoKit access, so it can be asserted directly.
+@Suite("MediaLibrary next mapping")
+struct MediaLibraryNextMappingTests {
+  @Suite("Date extensions")
+  struct DateExtensionTests {
+    @Test
+    func `converts a date to milliseconds since the epoch`() {
+      let date = Date(timeIntervalSince1970: 1_767_225_600)
+      #expect(date.millisecondsSince1970 == 1_767_225_600_000)
+    }
+
+    @Test
+    func `builds a date from milliseconds since the epoch`() {
+      let date = Date(milliseconds: 1_767_225_600_000)
+      #expect(date.timeIntervalSince1970 == 1_767_225_600)
+    }
+
+    @Test
+    func `round-trips through milliseconds`() {
+      let date = Date(timeIntervalSince1970: 1_767_225_600.25)
+      #expect(Date(milliseconds: date.millisecondsSince1970).millisecondsSince1970 == date.millisecondsSince1970)
+    }
+  }
+
+  @Suite("AssetMapper")
+  struct AssetMapperTests {
+    let mapper = AssetMapper()
+
+    @Test
+    func `maps the creation date to milliseconds`() {
+      #expect(mapper.mapCreationTime(Date(timeIntervalSince1970: 1_767_225_600)) == 1_767_225_600_000)
+    }
+
+    @Test
+    func `maps a missing creation date to nil`() {
+      #expect(mapper.mapCreationTime(nil) == nil)
+    }
+
+    @Test
+    func `maps the modification date to milliseconds`() {
+      #expect(mapper.mapModificationTime(Date(timeIntervalSince1970: 1_767_225_600)) == 1_767_225_600_000)
+    }
+
+    @Test
+    func `maps a missing modification date to nil`() {
+      #expect(mapper.mapModificationTime(nil) == nil)
+    }
+
+    @Test
+    func `maps the duration to milliseconds`() {
+      // PHAsset.duration is a TimeInterval in seconds; JS receives milliseconds
+      #expect(mapper.mapDuration(1.5) == 1500)
+      #expect(mapper.mapDuration(90) == 90_000)
+    }
+
+    @Test
+    func `maps a zero duration to nil`() {
+      // still images report a duration of 0
+      #expect(mapper.mapDuration(0) == nil)
+    }
+
+    @Test
+    func `maps PHAsset media types`() {
+      #expect(mapper.mapMediaType(.image) == .IMAGE)
+      #expect(mapper.mapMediaType(.video) == .VIDEO)
+      #expect(mapper.mapMediaType(.audio) == .AUDIO)
+      #expect(mapper.mapMediaType(.unknown) == .UNKNOWN)
+    }
+  }
+
+  @Suite("MediaType")
+  struct MediaTypeTests {
+    @Test
+    func `round-trips through PHAssetMediaType`() {
+      for mediaType in [MediaTypeNext.IMAGE, .VIDEO, .AUDIO, .UNKNOWN] {
+        #expect(MediaTypeNext.from(mediaType.toPHAssetMediaType()) == mediaType)
+      }
+    }
+
+    @Test
+    func `parses api names case-insensitively`() throws {
+      #expect(try MediaTypeNext.from("image") == .IMAGE)
+      #expect(try MediaTypeNext.from("IMAGE") == .IMAGE)
+      #expect(try MediaTypeNext.from("Video") == .VIDEO)
+      #expect(try MediaTypeNext.from("audio") == .AUDIO)
+      #expect(try MediaTypeNext.from("unknown") == .UNKNOWN)
+    }
+
+    @Test
+    func `throws on an unrecognised api name`() {
+      #expect(throws: MediaTypeFailedToParseString.self) {
+        try MediaTypeNext.from("photo")
+      }
+    }
+
+    @Test
+    func `uses the same raw values as the JS MediaType enum`() {
+      #expect(MediaTypeNext.IMAGE.rawValue == "image")
+      #expect(MediaTypeNext.VIDEO.rawValue == "video")
+      #expect(MediaTypeNext.AUDIO.rawValue == "audio")
+      #expect(MediaTypeNext.UNKNOWN.rawValue == "unknown")
+    }
+  }
+
+  @Suite("MediaSubtype")
+  struct MediaSubtypeTests {
+    @Test
+    func `stringifies a single subtype`() {
+      #expect(MediaSubtype.stringify(.photoPanorama) == ["panorama"])
+      #expect(MediaSubtype.stringify(.photoScreenshot) == ["screenshot"])
+      #expect(MediaSubtype.stringify(.videoTimelapse) == ["timelapse"])
+    }
+
+    @Test
+    func `stringifies an empty option set`() {
+      #expect(MediaSubtype.stringify([]).isEmpty)
+    }
+
+    @Test
+    func `stringifies every subtype in a combined mask`() {
+      let subtypes = MediaSubtype.stringify([.photoLive, .photoHDR])
+      #expect(subtypes.contains("livePhoto"))
+      #expect(subtypes.contains("hdr"))
+      #expect(subtypes.count == 2)
+    }
+
+    @Test
+    func `maps every case back to a PHAssetMediaSubtype`() {
+      // spatialMedia resolves to an empty option set below iOS 16, every other case must map
+      for subtype in [MediaSubtype.depthEffect, .hdr, .highFrameRate, .livePhoto, .panorama,
+                      .screenshot, .stream, .timelapse, .videoCinematic] {
+        #expect(!subtype.toPHAssetMediaSubtype().isEmpty)
+      }
+    }
+  }
+
+  @Suite("AssetField")
+  struct AssetFieldTests {
+    @Test
+    func `maps every field to a PHAsset key path`() {
+      #expect(AssetField.CREATION_TIME.photosKey() == "creationDate")
+      #expect(AssetField.MODIFICATION_TIME.photosKey() == "modificationDate")
+      #expect(AssetField.MEDIA_TYPE.photosKey() == "mediaType")
+      #expect(AssetField.WIDTH.photosKey() == "pixelWidth")
+      #expect(AssetField.HEIGHT.photosKey() == "pixelHeight")
+      #expect(AssetField.DURATION.photosKey() == "duration")
+      #expect(AssetField.IS_FAVORITE.photosKey() == "isFavorite")
+    }
+
+    @Test
+    func `uses the same raw values as the JS AssetField enum`() {
+      #expect(AssetField.CREATION_TIME.rawValue == "creationTime")
+      #expect(AssetField.MODIFICATION_TIME.rawValue == "modificationTime")
+      #expect(AssetField.MEDIA_TYPE.rawValue == "mediaType")
+      #expect(AssetField.WIDTH.rawValue == "width")
+      #expect(AssetField.HEIGHT.rawValue == "height")
+      #expect(AssetField.DURATION.rawValue == "duration")
+      #expect(AssetField.IS_FAVORITE.rawValue == "isFavorite")
+    }
+  }
+
+  @Suite("SortDescriptor")
+  struct SortDescriptorTests {
+    /// `SortDescriptor`'s members are `@Field`-wrapped, so the synthesised memberwise
+    /// initialiser takes `Field<Bool?>` rather than `Bool?`. Records are built by the
+    /// `init()` + assignment path instead, which is also how `Record.from(dictionary:)` does it.
+    private func makeDescriptor(
+      key: AssetField,
+      ascending: Bool? = nil
+    ) -> ExpoMediaLibrary.SortDescriptor {
+      // Foundation also declares a `SortDescriptor`, so the module-qualified name is required here
+      var descriptor = ExpoMediaLibrary.SortDescriptor()
+      descriptor.key = key
+      descriptor.ascending = ascending
+      return descriptor
+    }
+
+    @Test
+    func `sorts ascending when ascending is not provided`() {
+      let descriptor = makeDescriptor(key: .CREATION_TIME).toNSSortDescriptor()
+      #expect(descriptor.key == "creationDate")
+      #expect(descriptor.ascending)
+    }
+
+    @Test
+    func `sorts descending when ascending is false`() {
+      let descriptor = makeDescriptor(key: .MODIFICATION_TIME, ascending: false).toNSSortDescriptor()
+      #expect(descriptor.key == "modificationDate")
+      #expect(!descriptor.ascending)
+    }
+
+    @Test
+    func `defaults to the modification date when no key is set`() {
+      // the Record default, used when JS passes an AssetField instead of a SortDescriptor
+      #expect(ExpoMediaLibrary.SortDescriptor().toNSSortDescriptor().key == "modificationDate")
+    }
+
+    @Test
+    func `sorts by the PHAsset key path of every field`() {
+      for field in [AssetField.CREATION_TIME, .MODIFICATION_TIME, .MEDIA_TYPE, .WIDTH, .HEIGHT,
+                    .DURATION, .IS_FAVORITE] {
+        let descriptor = makeDescriptor(key: field, ascending: true).toNSSortDescriptor()
+        #expect(descriptor.key == field.photosKey())
+      }
+    }
+  }
+}

--- a/packages/expo-media-library/ios/Tests/MediaLibraryUtilitiesTests.swift
+++ b/packages/expo-media-library/ios/Tests/MediaLibraryUtilitiesTests.swift
@@ -1,0 +1,145 @@
+import Photos
+import Testing
+
+@testable import ExpoMediaLibrary
+
+/// Unit coverage for the pure helpers in the legacy iOS implementation. `assetType(for:)` in
+/// particular decides whether a file can be saved at all — `createAssetAsync` and
+/// `saveToLibraryAsync` both reject anything it reports as `.unknown` or `.audio`.
+@Suite("MediaLibrary utilities")
+struct MediaLibraryUtilitiesTests {
+  @Suite("assetType")
+  struct AssetTypeTests {
+    private func type(_ filename: String) -> PHAssetMediaType {
+      assetType(for: URL(fileURLWithPath: "/tmp/\(filename)"))
+    }
+
+    @Test
+    func `recognises common image extensions`() {
+      for filename in ["photo.jpg", "photo.jpeg", "photo.png", "photo.gif", "photo.heic",
+                       "photo.tiff", "photo.webp"] {
+        #expect(type(filename) == .image, "expected \(filename) to be an image")
+      }
+    }
+
+    @Test
+    func `recognises common video extensions`() {
+      for filename in ["clip.mov", "clip.mp4", "clip.m4v"] {
+        #expect(type(filename) == .video, "expected \(filename) to be a video")
+      }
+    }
+
+    @Test
+    func `recognises common audio extensions`() {
+      for filename in ["song.mp3", "song.m4a", "song.wav", "song.aiff"] {
+        #expect(type(filename) == .audio, "expected \(filename) to be audio")
+      }
+    }
+
+    @Test
+    func `is case-insensitive`() {
+      #expect(type("PHOTO.JPG") == .image)
+      #expect(type("CLIP.MOV") == .video)
+    }
+
+    @Test
+    func `reports an unknown type for a file with no extension`() {
+      #expect(type("noextension") == .unknown)
+    }
+
+    @Test
+    func `reports an unknown type for a non-media extension`() {
+      #expect(type("document.xyzzy") == .unknown)
+    }
+  }
+
+  @Suite("MediaType")
+  struct MediaTypeTests {
+    @Test
+    func `maps PHAsset media types to the legacy api names`() {
+      #expect(MediaType(fromPHAssetMediaType: .image) == .photo)
+      #expect(MediaType(fromPHAssetMediaType: .video) == .video)
+      #expect(MediaType(fromPHAssetMediaType: .audio) == .audio)
+      #expect(MediaType(fromPHAssetMediaType: .unknown) == .unknown)
+    }
+
+    @Test
+    func `maps the legacy api names back to PHAsset media types`() {
+      #expect(MediaType.photo.toPHMediaType() == .image)
+      #expect(MediaType.video.toPHMediaType() == .video)
+      #expect(MediaType.audio.toPHMediaType() == .audio)
+      #expect(MediaType.unknown.toPHMediaType() == .unknown)
+    }
+
+    @Test
+    func `uses the same raw values as the JS MediaType constant`() {
+      #expect(MediaType.photo.rawValue == "photo")
+      #expect(MediaType.video.rawValue == "video")
+      #expect(MediaType.audio.rawValue == "audio")
+      #expect(MediaType.unknown.rawValue == "unknown")
+      #expect(MediaType.all.rawValue == "all")
+    }
+  }
+
+  @Suite("exportDate")
+  struct ExportDateTests {
+    @Test
+    func `exports a date as milliseconds since the epoch`() {
+      #expect(exportDate(Date(timeIntervalSince1970: 1_767_225_600)) == 1_767_225_600_000)
+    }
+
+    @Test
+    func `exports a missing date as nil`() {
+      #expect(exportDate(nil) == nil)
+    }
+  }
+
+  @Suite("getFileExtension")
+  struct FileExtensionTests {
+    @Test
+    func `returns the extension with a leading dot`() {
+      #expect(getFileExtension(from: "IMG_0001.MOV") == ".MOV")
+    }
+
+    @Test
+    func `returns only the last extension`() {
+      #expect(getFileExtension(from: "my.holiday.clip.mov") == ".mov")
+    }
+
+    @Test
+    func `returns a bare dot when there is no extension`() {
+      #expect(getFileExtension(from: "IMG_0001") == ".")
+    }
+  }
+
+  @Suite("assetIdFromLocalId")
+  struct AssetIdTests {
+    @Test
+    func `strips the fragment from a PhotoKit local identifier`() {
+      #expect(assetIdFromLocalId(localId: "5E8C0C43-1234-5678-9ABC-DEF012345678/L0/001")
+        == "5E8C0C43-1234-5678-9ABC-DEF012345678")
+    }
+
+    @Test
+    func `returns nil when there is no fragment to strip`() {
+      #expect(assetIdFromLocalId(localId: "5E8C0C43-1234-5678-9ABC-DEF012345678") == nil)
+    }
+  }
+
+  @Suite("assetUriForLocalId")
+  struct AssetUriTests {
+    @Test
+    func `prefixes the local identifier with the ph scheme`() {
+      #expect(assetUriForLocalId(localId: "ABC/L0/001") == "ph://ABC/L0/001")
+    }
+  }
+
+  @Suite("stringifyAlbumType")
+  struct AlbumTypeTests {
+    @Test
+    func `maps PHAssetCollectionType to the legacy api names`() {
+      #expect(stringifyAlbumType(type: .album) == "album")
+      #expect(stringifyAlbumType(type: .smartAlbum) == "smartAlbum")
+    }
+  }
+}

--- a/packages/expo-media-library/ios/Tests/PredicateBuilderTests.swift
+++ b/packages/expo-media-library/ios/Tests/PredicateBuilderTests.swift
@@ -1,0 +1,116 @@
+import Photos
+import Testing
+
+@testable import ExpoMediaLibrary
+
+/// `Query` turns JS filter calls into `NSPredicate`s that PhotoKit evaluates against `PHAsset`.
+/// The predicates are asserted by evaluating them against a dictionary rather than by comparing
+/// `predicateFormat` strings, so these tests describe behaviour instead of formatting.
+@Suite("AssetFieldPredicateBuilder")
+struct PredicateBuilderTests {
+  /// 2026-01-01T00:00:00Z
+  static let timestampMillis = 1_767_225_600_000
+  static let date = Date(timeIntervalSince1970: 1_767_225_600)
+
+  @Suite("scalar values")
+  struct ScalarTests {
+    @Test
+    func `compares creation time against a millisecond timestamp`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .CREATION_TIME,
+        value: PredicateBuilderTests.timestampMillis,
+        symbol: "="
+      )
+
+      #expect(predicate.evaluate(with: ["creationDate": PredicateBuilderTests.date]))
+    }
+
+    @Test
+    func `compares modification time against a millisecond timestamp`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .MODIFICATION_TIME,
+        value: PredicateBuilderTests.timestampMillis,
+        symbol: "="
+      )
+
+      #expect(predicate.evaluate(with: ["modificationDate": PredicateBuilderTests.date]))
+    }
+
+    @Test
+    func `orders creation time comparisons`() {
+      let oneSecondEarlier = PredicateBuilderTests.timestampMillis - 1000
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .CREATION_TIME,
+        value: oneSecondEarlier,
+        symbol: ">"
+      )
+
+      #expect(predicate.evaluate(with: ["creationDate": PredicateBuilderTests.date]))
+      #expect(!predicate.evaluate(with: ["creationDate": Date(milliseconds: oneSecondEarlier - 1)]))
+    }
+
+    @Test
+    func `compares non-date fields as plain numbers`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .WIDTH,
+        value: 1080,
+        symbol: "<="
+      )
+
+      #expect(predicate.evaluate(with: ["pixelWidth": 1080]))
+      #expect(!predicate.evaluate(with: ["pixelWidth": 1081]))
+    }
+
+    @Test
+    func `compares media types by their PHAsset raw value`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .MEDIA_TYPE,
+        value: MediaTypeNext.IMAGE,
+        symbol: "="
+      )
+
+      #expect(predicate.evaluate(with: ["mediaType": PHAssetMediaType.image.rawValue]))
+      #expect(!predicate.evaluate(with: ["mediaType": PHAssetMediaType.video.rawValue]))
+    }
+
+    @Test
+    func `compares booleans`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .IS_FAVORITE,
+        value: true,
+        symbol: "="
+      )
+
+      #expect(predicate.evaluate(with: ["isFavorite": true]))
+      #expect(!predicate.evaluate(with: ["isFavorite": false]))
+    }
+  }
+
+  @Suite("array values")
+  struct ArrayTests {
+    @Test
+    func `matches any of several media types`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .MEDIA_TYPE,
+        values: [MediaTypeNext.IMAGE, .VIDEO],
+        symbol: "IN"
+      )
+
+      #expect(predicate.evaluate(with: ["mediaType": PHAssetMediaType.image.rawValue]))
+      #expect(predicate.evaluate(with: ["mediaType": PHAssetMediaType.video.rawValue]))
+      #expect(!predicate.evaluate(with: ["mediaType": PHAssetMediaType.audio.rawValue]))
+    }
+
+    @Test
+    func `matches any of several numbers`() {
+      let predicate = AssetFieldPredicateBuilder.buildPredicate(
+        assetField: .WIDTH,
+        values: [720, 1080],
+        symbol: "IN"
+      )
+
+      #expect(predicate.evaluate(with: ["pixelWidth": 1080]))
+      #expect(!predicate.evaluate(with: ["pixelWidth": 480]))
+    }
+  }
+}


### PR DESCRIPTION
# Why

The class-based API has almost no native unit test coverage. Android has one file (`AssetMapperTests.kt`, added alongside the orientation fix in #48150) and iOS has none.

The on-device test-suite covers a lot of the API surface, but it mostly asserts shapes rather than values (`toBeDefined()`, `toBeGreaterThan(0)`), so unit-level mistakes pass through it. A wrong unit conversion or column name returns the wrong data instead of failing.

The mapping layer is the cheapest part to cover and the most likely to drift: value conversions between MediaStore/PhotoKit and JS, enum and column mappings, and the validation wrappers.

# How

Android:

* `AssetMapperTests`: unit conversions (`DATE_TAKEN` is milliseconds, `DATE_MODIFIED` is seconds and gets converted, `DURATION` is milliseconds), `mapIsFavorite`, `mapUri`, audio DTOs, 180 degree and negative orientation, and the `AssetPropertyNotFoundException` paths.
* `MediaStoreQueryFormatterTests`: which field needs a unit conversion and which five don't. MediaStore isn't consistent here, so it's worth pinning.
* `MediaTypeTests`, `MimeTypeTests`, `RelativePathTests`: parsing, validation and directory routing for the value wrappers.
* `AssetFieldTests`, `SortDescriptorTests`: JS field names to MediaStore columns, and sort direction defaults.
* `BuildUniqueDisplayNameTests`: the collision fallback name stays a bare filename with its extension.
* `ExtractAssetContentUriTests`: `Asset.id` is the content uri built here, so its shape is public API. Also covers the API 29 volume pinning and the round trip through `MediaType.fromContentUri`.
* `AssetDimensionsResolverTests`: only images fall back to `BitmapFactory`, and only when MediaStore has no usable dimensions.
* `AlbumFactoryEmptyInputTests`: `AlbumLegacyFactory` rejects an empty list with a coded exception.

iOS:

* `MediaLibraryNextMappingTests`: `Date` extensions, `AssetMapper` units, `MediaTypeNext`, `MediaSubtype`, `AssetField`, `SortDescriptor`.
* `PredicateBuilderTests`: `Query` predicates, checked by evaluating them against a dictionary rather than comparing `predicateFormat` strings, so they describe behaviour instead of formatting.
* `MediaLibraryUtilitiesTests`: legacy `assetType(for:)`, which decides whether a file can be saved at all, plus `exportDate`, `getFileExtension` and `assetIdFromLocalId`.

Tests only, no source changes.

# Test Plan

Android:

```bash
et native-unit-tests -p android --packages expo-media-library
```

123 tests pass, 0 failures (78 new, 45 existing legacy).

iOS:

```bash
et native-unit-tests -p ios --packages expo-media-library
```

56 tests in 22 suites pass (50 new, 6 existing). The iOS numbers come from running the
`ExpoMediaLibrary-Unit-Tests` scheme directly, because `et` hits a linker error on my machine that
also reproduces on `main` without these tests.

Run on Xcode 26.5 with an iPhone 17 Pro simulator, and JDK 17 with Robolectric.

# Checklist

- [x] Documentation is up to date to reflect these changes (n/a, tests only)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (n/a, no docs changes)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no config plugin changes)
- [x] Added a `CHANGELOG.md` entry
