### PR TITLE
fix(cli): Fix `ManifestMiddleware` leaking cancellations as exceptions

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix opening web from the Terminal UI when the dev server was started without `--web` ([#48236](https://github.com/expo/expo/pull/48236) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null` ([#48300](https://github.com/expo/expo/pull/48300) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Resolve the signed-in username for partner provisioned actors so Expo Go can verify the account match ([#48354](https://github.com/expo/expo/pull/48354) by [@davidko604](https://github.com/davidko604))
+- Switch `ManifestMiddleware` to `expo-server`'s response helpers to avoid cancellations being surfaced as exceptions ([#48700](https://github.com/expo/expo/pull/48700) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -1,9 +1,8 @@
 import type { ExpoConfig, ExpoGoConfig, PackageJSONConfig, ProjectConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
 import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { respond } from 'expo-server/adapter/http';
 import { posix } from 'node:path';
-import { Readable } from 'node:stream';
-import { pipeline } from 'node:stream/promises';
 import { resolve } from 'url';
 
 import { getActorDisplayName, getUserAsync } from '../../../api/user/user';
@@ -405,18 +404,6 @@ export abstract class ManifestMiddleware<
     const options = this.getParsedHeaders(req);
 
     const response = await this._getManifestResponseAsync(options);
-    // Convert `Response` to node:http response
-    if (typeof res.setHeaders === 'function') {
-      res.setHeaders(response.headers);
-    } else {
-      for (const [key, value] of response.headers.entries()) {
-        res.appendHeader(key, value);
-      }
-    }
-    if (response.body) {
-      await pipeline(Readable.fromWeb(response.body as any), res);
-    } else {
-      res.end();
-    }
+    await respond(res, response);
   }
 }

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/DevToolsPluginMiddleware-test.ts
@@ -59,6 +59,8 @@ function createServerRequest(url: string): ServerRequest {
     headers: { host: 'localhost:8081' },
     rawHeaders: ['host', 'localhost:8081'],
     socket: {} as any,
+    destroyed: false,
+    destroy: jest.fn() as any,
     once: jest.fn() as any,
   });
 }
@@ -216,7 +218,8 @@ describe(DevToolsPluginMiddleware, () => {
       const requestHandler = jest.fn(async (request: Request) => {
         const url = new URL(request.url);
         return new Response(JSON.stringify({ pathname: url.pathname, query: url.search }), {
-          status: 200,
+          status: 201,
+          statusText: 'Created',
           headers: { 'Content-Type': 'application/json' },
         });
       });
@@ -237,13 +240,42 @@ describe(DevToolsPluginMiddleware, () => {
         response
       );
 
-      expect(response.statusCode).toBe(200);
+      expect(response.statusCode).toBe(201);
+      expect(response.statusMessage).toBe('Created');
+      expect(response.setHeader).toHaveBeenCalledWith('content-type', 'application/json');
       // The plugin prefix is stripped so handlers see package-relative URLs.
       expect(JSON.parse(response.body())).toEqual({
         pathname: '/api/hello',
         query: '?name=world',
       });
       expect(requestHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should abort the plugin request when the response closes while the handler resolves', async () => {
+      const response = createStreamingResponse();
+      let requestSignal: AbortSignal | undefined;
+      const requestHandler = jest.fn(async (request: Request) => {
+        requestSignal = request.signal;
+        response.destroy();
+        return new Response('body');
+      });
+      const middleware = createMiddleware(
+        createPluginManager({
+          packageName: 'hello-plugin',
+          packageRoot: '/root/packages/hello-plugin',
+          serverEntryPoint: '/root/packages/hello-plugin/dist/server.js',
+          getRequestHandlerAsync: async () => requestHandler,
+        })
+      );
+
+      await middleware.handleRequestAsync(
+        createServerRequest('http://localhost:8081/_expo/plugins/hello-plugin/api/hello'),
+        response
+      );
+      await delayAsync(0);
+
+      expect(requestSignal?.aborted).toBe(true);
+      expect(response.setHeader).not.toHaveBeenCalled();
     });
 
     it('should fall back to static serving when the handler returns null', async () => {

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -384,6 +384,8 @@ describe('getHandler', () => {
     middleware._getManifestResponseAsync = jest.fn(
       async () =>
         new Response('body', {
+          status: 201,
+          statusText: 'Created',
           headers: { header: 'value' },
         })
     );
@@ -399,6 +401,8 @@ describe('getHandler', () => {
       },
     });
     const res = new MockServerResponse();
+    const chunks: Buffer[] = [];
+    res.on('data', (chunk) => chunks.push(chunk));
     await handleAsync(req, asRes(res), next);
 
     // Ensure that devices are stored successfully.
@@ -408,7 +412,31 @@ describe('getHandler', () => {
     expect(middleware._getManifestResponseAsync).toHaveBeenCalled();
 
     // Generally tests that the server I/O works as expected so we don't need to test this in subclasses.
-    expect(res.statusCode).toEqual(200);
+    expect(res.statusCode).toEqual(201);
+    expect(res.statusMessage).toEqual('Created');
+    expect(res.setHeader).toHaveBeenCalledWith('header', 'value');
+    expect(Buffer.concat(chunks).toString()).toEqual('body');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it(`does not report an error when the response closes while the manifest resolves`, async () => {
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'http://fake.mock'),
+    });
+    middleware.getParsedHeaders = jest.fn(() => ({ platform: 'ios' }));
+    const res = new MockServerResponse();
+    middleware._getManifestResponseAsync = jest.fn(async () => {
+      res.destroy();
+      return new Response('body');
+    });
+
+    const handleAsync = middleware.getHandler();
+    const next = jest.fn();
+    const req = asReq({ url: '/', headers: {} });
+
+    await handleAsync(req, asRes(res), next);
+
+    expect(Log.exception).not.toHaveBeenCalled();
     expect(next).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Why

Resolves #48584
Resolves #48581

This is related to an underlying issue that's instead addressed in `expo-server` in #48699 due to the use of the `pipeline` helper. The `pipeline` helper in Node treats cancellations as exception cases rather than as regular control flow.

# How

- Replace `pipelin` and manual `Response` handling with `expo-server`'s `respond` helper

Note: Other relevant places in the CLI already use `expo-server` as intended.

# Test Plan

- Extend unit tests to add failing case

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
