### PR TITLE
[ios][dev-launcher] Add server discovery filter settings 

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Resolve asset URLs and `bundleUrl` from base request URL ([#47255](https://github.com/expo/expo/pull/47255) by [@kitten](https://github.com/kitten))
+- [iOS] Filter discovered development servers by bundle identifier, Expo account, or slug. ([#48697](https://github.com/expo/expo/pull/48697) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServerFiltersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServerFiltersView.swift
@@ -1,0 +1,71 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+// swiftlint:disable:next line_length
+private let serverDiscoveryInfoMessage = "Development servers on your network are listed automatically. These filters hide the ones that belong to a different app, a different Expo account, or a different project."
+
+struct DevServerFiltersView: View {
+  @EnvironmentObject var viewModel: DevLauncherViewModel
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      Text("Server discovery".uppercased())
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
+      VStack(spacing: 0) {
+        DevServerFilterRow(icon: "app") {
+          Toggle("Match bundle identifier", isOn: $viewModel.filterByBundleIdentifier)
+        }
+
+        Divider()
+
+        DevServerFilterRow(icon: "person") {
+          Toggle("Match Expo account", isOn: $viewModel.filterByUsername)
+        }
+
+        Divider()
+
+        DevServerFilterRow(icon: "tag") {
+          slugField
+        }
+      }
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
+
+      Text(serverDiscoveryInfoMessage)
+        .font(.system(size: 13))
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  private var slugField: some View {
+    TextField("Match slug", text: $viewModel.filterBySlug)
+      .disableAutocorrection(true)
+    #if !os(macOS) && !os(tvOS)
+      .autocapitalization(.none)
+    #endif
+  }
+}
+
+private struct DevServerFilterRow<Content: View>: View {
+  private let icon: String
+  private let content: Content
+
+  init(icon: String, @ViewBuilder content: () -> Content) {
+    self.icon = icon
+    self.content = content()
+  }
+
+  var body: some View {
+    HStack {
+      Image(systemName: icon)
+        .frame(width: 24, height: 24)
+        .opacity(0.6)
+      content
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 12)
+  }
+}

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -50,7 +50,8 @@ struct DevServersView: View {
 
       LazyVStack(alignment: .leading, spacing: 6) {
         if viewModel.devServers.isEmpty {
-          if viewModel.permissionStatus != .denied {
+          // Nothing left to search for when discovery found servers and the filters hid them all.
+          if viewModel.hiddenDevServerCount == 0 && viewModel.permissionStatus != .denied {
             HStack {
               Text("Searching for development servers...")
                 .foregroundColor(.secondary)
@@ -68,6 +69,11 @@ struct DevServersView: View {
             }
           }
         }
+
+        if viewModel.hiddenDevServerCount > 0 {
+          HiddenDevServersNotice(count: viewModel.hiddenDevServerCount)
+        }
+
         if viewModel.hasEmbeddedBundle {
           embeddedBundleRow
         }
@@ -223,6 +229,28 @@ struct DevServersView: View {
     }
     .disabled(urlText.isEmpty)
     .buttonStyle(.plain)
+  }
+}
+
+struct HiddenDevServersNotice: View {
+  let count: Int
+
+  private var message: String {
+    let servers = count == 1 ? "1 server" : "\(count) servers"
+    return "\(servers) hidden by your discovery filters. Change them in Settings."
+  }
+
+  var body: some View {
+    HStack(spacing: 6) {
+      Image(systemName: "line.3.horizontal.decrease.circle")
+        .foregroundColor(.secondary)
+      Text(message)
+        .font(.system(size: 13))
+        .foregroundColor(.secondary)
+      Spacer()
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
   }
 }
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -41,27 +41,13 @@ struct SettingsTabView: View {
           .font(.system(size: 13))
           .foregroundStyle(.secondary)
 
+        DevServerFiltersView()
+
         #if !targetEnvironment(simulator)
         localNetworkDebugSettings
         #endif
 
-        VStack(alignment: .leading, spacing: 8) {
-          Text("system".uppercased())
-            .font(.caption)
-            .foregroundColor(.primary.opacity(0.6))
-
-          VStack(spacing: 0) {
-            version
-            if let expiration = viewModel.buildInfo["appExpirationDate"] as? String {
-              Divider()
-              expirationRow(expiration)
-            }
-            Divider()
-            copyToClipboardButton
-          }
-          .background(Color.expoSecondarySystemBackground)
-          .cornerRadius(12)
-        }
+        systemSection
 
         if isAdminUser {
           debugSettings
@@ -158,6 +144,26 @@ struct SettingsTabView: View {
         }
         .padding(.horizontal)
         .padding(.vertical, 12)
+      }
+      .background(Color.expoSecondarySystemBackground)
+      .cornerRadius(12)
+    }
+  }
+
+  private var systemSection: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text("system".uppercased())
+        .font(.caption)
+        .foregroundColor(.primary.opacity(0.6))
+
+      VStack(spacing: 0) {
+        version
+        if let expiration = viewModel.buildInfo["appExpirationDate"] as? String {
+          Divider()
+          expirationRow(expiration)
+        }
+        Divider()
+        copyToClipboardButton
       }
       .background(Color.expoSecondarySystemBackground)
       .cornerRadius(12)


### PR DESCRIPTION
# Why
Adds the UI to for choosing how to filter servers.

# How
Adds a Server discovery section to the settings tab with toggles for matching the bundle identifier and the signed-in Expo account, and a field for matching a slug

# Test Plan
Bare expo. Also checked that running a project from my other laptop is filtered correctly

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-10 at 11 42 43" src="https://github.com/user-attachments/assets/a7a094dd-82b4-40d7-aef2-7475380cb546" />
