### PR TITLE
[router] Make `history` property optional in tab state

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Make `history` optional in `TabNavigationState` and `DrawerNavigationState` ([#48709](https://github.com/expo/expo/pull/48709) by [@Ubax](https://github.com/Ubax))
 - Make navigation state `type` optional for custom routers. ([#48757](https://github.com/expo/expo/pull/48757) by [@Ubax](https://github.com/Ubax))
 - Handle `PUSH` in tab and drawer routers instead of coercing it to `NAVIGATE`. Custom routers must now handle the `PUSH` action in `getStateForAction`. ([#48752](https://github.com/expo/expo/pull/48752) by [@Ubax](https://github.com/Ubax))
 - Remove the `initialParams` prop from Expo Router screens and `routeParamList` from custom router action options. ([#48756](https://github.com/expo/expo/pull/48756) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@jest/globals';
+
+import type { DrawerNavigationState, DrawerStatus, ParamListBase } from '../../native';
+import { getDrawerStatusFromState } from '../utils/getDrawerStatusFromState';
+
+const createState = (
+  history: DrawerNavigationState<ParamListBase>['history'],
+  defaultStatus: DrawerStatus = 'closed'
+): DrawerNavigationState<ParamListBase> => ({
+  stale: false,
+  type: 'drawer',
+  key: 'drawer-test',
+  index: 0,
+  routeNames: ['bar'],
+  preloadedRouteKeys: [],
+  routes: [{ key: 'bar', name: 'bar' }],
+  default: defaultStatus,
+  history,
+});
+
+test.each<{ defaultStatus: DrawerStatus }>([
+  { defaultStatus: 'closed' },
+  { defaultStatus: 'open' },
+])('falls back to defaultStatus: $defaultStatus without history', ({ defaultStatus }) => {
+  expect(getDrawerStatusFromState(createState(undefined, defaultStatus))).toBe(defaultStatus);
+});
+
+test('reads the status from the last drawer entry', () => {
+  expect(
+    getDrawerStatusFromState(
+      createState([
+        { type: 'route', key: 'bar' },
+        { type: 'drawer', status: 'open' },
+      ])
+    )
+  ).toBe('open');
+});
+
+test('falls back to defaultStatus when history has no drawer entry', () => {
+  expect(getDrawerStatusFromState(createState([{ type: 'route', key: 'bar' }], 'open'))).toBe(
+    'open'
+  );
+});

--- a/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
@@ -3,13 +3,7 @@ import type { DrawerNavigationState, DrawerStatus, ParamListBase } from '../../n
 export function getDrawerStatusFromState(
   state: DrawerNavigationState<ParamListBase>
 ): DrawerStatus {
-  if (state.history == null) {
-    throw new Error(
-      "Couldn't find the drawer status in the state object. Is it a valid state object of drawer navigator?"
-    );
-  }
-
-  const entry = state.history.findLast((it) => it.type === 'drawer') as
+  const entry = state.history?.findLast((it) => it.type === 'drawer') as
     | { type: 'drawer'; status: DrawerStatus }
     | undefined;
 

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -1,6 +1,7 @@
 import { nanoid } from 'nanoid/non-secure';
 
 import {
+  ensureStateHistory,
   type TabActionHelpers,
   TabActions,
   type TabActionType,
@@ -38,7 +39,7 @@ export type DrawerNavigationState<ParamList extends ParamListBase> = Omit<
   /**
    * List of previously visited route keys and drawer open status.
    */
-  history: ({ type: 'route'; key: string } | { type: 'drawer'; status: DrawerStatus })[];
+  history?: ({ type: 'route'; key: string } | { type: 'drawer'; status: DrawerStatus })[];
 };
 
 export type DrawerActionHelpers<ParamList extends ParamListBase> = TabActionHelpers<ParamList> & {
@@ -81,10 +82,21 @@ export function DrawerRouter({
   DrawerNavigationState<ParamListBase>,
   DrawerActionType | CommonNavigationAction
 > {
+  const { backBehavior = 'firstRoute', initialRouteName } = rest;
+
   const router = TabRouter(rest) as unknown as Router<
     DrawerNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
   >;
+
+  // `ensureStateHistory` is typed for the tab state. The drawer state differs only by the extra
+  // drawer entries in `history`, which reconstruction never produces.
+  const ensureDrawerStateHistory = (state: DrawerNavigationState<ParamListBase>) =>
+    ensureStateHistory(
+      state as unknown as TabNavigationState<ParamListBase>,
+      backBehavior,
+      initialRouteName
+    ) as unknown as DrawerNavigationState<ParamListBase>;
 
   const isDrawerInHistory = (
     state: DrawerNavigationState<ParamListBase> | PartialState<DrawerNavigationState<ParamListBase>>
@@ -100,7 +112,7 @@ export function DrawerRouter({
     return {
       ...state,
       history: [
-        ...state.history,
+        ...(state.history ?? []),
         {
           type: 'drawer',
           status: defaultStatus === 'open' ? 'closed' : 'open',
@@ -118,7 +130,7 @@ export function DrawerRouter({
 
     return {
       ...state,
-      history: state.history.filter((it) => it.type !== 'drawer'),
+      history: (state.history ?? []).filter((it) => it.type !== 'drawer'),
     };
   };
 
@@ -194,7 +206,10 @@ export function DrawerRouter({
       return closeDrawer(result);
     },
 
-    getStateForAction(state, action, options) {
+    getStateForAction(inputState, action, options) {
+      // Restore route history before drawer actions can add drawer-only history.
+      const state = ensureDrawerStateHistory(inputState);
+
       switch (action.type) {
         case 'OPEN_DRAWER':
           return openDrawer(state);

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -66,7 +66,7 @@ export type TabNavigationState<ParamList extends ParamListBase> = Omit<
   /**
    * List of previously visited route keys.
    */
-  history: { type: 'route'; key: string; params?: object | undefined }[];
+  history?: { type: 'route'; key: string; params?: object | undefined }[];
   /**
    * List of routes' key, which are supposed to be preloaded before navigating to.
    */
@@ -102,6 +102,9 @@ export type TabActionHelpers<ParamList extends ParamListBase> = {
       : never
   ): void;
 };
+
+type TabNavigationStateWithHistory = TabNavigationState<ParamListBase> &
+  Required<Pick<TabNavigationState<ParamListBase>, 'history'>>;
 
 const TYPE_ROUTE = 'route' as const;
 
@@ -155,7 +158,7 @@ const getRouteHistory = (
   index: number,
   backBehavior: BackBehavior,
   initialRouteName: string | undefined
-) => {
+): NonNullable<TabNavigationState<ParamListBase>['history']> => {
   if (routes.length === 0) {
     return [];
   }
@@ -205,8 +208,41 @@ const getRouteHistory = (
   return history;
 };
 
-const changeIndex = (
+export const ensureStateHistory = (
   state: TabNavigationState<ParamListBase>,
+  backBehavior: BackBehavior,
+  initialRouteName: string | undefined
+): TabNavigationStateWithHistory => {
+  if (state.history != null) {
+    // The null check narrows the optional property, but TypeScript doesn't narrow the object type.
+    return state as TabNavigationStateWithHistory;
+  }
+
+  const routes = orderRoutesByRouteNames(state.routes, state.routeNames);
+  const focusedRoute = state.routes[state.index];
+  const index = routes.findIndex((route) => route.key === focusedRoute?.key);
+
+  // `orderRoutesByRouteNames` drops undeclared routes, so the focused one can be missing from
+  // `routes`. Keep it in history anyway, so the current route is always the last entry.
+  const history =
+    index === -1
+      ? focusedRoute === undefined
+        ? []
+        : [{ type: TYPE_ROUTE, key: focusedRoute.key }]
+      : getRouteHistory(routes, index, backBehavior, initialRouteName);
+
+  if (backBehavior === 'fullHistory' && focusedRoute !== undefined) {
+    history[history.length - 1] = {
+      ...history[history.length - 1]!,
+      params: focusedRoute.params,
+    };
+  }
+
+  return { ...state, history };
+};
+
+const changeIndex = (
+  state: TabNavigationStateWithHistory,
   index: number,
   backBehavior: BackBehavior,
   initialRouteName: string | undefined
@@ -344,7 +380,8 @@ export function TabRouter({
       );
     },
 
-    getStateForRouteFocus(state, key) {
+    getStateForRouteFocus(inputState, key) {
+      const state = ensureStateHistory(inputState, backBehavior, initialRouteName);
       const index = state.routes.findIndex((r) => r.key === key);
 
       if (index === -1 || index === state.index) {
@@ -354,7 +391,9 @@ export function TabRouter({
       return changeIndex(state, index, backBehavior, initialRouteName);
     },
 
-    getStateForAction(state, action, { routeGetIdList }) {
+    getStateForAction(inputState, action, { routeGetIdList }) {
+      const state = ensureStateHistory(inputState, backBehavior, initialRouteName);
+
       if (action.target && action.target !== state.key) {
         return null;
       }
@@ -696,8 +735,8 @@ export function TabRouter({
 }
 
 function removeReplacedRouteFromHistory(
-  previousState: TabNavigationState<ParamListBase>,
-  nextState: TabNavigationState<ParamListBase>
+  previousState: TabNavigationStateWithHistory,
+  nextState: TabNavigationStateWithHistory
 ) {
   const replacedRouteKey = previousState.routes[previousState.index]?.key;
   const focusedRouteKey = nextState.routes[nextState.index]?.key;

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -2,9 +2,11 @@ import { expect, jest, test } from '@jest/globals';
 
 import {
   CommonActions,
+  type DrawerActionType,
   DrawerActions,
   type DrawerNavigationState,
   DrawerRouter,
+  type DrawerStatus,
   type ParamListBase,
   type RouterActionOptions,
   type RouterConfigOptions,
@@ -35,6 +37,156 @@ test('gets initial state from route names and params with initialRouteName', () 
     stale: false,
     type: 'drawer',
   });
+});
+
+type DrawerHistory = NonNullable<DrawerNavigationState<ParamListBase>['history']>;
+
+const stateWithoutHistory = (
+  defaultStatus: DrawerStatus = 'closed'
+): DrawerNavigationState<ParamListBase> => ({
+  stale: false,
+  type: 'drawer',
+  key: 'root',
+  index: 0,
+  routeNames: ['bar'],
+  preloadedRouteKeys: [],
+  routes: [{ key: 'bar', name: 'bar' }],
+  default: defaultStatus,
+});
+
+const optionsWithoutHistory: RouterConfigOptions = {
+  routeNames: ['bar'],
+  routeParamList: {},
+  routeGetIdList: {},
+};
+
+test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
+  {
+    action: DrawerActions.openDrawer(),
+    expectedHistory: [
+      { type: 'route', key: 'bar' },
+      { type: 'drawer', status: 'open' },
+    ],
+  },
+  {
+    action: DrawerActions.toggleDrawer(),
+    expectedHistory: [
+      { type: 'route', key: 'bar' },
+      { type: 'drawer', status: 'open' },
+    ],
+  },
+  {
+    action: DrawerActions.closeDrawer(),
+    expectedHistory: [{ type: 'route', key: 'bar' }],
+  },
+])('handles $action.type without history', ({ action, expectedHistory }) => {
+  const router = DrawerRouter({});
+
+  expect(
+    router.getStateForAction(stateWithoutHistory(), action, optionsWithoutHistory)?.history
+  ).toEqual(expectedHistory);
+});
+
+// With `defaultStatus: 'open'` the encoding is inverted: an open drawer is the absence of a
+// history entry, so opening removes one and closing adds one.
+test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
+  {
+    action: DrawerActions.openDrawer(),
+    expectedHistory: [{ type: 'route', key: 'bar' }],
+  },
+  {
+    action: DrawerActions.toggleDrawer(),
+    expectedHistory: [
+      { type: 'route', key: 'bar' },
+      { type: 'drawer', status: 'closed' },
+    ],
+  },
+  {
+    action: DrawerActions.closeDrawer(),
+    expectedHistory: [
+      { type: 'route', key: 'bar' },
+      { type: 'drawer', status: 'closed' },
+    ],
+  },
+])(
+  'handles $action.type without history and defaultStatus: open',
+  ({ action, expectedHistory }) => {
+    const router = DrawerRouter({ defaultStatus: 'open' });
+
+    expect(
+      router.getStateForAction(stateWithoutHistory('open'), action, optionsWithoutHistory)?.history
+    ).toEqual(expectedHistory);
+  }
+);
+
+// `getRouteHistory` falls through its switch for `none`, so only the focused route is
+// reconstructed. `firstRoute` would additionally prepend `bar` here.
+test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
+  {
+    action: DrawerActions.openDrawer(),
+    expectedHistory: [
+      { type: 'route', key: 'baz' },
+      { type: 'drawer', status: 'open' },
+    ],
+  },
+  {
+    action: DrawerActions.closeDrawer(),
+    expectedHistory: [{ type: 'route', key: 'baz' }],
+  },
+])('handles $action.type without history and backBehavior: none', ({ action, expectedHistory }) => {
+  const router = DrawerRouter({ backBehavior: 'none' });
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const state: DrawerNavigationState<ParamListBase> = {
+    ...stateWithoutHistory(),
+    index: 1,
+    routeNames: options.routeNames,
+    routes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'baz', name: 'baz' },
+    ],
+  };
+
+  expect(router.getStateForAction(state, action, options)?.history).toEqual(expectedHistory);
+});
+
+test('preserves reconstructed history after closing the drawer', () => {
+  const router = DrawerRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+  const state: DrawerNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'drawer',
+    key: 'root',
+    index: 1,
+    routeNames: options.routeNames,
+    preloadedRouteKeys: [],
+    routes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'baz', name: 'baz' },
+    ],
+    default: 'closed',
+  };
+
+  const openState = router.getStateForAction(
+    state,
+    DrawerActions.openDrawer(),
+    options
+  ) as DrawerNavigationState<ParamListBase>;
+  const closedState = router.getStateForAction(
+    openState,
+    CommonActions.goBack(),
+    options
+  ) as DrawerNavigationState<ParamListBase>;
+  const result = router.getStateForAction(closedState, CommonActions.goBack(), options);
+
+  expect(result?.routes[result.index ?? -1]?.name).toBe('bar');
 });
 
 test('gets initial state from route names and params without initialRouteName', () => {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 import { expectTypeOf } from 'expect-type';
 
 import {
@@ -2295,7 +2295,7 @@ test('preserves params in history with backBehavior: fullHistory', () => {
   ) as TabNavigationState<ParamListBase>;
 
   expect(state.routes[1]!.params).toEqual({ value: 'first' });
-  expect(state.history[1]!.params).toEqual({ value: 'first' });
+  expect(state.history?.[1]!.params).toEqual({ value: 'first' });
 
   state = router.getStateForAction(
     state,
@@ -2304,7 +2304,7 @@ test('preserves params in history with backBehavior: fullHistory', () => {
   ) as TabNavigationState<ParamListBase>;
 
   expect(state.routes[2]!.params).toEqual({ value: 'second' });
-  expect(state.history[2]!.params).toEqual({ value: 'second' });
+  expect(state.history?.[2]!.params).toEqual({ value: 'second' });
 
   state = router.getStateForAction(
     state,
@@ -2313,7 +2313,7 @@ test('preserves params in history with backBehavior: fullHistory', () => {
   ) as TabNavigationState<ParamListBase>;
 
   expect(state.routes[2]!.params).toEqual({ value: 'updated with setParams' });
-  expect(state.history[2]!.params).toEqual({ value: 'updated with setParams' });
+  expect(state.history?.[2]!.params).toEqual({ value: 'updated with setParams' });
 
   state = router.getStateForAction(
     state,
@@ -2322,7 +2322,7 @@ test('preserves params in history with backBehavior: fullHistory', () => {
   ) as TabNavigationState<ParamListBase>;
 
   expect(state.routes[2]!.params).toEqual({ value: 'replaced params' });
-  expect(state.history[2]!.params).toEqual({ value: 'replaced params' });
+  expect(state.history?.[2]!.params).toEqual({ value: 'replaced params' });
 
   state = router.getStateForAction(
     state,
@@ -2331,7 +2331,7 @@ test('preserves params in history with backBehavior: fullHistory', () => {
   ) as TabNavigationState<ParamListBase>;
 
   expect(state.routes[1]!.params).toEqual({ value: 'updated' });
-  expect(state.history[3]!.params).toEqual({ value: 'updated' });
+  expect(state.history?.[3]!.params).toEqual({ value: 'updated' });
 
   state = router.getStateForAction(
     state,
@@ -3193,5 +3193,166 @@ test('handles screen preloading', () => {
       { key: 'qux-test', name: 'qux' },
     ],
     history: [{ type: 'route', key: 'qux-test' }],
+  });
+});
+
+describe('state without history', () => {
+  const options: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeParamList: {},
+    routeGetIdList: {},
+  };
+
+  const createState = (index = 1): TabNavigationState<ParamListBase> => ({
+    stale: false,
+    type: 'tab',
+    preloadedRouteKeys: [],
+    key: 'root',
+    index,
+    routeNames: options.routeNames,
+    routes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'baz', name: 'baz' },
+      { key: 'qux', name: 'qux' },
+    ],
+  });
+
+  test.each<['firstRoute' | 'history' | 'fullHistory', string[]]>([
+    ['firstRoute', ['bar', 'qux']],
+    ['history', ['baz', 'qux']],
+    ['fullHistory', ['baz', 'qux']],
+  ])('handles navigation with backBehavior: %s', (backBehavior, expectedKeys) => {
+    const router = TabRouter({ backBehavior });
+
+    for (const action of [CommonActions.navigate('qux'), TabActions.jumpTo('qux')]) {
+      const result = router.getStateForAction(createState(), action, options);
+
+      expect(result?.history?.map((item) => item.key)).toEqual(expectedKeys);
+    }
+  });
+
+  test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>([
+    ['firstRoute', undefined, 'bar'],
+    ['initialRoute', 'baz', 'baz'],
+    ['order', undefined, 'baz'],
+  ])(
+    'reconstructs the back target with backBehavior: %s',
+    (backBehavior, initialRouteName, expectedName) => {
+      const router = TabRouter({ backBehavior, initialRouteName });
+      const result = router.getStateForAction(createState(2), CommonActions.goBack(), options);
+
+      expect(result && result.routes[result.index ?? -1]?.name).toBe(expectedName);
+      expect(result?.history).toBeDefined();
+    }
+  );
+
+  test.each(['history', 'fullHistory'] as const)(
+    'does not go back with an absent visit history and backBehavior: %s',
+    (backBehavior) => {
+      const router = TabRouter({ backBehavior });
+
+      expect(router.getStateForAction(createState(2), CommonActions.goBack(), options)).toBeNull();
+    }
+  );
+
+  test.each([
+    CommonActions.setParams({ answer: 42 }),
+    CommonActions.preload('bar'),
+    TabActions.replace('qux'),
+  ])('handles $type', (action) => {
+    const router = TabRouter({ backBehavior: 'history' });
+    const result = router.getStateForAction(createState(), action, options);
+
+    expect(result?.history).toBeDefined();
+  });
+
+  test('handles ROUTE_NAMES_CHANGED', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    const routeNames = ['qux', 'baz', 'bar'];
+    const result = router.getStateForAction(
+      createState(),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames } },
+      { ...options, routeNames }
+    );
+
+    expect(result?.history).toBeDefined();
+  });
+
+  test('handles route focus', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+
+    expect(router.getStateForRouteFocus(createState(), 'qux').history).toEqual([
+      { type: 'route', key: 'baz' },
+      { type: 'route', key: 'qux' },
+    ]);
+  });
+
+  test('preserves params when reconstructing full history', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    const state = createState(0);
+    const stateWithParams = {
+      ...state,
+      routes: state.routes.map((route, index) =>
+        index === 0 ? { ...route, params: { answer: 42 } } : route
+      ),
+    };
+    // The action starts from a complete state and returns a complete state.
+    const navigatedState = router.getStateForAction(
+      stateWithParams,
+      TabActions.jumpTo('baz'),
+      options
+    ) as TabNavigationState<ParamListBase>;
+    const result = router.getStateForAction(navigatedState, CommonActions.goBack(), options);
+
+    expect(result?.routes[0]!.params).toEqual({ answer: 42 });
+  });
+
+  test('keeps the focused route in history when it is not declared', () => {
+    const router = TabRouter({});
+    const state = {
+      ...createState(1),
+      routeNames: ['bar'],
+      routes: [
+        { key: 'bar', name: 'bar' },
+        { key: 'zap', name: 'zap' },
+      ],
+    };
+
+    expect(router.getStateForRouteFocus(state, 'missing').history).toEqual([
+      { type: 'route', key: 'zap' },
+    ]);
+  });
+
+  test('keeps the params of an undeclared focused route with backBehavior: fullHistory', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    const state = {
+      ...createState(1),
+      routeNames: ['bar'],
+      routes: [
+        { key: 'bar', name: 'bar' },
+        { key: 'zap', name: 'zap', params: { answer: 42 } },
+      ],
+    };
+
+    // Going back must restore the params, not overwrite them with `undefined`.
+    const navigatedState = router.getStateForAction(
+      state,
+      TabActions.jumpTo('bar'),
+      options
+    ) as TabNavigationState<ParamListBase>;
+    const result = router.getStateForAction(navigatedState, CommonActions.goBack(), options);
+
+    expect(result?.routes[1]!.params).toEqual({ answer: 42 });
+  });
+
+  test('handles an empty state', () => {
+    const router = TabRouter({});
+    const state = {
+      ...createState(-1),
+      routeNames: [],
+      routes: [],
+    };
+
+    expect(router.getStateForRouteFocus(state, 'missing').history).toEqual([]);
   });
 });

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -46,8 +46,11 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
         return rnTabRouter.getStateForAction(state, action, routerConfigOptions);
       }
 
-      // We should reset if this is the first time visiting the route
-      let shouldReset = !state.history?.some((item) => item.key === route?.key) && !route.state;
+      // We should reset if this is the first time visiting the route.
+      let shouldReset =
+        !(state.history == null ? state.routes : state.history).some(
+          (item) => item.key === route.key
+        ) && !route.state;
 
       if (!shouldReset && 'resetOnFocus' in action.payload && action.payload.resetOnFocus) {
         shouldReset = state.routes[state.index ?? 0]!.key !== route.key;


### PR DESCRIPTION
# Why

In order to be able to create initial state without knowing the unmounted navigator types first, we need to make the all navigator specific properties optional. This PR changes `history` to be optional

# How

1. Change the type to `| undefined`
2. Add fallback to `?? []`
3. Rework the logic for when history is not present - no action is dispatched until then, so `state.history = state.routes`

# Test Plan

CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

## Accepted breaking changes

`history` becomes optional on `TabNavigationState` and `DrawerNavigationState`. Code that reads
`state.history` off these types must handle `undefined`.
