### PR TITLE
fix(cli): Set NODE_ENV before loading env files

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Use the Expo command mode to set `NODE_ENV` and load **.env** files.
 - Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Use the Expo command mode to set `NODE_ENV` and load **.env** files.
+- Use the Expo command mode to set `NODE_ENV` and load **.env** files. ([#48741](https://github.com/expo/expo/pull/48741) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Make browser-based login the default for `expo login`. Use `--no-browser` (or pass `--username`/`--password`) for username/password login. Non-interactive environments such as CI continue to use username/password login. ([#46832](https://github.com/expo/expo/pull/46832) by [@byronkarlen](https://github.com/byronkarlen))
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
 

--- a/packages/@expo/cli/e2e/__tests__/config-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/config-test.ts
@@ -18,9 +18,16 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/config').expoConfig`);
   expect(modules).toStrictEqual([
+    expect.stringMatching(/\/2g\/dist\/2g\.js$/),
+    expect.stringMatching(/\/2g\/dist\/chunks\/pretty-chunk\.js$/),
+    expect.stringMatching(/\/2g\/dist\/chunks\/sessionSockets-chunk\.js$/),
     '@expo/cli/build/src/config/index.js',
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/env.js',
+    '@expo/cli/build/src/utils/errors.js',
+    '@expo/cli/build/src/utils/interactive.js',
+    '@expo/cli/build/src/utils/nodeEnv.js',
   ]);
 });
 

--- a/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/prebuild-test.ts
@@ -30,9 +30,16 @@ afterAll(() => {
 it('loads expected modules by default', async () => {
   const modules = await getLoadedModulesAsync(`require('../../build/src/prebuild').expoPrebuild`);
   expect(modules).toStrictEqual([
+    expect.stringMatching(/\/2g\/dist\/2g\.js$/),
+    expect.stringMatching(/\/2g\/dist\/chunks\/pretty-chunk\.js$/),
+    expect.stringMatching(/\/2g\/dist\/chunks\/sessionSockets-chunk\.js$/),
     '@expo/cli/build/src/log.js',
     '@expo/cli/build/src/prebuild/index.js',
     '@expo/cli/build/src/utils/args.js',
+    '@expo/cli/build/src/utils/env.js',
+    '@expo/cli/build/src/utils/errors.js',
+    '@expo/cli/build/src/utils/interactive.js',
+    '@expo/cli/build/src/utils/nodeEnv.js',
   ]);
 });
 

--- a/packages/@expo/cli/src/config/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/config/__tests__/index-test.ts
@@ -1,0 +1,77 @@
+import { expoConfig } from '../index';
+
+jest.mock('../../utils/args', () => ({
+  assertArgs: jest.fn(() => ({ '--help': false })),
+  getProjectRoot: jest.fn(() => '/app'),
+  printHelp: jest.fn(),
+}));
+jest.mock(
+  '../../utils/nodeEnv.js',
+  () => ({
+    getConfigEnvMode: jest.fn(() => 'development'),
+    loadEnvFiles: jest.fn(),
+  }),
+  {
+    virtual: true,
+  }
+);
+jest.mock('../../utils/errors.js', () => ({ logCmdError: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../configAsync.js', () => ({ configAsync: jest.fn(async () => {}) }), {
+  virtual: true,
+});
+
+const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
+  loadEnvFiles: jest.Mock;
+};
+const { getConfigEnvMode } = require('../../utils/nodeEnv.js') as {
+  getConfigEnvMode: jest.Mock;
+};
+const { assertArgs } = require('../../utils/args') as {
+  assertArgs: jest.Mock;
+};
+const { configAsync } = require('../configAsync.js') as {
+  configAsync: jest.Mock;
+};
+
+describe('config mode', () => {
+  beforeEach(() => {
+    getConfigEnvMode.mockReturnValue('development');
+    assertArgs.mockReturnValue({ '--help': false });
+  });
+
+  it('loads development env files before evaluating config', async () => {
+    await expoConfig([]);
+
+    expect(loadEnvFiles).toHaveBeenCalledWith(
+      '/app',
+      expect.objectContaining({ mode: 'development' })
+    );
+    expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+      configAsync.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it('uses the production mode from EXPO_CONFIG_MODE', async () => {
+    getConfigEnvMode.mockReturnValue('production');
+
+    await expoConfig([]);
+
+    expect(loadEnvFiles).toHaveBeenCalledWith(
+      '/app',
+      expect.objectContaining({ mode: 'production' })
+    );
+  });
+
+  it('silences env output with --json', async () => {
+    assertArgs.mockReturnValue({ '--help': false, '--json': true });
+
+    await expoConfig([]);
+
+    expect(loadEnvFiles).toHaveBeenCalledWith('/app', {
+      mode: 'development',
+      silent: true,
+    });
+  });
+});

--- a/packages/@expo/cli/src/config/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/config/__tests__/index-test.ts
@@ -5,27 +5,19 @@ jest.mock('../../utils/args', () => ({
   getProjectRoot: jest.fn(() => '/app'),
   printHelp: jest.fn(),
 }));
-jest.mock(
-  '../../utils/nodeEnv.js',
-  () => ({
-    getConfigEnvMode: jest.fn(() => 'development'),
-    loadEnvFiles: jest.fn(),
-  }),
-  {
-    virtual: true,
-  }
-);
-jest.mock('../../utils/errors.js', () => ({ logCmdError: jest.fn() }), {
-  virtual: true,
-});
+jest.mock('../../utils/nodeEnv', () => ({
+  getConfigEnvMode: jest.fn(() => 'development'),
+  loadEnvFiles: jest.fn(),
+}));
+jest.mock('../../utils/errors', () => ({ logCmdError: jest.fn() }));
 jest.mock('../configAsync.js', () => ({ configAsync: jest.fn(async () => {}) }), {
   virtual: true,
 });
 
-const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
+const { loadEnvFiles } = require('../../utils/nodeEnv') as {
   loadEnvFiles: jest.Mock;
 };
-const { getConfigEnvMode } = require('../../utils/nodeEnv.js') as {
+const { getConfigEnvMode } = require('../../utils/nodeEnv') as {
   getConfigEnvMode: jest.Mock;
 };
 const { assertArgs } = require('../../utils/args') as {

--- a/packages/@expo/cli/src/config/configAsync.ts
+++ b/packages/@expo/cli/src/config/configAsync.ts
@@ -5,7 +5,6 @@ import util from 'util';
 
 import * as Log from '../log';
 import { CommandError } from '../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { profile } from '../utils/profile';
 
 type Options = {
@@ -45,9 +44,6 @@ export async function configAsync(projectRoot: string, options: Options) {
     console.warn = function () {};
     console.error = function () {};
   }
-  setNodeEnv('development');
-  loadEnvFiles(projectRoot);
-
   if (options.type) {
     assert.match(options.type, /^(public|prebuild|introspect)$/);
   }

--- a/packages/@expo/cli/src/config/index.ts
+++ b/packages/@expo/cli/src/config/index.ts
@@ -34,17 +34,20 @@ export const expoConfig: Command = async (argv) => {
   }
 
   // Load modules after the help prompt so `npx expo config -h` shows as fast as possible.
-  const [
-    // ./configAsync
-    { configAsync },
-    // ../utils/errors
-    { logCmdError },
-  ] = await Promise.all([import('./configAsync.js'), import('../utils/errors.js')]);
+  const [{ getConfigEnvMode, loadEnvFiles }, { logCmdError }] = await Promise.all([
+    import('../utils/nodeEnv.js'),
+    import('../utils/errors.js'),
+  ]);
 
-  return configAsync(getProjectRoot(args), {
-    // Parsed options
-    full: args['--full'],
-    json: args['--json'],
-    type: args['--type'],
-  }).catch(logCmdError);
+  return (async () => {
+    const projectRoot = getProjectRoot(args);
+    loadEnvFiles(projectRoot, { mode: getConfigEnvMode(), silent: args['--json'] });
+
+    const { configAsync } = await import('./configAsync.js');
+    return configAsync(projectRoot, {
+      full: args['--full'],
+      json: args['--json'],
+      type: args['--type'],
+    });
+  })().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/config/index.ts
+++ b/packages/@expo/cli/src/config/index.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { logCmdError } from '../utils/errors';
+import { getConfigEnvMode, loadEnvFiles } from '../utils/nodeEnv';
 
 export const expoConfig: Command = async (argv) => {
   const args = assertArgs(
@@ -33,16 +35,14 @@ export const expoConfig: Command = async (argv) => {
     );
   }
 
-  // Load modules after the help prompt so `npx expo config -h` shows as fast as possible.
-  const [{ getConfigEnvMode, loadEnvFiles }, { logCmdError }] = await Promise.all([
-    import('../utils/nodeEnv.js'),
-    import('../utils/errors.js'),
-  ]);
-
   return (async () => {
     const projectRoot = getProjectRoot(args);
-    loadEnvFiles(projectRoot, { mode: getConfigEnvMode(), silent: args['--json'] });
+    loadEnvFiles(projectRoot, {
+      mode: getConfigEnvMode(),
+      silent: args['--json'],
+    });
 
+    // Load the config module after the help prompt so `npx expo config -h` shows as fast as possible.
     const { configAsync } = await import('./configAsync.js');
     return configAsync(projectRoot, {
       full: args['--full'],

--- a/packages/@expo/cli/src/customize/customizeAsync.ts
+++ b/packages/@expo/cli/src/customize/customizeAsync.ts
@@ -3,18 +3,17 @@ import { getConfig } from '@expo/config';
 import { getRouterDirectoryModuleIdWithManifest } from '../start/server/metro/router';
 import { getPlatformBundlers } from '../start/server/platformBundlers';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
+import { loadEnvFiles } from '../utils/nodeEnv';
 import { queryAndGenerateAsync, selectAndGenerateAsync } from './generate';
 import type { Options } from './resolveOptions';
 import type { DestinationResolutionProps } from './templates';
 
 export async function customizeAsync(files: string[], options: Options, extras: any[]) {
-  setNodeEnv('development');
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo customize` from a subdirectory of the project.
   const projectRoot = findUpProjectRootOrAssert(process.cwd());
 
-  loadEnvFiles(projectRoot);
+  loadEnvFiles(projectRoot, { mode: 'development' });
 
   // Get the static path (defaults to 'web/')
   // Doesn't matter if expo is installed or which mode is used.

--- a/packages/@expo/cli/src/export/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/index-test.ts
@@ -1,0 +1,41 @@
+import { expoExport } from '../index';
+
+jest.mock('../../utils/nodeEnv.js', () => ({ loadEnvFiles: jest.fn() }), { virtual: true });
+jest.mock('../../utils/resolveArgs.js', () => ({ resolveStringOrBooleanArgsAsync: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../resolveOptions.js', () => ({ resolveOptionsAsync: jest.fn(async () => ({})) }), {
+  virtual: true,
+});
+jest.mock('../exportAsync.js', () => ({ exportAsync: jest.fn(async () => {}) }), {
+  virtual: true,
+});
+
+const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
+  loadEnvFiles: jest.Mock;
+};
+const { resolveStringOrBooleanArgsAsync } = require('../../utils/resolveArgs.js') as {
+  resolveStringOrBooleanArgsAsync: jest.Mock;
+};
+const { resolveOptionsAsync } = require('../resolveOptions.js') as {
+  resolveOptionsAsync: jest.Mock;
+};
+
+beforeEach(() => {
+  resolveStringOrBooleanArgsAsync.mockResolvedValue({
+    projectRoot: '/app',
+    args: { '--source-maps': false },
+  });
+});
+
+it.each([
+  { argv: [], mode: 'production' },
+  { argv: ['--dev'], mode: 'development' },
+])('loads $mode env files before resolving export options', async ({ argv, mode }) => {
+  await expoExport(argv);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    resolveOptionsAsync.mock.invocationCallOrder[0]!
+  );
+});

--- a/packages/@expo/cli/src/export/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/index-test.ts
@@ -1,6 +1,7 @@
 import { expoExport } from '../index';
 
 jest.mock('../../utils/nodeEnv.js', () => ({ loadEnvFiles: jest.fn() }), { virtual: true });
+jest.mock('../../utils/errors', () => ({ logCmdError: jest.fn() }));
 jest.mock('../../utils/resolveArgs.js', () => ({ resolveStringOrBooleanArgsAsync: jest.fn() }), {
   virtual: true,
 });
@@ -14,6 +15,7 @@ jest.mock('../exportAsync.js', () => ({ exportAsync: jest.fn(async () => {}) }),
 const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
   loadEnvFiles: jest.Mock;
 };
+const { logCmdError } = require('../../utils/errors') as { logCmdError: jest.Mock };
 const { resolveStringOrBooleanArgsAsync } = require('../../utils/resolveArgs.js') as {
   resolveStringOrBooleanArgsAsync: jest.Mock;
 };
@@ -38,4 +40,15 @@ it.each([
   expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
     resolveOptionsAsync.mock.invocationCallOrder[0]!
   );
+});
+
+it('handles env file errors', async () => {
+  const error = new Error('env error');
+  loadEnvFiles.mockImplementationOnce(() => {
+    throw error;
+  });
+
+  await expoExport([]);
+
+  expect(logCmdError).toHaveBeenCalledWith(error);
 });

--- a/packages/@expo/cli/src/export/embed/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/export/embed/__tests__/index-test.ts
@@ -1,0 +1,48 @@
+import { expoExportEmbed } from '../index';
+
+jest.mock('../../../utils/args', () => ({
+  assertWithOptionsArgs: jest.fn(() => ({})),
+  printHelp: jest.fn(),
+}));
+jest.mock('../../../utils/nodeEnv.js', () => ({ loadEnvFiles: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../../../utils/errors.js', () => ({ logCmdError: jest.fn() }), { virtual: true });
+jest.mock('../../../utils/resolveArgs.js', () => ({ resolveCustomBooleanArgsAsync: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../resolveOptions.js', () => ({ resolveOptions: jest.fn() }), { virtual: true });
+jest.mock('../exportEmbedAsync.js', () => ({ exportEmbedAsync: jest.fn(async () => {}) }), {
+  virtual: true,
+});
+
+const { loadEnvFiles } = require('../../../utils/nodeEnv.js') as {
+  loadEnvFiles: jest.Mock;
+};
+const { resolveCustomBooleanArgsAsync } = require('../../../utils/resolveArgs.js') as {
+  resolveCustomBooleanArgsAsync: jest.Mock;
+};
+const { resolveOptions } = require('../resolveOptions.js') as {
+  resolveOptions: jest.Mock;
+};
+
+beforeEach(() => {
+  resolveOptions.mockReturnValue({});
+});
+
+it.each([
+  { dev: undefined, mode: 'development' },
+  { dev: false, mode: 'production' },
+])('loads $mode env files before resolving export:embed options', async ({ dev, mode }) => {
+  resolveCustomBooleanArgsAsync.mockResolvedValue({
+    projectRoot: '/app',
+    args: { '--dev': dev },
+  });
+
+  await expoExportEmbed([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    resolveOptions.mock.invocationCallOrder[0]!
+  );
+});

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -29,7 +29,6 @@ import { stripAnsi } from '../../utils/ansi';
 import { copyAsync, removeAsync } from '../../utils/dir';
 import { env } from '../../utils/env';
 import { ensureProcessExitsAfterDelay } from '../../utils/exit';
-import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import { debugEvent } from '../events';
 import { exportDomComponentAsync } from '../exportDomComponents';
 import { isEnableHermesManaged } from '../exportHermes';
@@ -69,9 +68,6 @@ export async function exportEmbedAsync(projectRoot: string, options: Options) {
   if (env.CI && options.resetCache) {
     options.resetCache = false;
   }
-
-  setNodeEnv(options.dev ? 'development' : 'production');
-  loadEnvFiles(projectRoot);
 
   // This is an optimized codepath that can occur during `npx expo run` and does not occur during builds from Xcode or Android Studio.
   // Here we reconcile a bundle pass that was run before the native build process. This order can fail faster and is show better errors since the logs won't be obscured by Xcode and Android Studio.

--- a/packages/@expo/cli/src/export/embed/index.ts
+++ b/packages/@expo/cli/src/export/embed/index.ts
@@ -85,14 +85,7 @@ export const expoExportEmbed: Command = async (argv) => {
     );
   }
 
-  const [
-    { exportEmbedAsync },
-    { resolveOptions },
-    { logCmdError },
-    { resolveCustomBooleanArgsAsync },
-  ] = await Promise.all([
-    import('./exportEmbedAsync.js'),
-    import('./resolveOptions.js'),
+  const [{ logCmdError }, { resolveCustomBooleanArgsAsync }] = await Promise.all([
     import('../../utils/errors.js'),
     import('../../utils/resolveArgs.js'),
   ]);
@@ -109,6 +102,16 @@ export const expoExportEmbed: Command = async (argv) => {
     });
 
     const projectRoot = path.resolve(parsed.projectRoot);
-    return exportEmbedAsync(projectRoot, resolveOptions(projectRoot, args, parsed));
+
+    const { loadEnvFiles } = await import('../../utils/nodeEnv.js');
+    loadEnvFiles(projectRoot, {
+      mode: (parsed.args['--dev'] ?? true) ? 'development' : 'production',
+    });
+
+    const { resolveOptions } = await import('./resolveOptions.js');
+    const options = resolveOptions(projectRoot, args, parsed);
+
+    const { exportEmbedAsync } = await import('./exportEmbedAsync.js');
+    return exportEmbedAsync(projectRoot, options);
   })().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -18,7 +18,6 @@ import { getBaseUrlFromExpoConfig } from '../start/server/middleware/metroOption
 import { createTemplateHtmlFromExpoConfigAsync } from '../start/server/webTemplate';
 import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { type PlatformMetadata, createMetadataJson } from './createMetadataJson';
 import { event } from './events';
 import { exportAssetsAsync } from './exportAssets';
@@ -69,12 +68,6 @@ export async function exportAppAsync(
     | 'hostedNative'
   >
 ): Promise<void> {
-  // Force the environment during export and do not allow overriding it.
-  const environment = dev ? 'development' : 'production';
-  process.env.NODE_ENV = environment;
-  setNodeEnv(environment);
-  loadEnvFiles(projectRoot);
-
   const projectConfig = getConfig(projectRoot);
   const exp = await getPublicExpoManifestAsync(projectRoot, {
     // Web doesn't require validation.

--- a/packages/@expo/cli/src/export/exportStaticAsync.ts
+++ b/packages/@expo/cli/src/export/exportStaticAsync.ts
@@ -208,6 +208,7 @@ export async function exportFromServerAsync(
     files = new Map(),
     exp,
     scriptTags,
+    mode,
   }: Options
 ): Promise<ExportAssetMap> {
   const useServerRendering = exp?.extra?.router?.unstable_useServerRendering ?? false;
@@ -500,7 +501,7 @@ export async function exportFromServerAsync(
       });
     }
   } else {
-    warnPossibleInvalidExportType(appDir);
+    warnPossibleInvalidExportType(appDir, mode);
   }
 
   return files;
@@ -746,7 +747,7 @@ async function exportApiRoutesAsync({
   return files;
 }
 
-function warnPossibleInvalidExportType(appDir: string) {
+function warnPossibleInvalidExportType(appDir: string, mode: Options['mode']) {
   const apiRoutes = getApiRoutesForDirectory(appDir);
   if (apiRoutes.length) {
     // TODO: Allow API Routes for native-only.
@@ -757,7 +758,7 @@ function warnPossibleInvalidExportType(appDir: string) {
     );
   }
 
-  const middlewareFile = getMiddlewareForDirectory(appDir);
+  const middlewareFile = getMiddlewareForDirectory(appDir, mode);
   if (middlewareFile) {
     Log.warn(
       chalk.yellow`Skipping export for middleware because \`web.output\` is not "server". You may want to remove ${path.relative(appDir, middlewareFile)}`

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -75,6 +75,11 @@ export const expoExport: Command = async (argv) => {
 
   const projectRoot = path.resolve(parsed.projectRoot);
 
+  const { loadEnvFiles } = await import('../utils/nodeEnv.js');
+  loadEnvFiles(projectRoot, {
+    mode: args['--dev'] ? 'development' : 'production',
+  });
+
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
   const options = await resolveOptionsAsync(projectRoot, {
     ...args,

--- a/packages/@expo/cli/src/export/index.ts
+++ b/packages/@expo/cli/src/export/index.ts
@@ -63,29 +63,31 @@ export const expoExport: Command = async (argv) => {
     );
   }
 
-  // Handle --source-maps which can be a string or boolean (e.g., --source-maps or --source-maps inline)
-  const { resolveStringOrBooleanArgsAsync } = await import('../utils/resolveArgs.js');
-  const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
-    // Restrict to 'true', 'false', 'inline', 'external'. Other values are treated as project root.
-    '--source-maps': [Boolean, 'inline', 'external'],
-    '-s': '--source-maps',
-    // Deprecated
-    '--dump-sourcemap': '--source-maps',
-  }).catch(logCmdError);
+  return (async () => {
+    // Handle --source-maps which can be a string or boolean (e.g., --source-maps or --source-maps inline)
+    const { resolveStringOrBooleanArgsAsync } = await import('../utils/resolveArgs.js');
+    const parsed = await resolveStringOrBooleanArgsAsync(argv ?? [], rawArgsMap, {
+      // Restrict to 'true', 'false', 'inline', 'external'. Other values are treated as project root.
+      '--source-maps': [Boolean, 'inline', 'external'],
+      '-s': '--source-maps',
+      // Deprecated
+      '--dump-sourcemap': '--source-maps',
+    });
 
-  const projectRoot = path.resolve(parsed.projectRoot);
+    const projectRoot = path.resolve(parsed.projectRoot);
 
-  const { loadEnvFiles } = await import('../utils/nodeEnv.js');
-  loadEnvFiles(projectRoot, {
-    mode: args['--dev'] ? 'development' : 'production',
-  });
+    const { loadEnvFiles } = await import('../utils/nodeEnv.js');
+    loadEnvFiles(projectRoot, {
+      mode: args['--dev'] ? 'development' : 'production',
+    });
 
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
-  const options = await resolveOptionsAsync(projectRoot, {
-    ...args,
-    '--source-maps': parsed.args['--source-maps'],
-  }).catch(logCmdError);
+    const { resolveOptionsAsync } = await import('./resolveOptions.js');
+    const options = await resolveOptionsAsync(projectRoot, {
+      ...args,
+      '--source-maps': parsed.args['--source-maps'],
+    });
 
-  const { exportAsync } = await import('./exportAsync.js');
-  return exportAsync(projectRoot, options).catch(logCmdError);
+    const { exportAsync } = await import('./exportAsync.js');
+    return exportAsync(projectRoot, options);
+  })().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/export/web/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/export/web/__tests__/index-test.ts
@@ -1,0 +1,37 @@
+import { expoExportWeb } from '../index';
+
+jest.mock('../../../utils/args', () => ({
+  assertArgs: jest.fn(),
+  getProjectRoot: jest.fn(() => '/app'),
+  printHelp: jest.fn(),
+}));
+jest.mock('../../../utils/nodeEnv.js', () => ({ loadEnvFiles: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../../../utils/errors', () => ({ logCmdError: jest.fn() }));
+jest.mock('../resolveOptions.js', () => ({ resolveOptionsAsync: jest.fn(async () => ({})) }), {
+  virtual: true,
+});
+jest.mock('../exportWebAsync.js', () => ({ exportWebAsync: jest.fn(async () => {}) }), {
+  virtual: true,
+});
+
+const { assertArgs } = require('../../../utils/args') as { assertArgs: jest.Mock };
+const { loadEnvFiles } = require('../../../utils/nodeEnv.js') as { loadEnvFiles: jest.Mock };
+const { resolveOptionsAsync } = require('../resolveOptions.js') as {
+  resolveOptionsAsync: jest.Mock;
+};
+
+it.each([
+  { dev: false, mode: 'production' },
+  { dev: true, mode: 'development' },
+])('loads $mode env files before resolving export:web options', async ({ dev, mode }) => {
+  assertArgs.mockReturnValue({ '--dev': dev });
+
+  await expoExportWeb([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    resolveOptionsAsync.mock.invocationCallOrder[0]!
+  );
+});

--- a/packages/@expo/cli/src/export/web/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/export/web/__tests__/index-test.ts
@@ -18,6 +18,7 @@ jest.mock('../exportWebAsync.js', () => ({ exportWebAsync: jest.fn(async () => {
 
 const { assertArgs } = require('../../../utils/args') as { assertArgs: jest.Mock };
 const { loadEnvFiles } = require('../../../utils/nodeEnv.js') as { loadEnvFiles: jest.Mock };
+const { logCmdError } = require('../../../utils/errors') as { logCmdError: jest.Mock };
 const { resolveOptionsAsync } = require('../resolveOptions.js') as {
   resolveOptionsAsync: jest.Mock;
 };
@@ -34,4 +35,16 @@ it.each([
   expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
     resolveOptionsAsync.mock.invocationCallOrder[0]!
   );
+});
+
+it('handles env file errors', async () => {
+  const error = new Error('env error');
+  assertArgs.mockReturnValue({ '--dev': false });
+  loadEnvFiles.mockImplementationOnce(() => {
+    throw error;
+  });
+
+  await expoExportWeb([]);
+
+  expect(logCmdError).toHaveBeenCalledWith(error);
 });

--- a/packages/@expo/cli/src/export/web/exportWebAsync.ts
+++ b/packages/@expo/cli/src/export/web/exportWebAsync.ts
@@ -6,15 +6,11 @@ import { WebSupportProjectPrerequisite } from '../../start/doctor/web/WebSupport
 import { getPlatformBundlers } from '../../start/server/platformBundlers';
 import { WebpackBundlerDevServer } from '../../start/server/webpack/WebpackBundlerDevServer';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import type { Options } from './resolveOptions';
 
 export async function exportWebAsync(projectRoot: string, options: Options) {
   // Ensure webpack is available
   await new WebSupportProjectPrerequisite(projectRoot).assertAsync();
-
-  setNodeEnv(options.dev ? 'development' : 'production');
-  loadEnvFiles(projectRoot);
 
   const { exp } = getConfig(projectRoot);
   const platformBundlers = getPlatformBundlers(projectRoot, exp);

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -32,15 +32,17 @@ export const expoExportWeb: Command = async (argv) => {
     );
   }
 
-  const projectRoot = getProjectRoot(args);
-  const { loadEnvFiles } = await import('../../utils/nodeEnv.js');
-  loadEnvFiles(projectRoot, {
-    mode: args['--dev'] ? 'development' : 'production',
-  });
+  return (async () => {
+    const projectRoot = getProjectRoot(args);
+    const { loadEnvFiles } = await import('../../utils/nodeEnv.js');
+    loadEnvFiles(projectRoot, {
+      mode: args['--dev'] ? 'development' : 'production',
+    });
 
-  const { resolveOptionsAsync } = await import('./resolveOptions.js');
-  const options = await resolveOptionsAsync(args).catch(logCmdError);
+    const { resolveOptionsAsync } = await import('./resolveOptions.js');
+    const options = await resolveOptionsAsync(args);
 
-  const { exportWebAsync } = await import('./exportWebAsync.js');
-  return exportWebAsync(projectRoot, options).catch(logCmdError);
+    const { exportWebAsync } = await import('./exportWebAsync.js');
+    return exportWebAsync(projectRoot, options);
+  })().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/export/web/index.ts
+++ b/packages/@expo/cli/src/export/web/index.ts
@@ -33,6 +33,11 @@ export const expoExportWeb: Command = async (argv) => {
   }
 
   const projectRoot = getProjectRoot(args);
+  const { loadEnvFiles } = await import('../../utils/nodeEnv.js');
+  loadEnvFiles(projectRoot, {
+    mode: args['--dev'] ? 'development' : 'production',
+  });
+
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
   const options = await resolveOptionsAsync(args).catch(logCmdError);
 

--- a/packages/@expo/cli/src/index.ts
+++ b/packages/@expo/cli/src/index.ts
@@ -18,7 +18,7 @@ export type Command = (argv?: string[]) => void;
 
 const commands: { [command: string]: () => Promise<Command> } = {
   // Add a new command here
-  // NOTE(EvanBacon): Ensure every bundler-related command sets `NODE_ENV` as expected for the command.
+  // Project commands must select a mode before loading app config or env files.
   run: () => import('../src/run/index.js').then((i) => i.expoRun),
   'run:ios': () => import('../src/run/ios/index.js').then((i) => i.expoRunIos),
   'run:android': () => import('../src/run/android/index.js').then((i) => i.expoRunAndroid),

--- a/packages/@expo/cli/src/install/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/index-test.ts
@@ -1,0 +1,32 @@
+import { expoInstall } from '../index';
+
+jest.mock('../../utils/findUp', () => ({
+  findUpProjectRootOrAssert: jest.fn(() => '/app'),
+}));
+jest.mock('../../utils/nodeEnv', () => ({ loadEnvFiles: jest.fn() }));
+jest.mock('../../utils/errors', () => ({ logCmdError: jest.fn() }));
+jest.mock('../installAsync', () => ({ installAsync: jest.fn(async () => {}) }));
+jest.mock('../resolveOptions', () => ({
+  resolveArgsAsync: jest.fn(async () => ({
+    variadic: [],
+    options: {},
+    extras: [],
+  })),
+}));
+
+const { loadEnvFiles } = require('../../utils/nodeEnv') as {
+  loadEnvFiles: jest.Mock;
+};
+const { installAsync } = require('../installAsync') as {
+  installAsync: jest.Mock;
+};
+
+it('loads development env files before install', async () => {
+  await expoInstall([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode: 'development' });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    installAsync.mock.invocationCallOrder[0]!
+  );
+  expect(installAsync).toHaveBeenCalledWith([], { projectRoot: '/app' }, []);
+});

--- a/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installAsync-test.ts
@@ -19,11 +19,6 @@ jest.mock('../../start/doctor/dependencies/getVersionedPackages', () => ({
   getVersionedPackagesAsync: jest.fn(),
 }));
 
-jest.mock('../../utils/nodeEnv', () => ({
-  loadEnvFiles: jest.fn(),
-  setNodeEnv: jest.fn(),
-}));
-
 jest.mock('../applyPlugins', () => ({
   applyPluginsAsync: jest.fn(),
 }));
@@ -123,6 +118,23 @@ describe(installAsync, () => {
       'expo-camera@~16.0.0',
       'react-native-reanimated@~3.17.0',
     ]);
+  });
+
+  it('keeps NODE_ENV when called internally', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await installAsync([], { projectRoot });
+
+      expect(process.env.NODE_ENV).toBe('production');
+    } finally {
+      if (originalNodeEnv === undefined) {
+        Reflect.deleteProperty(process.env, 'NODE_ENV');
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
   });
 
   it('installs a resolved Expo canary first and forwards --fix to the follow-up command', async () => {

--- a/packages/@expo/cli/src/install/index.ts
+++ b/packages/@expo/cli/src/install/index.ts
@@ -46,12 +46,18 @@ export const expoInstall: Command = async (argv) => {
   }
 
   // Load modules after the help prompt so `npx expo install -h` shows as fast as possible.
-  const { installAsync } = require('./installAsync') as typeof import('./installAsync');
   const { logCmdError } = require('../utils/errors') as typeof import('../utils/errors');
+  const { findUpProjectRootOrAssert } =
+    require('../utils/findUp') as typeof import('../utils/findUp');
+  const { loadEnvFiles } = require('../utils/nodeEnv') as typeof import('../utils/nodeEnv');
   const { resolveArgsAsync } = require('./resolveOptions') as typeof import('./resolveOptions');
 
-  const { variadic, options, extras } = await resolveArgsAsync(process.argv.slice(3)).catch(
-    logCmdError
-  );
-  return installAsync(variadic, options, extras).catch(logCmdError);
+  return (async () => {
+    const { variadic, options, extras } = await resolveArgsAsync(process.argv.slice(3));
+    const projectRoot = findUpProjectRootOrAssert(process.cwd());
+    loadEnvFiles(projectRoot, { mode: 'development' });
+
+    const { installAsync } = require('./installAsync') as typeof import('./installAsync');
+    return installAsync(variadic, { ...options, projectRoot }, extras);
+  })().catch(logCmdError);
 };

--- a/packages/@expo/cli/src/install/installAsync.ts
+++ b/packages/@expo/cli/src/install/installAsync.ts
@@ -8,7 +8,6 @@ import { env } from '../utils/env';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
 import { learnMore } from '../utils/link';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { joinWithCommasAnd } from '../utils/strings';
 import { applyPluginsAsync } from './applyPlugins';
 import { checkPackagesAsync } from './checkPackages';
@@ -31,11 +30,9 @@ export async function installAsync(
   options: Options & { projectRoot?: string },
   packageManagerArguments: string[] = []
 ) {
-  setNodeEnv('development');
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo install` from a subdirectory of the project.
   const projectRoot = options?.projectRoot ?? findUpProjectRootOrAssert(process.cwd());
-  loadEnvFiles(projectRoot);
 
   // Resolve the package manager used by the project, or based on the provided arguments.
   const packageManager = PackageManager.createForProject(projectRoot, {

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
+import { loadEnvFiles } from '../utils/nodeEnv';
 import { ESLintProjectPrerequisite } from './ESlintPrerequisite';
 import { event } from './events';
 import type { Options } from './resolveOptions';
@@ -17,11 +17,10 @@ export const lintAsync = async (
   options: Options & { projectRoot?: string },
   eslintArguments: string[] = []
 ) => {
-  setNodeEnv('development');
   // Locate the project root based on the process current working directory.
   // This enables users to run `npx expo install` from a subdirectory of the project.
   const projectRoot = options?.projectRoot ?? findUpProjectRootOrAssert(process.cwd());
-  loadEnvFiles(projectRoot);
+  loadEnvFiles(projectRoot, { mode: 'development' });
 
   // TODO: Perhaps we should assert that TypeScript is required.
 

--- a/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
@@ -5,19 +5,11 @@ jest.mock('../../utils/args', () => ({
   getProjectRoot: jest.fn(() => '/app'),
   printHelp: jest.fn(),
 }));
-jest.mock(
-  '../../utils/nodeEnv.js',
-  () => ({
-    getConfigEnvMode: jest.fn(() => 'development'),
-    loadEnvFiles: jest.fn(),
-  }),
-  {
-    virtual: true,
-  }
-);
-jest.mock('../../utils/errors.js', () => ({ logCmdError: jest.fn() }), {
-  virtual: true,
-});
+jest.mock('../../utils/nodeEnv', () => ({
+  getConfigEnvMode: jest.fn(() => 'development'),
+  loadEnvFiles: jest.fn(),
+}));
+jest.mock('../../utils/errors', () => ({ logCmdError: jest.fn() }));
 jest.mock('../prebuildAsync.js', () => ({ prebuildAsync: jest.fn(async () => {}) }), {
   virtual: true,
 });
@@ -31,10 +23,10 @@ jest.mock(
   { virtual: true }
 );
 
-const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
+const { loadEnvFiles } = require('../../utils/nodeEnv') as {
   loadEnvFiles: jest.Mock;
 };
-const { getConfigEnvMode } = require('../../utils/nodeEnv.js') as {
+const { getConfigEnvMode } = require('../../utils/nodeEnv') as {
   getConfigEnvMode: jest.Mock;
 };
 const { prebuildAsync } = require('../prebuildAsync.js') as {

--- a/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
@@ -1,0 +1,63 @@
+import { expoPrebuild } from '../index';
+
+jest.mock('../../utils/args', () => ({
+  assertArgs: jest.fn(() => ({ '--help': false })),
+  getProjectRoot: jest.fn(() => '/app'),
+  printHelp: jest.fn(),
+}));
+jest.mock(
+  '../../utils/nodeEnv.js',
+  () => ({
+    getConfigEnvMode: jest.fn(() => 'development'),
+    loadEnvFiles: jest.fn(),
+  }),
+  {
+    virtual: true,
+  }
+);
+jest.mock('../../utils/errors.js', () => ({ logCmdError: jest.fn() }), {
+  virtual: true,
+});
+jest.mock('../prebuildAsync.js', () => ({ prebuildAsync: jest.fn(async () => {}) }), {
+  virtual: true,
+});
+jest.mock(
+  '../resolveOptions.js',
+  () => ({
+    resolvePackageManagerOptions: jest.fn(() => ({})),
+    resolvePlatformOption: jest.fn(() => ['android']),
+    resolveSkipDependencyUpdate: jest.fn(() => []),
+  }),
+  { virtual: true }
+);
+
+const { loadEnvFiles } = require('../../utils/nodeEnv.js') as {
+  loadEnvFiles: jest.Mock;
+};
+const { getConfigEnvMode } = require('../../utils/nodeEnv.js') as {
+  getConfigEnvMode: jest.Mock;
+};
+const { prebuildAsync } = require('../prebuildAsync.js') as {
+  prebuildAsync: jest.Mock;
+};
+
+beforeEach(() => {
+  getConfigEnvMode.mockReturnValue('development');
+});
+
+it('loads development env files before prebuild', async () => {
+  await expoPrebuild([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode: 'development' });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    prebuildAsync.mock.invocationCallOrder[0]!
+  );
+});
+
+it('uses the production mode from EXPO_CONFIG_MODE', async () => {
+  getConfigEnvMode.mockReturnValue('production');
+
+  await expoPrebuild([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode: 'production' });
+});

--- a/packages/@expo/cli/src/prebuild/__tests__/prebuildAsync-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/prebuildAsync-test.ts
@@ -1,0 +1,30 @@
+import { getConfig } from '@expo/config';
+
+import { prebuildAsync } from '../prebuildAsync';
+
+jest.mock('@expo/config', () => ({
+  ...jest.requireActual('@expo/config'),
+  getConfig: jest.fn(),
+}));
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  process.env = {
+    ...originalEnv,
+    NODE_ENV: 'production',
+  };
+  jest.mocked(getConfig).mockImplementation(() => {
+    throw new Error('stop');
+  });
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+it('keeps NODE_ENV when called internally', async () => {
+  await expect(prebuildAsync('/', { platforms: ['android'] })).rejects.toThrow('stop');
+
+  expect(process.env.NODE_ENV).toBe('production');
+});

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -48,22 +48,21 @@ export const expoPrebuild: Command = async (argv) => {
   }
 
   // Load modules after the help prompt so `npx expo prebuild -h` shows as fast as possible.
-  const [
-    // ./prebuildAsync
-    { prebuildAsync },
-    // ./resolveOptions
-    { resolvePlatformOption, resolvePackageManagerOptions, resolveSkipDependencyUpdate },
-    // ../utils/errors
-    { logCmdError },
-  ] = await Promise.all([
-    import('./prebuildAsync.js'),
-    import('./resolveOptions.js'),
+  const [{ getConfigEnvMode, loadEnvFiles }, { logCmdError }] = await Promise.all([
+    import('../utils/nodeEnv.js'),
     import('../utils/errors.js'),
   ]);
 
-  return (() => {
-    return prebuildAsync(getProjectRoot(args), {
-      // Parsed options
+  return (async () => {
+    const projectRoot = getProjectRoot(args);
+    loadEnvFiles(projectRoot, { mode: getConfigEnvMode() });
+
+    const [
+      { prebuildAsync },
+      { resolvePlatformOption, resolvePackageManagerOptions, resolveSkipDependencyUpdate },
+    ] = await Promise.all([import('./prebuildAsync.js'), import('./resolveOptions.js')]);
+
+    return prebuildAsync(projectRoot, {
       clean: !args['--no-clean'],
 
       packageManager: resolvePackageManagerOptions(args),

--- a/packages/@expo/cli/src/prebuild/index.ts
+++ b/packages/@expo/cli/src/prebuild/index.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk';
 
 import type { Command } from '../index';
 import { assertArgs, getProjectRoot, printHelp } from '../utils/args';
+import { logCmdError } from '../utils/errors';
+import { getConfigEnvMode, loadEnvFiles } from '../utils/nodeEnv';
 
 export const expoPrebuild: Command = async (argv) => {
   const args = assertArgs(
@@ -46,12 +48,6 @@ export const expoPrebuild: Command = async (argv) => {
       ].join('\n')
     );
   }
-
-  // Load modules after the help prompt so `npx expo prebuild -h` shows as fast as possible.
-  const [{ getConfigEnvMode, loadEnvFiles }, { logCmdError }] = await Promise.all([
-    import('../utils/nodeEnv.js'),
-    import('../utils/errors.js'),
-  ]);
 
   return (async () => {
     const projectRoot = getProjectRoot(args);

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -7,7 +7,6 @@ import chalk from 'chalk';
 import { installAsync } from '../install/installAsync';
 import { Log } from '../log';
 import { env } from '../utils/env';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
 import { clearNodeModulesAsync } from '../utils/nodeModules';
 import { logNewSection } from '../utils/ora';
 import { profile } from '../utils/profile';
@@ -68,9 +67,6 @@ export async function prebuildAsync(
     skipDependencyUpdate?: string[];
   }
 ): Promise<PrebuildResults | null> {
-  setNodeEnv('development');
-  loadEnvFiles(projectRoot);
-
   const { platforms } = getConfig(projectRoot).exp;
   if (platforms?.length) {
     // Filter out platforms that aren't in the app.json.

--- a/packages/@expo/cli/src/run/__tests__/startBundler-test.ts
+++ b/packages/@expo/cli/src/run/__tests__/startBundler-test.ts
@@ -53,6 +53,7 @@ describe(startBundlerAsync, () => {
   it(`starts in headless mode`, async () => {
     const manager = await startBundlerAsync('/', {
       headless: true,
+      mode: 'production',
       port: 3000,
     });
 
@@ -63,6 +64,7 @@ describe(startBundlerAsync, () => {
           headless: true,
           location: {},
           minify: false,
+          mode: 'production',
           port: 3000,
         },
         type: 'metro',
@@ -74,6 +76,7 @@ describe(startBundlerAsync, () => {
   it(`starts a server`, async () => {
     const manager = await startBundlerAsync('/', {
       headless: false,
+      mode: 'development',
       port: 3000,
     });
 
@@ -84,6 +87,7 @@ describe(startBundlerAsync, () => {
           headless: false,
           location: {},
           minify: false,
+          mode: 'development',
           port: 3000,
         },
         type: 'metro',

--- a/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/runAndroidAsync-test.ts
@@ -2,12 +2,19 @@ import { vol } from 'memfs';
 
 import rnFixture from '../../../prebuild/__tests__/fixtures/react-native-project';
 import { assembleAsync, installAsync } from '../../../start/platforms/android/gradle';
-import { resolveOptionsAsync } from '../resolveOptions';
+import { loadEnvFiles } from '../../../utils/nodeEnv';
+import { startBundlerAsync } from '../../startBundler';
 import { runAndroidAsync } from '../runAndroidAsync';
 
 jest.mock('../../../log');
 
 jest.mock('../../../utils/port');
+jest.mock('../../../utils/nodeEnv', () => ({
+  loadEnvFiles: jest.fn(),
+}));
+jest.mock('../../../export/embed/exportEager', () => ({
+  exportEagerAsync: jest.fn(async () => ({})),
+}));
 
 jest.mock('../../../start/platforms/android/gradle', () => ({
   assembleAsync: jest.fn(async () => {}),
@@ -39,8 +46,29 @@ jest.mock('../../startBundler', () => ({
   })),
 }));
 
-describe(resolveOptionsAsync, () => {
+describe(runAndroidAsync, () => {
   afterEach(() => vol.reset());
+
+  it('uses production mode for a release variant', async () => {
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        '/package.json': JSON.stringify({}),
+        'node_modules/expo/package.json': JSON.stringify({
+          version: '53.0.0',
+        }),
+      },
+      '/'
+    );
+
+    await runAndroidAsync('/', { variant: 'demoRelease' });
+
+    expect(loadEnvFiles).toHaveBeenCalledWith('/', { mode: 'production' });
+    expect(startBundlerAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ mode: 'production' })
+    );
+  });
 
   it(`runs android`, async () => {
     vol.fromJSON(

--- a/packages/@expo/cli/src/run/android/runAndroidAsync.ts
+++ b/packages/@expo/cli/src/run/android/runAndroidAsync.ts
@@ -7,7 +7,7 @@ import { Log } from '../../log';
 import { assembleAsync, installAsync } from '../../start/platforms/android/gradle';
 import { resolveBuildCache, uploadBuildCache } from '../../utils/build-cache-providers';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
+import { loadEnvFiles } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { getSchemesForAndroidAsync } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
@@ -19,10 +19,12 @@ import type { Options, ResolvedOptions } from './resolveOptions';
 import { resolveOptionsAsync } from './resolveOptions';
 
 export async function runAndroidAsync(projectRoot: string, { install, ...options }: Options) {
-  // NOTE: This is a guess, the developer can overwrite with `NODE_ENV`.
+  // Guess the mode from the selected native build variant.
   const isProduction = options.variant?.toLowerCase().endsWith('release');
-  setNodeEnv(isProduction ? 'production' : 'development');
-  loadEnvFiles(projectRoot);
+  const mode = isProduction ? 'production' : 'development';
+  loadEnvFiles(projectRoot, {
+    mode,
+  });
 
   await ensureNativeProjectAsync(projectRoot, { platform: 'android', install });
 
@@ -96,6 +98,7 @@ export async function runAndroidAsync(projectRoot: string, { install, ...options
 
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
+    mode,
     // If a scheme is specified then use that instead of the package name.
     scheme: (await getSchemesForAndroidAsync(projectRoot))?.[0],
     headless: !props.shouldStartBundler,

--- a/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
+++ b/packages/@expo/cli/src/run/ios/__tests__/runIosAsync-test.ts
@@ -2,11 +2,12 @@ import { vol } from 'memfs';
 
 import { Log } from '../../../log';
 import rnFixture from '../../../prebuild/__tests__/fixtures/react-native-project';
+import { loadEnvFiles } from '../../../utils/nodeEnv';
 import { logProjectLogsLocation } from '../../hints';
+import { startBundlerAsync } from '../../startBundler';
 import { buildAsync } from '../XcodeBuild';
 import { launchAppAsync } from '../launchApp';
 import { isSimulatorDevice, resolveDeviceAsync } from '../options/resolveDevice';
-import { resolveOptionsAsync } from '../options/resolveOptions';
 import { runIosAsync } from '../runIosAsync';
 
 jest.mock('../../hints', () => ({
@@ -17,6 +18,12 @@ jest.mock('../../hints', () => ({
 jest.mock('../../../log');
 
 jest.mock('../../../utils/port');
+jest.mock('../../../utils/nodeEnv', () => ({
+  loadEnvFiles: jest.fn(),
+}));
+jest.mock('../../../export/embed/exportEager', () => ({
+  exportEagerAsync: jest.fn(async () => ({})),
+}));
 
 jest.mock('../options/resolveDevice', () => ({
   isSimulatorDevice: jest.fn(() => true),
@@ -69,8 +76,30 @@ afterEach(() => {
   mockPlatform(platform);
 });
 
-describe(resolveOptionsAsync, () => {
+describe(runIosAsync, () => {
   afterEach(() => vol.reset());
+
+  it('uses production mode for a release configuration', async () => {
+    mockPlatform('darwin');
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        '/package.json': JSON.stringify({}),
+        'node_modules/expo/package.json': JSON.stringify({
+          version: '53.0.0',
+        }),
+      },
+      '/'
+    );
+
+    await runIosAsync('/', { configuration: 'Release' });
+
+    expect(loadEnvFiles).toHaveBeenCalledWith('/', { mode: 'production' });
+    expect(startBundlerAsync).toHaveBeenCalledWith(
+      '/',
+      expect.objectContaining({ mode: 'production' })
+    );
+  });
 
   it(`asserts that the function only runs on darwin machines`, async () => {
     mockPlatform('win32');

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -10,7 +10,7 @@ import { getContainerPathAsync, simctlAsync } from '../../start/platforms/ios/si
 import { resolveBuildCache, uploadBuildCache } from '../../utils/build-cache-providers';
 import { maybePromptToSyncPodsAsync } from '../../utils/cocoapods';
 import { CommandError } from '../../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
+import { loadEnvFiles } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { profile } from '../../utils/profile';
 import { getSchemesForIosAsync } from '../../utils/scheme';
@@ -25,8 +25,8 @@ import { resolveOptionsAsync } from './options/resolveOptions';
 import { getValidBinaryPathAsync } from './validateExternalBinary';
 
 export async function runIosAsync(projectRoot: string, options: Options) {
-  setNodeEnv(options.configuration === 'Release' ? 'production' : 'development');
-  loadEnvFiles(projectRoot);
+  const mode = options.configuration === 'Release' ? 'production' : 'development';
+  loadEnvFiles(projectRoot, { mode });
 
   assertPlatform();
 
@@ -129,7 +129,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   } else {
     let eagerBundleOptions: string | undefined;
 
-    if (options.configuration === 'Release') {
+    if (mode === 'production') {
       eagerBundleOptions = JSON.stringify(
         await exportEagerAsync(projectRoot, {
           dev: false,
@@ -210,6 +210,7 @@ export async function runIosAsync(projectRoot: string, options: Options) {
   // launching the app on a simulator.
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
+    mode,
     headless: !props.shouldStartBundler,
     // If a scheme is specified then use that instead of the package name.
 

--- a/packages/@expo/cli/src/run/startBundler.ts
+++ b/packages/@expo/cli/src/run/startBundler.ts
@@ -7,6 +7,7 @@ import type { BundlerStartOptions } from '../start/server/BundlerDevServer';
 import { DevServerManager } from '../start/server/DevServerManager';
 import { env } from '../utils/env';
 import { isInteractive } from '../utils/interactive';
+import type { EnvironmentMode } from '../utils/nodeEnv';
 
 export async function startBundlerAsync(
   projectRoot: string,
@@ -14,10 +15,12 @@ export async function startBundlerAsync(
     port,
     headless,
     scheme,
+    mode,
   }: {
     port: number;
     headless?: boolean;
     scheme?: string;
+    mode: EnvironmentMode;
   }
 ): Promise<DevServerManager> {
   const options: BundlerStartOptions = {
@@ -25,6 +28,7 @@ export async function startBundlerAsync(
     headless,
     devClient: true,
     minify: false,
+    mode,
 
     location: {
       scheme,

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -9,7 +9,7 @@ import * as Log from '../log';
 import { directoryExistsAsync, fileExistsAsync } from '../utils/dir';
 import { CommandError } from '../utils/errors';
 import { findUpProjectRootOrAssert } from '../utils/findUp';
-import { setNodeEnv, loadEnvFiles } from '../utils/nodeEnv';
+import { loadEnvFiles } from '../utils/nodeEnv';
 import { resolveMetroPortAsync } from '../utils/port';
 import { applyStaticHeaders, loadStaticManifestAsync, resolveStaticHeaders } from './static';
 
@@ -22,8 +22,7 @@ type Options = {
 export async function serveAsync(inputDir: string, options: Options) {
   const projectRoot = findUpProjectRootOrAssert(inputDir);
 
-  setNodeEnv('production');
-  loadEnvFiles(projectRoot);
+  loadEnvFiles(projectRoot, { mode: 'production' });
 
   const port = await resolveMetroPortAsync(projectRoot, {
     defaultPort: options.port,

--- a/packages/@expo/cli/src/start/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/index-test.ts
@@ -1,0 +1,33 @@
+import { expoStart } from '../index';
+
+jest.mock('../../utils/args', () => ({
+  assertArgs: jest.fn(),
+  getProjectRoot: jest.fn(() => '/app'),
+  printHelp: jest.fn(),
+}));
+jest.mock('../../utils/nodeEnv.js', () => ({ loadEnvFiles: jest.fn() }), { virtual: true });
+jest.mock('../../utils/errors', () => ({ logCmdError: jest.fn() }));
+jest.mock('../resolveOptions.js', () => ({ resolveOptionsAsync: jest.fn(async () => ({})) }), {
+  virtual: true,
+});
+jest.mock('../startAsync.js', () => ({ startAsync: jest.fn(async () => {}) }), { virtual: true });
+
+const { assertArgs } = require('../../utils/args') as { assertArgs: jest.Mock };
+const { loadEnvFiles } = require('../../utils/nodeEnv.js') as { loadEnvFiles: jest.Mock };
+const { resolveOptionsAsync } = require('../resolveOptions.js') as {
+  resolveOptionsAsync: jest.Mock;
+};
+
+it.each([
+  { noDev: false, mode: 'development' },
+  { noDev: true, mode: 'production' },
+])('loads $mode env files before resolving start options', async ({ noDev, mode }) => {
+  assertArgs.mockReturnValue({ '--no-dev': noDev });
+
+  await expoStart([]);
+
+  expect(loadEnvFiles).toHaveBeenCalledWith('/app', { mode });
+  expect(loadEnvFiles.mock.invocationCallOrder[0]).toBeLessThan(
+    resolveOptionsAsync.mock.invocationCallOrder[0]!
+  );
+});

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -84,9 +84,10 @@ export const expoStart: Command = async (argv) => {
   const projectRoot = getProjectRoot(args);
 
   // NOTE(cedric): `./resolveOptions` loads the expo config when using dev clients, this needs to be initialized before that
-  const { setNodeEnv, loadEnvFiles } = await import('../utils/nodeEnv.js');
-  setNodeEnv(!args['--no-dev'] ? 'development' : 'production');
-  loadEnvFiles(projectRoot);
+  const { loadEnvFiles } = await import('../utils/nodeEnv.js');
+  loadEnvFiles(projectRoot, {
+    mode: !args['--no-dev'] ? 'development' : 'production',
+  });
 
   const { resolveOptionsAsync } = await import('./resolveOptions.js');
   const options = await resolveOptionsAsync(projectRoot, args).catch(logCmdError);

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1231,16 +1231,18 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       return;
     }
 
+    const mode = this.instanceMetroOptions.mode ?? 'development';
+
     observeFileChanges(
       {
         metro: this.metro,
         server: this.instance.server,
       },
-      getEnvFiles(this.projectRoot),
+      getEnvFiles(this.projectRoot, mode),
       () => {
         debugEvent('env_reload', {});
         // Force reload the environment variables.
-        reloadEnvFiles(this.projectRoot);
+        reloadEnvFiles(this.projectRoot, mode);
       }
     );
   }

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -4,15 +4,21 @@ import { ImmutableRequest } from 'expo-server/private';
 import { vol } from 'memfs';
 
 import type { ExportAssetMap } from '../../../../export/saveAssets';
+import { getEnvFiles, reloadEnvFiles } from '../../../../utils/nodeEnv';
 import type { BundlerStartOptions } from '../../BundlerDevServer';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { instantiateMetroAsync } from '../instantiateMetro';
 import { warnInvalidWebOutput } from '../router';
-import { observeAnyFileChanges } from '../waitForMetroToObserveTypeScriptFile';
+import { observeAnyFileChanges, observeFileChanges } from '../waitForMetroToObserveTypeScriptFile';
 
 jest.mock('../waitForMetroToObserveTypeScriptFile', () => ({
   observeAnyFileChanges: jest.fn(),
+  observeFileChanges: jest.fn(),
+}));
+jest.mock('../../../../utils/nodeEnv', () => ({
+  getEnvFiles: jest.fn(() => []),
+  reloadEnvFiles: jest.fn(),
 }));
 jest.mock('../router', () => {
   return {
@@ -144,6 +150,24 @@ describe('startAsync', () => {
     expect(devServer.getUrlCreator().constructUrl({ hostType: 'localhost' })).toBe(
       'http://127.0.0.1:3000'
     );
+  });
+});
+
+describe('watchEnvironmentVariables', () => {
+  it('keeps the Metro mode when env files reload', async () => {
+    const devServer = new MetroBundlerDevServer(
+      '/',
+      getPlatformBundlers('/', { web: { bundler: 'metro' } })
+    );
+    devServer['instance'] = { server: {} } as any;
+    devServer['metro'] = {} as any;
+    devServer['instanceMetroOptions'] = { mode: 'production' };
+
+    await devServer.watchEnvironmentVariables();
+
+    expect(getEnvFiles).toHaveBeenCalledWith('/', 'production');
+    jest.mocked(observeFileChanges).mock.calls[0]![2]();
+    expect(reloadEnvFiles).toHaveBeenCalledWith('/', 'production');
   });
 });
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/router-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/router-test.ts
@@ -107,7 +107,7 @@ describe(getMiddlewareForDirectory, () => {
       },
       '/project'
     );
-    expect(getMiddlewareForDirectory('/project/app')).toBeNull();
+    expect(getMiddlewareForDirectory('/project/app', 'development')).toBeNull();
   });
 
   it('returns the middleware file when only one exists', () => {
@@ -118,30 +118,12 @@ describe(getMiddlewareForDirectory, () => {
       },
       '/project'
     );
-    expect(getMiddlewareForDirectory('/project/app')).toBe('/project/app/+middleware.ts');
-  });
-
-  it('returns the middleware file when only one exists', () => {
-    vol.fromJSON(
-      {
-        'app/+middleware.ts': 'export default () => {}',
-        'app/index.tsx': 'export default () => {}',
-      },
-      '/project'
+    expect(getMiddlewareForDirectory('/project/app', 'development')).toBe(
+      '/project/app/+middleware.ts'
     );
-    expect(getMiddlewareForDirectory('/project/app')).toBe('/project/app/+middleware.ts');
   });
 
   describe('in development', () => {
-    let originalEnv: typeof process.env.NODE_ENV;
-    beforeAll(() => {
-      originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'development';
-    });
-    afterAll(() => {
-      process.env.NODE_ENV = originalEnv;
-    });
-
     it('throws an error when multiple middleware files exist in development', () => {
       vol.fromJSON(
         {
@@ -152,7 +134,7 @@ describe(getMiddlewareForDirectory, () => {
         '/project'
       );
 
-      expect(() => getMiddlewareForDirectory('/project/app')).toThrow(
+      expect(() => getMiddlewareForDirectory('/project/app', 'development')).toThrow(
         'Only one middleware file is allowed. Keep one of the conflicting files: "./+middleware.js" or "./+middleware.ts"'
       );
     });
@@ -167,22 +149,13 @@ describe(getMiddlewareForDirectory, () => {
         '/project'
       );
 
-      expect(() => getMiddlewareForDirectory('/project/app')).toThrow(
+      expect(() => getMiddlewareForDirectory('/project/app', 'development')).toThrow(
         'Only one middleware file is allowed. Keep one of the conflicting files: "./+middleware.jsx" or "./+middleware.tsx"'
       );
     });
   });
 
   describe('in production', () => {
-    let originalEnv: typeof process.env.NODE_ENV;
-    beforeAll(() => {
-      originalEnv = process.env.NODE_ENV;
-      process.env.NODE_ENV = 'production';
-    });
-    afterAll(() => {
-      process.env.NODE_ENV = originalEnv;
-    });
-
     it('returns the first middleware file in production when multiple exist', () => {
       vol.fromJSON(
         {
@@ -193,7 +166,7 @@ describe(getMiddlewareForDirectory, () => {
         '/project'
       );
 
-      const result = getMiddlewareForDirectory('/project/app');
+      const result = getMiddlewareForDirectory('/project/app', 'production');
       expect(result).toBeTruthy();
       expect(result).toMatch('/project/app/+middleware.ts');
     });

--- a/packages/@expo/cli/src/start/server/metro/router.ts
+++ b/packages/@expo/cli/src/start/server/metro/router.ts
@@ -10,6 +10,7 @@ import { directoryExistsSync, isPathInside } from '../../../utils/dir';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
 import { learnMore } from '../../../utils/link';
+import type { EnvironmentMode } from '../../../utils/nodeEnv';
 import { event } from './routerEvents';
 
 /**
@@ -97,7 +98,7 @@ export function getApiRoutesForDirectory(cwd: string) {
  * Gets the +middleware file for a given directory.
  * @param cwd
  */
-export function getMiddlewareForDirectory(cwd: string): string | null {
+export function getMiddlewareForDirectory(cwd: string, mode: EnvironmentMode): string | null {
   const files = globSync('+middleware.@(ts|tsx|js|jsx)', {
     cwd,
     absolute: true,
@@ -108,7 +109,7 @@ export function getMiddlewareForDirectory(cwd: string): string | null {
 
   if (files.length > 1) {
     // In development, throw an error if there are multiple root-level middleware files
-    if (process.env.NODE_ENV !== 'production') {
+    if (mode === 'development') {
       const relativePaths = files.map((f) => './' + path.relative(cwd, f)).sort();
       throw new Error(
         `Only one middleware file is allowed. Keep one of the conflicting files: ${relativePaths.map((p) => `"${p}"`).join(' or ')}`

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -5,6 +5,7 @@ import type { BundleOptions as MetroBundleOptions } from '@expo/metro/metro/shar
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { toPosixPath } from '../../../utils/filePath';
+import type { EnvironmentMode } from '../../../utils/nodeEnv';
 import { debugEvent } from '../metro/metroDebugEvents';
 import { getRouterDirectoryModuleIdWithManifest } from '../metro/router';
 
@@ -21,7 +22,7 @@ export type MetroEnvironment = 'node' | 'react-server' | 'client';
 export type ExpoMetroOptions = {
   platform: string;
   mainModuleName: string;
-  mode: string;
+  mode: EnvironmentMode;
   minify?: boolean;
   environment?: MetroEnvironment;
   serializerOutput?: 'static';
@@ -119,7 +120,11 @@ export function getBaseUrlFromExpoConfig(exp: ExpoConfig) {
   return exp.experiments?.baseUrl?.trim().replace(/\/+$/, '') ?? '';
 }
 
-export function getAsyncRoutesFromExpoConfig(exp: ExpoConfig, mode: string, platform: string) {
+export function getAsyncRoutesFromExpoConfig(
+  exp: ExpoConfig,
+  mode: EnvironmentMode,
+  platform: string
+) {
   let asyncRoutesSetting;
 
   if (exp.extra?.router?.asyncRoutes) {

--- a/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/webpack/WebpackBundlerDevServer.ts
@@ -11,7 +11,7 @@ import type WebpackDevServer from 'webpack-dev-server';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
-import { setNodeEnv, loadEnvFiles } from '../../../utils/nodeEnv';
+import { type EnvironmentMode, loadEnvFiles } from '../../../utils/nodeEnv';
 import { createProgressBar } from '../../../utils/progress';
 import { ensureDotExpoProjectDirectoryInitialized } from '../../project/dotExpo';
 import type { BundlerStartOptions, DevServerInstance } from '../BundlerDevServer';
@@ -239,8 +239,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
       https: options.https,
     };
 
-    setNodeEnv(env.mode ?? 'development');
-    loadEnvFiles(env.projectRoot);
+    loadEnvFiles(env.projectRoot, { mode: env.mode ?? 'development' });
 
     // Check if the project has a webpack.config.js in the root.
     const projectWebpackConfig = this.getProjectConfigFilePath();
@@ -266,7 +265,7 @@ export class WebpackBundlerDevServer extends BundlerDevServer {
 
   protected async clearWebProjectCacheAsync(
     projectRoot: string,
-    mode: string = 'development'
+    mode: EnvironmentMode = 'development'
   ): Promise<void> {
     Log.log(chalk.dim(`Clearing Webpack ${mode} cache directory...`));
 

--- a/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/webpack/__tests__/WebpackBundlerDevServer-test.ts
@@ -1,11 +1,15 @@
 import { vol } from 'memfs';
 import webpack from 'webpack';
 
+import { loadEnvFiles } from '../../../../utils/nodeEnv';
 import type { BundlerStartOptions } from '../../BundlerDevServer';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { WebpackBundlerDevServer } from '../WebpackBundlerDevServer';
 
 jest.mock('../../../../log');
+jest.mock('../../../../utils/nodeEnv', () => ({
+  loadEnvFiles: jest.fn(),
+}));
 jest.mock('../resolveFromProject');
 
 jest.mock('../compile', () => ({
@@ -51,6 +55,26 @@ describe('bundleAsync', () => {
       mode: 'development',
     });
   });
+});
+
+describe('loadConfigAsync', () => {
+  it.each(['development', 'production'] as const)(
+    'loads %s env files before Webpack config',
+    async (mode) => {
+      const devServer = new WebpackBundlerDevServer(
+        '/',
+        getPlatformBundlers('/', { web: { bundler: 'webpack' } })
+      );
+      const expoWebpackConfig = require('@expo/webpack-config') as jest.Mock;
+
+      await devServer.loadConfigAsync({ mode, isImageEditingEnabled: false });
+
+      expect(loadEnvFiles).toHaveBeenCalledWith('/', { mode });
+      expect(jest.mocked(loadEnvFiles).mock.invocationCallOrder[0]).toBeLessThan(
+        expoWebpackConfig.mock.invocationCallOrder[0]!
+      );
+    }
+  );
 });
 
 describe('startAsync', () => {

--- a/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
@@ -1,0 +1,83 @@
+import { vol } from 'memfs';
+
+import { CommandError } from '../errors';
+import { getConfigEnvMode, getEnvFiles, loadEnvFiles, reloadEnvFiles } from '../nodeEnv';
+
+describe('Node environment', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.__EXPO_ENV_LOADED;
+    delete process.env.EXPO_CONFIG_MODE;
+    delete process.env.EXPO_PUBLIC_VALUE;
+    vol.reset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('reads and removes EXPO_CONFIG_MODE', () => {
+    process.env.EXPO_CONFIG_MODE = 'production';
+
+    expect(getConfigEnvMode()).toBe('production');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('uses development when EXPO_CONFIG_MODE is empty', () => {
+    process.env.EXPO_CONFIG_MODE = '';
+
+    expect(getConfigEnvMode()).toBe('development');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('rejects an invalid EXPO_CONFIG_MODE value', () => {
+    process.env.EXPO_CONFIG_MODE = 'staging';
+
+    try {
+      getConfigEnvMode();
+      throw new Error('Expected getConfigEnvMode to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CommandError);
+      expect(error).toMatchObject({
+        code: 'BAD_ARGS',
+        message: 'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".',
+      });
+    }
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('uses production mode when loading and reloading env files', () => {
+    vol.fromJSON(
+      {
+        '.env.production': ['EXPO_CONFIG_MODE=development', 'EXPO_PUBLIC_VALUE=production-v1'].join(
+          '\n'
+        ),
+        '.env.development': 'EXPO_PUBLIC_VALUE=development',
+      },
+      '/app'
+    );
+    (process.env as Record<string, string | undefined>).NODE_ENV = 'staging';
+
+    const mode = 'production';
+    loadEnvFiles('/app', { mode, silent: true });
+
+    expect(process.env.NODE_ENV).toBe('production');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.EXPO_PUBLIC_VALUE).toBe('production-v1');
+    expect(getEnvFiles('/app', mode)).toContain('/app/.env.production');
+    expect(getEnvFiles('/app', mode)).not.toContain('/app/.env.development');
+
+    process.env.NODE_ENV = 'development';
+    vol.writeFileSync(
+      '/app/.env.production',
+      ['EXPO_CONFIG_MODE=development', 'EXPO_PUBLIC_VALUE=production-v2'].join('\n')
+    );
+    reloadEnvFiles('/app', mode);
+
+    expect(process.env.NODE_ENV).toBe('production');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.EXPO_PUBLIC_VALUE).toBe('production-v2');
+  });
+});

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -245,6 +245,11 @@ class Env {
     return getOriginalEnvValue('__EXPO_EAGER_BUNDLE_OPTIONS') || '';
   }
 
+  /** @internal Mode passed to `expo config` or `expo prebuild` by another tool. */
+  get EXPO_CONFIG_MODE(): string | undefined {
+    return getOriginalEnvValue('EXPO_CONFIG_MODE') || undefined;
+  }
+
   /** Disable server deployment during production builds (during `expo export:embed`). This is useful for testing API routes and server components against a local server. */
   get EXPO_NO_DEPLOY(): boolean {
     return boolish('EXPO_NO_DEPLOY', false);

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -2,9 +2,13 @@ import { events } from '2g';
 import * as env from '@expo/env';
 import path from 'node:path';
 
+import { env as cliEnv } from './env';
+import { CommandError } from './errors';
 import { shouldReduceLogs } from './interactive';
 
 type EnvOutput = Record<string, string | undefined>;
+
+export type EnvironmentMode = env.EnvMode;
 
 // TODO(@kitten): We assign this here to run server-side code bundled by metro
 // It's not isolated into a worker thread yet
@@ -15,12 +19,12 @@ declare namespace globalThis {
 declare module '2g' {
   interface EventRegistry {
     'env:mode': {
-      nodeEnv: string;
+      nodeEnv: EnvironmentMode;
       babelEnv: string;
-      mode: 'development' | 'production';
+      mode: EnvironmentMode;
     };
     'env:load': {
-      mode: string | undefined;
+      mode: EnvironmentMode;
       files: string[];
       keys: string[];
     };
@@ -34,44 +38,59 @@ function relativeFiles(files: string[]) {
   return { toJSON: () => files.map((file) => event.path(file).toJSON()) };
 }
 
-/**
- * Set the environment to production or development
- * lots of tools use this to determine if they should run in a dev mode.
- */
-export function setNodeEnv(mode: 'development' | 'production') {
-  process.env.NODE_ENV = process.env.NODE_ENV || mode;
-  process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
-  globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
+export function setNodeEnv(mode: EnvironmentMode) {
+  env.setNodeEnv(mode);
+  process.env.BABEL_ENV = process.env.BABEL_ENV || mode;
+  globalThis.__DEV__ = mode === 'development';
 
   event('mode', {
-    nodeEnv: process.env.NODE_ENV,
+    nodeEnv: mode,
     babelEnv: process.env.BABEL_ENV,
     mode,
   });
 }
 
+export function getConfigEnvMode(): EnvironmentMode {
+  const mode = cliEnv.EXPO_CONFIG_MODE;
+  delete process.env.EXPO_CONFIG_MODE;
+
+  if (!mode) {
+    return 'development';
+  }
+  if (mode !== 'development' && mode !== 'production') {
+    throw new CommandError(
+      'BAD_ARGS',
+      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
+    );
+  }
+  return mode;
+}
+
 interface LoadEnvFilesOptions {
   force?: boolean;
   silent?: boolean;
-  mode?: string;
+  mode: EnvironmentMode;
 }
 
 let prevEnvKeys: Set<string> | undefined;
 
-/**
- * Load the dotenv files into the current `process.env` scope.
- * Note, this requires `NODE_ENV` being set through `setNodeEnv`.
- */
-export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions) {
+/** Set the mode before loading env files. */
+export function loadEnvFiles(projectRoot: string, options: LoadEnvFilesOptions) {
+  setNodeEnv(options.mode);
+
   const params = {
     ...options,
-    silent: !!options?.silent || shouldReduceLogs(),
-    force: !!options?.force,
-    mode: process.env.NODE_ENV,
+    silent: !!options.silent || shouldReduceLogs(),
+    force: !!options.force,
     systemEnv: process.env,
   };
 
-  const envInfo = env.loadProjectEnv(projectRoot, params);
+  let envInfo: ReturnType<typeof env.loadProjectEnv>;
+  try {
+    envInfo = env.loadProjectEnv(projectRoot, params);
+  } finally {
+    delete process.env.EXPO_CONFIG_MODE;
+  }
   const envOutput: EnvOutput = {};
   if (envInfo.result === 'loaded') {
     prevEnvKeys = new Set();
@@ -95,43 +114,47 @@ export function loadEnvFiles(projectRoot: string, options?: LoadEnvFilesOptions)
   return process.env;
 }
 
-export function getEnvFiles(projectRoot: string) {
-  return env
-    .getEnvFiles({ mode: process.env.NODE_ENV })
-    .map((fileName) => path.join(projectRoot, fileName));
+export function getEnvFiles(projectRoot: string, mode: EnvironmentMode) {
+  return env.getEnvFiles({ mode }).map((fileName) => path.join(projectRoot, fileName));
 }
 
-export function reloadEnvFiles(projectRoot: string) {
-  const isEnabled = env.isEnabled();
-  if (isEnabled) {
-    const params = {
-      force: true,
-      silent: true,
-      mode: process.env.NODE_ENV,
-      systemEnv: process.env,
-    };
+export function reloadEnvFiles(projectRoot: string, mode: EnvironmentMode) {
+  setNodeEnv(mode);
 
-    // We use a global tracker to allow overwrites of env vars we set ourselves
-    const envInfo = env.parseProjectEnv(projectRoot, params);
-    const envOutput: EnvOutput = {};
-    for (const key in envInfo.env) {
-      const value = envInfo.env[key];
-      if (process.env[key] !== value) {
-        if (
-          typeof process.env[key] === 'undefined' ||
-          ((!prevEnvKeys || prevEnvKeys.has(key)) && process.env[key] !== value)
-        ) {
-          (prevEnvKeys ||= new Set()).add(key);
-          process.env[key] = envInfo.env[key];
-          envOutput[key] = value ?? undefined;
+  try {
+    const isEnabled = env.isEnabled();
+    if (isEnabled) {
+      const params = {
+        force: true,
+        silent: true,
+        mode,
+        systemEnv: process.env,
+      };
+
+      // We use a global tracker to allow overwrites of env vars we set ourselves
+      const envInfo = env.parseProjectEnv(projectRoot, params);
+      const envOutput: EnvOutput = {};
+      for (const key in envInfo.env) {
+        const value = envInfo.env[key];
+        if (process.env[key] !== value) {
+          if (
+            typeof process.env[key] === 'undefined' ||
+            ((!prevEnvKeys || prevEnvKeys.has(key)) && process.env[key] !== value)
+          ) {
+            (prevEnvKeys ||= new Set()).add(key);
+            process.env[key] = envInfo.env[key];
+            envOutput[key] = value ?? undefined;
+          }
         }
       }
-    }
 
-    event('load', {
-      mode: params.mode,
-      files: relativeFiles(envInfo.files),
-      keys: Object.keys(envOutput),
-    });
+      event('load', {
+        mode: params.mode,
+        files: relativeFiles(envInfo.files),
+        keys: Object.keys(envOutput),
+      });
+    }
+  } finally {
+    delete process.env.EXPO_CONFIG_MODE;
   }
 }


### PR DESCRIPTION
# Why

Expo CLI doesn't always set `NODE_ENV` before loading the app config or env files.

# How

I updated Expo CLI commands to use the new shared API and set the mode to either `development` or `production`.

# Test Plan

Tests and CI checks pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)