### PR TITLE
[updates][android] Self-heal an update whose launch asset was never registered

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix devices getting permanently stuck in emergency launch after the embedded update is registered only partially. An update row whose `launch_asset_id` is missing is now excluded from launchable updates and is no longer treated as `READY`, so the loader re-runs and repairs it instead of `DatabaseLauncher` throwing "Launch asset not found for update" on every cold start. ([#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
 - [iOS] Set `always_out_of_date` on the `Generate updates resources for expo-updates` script_phase to silence the Xcode "run script phase will run on every build" dependency-analysis warning. ([#47622](https://github.com/expo/expo/pull/47622) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -10,8 +10,10 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.spyk
@@ -89,5 +91,66 @@ class DatabaseLauncherTest {
       "new lastAccessed date should be within 1000 ms of now",
       Date().time - sameUpdate.lastAccessed.time < 1000
     )
+  }
+
+  @Test
+  fun testGetLaunchableUpdate_SkipsUpdateWithMissingLaunchAsset() = runTest {
+    val configuration = testConfiguration()
+
+    val completeUpdate = readyUpdate(configuration.scopeKey, Date(1000))
+    db.updateDao().insertUpdate(completeUpdate)
+    db.assetDao().insertAssets(listOf(launchAssetEntity()), completeUpdate)
+
+    // newer, but its launch asset was never registered -- launching it would throw
+    val incompleteUpdate = readyUpdate(configuration.scopeKey, Date(2000))
+    db.updateDao().insertUpdate(incompleteUpdate)
+
+    val launchableUpdate = databaseLauncher(configuration).getLaunchableUpdate(db)
+
+    Assert.assertEquals(completeUpdate.id, launchableUpdate?.id)
+  }
+
+  @Test
+  fun testGetLaunchableUpdate_NullWhenEveryUpdateIsMissingItsLaunchAsset() = runTest {
+    val configuration = testConfiguration()
+
+    val incompleteUpdate = readyUpdate(configuration.scopeKey, Date(1000))
+    db.updateDao().insertUpdate(incompleteUpdate)
+
+    Assert.assertNull(databaseLauncher(configuration).getLaunchableUpdate(db))
+  }
+
+  private fun testConfiguration() = UpdatesConfiguration(
+    null,
+    mapOf(
+      "updateUrl" to Uri.parse("https://example.com"),
+      "runtimeVersion" to "1.0",
+      "hasEmbeddedUpdate" to false
+    )
+  )
+
+  private fun databaseLauncher(configuration: UpdatesConfiguration) = DatabaseLauncher(
+    context,
+    configuration,
+    File("test"),
+    mockk(),
+    SelectionPolicyFactory.createFilterAwarePolicy("1.0", configuration),
+    UpdatesLogger(context.filesDir),
+    TestScope()
+  )
+
+  private fun readyUpdate(scopeKey: String, commitTime: Date) = UpdateEntity(
+    UUID.randomUUID(),
+    commitTime,
+    "1.0",
+    scopeKey,
+    JSONObject("{}"),
+    null,
+    null
+  ).apply { status = UpdateStatus.READY }
+
+  private fun launchAssetEntity() = AssetEntity("bundle-1234", "js").apply {
+    relativePath = "bundle-1234"
+    isLaunchAsset = true
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -265,6 +265,11 @@ class EmbeddedLoaderTest {
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
 
+    val launchAsset = AssetEntity("bundle-1234", "js")
+    launchAsset.relativePath = "bundle-1234"
+    launchAsset.isLaunchAsset = true
+    db.assetDao().insertAssets(listOf(launchAsset), update)
+
     val result = loader.load { _ ->
       Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
     }
@@ -275,6 +280,39 @@ class EmbeddedLoaderTest {
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
     Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+
+    // short-circuited, so the manifest's assets were never registered
+    Assert.assertEquals(1, db.assetDao().loadAllAssets().size.toLong())
+  }
+
+  @Test
+  @Throws(IOException::class, NoSuchAlgorithmException::class)
+  fun testEmbeddedLoader_UpdateExists_ReadyButMissingLaunchAsset() = runTest {
+    val update = UpdateEntity(
+      manifest.updateEntity!!.id,
+      manifest.updateEntity!!.commitTime,
+      manifest.updateEntity!!.runtimeVersion,
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest,
+      null,
+      null
+    )
+    update.status = UpdateStatus.READY
+    db.updateDao().insertUpdate(update)
+
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
+
+    val updates = db.updateDao().loadAllUpdates()
+    Assert.assertEquals(1, updates.size.toLong())
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+
+    // the incomplete row is repaired rather than short-circuited
+    Assert.assertNotNull(db.updateDao().loadLaunchAssetForUpdate(update.id))
+    Assert.assertEquals(2, db.assetDao().loadAllAssets().size.toLong())
   }
 
   @Test

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -161,6 +161,18 @@ class DatabaseLauncher(
       if (!configuration.hasEmbeddedUpdate && embeddedUpdate?.updateEntity?.id == update.id) {
         continue
       }
+
+      // An update whose launch asset is missing can never launch -- launch() would throw and the
+      // app would fall back to an emergency launch on every cold start. This happens when the
+      // process is killed between Loader's insertUpdate and insertAssets calls, or when the launch
+      // asset row is deleted out from under the update. Excluding it here lets LoaderTask see a
+      // newer embedded update (or none at all) and re-run the loader, which repairs the row.
+      if (update.status != UpdateStatus.DEVELOPMENT &&
+        database.updateDao().loadLaunchAssetForUpdate(update.id) == null
+      ) {
+        logger.warn("Skipping launchable update with no launch asset. Debug info: ${update.debugInfo()}")
+        continue
+      }
       filteredLaunchableUpdates.add(update)
     }
     val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -164,7 +164,12 @@ abstract class Loader protected constructor(
       database.updateDao().setUpdateScopeKey(existingUpdateEntity, newUpdateEntity.scopeKey)
     }
 
-    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
+    // A READY update whose launch asset is missing is not actually ready -- it can only have got
+    // that way through a partial write or a deleted asset row, and short-circuiting here would
+    // leave it broken forever. Fall through to downloadAllAssets so the assets are re-registered.
+    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY &&
+      database.updateDao().loadLaunchAssetForUpdate(existingUpdateEntity.id) != null
+    ) {
       // hooray, we already have this update downloaded and ready to go!
       updateEntity = existingUpdateEntity
       return finish()


### PR DESCRIPTION
# Why

`Loader` registers an update in two steps. `insertUpdate` ([Loader.kt#L175](https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt#L175)) writes the row with a NULL `launch_asset_id`, and only after every asset has been processed do `insertAssets` + `markUpdateFinished` ([Loader.kt#L256-L257](https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt#L256-L257)) set the launch asset and mark the update `READY`.

If the process is killed in between, the row is left unlaunchable — and nothing ever repairs it:

1. `DatabaseLauncher.getLaunchableUpdate()` still returns it: `EMBEDDED` is a launchable status and the row belongs to the current binary, so neither existing guard rejects it.
2. `LoaderTask.launchFallbackUpdateFromDisk` therefore calls `shouldLoadNewUpdate(embeddedUpdate, launchableUpdate)` with the broken row as `launchableUpdate` — identical commit time, so it returns `false` and `EmbeddedLoader` never re-runs.
3. `DatabaseLauncher.launch` then throws `Launch asset not found for update; this should never happen`, and with `checkAutomatically: NEVER` `LoaderTask.start` routes straight to emergency launch instead of `launchRemoteUpdate()`.

From then on the device emergency-launches on **every** cold start and is permanently pinned to the JS embedded in the binary — it can never apply an update again.

We hit this in production across **~2,027 Android users / 9.1k events in 30 days**, growing with each binary release. Every report carries `status: EMBEDDED`, which can only occur *before* `markUpdateFinished` runs (a completed load marks the row `READY`), and there is exactly one update id per binary release — always that binary's own embedded update. The population skews to `device.class: low` (75%) and backgrounded processes (85%), which is consistent with the process being killed mid-registration. Zero iOS occurrences.

A `READY` row can reach an equivalent state if the asset its `launch_asset_id` points at is removed, so both fast paths are guarded.

Same root cause as #46741 (closed automatically for lacking a repro).

# How

Two guards, both of which simply stop hiding the problem from the *existing* repair path:

- **`DatabaseLauncher.getLaunchableUpdate`** — skip a non-`DEVELOPMENT` update with no launch asset. `LoaderTask` then sees a newer embedded update (or none at all) and re-runs the loader.
- **`Loader.processUpdate`** — don't short-circuit on `status == READY` when the launch asset is missing, so the row falls through to `downloadAllAssets`.

`downloadAllAssets` already handles a partially-registered update (`existingUpdateEntity != null` → re-download all assets), so it re-registers the assets and rewrites `launch_asset_id`. Net effect: one bad launch instead of a permanent one.

`DEVELOPMENT` updates are exempt from the first guard — they legitimately have no launch asset ([Loader.kt#L144-L152](https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt#L144-L152)).

This is deliberately a recovery fix rather than a rewrite of the registration into a single transaction: the two writes are separated by all of the asset downloading, so making them atomic is a much larger change. Recovery also helps the databases that are already broken in the field, which an atomicity fix alone would not.

# Test Plan

New instrumentation tests:

- `DatabaseLauncherTest.testGetLaunchableUpdate_SkipsUpdateWithMissingLaunchAsset` — a newer update with no launch asset must not be selected over an older complete one. Fails on `main` (the newer broken row wins, and `launch()` would throw).
- `DatabaseLauncherTest.testGetLaunchableUpdate_NullWhenEveryUpdateIsMissingItsLaunchAsset` — returns `null` so `LoaderTask` re-runs the loader.
- `EmbeddedLoaderTest.testEmbeddedLoader_UpdateExists_ReadyButMissingLaunchAsset` — a `READY` row with no launch asset is repaired: assets registered and `launch_asset_id` set.

`EmbeddedLoaderTest.testEmbeddedLoader_UpdateExists_Ready` also now inserts a launch asset for the pre-existing update, so it genuinely exercises the `READY` short-circuit (previously the row it inserted had no assets at all, i.e. exactly the broken state), and asserts the manifest's assets are *not* re-registered.

Reproducing the field failure directly, on an API-34 AOSP emulator:

```bash
adb root
adb shell "sqlite3 /data/data/<applicationId>/databases/updates.db \
  'UPDATE updates SET launch_asset_id = NULL, status = 5;'"
adb shell am force-stop <applicationId> && adb shell monkey -p <applicationId> 1
```

Before: `Launch asset not found for update; this should never happen`, and the row stays `5 | NULL` on every subsequent launch. After: the update relaunches normally and the row reads `status = 1` with a non-null `launch_asset_id`. Same with `status = 1` for the dangling-asset variant.

# Checklist

- [x] Documented changes in `CHANGELOG.md`
- [ ] iOS parity — `AppLauncherWithDatabase.launchableUpdate` and `AppLoader` have the identical two-phase shape and the same missing guards, so the bug is latent there too (we have no iOS occurrences in production). It needs a new `launchAsset(withUpdateId:)` query on `UpdatesDatabase`, which I left out rather than ship untested. Happy to add it here or in a follow-up — let me know which you'd prefer.