### PR TITLE
[docs] Add instructions to view console logs with `--no-dev`

### DIFF
--- a/docs/pages/workflow/development-mode.mdx
+++ b/docs/pages/workflow/development-mode.mdx
@@ -44,4 +44,6 @@ The easiest way to simulate how your project will run on end users' devices is w
 
 It runs the JavaScript of your app in production mode (which tells the Metro bundler to set the `__DEV__` environment variable to `false`, among a few other things). The `--minify` flag minifies your app. This flag also eliminates unnecessary data such as comments, formatting, and unused code. If you are getting an error or crash in your standalone app, running your project with this command can save you a lot of time in finding the root cause.
 
+> **info** In production mode, console logs do not appear in the Expo CLI terminal. To access them through the native logs on your device, see [View console logs in production mode](/workflow/logging/#view-console-logs-in-production-mode).
+
 To completely compile your app for production see [Compiling Android](/more/expo-cli/#compiling-android) and [Compiling iOS](/more/expo-cli/#compiling-ios).

--- a/docs/pages/workflow/logging.mdx
+++ b/docs/pages/workflow/logging.mdx
@@ -13,6 +13,10 @@ When you run `npx expo start` and connect a device, console logs will show up in
 
 You can view **high fidelity** logs and use advanced logging functions like `console.table` by creating a development build with [Hermes](/guides/using-hermes), and [connecting the inspector](/guides/using-hermes#javascript-debugger).
 
+### View console logs in production mode
+
+When you start your app with [`npx expo start --no-dev`](/workflow/development-mode/#production-mode), console logs do not appear in the Expo CLI terminal. The runtime code that forwards logs to Expo CLI only runs in development mode. You cannot re-enable it in production mode. However, `console.log` still writes to the native log on the device. To view these logs, use `adb logcat` on Android or the Console app on iOS. For step-by-step instructions, see [Viewing native logs](/debugging/runtime-issues/#viewing-native-logs).
+
 ## Native logs
 
 You can view native runtime logs in Android Studio and Xcode by compiling the native app locally. For more information, see [native debugging](/debugging/runtime-issues/#native-debugging).


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18044

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add info on console logs skip the Expo CLI terminal with `--no-dev` and point to native device logs (`adb logcat`, iOS Console app) instead, with a new section on the View logs page and a linking callout on the development modes page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
