### PR TITLE
[fingerprint] Hash the font file an expo-font family declares once

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added a `package` source type that hashes a dependency by its `package.json` name and version. ([#47667](https://github.com/expo/expo/pull/47667) by [@kudo](https://github.com/kudo))
 - Added fingerprint presets (`strict`, `balanced`, `relaxed`), selectable via `preset` in **fingerprint.config.js** or the `--preset` CLI flag. ([#47668](https://github.com/expo/expo/pull/47668) by [@kudo](https://github.com/kudo))
 - Added `SourceSkips.EasJson` and `SourceSkips.Easignore` to exclude `eas.json` and `.easignore` from fingerprints. ([#48586](https://github.com/expo/expo/pull/48586) by [@kudo](https://github.com/kudo))
+- Hash the font file an `expo-font` Android family declares once for all of its definitions, as done with variable fonts. ([#48737](https://github.com/expo/expo/pull/48737) by [@vonovak](https://github.com/vonovak))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/fingerprint/src/sourcer/Expo.ts
+++ b/packages/@expo/fingerprint/src/sourcer/Expo.ts
@@ -46,9 +46,11 @@ export async function getExpoConfigSourcesAsync(
     'expo-splash-screen'
   );
   const fontPluginProps = getConfigPluginProps<{
-    // Type mirrors FontProps from expo-font/plugin/src/withFonts.ts
+    // Type mirrors FontProps from expo-font/plugin/src/withFonts.ts and must stay in sync with it
     fonts?: string[];
-    android?: { fonts?: (string | { fontDefinitions: { path: string }[] })[] };
+    android?: {
+      fonts?: (string | { path?: string; fontDefinitions: { path?: string }[] })[];
+    };
     ios?: { fonts?: string[] };
   }>(expoConfig, 'expo-font');
 
@@ -58,7 +60,11 @@ export async function getExpoConfigSourcesAsync(
     ...(isIos ? (fontPluginProps?.ios?.fonts ?? []) : []),
     ...(isAndroid
       ? (fontPluginProps?.android?.fonts ?? []).flatMap((f) =>
-          typeof f === 'string' ? [f] : (f.fontDefinitions ?? []).map((d) => d.path)
+          typeof f === 'string'
+            ? [f]
+            : // When a variable font file backs several definitions,
+              // a family may name the file path once instead of each definition repeating it
+              (f.fontDefinitions ?? []).map((d) => d.path ?? f.path)
         )
       : []),
 

--- a/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
+++ b/packages/@expo/fingerprint/src/sourcer/__tests__/Expo-test.ts
@@ -424,6 +424,8 @@ describe(getExpoConfigSourcesAsync, () => {
         'assets/fonts/SF-Pro.ttf': 'sf pro data',
         'assets/fonts/Roboto-Regular.ttf': 'roboto regular data',
         'assets/fonts/Roboto-Bold.ttf': 'roboto bold data',
+        'assets/fonts/RobotoFlex.ttf': 'roboto flex data',
+        'assets/fonts/RobotoFlex-Italic.ttf': 'roboto flex italic data',
       };
       const pluginProps = {
         fonts: ['./assets/fonts/SpaceMono-Regular.ttf'],
@@ -437,6 +439,17 @@ describe(getExpoConfigSourcesAsync, () => {
                 { path: './assets/fonts/Roboto-Bold.ttf', weight: 700 },
               ],
             },
+            {
+              // A family may name its file once instead of each definition repeating it.
+              fontFamily: 'Roboto Flex',
+              path: './assets/fonts/RobotoFlex.ttf',
+              fontDefinitions: [
+                { weight: 400 },
+                { weight: 700, axes: { wght: 650 } },
+                // A definition may still name a file of its own.
+                { path: './assets/fonts/RobotoFlex-Italic.ttf', weight: 400, style: 'italic' },
+              ],
+            },
           ],
         },
       };
@@ -446,11 +459,14 @@ describe(getExpoConfigSourcesAsync, () => {
       expectFontSource(iosSources, 'assets/fonts/SF-Pro.ttf');
       expectNoFontSource(iosSources, 'assets/fonts/Roboto-Regular.ttf');
       expectNoFontSource(iosSources, 'assets/fonts/Roboto-Bold.ttf');
+      expectNoFontSource(iosSources, 'assets/fonts/RobotoFlex.ttf');
 
       const androidSources = await getFontSources(files, pluginProps, 'android');
       expectFontSource(androidSources, 'assets/fonts/SpaceMono-Regular.ttf');
       expectFontSource(androidSources, 'assets/fonts/Roboto-Regular.ttf');
       expectFontSource(androidSources, 'assets/fonts/Roboto-Bold.ttf');
+      expectFontSource(androidSources, 'assets/fonts/RobotoFlex.ttf');
+      expectFontSource(androidSources, 'assets/fonts/RobotoFlex-Italic.ttf');
       expectNoFontSource(androidSources, 'assets/fonts/SF-Pro.ttf');
     });
 

--- a/packages/expo-font/plugin/src/withFonts.ts
+++ b/packages/expo-font/plugin/src/withFonts.ts
@@ -48,6 +48,9 @@ export type FontObject = {
 
 export type Font = string | FontObject;
 
+// NOTE(@vonovak): `@expo/fingerprint` reads these props to hash the font files this plugin embeds
+// (see `getExpoConfigSourcesAsync` in `packages/@expo/fingerprint/src/sourcer/Expo.ts`).
+// When a new way to declare a font file path is added here, teach the sourcer to read it too.
 export type FontProps = {
   /**
    * An array of font file paths to link to the native project, relative to the project root.


### PR DESCRIPTION
PR 2/2 in a stack. Stacked on #48621, which adds the syntax this PR teaches the fingerprint to read.

# Why

`expo-font` lets an Android family name its font file once instead of each definition repeating it, the shape one variable font takes when it backs several definitions:

```json
{
  "fontFamily": "Roboto Flex",
  "path": "./assets/fonts/RobotoFlex.ttf",
  "fontDefinitions": [{ "weight": 400 }, { "weight": 700, "axes": { "wght": 650 } }]
}
```

The Expo config sourcer previously read the file path from the definition only.

# How

`getExpoConfigSourcesAsync` now falls back to the family's `path` when a definition declares none: `(f.fontDefinitions ?? []).map((d) => d.path ?? f.path)`. 

# Test Plan

expanded unit test in `src/sourcer/__tests__/Expo-test.ts`


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
