### PR TITLE
ci(cli): Reduce repeated dev-server startups in Playwright tests

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/01-rsc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/01-rsc.test.ts
@@ -34,7 +34,7 @@ for (const outputMode of outputModes) {
       },
     });
 
-    test.beforeEach(async () => {
+    test.beforeAll(async () => {
       console.time('expo start');
       await expoStart.startAsync();
       console.timeEnd('expo start');
@@ -43,7 +43,7 @@ for (const outputMode of outputModes) {
       await expoStart.fetchBundleAsync('/');
       console.timeEnd('Eagerly bundled JS');
     });
-    test.afterEach(async () => {
+    test.afterAll(async () => {
       await expoStart.stopAsync();
     });
 

--- a/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
@@ -12,9 +14,15 @@ test.afterAll(() => restoreEnv());
 const projectRoot = getRouterE2ERoot();
 const testName = '03-server-actions-only';
 const inputDir = 'dist-' + testName;
+const mutatedServerAction = path.join(
+  projectRoot,
+  '__e2e__/03-server-actions-only/components/two-action.tsx'
+);
 
 test.describe(inputDir, () => {
   test.describe.configure({ mode: 'serial' });
+
+  let originalServerAction: string;
 
   const expoStart = createExpoStart({
     cwd: projectRoot,
@@ -32,7 +40,9 @@ test.describe(inputDir, () => {
     },
   });
 
-  test.beforeEach('bundle and serve', async () => {
+  test.beforeAll('bundle and serve', async () => {
+    originalServerAction = await fs.promises.readFile(mutatedServerAction, 'utf8');
+
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -41,8 +51,12 @@ test.describe(inputDir, () => {
     await expoStart.fetchBundleAsync('/');
     console.timeEnd('Eagerly bundled JS');
   });
-  test.afterEach(async () => {
-    await expoStart.stopAsync();
+  test.afterAll(async () => {
+    try {
+      await expoStart.stopAsync();
+    } finally {
+      await fs.promises.writeFile(mutatedServerAction, originalServerAction);
+    }
   });
 
   test('renders RSC and calls server action', async ({ page }) => {

--- a/packages/@expo/cli/e2e/playwright/dev/04-server-error-boundaries.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/04-server-error-boundaries.test.ts
@@ -13,6 +13,8 @@ const testName = '04-server-error-boundaries';
 const inputDir = 'dist-' + testName;
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -27,7 +29,7 @@ test.describe(inputDir, () => {
     },
   });
 
-  test.beforeEach('bundle and serve', async () => {
+  test.beforeAll('bundle and serve', async () => {
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -36,7 +38,7 @@ test.describe(inputDir, () => {
     await expoStart.fetchBundleAsync('/');
     console.timeEnd('Eagerly bundled JS');
   });
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync();
   });
 

--- a/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/dev-console-errors.test.ts
@@ -15,6 +15,8 @@ const projectRoot = getRouterE2ERoot();
 const isWindows = platform === 'win32';
 
 test.describe('dev console errors', () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -29,7 +31,7 @@ test.describe('dev console errors', () => {
     },
   });
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -39,7 +41,7 @@ test.describe('dev console errors', () => {
     console.timeEnd('Eagerly bundled JS');
   });
 
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync();
   });
 

--- a/packages/@expo/cli/e2e/playwright/dev/devtools-e2e.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/devtools-e2e.test.ts
@@ -9,6 +9,8 @@ const projectRoot = getRouterE2ERoot();
 const pluginPath = '/_expo/plugins/devtools-e2e';
 
 test.describe('devtools-e2e', () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -19,7 +21,7 @@ test.describe('devtools-e2e', () => {
   });
   let output: ReturnType<typeof processCollectOutput>;
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     const startPromise = expoStart.startAsync();
 
     await expect
@@ -37,7 +39,7 @@ test.describe('devtools-e2e', () => {
     await startPromise;
   });
 
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync(true);
   });
 

--- a/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/fast-refresh.test.ts
@@ -20,6 +20,8 @@ const tempRoute = '/temp-route.tsx';
 const renamedRoute = '/renamed.tsx';
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -34,8 +36,13 @@ test.describe(inputDir, () => {
     },
   });
 
+  test.beforeAll(async () => {
+    console.time('expo start');
+    await expoStart.startAsync();
+    console.timeEnd('expo start');
+  });
   test.beforeEach(async () => {
-    // Ensure `const ROUTE_VALUE = 'ROUTE_VALUE_1';` -> `const ROUTE_VALUE = 'ROUTE_VALUE';` before starting
+    // Restore fixture state while keeping Metro's process and graph alive.
     await mutateFile(indexFile, (contents) => {
       return contents.replace(/ROUTE_VALUE_[\d\w]+/g, 'ROUTE_VALUE');
     });
@@ -44,18 +51,12 @@ test.describe(inputDir, () => {
       return contents.replace(/LAYOUT_VALUE_[\d\w]+/g, 'LAYOUT_VALUE');
     });
 
-    console.time('expo start');
-    await expoStart.startAsync();
-    console.timeEnd('expo start');
-
     console.time('Eagerly bundled JS');
     await expoStart.fetchBundleAsync('/').then((response) => response.text());
     console.timeEnd('Eagerly bundled JS');
   });
   test.afterEach(async () => {
-    await expoStart.stopAsync();
-
-    // Ensure `const ROUTE_VALUE = 'ROUTE_VALUE_1';` -> `const ROUTE_VALUE = 'ROUTE_VALUE';` before starting
+    // Ensure mutations never leak into the next test or the worktree.
     await mutateFile(indexFile, (contents) => {
       return contents.replace(/ROUTE_VALUE_[\d\w]+/g, 'ROUTE_VALUE');
     });
@@ -69,6 +70,9 @@ test.describe(inputDir, () => {
     if (fs.existsSync(appDir + renamedRoute)) {
       await fsPromise.unlink(appDir + renamedRoute);
     }
+  });
+  test.afterAll(async () => {
+    await expoStart.stopAsync();
   });
 
   const targetDirectory = path.join(projectRoot, '__e2e__/fast-refresh/app');

--- a/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
@@ -12,6 +12,8 @@ const projectRoot = getRouterE2ERoot();
 const inputDir = 'headless';
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -26,7 +28,7 @@ test.describe(inputDir, () => {
     },
   });
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -35,7 +37,7 @@ test.describe(inputDir, () => {
     await expoStart.fetchBundleAsync('/');
     console.timeEnd('Eagerly bundled JS');
   });
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync();
   });
 
@@ -45,19 +47,19 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
 
     await page.getByText('Go to Tab functions').click();
 
-    expect(page.getByTestId('tab-home-functions')).toBeDefined();
+    await expect(page.getByTestId('tab-home-functions').filter({ visible: true })).toBeVisible();
 
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(page.getByTestId('tab-movies-index').filter({ visible: true })).toBeVisible();
 
     await page.getByTestId('tab-home').click();
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -70,29 +72,33 @@ test.describe(inputDir, () => {
 
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(page.getByTestId('tab-movies-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('link', { name: 'Toy Story' }).click();
 
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    expect(page.getByText('Toy Story')).toBeDefined();
-    expect(page.getByText('Lorem ipsum dolor sit amet')).toBeDefined();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
+      'Toy Story'
+    );
+    await expect(page.getByText('Lorem ipsum dolor sit amet')).toBeVisible();
 
     await page.getByTestId('tab-home').click();
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
 
     await page.getByTestId('tab-movies').click();
 
     // Still on the movie details page
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
-    expect(page.getByText('Toy Story')).toBeDefined();
-    expect(page.getByText('Lorem ipsum dolor sit amet')).toBeDefined();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
+      'Toy Story'
+    );
+    await expect(page.getByText('Lorem ipsum dolor sit amet')).toBeVisible();
 
     // Second click on focused tab resets it
     await page.getByTestId('tab-movies').click();
 
-    expect(page.getByTestId('tab-movies-index')).toBeDefined();
+    await expect(page.getByTestId('tab-movies-index').filter({ visible: true })).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -105,32 +111,38 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
+    await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
 
     await page.getByText('Toy Story').click();
 
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
     // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Toy Story' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
+      'Toy Story'
+    );
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     await page.getByRole('link', { name: 'Monsters Inc.' }).click();
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
     // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Monsters Inc.' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Monsters%20Inc$/);
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
+      'Monsters Inc.'
+    );
+    await expect(page).toHaveURL(/\/movies\/Monsters%20Inc$/);
 
     // Go back to Toy Story
     await page.goBack();
-    expect(page.getByTestId('tab-movies-details')).toBeDefined();
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
     // Title + link (link is interpreted as two elements)
-    expect(page.getByRole('heading', { name: 'Toy Story' })).toBeDefined();
-    expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
+    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
+      'Toy Story'
+    );
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     // Go back to movies index
     await page.goBack();
-    expect(page.getByTestId('tab-home-index')).toBeDefined();
-    expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/headless.test.ts
@@ -52,19 +52,24 @@ test.describe(inputDir, () => {
     await page.getByText('Go to Tab functions').click();
 
     await expect(page.getByTestId('tab-home-functions').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/tab-functions$/);
 
     await page.getByTestId('tab-movies').click();
 
     await expect(page.getByTestId('tab-movies-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/movies$/);
 
     await page.getByTestId('tab-home').click();
 
     await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
 
     expect(pageErrors.all).toEqual([]);
   });
 
-  test('when resetOnFocus is false, does reset the tab until second click', async ({ page }) => {
+  test('when resetOnFocus is false, does not reset the tab until second click', async ({
+    page,
+  }) => {
     // Listen for console logs and errors
     const pageErrors = pageCollectErrors(page);
 
@@ -76,29 +81,28 @@ test.describe(inputDir, () => {
 
     await page.getByRole('link', { name: 'Toy Story' }).click();
 
-    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
-    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
-      'Toy Story'
-    );
-    await expect(page.getByText('Lorem ipsum dolor sit amet')).toBeVisible();
+    const visibleMovieDetails = page.getByTestId('tab-movie-details').filter({ visible: true });
+    await expect(visibleMovieDetails).toContainText('Toy Story');
+    await expect(visibleMovieDetails).toContainText('Lorem ipsum dolor sit amet');
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     await page.getByTestId('tab-home').click();
 
     await expect(page.getByTestId('tab-home-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
 
     await page.getByTestId('tab-movies').click();
 
     // Still on the movie details page
-    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toBeVisible();
-    await expect(page.getByTestId('tab-movie-details').filter({ visible: true })).toContainText(
-      'Toy Story'
-    );
-    await expect(page.getByText('Lorem ipsum dolor sit amet')).toBeVisible();
+    await expect(visibleMovieDetails).toContainText('Toy Story');
+    await expect(visibleMovieDetails).toContainText('Lorem ipsum dolor sit amet');
+    await expect(page).toHaveURL(/\/movies\/Toy%20Story$/);
 
     // Second click on focused tab resets it
     await page.getByTestId('tab-movies').click();
 
     await expect(page.getByTestId('tab-movies-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/movies$/);
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
@@ -54,16 +54,19 @@ test.describe(inputDir, () => {
     await expect(
       page.getByTestId('native-tabs-nested-inner').filter({ visible: true })
     ).toBeVisible();
+    await expect(page).toHaveURL(/\/nested\/inner$/);
 
     await page.getByRole('link', { name: 'Go to /', exact: true }).click();
 
     await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/$/);
 
     await page.getByRole('link', { name: 'Go to /nested', exact: true }).click();
 
     await expect(
       page.getByTestId('native-tabs-nested-index').filter({ visible: true })
     ).toBeVisible();
+    await expect(page).toHaveURL(/\/nested$/);
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -128,8 +131,10 @@ test.describe(inputDir, () => {
     await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).toBeVisible();
     await page.getByRole('tab', { name: 'Dynamic 9', exact: true }).click();
     await expect(page.getByTestId('label-input').filter({ visible: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/dynamic$/);
 
     await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).not.toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Tab 2 9+', exact: true })).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/native-tabs.test.ts
@@ -12,6 +12,8 @@ const projectRoot = getRouterE2ERoot();
 const inputDir = 'native-tabs';
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -26,7 +28,7 @@ test.describe(inputDir, () => {
     },
   });
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -35,7 +37,7 @@ test.describe(inputDir, () => {
     await expoStart.fetchBundleAsync('/');
     console.timeEnd('Eagerly bundled JS');
   });
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync();
   });
 
@@ -45,19 +47,23 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested/inner', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-inner').filter({ visible: true })
+    ).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested', exact: true }).click();
 
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-index').filter({ visible: true })
+    ).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -68,35 +74,45 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     // 1 is the badge value on the "nested" tab
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-index').filter({ visible: true })
+    ).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested/inner', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-inner').filter({ visible: true })
+    ).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-inner')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-inner').filter({ visible: true })
+    ).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('link', { name: 'Go to /nested', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-index').filter({ visible: true })
+    ).toBeVisible();
 
     await page.getByRole('tab', { name: 'Index label', exact: true }).click();
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
     await page.getByRole('tab', { name: 'nested 1', exact: true }).click();
-    expect(page.getByTestId('native-tabs-nested-index')).toBeDefined();
+    await expect(
+      page.getByTestId('native-tabs-nested-index').filter({ visible: true })
+    ).toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });
@@ -107,14 +123,13 @@ test.describe(inputDir, () => {
 
     await page.goto(new URL('/', expoStart.url).href);
 
-    expect(page.getByTestId('native-tabs-index')).toBeDefined();
+    await expect(page.getByTestId('native-tabs-index').filter({ visible: true })).toBeVisible();
 
-    expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).toBeDefined();
+    await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).toBeVisible();
     await page.getByRole('tab', { name: 'Dynamic 9', exact: true }).click();
-    expect(page.getByTestId('native-tabs-dynamic')).toBeDefined();
-    expect(page.getByTestId('label-input')).toBeDefined();
+    await expect(page.getByTestId('label-input').filter({ visible: true })).toBeVisible();
 
-    expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).not.toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Dynamic 9', exact: true })).not.toBeVisible();
 
     expect(pageErrors.all).toEqual([]);
   });

--- a/packages/@expo/cli/e2e/playwright/dev/react-compiler.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/react-compiler.test.ts
@@ -16,6 +16,8 @@ const projectRoot = getRouterE2ERoot();
 const baseDir = 'dist-react-compiler';
 
 test.describe(baseDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoServe = createExpoServe({
     cwd: projectRoot,
     env: {
@@ -26,7 +28,7 @@ test.describe(baseDir, () => {
   test.describe('default', () => {
     const inputDir = 'dist-react-compiler-default';
 
-    test.beforeEach('bundle and serve', async () => {
+    test.beforeAll('bundle and serve', async () => {
       console.time('expo export');
       await executeExpoAsync(projectRoot, ['export', '-p', 'web', '--output-dir', inputDir], {
         env: {
@@ -42,7 +44,7 @@ test.describe(baseDir, () => {
       await expoServe.startAsync([inputDir]);
       console.timeEnd('npx serve');
     });
-    test.afterEach(async () => {
+    test.afterAll(async () => {
       await expoServe.stopAsync();
     });
 
@@ -86,7 +88,7 @@ test.describe(baseDir, () => {
   test.describe('without live bindings', () => {
     const inputDir = 'dist-react-compiler-no-live-bindings';
 
-    test.beforeEach('bundle and serve', async () => {
+    test.beforeAll('bundle and serve', async () => {
       console.time('expo export');
       const res = await executeExpoAsync(
         projectRoot,
@@ -109,7 +111,7 @@ test.describe(baseDir, () => {
       await expoServe.startAsync([inputDir]);
       console.timeEnd('npx serve');
     });
-    test.afterEach(async () => {
+    test.afterAll(async () => {
       await expoServe.stopAsync();
     });
 

--- a/packages/@expo/cli/e2e/playwright/dev/router-misc.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/router-misc.test.ts
@@ -12,6 +12,8 @@ const projectRoot = getRouterE2ERoot();
 const inputDir = 'router-misc';
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
+
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {
@@ -26,7 +28,7 @@ test.describe(inputDir, () => {
     },
   });
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     console.time('expo start');
     await expoStart.startAsync();
     console.timeEnd('expo start');
@@ -35,7 +37,7 @@ test.describe(inputDir, () => {
     await expoStart.fetchBundleAsync('/');
     console.timeEnd('Eagerly bundled JS');
   });
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await expoStart.stopAsync();
   });
 


### PR DESCRIPTION
# Why

**Note:** This will be the first PR of a stack of several changes

We're currently spending a lot of time in our Playwright test suite restarting the dev-servers when we can reuse them per test suite, if a test doesn't depend on a fresh session. Any given test suite actually rarely depends on having a fresh dev-server suite, and only change/error-sensitive CLI runs will suffer from this.

# How

- Restructure individual test suites to switch to one dev-server startup and shutdown, instead of one per test
- Fix missing element assertions that may make some tests less accurate than intended

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
