### PR TITLE
[docs] Fix sidebar tutorial progress counter layout for Japanese titles

### DIFF
--- a/docs/pages/ja/tutorial/introduction.mdx
+++ b/docs/pages/ja/tutorial/introduction.mdx
@@ -11,7 +11,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 これからユニバーサルアプリを作る旅に出発しましょう。このチュートリアルでは、Android、iOS、web で動作する Expo アプリを、ひとつのコードベースで作成します。さっそく始めましょう！
 
-> **info** **プログラミングが初めてですか？** コードを自分で書く代わりに、AI コーディングエージェントにプロンプトを与えて同じアプリを作ることもできます。[AI を使って作るチュートリアル](/tutorial/build-with-ai/introduction/) に従ってください。環境構築をゼロから解説しています。
+> **info** **プログラミングが初めてですか？** コードを自分で書く代わりに、AI コーディングエージェントにプロンプトを与えて同じアプリを作ることもできます。[AI を使って作るチュートリアル](/ja/tutorial/build-with-ai/introduction/) に従ってください。環境構築をゼロから解説しています。
 
 ## React Native と Expo チュートリアルについて
 

--- a/docs/pages/ja/tutorial/overview.mdx
+++ b/docs/pages/ja/tutorial/overview.mdx
@@ -18,9 +18,9 @@ import { BoxLink } from '~/ui/components/BoxLink';
 />
 
 <BoxLink
-  title="Build with AI チュートリアル"
+  title="AI エージェントで作るチュートリアル"
   description="プログラミング経験がなくても、AI コーディングエージェントに指示しながら初めてのアプリを作成できるチュートリアルです。ツールを一からセットアップする方法から、各ステップでスマートフォンでアプリを確認する方法までを解説します。"
-  href="/tutorial/build-with-ai/introduction/"
+  href="/ja/tutorial/build-with-ai/introduction/"
   Icon={GraduationHat02DuotoneIcon}
 />
 

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -365,3 +365,7 @@ div.tippy-box {
 .react-player > video {
   outline: none;
 }
+
+:lang(ja) {
+  line-break: strict;
+}

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -115,9 +115,9 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             <SidebarTitle Icon={Icon} sectionName={title}>
               {title}
             </SidebarTitle>
-            <div className="flex flex-row items-center pb-1">
+            <div className="flex shrink-0 flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="ml-2 text-sm text-tertiary">
+              <p className="ml-2 text-sm whitespace-nowrap text-tertiary">
                 {intl.formatMessage(
                   { id: 'sidebarTutorialProgress' },
                   { completed: completedChaptersCount, total: totalChapters }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25744 ENG-25745

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix sidebar tutorial progress counter layout for Japanese titles
- Fix the link and title of Build with AI tutorial BoxLink in Japanese to match the title in the sidebar and its link

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="488" height="540" alt="CleanShot 2026-08-10 at 19 44 33@2x" src="https://github.com/user-attachments/assets/68f0d028-cf7b-44b9-b2cc-830f52609322" />


<img width="2394" height="1226" alt="CleanShot 2026-08-10 at 19 48 46@2x" src="https://github.com/user-attachments/assets/02311814-7ca1-4e80-9c5a-48e48b715271" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
