### PR TITLE
[router] Remove navigator level `initialRouteName` prop

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the `initialRouteName` prop from Expo Router navigators. Configure the initial route with `unstable_settings.initialRouteName` in the route layout instead. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Remove `NavigationContainerRefContext` fallback in `useNavigation`. The hook now throws when called outside a navigator, including components rendered via `ExpoRoot`'s `wrapper` prop. ([#48638](https://github.com/expo/expo/pull/48638) by [@Ubax](https://github.com/Ubax))
 - Allow `key` to be `undefined` in the `Descriptor` type and in routes passed to screen `options`, navigator `screenOptions`, and `RouteGroupConfig.screenOptions` callbacks. ([#48596](https://github.com/expo/expo/pull/48596) by [@Ubax](https://github.com/Ubax))
 - Unify JS Tabs, TopTabs, Drawer, and headless tabs with NativeTabs - only screens declared in the layout become visible. ([#48499](https://github.com/expo/expo/pull/48499) by [@Ubax](https://github.com/Ubax))
@@ -33,6 +34,7 @@
 
 ### 🐛 Bug fixes
 
+- Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
 - Redirect fully guarded navigators to parent ([#47984](https://github.com/expo/expo/pull/47984) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/Route.tsx
+++ b/packages/expo-router/src/Route.tsx
@@ -81,6 +81,42 @@ export function useRouteNode(): RouteNode | null {
   return use(CurrentRouteContext);
 }
 
+export function findRouteNodeByName(
+  children: RouteNode[] | undefined,
+  routeName: string | undefined
+): RouteNode | undefined {
+  if (!routeName) {
+    return undefined;
+  }
+  return children?.find(
+    (child) => child.route === routeName || child.route === `${routeName}/index`
+  );
+}
+
+export function getValidInitialRoute(
+  node: RouteNode | null,
+  initialRouteName = node?.initialRouteName,
+  groupName?: string
+): RouteNode | undefined {
+  if (!node || !initialRouteName) {
+    return undefined;
+  }
+  const route = findRouteNodeByName(node.children, initialRouteName);
+  if (!route) {
+    throw new Error(
+      `The initial route name "${initialRouteName}"${groupName ? ` for group "${groupName}"` : ''} was not found in the layout at "${node.contextKey}". ` +
+        `Available routes are: ${node.children.map(({ route }) => `"${route}"`).join(', ')}. ` +
+        'Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
+    );
+  }
+  return route;
+}
+
+export const getValidInitialRouteName = (
+  node: RouteNode | null,
+  initialRouteName = node?.initialRouteName
+) => getValidInitialRoute(node, initialRouteName)?.route;
+
 export function useContextKey(): string {
   const node = useRouteNode();
   if (node == null) {

--- a/packages/expo-router/src/__tests__/Route.test.ios.ts
+++ b/packages/expo-router/src/__tests__/Route.test.ios.ts
@@ -1,5 +1,10 @@
 import type { RouteNode } from '../Route';
-import { sortRoutes } from '../Route';
+import {
+  findRouteNodeByName,
+  getValidInitialRouteName,
+  sortRoutes,
+  sortRoutesWithInitial,
+} from '../Route';
 import { generateDynamic } from '../getRoutes';
 
 const asRouteNode = (route: string): RouteNode => {
@@ -86,5 +91,65 @@ describe(sortRoutes, () => {
     expect(sortRoutes(asRouteNode('[...a]'), asRouteNode('index'))).toBe(1);
     expect(sortRoutes(asRouteNode('[...a]'), asRouteNode('a'))).toBe(1);
     expect(sortRoutes(asRouteNode('[...a]'), asRouteNode('(a)'))).toBe(1);
+  });
+});
+
+describe(getValidInitialRouteName, () => {
+  it('returns the registered route name for a valid setting', () => {
+    const node = asRouteNode('_layout');
+    node.initialRouteName = 'a';
+    node.children = [asRouteNode('a')];
+
+    expect(getValidInitialRouteName(node)).toBe('a');
+  });
+
+  it('resolves a directory setting to its registered index route', () => {
+    const node = asRouteNode('_layout');
+    node.initialRouteName = 'a';
+    node.children = [asRouteNode('a/index')];
+
+    expect(getValidInitialRouteName(node)).toBe('a/index');
+  });
+
+  it('sorts a resolved directory setting before other routes', () => {
+    const node = asRouteNode('_layout');
+    node.initialRouteName = 'a';
+    node.children = [asRouteNode('b'), asRouteNode('a/index')];
+
+    expect(
+      node.children
+        .sort(sortRoutesWithInitial(getValidInitialRouteName(node)))
+        .map(({ route }) => route)
+    ).toEqual(['a/index', 'b']);
+  });
+
+  it('throws for a missing route', () => {
+    const node = asRouteNode('_layout');
+    node.initialRouteName = 'missing';
+    node.contextKey = './app/(tabs)/_layout.tsx';
+    node.children = [asRouteNode('index'), asRouteNode('settings/index')];
+
+    expect(() => getValidInitialRouteName(node)).toThrow(
+      'The initial route name "missing" was not found in the layout at "./app/(tabs)/_layout.tsx". Available routes are: "index", "settings/index". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
+    );
+  });
+
+  it('returns undefined without a route node', () => {
+    expect(getValidInitialRouteName(null)).toBeUndefined();
+  });
+});
+
+describe(findRouteNodeByName, () => {
+  it.each([
+    ['settings', 'settings'],
+    ['settings/index', 'settings'],
+  ])('matches the registered route %s by the name %s', (route, name) => {
+    expect(findRouteNodeByName([asRouteNode('index'), asRouteNode(route)], name)?.route).toBe(
+      route
+    );
+  });
+
+  it('does not match a nested route with the same prefix', () => {
+    expect(findRouteNodeByName([asRouteNode('settings/profile')], 'settings')).toBeUndefined();
   });
 });

--- a/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
@@ -1,7 +1,10 @@
-import { screen } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
+import type { ComponentProps } from 'react';
 import { Text } from 'react-native';
 
 import { Navigator, Slot } from '../index';
+import JSStack from '../layouts/JSStack';
+import { Tabs } from '../layouts/Tabs';
 import { withLayoutContext } from '../layouts/withLayoutContext';
 import type { TabRouterOptions } from '../react-navigation/native';
 import { TabRouter } from '../react-navigation/native';
@@ -40,7 +43,11 @@ it('can render a custom navigator', () => {
         initialRouteName: 'two',
       },
       default: () => (
-        <Navigator router={customRouter} routerOptions={{ backBehavior: 'history' }}>
+        <Navigator
+          router={customRouter}
+          routerOptions={{ backBehavior: 'history' }}
+          // @ts-expect-error `initialRouteName` is only supported through `unstable_settings`.
+          initialRouteName="index">
           <Slot />
         </Navigator>
       ),
@@ -53,8 +60,90 @@ it('can render a custom navigator', () => {
   expect(customRouter).toHaveBeenCalledWith({
     id: '/(app)',
     backBehavior: 'history',
-    initialRouteName: undefined,
+    initialRouteName: 'two',
   });
+});
+
+// The casts simulate stale props supplied by untyped JavaScript.
+it.each([
+  ['Slot', () => <Slot {...({ initialRouteName: 'index' } as ComponentProps<typeof Slot>)} />],
+  [
+    'JS Stack',
+    () => <JSStack {...({ initialRouteName: 'index' } as ComponentProps<typeof JSStack>)} />,
+  ],
+])('%s uses the configured anchor instead of a stale JavaScript prop', (_, Layout) => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="inner" />
+      </Tabs>
+    ),
+    index: () => <Text testID="root-index" />,
+    'inner/_layout': {
+      unstable_settings: { initialRouteName: 'two' },
+      default: () => <Layout />,
+    },
+    'inner/index': () => <Text testID="index" />,
+    'inner/two': () => <Text testID="two" />,
+  });
+
+  act(() => fireEvent.press(screen.getByLabelText('inner, tab, 2 of 2')));
+
+  expect(screen.getByTestId('two')).toBeVisible();
+});
+
+it('honors the configured anchor when screens are explicitly declared', () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="inner" />
+      </Tabs>
+    ),
+    index: () => <Text testID="root-index" />,
+    'inner/_layout': {
+      unstable_settings: { initialRouteName: 'two' },
+      default: () => (
+        <Navigator>
+          <Navigator.Screen name="index" />
+          <Navigator.Screen name="two" />
+          <Slot />
+        </Navigator>
+      ),
+    },
+    'inner/index': () => <Text testID="index" />,
+    'inner/two': () => <Text testID="two" />,
+  });
+
+  act(() => fireEvent.press(screen.getByLabelText('inner, tab, 2 of 2')));
+
+  expect(screen.getByTestId('two')).toBeVisible();
+});
+
+it('throws for an invalid configured anchor', () => {
+  expect(() =>
+    renderRouter(
+      {
+        _layout: () => (
+          <Tabs>
+            <Tabs.Screen name="index" />
+            <Tabs.Screen name="inner" />
+          </Tabs>
+        ),
+        index: () => <Text testID="root-index" />,
+        'inner/_layout': {
+          unstable_settings: { initialRouteName: 'missing' },
+          default: () => <Navigator />,
+        },
+        'inner/index': () => <Text testID="index" />,
+        'inner/two': () => <Text testID="two" />,
+      },
+      { initialUrl: '/inner' }
+    )
+  ).toThrow(
+    'The initial route name "missing" was not found in the layout at "./inner/_layout.js". Available routes are: "index", "two". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
+  );
 });
 
 it.each([

--- a/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
+++ b/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
@@ -601,26 +601,25 @@ describe('anchor', () => {
   });
 
   it(`throws if anchor does not match a route`, () => {
-    expect(() => {
+    expect(() =>
       getRoutes(
         inMemoryContext({
           _layout: {
-            unstable_settings: {
-              anchor: 'c',
-            },
+            unstable_settings: { anchor: 'c' },
             default: () => null,
           },
           a: () => null,
           b: () => null,
-        })
-      );
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"Layout ./_layout.js has invalid anchor 'c'. Valid options are: 'a', 'b'"`
+        }),
+        { skipGenerated: true }
+      )
+    ).toThrow(
+      'The initial route name "c" was not found in the layout at "./_layout.js". Available routes are: "a", "b". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
     );
   });
 
   it(`throws if anchor with group selection does not match a route`, () => {
-    expect(() => {
+    expect(() =>
       getRoutes(
         inMemoryContext({
           '(a,b)/_layout': {
@@ -635,11 +634,46 @@ describe('anchor', () => {
             default: () => null,
           },
           '(a,b)/c': () => null,
-        })
-      );
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"Layout ./(a,b)/_layout.js has invalid anchor 'd' for group '(b)'. Valid options are: 'c'"`
+        }),
+        { skipGenerated: true }
+      )
+    ).toThrow(
+      'The initial route name "d" for group "b" was not found in the layout at "./(a,b)/_layout.js". Available routes are: "c". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
     );
+  });
+
+  it(`does not label a shared anchor as group-specific`, () => {
+    expect(() =>
+      getRoutes(
+        inMemoryContext({
+          '(a)/_layout': {
+            unstable_settings: { anchor: 'missing' },
+            default: () => null,
+          },
+          '(a)/index': () => null,
+        }),
+        { skipGenerated: true }
+      )
+    ).toThrow(
+      'The initial route name "missing" was not found in the layout at "./(a)/_layout.js". Available routes are: "index".'
+    );
+  });
+
+  it(`resolves a directory anchor to its index route entry point`, () => {
+    const routes = getRoutes(
+      inMemoryContext({
+        _layout: {
+          unstable_settings: { anchor: 'a' },
+          default: () => null,
+        },
+        'a/index': () => null,
+        b: () => null,
+      }),
+      { skipGenerated: true }
+    );
+
+    expect(routes?.initialRouteName).toBe('a/index');
+    expect(routes?.children[0]?.entryPoints).toContain('./a/index.js');
   });
 });
 

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -862,7 +862,8 @@ it.each(['second', 'second/index'])('redirects to initial route %s', (initialRou
       _layout: {
         unstable_settings: { initialRouteName },
         default: () => (
-          <Tabs>
+          // The cast simulates a stale prop supplied by untyped JavaScript.
+          <Tabs options={{ initialRouteName: 'index' } as never}>
             <TabList>
               <TabTrigger name="index" href="/" />
               <TabTrigger name="second" href="/second" />
@@ -906,6 +907,29 @@ it('falls back to the first trigger when the initial route has no trigger', () =
 
   expect(screen).toHavePathname('/');
   expect(screen.getByTestId('index')).toBeVisible();
+});
+
+it('throws when the configured initial route does not exist', () => {
+  expect(() =>
+    renderRouter({
+      _layout: {
+        unstable_settings: { initialRouteName: 'missing' },
+        default: () => (
+          <Tabs>
+            <TabList>
+              <TabTrigger name="index" href="/" />
+              <TabTrigger name="second" href="/second" />
+            </TabList>
+            <TabSlot />
+          </Tabs>
+        ),
+      },
+      index: () => <Text testID="index">Index</Text>,
+      second: () => <Text testID="second">Second</Text>,
+    })
+  ).toThrow(
+    'The initial route name "missing" was not found in the layout at "./_layout.js". Available routes are: "index", "second". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
+  );
 });
 
 describe('warnings/errors', () => {

--- a/packages/expo-router/src/__tests__/issues.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/issues.test.ios.tsx
@@ -25,7 +25,15 @@ it('should return correct pathname for nested stack with initialRouteName', asyn
       indexRenderCount();
       return <Text testID="index-pathname">{usePathname()}</Text>;
     },
-    'inner/_layout': () => <Stack initialRouteName="a" />,
+    'inner/_layout': {
+      unstable_settings: { initialRouteName: 'a' },
+      default: () => (
+        <Stack>
+          <Stack.Screen name="index" />
+          <Stack.Screen name="a" />
+        </Stack>
+      ),
+    },
     'inner/index': function InnerIndex() {
       innerIndexRenderCount();
       return <Text testID="inner-index-pathname">{usePathname()}</Text>;
@@ -74,7 +82,10 @@ it('should return correct pathname for nested stack with initialRouteName, after
       indexRenderCount();
       return <Text testID="index-pathname">{usePathname()}</Text>;
     },
-    'inner/_layout': () => <Stack initialRouteName="a" />,
+    'inner/_layout': {
+      unstable_settings: { initialRouteName: 'a' },
+      default: () => <Stack />,
+    },
     'inner/index': function InnerIndex() {
       innerIndexRenderCount();
       return <Text testID="inner-index-pathname">{usePathname()}</Text>;

--- a/packages/expo-router/src/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/navigation.test.ios.tsx
@@ -323,8 +323,9 @@ it('pushes auto-encoded params and fully qualified URLs', () => {
   });
 });
 
-it('does not loop infinitely when pushing a screen with empty options to an invalid initial route name', () => {
+it('throws when pushing to a layout with an invalid initial route name', () => {
   /** https://github.com/expo/router/issues/452 */
+  // Throwing before the invalid layout mounts makes the reported render loop unreachable.
 
   renderRouter({
     _layout: () => <Stack />,
@@ -345,8 +346,9 @@ it('does not loop infinitely when pushing a screen with empty options to an inva
   });
 
   expect(screen).toHavePathname('/');
-  act(() => router.push('/main/welcome'));
-  expect(screen).toHavePathname('/main/welcome');
+  expect(() => act(() => router.push('/main/welcome'))).toThrow(
+    'The initial route name "index" was not found in the layout at "./main/_layout.js". Available routes are: "welcome". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
+  );
 });
 
 it('can push nested initial route name', () => {

--- a/packages/expo-router/src/__tests__/types.test.ts
+++ b/packages/expo-router/src/__tests__/types.test.ts
@@ -1,4 +1,8 @@
+import type { ComponentProps } from 'react';
+
+import type { Stack as JSStack } from '../layouts/JSStack';
 import type { ScreenProps } from '../useScreens';
+import type { Navigator, Slot } from '../views/Navigator';
 
 type Expect<T extends true> = T;
 type Equal<A, B> =
@@ -7,6 +11,16 @@ type CallbackArgument<T> = T extends (arg: infer P) => unknown ? P : never;
 
 export type _ScreenOptionsRouteKeyMayBeUndefined = Expect<
   Equal<CallbackArgument<NonNullable<ScreenProps['options']>>['route']['key'], string | undefined>
+>;
+
+export type _NavigatorLacksInitialRouteName = Expect<
+  Equal<'initialRouteName' extends keyof ComponentProps<typeof Navigator> ? true : false, false>
+>;
+export type _SlotLacksInitialRouteName = Expect<
+  Equal<'initialRouteName' extends keyof ComponentProps<typeof Slot> ? true : false, false>
+>;
+export type _JSStackLacksInitialRouteName = Expect<
+  Equal<'initialRouteName' extends keyof ComponentProps<typeof JSStack> ? true : false, false>
 >;
 
 describe('public types', () => {

--- a/packages/expo-router/src/getRoutesCore.ts
+++ b/packages/expo-router/src/getRoutesCore.ts
@@ -1,4 +1,9 @@
-import type { DynamicConvention, MiddlewareNode, RouteNode } from './Route';
+import {
+  getValidInitialRoute,
+  type DynamicConvention,
+  type MiddlewareNode,
+  type RouteNode,
+} from './Route';
 import {
   matchArrayGroupName,
   matchDynamicName,
@@ -933,6 +938,7 @@ function crawlAndAppendInitialRoutesAndEntryFiles(
       return child.route.replace(/\/index$/, '') === groupName;
     });
     let anchor = childMatchingGroup?.route;
+    let anchorGroupName: string | undefined;
     // We may strip loadRoute during testing
     if (!options.internal_stripLoadRoute) {
       const loaded = node.loadRoute();
@@ -956,31 +962,15 @@ function crawlAndAppendInitialRoutesAndEntryFiles(
             loaded.unstable_settings?.[groupName]?.initialRouteName;
 
           anchor = groupSpecificInitialRouteName ?? anchor;
+          anchorGroupName = groupSpecificInitialRouteName ? groupName : undefined;
         }
       }
     }
 
     if (anchor) {
-      const anchorRoute = node.children.find((child) => child.route === anchor);
-      if (!anchorRoute) {
-        const validAnchorRoutes = node.children
-          .filter((child) => !child.generated)
-          .map((child) => `'${child.route}'`)
-          .join(', ');
-
-        if (groupName) {
-          throw new Error(
-            `Layout ${node.contextKey} has invalid anchor '${anchor}' for group '(${groupName})'. Valid options are: ${validAnchorRoutes}`
-          );
-        } else {
-          throw new Error(
-            `Layout ${node.contextKey} has invalid anchor '${anchor}'. Valid options are: ${validAnchorRoutes}`
-          );
-        }
-      }
-
       // Navigators can add initialRoutes into the history, so they need to be included in the entryPoints
-      node.initialRouteName = anchor;
+      const anchorRoute = getValidInitialRoute(node, anchor, anchorGroupName)!;
+      node.initialRouteName = anchorRoute.route;
       entryPoints.push(anchorRoute.contextKey);
     }
 

--- a/packages/expo-router/src/layouts/GuardContext.tsx
+++ b/packages/expo-router/src/layouts/GuardContext.tsx
@@ -3,7 +3,7 @@
 import { createContext, use, useMemo, type ReactNode } from 'react';
 
 import type { RouteNode } from '../Route';
-import { LocalRouteParamsContext, sortRoutesWithInitial } from '../Route';
+import { getValidInitialRoute, LocalRouteParamsContext, sortRoutesWithInitial } from '../Route';
 import { getContextKey } from '../matchers';
 import type { Href } from '../types';
 
@@ -119,17 +119,11 @@ function removeFallbacksTargetingNavigator(
 }
 
 function findDefaultRedirectRouteInNavigator(
-  node: Pick<RouteNode, 'children' | 'initialRouteName'>,
+  node: RouteNode,
   guardedRedirects: GuardedRedirects
 ): RouteNode | undefined {
-  const children = [...node.children].sort(sortRoutesWithInitial(node.initialRouteName));
-  const anchor = node.initialRouteName
-    ? children.find(
-        (child) =>
-          child.route === node.initialRouteName ||
-          normalizeRouteName(child.route) === node.initialRouteName
-      )
-    : undefined;
+  const anchor = getValidInitialRoute(node);
+  const children = [...node.children].sort(sortRoutesWithInitial(anchor?.route));
 
   if (anchor && !isRouteGuarded(anchor.route, guardedRedirects)) {
     return anchor;

--- a/packages/expo-router/src/layouts/JSStack.tsx
+++ b/packages/expo-router/src/layouts/JSStack.tsx
@@ -2,6 +2,7 @@
 
 import type { ComponentProps } from 'react';
 
+import { getValidInitialRouteName, useRouteNode } from '../Route';
 import type { ParamListBase, StackNavigationState } from '../react-navigation/native';
 import type { StackNavigationEventMap, StackNavigationOptions } from '../react-navigation/stack';
 import { createStackNavigator } from '../react-navigation/stack';
@@ -11,6 +12,7 @@ import { withLayoutContext } from './withLayoutContext';
 
 const JSStackNavigator = createStackNavigator().Navigator;
 
+// TODO(@ubax): Update docs/pages/router/migrate/from-react-navigation.mdx:387 for the removed prop.
 const JSStack = withLayoutContext<
   StackNavigationOptions,
   typeof JSStackNavigator,
@@ -24,8 +26,9 @@ const JSStack = withLayoutContext<
  * @hideType
  */
 const Stack = Object.assign(
-  (props: ComponentProps<typeof JSStack>) => {
-    return <JSStack {...props} />;
+  (props: Omit<ComponentProps<typeof JSStack>, 'initialRouteName'>) => {
+    const routeNode = useRouteNode();
+    return <JSStack {...props} initialRouteName={getValidInitialRouteName(routeNode)} />;
   },
   {
     Screen,

--- a/packages/expo-router/src/layouts/experimental-stack/createExperimentalStackNavigator.tsx
+++ b/packages/expo-router/src/layouts/experimental-stack/createExperimentalStackNavigator.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { use, useMemo } from 'react';
 
+import { getValidInitialRouteName, useRouteNode } from '../../Route';
 import {
   CompositionContext,
   mergeOptions,
@@ -31,7 +32,6 @@ import type {
 
 function ExperimentalStackNavigator({
   id,
-  initialRouteName,
   children,
   layout,
   screenListeners,
@@ -40,6 +40,7 @@ function ExperimentalStackNavigator({
   UNSTABLE_router,
   ...rest
 }: ExperimentalStackNavigatorProps) {
+  const routeNode = useRouteNode();
   const { state, descriptors, navigation, NavigationContent } = useNavigationBuilder<
     StackNavigationState<ParamListBase>,
     StackRouterOptions,
@@ -48,7 +49,7 @@ function ExperimentalStackNavigator({
     ExperimentalStackNavigationEventMap
   >(StackRouter, {
     id,
-    initialRouteName,
+    initialRouteName: getValidInitialRouteName(routeNode),
     children,
     layout,
     screenListeners,

--- a/packages/expo-router/src/layouts/experimental-stack/types.ts
+++ b/packages/expo-router/src/layouts/experimental-stack/types.ts
@@ -68,15 +68,18 @@ export type ExperimentalStackNavigationHelpers = NavigationHelpers<
   ExperimentalStackNavigationEventMap
 >;
 
-export type ExperimentalStackNavigatorProps = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  StackNavigationState<ParamListBase>,
-  ExperimentalStackNavigationOptions,
-  ExperimentalStackNavigationEventMap,
-  ExperimentalStackNavigationProp<ParamListBase>
-> &
-  StackRouterOptions;
+export type ExperimentalStackNavigatorProps = Omit<
+  DefaultNavigatorOptions<
+    ParamListBase,
+    string | undefined,
+    StackNavigationState<ParamListBase>,
+    ExperimentalStackNavigationOptions,
+    ExperimentalStackNavigationEventMap,
+    ExperimentalStackNavigationProp<ParamListBase>
+  > &
+    StackRouterOptions,
+  'initialRouteName'
+>;
 
 export type ExperimentalStackDescriptor = Descriptor<
   ExperimentalStackNavigationOptions,

--- a/packages/expo-router/src/modal/web/ModalStack.tsx
+++ b/packages/expo-router/src/modal/web/ModalStack.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useCallback, useEffect } from 'react';
 
+import { getValidInitialRouteName, useRouteNode } from '../../Route';
 import type { ExtendedStackNavigationOptions } from '../../layouts/StackClient';
 import { withLayoutContext } from '../../layouts/withLayoutContext';
 import type {
@@ -32,11 +33,8 @@ import {
   isTransparentModalPresentation,
 } from './utils';
 
-function ModalStackNavigator({
-  initialRouteName,
-  children,
-  screenOptions,
-}: ModalStackNavigatorProps) {
+function ModalStackNavigator({ children, screenOptions }: ModalStackNavigatorProps) {
+  const routeNode = useRouteNode();
   const { state, navigation, descriptors, NavigationContent } = useNavigationBuilder<
     StackNavigationState<ParamListBase>,
     StackRouterOptions,
@@ -46,7 +44,7 @@ function ModalStackNavigator({
   >(StackRouter, {
     children,
     screenOptions,
-    initialRouteName,
+    initialRouteName: getValidInitialRouteName(routeNode),
   });
 
   useEffect(

--- a/packages/expo-router/src/modal/web/types.ts
+++ b/packages/expo-router/src/modal/web/types.ts
@@ -12,7 +12,6 @@ import type {
 } from '../../react-navigation/native-stack';
 
 export type ModalStackNavigatorProps = {
-  initialRouteName?: string;
   screenOptions?: ExtendedStackNavigationOptions;
   children: React.ReactNode;
 };

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -2,7 +2,6 @@
 
 import React, { use, useCallback, useMemo, useRef } from 'react';
 
-import { useRouteNode } from '../Route';
 import type {
   ParamListBase,
   TabNavigationState,
@@ -198,7 +197,6 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
 });
 
 export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
-  const routeNode = useRouteNode();
   const triggerChildren = useMemo(
     () =>
       getAllChildrenOfType(props.children, NativeTabTrigger).filter((child) => !child.props.hidden),
@@ -278,7 +276,6 @@ export function NativeTabsNavigatorWrapper(props: NativeTabsProps) {
       children={triggerChildren}
       nonTriggerChildren={nonTriggerChildren}
       screenOptions={screenOptions}
-      initialRouteName={routeNode?.initialRouteName}
       // Passed to TabRouter
       backBehavior={backBehavior}
     />

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -403,12 +403,12 @@ describe('unstable_integrateWithRouter / unstable_createStandardRouterNavigator'
     expect(lastArgs().state.routes[lastArgs().state.index]!.name).toBe('second');
   });
 
-  // initialRouteName is a router option, not a NavigatorContent prop: it is destructured out of the
-  // props spread so it never reaches the content component (the focused route itself is URL-driven).
   it('does not leak initialRouteName to NavigatorContent', () => {
     renderRouter({
       _layout: () => (
-        <StandardTabs initialRouteName="second">
+        <StandardTabs
+          // @ts-expect-error `initialRouteName` is only supported through `unstable_settings`.
+          initialRouteName="second">
           <StandardTabs.Screen name="index" />
           <StandardTabs.Screen name="second" />
         </StandardTabs>

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -67,7 +67,7 @@ const Nav = unstable_createStandardRouterNavigator<
   Opts,
   TabNavigationState<ParamListBase>,
   EventMap,
-  object,
+  { initialRouteName?: string },
   TabRouterOptions
 >(Content, TabRouter);
 
@@ -81,6 +81,14 @@ export type _HasProtected = Expect<
 // ---------------------------------------------------------------------------
 
 type Props = ComponentProps<typeof Nav>;
+
+// ---------------------------------------------------------------------------
+// initialRouteName is only supported through unstable_settings
+// ---------------------------------------------------------------------------
+
+export type _ElementLacksInitialRouteName = Expect<
+  Equal<'initialRouteName' extends keyof Props ? true : false, false>
+>;
 
 type ListenersFn = Extract<Props['screenListeners'], (...args: any) => any>;
 type OptionsFn = Extract<Props['screenOptions'], (...args: any) => any>;

--- a/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useVisibleTabsWithRedirect.test.ios.tsx
@@ -36,6 +36,15 @@ const descriptors = {
 };
 const routeNames = routes.map((route) => route.name);
 
+function routeNode(initialRouteName: string) {
+  // Only route names are relevant to this hook test fixture.
+  return {
+    initialRouteName,
+    contextKey: './_layout.js',
+    children: routes.map(({ name }) => ({ route: name })),
+  } as ReturnType<typeof useRouteNode>;
+}
+
 let replaceSpy: jest.SpyInstance;
 let warnSpy: jest.SpyInstance;
 let buildHref: jest.Mock;
@@ -84,9 +93,7 @@ describe('useVisibleTabsWithRedirect', () => {
   });
 
   it('redirects an unavailable focused route to the configured visible route', () => {
-    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'settings' } as ReturnType<
-      typeof useRouteNode
-    >);
+    mockedUseRouteNode.mockReturnValue(routeNode('settings'));
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
@@ -101,9 +108,7 @@ describe('useVisibleTabsWithRedirect', () => {
   });
 
   it('builds the redirect href from the selected route', () => {
-    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'settings' } as ReturnType<
-      typeof useRouteNode
-    >);
+    mockedUseRouteNode.mockReturnValue(routeNode('settings'));
     renderHook(() =>
       useVisibleTabsWithRedirect({
         routes,
@@ -116,21 +121,20 @@ describe('useVisibleTabsWithRedirect', () => {
     expect(buildHref).toHaveBeenCalledWith(routes[1]);
   });
 
-  it('falls back to the first visible route when the configured route is unavailable', () => {
-    mockedUseRouteNode.mockReturnValue({ initialRouteName: 'missing' } as ReturnType<
-      typeof useRouteNode
-    >);
-    renderHook(() =>
-      useVisibleTabsWithRedirect({
-        routes,
-        routeNames,
-        focusedRouteKey: 'hidden-key',
-        descriptors,
-      })
+  it('throws when the configured route is unavailable', () => {
+    mockedUseRouteNode.mockReturnValue(routeNode('missing'));
+    expect(() =>
+      renderHook(() =>
+        useVisibleTabsWithRedirect({
+          routes,
+          routeNames,
+          focusedRouteKey: 'hidden-key',
+          descriptors,
+        })
+      )
+    ).toThrow(
+      'The initial route name "missing" was not found in the layout at "./_layout.js". Available routes are: "home", "settings/index", "hidden", "filesystem". Set `unstable_settings.initialRouteName` to the name of a route in this layout.'
     );
-
-    expect(replaceSpy).toHaveBeenCalledTimes(1);
-    expect(replaceSpy).toHaveBeenCalledWith('/href/home');
   });
 
   it('redirects when a navigator with no visible focused route becomes focused', () => {

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -4,6 +4,7 @@ import { type ComponentType, useMemo } from 'react';
 import { createStandardNavigator } from 'standard-navigation';
 import type { NavigatorArgs } from 'standard-navigation';
 
+import { getValidInitialRouteName, useRouteNode } from '../Route';
 import { withLayoutContext } from '../layouts/withLayoutContext';
 import {
   useNavigationBuilder,
@@ -173,13 +174,14 @@ export function unstable_integrateWithRouter<
   >;
 
   function StandardRouterNavigator(props: NavPropsType) {
+    const routeNode = useRouteNode();
     const { extraProps, useNavigationBuilderProps } = partitionNavigatorProps<
       NavigatorOptions,
       State,
       EventMap,
       NavigatorProps,
       RouterOptions
-    >(props);
+    >(props, getValidInitialRouteName(routeNode));
     const { state, navigation, describe, descriptors, NavigationContent } = useNavigationBuilder<
       State,
       RouterOptions,
@@ -257,13 +259,15 @@ function partitionNavigatorProps<
     NavigatorProps,
     RouterOptions
   > & {
+    initialRouteName?: unknown;
     ref?: unknown;
-  }
+  },
+  routeNodeInitialRouteName?: string
 ) {
   const {
     id,
     children,
-    initialRouteName,
+    initialRouteName: _initialRouteName,
     layout,
     // `ref` is supplied by `withLayoutContext` and consumed by React; it must not be forwarded
     // to `NavigatorContent`, so it is pulled out of the props here and intentionally dropped.
@@ -286,7 +290,7 @@ function partitionNavigatorProps<
   > = {
     id,
     children,
-    initialRouteName,
+    initialRouteName: routeNodeInitialRouteName,
     layout,
     screenLayout,
     screenListeners,

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -217,6 +217,9 @@ export type StandardRouterNavigatorProps<
   EventMap extends StandardNavigatorEventMapBase,
   NavigatorProps extends object,
   RouterOptions extends DefaultRouterOptions,
-> = StandardUseNavigationBuilderOptions<State, NavigatorOptions, EventMap> &
-  NavigatorProps &
-  RouterOptions;
+> = Omit<
+  StandardUseNavigationBuilderOptions<State, NavigatorOptions, EventMap>,
+  'initialRouteName'
+> &
+  Omit<NavigatorProps, 'initialRouteName'> &
+  Omit<RouterOptions, 'initialRouteName'>;

--- a/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
+++ b/packages/expo-router/src/standard-navigation/useVisibleTabsWithRedirect.ts
@@ -1,8 +1,8 @@
 import { useEffect, useMemo } from 'react';
 
-import { useRouteNode } from '../Route';
+import { getValidInitialRouteName, useRouteNode } from '../Route';
 import { router } from '../imperative-api';
-import { normalizeRouteName, useGuardRedirect } from '../layouts/GuardContext';
+import { useGuardRedirect } from '../layouts/GuardContext';
 import {
   type Descriptor,
   type ParamListBase,
@@ -61,17 +61,19 @@ export function useVisibleTabsWithRedirect<
   // TODO(@ubax): https://github.com/expo/expo/pull/48618#discussion_r3735996409
   const focusedIndex = visibleFocusedIndex;
 
+  const initialRouteName = getValidInitialRouteName(routeNode);
+
   const redirectHref = useMemo(() => {
     if (guardRedirect !== undefined) {
       return guardRedirect;
     }
     const redirectRoute =
-      findRouteByName(visibleRoutes, routeNode?.initialRouteName) ?? visibleRoutes[0];
+      visibleRoutes.find((route) => route.name === initialRouteName) ?? visibleRoutes[0];
     if (redirectRoute) {
       return buildHref(redirectRoute);
     }
     return null;
-  }, [buildHref, guardRedirect, routeNode?.initialRouteName, visibleRoutes]);
+  }, [buildHref, guardRedirect, initialRouteName, visibleRoutes]);
 
   useEffect(() => {
     // TODO(@ubax): Consider throwing in __DEV__ instead of warning.
@@ -107,8 +109,4 @@ function isDeclaredInLayout<Options extends object>(
   descriptor: TabDescriptor<Options> | undefined
 ): boolean {
   return descriptor?.routeSource === 'layout';
-}
-
-function findRouteByName<Route extends TabRoute>(routes: Route[], name: string | undefined) {
-  return routes.find((route) => route.name === name || normalizeRouteName(route.name) === name);
 }

--- a/packages/expo-router/src/ui/TabContext.tsx
+++ b/packages/expo-router/src/ui/TabContext.tsx
@@ -22,17 +22,20 @@ export type ExpoTabsNavigatorScreenOptions = {
   lazy?: boolean;
 };
 
-export type ExpoTabsNavigatorOptions = DefaultNavigatorOptions<
-  ParamListBase,
-  string | undefined,
-  TabNavigationState<ParamListBase>,
-  ExpoTabsScreenOptions,
-  TabNavigationEventMap,
-  ExpoTabsNavigationProp<ParamListBase>
-> &
+export type ExpoTabsNavigatorOptions = Omit<
+  DefaultNavigatorOptions<
+    ParamListBase,
+    string | undefined,
+    TabNavigationState<ParamListBase>,
+    ExpoTabsScreenOptions,
+    TabNavigationEventMap,
+    ExpoTabsNavigationProp<ParamListBase>
+  > &
+    TabRouterOptions &
+    ExpoTabsNavigatorScreenOptions,
   // Should be set through `unstable_settings`
-  Omit<TabRouterOptions, 'initialRouteName'> &
-  ExpoTabsNavigatorScreenOptions;
+  'initialRouteName'
+>;
 
 export type ExpoTabsNavigationProp<
   ParamList extends ParamListBase,

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -3,7 +3,7 @@ import { Children, Fragment, isValidElement, use, useMemo } from 'react';
 import type { ViewProps } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 
-import { useRouteNode, useContextKey } from '../Route';
+import { getValidInitialRouteName, useRouteNode, useContextKey } from '../Route';
 import { useRouteInfo } from '../hooks';
 import { GuardContextProvider, type GuardedRedirects } from '../layouts/GuardContext';
 import { resolveHref } from '../link/href';
@@ -54,7 +54,7 @@ export type UseTabsOptions = Omit<
     TabNavigationEventMap,
     any
   >,
-  'children'
+  'children' | 'initialRouteName'
 > & {
   backBehavior?: TabRouterOptions['backBehavior'];
 };
@@ -160,7 +160,7 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     throw new Error('No RouteNode. This is likely a bug in expo-router.');
   }
 
-  const initialRouteName = routeNode.initialRouteName;
+  const initialRouteName = getValidInitialRouteName(routeNode);
 
   const { children, triggerMap } = useTriggersToScreens(
     triggers,

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -3,7 +3,14 @@
 import React, { use, useEffect } from 'react';
 
 import type { LoadedRoute, RouteNode } from './Route';
-import { SuspenseFallbackContext, Route, sortRoutesWithInitial, useRouteNode } from './Route';
+import {
+  findRouteNodeByName,
+  getValidInitialRouteName,
+  SuspenseFallbackContext,
+  Route,
+  sortRoutesWithInitial,
+  useRouteNode,
+} from './Route';
 import { useExpoRouterStore } from './global-state/storeContext';
 import { useColorSchemeChangesIfNeeded } from './global-state/utils';
 // Direct import to prevent a require cycle
@@ -102,10 +109,8 @@ function getSortedChildren<
         console.warn(`[Layout children]: Too many screens defined. Route "${name}" is extraneous.`);
         return null;
       }
-      const matchIndex = entries.findIndex(
-        (child) => child.route === name || child.route === `${name}/index`
-      );
-      if (matchIndex === -1) {
+      const match = findRouteNodeByName(entries, name);
+      if (!match) {
         console.warn(
           `[Layout children]: No route named "${name}" exists in nested children:`,
           children.map(({ route }) => route)
@@ -113,8 +118,7 @@ function getSortedChildren<
         return null;
       } else {
         // Get match and remove from entries
-        const match = entries[matchIndex];
-        entries.splice(matchIndex, 1);
+        entries.splice(entries.indexOf(match), 1);
 
         if (getId) {
           console.warn(
@@ -171,7 +175,9 @@ export function useSortedScreens<
   const node = useRouteNode();
 
   const children = node?.children ?? [];
-  const sorted = children.length ? getSortedChildren(children, order, node?.initialRouteName) : [];
+  const sorted = children.length
+    ? getSortedChildren(children, order, getValidInitialRouteName(node))
+    : [];
   return React.useMemo(() => {
     const screensWithGuarded = sorted.map((value) => {
       const route = value.route.route;

--- a/packages/expo-router/src/views/Navigator.tsx
+++ b/packages/expo-router/src/views/Navigator.tsx
@@ -4,7 +4,7 @@
 import * as React from 'react';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { useContextKey, useRouteNode } from '../Route';
+import { getValidInitialRouteName, useContextKey, useRouteNode } from '../Route';
 import { GuardContextProvider } from '../layouts/GuardContext';
 import { StackRouter } from '../layouts/StackClient';
 import { useFilterScreenChildren } from '../layouts/withLayoutContext';
@@ -28,12 +28,13 @@ type UseNavigationBuilderRouter = Parameters<typeof useNavigationBuilder>[0];
 type UseNavigationBuilderOptions = Parameters<typeof useNavigationBuilder>[1];
 
 export type NavigatorProps<T extends UseNavigationBuilderRouter> = {
-  initialRouteName?: UseNavigationBuilderOptions['initialRouteName'];
   screenOptions?: UseNavigationBuilderOptions['screenOptions'];
   children?: UseNavigationBuilderOptions['children'];
   router?: T;
   routerOptions?: Omit<Parameters<T>[0], 'initialRouteName'>;
 };
+
+// TODO(@ubax): Update docs/pages/router/migrate/from-react-navigation.mdx:387 for the removed prop.
 
 /**
  * An unstyled custom navigator. Good for basic web layouts.
@@ -41,7 +42,6 @@ export type NavigatorProps<T extends UseNavigationBuilderRouter> = {
  * @hidden
  */
 export function Navigator<T extends UseNavigationBuilderRouter = typeof StackRouter>({
-  initialRouteName,
   screenOptions,
   children,
   router,
@@ -70,7 +70,7 @@ export function Navigator<T extends UseNavigationBuilderRouter = typeof StackRou
     id: contextKey,
     children: sortedScreens || [<Screen key="default" />],
     screenOptions,
-    initialRouteName,
+    initialRouteName: getValidInitialRouteName(node),
   });
 
   // useNavigationBuilder requires at least one screen to be defined otherwise it will throw.
@@ -117,6 +117,7 @@ function SlotNavigator(props: NavigatorProps<any>) {
     ...props,
     id: contextKey,
     children: useSortedScreens(screens ?? [], guardedRedirects),
+    initialRouteName: getValidInitialRouteName(node),
   });
   const focusedRouteKey = state.routes[state.index]?.key;
 


### PR DESCRIPTION
# Why

For a long time now router exposed an `unstable_setting` for `initialRouteName`. It is much more handy from routing logic perspective then the prop, because it is known in advance and stable across the app runtime.

This PR removes the additional `initialRouteName` from all the navigators leaving the file level one as the only way to configure initial route name

# How

1. Remove `initialRouteName` from public props
2. Replace `<SomeNavigator initialRouteName` with `unstable_settings: { initialRouteName: '...' }, <SomeNavigator` in tests

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
