### PR TITLE
[android][local-authentication] Fix crash when using strong biometric security level with device fallback on Android 9 and 10

### DIFF
--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `authenticateAsync` crashing on Android 9 and 10 when `biometricsSecurityLevel` is set to `'strong'` and the device credential fallback is enabled. On those Android versions the security level now automatically falls back to `'weak'` (the system cannot combine strong biometrics with device credentials in a single prompt there), and the successful result contains a `warning` reporting the downgrade. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@sbaiahmed1](https://github.com/sbaiahmed1))
+- [Android] Fix `authenticateAsync` crashing on Android 9 and 10 when `biometricsSecurityLevel` is set to `'strong'` and the device credential fallback is enabled. On those Android versions the security level now automatically falls back to `'weak'` (the system cannot combine strong biometrics with device credentials in a single prompt there), and the successful result contains a `warning` reporting the downgrade. ([#48723](https://github.com/expo/expo/pull/48723) by [@sbaiahmed1](https://github.com/sbaiahmed1))
 
 ### 💡 Others
 

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `authenticateAsync` crashing on Android 9 and 10 when `biometricsSecurityLevel` is set to `'strong'` and the device credential fallback is enabled. On those Android versions the security level now automatically falls back to `'weak'` (the system cannot combine strong biometrics with device credentials in a single prompt there), and the successful result contains a `warning` reporting the downgrade. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@sbaiahmed1](https://github.com/sbaiahmed1))
+
 ### 💡 Others
 
 ## 57.0.2 - 2026-07-22

--- a/packages/expo-local-authentication/android/build.gradle
+++ b/packages/expo-local-authentication/android/build.gradle
@@ -16,4 +16,6 @@ android {
 
 dependencies {
   implementation "androidx.biometric:biometric:1.2.0-alpha04"
+
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -150,15 +150,12 @@ class LocalAuthenticationModule : Module() {
 
   private fun buildAuthenticationCallback(
     callPromise: Promise,
-    callOptions: AuthOptions
+    callOptions: AuthOptions,
+    successWarning: String? = null
   ): BiometricPrompt.AuthenticationCallback = object : BiometricPrompt.AuthenticationCallback() {
     override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
       finishCall(callPromise) {
-        callPromise.resolve(
-          Bundle().apply {
-            putBoolean("success", true)
-          }
-        )
+        callPromise.resolve(createResponse(warning = successWarning))
       }
     }
 
@@ -206,16 +203,21 @@ class LocalAuthenticationModule : Module() {
       return
     }
 
-    val allowedAuthenticators = if (options.disableDeviceFallback) {
-      options.biometricsSecurityLevel.toNativeBiometricSecurityLevel()
+    val (allowedAuthenticators, fallbackToWeakUsed) = selectAuthenticators(
+      securityLevel = options.biometricsSecurityLevel,
+      disableDeviceFallback = options.disableDeviceFallback,
+      apiLevel = Build.VERSION.SDK_INT
+    )
+    val successWarning = if (fallbackToWeakUsed) {
+      "Biometric strength 'strong' cannot be combined with the device credential fallback on Android 9 and 10, so the prompt also accepted Class 2 (weak) biometrics. Set `disableDeviceFallback: true` to enforce strong biometrics only."
     } else {
-      options.biometricsSecurityLevel.toNativeBiometricSecurityLevel() or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+      null
     }
 
     isAuthenticating = true
     activePromise = promise
     val executor: Executor = Executors.newSingleThreadExecutor()
-    val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, buildAuthenticationCallback(promise, options))
+    val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, buildAuthenticationCallback(promise, options, successWarning))
     biometricPrompt = localBiometricPrompt
     val promptInfoBuilder = PromptInfo.Builder().apply {
       setTitle(options.promptMessage)

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationRecords.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationRecords.kt
@@ -1,5 +1,6 @@
 package expo.modules.localauthentication
 
+import android.os.Build
 import androidx.biometric.BiometricManager
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
@@ -16,6 +17,38 @@ internal enum class BiometricsSecurityLevel(val value: String) : Enumerable {
       STRONG -> BiometricManager.Authenticators.BIOMETRIC_STRONG
     }
   }
+}
+
+internal data class AuthenticatorSelection(
+  val allowedAuthenticators: Int,
+  val fallbackToWeakUsed: Boolean
+)
+
+internal fun selectAuthenticators(
+  securityLevel: BiometricsSecurityLevel,
+  disableDeviceFallback: Boolean,
+  apiLevel: Int
+): AuthenticatorSelection {
+  val biometricAuthenticators = securityLevel.toNativeBiometricSecurityLevel()
+  if (disableDeviceFallback) {
+    return AuthenticatorSelection(biometricAuthenticators, fallbackToWeakUsed = false)
+  }
+  // `BIOMETRIC_STRONG or DEVICE_CREDENTIAL` makes `PromptInfo.Builder.build()` throw on API 28-29.
+  // Since the device credential fallback already caps the security level at the lock screen,
+  // fall back to weak biometrics (Class 2 or better, so strong sensors keep working) instead of
+  // crashing on those API levels.
+  if (securityLevel == BiometricsSecurityLevel.STRONG &&
+    apiLevel in Build.VERSION_CODES.P..Build.VERSION_CODES.Q
+  ) {
+    return AuthenticatorSelection(
+      BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL,
+      fallbackToWeakUsed = true
+    )
+  }
+  return AuthenticatorSelection(
+    biometricAuthenticators or BiometricManager.Authenticators.DEVICE_CREDENTIAL,
+    fallbackToWeakUsed = false
+  )
 }
 
 @OptimizedRecord

--- a/packages/expo-local-authentication/android/src/test/java/expo/modules/localauthentication/AuthenticatorSelectionTest.kt
+++ b/packages/expo-local-authentication/android/src/test/java/expo/modules/localauthentication/AuthenticatorSelectionTest.kt
@@ -1,0 +1,59 @@
+package expo.modules.localauthentication
+
+import androidx.biometric.BiometricManager.Authenticators
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// API levels around the range where `BIOMETRIC_STRONG or DEVICE_CREDENTIAL` is rejected by
+// `BiometricPrompt.PromptInfo.Builder.build()` (rejected on 28 and 29 only).
+private const val API_27 = 27
+private const val API_28 = 28
+private const val API_29 = 29
+private const val API_30 = 30
+private const val API_34 = 34
+
+class AuthenticatorSelectionTest {
+  @Test
+  fun `weak biometrics with device fallback allows weak or device credential on every API level`() {
+    for (apiLevel in intArrayOf(API_27, API_28, API_29, API_30, API_34)) {
+      val selection = selectAuthenticators(BiometricsSecurityLevel.WEAK, disableDeviceFallback = false, apiLevel = apiLevel)
+      assertEquals(Authenticators.BIOMETRIC_WEAK or Authenticators.DEVICE_CREDENTIAL, selection.allowedAuthenticators)
+      assertFalse(selection.fallbackToWeakUsed)
+    }
+  }
+
+  @Test
+  fun `disabling device fallback requests only the biometric class on every API level`() {
+    for (apiLevel in intArrayOf(API_27, API_28, API_29, API_30, API_34)) {
+      val weak = selectAuthenticators(BiometricsSecurityLevel.WEAK, disableDeviceFallback = true, apiLevel = apiLevel)
+      assertEquals(Authenticators.BIOMETRIC_WEAK, weak.allowedAuthenticators)
+      assertFalse(weak.fallbackToWeakUsed)
+
+      val strong = selectAuthenticators(BiometricsSecurityLevel.STRONG, disableDeviceFallback = true, apiLevel = apiLevel)
+      assertEquals(Authenticators.BIOMETRIC_STRONG, strong.allowedAuthenticators)
+      assertFalse(strong.fallbackToWeakUsed)
+    }
+  }
+
+  @Test
+  fun `strong biometrics with device fallback combines both authenticators outside API 28-29`() {
+    for (apiLevel in intArrayOf(API_27, API_30, API_34)) {
+      val selection = selectAuthenticators(BiometricsSecurityLevel.STRONG, disableDeviceFallback = false, apiLevel = apiLevel)
+      assertEquals(Authenticators.BIOMETRIC_STRONG or Authenticators.DEVICE_CREDENTIAL, selection.allowedAuthenticators)
+      assertFalse(selection.fallbackToWeakUsed)
+    }
+  }
+
+  @Test
+  fun `strong biometrics with device fallback falls back to weak biometrics on API 28-29`() {
+    for (apiLevel in intArrayOf(API_28, API_29)) {
+      val selection = selectAuthenticators(BiometricsSecurityLevel.STRONG, disableDeviceFallback = false, apiLevel = apiLevel)
+      // `BIOMETRIC_STRONG or DEVICE_CREDENTIAL` makes `PromptInfo.Builder.build()` throw on these
+      // API levels, so the prompt must downgrade to weak biometrics and report the fallback.
+      assertEquals(Authenticators.BIOMETRIC_WEAK or Authenticators.DEVICE_CREDENTIAL, selection.allowedAuthenticators)
+      assertTrue(selection.fallbackToWeakUsed)
+    }
+  }
+}

--- a/packages/expo-local-authentication/src/LocalAuthentication.types.ts
+++ b/packages/expo-local-authentication/src/LocalAuthentication.types.ts
@@ -1,7 +1,17 @@
 import { Platform } from 'expo';
 
 export type LocalAuthenticationResult =
-  | { success: true }
+  | {
+      success: true;
+      /**
+       * A warning message emitted when authentication succeeded in a degraded mode. For example,
+       * on Android 9 and 10 requesting `biometricsSecurityLevel: 'strong'` with the device
+       * credential fallback enabled also accepts weak biometrics, as the system cannot combine
+       * strong biometrics and device credentials in a single prompt on those versions.
+       * @platform android
+       */
+      warning?: string;
+    }
   | {
       success: false;
       error: LocalAuthenticationError;
@@ -116,6 +126,11 @@ export type LocalAuthenticationOptions = {
    * Sets the security class of biometric authentication to allow.
    * `strong` allows only Android Class 3 biometrics. For example, a fingerprint or a 3D face scan.
    * `weak` allows both Android Class 3 and Class 2 biometrics. Class 2 biometrics are less secure than Class 3. For example, a camera-based face unlock.
+   * > On Android 9 and 10, the system cannot combine `strong` biometrics and device credentials in
+   * > a single prompt. On those versions, when the device fallback is enabled, `strong`
+   * > automatically falls back to `weak` and the successful authentication result contains a
+   * > `warning` reporting the downgrade. Set `disableDeviceFallback: true` to enforce
+   * > strong biometrics only.
    * @platform android
    * @default 'weak'
    */


### PR DESCRIPTION
# Why

Calling `LocalAuthentication.authenticateAsync({ biometricsSecurityLevel: 'strong' })` crashes the app on Android 9 and 10 (API 28–29) when the device credential fallback is enabled (`disableDeviceFallback: false`, the default).

The module requests `BIOMETRIC_STRONG | DEVICE_CREDENTIAL`, but `androidx.biometric`'s `PromptInfo.Builder.build()` rejects that combination on API 28–29 and throws:

```
java.lang.IllegalArgumentException: Authenticator combination is unsupported on API 29: BIOMETRIC_STRONG | DEVICE_CREDENTIAL
```

The module only catches `NullPointerException` around `BiometricPrompt.authenticate()`, so the exception propagates and hard-crashes the app. See [`AuthenticatorUtils.isSupportedCombination`](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/biometric/biometric/src/main/java/androidx/biometric/AuthenticatorUtils.java) — `BIOMETRIC_STRONG | DEVICE_CREDENTIAL` is only supported on API < 28 or API 30+.

# How

Added an automatic fallback: on API 28–29, when `strong` is requested and the device credential fallback is enabled, the module now requests `BIOMETRIC_WEAK | DEVICE_CREDENTIAL` (a combination supported on those API levels) instead of crashing, and the successful authentication result carries a `warning` string reporting the downgrade.

Notes on the approach:

- `BIOMETRIC_WEAK` means "Class 2 *or better*", so devices with Class 3 sensors (fingerprint on most Android 9/10 devices) behave exactly as before — only Class-2-only devices gain a biometric option where they previously crashed.
- The downgrade only applies when the device credential fallback is enabled — in that configuration the app already accepts PIN/pattern/password, so the effective security floor is already the lock screen. With `disableDeviceFallback: true` there is no downgrade (strong-only never crashed, and the strict Class 3 contract stays intact).
- The authenticator selection was extracted into a pure `selectAuthenticators()` function so it can be unit-tested, and the success result type gained an optional `warning` field (previously only failure results could carry one).

# Test Plan

- Added Android unit tests (`AuthenticatorSelectionTest.kt`, the package's first) covering the authenticator selection for weak/strong × fallback enabled/disabled across API 27, 28, 29, 30, and 34. Written red-first: the API 28–29 case failed against the original logic and passes with the fix. Run with `et native-unit-tests -p android -t local --packages expo-local-authentication`.
- `et check-packages expo-local-authentication` passes (build, typecheck, JS unit tests, lint, format).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
