### PR TITLE
[ios][dev-launcher] Add a dev server discovery filter

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
@@ -1,7 +1,7 @@
 import Network
 
 struct DiscoveryResult {
-  let name: String?
+  let metadata: DevServerMetadata
   let endpoint: NWEndpoint
 }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Data.swift
@@ -16,6 +16,9 @@ struct DevServer: Hashable {
   let url: String
   let description: String
   let source: String
+  let slug: String?
+  let bundleIdentifier: String?
+  let username: String?
 
   static func == (lhs: Self, rhs: Self) -> Bool {
     return lhs.url == rhs.url

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -246,7 +246,7 @@ class DevLauncherViewModel: ObservableObject {
     }
     await pingDiscoveryResults(browser.browseResults.map { result in
       DiscoveryResult(
-        name: NetworkUtilities.getNWBrowserResultName(result),
+        metadata: DevServerMetadata(result: result),
         endpoint: result.endpoint
       )
     })
@@ -433,7 +433,7 @@ class DevLauncherViewModel: ObservableObject {
           defer { self.pingTask = nil }
           await self.pingDiscoveryResults(results.map { result in
             DiscoveryResult(
-              name: NetworkUtilities.getNWBrowserResultName(result),
+              metadata: DevServerMetadata(result: result),
               endpoint: result.endpoint
             )
           })
@@ -481,11 +481,11 @@ class DevLauncherViewModel: ObservableObject {
       ) {
         return DevServer(
           url: host,
-          description: result.name ?? host,
+          description: result.metadata.name ?? host,
           source: "local",
-          slug: nil,
-          bundleIdentifier: nil,
-          username: nil
+          slug: result.metadata.slug,
+          bundleIdentifier: result.metadata.bundleIdentifier,
+          username: result.metadata.username
         )
       }
     } catch {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -482,7 +482,10 @@ class DevLauncherViewModel: ObservableObject {
         return DevServer(
           url: host,
           description: result.name ?? host,
-          source: "local"
+          source: "local",
+          slug: nil,
+          bundleIdentifier: nil,
+          username: nil
         )
       }
     } catch {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerFilter.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerFilter.swift
@@ -1,0 +1,46 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+struct DevServerFilterSettings {
+  let filterByBundleIdentifier: Bool
+  let filterByUsername: Bool
+  let slug: String
+
+  static let disabled = DevServerFilterSettings(
+    filterByBundleIdentifier: false,
+    filterByUsername: false,
+    slug: ""
+  )
+}
+
+struct DevServerFilter {
+  /// Narrows discovered servers to the ones this developer cares about.
+  ///
+  /// A filter with nothing to compare against is skipped rather than applied, so an app with no
+  /// bundle identifier and a logged-out user both keep seeing the full list instead of an
+  /// unexplained empty one.
+  static func apply(
+    _ servers: [DevServer],
+    settings: DevServerFilterSettings,
+    bundleIdentifier: String?,
+    username: String?
+  ) -> [DevServer] {
+    var filtered = servers
+
+    if settings.filterByBundleIdentifier, let bundleIdentifier {
+      filtered = filtered.filter { $0.bundleIdentifier == bundleIdentifier }
+    }
+
+    if settings.filterByUsername, let username {
+      filtered = filtered.filter { $0.username == username }
+    }
+
+    let slug = settings.slug.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !slug.isEmpty {
+      filtered = filtered.filter { $0.slug == slug }
+    }
+
+    return filtered
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerMetadata.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerMetadata.swift
@@ -1,0 +1,52 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Network
+
+/// The fields the Expo CLI advertises in a dev server's Bonjour TXT record.
+/// Source of truth: `packages/@expo/cli/src/start/server/Bonjour.ts`.
+struct DevServerMetadata {
+  let name: String?
+  let slug: String?
+  let bundleIdentifier: String?
+  let username: String?
+
+  static let empty = DevServerMetadata(
+    name: nil,
+    slug: nil,
+    bundleIdentifier: nil,
+    username: nil
+  )
+
+  init(name: String?, slug: String?, bundleIdentifier: String?, username: String?) {
+    self.name = name
+    self.slug = slug
+    self.bundleIdentifier = bundleIdentifier
+    self.username = username
+  }
+
+  init(txtRecord: NWTXTRecord) {
+    self.init(
+      name: Self.string(txtRecord, forKey: "name"),
+      slug: Self.string(txtRecord, forKey: "slug"),
+      bundleIdentifier: Self.string(txtRecord, forKey: "iosBundleIdentifier"),
+      username: Self.string(txtRecord, forKey: "username")
+    )
+  }
+
+  init(result: NWBrowser.Result) {
+    guard case .bonjour(let txtRecord) = result.metadata else {
+      self = .empty
+      return
+    }
+    self.init(txtRecord: txtRecord)
+  }
+
+  /// An entry that is absent, non-string, or empty all mean the same thing to a filter:
+  /// nothing to compare against.
+  private static func string(_ txtRecord: NWTXTRecord, forKey key: String) -> String? {
+    guard case .string(let value)? = txtRecord.getEntry(for: key), !value.isEmpty else {
+      return nil
+    }
+    return value
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/NetworkUtilities.swift
@@ -129,20 +129,6 @@ func connectionReceive(_ connection: NWConnection) async throws -> String {
 }
 
 class NetworkUtilities {
-  static func getNWBrowserResultName(_ result: NWBrowser.Result) -> String? {
-    if case .bonjour(let txtRecord) = result.metadata {
-      return txtRecord.getEntry(for: "name").flatMap {
-        if case .string(let value) = $0 {
-          value
-        } else {
-          nil
-        }
-      }
-    } else {
-      return nil
-    }
-  }
-
   static func resolveBundlerEndpoint(
     endpoint: NWEndpoint,
     queue: DispatchQueue,

--- a/packages/expo-dev-launcher/ios/Tests/DevServerFilterTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/DevServerFilterTests.swift
@@ -1,0 +1,205 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import EXDevLauncher
+
+class DevServerFilterTests: XCTestCase {
+  private func server(
+    _ url: String,
+    slug: String? = nil,
+    bundleIdentifier: String? = nil,
+    username: String? = nil
+  ) -> DevServer {
+    return DevServer(
+      url: url,
+      description: url,
+      source: "local",
+      slug: slug,
+      bundleIdentifier: bundleIdentifier,
+      username: username
+    )
+  }
+
+  private func settings(
+    bundleIdentifier: Bool = false,
+    username: Bool = false,
+    slug: String = ""
+  ) -> DevServerFilterSettings {
+    return DevServerFilterSettings(
+      filterByBundleIdentifier: bundleIdentifier,
+      filterByUsername: username,
+      slug: slug
+    )
+  }
+
+  func testAllFiltersOffKeepsEveryServer() {
+    let servers = [
+      server("http://10.0.0.1:8081", bundleIdentifier: "dev.expo.mine"),
+      server("http://10.0.0.2:8081", bundleIdentifier: "dev.expo.theirs")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: .disabled,
+      bundleIdentifier: "dev.expo.mine",
+      username: "alanjhughes"
+    )
+
+    XCTAssertEqual(result.map(\.url), servers.map(\.url))
+  }
+
+  func testBundleIdentifierFilterKeepsOnlyMatchingServers() {
+    let servers = [
+      server("http://10.0.0.1:8081", bundleIdentifier: "dev.expo.mine"),
+      server("http://10.0.0.2:8081", bundleIdentifier: "dev.expo.theirs")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(bundleIdentifier: true),
+      bundleIdentifier: "dev.expo.mine",
+      username: nil
+    )
+
+    XCTAssertEqual(result.map(\.url), ["http://10.0.0.1:8081"])
+  }
+
+  func testBundleIdentifierFilterDropsServersThatAdvertiseNone() {
+    let servers = [server("http://10.0.0.1:8081", bundleIdentifier: nil)]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(bundleIdentifier: true),
+      bundleIdentifier: "dev.expo.mine",
+      username: nil
+    )
+
+    XCTAssertTrue(result.isEmpty)
+  }
+
+  func testBundleIdentifierFilterIsSkippedWithoutAHostIdentifier() {
+    let servers = [
+      server("http://10.0.0.1:8081", bundleIdentifier: "dev.expo.mine"),
+      server("http://10.0.0.2:8081", bundleIdentifier: "dev.expo.theirs")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(bundleIdentifier: true),
+      bundleIdentifier: nil,
+      username: nil
+    )
+
+    XCTAssertEqual(result.count, 2)
+  }
+
+  func testUsernameFilterKeepsOnlyMatchingServers() {
+    let servers = [
+      server("http://10.0.0.1:8081", username: "alanjhughes"),
+      server("http://10.0.0.2:8081", username: "keith")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(username: true),
+      bundleIdentifier: nil,
+      username: "alanjhughes"
+    )
+
+    XCTAssertEqual(result.map(\.url), ["http://10.0.0.1:8081"])
+  }
+
+  func testUsernameFilterIsSkippedWhenLoggedOut() {
+    let servers = [
+      server("http://10.0.0.1:8081", username: "alanjhughes"),
+      server("http://10.0.0.2:8081", username: "keith")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(username: true),
+      bundleIdentifier: nil,
+      username: nil
+    )
+
+    XCTAssertEqual(result.count, 2)
+  }
+
+  func testSlugFilterKeepsOnlyMatchingServers() {
+    let servers = [
+      server("http://10.0.0.1:8081", slug: "my-app"),
+      server("http://10.0.0.2:8081", slug: "other-app")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(slug: "my-app"),
+      bundleIdentifier: nil,
+      username: nil
+    )
+
+    XCTAssertEqual(result.map(\.url), ["http://10.0.0.1:8081"])
+  }
+
+  func testWhitespaceOnlySlugDisablesTheSlugFilter() {
+    let servers = [
+      server("http://10.0.0.1:8081", slug: "my-app"),
+      server("http://10.0.0.2:8081", slug: "other-app")
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(slug: "   "),
+      bundleIdentifier: nil,
+      username: nil
+    )
+
+    XCTAssertEqual(result.count, 2)
+  }
+
+  func testSlugFilterIgnoresSurroundingWhitespace() {
+    let servers = [server("http://10.0.0.1:8081", slug: "my-app")]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(slug: " my-app "),
+      bundleIdentifier: nil,
+      username: nil
+    )
+
+    XCTAssertEqual(result.count, 1)
+  }
+
+  func testFiltersComposeCumulatively() {
+    let servers = [
+      server(
+        "http://10.0.0.1:8081",
+        slug: "my-app",
+        bundleIdentifier: "dev.expo.mine",
+        username: "alanjhughes"
+      ),
+      server(
+        "http://10.0.0.2:8081",
+        slug: "my-app",
+        bundleIdentifier: "dev.expo.mine",
+        username: "keith"
+      ),
+      server(
+        "http://10.0.0.3:8081",
+        slug: "other-app",
+        bundleIdentifier: "dev.expo.mine",
+        username: "alanjhughes"
+      )
+    ]
+
+    let result = DevServerFilter.apply(
+      servers,
+      settings: settings(bundleIdentifier: true, username: true, slug: "my-app"),
+      bundleIdentifier: "dev.expo.mine",
+      username: "alanjhughes"
+    )
+
+    XCTAssertEqual(result.map(\.url), ["http://10.0.0.1:8081"])
+  }
+}

--- a/packages/expo-dev-launcher/ios/Tests/DevServerMetadataTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/DevServerMetadataTests.swift
@@ -1,0 +1,52 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Network
+import XCTest
+
+@testable import EXDevLauncher
+
+class DevServerMetadataTests: XCTestCase {
+  func testParsesEveryAdvertisedField() {
+    let record = NWTXTRecord([
+      "name": "My App",
+      "slug": "my-app",
+      "iosBundleIdentifier": "dev.expo.myapp",
+      "username": "alanjhughes"
+    ])
+
+    let metadata = DevServerMetadata(txtRecord: record)
+
+    XCTAssertEqual(metadata.name, "My App")
+    XCTAssertEqual(metadata.slug, "my-app")
+    XCTAssertEqual(metadata.bundleIdentifier, "dev.expo.myapp")
+    XCTAssertEqual(metadata.username, "alanjhughes")
+  }
+
+  func testMissingEntriesAreNil() {
+    let record = NWTXTRecord(["name": "My App"])
+
+    let metadata = DevServerMetadata(txtRecord: record)
+
+    XCTAssertEqual(metadata.name, "My App")
+    XCTAssertNil(metadata.slug)
+    XCTAssertNil(metadata.bundleIdentifier)
+    XCTAssertNil(metadata.username)
+  }
+
+  func testEmptyEntryIsTreatedAsMissing() {
+    let record = NWTXTRecord(["name": "My App", "username": ""])
+
+    let metadata = DevServerMetadata(txtRecord: record)
+
+    XCTAssertNil(metadata.username)
+  }
+
+  func testEmptyRecordYieldsNoFields() {
+    let metadata = DevServerMetadata(txtRecord: NWTXTRecord([:]))
+
+    XCTAssertNil(metadata.name)
+    XCTAssertNil(metadata.slug)
+    XCTAssertNil(metadata.bundleIdentifier)
+    XCTAssertNil(metadata.username)
+  }
+}


### PR DESCRIPTION
# Why
Android supports filtering dev servers so I'm adding the same on iOS.

The CLI advertises name, slug, androidPackage, iosBundleIdentifier, and username in the TXT record. NetworkUtilities.getNWBrowserResultName read only name and discarded the rest.

# How
Adds DevServerMetadata, which parses all four fields iOS cares about out of an NWTXTRecord, and adds them on DevServer. 

# Test Plan
Added DevServerMetadataTests
