### PR TITLE
[tools] Fix stale template tarballs

### DIFF
--- a/tools/src/Npm.test.ts
+++ b/tools/src/Npm.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { packToTarballAsync } from './Npm';
+
+describe('packToTarballAsync', () => {
+  let packageDir: string;
+
+  beforeEach(async () => {
+    packageDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'expotools-pack-test-'));
+    await fs.promises.writeFile(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: 'pack-fixture', version: '2.0.0' })
+    );
+    await fs.promises.writeFile(path.join(packageDir, 'index.js'), '');
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(packageDir, { recursive: true, force: true });
+  });
+
+  it('returns the tarball it has just created', async () => {
+    const result = await packToTarballAsync(packageDir);
+
+    assert.equal(result.name, 'pack-fixture');
+    assert.equal(result.version, '2.0.0');
+    assert.equal(path.basename(result.filePath), 'pack-fixture-2.0.0.tgz');
+    assert.ok(fs.existsSync(result.filePath));
+  });
+
+  it('ignores tarballs left in the package directory by earlier packs', async () => {
+    await fs.promises.writeFile(path.join(packageDir, 'pack-fixture-1.0.0.tgz'), '');
+
+    const result = await packToTarballAsync(packageDir);
+
+    assert.equal(path.basename(result.filePath), 'pack-fixture-2.0.0.tgz');
+    assert.ok(fs.statSync(result.filePath).size > 0);
+  });
+
+  it('does not write the tarball into the package directory', async () => {
+    await packToTarballAsync(packageDir);
+
+    const entries = await fs.promises.readdir(packageDir);
+    assert.deepEqual(
+      entries.filter((entry) => entry.endsWith('.tgz')),
+      []
+    );
+  });
+});

--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import os from 'os';
 import path from 'path';
 
 import { spawnAsync, spawnJSONCommandAsync, SpawnOptions } from './Utils';
@@ -47,7 +48,8 @@ export type ProfileType = null | {
 export type PackResult = {
   name: string;
   version: string;
-  filename: string;
+  /** Absolute path to the created tarball. */
+  filePath: string;
   files: { path: string }[];
 };
 
@@ -101,29 +103,35 @@ export async function downloadPackageTarballAsync(
 }
 
 /**
- * Creates a tarball from a package.
+ * Creates a tarball from a package. The returned `filePath` points into a temporary directory.
  *
  * We deliberately don't use `pnpm pack --json` here: pnpm prefixes the JSON
  * output with `prepack`/`prepare` lifecycle script stdout, which breaks
- * `JSON.parse` for packages that define those scripts. Instead we let `pnpm pack` write the
- * tarball to the package directory and discover the produced file via glob,
- * matching what is done by `downloadPackageTarballAsync` above.
+ * `JSON.parse` for packages that define those scripts. Instead we pack into an empty
+ * directory, so the tarball we just created is the only file we can find there.
+ * Packing into the package directory would be ambiguous: publish runs that fail before
+ * the cleanup step leave their tarballs behind, and we cannot tell those apart from a
+ * fresh one.
  */
 export async function packToTarballAsync(packageDir: string): Promise<PackResult> {
-  await spawnAsync('pnpm', ['pack'], {
+  const destination = await fs.mkdtemp(path.join(os.tmpdir(), 'expotools-pack-'));
+
+  await spawnAsync('pnpm', ['pack', '--pack-destination', destination], {
     cwd: packageDir,
     stdio: 'ignore',
     // Prevent expo-module-scripts from auto-adding --watch during lifecycle scripts
     env: { ...process.env, EXPO_NONINTERACTIVE: '1' },
   });
 
-  const tarballs = await glob('*.tgz', { cwd: packageDir });
-  if (tarballs.length === 0) {
-    throw new Error(`pnpm pack did not produce a tarball in ${packageDir}`);
+  const tarballs = await glob('*.tgz', { cwd: destination, absolute: true });
+  if (tarballs.length !== 1) {
+    throw new Error(
+      `Expected \`pnpm pack\` to produce exactly one tarball for ${packageDir} in ${destination}, found ${tarballs.length}.`
+    );
   }
 
   const { name, version } = require(path.join(packageDir, 'package.json'));
-  return { name, version, filename: tarballs[0], files: [] };
+  return { name, version, filePath: tarballs[0], files: [] };
 }
 
 type PublishOptions = {

--- a/tools/src/publish-packages/tasks/addTemplateTarball.ts
+++ b/tools/src/publish-packages/tasks/addTemplateTarball.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 
-import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { TEMPLATES_DIR } from '../../Constants';
 import { packToTarballAsync } from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { Parcel, TaskArgs } from '../types';
+import { selectPackagesToPublish } from './selectPackagesToPublish';
 
 /**
  * Add template tarball to Expo package.
@@ -31,10 +31,7 @@ export const addTemplateTarball = new Task<TaskArgs>(
 
         const tarballDestinationPath = path.join(expoPackage.pkg.path, 'template.tgz');
         await fs.promises.rm(tarballDestinationPath, { force: true });
-        await fs.promises.copyFile(
-          path.join(templatePath, templateTarball.filename),
-          tarballDestinationPath
-        );
+        await fs.promises.copyFile(templateTarball.filePath, tarballDestinationPath);
       },
       'Copied template tarball to Expo package'
     );

--- a/tools/src/publish-packages/tasks/packPackageToTarball.ts
+++ b/tools/src/publish-packages/tasks/packPackageToTarball.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
 
-import { loadRequestedParcels } from './loadRequestedParcels';
 import logger from '../../Logger';
 import { packToTarballAsync } from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { Parcel, TaskArgs } from '../types';
+import { loadRequestedParcels } from './loadRequestedParcels';
 
 /**
  * Runs `npm pack` on each package to prepare tarballs to publish.
@@ -25,7 +25,7 @@ export const packPackageToTarball = new Task<TaskArgs>(
 
             const packResult = await packToTarballAsync(pkg.path);
 
-            state.packageTarballFilename = packResult.filename;
+            state.packageTarballPath = packResult.filePath;
           }
           // eslint-disable-next-line no-useless-return
           return;

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -1,9 +1,9 @@
-import { BACKUPABLE_OPTIONS_FIELDS } from './constants';
 import { Changelog, ChangelogChanges } from '../Changelogs';
 import { GitLog, GitFileLog, GitDirectory } from '../Git';
 import { PackageViewType } from '../Npm';
 import { Package } from '../Packages';
 import { PackagesGraphNode } from '../packages-graph';
+import { BACKUPABLE_OPTIONS_FIELDS } from './constants';
 
 /**
  * Command's options.
@@ -85,9 +85,9 @@ export type PublishState = {
   isRequested?: boolean;
 
   /**
-   * Name of the tarball the package was packed to.
+   * Path to the tarball the package was packed to.
    */
-  packageTarballFilename?: string;
+  packageTarballPath?: string;
 };
 
 export type BaseParcel<State> = {


### PR DESCRIPTION
# Why
In a clean 57 project we are seeing a warning about not using the recommended react native version. This is incorrect. Prebuild reads its recommended versions from expo/template.tgz, a tarball of expo-template-bare-minimum bundled inside the expo package.

The tarball was stale because `packToTarballAsync` packed the template in place, then globbed the package directory and took the first *.tgz it found. That directory also accumulates tarballs from earlier publish runs, because `cleanWorkingTree` deletes them only at the very end of a successful publish. Every run that aborts leaves one behind.

# How
pnpm pack now writes into a fresh empty temporary directory, so the tarball we just created is the only candidate. PackResult.filename becomes filePath and carries an absolute path, which also removes the need for callers to rebuild the path themselves. The guard changes from at least one to exactly one, so an ambiguous result fails loudly instead of silently picking a stale file.

# Test Plan
Added tests
Ran on the 57 branch where I have 24 stale artifacts. The correct one is selected.
