### PR TITLE
fix(ci): Use pnpm global virtual store and prefer offline artifacts in E2E tests

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/utils.ts
+++ b/packages/@expo/cli/e2e/__tests__/utils.ts
@@ -164,8 +164,13 @@ export async function createFromFixtureAsync(
       await JsonFile.writeAsync(staticConfigPath, modifiedConfig as any);
     }
 
-    // Install the packages for e2e experience.
-    await executePnpmAsync(projectRoot, ['install']);
+    // Reuse virtual store installs and prefer offline artifacts to speed up repeated installs
+    await executePnpmAsync(projectRoot, ['install', '--prefer-offline'], {
+      env: {
+        NODE_ENV: 'development',
+        npm_config_enable_global_virtual_store: 'true',
+      },
+    });
   } catch (error) {
     log.error(error);
     throw error;


### PR DESCRIPTION
# Why

We perform a lot of repeated pnpm installs in our E2E fixtures. A lot of these aren't removable or reducible, but we can try to make them cheaper.

Specifically, using a global virtual store and using `--prefer-offline` to prefer offline artifacts should speed up repeated installs for E2E tests a lot.

# How

- Pass global virtual store option to `pnpm install` helper
- Switch to `--prefer-offline` in helper

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
