### PR TITLE
[router] Hide the splash screen in built-in `+not-found` screen

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -28,7 +28,7 @@
 - Upgrade react-native-screens to 4.26.0 ([#47770](https://github.com/expo/expo/pull/47770) by [@Ubax](https://github.com/Ubax))
 - Improve standard-navigation types for `createProps`. ([#47825](https://github.com/expo/expo/pull/47825) by [@Ubax](https://github.com/Ubax))
 - Add a `processScreens` option to the `standard-navigation` integration. ([#48290](https://github.com/expo/expo/pull/48290) by [@Ubax](https://github.com/Ubax))
-- Hide the splash screen when the built-in `+not-found` screen renders
+- Hide the splash screen when the built-in `+not-found` screen renders ([#48721](https://github.com/expo/expo/pull/48721) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Upgrade react-native-screens to 4.26.0 ([#47770](https://github.com/expo/expo/pull/47770) by [@Ubax](https://github.com/Ubax))
 - Improve standard-navigation types for `createProps`. ([#47825](https://github.com/expo/expo/pull/47825) by [@Ubax](https://github.com/Ubax))
 - Add a `processScreens` option to the `standard-navigation` integration. ([#48290](https://github.com/expo/expo/pull/48290) by [@Ubax](https://github.com/Ubax))
+- Hide the splash screen when the built-in `+not-found` screen renders
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -21,9 +21,9 @@ import { StackRouter, useNavigationBuilder } from './react-navigation/native';
 import { initScreensFeatureFlags } from './screensFeatureFlags';
 import type { RequireContext } from './types';
 import { parseUrlUsingCustomBase } from './utils/url';
+import { RootUnmatched } from './views/RootUnmatched';
 import { Sitemap } from './views/Sitemap';
 import * as SplashScreen from './views/Splash';
-import { Unmatched } from './views/Unmatched';
 
 export type ExpoRootProps = {
   context: RequireContext;
@@ -177,7 +177,7 @@ function Content() {
     <Screen key="SLOT" name={INTERNAL_SLOT_NAME} component={store.rootComponent} />,
   ];
   if (shouldAppendNotFound()) {
-    children.push(<Screen key="NOT-FOUND" name={NOT_FOUND_ROUTE_NAME} component={Unmatched} />);
+    children.push(<Screen key="NOT-FOUND" name={NOT_FOUND_ROUTE_NAME} component={RootUnmatched} />);
   }
   if (shouldAppendSitemap()) {
     children.push(<Screen key="SITEMAP" name={SITEMAP_ROUTE_NAME} component={Sitemap} />);

--- a/packages/expo-router/src/views/RootUnmatched.tsx
+++ b/packages/expo-router/src/views/RootUnmatched.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import * as SplashScreen from '../utils/splash';
+import { Unmatched } from './Unmatched';
+
+/**
+ * Renders the built-in `+not-found` screen for the root router's outer slot,
+ * used when no route in the app matches the URL at all.
+ *
+ * @hidden
+ */
+export function RootUnmatched() {
+  // https://github.com/expo/expo/issues/47687
+  useEffect(() => {
+    SplashScreen.hideAsync();
+  }, []);
+
+  return <Unmatched />;
+}

--- a/packages/expo-router/src/views/__tests__/RootUnmatched.test.ios.tsx
+++ b/packages/expo-router/src/views/__tests__/RootUnmatched.test.ios.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { renderRouter } from '../../testing-library';
+import * as SplashScreen from '../../utils/splash';
+import { Unmatched } from '../Unmatched';
+
+jest.mock('../../utils/splash', () => {
+  const actualSplash = jest.requireActual(
+    '../../utils/splash'
+  ) as typeof import('../../utils/splash');
+  return {
+    ...actualSplash,
+    hideAsync: jest.fn(),
+  };
+});
+
+it('hides the splash screen when the root router falls back to the built-in unmatched screen', () => {
+  renderRouter(
+    {
+      index: () => null,
+    },
+    {
+      initialUrl: '/404',
+    }
+  );
+
+  expect(screen.getByText('Unmatched Route')).toBeOnTheScreen();
+  expect(SplashScreen.hideAsync).toHaveBeenCalled();
+});
+
+it('does not hide the splash screen when a route matches', () => {
+  renderRouter({
+    index: () => <Text>Hello</Text>,
+  });
+
+  expect(screen.getByText('Hello')).toBeOnTheScreen();
+  expect(SplashScreen.hideAsync).not.toHaveBeenCalled();
+});
+
+it('does not hide the splash screen when a user-defined +not-found matches', () => {
+  renderRouter(
+    {
+      index: () => null,
+      '+not-found': () => <Text>Custom not found</Text>,
+    },
+    {
+      initialUrl: '/404',
+    }
+  );
+
+  expect(screen.getByText('Custom not found')).toBeOnTheScreen();
+  expect(SplashScreen.hideAsync).not.toHaveBeenCalled();
+});
+
+it('does not hide the splash screen when the app renders Unmatched itself inside its own layout', () => {
+  renderRouter(
+    {
+      index: () => null,
+      '+not-found': () => <Unmatched />,
+    },
+    {
+      initialUrl: '/404',
+    }
+  );
+
+  expect(screen.getByText('Unmatched Route')).toBeOnTheScreen();
+  expect(SplashScreen.hideAsync).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
# Why

Related to https://github.com/expo/expo/issues/47687

When someone calls `SplashScreen.preventAutoHideAsync();` and then lands on `404` before they hid the SplashScreen, the 404 screen is not visible (it's hidden behind SplashScreen)

# How

Similar to `Try.tsx` autohide SplashScreen for the default 404 screen:
1. Extract `RootUnmatched` - the screen which is internal implementation of public `Unmatched`
2. Hide SplashScreen when `RootUnmatched` is rendered

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
