### PR TITLE
[create-expo] backport canonical agent files to SDK 57

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Reuse agent files from `@expo/llm-configs` ([#46968](https://github.com/expo/expo/pull/46968) by [@davidmokos](https://github.com/davidmokos))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -33,8 +33,9 @@
     "typecheck": "expo-module typecheck",
     "test": "expo-module test",
     "test:e2e": "expo-module test --config e2e/jest.config.js --runInBand",
+    "sync-agent-templates": "node scripts/sync-agent-templates.js",
     "watch": "pnpm run build --watch",
-    "prepublishOnly": "pnpm run clean && pnpm run build:prod"
+    "prepublishOnly": "pnpm run sync-agent-templates && pnpm run clean && pnpm run build:prod"
   },
   "devDependencies": {
     "@expo/config": "workspace:*",

--- a/packages/create-expo/scripts/sync-agent-templates.js
+++ b/packages/create-expo/scripts/sync-agent-templates.js
@@ -1,0 +1,32 @@
+const fs = require('fs/promises');
+const path = require('path');
+
+const LLM_CONFIGS_EXPO_APP_TEMPLATE_BASE_URL =
+  'https://raw.githubusercontent.com/expo/llm-configs/main/expo-app';
+const AGENT_TEMPLATE_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md'];
+
+async function fetchTemplateAsync(fileName) {
+  const url = `${LLM_CONFIGS_EXPO_APP_TEMPLATE_BASE_URL}/${fileName}`;
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+(async () => {
+  const templatesDir = path.join(__dirname, '..', 'template', 'agent-files');
+  await fs.mkdir(templatesDir, { recursive: true });
+
+  await Promise.all(
+    AGENT_TEMPLATE_FILE_NAMES.map(async (fileName) => {
+      const content = await fetchTemplateAsync(fileName);
+      await fs.writeFile(path.join(templatesDir, fileName), content);
+    })
+  );
+
+  // eslint-disable-next-line no-console
+  console.log('Synced new app agent templates from expo/llm-configs');
+})();

--- a/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
+++ b/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
@@ -4,6 +4,13 @@ import path from 'path';
 
 import { generateAgentFiles } from '../generateAgentFiles';
 
+function readAgentTemplate(fileName: 'AGENTS.md' | 'CLAUDE.md'): string {
+  return fs.readFileSync(
+    path.join(__dirname, '..', '..', 'template', 'agent-files', fileName),
+    'utf-8'
+  );
+}
+
 describe(generateAgentFiles, () => {
   let tmpDir: string;
   let homeDir: string;
@@ -12,11 +19,6 @@ describe(generateAgentFiles, () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-test-'));
     homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-home-'));
     jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
-    // Write a minimal package.json so the SDK version can be resolved
-    fs.writeFileSync(
-      path.join(tmpDir, 'package.json'),
-      JSON.stringify({ dependencies: { expo: '~55.0.0' } })
-    );
   });
 
   afterEach(() => {
@@ -25,50 +27,39 @@ describe(generateAgentFiles, () => {
     jest.restoreAllMocks();
   });
 
-  it('always generates AGENTS.md', () => {
-    generateAgentFiles(tmpDir);
+  it('always generates AGENTS.md', async () => {
+    await generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
   });
 
-  it('does not generate Claude files when Claude Code is not installed', () => {
-    generateAgentFiles(tmpDir);
+  it('does not generate Claude files when Claude Code is not installed', async () => {
+    await generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(false);
   });
 
-  it('writes correct content to AGENTS.md with versioned docs URL', () => {
-    generateAgentFiles(tmpDir);
+  it('copies AGENTS.md from the bundled agent templates', async () => {
+    await generateAgentFiles(tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
-    expect(content).toContain('# Expo');
-    expect(content).toContain('https://docs.expo.dev/versions/v55.0.0/');
+    expect(content).toBe(readAgentTemplate('AGENTS.md'));
   });
 
-  it('falls back to unversioned docs URL when expo version is missing', () => {
-    fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ dependencies: {} }));
-
-    generateAgentFiles(tmpDir);
-
-    const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
-    expect(content).toContain('https://docs.expo.dev');
-    expect(content).not.toContain('/versions/');
-  });
-
-  it('writes correct content to CLAUDE.md', () => {
+  it('copies CLAUDE.md from the bundled agent templates', async () => {
     fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
 
-    generateAgentFiles(tmpDir);
+    await generateAgentFiles(tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
-    expect(content).toBe('@AGENTS.md\n');
+    expect(content).toBe(readAgentTemplate('CLAUDE.md'));
   });
 
-  it('writes correct content to .claude/settings.json', () => {
+  it('writes correct content to .claude/settings.json', async () => {
     fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
 
-    generateAgentFiles(tmpDir);
+    await generateAgentFiles(tmpDir);
 
     const content = JSON.parse(
       fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8')
@@ -76,12 +67,12 @@ describe(generateAgentFiles, () => {
     expect(content).toEqual({ enabledPlugins: { 'expo@claude-plugins-official': true } });
   });
 
-  it('skips files that already exist', () => {
+  it('skips files that already exist', async () => {
     fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
     fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), 'custom content');
     fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), 'custom claude');
 
-    generateAgentFiles(tmpDir);
+    await generateAgentFiles(tmpDir);
 
     expect(fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8')).toBe('custom content');
     expect(fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8')).toBe('custom claude');
@@ -89,21 +80,21 @@ describe(generateAgentFiles, () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
 
-  it('creates .claude/ directory for settings when global .claude.json exists', () => {
+  it('creates .claude/ directory for settings when global .claude.json exists', async () => {
     fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
 
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
 
-    generateAgentFiles(tmpDir);
+    await generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
     expect(fs.statSync(path.join(tmpDir, '.claude')).isDirectory()).toBe(true);
   });
 
-  it('generates Claude files when global .claude directory exists', () => {
+  it('generates Claude files when global .claude directory exists', async () => {
     fs.mkdirSync(path.join(homeDir, '.claude'));
 
-    generateAgentFiles(tmpDir);
+    await generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);

--- a/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
+++ b/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
@@ -6,9 +6,12 @@ import { generateAgentFiles } from '../generateAgentFiles';
 
 describe(generateAgentFiles, () => {
   let tmpDir: string;
+  let homeDir: string;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-test-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-home-'));
+    jest.spyOn(os, 'homedir').mockReturnValue(homeDir);
     // Write a minimal package.json so the SDK version can be resolved
     fs.writeFileSync(
       path.join(tmpDir, 'package.json'),
@@ -18,14 +21,21 @@ describe(generateAgentFiles, () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
+    jest.restoreAllMocks();
   });
 
-  it('generates all three files when none exist', () => {
+  it('always generates AGENTS.md', () => {
     generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
+  });
+
+  it('does not generate Claude files when Claude Code is not installed', () => {
+    generateAgentFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(false);
   });
 
   it('writes correct content to AGENTS.md with versioned docs URL', () => {
@@ -47,6 +57,8 @@ describe(generateAgentFiles, () => {
   });
 
   it('writes correct content to CLAUDE.md', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     generateAgentFiles(tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
@@ -54,6 +66,8 @@ describe(generateAgentFiles, () => {
   });
 
   it('writes correct content to .claude/settings.json', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     generateAgentFiles(tmpDir);
 
     const content = JSON.parse(
@@ -63,6 +77,7 @@ describe(generateAgentFiles, () => {
   });
 
   it('skips files that already exist', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
     fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), 'custom content');
     fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), 'custom claude');
 
@@ -74,12 +89,23 @@ describe(generateAgentFiles, () => {
     expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
 
-  it('creates .claude/ directory when it does not exist', () => {
+  it('creates .claude/ directory for settings when global .claude.json exists', () => {
+    fs.writeFileSync(path.join(homeDir, '.claude.json'), '{}');
+
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
 
     generateAgentFiles(tmpDir);
 
     expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(true);
     expect(fs.statSync(path.join(tmpDir, '.claude')).isDirectory()).toBe(true);
+  });
+
+  it('generates Claude files when global .claude directory exists', () => {
+    fs.mkdirSync(path.join(homeDir, '.claude'));
+
+    generateAgentFiles(tmpDir);
+
+    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'settings.json'))).toBe(true);
   });
 });

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -138,7 +138,7 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
   await setupDependenciesAsync(projectRoot, props);
 
   if (props.agentsMd) {
-    generateAgentFiles(projectRoot);
+    await generateAgentFiles(projectRoot);
   }
 
   // for now, we will just init a git repo if they have git installed and the
@@ -227,7 +227,7 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
   await setupDependenciesAsync(projectRoot, props);
 
   if (props.agentsMd) {
-    generateAgentFiles(projectRoot);
+    await generateAgentFiles(projectRoot);
   }
 
   // for now, we will just init a git repo if they have git installed and the

--- a/packages/create-expo/src/generateAgentFiles.ts
+++ b/packages/create-expo/src/generateAgentFiles.ts
@@ -2,30 +2,17 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-function getExpoSdkVersion(root: string): string | null {
-  try {
-    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
-    const expoVersion = (pkg.dependencies?.expo ?? pkg.devDependencies?.expo) as string | undefined;
-    if (!expoVersion) return null;
-    const match = expoVersion.match(/(\d+)\./);
-    return match?.[1] ?? null;
-  } catch {
-    return null;
-  }
+const AGENT_TEMPLATE_FILE_NAMES = ['AGENTS.md', 'CLAUDE.md'] as const;
+
+// Agent templates are synced from `expo/llm-configs` at publish time (see
+// `scripts/sync-agent-templates.js`) and bundled under `template/agent-files`, so project
+// creation works offline. `__dirname` is the build output directory, one level below the
+// package root in both the source tree and the published package.
+const AGENT_TEMPLATES_DIR = path.join(__dirname, '..', 'template', 'agent-files');
+
+function resolveAgentTemplatePath(fileName: (typeof AGENT_TEMPLATE_FILE_NAMES)[number]): string {
+  return path.join(AGENT_TEMPLATES_DIR, fileName);
 }
-
-function getAgentsMdContent(sdkVersion: string | null): string {
-  const docsUrl = sdkVersion
-    ? `https://docs.expo.dev/versions/v${sdkVersion}.0.0/`
-    : 'https://docs.expo.dev';
-  return `# Expo HAS CHANGED
-
-Read the exact versioned docs at ${docsUrl} before writing any code.
-`;
-}
-
-const CLAUDE_MD_CONTENT = `@AGENTS.md
-`;
 
 const CLAUDE_SETTINGS_CONTENT = `{
   "enabledPlugins": {
@@ -42,26 +29,35 @@ function isClaudeCodeInstalled(): boolean {
   );
 }
 
-export function generateAgentFiles(root: string): void {
-  const sdkVersion = getExpoSdkVersion(root);
+async function copyFileIfMissing(sourcePath: string, destinationPath: string): Promise<void> {
+  if (fs.existsSync(destinationPath)) {
+    return;
+  }
+  const dir = path.dirname(destinationPath);
+  await fs.promises.mkdir(dir, { recursive: true });
+  await fs.promises.copyFile(sourcePath, destinationPath);
+}
 
-  const files: { filePath: string; content: string }[] = [
-    { filePath: path.join(root, 'AGENTS.md'), content: getAgentsMdContent(sdkVersion) },
+async function writeFileIfMissing(filePath: string, content: string): Promise<void> {
+  if (fs.existsSync(filePath)) {
+    return;
+  }
+  const dir = path.dirname(filePath);
+  await fs.promises.mkdir(dir, { recursive: true });
+  await fs.promises.writeFile(filePath, content);
+}
+
+export async function generateAgentFiles(root: string): Promise<void> {
+  const tasks: Promise<void>[] = [
+    copyFileIfMissing(resolveAgentTemplatePath('AGENTS.md'), path.join(root, 'AGENTS.md')),
   ];
 
   if (isClaudeCodeInstalled()) {
-    files.push(
-      { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
-      { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT }
+    tasks.push(
+      copyFileIfMissing(resolveAgentTemplatePath('CLAUDE.md'), path.join(root, 'CLAUDE.md')),
+      writeFileIfMissing(path.join(root, '.claude', 'settings.json'), CLAUDE_SETTINGS_CONTENT)
     );
   }
 
-  for (const { filePath, content } of files) {
-    if (fs.existsSync(filePath)) {
-      continue;
-    }
-    const dir = path.dirname(filePath);
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(filePath, content);
-  }
+  await Promise.all(tasks);
 }

--- a/packages/create-expo/src/generateAgentFiles.ts
+++ b/packages/create-expo/src/generateAgentFiles.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 function getExpoSdkVersion(root: string): string | null {
@@ -33,14 +34,27 @@ const CLAUDE_SETTINGS_CONTENT = `{
 }
 `;
 
+function isClaudeCodeInstalled(): boolean {
+  const home = os.homedir();
+  return (
+    !!home &&
+    (fs.existsSync(path.join(home, '.claude.json')) || fs.existsSync(path.join(home, '.claude')))
+  );
+}
+
 export function generateAgentFiles(root: string): void {
   const sdkVersion = getExpoSdkVersion(root);
 
   const files: { filePath: string; content: string }[] = [
     { filePath: path.join(root, 'AGENTS.md'), content: getAgentsMdContent(sdkVersion) },
-    { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
-    { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT },
   ];
+
+  if (isClaudeCodeInstalled()) {
+    files.push(
+      { filePath: path.join(root, 'CLAUDE.md'), content: CLAUDE_MD_CONTENT },
+      { filePath: path.join(root, '.claude', 'settings.json'), content: CLAUDE_SETTINGS_CONTENT }
+    );
+  }
 
   for (const { filePath, content } of files) {
     if (fs.existsSync(filePath)) {

--- a/packages/create-expo/template/agent-files/AGENTS.md
+++ b/packages/create-expo/template/agent-files/AGENTS.md
@@ -1,0 +1,41 @@
+This is an Expo/React Native mobile application. Prioritize mobile-first patterns, performance, and cross-platform compatibility.
+
+## Expo has changed — do not trust your training data
+
+Expo ships breaking changes every SDK release. APIs you remember are likely renamed, moved, or removed. Before writing any code that touches an Expo, EAS, or React Native API:
+
+1. Read the major version of the `expo` package in `package.json`.
+2. Fetch the matching versioned docs: `https://docs.expo.dev/versions/v<major>.0.0/`
+3. For anything else, fetch https://docs.expo.dev/llms.txt — an index of all Expo docs with corrections to common LLM misconceptions. Follow its links to the specific page you need; never answer from memory.
+
+## Commands
+
+Use `bunx` instead of `npx` if the project uses bun (`bun.lock` present).
+
+```bash
+npx expo install <package>  # ALWAYS use instead of npm/yarn/pnpm/bun add — resolves SDK-compatible versions
+npx expo start              # start the dev server
+npx expo lint               # lint
+npx tsc --noEmit            # typecheck
+npx expo-doctor             # diagnose dependency and config issues
+npx expo install --fix      # fix incompatible package versions
+```
+
+Run lint and typecheck before declaring any task done.
+
+## Navigation & Routing
+
+- Use **Expo Router** for all navigation. Routes live in `src/app/` — every file there is a screen, `_layout.tsx` files define navigators. Keep non-route code (components, hooks, utils) outside `src/app/`.
+- Import `Link`, `router`, and `useLocalSearchParams` from `expo-router`.
+- Docs: https://docs.expo.dev/router/introduction.md
+
+## Building with EAS
+
+Use EAS to build, sign, and submit the app in the cloud (`eas build`, `eas submit`) and to ship over-the-air updates (`eas update`) — no local Xcode or Android Studio required. Run EAS CLI as `bunx eas-cli <command>` in Bun projects, or `npx eas-cli@latest <command>` otherwise; substitute that for bare `eas` in docs examples.
+Docs: https://docs.expo.dev/eas/index.md
+
+## Rules
+
+- If `ios/` and `android/` directories do not exist, they are generated (Continuous Native Generation). Never create or edit them by hand — configure native behavior in `app.json` and config plugins.
+- Expo Go only includes its bundled native modules. After adding a library with native code, the app needs a development build: `npx expo run:ios|android` locally, or `eas build --profile development`.
+- Prefer recommended Expo modules over third-party libraries, and check your available skills before adding dependencies. Docs: https://docs.expo.dev/versions/latest/index.md

--- a/packages/create-expo/template/agent-files/CLAUDE.md
+++ b/packages/create-expo/template/agent-files/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

Backports #46666 and #46968 to the SDK 57 release branch.

- always generates `AGENTS.md` from the canonical bundled `expo/llm-configs` template
- generates Claude-specific files only when Claude Code is installed
- syncs the templates during package publishing so project creation continues to work offline
- preserves existing project-owned agent files

## Validation

- generate a project from `default@sdk-57` and verified the `AGENTS.md` is coming from llm-configs repo