### PR TITLE
[router] Add global registry for routers.

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🎉 New features
 
+- Add global registry for routers.
 - Improve withLayoutContext types ([#48356](https://github.com/expo/expo/pull/48356) by [@Ubax](https://github.com/Ubax))
 - Expose `unstable_nativeProps` props from Stack component ([#48152](https://github.com/expo/expo/pull/48152) by [@Ubax](https://github.com/Ubax))
 - Expose route provenance to custom navigators through descriptor `routeSource`. ([#47827](https://github.com/expo/expo/pull/47827) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### 🎉 New features
 
-- Add global registry for routers.
+- Add global registry for routers. ([#48707](https://github.com/expo/expo/pull/48707) by [@Ubax](https://github.com/Ubax))
 - Improve withLayoutContext types ([#48356](https://github.com/expo/expo/pull/48356) by [@Ubax](https://github.com/Ubax))
 - Expose `unstable_nativeProps` props from Stack component ([#48152](https://github.com/expo/expo/pull/48152) by [@Ubax](https://github.com/Ubax))
 - Expose route provenance to custom navigators through descriptor `routeSource`. ([#47827](https://github.com/expo/expo/pull/47827) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -9,6 +9,7 @@ import { useDomComponentNavigation } from './domComponents/useDomComponentNaviga
 import { NavigationContainer as UpstreamNavigationContainer } from './fork/NavigationContainer';
 import type { ExpoLinkingOptions } from './getLinkingConfig';
 import { store, useStore } from './global-state/router-store';
+import { RouterRegistryProvider } from './global-state/routerRegistry';
 import type { ServerContextType } from './global-state/serverLocationContext';
 import { ServerContext } from './global-state/serverLocationContext';
 import { StoreContext } from './global-state/storeContext';
@@ -154,20 +155,22 @@ function ContextNavigator({
 
   return (
     <StoreContext.Provider value={store}>
-      <UpstreamNavigationContainer
-        ref={store.navigationRef}
-        initialState={store.state}
-        linking={store.linking as LinkingOptions<any>}
-        onUnhandledAction={onUnhandledAction}
-        onStateChange={store.onStateChange}
-        documentTitle={documentTitle}
-        onReady={onNavigationReady}>
-        <ServerContext.Provider value={serverContext}>
-          <WrapperComponent>
-            <Content />
-          </WrapperComponent>
-        </ServerContext.Provider>
-      </UpstreamNavigationContainer>
+      <RouterRegistryProvider>
+        <UpstreamNavigationContainer
+          ref={store.navigationRef}
+          initialState={store.state}
+          linking={store.linking as LinkingOptions<any>}
+          onUnhandledAction={onUnhandledAction}
+          onStateChange={store.onStateChange}
+          documentTitle={documentTitle}
+          onReady={onNavigationReady}>
+          <ServerContext.Provider value={serverContext}>
+            <WrapperComponent>
+              <Content />
+            </WrapperComponent>
+          </ServerContext.Provider>
+        </UpstreamNavigationContainer>
+      </RouterRegistryProvider>
     </StoreContext.Provider>
   );
 }

--- a/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 import { act, render } from '@testing-library/react-native';
-import { StrictMode, use, type ReactNode } from 'react';
+import { StrictMode, use, useState, type ReactNode } from 'react';
 import { Text } from 'react-native';
 
 import { ExpoRoot } from '../../ExpoRoot';
@@ -231,6 +231,29 @@ describe('navigation builder registration', () => {
     const nextState = entry.reduce(layoutState, StackActions.push('second'));
 
     expect(nextState?.routes.map((route) => route.name)).toEqual(['index', 'second']);
+  });
+
+  it('preserves registry identity when screens do not change', () => {
+    let rerenderLayout: () => void;
+    function Layout() {
+      const [, setRenderCount] = useState(0);
+      rerenderLayout = () => setRenderCount((count) => count + 1);
+      return <Stack />;
+    }
+
+    renderRouter({
+      _layout: Layout,
+      index: Probe,
+    });
+    const initialRegistry = registry;
+    const initialEntry = registry.get(getLayoutState().key);
+    const initialRenders = registryRenders;
+
+    act(() => rerenderLayout());
+
+    expect(registry).toBe(initialRegistry);
+    expect(registry.get(getLayoutState().key)).toBe(initialEntry);
+    expect(registryRenders).toBe(initialRenders);
   });
 
   it('replaces the entry when screens change', () => {

--- a/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
@@ -1,0 +1,265 @@
+import { jest } from '@jest/globals';
+import { act, render } from '@testing-library/react-native';
+import { StrictMode, use, type ReactNode } from 'react';
+import { Text } from 'react-native';
+
+import { ExpoRoot } from '../../ExpoRoot';
+import { router } from '../../imperative-api';
+import Stack from '../../layouts/Stack';
+import { StackActions, type NavigationState } from '../../react-navigation/native';
+import { getMockContext, renderRouter } from '../../testing-library';
+import { store } from '../router-store';
+import {
+  RouterRegistryProvider,
+  RouterRegistryContext,
+  type RouterRegistry,
+  type RouterRegistryEntry,
+  useRegisterRouter,
+} from '../routerRegistry';
+
+const state: NavigationState = {
+  stale: false,
+  type: 'stack',
+  key: 'stack-key',
+  index: 0,
+  routeNames: ['index'],
+  routes: [{ key: 'index-key', name: 'index' }],
+};
+
+const firstEntry: RouterRegistryEntry = {
+  reduce: () => state,
+  routerType: 'stack',
+};
+
+const secondEntry: RouterRegistryEntry = {
+  reduce: () => state,
+  routerType: 'stack',
+};
+
+function getLayoutState(): NavigationState {
+  const layoutState = store.navigationRef.current!.getRootState().routes[0]!.state;
+
+  if (layoutState?.stale !== false) {
+    throw new Error('Expected initialized layout state');
+  }
+
+  return layoutState;
+}
+
+function Registrant({
+  entry,
+  stateKey = state.key,
+}: {
+  entry: RouterRegistryEntry;
+  stateKey?: string;
+}) {
+  useRegisterRouter(stateKey, entry);
+  return null;
+}
+
+function RegistryProbe({ onRender }: { onRender: (registry: RouterRegistry) => void }) {
+  const registry = use(RouterRegistryContext);
+  if (registry === undefined) {
+    throw new Error('Expected RouterRegistryProvider');
+  }
+  onRender(registry);
+  return null;
+}
+
+describe(RouterRegistryProvider, () => {
+  it('warns when registering outside the provider', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      render(<Registrant entry={firstEntry} />);
+
+      expect(warn).toHaveBeenCalledWith(
+        'Router registry is unavailable. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.'
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('registers and unregisters entries', () => {
+    const registries: RouterRegistry[] = [];
+    const result = render(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+        <Registrant entry={firstEntry} />
+      </RouterRegistryProvider>
+    );
+
+    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
+
+    result.rerender(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+      </RouterRegistryProvider>
+    );
+
+    expect(registries.at(-1)?.size).toBe(0);
+  });
+
+  it('keeps a newer registration when an older owner unmounts', () => {
+    const registries: RouterRegistry[] = [];
+    const result = render(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+        <Registrant entry={firstEntry} />
+        <Registrant entry={secondEntry} />
+      </RouterRegistryProvider>
+    );
+
+    expect(registries.at(-1)?.get(state.key)).toBe(secondEntry);
+
+    result.rerender(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+        <Registrant entry={secondEntry} />
+      </RouterRegistryProvider>
+    );
+
+    expect(registries.at(-1)?.get(state.key)).toBe(secondEntry);
+  });
+
+  it('handles StrictMode effect replay', () => {
+    const registries: RouterRegistry[] = [];
+
+    render(
+      <StrictMode>
+        <RouterRegistryProvider>
+          <RegistryProbe onRender={(registry) => registries.push(registry)} />
+          <Registrant entry={firstEntry} />
+        </RouterRegistryProvider>
+      </StrictMode>
+    );
+
+    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
+  });
+
+  it('preserves map identity when registration does not change', () => {
+    const registries: RouterRegistry[] = [];
+
+    render(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+        <Registrant entry={firstEntry} />
+        <Registrant entry={firstEntry} />
+      </RouterRegistryProvider>
+    );
+
+    expect(new Set(registries).size).toBe(2);
+    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
+  });
+});
+
+describe('navigation builder registration', () => {
+  let registry: RouterRegistry;
+  let registryRenders: number;
+
+  function Probe() {
+    const currentRegistry = use(RouterRegistryContext);
+    if (currentRegistry === undefined) {
+      throw new Error('Expected RouterRegistryProvider');
+    }
+    registry = currentRegistry;
+    registryRenders++;
+    return <Text testID="probe" />;
+  }
+
+  beforeEach(() => {
+    registry = new Map();
+    registryRenders = 0;
+  });
+
+  it('registers each mounted navigator by its state key', () => {
+    renderRouter({
+      _layout: () => <Stack />,
+      index: Probe,
+    });
+
+    const rootState = store.navigationRef.current!.getRootState();
+    const layoutState = rootState.routes[0]!.state!;
+
+    expect([...registry.keys()]).toEqual(expect.arrayContaining([rootState.key, layoutState.key]));
+    expect(registry.size).toBe(2);
+  });
+
+  it('registers an inactive nested navigator only after its screen mounts', () => {
+    renderRouter({
+      _layout: () => <Stack />,
+      index: Probe,
+      'nested/_layout': () => <Stack />,
+      'nested/index': () => <Text testID="nested" />,
+    });
+
+    expect(registry.size).toBe(2);
+
+    act(() => router.push('/nested'));
+
+    expect(registry.size).toBe(3);
+  });
+
+  it('notifies consumers when a navigator mounts and unmounts', () => {
+    renderRouter({
+      _layout: () => <Stack />,
+      index: Probe,
+      'nested/_layout': () => <Stack />,
+      'nested/index': () => <Text testID="nested" />,
+    });
+    const initialRenders = registryRenders;
+
+    act(() => router.push('/nested'));
+    expect(registryRenders).toBeGreaterThan(initialRenders);
+
+    const mountedRenders = registryRenders;
+    act(() => router.back());
+    expect(registryRenders).toBeGreaterThan(mountedRenders);
+    expect(registry.size).toBe(2);
+  });
+
+  it('reduces actions with the registered router configuration', () => {
+    renderRouter({
+      _layout: () => <Stack />,
+      index: Probe,
+      second: () => <Text testID="second" />,
+    });
+    const layoutState = getLayoutState();
+    const entry = registry.get(layoutState.key)!;
+
+    const nextState = entry.reduce(layoutState, StackActions.push('second'));
+
+    expect(nextState?.routes.map((route) => route.name)).toEqual(['index', 'second']);
+  });
+
+  it('replaces the entry when screens change', () => {
+    const routes: Record<string, () => ReactNode> = {
+      _layout: () => <Stack />,
+      index: Probe,
+    };
+    const context = getMockContext(routes);
+    const previousImportMode = process.env.EXPO_ROUTER_IMPORT_MODE;
+    process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
+
+    try {
+      const result = render(<ExpoRoot context={context} location="/" />);
+      const initialEntry = registry.get(getLayoutState().key)!;
+
+      routes.second = () => <Text testID="second" />;
+      result.rerender(<ExpoRoot context={context} location="/" />);
+
+      const updatedEntry = [...registry.values()].find((entry) => entry.contextKey === '')!;
+      expect(updatedEntry).not.toBe(initialEntry);
+      expect(updatedEntry.reduce(getLayoutState(), StackActions.push('second'))?.routes).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'second' })])
+      );
+    } finally {
+      if (previousImportMode === undefined) {
+        delete process.env.EXPO_ROUTER_IMPORT_MODE;
+      } else {
+        process.env.EXPO_ROUTER_IMPORT_MODE = previousImportMode;
+      }
+    }
+  });
+});

--- a/packages/expo-router/src/global-state/routerRegistry.tsx
+++ b/packages/expo-router/src/global-state/routerRegistry.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { createContext, use, useMemo, useState, type PropsWithChildren } from 'react';
+
+import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
+import type { NavigationAction, NavigationState, PartialState } from '../react-navigation/routers';
+
+export type RouterRegistryEntry = {
+  reduce: (
+    state: NavigationState,
+    action: NavigationAction
+  ) => NavigationState | PartialState<NavigationState> | null;
+  routerType: string;
+  contextKey?: string;
+};
+
+// Entries appear after the first commit and state keys can change when navigation state is reset.
+export type RouterRegistry = ReadonlyMap<string, RouterRegistryEntry>;
+
+type RouterRegistrySetters = {
+  register: (stateKey: string, entry: RouterRegistryEntry) => void;
+  unregister: (stateKey: string, entry: RouterRegistryEntry) => void;
+};
+
+export const RouterRegistryContext = createContext<RouterRegistry | undefined>(undefined);
+const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(undefined);
+
+export function RouterRegistryProvider({ children }: PropsWithChildren) {
+  const [registry, setRegistry] = useState<RouterRegistry>(() => new Map());
+  const setters = useMemo<RouterRegistrySetters>(
+    () => ({
+      register(stateKey, entry) {
+        setRegistry((previous) => {
+          if (previous.get(stateKey) === entry) {
+            return previous;
+          }
+
+          return new Map(previous).set(stateKey, entry);
+        });
+      },
+      unregister(stateKey, entry) {
+        setRegistry((previous) => {
+          if (previous.get(stateKey) !== entry) {
+            return previous;
+          }
+
+          const next = new Map(previous);
+          next.delete(stateKey);
+          return next;
+        });
+      },
+    }),
+    []
+  );
+
+  return (
+    <RouterRegistrySettersContext.Provider value={setters}>
+      <RouterRegistryContext.Provider value={registry}>{children}</RouterRegistryContext.Provider>
+    </RouterRegistrySettersContext.Provider>
+  );
+}
+
+export function useRegisterRouter(stateKey: string, entry: RouterRegistryEntry): void {
+  const setters = use(RouterRegistrySettersContext);
+
+  useClientLayoutEffect(() => {
+    if (setters === undefined) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'Router registry is unavailable. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.'
+        );
+      }
+      return;
+    }
+
+    setters.register(stateKey, entry);
+    return () => setters.unregister(stateKey, entry);
+  }, [entry, setters, stateKey]);
+}

--- a/packages/expo-router/src/global-state/routerRegistry.tsx
+++ b/packages/expo-router/src/global-state/routerRegistry.tsx
@@ -10,7 +10,7 @@ export type RouterRegistryEntry = {
     state: NavigationState,
     action: NavigationAction
   ) => NavigationState | PartialState<NavigationState> | null;
-  routerType: string;
+  routerType: string | undefined;
   contextKey?: string;
 };
 
@@ -22,6 +22,7 @@ type RouterRegistrySetters = {
   unregister: (stateKey: string, entry: RouterRegistryEntry) => void;
 };
 
+// React components read this map during render, so React state is intentional.
 export const RouterRegistryContext = createContext<RouterRegistry | undefined>(undefined);
 const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(undefined);
 

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -9,13 +9,13 @@ import {
   StackRouter,
   TabRouter,
 } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { NavigationIndependentTree } from '../NavigationIndependentTree';
 import { NavigationStateContext } from '../NavigationStateContext';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import type { EventListenerCallback, NavigationContainerEventMap } from '../types';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { type MockActions, MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+
+import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
+import { BaseNavigationContainer as BaseNavigationContainerImpl } from '../../BaseNavigationContainer';
+
+export function BaseNavigationContainer(
+  props: React.ComponentProps<typeof BaseNavigationContainerImpl>
+) {
+  return (
+    <RouterRegistryProvider>
+      <BaseNavigationContainerImpl {...props} />
+    </RouterRegistryProvider>
+  );
+}

--- a/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react-native';
 
 import type { NavigationState, ParamListBase } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
@@ -8,12 +8,12 @@ import {
   type ParamListBase,
   type Router,
 } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Group } from '../Group';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigation } from '../useNavigation';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
@@ -2,11 +2,11 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import { type ParamListBase, StackActions, StackRouter } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { usePreventRemove } from '../usePreventRemove';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 
 jest.mock('nanoid/non-secure', () => {
   const m = { nanoid: () => String(++m.__key), __key: 0 };

--- a/packages/expo-router/src/react-navigation/core/__tests__/theming.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/theming.test.ios.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react-native';
 import * as React from 'react';
 
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { useTheme } from '../theming/useTheme';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter } from './__fixtures__/MockRouter';
 
 test('can get current theme with useTheme', () => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
@@ -8,11 +8,11 @@ import type {
   NavigationState,
   ParamListBase,
 } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { NavigatorTypeContext } from '../NavigatorTypeContext';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useDescriptors.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useDescriptors.test.ios.tsx
@@ -2,10 +2,10 @@ import { act, render, renderHook } from '@testing-library/react-native';
 import * as React from 'react';
 
 import type { DefaultRouterOptions, NavigationState, Router } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Group } from '../Group';
 import { Screen } from '../Screen';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { type MockActions, MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 jest.useFakeTimers();

--- a/packages/expo-router/src/react-navigation/core/__tests__/useEventEmitter.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useEventEmitter.test.ios.tsx
@@ -2,9 +2,9 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import type { NavigationState, Router } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useFocusEffect.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useFocusEffect.test.ios.tsx
@@ -1,10 +1,10 @@
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { useFocusEffect } from '../useFocusEffect';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useIsFocused.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useIsFocused.test.ios.tsx
@@ -2,12 +2,12 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import type { ParamListBase } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useIsFocused } from '../useIsFocused';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useRoute } from '../useRoute';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigation.test.ios.tsx
@@ -1,9 +1,9 @@
 import { render } from '@testing-library/react-native';
 
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { useNavigation } from '../useNavigation';
 import { useNavigationBuilder } from '../useNavigationBuilder';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
@@ -7,12 +7,12 @@ import {
   type ParamListBase,
   StackRouter,
 } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useEventEmitter } from '../useEventEmitter';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useNavigationCache } from '../useNavigationCache';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
@@ -2,10 +2,10 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import type { NavigationState } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useNavigationState } from '../useNavigationState';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
@@ -10,11 +10,11 @@ import {
   StackActions,
   StackRouter,
 } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { usePreventRemove } from '../usePreventRemove';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { type MockActions, MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 jest.mock('nanoid/non-secure', () => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/usePreventRemove.test.ios.tsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { use, useEffect } from 'react';
 
 import { CommonActions, type ParamListBase, StackActions, StackRouter } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { type PreventedRoutes, PreventRemoveContext } from '../PreventRemoveContext';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
@@ -11,6 +10,7 @@ import { useNavigationBuilder } from '../useNavigationBuilder';
 import { getPreventableRoutes } from '../useOnPreventRemove';
 import { usePreventRemove } from '../usePreventRemove';
 import { usePreventRemoveContext } from '../usePreventRemoveContext';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouterKey } from './__fixtures__/MockRouter';
 
 jest.mock('nanoid/non-secure', () => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useRoute.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useRoute.test.ios.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react-native';
 
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import type { RouteProp } from '../types';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useRoute } from '../useRoute';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
 
 beforeEach(() => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useStateForPath.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useStateForPath.test.ios.tsx
@@ -1,13 +1,13 @@
 import { act, render, screen } from '@testing-library/react-native';
 
 import type { ParamListBase } from '../../routers';
-import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { getPathFromState } from '../getPathFromState';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useRoute } from '../useRoute';
 import { useStateForPath } from '../useStateForPath';
+import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
 import { MockRouter } from './__fixtures__/MockRouter';
 
 test('gets focused route state at root', () => {

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -4,6 +4,7 @@ import { use } from 'react';
 // TODO(@ubax) - RN Migration: remove this dependency and just add this function to our codebase
 import { isValidElementType } from 'react-is';
 
+import { type RouterRegistryEntry, useRegisterRouter } from '../../global-state/routerRegistry';
 import useLatestCallback from '../../utils/useLatestCallback';
 import {
   CommonActions,
@@ -566,6 +567,24 @@ export function useNavigationBuilder<
   // decides which survivor takes focus, so the interim render agrees with the state that
   // `ROUTE_NAMES_CHANGED` commits and no screen is focused only to be unfocused again.
   state = router.getStateForDeclaredRoutes(state, routeNames);
+
+  const reduce = React.useCallback<RouterRegistryEntry['reduce']>(
+    (registryState, action) =>
+      // The registry stores states from different router types; this entry only receives its own state key.
+      router.getStateForAction(registryState as State, action, {
+        routeNames,
+        routeParamList,
+        routeGetIdList,
+      }),
+    [routeGetIdList, routeNames, routeParamList, router]
+  );
+  const registryEntry = React.useMemo<RouterRegistryEntry>(
+    () => ({ reduce, routerType: router.type, contextKey: options.id }),
+    [options.id, reduce, router.type]
+  );
+
+  // TODO(@ubax): Nested navigators must stay mounted. Hide screen content with `<Activity>` instead.
+  useRegisterRouter(state.key, registryEntry);
 
   // Last state to reuse if component gets cleaned up due to `<Activity mode="hidden">`
   React.useEffect(() => {

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -568,15 +568,21 @@ export function useNavigationBuilder<
   // `ROUTE_NAMES_CHANGED` commits and no screen is focused only to be unfocused again.
   state = router.getStateForDeclaredRoutes(state, routeNames);
 
+  // TODO(@ubax): find a better way to implement this then ref approach
+  const registryConfigRef = React.useRef({ routeNames, routeGetIdList });
+  useClientLayoutEffect(() => {
+    registryConfigRef.current = { routeNames, routeGetIdList };
+  });
+  // Screen-list changes invalidate render consumers even though the reducer reads committed config.
+  const routeNamesKey = routeNames.join('\0');
   const reduce = React.useCallback<RouterRegistryEntry['reduce']>(
     (registryState, action) =>
       // The registry stores states from different router types; this entry only receives its own state key.
       router.getStateForAction(registryState as State, action, {
-        routeNames,
-        routeParamList,
-        routeGetIdList,
+        routeNames: registryConfigRef.current.routeNames,
+        routeGetIdList: registryConfigRef.current.routeGetIdList,
       }),
-    [routeGetIdList, routeNames, routeParamList, router]
+    [routeNamesKey, router]
   );
   const registryEntry = React.useMemo<RouterRegistryEntry>(
     () => ({ reduce, routerType: router.type, contextKey: options.id }),
@@ -584,6 +590,8 @@ export function useNavigationBuilder<
   );
 
   // TODO(@ubax): Nested navigators must stay mounted. Hide screen content with `<Activity>` instead.
+  // TODO(@ubax): Move registration to a fork-level context like `UnhandledActionContext` so
+  // vendored core no longer imports expo-router global state.
   useRegisterRouter(state.key, registryEntry);
 
   // Last state to reuse if component gets cleaned up due to `<Activity mode="hidden">`


### PR DESCRIPTION
# Why

In order to be able to attach correct and not stale state when actions are dispatched, we need to know all the mounted routers. This is a prerequisite for the follow-up nested param and hydration removal.

# How

1. Add global router registry context
2. Register every router identified by `navigatorKey` in `useNavigationBuilder`.
3. Update tests

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
