### PR TITLE
[docs] Update Android keystore security info to cover upload key reset

### DIFF
--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -25,15 +25,15 @@ None. You can access it through the Firebase console.
 
 ## Android build credentials
 
-A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. After an app is first submitted to the Google Play Store, the same keystore must be used to sign the app again to update it. It proves that the APK came from the developer who owns the keystore. The keystore alone doesn't let you submit to Google Play — your Google account needs access to the Google Play Console as well.
+A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key, and your keystore is the upload key. The keystore alone doesn't let you submit to Google Play. Your Google account also needs access to the Google Play Console.
 
 ### Consequences if compromised
 
-Provided that your Google Play Developer account is secure, a malicious actor will not be able to update your app with your keystore and keystore password. You cannot change your keystore.
+Provided that your Google Play Developer account is secure, a malicious actor will not be able to update your app with your keystore and keystore password. If your app uses App signing by Google Play, you can also create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). After the reset, the compromised key can no longer be used.
 
 ### Consequences if lost
 
-You will not be able to update your app on Google Play. You may want to download and backup the keystore and keystore password in a secure location of your choosing or in Google Play with the App Signing feature.
+If your app uses App signing by Google Play, a lost keystore is recoverable: create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). You will not be able to update your app until Google completes the reset. If your app doesn't use App signing by Google Play, the lost keystore is the app signing key itself, and you will not be able to update your app on Google Play. We recommend downloading and backing up your keystore and keystore password to a secure location.
 
 ## Google Developer credentials
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -25,7 +25,7 @@ None. You can access it through the Firebase console.
 
 ## Android build credentials
 
-A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key. Your keystore is the upload key. The keystore alone doesn't let you submit to Google Play. Your Google account also needs access to the Google Play Console.
+A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key and your keystore is the upload key. The keystore alone doesn't let you submit to Google Play: your Google account also needs access to the Google Play Console.
 
 ### Consequences if compromised
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -25,7 +25,7 @@ None. You can access it through the Firebase console.
 
 ## Android build credentials
 
-A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key and your keystore is the upload key. The keystore alone doesn't let you submit to Google Play: your Google account also needs access to the Google Play Console.
+A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key and your keystore is the upload key. The keystore alone doesn't let you submit to Google Play, your Google account also needs access to the Google Play Console.
 
 ### Consequences if compromised
 

--- a/docs/pages/app-signing/security.mdx
+++ b/docs/pages/app-signing/security.mdx
@@ -25,15 +25,15 @@ None. You can access it through the Firebase console.
 
 ## Android build credentials
 
-A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key, and your keystore is the upload key. The keystore alone doesn't let you submit to Google Play. Your Google account also needs access to the Google Play Console.
+A keystore and keystore password are required to sign a build for release to the Play Store. These are encrypted with KMS and additionally at rest. Signing proves that an update comes from the developer who owns the keystore. Google Play only accepts updates signed with the key registered for your app. For apps that use [App signing by Google Play](/app-signing/app-credentials/#app-signing-by-google-play) (the default for new apps), Google holds the app signing key. Your keystore is the upload key. The keystore alone doesn't let you submit to Google Play. Your Google account also needs access to the Google Play Console.
 
 ### Consequences if compromised
 
-Provided that your Google Play Developer account is secure, a malicious actor will not be able to update your app with your keystore and keystore password. If your app uses App signing by Google Play, you can also create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). After the reset, the compromised key can no longer be used.
+If your Google Play Developer account is secure, a malicious actor cannot update your app with your keystore and keystore password. If your app uses App signing by Google Play, you can also create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). After the reset, Google Play no longer accepts builds signed with the compromised key.
 
 ### Consequences if lost
 
-If your app uses App signing by Google Play, a lost keystore is recoverable: create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). You will not be able to update your app until Google completes the reset. If your app doesn't use App signing by Google Play, the lost keystore is the app signing key itself, and you will not be able to update your app on Google Play. We recommend downloading and backing up your keystore and keystore password to a secure location.
+If your app uses App signing by Google Play, a lost keystore is recoverable. Create a new keystore and [ask Google to reset your upload key](/app-signing/app-credentials/#lost-your-keystore-learn-how-to-reset). You cannot update your app until Google completes the reset. If your app doesn't use App signing by Google Play, the lost keystore is the app signing key itself. In that case, you cannot update your app on Google Play. We recommend downloading and backing up your keystore and keystore password to a secure location.
 
 ## Google Developer credentials
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18804

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update security page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
