### PR TITLE
ci(cli): Redistribute `installAsync` tests to unit tests and perform E2E tests offline

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -3,7 +3,7 @@ import JsonFile from '@expo/json-file';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { executePnpmAsync, executeExpoAsync } from '../utils/expo';
+import { executeExpoAsync } from '../utils/expo';
 import {
   projectRoot,
   getLoadedModulesAsync,
@@ -81,45 +81,6 @@ it('runs `npx expo install expo-sms`', async () => {
     'package.json',
     'pnpm-lock.yaml',
   ]);
-});
-
-it('runs `npx expo install --fix` fails', async () => {
-  const projectRoot = await setupTestProjectWithOptionsAsync('install-fix-fail', 'with-blank', {
-    reuseExisting: false,
-  });
-
-  // Install wrong package versions of `expo-sms` and `expo-auth-session`
-  await executePnpmAsync(projectRoot, ['install', 'expo-sms@9.0.0', 'expo-auth-session@4.0.0']);
-
-  // Load the installed and expected dependency versions
-  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
-
-  // Only fix `expo-sms`
-  await executeExpoAsync(projectRoot, ['install', '--fix', 'expo-sms']);
-
-  // Ensure `expo-sms` is fixed to match the expected version
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-sms': expect.not.stringContaining('9.0.0'), // Expect the version to change from `9.0.0`
-  });
-
-  // Ensure `expo-auth-session` is still invalid
-  await expect(
-    executeExpoAsync(projectRoot, ['install', '--check'], { verbose: false })
-  ).rejects.toThrow();
-
-  // Ensure `--check` didn't fix the version
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-auth-session': '4.0.0',
-  });
-
-  // Fix all versions
-  await executeExpoAsync(projectRoot, ['install', '--fix']);
-
-  // Ensure both `expo-sms` and `expo-auth-session` are fixed
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-sms': expect.not.stringContaining('9.0.0'), // Expect the version to change from `9.0.0`
-    'expo-auth-session': expect.not.stringContaining('4.0.0'), // Expect the version to change from `4.0.0`
-  });
 });
 
 it('runs `npx expo install expo@<version> --fix`', async () => {

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -83,33 +83,6 @@ it('runs `npx expo install expo-sms`', async () => {
   ]);
 });
 
-it('runs `npx expo install expo@<version> --fix`', async () => {
-  const projectRoot = await setupTestProjectWithOptionsAsync(
-    'install-expo-canary-fix',
-    'with-blank',
-    {
-      reuseExisting: false,
-    }
-  );
-  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
-
-  // Add a package that requires "fixing" when using canary
-  await executeExpoAsync(projectRoot, ['install', 'expo-dev-client']);
-
-  // Ensure `expo-dev-client` is installed
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-dev-client': expect.any(String),
-  });
-
-  // Add `expo@canary` to the project, and `--fix` project dependencies
-  await executeExpoAsync(projectRoot, ['install', 'expo@canary', '--fix']);
-
-  // Ensure `expo-dev-client` is using canary version
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-dev-client': expect.stringContaining('canary'),
-  });
-});
-
 it('validates when with `EXPO_NO_DEPENDENCY_VALIDATION=1 npx expo install --check`', async () => {
   const env = {
     EXPO_NO_DEPENDENCY_VALIDATION: '1',

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -4,12 +4,8 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { executeExpoAsync } from '../utils/expo';
-import {
-  projectRoot,
-  getLoadedModulesAsync,
-  setupTestProjectWithOptionsAsync,
-  findProjectFiles,
-} from './utils';
+import { createPackageTarball } from '../utils/package';
+import { projectRoot, getLoadedModulesAsync, setupTestProjectWithOptionsAsync } from './utils';
 
 const originalForceColor = process.env.FORCE_COLOR;
 const originalCI = process.env.CI;
@@ -60,25 +56,32 @@ it('runs `npx expo install --help`', async () => {
   `);
 });
 
-it('runs `npx expo install expo-sms`', async () => {
-  const projectRoot = await setupTestProjectWithOptionsAsync('basic-install', 'with-blank', {
-    reuseExisting: false,
-  });
+it('installs a local package tarball without network access', async () => {
+  const projectRoot = await setupTestProjectWithOptionsAsync(
+    'local-package-install',
+    'with-blank',
+    {
+      reuseExisting: false,
+    }
+  );
+  const tarball = await createPackageTarball(
+    projectRoot,
+    'packages/@expo/cli/e2e/fixtures/install-smoke-package'
+  );
 
-  // `npx expo install expo-sms`
-  await executeExpoAsync(projectRoot, ['install', 'expo-sms']);
+  await expect(
+    executeExpoAsync(projectRoot, ['install', tarball.packageReference, '--', '--offline'], {
+      env: {
+        EXPO_OFFLINE: '1',
+        EXPO_NO_NEW_ARCH_COMPAT_CHECK: '1',
+        HTTP_PROXY: 'http://127.0.0.1:9',
+        HTTPS_PROXY: 'http://127.0.0.1:9',
+        NO_PROXY: '',
+      },
+    })
+  ).resolves.toMatchObject({ exitCode: 0 });
 
   const pkg: any = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
-
-  // Added expected package
-  expect(pkg?.dependencies!['expo-sms']).toBeTruthy();
-
-  expect(findProjectFiles(projectRoot)).toStrictEqual([
-    'App.js',
-    'app.json',
-    'index.js',
-    'metro.config.js',
-    'package.json',
-    'pnpm-lock.yaml',
-  ]);
+  expect(pkg.dependencies?.[tarball.name]).toEqual(expect.any(String));
+  expect(require.resolve(tarball.name, { paths: [projectRoot] })).toEqual(expect.any(String));
 });

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -82,32 +82,3 @@ it('runs `npx expo install expo-sms`', async () => {
     'pnpm-lock.yaml',
   ]);
 });
-
-it('validates when with `EXPO_NO_DEPENDENCY_VALIDATION=1 npx expo install --check`', async () => {
-  const env = {
-    EXPO_NO_DEPENDENCY_VALIDATION: '1',
-  } as Partial<NodeJS.ProcessEnv> as NodeJS.ProcessEnv;
-  const projectRoot = await setupTestProjectWithOptionsAsync(
-    'install-check-no-validation',
-    'with-blank',
-    {
-      reuseExisting: false,
-    }
-  );
-  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
-
-  // Install wrong package version of `expo-image`
-  await expect(
-    executeExpoAsync(projectRoot, ['install', 'expo-image@1.0.0'], { env })
-  ).resolves.toMatchObject({
-    stdout: expect.stringContaining('Installing 1 other package using'),
-  });
-
-  // Ensure the wrong version is installed
-  expect(pkg.read().dependencies).toMatchObject({ 'expo-image': '1.0.0' });
-
-  // Ensure `expo install --check` does not throw when validation is disabled
-  await expect(() => {
-    return executeExpoAsync(projectRoot, ['install', '--check'], { env, verbose: false });
-  }).rejects.toThrow(/Found outdated dependencies/);
-});

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -83,43 +83,6 @@ it('runs `npx expo install expo-sms`', async () => {
   ]);
 });
 
-it('runs `npx expo install --check` fails', async () => {
-  const projectRoot = await setupTestProjectWithOptionsAsync('install-check-fail', 'with-blank', {
-    reuseExisting: false,
-  });
-
-  const pkg = new JsonFile(path.resolve(projectRoot, 'package.json'));
-
-  // Install wrong package versions of `expo-sms` and `expo-auth-session`
-  await executePnpmAsync(projectRoot, ['install', 'expo-sms@1.0.0', 'expo-auth-session@1.0.0']);
-
-  // Ensure the wrong versions are installed
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-sms': '1.0.0',
-    'expo-auth-session': '1.0.0',
-  });
-
-  // Ensure `expo install --check` throws for all wrong packages
-  try {
-    await executeExpoAsync(projectRoot, ['install', '--check'], { verbose: false });
-    throw new Error('SHOULD NOT HAPPEN');
-  } catch (error: any) {
-    expect(error.stderr).toMatch(/expo-auth-session@1\.0\.0 - expected version: ~\d+\.\d+\.\d+/);
-    expect(error.stderr).toMatch(/expo-sms@1\.0\.0 - expected version: ~\d+\.\d+\.\d+/);
-  }
-
-  // Ensure `expo install --check <package>` only throws for the selected package
-  await expect(
-    executeExpoAsync(projectRoot, ['install', 'expo-sms', '--check'], { verbose: false })
-  ).rejects.toThrow(/expo-sms@1\.0\.0 - expected version: ~\d+\.\d+\.\d+/);
-
-  // Ensure `--check` did not fix the version
-  expect(pkg.read().dependencies).toMatchObject({
-    'expo-sms': '1.0.0',
-    'expo-auth-session': '1.0.0',
-  });
-});
-
 it('runs `npx expo install --fix` fails', async () => {
   const projectRoot = await setupTestProjectWithOptionsAsync('install-fix-fail', 'with-blank', {
     reuseExisting: false,

--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -57,31 +57,48 @@ it('runs `npx expo install --help`', async () => {
 });
 
 it('installs a local package tarball without network access', async () => {
-  const projectRoot = await setupTestProjectWithOptionsAsync(
-    'local-package-install',
-    'with-blank',
-    {
-      reuseExisting: false,
+  const offlineEnv = {
+    EXPO_OFFLINE: '1',
+    EXPO_NO_NEW_ARCH_COMPAT_CHECK: '1',
+    npm_config_offline: 'true',
+    HTTP_PROXY: 'http://127.0.0.1:9',
+    HTTPS_PROXY: 'http://127.0.0.1:9',
+    NO_PROXY: '',
+  };
+  const originalEnv = Object.fromEntries(
+    Object.keys(offlineEnv).map((key) => [key, process.env[key]])
+  );
+  Object.assign(process.env, offlineEnv);
+
+  try {
+    const projectRoot = await setupTestProjectWithOptionsAsync(
+      'local-package-install',
+      'with-blank',
+      {
+        reuseExisting: false,
+      }
+    );
+    const tarball = await createPackageTarball(
+      projectRoot,
+      'packages/@expo/cli/e2e/fixtures/install-smoke-package'
+    );
+
+    await expect(
+      executeExpoAsync(projectRoot, ['install', tarball.packageReference, '--', '--offline'], {
+        env: offlineEnv,
+      })
+    ).resolves.toMatchObject({ exitCode: 0 });
+
+    const pkg: any = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
+    expect(pkg.dependencies?.[tarball.name]).toEqual(expect.any(String));
+    expect(require.resolve(tarball.name, { paths: [projectRoot] })).toEqual(expect.any(String));
+  } finally {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
-  );
-  const tarball = await createPackageTarball(
-    projectRoot,
-    'packages/@expo/cli/e2e/fixtures/install-smoke-package'
-  );
-
-  await expect(
-    executeExpoAsync(projectRoot, ['install', tarball.packageReference, '--', '--offline'], {
-      env: {
-        EXPO_OFFLINE: '1',
-        EXPO_NO_NEW_ARCH_COMPAT_CHECK: '1',
-        HTTP_PROXY: 'http://127.0.0.1:9',
-        HTTPS_PROXY: 'http://127.0.0.1:9',
-        NO_PROXY: '',
-      },
-    })
-  ).resolves.toMatchObject({ exitCode: 0 });
-
-  const pkg: any = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
-  expect(pkg.dependencies?.[tarball.name]).toEqual(expect.any(String));
-  expect(require.resolve(tarball.name, { paths: [projectRoot] })).toEqual(expect.any(String));
+  }
 });

--- a/packages/@expo/cli/e2e/fixtures/install-smoke-package/index.js
+++ b/packages/@expo/cli/e2e/fixtures/install-smoke-package/index.js
@@ -1,0 +1,1 @@
+module.exports = 'installed';

--- a/packages/@expo/cli/e2e/fixtures/install-smoke-package/package.json
+++ b/packages/@expo/cli/e2e/fixtures/install-smoke-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "expo-install-smoke-package",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
@@ -202,39 +202,84 @@ describe(checkPackagesAsync, () => {
     );
   });
 
-  it(`fixes invalid packages`, async () => {
+  it(`delegates all invalid packages when fixing all dependencies`, async () => {
     const issues: Awaited<ReturnType<typeof getVersionedDependenciesAsync>> = [
       {
-        packageName: 'react-native',
+        packageName: 'expo-sms',
         packageType: 'dependencies',
-        expectedVersionOrRange: '^1.0.0',
-        actualVersion: '0.69.0',
+        expectedVersionOrRange: '~14.0.0',
+        actualVersion: '9.0.0',
       },
       {
-        packageName: 'expo',
+        packageName: 'expo-auth-session',
         packageType: 'dependencies',
-        expectedVersionOrRange: '^1.0.0',
-        actualVersion: '0.69.0',
+        expectedVersionOrRange: '~7.0.0',
+        actualVersion: '4.0.0',
       },
     ];
+    const packageManagerArguments = ['--ignore-scripts'];
 
     jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce(issues);
 
     await checkPackagesAsync('/', {
-      packages: ['react-native', 'expo'],
+      packages: [],
       options: { fix: true },
       // @ts-expect-error
       packageManager: {},
-      packageManagerArguments: [],
+      packageManagerArguments,
     });
 
     expect(fixPackagesAsync).toHaveBeenCalledWith('/', {
       packageManager: {},
-      packageManagerArguments: [],
+      packageManagerArguments,
       packages: issues,
       sdkVersion: '45.0.0',
     });
-    expect(logIncorrectDependencies).toHaveBeenCalledTimes(1);
+    expect(logIncorrectDependencies).toHaveBeenCalledWith(issues);
+  });
+
+  it(`delegates only the selected invalid package when fixing`, async () => {
+    const selectedIssue: Awaited<ReturnType<typeof getVersionedDependenciesAsync>> = [
+      {
+        packageName: 'expo-sms',
+        packageType: 'dependencies',
+        expectedVersionOrRange: '~14.0.0',
+        actualVersion: '9.0.0',
+      },
+    ];
+    const packageManager = {};
+    const packageManagerArguments = ['--ignore-scripts'];
+
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce(selectedIssue);
+
+    await checkPackagesAsync('/', {
+      packages: ['expo-sms'],
+      options: { fix: true },
+      // @ts-expect-error
+      packageManager,
+      packageManagerArguments,
+    });
+
+    expect(getVersionedDependenciesAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ sdkVersion: '45.0.0' }),
+      {},
+      ['expo-sms']
+    );
+    expect(fixPackagesAsync).toHaveBeenCalledWith('/', {
+      packageManager,
+      packageManagerArguments,
+      packages: selectedIssue,
+      sdkVersion: '45.0.0',
+    });
+    expect(fixPackagesAsync).not.toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({
+        packages: expect.arrayContaining([
+          expect.objectContaining({ packageName: 'expo-auth-session' }),
+        ]),
+      })
+    );
   });
 
   it(`outputs JSON when --json flag is used with up-to-date dependencies`, async () => {

--- a/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/checkPackages-test.ts
@@ -50,33 +50,96 @@ describe(checkPackagesAsync, () => {
     mockProcessExit.mockRestore();
   });
 
-  it(`checks packages and exits when packages are invalid`, async () => {
-    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
-    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce([
+  it(`reports all invalid packages without mutating dependencies`, async () => {
+    const packages = ['expo-sms', 'expo-auth-session'];
+    const packageManager = {
+      addAsync: jest.fn(),
+      addDevAsync: jest.fn(),
+    };
+    const issues: Awaited<ReturnType<typeof getVersionedDependenciesAsync>> = [
       {
-        packageName: 'react-native',
+        packageName: 'expo-sms',
         packageType: 'dependencies',
-        expectedVersionOrRange: '^1.0.0',
-        actualVersion: '0.69.0',
+        expectedVersionOrRange: '~14.0.0',
+        actualVersion: '1.0.0',
       },
-    ]);
+      {
+        packageName: 'expo-auth-session',
+        packageType: 'dependencies',
+        expectedVersionOrRange: '~7.0.0',
+        actualVersion: '1.0.0',
+      },
+    ];
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce(issues);
+
     await expect(
       checkPackagesAsync('/', {
-        packages: ['react-native'],
+        packages,
         options: { fix: false },
         // @ts-expect-error
-        packageManager: {},
-        packageManagerArguments: [],
+        packageManager,
+        packageManagerArguments: ['--ignore-scripts'],
       })
     ).rejects.toThrow(/EXIT/);
 
-    expect(logIncorrectDependencies).toHaveBeenCalledTimes(1);
-
+    expect(getVersionedDependenciesAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ sdkVersion: '45.0.0' }),
+      {},
+      packages
+    );
+    expect(logIncorrectDependencies).toHaveBeenCalledWith(issues);
     expect(Log.exit).toHaveBeenCalledWith(
       // Because of ansi
       expect.stringContaining('Found outdated dependencies'),
       1
     );
+    expect(fixPackagesAsync).not.toHaveBeenCalled();
+    expect(packageManager.addAsync).not.toHaveBeenCalled();
+    expect(packageManager.addDevAsync).not.toHaveBeenCalled();
+  });
+
+  it(`checks and reports only the requested package without mutating dependencies`, async () => {
+    const packages = ['expo-sms'];
+    const packageManager = {
+      addAsync: jest.fn(),
+      addDevAsync: jest.fn(),
+    };
+    const selectedIssue: Awaited<ReturnType<typeof getVersionedDependenciesAsync>> = [
+      {
+        packageName: 'expo-sms',
+        packageType: 'dependencies',
+        expectedVersionOrRange: '~14.0.0',
+        actualVersion: '1.0.0',
+      },
+    ];
+    jest.mocked(confirmAsync).mockResolvedValueOnce(false);
+    jest.mocked(getVersionedDependenciesAsync).mockResolvedValueOnce(selectedIssue);
+
+    await expect(
+      checkPackagesAsync('/', {
+        packages,
+        options: { fix: false },
+        // @ts-expect-error
+        packageManager,
+        packageManagerArguments: [],
+      })
+    ).rejects.toThrow(/EXIT/);
+
+    expect(getVersionedDependenciesAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ sdkVersion: '45.0.0' }),
+      {},
+      packages
+    );
+    expect(logIncorrectDependencies).toHaveBeenCalledWith(selectedIssue);
+    expect(logIncorrectDependencies).not.toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ packageName: 'expo-auth-session' })])
+    );
+    expect(fixPackagesAsync).not.toHaveBeenCalled();
+    expect(packageManager.addAsync).not.toHaveBeenCalled();
+    expect(packageManager.addDevAsync).not.toHaveBeenCalled();
   });
 
   it(`notifies when dependencies are on exclude list`, async () => {

--- a/packages/@expo/cli/src/install/__tests__/fixPackages-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/fixPackages-test.ts
@@ -48,27 +48,71 @@ describe(fixPackagesAsync, () => {
     expect(installExpoPackageAsync).not.toHaveBeenCalled();
   });
 
-  it('passes packageManagerArguments through to addAsync', async () => {
+  it('fixes multiple runtime dependencies with exact versions and forwarded arguments', async () => {
     const packageManager = PackageManager.createForProject('/path/to/project');
 
     await fixPackagesAsync('/path/to/project', {
       packageManager,
       packages: [
         {
-          packageName: 'react-native',
+          packageName: 'expo-sms',
           packageType: 'dependencies',
-          expectedVersionOrRange: 'npm:react-native-tvos@0.85-stable',
-          actualVersion: '0.83.0-0',
+          expectedVersionOrRange: '~14.0.0',
+          actualVersion: '9.0.0',
+        },
+        {
+          packageName: 'expo-auth-session',
+          packageType: 'dependencies',
+          expectedVersionOrRange: '~7.0.0',
+          actualVersion: '4.0.0',
         },
       ],
-      packageManagerArguments: ['--no-save'],
+      packageManagerArguments: ['--no-save', '--ignore-scripts'],
       sdkVersion: '55.0.0',
     });
 
     expect(packageManager.addAsync).toHaveBeenCalledWith([
       '--no-save',
-      'react-native@npm:react-native-tvos@0.85-stable',
+      '--ignore-scripts',
+      'expo-sms@~14.0.0',
+      'expo-auth-session@~7.0.0',
     ]);
+    expect(packageManager.addDevAsync).not.toHaveBeenCalled();
+    expect(applyPluginsAsync).toHaveBeenCalledWith('/path/to/project', [
+      'expo-sms',
+      'expo-auth-session',
+    ]);
+  });
+
+  it('groups runtime and dev dependencies into separate package-manager operations', async () => {
+    const packageManager = PackageManager.createForProject('/path/to/project');
+
+    await fixPackagesAsync('/path/to/project', {
+      packageManager,
+      packages: [
+        {
+          packageName: 'expo-sms',
+          packageType: 'dependencies',
+          expectedVersionOrRange: '~14.0.0',
+          actualVersion: '9.0.0',
+        },
+        {
+          packageName: 'typescript',
+          packageType: 'devDependencies',
+          expectedVersionOrRange: '^5.9.0',
+          actualVersion: '5.7.0',
+        },
+      ],
+      packageManagerArguments: ['--ignore-scripts'],
+      sdkVersion: '55.0.0',
+    });
+
+    expect(packageManager.addAsync).toHaveBeenCalledWith(['--ignore-scripts', 'expo-sms@~14.0.0']);
+    expect(packageManager.addDevAsync).toHaveBeenCalledWith([
+      '--ignore-scripts',
+      'typescript@^5.9.0',
+    ]);
+    expect(applyPluginsAsync).toHaveBeenCalledWith('/path/to/project', ['expo-sms']);
   });
 
   it('routes through installExpoPackageAsync when expo itself is outdated', async () => {

--- a/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
@@ -155,6 +155,65 @@ describe(installAsync, () => {
     expect(applyPluginsAsync).not.toHaveBeenCalled();
   });
 
+  describe('with EXPO_NO_DEPENDENCY_VALIDATION enabled', () => {
+    let originalNoDependencyValidation: string | undefined;
+
+    beforeEach(() => {
+      originalNoDependencyValidation = process.env.EXPO_NO_DEPENDENCY_VALIDATION;
+      process.env.EXPO_NO_DEPENDENCY_VALIDATION = '1';
+    });
+
+    afterEach(() => {
+      if (originalNoDependencyValidation === undefined) {
+        delete process.env.EXPO_NO_DEPENDENCY_VALIDATION;
+      } else {
+        process.env.EXPO_NO_DEPENDENCY_VALIDATION = originalNoDependencyValidation;
+      }
+    });
+
+    it('skips automatic compatibility checking but still versions and installs packages', async () => {
+      jest.mocked(getVersionedPackagesAsync).mockResolvedValueOnce({
+        packages: ['react-native-reanimated@~3.17.0'],
+        messages: [],
+        excludedNativeModules: [],
+      });
+
+      await installAsync(
+        ['react-native-reanimated'],
+        { projectRoot, pnpm: true },
+        packageManagerArguments
+      );
+
+      expect(checkPackagesCompatibility).not.toHaveBeenCalled();
+      expect(getVersionedPackagesAsync).toHaveBeenCalledWith(projectRoot, {
+        packages: ['react-native-reanimated'],
+        sdkVersion: '54.0.0',
+        pkg: {},
+      });
+      expect(packageManager.addAsync).toHaveBeenCalledWith([
+        ...packageManagerArguments,
+        'react-native-reanimated@~3.17.0',
+      ]);
+    });
+
+    it('still delegates an explicit dependency check', async () => {
+      const packages = ['expo-image'];
+      const options = { projectRoot, check: true, fix: false, pnpm: true };
+
+      await installAsync(packages, options, packageManagerArguments);
+
+      expect(checkPackagesAsync).toHaveBeenCalledWith(projectRoot, {
+        packages,
+        options,
+        packageManager,
+        packageManagerArguments,
+      });
+      expect(checkPackagesCompatibility).not.toHaveBeenCalled();
+      expect(getVersionedPackagesAsync).not.toHaveBeenCalled();
+      expect(packageManager.addAsync).not.toHaveBeenCalled();
+    });
+  });
+
   it('installs resolved dev dependencies with forwarded package-manager arguments', async () => {
     jest.mocked(getVersionedPackagesAsync).mockResolvedValueOnce({
       packages: ['eslint@^9.0.0'],

--- a/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
@@ -1,0 +1,139 @@
+import { getConfig, getPackageJson } from '@expo/config';
+import * as PackageManager from '@expo/package-manager';
+
+import { getVersionedPackagesAsync } from '../../start/doctor/dependencies/getVersionedPackages';
+import { applyPluginsAsync } from '../applyPlugins';
+import { checkPackagesAsync } from '../checkPackages';
+import { installAsync } from '../installAsync';
+import { checkPackagesCompatibility } from '../utils/checkPackagesCompatibility';
+
+jest.mock('@expo/config', () => ({
+  getConfig: jest.fn(() => ({ exp: { sdkVersion: '54.0.0' } })),
+  getPackageJson: jest.fn(() => ({})),
+}));
+
+jest.mock('../../log');
+
+jest.mock('../../start/doctor/dependencies/getVersionedPackages', () => ({
+  getVersionedPackagesAsync: jest.fn(),
+}));
+
+jest.mock('../../utils/nodeEnv', () => ({
+  loadEnvFiles: jest.fn(),
+  setNodeEnv: jest.fn(),
+}));
+
+jest.mock('../applyPlugins', () => ({
+  applyPluginsAsync: jest.fn(),
+}));
+
+jest.mock('../checkPackages', () => ({
+  checkPackagesAsync: jest.fn(),
+}));
+
+jest.mock('../utils/checkPackagesCompatibility', () => ({
+  checkPackagesCompatibility: jest.fn(),
+}));
+
+const projectRoot = '/path/to/project';
+const packageManagerArguments = ['--ignore-scripts', '--strict-peer-dependencies=false'];
+
+function createPackageManager() {
+  return {
+    name: 'pnpm',
+    addAsync: jest.fn(),
+    addDevAsync: jest.fn(),
+  } as unknown as PackageManager.NodePackageManager;
+}
+
+describe(installAsync, () => {
+  let packageManager: PackageManager.NodePackageManager;
+
+  beforeEach(() => {
+    packageManager = createPackageManager();
+    jest.mocked(PackageManager.createForProject).mockReturnValue(packageManager);
+    jest.mocked(getConfig).mockReturnValue({ exp: { sdkVersion: '54.0.0' } } as any);
+    jest.mocked(getPackageJson).mockReturnValue({});
+    jest.mocked(getVersionedPackagesAsync).mockResolvedValue({
+      packages: ['expo-camera@~16.0.0', 'react-native-reanimated@~3.17.0'],
+      messages: [],
+      excludedNativeModules: [],
+    });
+  });
+
+  it.each([
+    ['--check', { check: true, fix: false }],
+    ['--fix', { check: false, fix: true }],
+  ] as const)(
+    'delegates %s with the selected package manager and forwarded arguments',
+    async (_flag, options) => {
+      const packages = ['expo-camera', 'react-native-reanimated'];
+
+      await installAsync(
+        packages,
+        { ...options, projectRoot, pnpm: true },
+        packageManagerArguments
+      );
+
+      expect(checkPackagesAsync).toHaveBeenCalledWith(projectRoot, {
+        packages,
+        options: { ...options, projectRoot, pnpm: true },
+        packageManager,
+        packageManagerArguments,
+      });
+      expect(PackageManager.createForProject).toHaveBeenCalledWith(projectRoot, {
+        npm: undefined,
+        yarn: undefined,
+        bun: undefined,
+        pnpm: true,
+        silent: undefined,
+        log: expect.any(Function),
+      });
+      expect(getVersionedPackagesAsync).not.toHaveBeenCalled();
+      expect(packageManager.addAsync).not.toHaveBeenCalled();
+      expect(packageManager.addDevAsync).not.toHaveBeenCalled();
+      expect(checkPackagesCompatibility).not.toHaveBeenCalled();
+    }
+  );
+
+  it('installs resolved dependencies with forwarded package-manager arguments', async () => {
+    await installAsync(
+      ['expo-camera', 'react-native-reanimated'],
+      { projectRoot, pnpm: true },
+      packageManagerArguments
+    );
+
+    expect(getVersionedPackagesAsync).toHaveBeenCalledWith(projectRoot, {
+      packages: ['expo-camera', 'react-native-reanimated'],
+      sdkVersion: '54.0.0',
+      pkg: {},
+    });
+    expect(packageManager.addAsync).toHaveBeenCalledWith([
+      ...packageManagerArguments,
+      'expo-camera@~16.0.0',
+      'react-native-reanimated@~3.17.0',
+    ]);
+    expect(packageManager.addDevAsync).not.toHaveBeenCalled();
+    expect(applyPluginsAsync).toHaveBeenCalledWith(projectRoot, [
+      'expo-camera@~16.0.0',
+      'react-native-reanimated@~3.17.0',
+    ]);
+  });
+
+  it('installs resolved dev dependencies with forwarded package-manager arguments', async () => {
+    jest.mocked(getVersionedPackagesAsync).mockResolvedValueOnce({
+      packages: ['eslint@^9.0.0'],
+      messages: [],
+      excludedNativeModules: [],
+    });
+
+    await installAsync(['eslint'], { projectRoot, dev: true, pnpm: true }, packageManagerArguments);
+
+    expect(packageManager.addDevAsync).toHaveBeenCalledWith([
+      ...packageManagerArguments,
+      'eslint@^9.0.0',
+    ]);
+    expect(packageManager.addAsync).not.toHaveBeenCalled();
+    expect(applyPluginsAsync).toHaveBeenCalledWith(projectRoot, ['eslint@^9.0.0']);
+  });
+});

--- a/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
@@ -5,6 +5,7 @@ import { getVersionedPackagesAsync } from '../../start/doctor/dependencies/getVe
 import { applyPluginsAsync } from '../applyPlugins';
 import { checkPackagesAsync } from '../checkPackages';
 import { installAsync } from '../installAsync';
+import { installExpoPackageAsync } from '../installExpoPackage';
 import { checkPackagesCompatibility } from '../utils/checkPackagesCompatibility';
 
 jest.mock('@expo/config', () => ({
@@ -29,6 +30,10 @@ jest.mock('../applyPlugins', () => ({
 
 jest.mock('../checkPackages', () => ({
   checkPackagesAsync: jest.fn(),
+}));
+
+jest.mock('../installExpoPackage', () => ({
+  installExpoPackageAsync: jest.fn(),
 }));
 
 jest.mock('../utils/checkPackagesCompatibility', () => ({
@@ -118,6 +123,36 @@ describe(installAsync, () => {
       'expo-camera@~16.0.0',
       'react-native-reanimated@~3.17.0',
     ]);
+  });
+
+  it('installs a resolved Expo canary first and forwards --fix to the follow-up command', async () => {
+    jest.mocked(getVersionedPackagesAsync).mockResolvedValueOnce({
+      packages: ['expo@56.0.0-canary-20260810-abcd123'],
+      messages: [],
+      excludedNativeModules: [],
+    });
+
+    await installAsync(
+      ['expo@canary'],
+      { projectRoot, fix: true, pnpm: true },
+      packageManagerArguments
+    );
+
+    expect(getVersionedPackagesAsync).toHaveBeenCalledWith(projectRoot, {
+      packages: ['expo@canary'],
+      sdkVersion: '54.0.0',
+      pkg: {},
+    });
+    expect(installExpoPackageAsync).toHaveBeenCalledWith(projectRoot, {
+      packageManager,
+      packageManagerArguments,
+      expoPackageToInstall: 'expo@56.0.0-canary-20260810-abcd123',
+      followUpCommandArgs: ['--fix'],
+    });
+    expect(checkPackagesAsync).not.toHaveBeenCalled();
+    expect(packageManager.addAsync).not.toHaveBeenCalled();
+    expect(packageManager.addDevAsync).not.toHaveBeenCalled();
+    expect(applyPluginsAsync).not.toHaveBeenCalled();
   });
 
   it('installs resolved dev dependencies with forwarded package-manager arguments', async () => {

--- a/packages/@expo/cli/src/install/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/resolveOptions-test.ts
@@ -12,6 +12,52 @@ describe(resolveArgsAsync, () => {
       /Specify at most one of: --npm, --pnpm, --yarn/
     );
   });
+  it('rejects --check with --fix', async () => {
+    await expect(resolveArgsAsync(['--check', '--fix'])).rejects.toMatchObject({
+      code: 'BAD_ARGS',
+      message: 'Specify at most one of: --check, --fix',
+    });
+  });
+  it('rejects --json without --check', async () => {
+    await expect(resolveArgsAsync(['--json'])).rejects.toMatchObject({
+      code: 'BAD_ARGS',
+      message: 'The --json flag can only be used with --check',
+    });
+  });
+  it('allows --json with --check', async () => {
+    await expect(resolveArgsAsync(['--json', '--check'])).resolves.toEqual({
+      variadic: [],
+      options: {
+        npm: false,
+        yarn: false,
+        check: true,
+        json: true,
+        pnpm: false,
+        bun: false,
+        fix: false,
+        dev: false,
+      },
+      extras: [],
+    });
+  });
+  it('keeps arguments after -- separate from install options', async () => {
+    await expect(
+      resolveArgsAsync(['expo-camera', '--pnpm', '--', '--save-exact', '--ignore-scripts'])
+    ).resolves.toEqual({
+      variadic: ['expo-camera'],
+      options: {
+        npm: false,
+        yarn: false,
+        check: false,
+        json: false,
+        pnpm: true,
+        bun: false,
+        fix: false,
+        dev: false,
+      },
+      extras: ['--save-exact', '--ignore-scripts'],
+    });
+  });
   it(`allows known values`, async () => {
     const result = await resolveArgsAsync([
       'bacon',


### PR DESCRIPTION
# Why

Too much of the `installAsync` surface was tested in E2E tests against real network requests and package manager behaviour. While this correctly tests E2E, strictly speaking, we shouldn't be reliant on making tests in the `expo/expo` repo this heavy to assert this behaviour.

# How

- Move more install tests into unit tests with mocks as needed
- Isolate E2E test to installing a fixture and being offline-only

**Note:** We give up some coverage here, but this should be filled up with out-of-repo tests that assert real project structures against fixed/published versions of Expo SDK packages.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
