### PR TITLE
ci(cli): Reduce E2E Windows runs and narrow paths scope

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -18,12 +18,10 @@ on:
       - packages/@expo/router-server/**
       - packages/@expo/log-box/**
       - packages/@expo/metro-file-map/**
-      - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - packages/expo-server/**
-      - pnpm-lock.yaml
       - '!**.md'
   pull_request:
     paths:
@@ -41,12 +39,10 @@ on:
       - packages/@expo/router-server/**
       - packages/@expo/log-box/**
       - packages/@expo/metro-file-map/**
-      - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
       - packages/expo-router/**
       - packages/expo-server/**
-      - pnpm-lock.yaml
       - '!**.md'
   schedule:
     - cron: 0 14 * * *

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -107,7 +107,9 @@ jobs:
         run: pnpm test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   jest-windows:
-    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'schedule' && github.repository == 'expo/expo')
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -236,7 +238,9 @@ jobs:
           retention-days: 30
 
   playwright-windows:
-    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'schedule' && github.repository == 'expo/expo')
     runs-on: windows-2022
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Why

We previously discussed removing per-PR runs of Windows CI E2E tests in favour of the schedule approach that we also use for `check-packages`. This is to reduce cost and speed up CI, since this adds significant noise. The shards of these tests didn't significantly speed up the tests but ramped up costs a lot.

# How

- Don't run Windows E2E on per PR pushes
- Run Windows E2E only on schedule or pushes to `main`
- Remove `create-expo` from paths filter
- Remove `pnpm-lock.yaml` from paths filter (this triggers too often)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
