### PR TITLE
[router] Remove the `default` field from `DrawerNavigationState` and deprecate `getDrawerStatusFromState`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove the static `default` field from `DrawerNavigationState` and deprecate `getDrawerStatusFromState`. ([#48750](https://github.com/expo/expo/pull/48750) by [@Ubax](https://github.com/Ubax))
 - Remove the `preloadedRouteKeys` field from `TabNavigationState`. ([#48718](https://github.com/expo/expo/pull/48718) by [@Ubax](https://github.com/Ubax))
 - Make `history` optional in `TabNavigationState` and `DrawerNavigationState` ([#48709](https://github.com/expo/expo/pull/48709) by [@Ubax](https://github.com/Ubax))
 - Make navigation state `type` optional for custom routers. ([#48757](https://github.com/expo/expo/pull/48757) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
@@ -1,42 +1,57 @@
-import { expect, test } from '@jest/globals';
-
-import type { DrawerNavigationState, DrawerStatus, ParamListBase } from '../../native';
+import { DrawerRouter } from '../../routers';
 import { getDrawerStatusFromState } from '../utils/getDrawerStatusFromState';
 
-const createState = (
-  history: DrawerNavigationState<ParamListBase>['history'],
-  defaultStatus: DrawerStatus = 'closed'
-): DrawerNavigationState<ParamListBase> => ({
-  stale: false,
-  type: 'drawer',
-  key: 'drawer-test',
-  index: 0,
-  routeNames: ['bar'],
-  routes: [{ key: 'bar', name: 'bar' }],
-  default: defaultStatus,
-  history,
+const state = DrawerRouter({}).getInitialState({
+  routeNames: ['index'],
+  routeParamList: {},
+  routeGetIdList: {},
 });
 
-test.each<{ defaultStatus: DrawerStatus }>([
-  { defaultStatus: 'closed' },
-  { defaultStatus: 'open' },
-])('falls back to defaultStatus: $defaultStatus without history', ({ defaultStatus }) => {
-  expect(getDrawerStatusFromState(createState(undefined, defaultStatus))).toBe(defaultStatus);
+const openState = DrawerRouter({ defaultStatus: 'open' }).getInitialState({
+  routeNames: ['index'],
+  routeParamList: {},
+  routeGetIdList: {},
 });
 
-test('reads the status from the last drawer entry', () => {
+it.each(['closed', 'open'] as const)(
+  'uses the provided default status %s when history has no drawer entry',
+  (defaultStatus) => {
+    expect(getDrawerStatusFromState(state, defaultStatus)).toBe(defaultStatus);
+  }
+);
+
+it('reports open for a router with defaultStatus open and no drawer entry', () => {
+  expect(getDrawerStatusFromState(openState, 'open')).toBe('open');
+});
+
+it('reports closed for a router with defaultStatus open after the drawer is closed', () => {
   expect(
     getDrawerStatusFromState(
-      createState([
-        { type: 'route', key: 'bar' },
-        { type: 'drawer', status: 'open' },
-      ])
+      {
+        ...openState,
+        history: [...(openState.history ?? []), { type: 'drawer', status: 'closed' }],
+      },
+      'open'
     )
-  ).toBe('open');
+  ).toBe('closed');
 });
 
-test('falls back to defaultStatus when history has no drawer entry', () => {
-  expect(getDrawerStatusFromState(createState([{ type: 'route', key: 'bar' }], 'open'))).toBe(
-    'open'
-  );
+it('uses the last drawer status from history instead of the provided default', () => {
+  expect(
+    getDrawerStatusFromState(
+      {
+        ...state,
+        history: [
+          ...(state.history ?? []),
+          { type: 'drawer', status: 'open' },
+          { type: 'drawer', status: 'closed' },
+        ],
+      },
+      'open'
+    )
+  ).toBe('closed');
+});
+
+it('uses the provided default status when history is absent', () => {
+  expect(getDrawerStatusFromState({ ...state, history: undefined }, 'open')).toBe('open');
 });

--- a/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
@@ -1,11 +1,18 @@
 import type { DrawerNavigationState, DrawerStatus, ParamListBase } from '../../native';
 
+/**
+ * Returns the drawer's current status.
+ *
+ * @param defaultStatus Status returned when the state has no drawer history entry.
+ * @deprecated Use `useDrawerStatus` instead.
+ */
 export function getDrawerStatusFromState(
-  state: DrawerNavigationState<ParamListBase>
+  state: DrawerNavigationState<ParamListBase>,
+  defaultStatus: DrawerStatus
 ): DrawerStatus {
   const entry = state.history?.findLast((it) => it.type === 'drawer') as
     | { type: 'drawer'; status: DrawerStatus }
     | undefined;
 
-  return entry?.status ?? state.default ?? 'closed';
+  return entry?.status ?? defaultStatus;
 }

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -112,7 +112,7 @@ function DrawerViewBase({
 
   const { colors } = useTheme();
 
-  const drawerStatus = getDrawerStatusFromState(state);
+  const drawerStatus = getDrawerStatusFromState(state, defaultStatus);
 
   const handleDrawerOpen = useLatestCallback(() => {
     navigation.dispatch({

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -33,10 +33,6 @@ export type DrawerNavigationState<ParamList extends ParamListBase> = Omit<
    */
   type: 'drawer';
   /**
-   * Default status of the drawer.
-   */
-  default: DrawerStatus;
-  /**
    * List of previously visited route keys and drawer open status.
    */
   history?: ({ type: 'route'; key: string } | { type: 'drawer'; status: DrawerStatus })[];
@@ -168,7 +164,6 @@ export function DrawerRouter({
 
       return {
         ...state,
-        default: defaultStatus,
         stale: false,
         type: 'drawer',
         key: `drawer-${nanoid()}`,
@@ -194,7 +189,6 @@ export function DrawerRouter({
 
       return {
         ...state,
-        default: defaultStatus,
         type: 'drawer',
         key: `drawer-${nanoid()}`,
       };

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -6,7 +6,6 @@ import {
   DrawerActions,
   type DrawerNavigationState,
   DrawerRouter,
-  type DrawerStatus,
   type ParamListBase,
   type RouterActionOptions,
   type RouterConfigOptions,
@@ -32,7 +31,6 @@ test('gets initial state from route names and params with initialRouteName', () 
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'baz-test', name: 'baz', params: { answer: 42 } }],
     history: [{ type: 'route', key: 'baz-test' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -40,16 +38,13 @@ test('gets initial state from route names and params with initialRouteName', () 
 
 type DrawerHistory = NonNullable<DrawerNavigationState<ParamListBase>['history']>;
 
-const stateWithoutHistory = (
-  defaultStatus: DrawerStatus = 'closed'
-): DrawerNavigationState<ParamListBase> => ({
+const stateWithoutHistory = (): DrawerNavigationState<ParamListBase> => ({
   stale: false,
   type: 'drawer',
   key: 'root',
   index: 0,
   routeNames: ['bar'],
   routes: [{ key: 'bar', name: 'bar' }],
-  default: defaultStatus,
 });
 
 const optionsWithoutHistory: RouterConfigOptions = {
@@ -112,7 +107,7 @@ test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
     const router = DrawerRouter({ defaultStatus: 'open' });
 
     expect(
-      router.getStateForAction(stateWithoutHistory('open'), action, optionsWithoutHistory)?.history
+      router.getStateForAction(stateWithoutHistory(), action, optionsWithoutHistory)?.history
     ).toEqual(expectedHistory);
   }
 );
@@ -168,7 +163,6 @@ test('preserves reconstructed history after closing the drawer', () => {
       { key: 'bar', name: 'bar' },
       { key: 'baz', name: 'baz' },
     ],
-    default: 'closed',
   };
 
   const openState = router.getStateForAction(
@@ -204,7 +198,6 @@ test('gets initial state from route names and params without initialRouteName', 
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
     history: [{ type: 'route', key: 'bar-test' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -320,7 +313,6 @@ test('gets rehydrated state from partial state', () => {
       { key: 'qux-1', name: 'qux', params: { name: 'Jane' } },
     ],
     history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -338,7 +330,6 @@ test('gets rehydrated state from partial state', () => {
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'baz-0', name: 'baz', params: { answer: 42 } }],
     history: [{ type: 'route', key: 'baz-0' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -368,7 +359,6 @@ test('gets rehydrated state from partial state', () => {
       { type: 'route', key: 'bar-0' },
       { type: 'route', key: 'qux-2' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -387,7 +377,6 @@ test('gets rehydrated state from partial state', () => {
     routeNames: ['bar', 'baz', 'qux'],
     routes: [{ key: 'bar-test', name: 'bar' }],
     history: [{ type: 'route', key: 'bar-test' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -415,7 +404,6 @@ test('gets rehydrated state from partial state', () => {
       { type: 'route', key: 'bar-test' },
       { type: 'drawer', status: 'open' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -437,7 +425,6 @@ test("doesn't rehydrate state if it's not stale", () => {
       { type: 'route', key: 'bar-test' },
       { type: 'drawer', status: 'open' },
     ],
-    default: 'closed',
     stale: false as const,
     type: 'drawer' as const,
   };
@@ -471,7 +458,6 @@ test('handles navigate action', () => {
           { key: 'bar', name: 'bar' },
         ],
         history: [{ type: 'route', key: 'bar' }],
-        default: 'closed',
       },
       CommonActions.navigate('baz', { answer: 42 }),
       options
@@ -487,7 +473,6 @@ test('handles navigate action', () => {
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'baz' }],
-    default: 'closed',
   });
 });
 
@@ -514,7 +499,6 @@ test('handles navigate action with open drawer', () => {
           { type: 'route', key: 'bar' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
       },
       CommonActions.navigate('baz', { answer: 42 }),
       options
@@ -530,7 +514,6 @@ test('handles navigate action with open drawer', () => {
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'baz' }],
-    default: 'closed',
   });
 });
 
@@ -557,7 +540,6 @@ test('closes open drawer on replace with backBehavior: fullHistory', () => {
           { type: 'route', key: 'bar' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
       },
       DrawerActions.replace('baz'),
       options
@@ -573,7 +555,6 @@ test('closes open drawer on replace with backBehavior: fullHistory', () => {
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'baz' }],
-    default: 'closed',
   });
 });
 
@@ -597,7 +578,6 @@ test('handles open drawer action', () => {
           { key: 'bar', name: 'bar' },
         ],
         history: [{ type: 'route', key: 'bar' }],
-        default: 'closed',
       },
       DrawerActions.openDrawer(),
       options
@@ -616,7 +596,6 @@ test('handles open drawer action', () => {
       { type: 'route', key: 'bar' },
       { type: 'drawer', status: 'open' },
     ],
-    default: 'closed',
   });
 
   const state: DrawerNavigationState<ParamListBase> = {
@@ -633,7 +612,6 @@ test('handles open drawer action', () => {
       { type: 'route', key: 'bar' },
       { type: 'drawer', status: 'open' },
     ],
-    default: 'closed',
   };
 
   expect(router.getStateForAction(state, DrawerActions.openDrawer(), options)).toBe(state);
@@ -662,7 +640,6 @@ test('handles close drawer action', () => {
           { type: 'route', key: 'bar' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
       },
       DrawerActions.closeDrawer(),
       options
@@ -678,7 +655,6 @@ test('handles close drawer action', () => {
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'bar' }],
-    default: 'closed',
   });
 
   const state: DrawerNavigationState<ParamListBase> = {
@@ -695,7 +671,6 @@ test('handles close drawer action', () => {
       { type: 'route', key: 'bar' },
       { type: 'route', key: 'baz' },
     ],
-    default: 'closed',
   };
 
   expect(router.getStateForAction(state, DrawerActions.closeDrawer(), options)).toBe(state);
@@ -724,7 +699,6 @@ test('handles toggle drawer action', () => {
           { type: 'route', key: 'bar' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
       },
       DrawerActions.toggleDrawer(),
       options
@@ -740,7 +714,6 @@ test('handles toggle drawer action', () => {
       { key: 'bar', name: 'bar' },
     ],
     history: [{ type: 'route', key: 'bar' }],
-    default: 'closed',
   });
 
   expect(
@@ -756,7 +729,6 @@ test('handles toggle drawer action', () => {
           { key: 'bar', name: 'bar' },
         ],
         history: [{ type: 'route', key: 'bar' }],
-        default: 'closed',
       },
       DrawerActions.toggleDrawer(),
       options
@@ -775,7 +747,6 @@ test('handles toggle drawer action', () => {
       { type: 'route', key: 'bar' },
       { type: 'drawer', status: 'open' },
     ],
-    default: 'closed',
   });
 });
 
@@ -792,7 +763,6 @@ test('updates history on focus change with backBehavior: history', () => {
       { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
     ],
     history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
     stale: false as const,
     type: 'drawer' as const,
   };
@@ -838,7 +808,6 @@ test('updates history on focus change with backBehavior: fullHistory', () => {
       { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
     ],
     history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
     stale: false as const,
     type: 'drawer' as const,
   };
@@ -887,7 +856,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
           { key: 'qux-0', name: 'qux' },
         ],
         history: [{ type: 'route', key: 'bar-0' }],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -906,7 +874,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
       { type: 'route', key: 'bar-0' },
       { type: 'route', key: 'baz-0' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -926,7 +893,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
           { type: 'route', key: 'bar-0' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -942,7 +908,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
       { key: 'qux-0', name: 'qux' },
     ],
     history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -962,7 +927,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
           { type: 'route', key: 'bar-0' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -981,7 +945,6 @@ test('closes drawer on focus change with backBehavior: history', () => {
       { type: 'route', key: 'bar-0' },
       { type: 'route', key: 'baz-0' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -1002,7 +965,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
           { key: 'qux-0', name: 'qux' },
         ],
         history: [{ type: 'route', key: 'bar-0' }],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -1021,7 +983,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
       { type: 'route', key: 'bar-0' },
       { type: 'route', key: 'baz-0' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -1041,7 +1002,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
           { type: 'route', key: 'bar-0' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -1057,7 +1017,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
       { key: 'qux-0', name: 'qux' },
     ],
     history: [{ type: 'route', key: 'bar-0' }],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });
@@ -1077,7 +1036,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
           { type: 'route', key: 'bar-0' },
           { type: 'drawer', status: 'open' },
         ],
-        default: 'closed',
         stale: false,
         type: 'drawer',
       },
@@ -1096,7 +1054,6 @@ test('closes drawer on focus change with backBehavior: fullHistory', () => {
       { type: 'route', key: 'bar-0' },
       { type: 'route', key: 'baz-0' },
     ],
-    default: 'closed',
     stale: false,
     type: 'drawer',
   });


### PR DESCRIPTION
# Why

`default` drawer status (wether it is opened or not) is stored in state. In my opinion this is only navigator's concern, and not relevant from the navigation state perspective.

# How

1. Remove `default` from `DrawerNavigationState`
2. Add second parameter to `getDrawerStatusFromState` - `defaultState` which is used when no open/closed information is stored in the `history`
3. Deprecate `getDrawerStatusFromState` - the recommended solution is using hook, which can only be accessed from within the navigator content and thus get the status directly from the navigator. In the future we may consider dropping the whole open/closed information from state and making it available only via the hook/context.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
