### PR TITLE
[submit-expo-feedback] remove user metadata

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -7,7 +7,6 @@ import packageJson from '../../package.json';
 import {
   createFeedbackMetadataAsync,
   getProjectMetadata,
-  getUserMetadataAsync,
   resolveFeedbackAsync,
   resolveFeedbackId,
   runExpoFeedbackAsync,
@@ -84,6 +83,9 @@ describe('help output', () => {
       expect(helpOutput).toContain('Feedback messages can be up to 5,000 characters.');
       expect(helpOutput).toContain(
         'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected'
+      );
+      expect(helpOutput).toContain(
+        'Authenticated submissions are associated\n    with your Expo account.'
       );
     } finally {
       process.argv = originalArgv;
@@ -260,7 +262,6 @@ describe('project metadata', () => {
     await expect(
       createFeedbackMetadataAsync(
         projectRoot,
-        null,
         'docs',
         ' https://docs.expo.dev/router/introduction/ '
       )
@@ -277,37 +278,9 @@ describe('project metadata', () => {
       version: '1.0.0',
     });
 
-    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'docs', '   ');
+    const metadata = await createFeedbackMetadataAsync(projectRoot, 'docs', '   ');
 
     expect(metadata).not.toHaveProperty('subject');
-  });
-});
-
-describe('user metadata', () => {
-  it('includes username and id from the local session state', async () => {
-    await expect(
-      getUserMetadataAsync({
-        sessionSecret: 'secret',
-        userId: 'user-id',
-        username: 'expo-user',
-      })
-    ).resolves.toEqual({
-      authType: 'session',
-      id: 'user-id',
-      username: 'expo-user',
-    });
-  });
-
-  it('does not shell out to expo whoami when username is missing', async () => {
-    await expect(
-      getUserMetadataAsync({
-        sessionSecret: 'secret',
-        userId: 'user-id',
-      })
-    ).resolves.toEqual({
-      authType: 'session',
-      id: 'user-id',
-    });
   });
 });
 
@@ -346,10 +319,8 @@ describe('feedback submission', () => {
     jest.spyOn(AbortSignal, 'timeout').mockReturnValue(timeoutSignal);
     const session = {
       sessionSecret: 'session-secret',
-      userId: 'user-id',
-      username: 'expo-user',
     };
-    const metadata = await createFeedbackMetadataAsync(projectRoot, session, 'mcp', 'expo-mcp');
+    const metadata = await createFeedbackMetadataAsync(projectRoot, 'mcp', 'expo-mcp');
 
     await sendFeedbackAsync({
       feedback: 'please make errors clearer',
@@ -393,12 +364,8 @@ describe('feedback submission', () => {
       project: {
         isExpoProject: false,
       },
-      user: {
-        authType: 'session',
-        id: 'user-id',
-        username: 'expo-user',
-      },
     });
+    expect(metadata).not.toHaveProperty('user');
   });
 
   it('does not submit feedback over the maximum length', async () => {

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -31,8 +31,6 @@ const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 type UserSession = {
   sessionSecret?: string;
-  userId?: string;
-  username?: string;
 };
 
 type PackageJson = {
@@ -96,7 +94,6 @@ async function runAsync(): Promise<void> {
   const session = telemetryDisabled ? null : getSession();
   const metadata = await createFeedbackMetadataAsync(
     process.cwd(),
-    session,
     category,
     args['--subject'],
     args['--resume']
@@ -113,7 +110,7 @@ async function runAsync(): Promise<void> {
     chalk.dim(
       telemetryDisabled
         ? 'Submitting feedback without telemetry data because telemetry collection is disabled.'
-        : 'Submitting feedback with available agent, sandbox, environment, project, and Expo account metadata.'
+        : 'Submitting feedback with detected agent, sandbox, environment, and project metadata. Authenticated submissions are associated with your Expo account.'
     )
   );
   await sendFeedbackAsync({
@@ -186,7 +183,6 @@ export async function resolveFeedbackAsync(
 
 export async function createFeedbackMetadataAsync(
   projectRoot: string,
-  session?: UserSession | null,
   category: CliFeedbackCategory = 'unknown',
   subjectValue?: string,
   feedbackIdValue?: string
@@ -202,7 +198,6 @@ export async function createFeedbackMetadataAsync(
   if (isTelemetryDisabled()) {
     return context;
   }
-  const resolvedSession = session === undefined ? getSession() : session;
 
   return {
     ...context,
@@ -227,7 +222,6 @@ export async function createFeedbackMetadataAsync(
     },
     packageManager: resolvePackageManager(projectRoot),
     project: getProjectMetadata(projectRoot),
-    user: await getUserMetadataAsync(resolvedSession),
   };
 }
 
@@ -251,29 +245,6 @@ function getSandboxEnvironment(): CliFeedbackTelemetryMetadata['sandboxEnvironme
         sandbox: result.sandbox,
       }
     : { detected: false };
-}
-
-export async function getUserMetadataAsync(
-  session: UserSession | null
-): Promise<CliFeedbackTelemetryMetadata['user']> {
-  const authType = process.env.EXPO_TOKEN ? 'token' : session?.sessionSecret ? 'session' : null;
-  if (!authType) {
-    return undefined;
-  }
-
-  const username = session?.username;
-  if (username) {
-    return {
-      id: session?.userId,
-      username,
-      authType,
-    };
-  }
-
-  return {
-    id: session?.userId,
-    authType,
-  };
 }
 
 export function getProjectMetadata(projectRoot: string): CliFeedbackProjectMetadata {
@@ -473,8 +444,9 @@ function printHelp(): void {
     Feedback messages can be up to ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.
 
   {bold Data collection}
-    Feedback includes available agent/session identifiers, sandbox and environment
-    details, Expo project metadata, and Expo account identifiers.
+    Feedback includes detected agent, sandbox and environment
+    details, and Expo project metadata. Authenticated submissions are associated
+    with your Expo account.
     Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected
     metadata and authentication.
 

--- a/packages/submit-expo-feedback/src/index.ts
+++ b/packages/submit-expo-feedback/src/index.ts
@@ -10,7 +10,6 @@ export type {
   CliFeedbackRequest,
   CliFeedbackSandboxEnvironment,
   CliFeedbackTelemetryMetadata,
-  CliFeedbackUserMetadata,
 } from './types';
 
 runExpoFeedbackAsync().catch(logErrorAndExit);

--- a/packages/submit-expo-feedback/src/types.ts
+++ b/packages/submit-expo-feedback/src/types.ts
@@ -52,16 +52,6 @@ export type CliFeedbackProjectMetadata =
       expoRouterPackageVersion?: string;
     };
 
-/**
- * Expo account identifiers. Consumers must treat these fields as personal data and remove them
- * before storing metadata with external processors.
- */
-export type CliFeedbackUserMetadata = {
-  id?: string;
-  username?: string;
-  authType: 'token' | 'session';
-};
-
 export type CliFeedbackTelemetryMetadata = {
   cli: {
     name: 'submit-expo-feedback';
@@ -82,7 +72,6 @@ export type CliFeedbackTelemetryMetadata = {
   };
   packageManager: string | null;
   project: CliFeedbackProjectMetadata;
-  user?: CliFeedbackUserMetadata;
 };
 
 export type CliFeedbackMetadata =


### PR DESCRIPTION
Removes Expo account identifiers from `submit-expo-feedback` metadata so the Universe endpoint relies on request authentication instead of duplicated user fields.