### PR TITLE
[router] Handle PUSH action in all routers

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Handle `PUSH` in tab and drawer routers instead of coercing it to `NAVIGATE`. Custom routers must now handle the `PUSH` action in `getStateForAction`. ([#48752](https://github.com/expo/expo/pull/48752) by [@Ubax](https://github.com/Ubax))
 - Remove the `initialParams` prop from Expo Router screens and `routeParamList` from custom router action options. ([#48756](https://github.com/expo/expo/pull/48756) by [@Ubax](https://github.com/Ubax))
 - Remove the `initialRouteName` prop from Expo Router navigators. Configure the initial route with `unstable_settings.initialRouteName` in the route layout instead. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Remove `NavigationContainerRefContext` fallback in `useNavigation`. The hook now throws when called outside a navigator, including components rendered via `ExpoRoot`'s `wrapper` prop. ([#48638](https://github.com/expo/expo/pull/48638) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/tab-router-push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tab-router-push.test.ios.tsx
@@ -1,0 +1,247 @@
+import { act, fireEvent, screen } from '@testing-library/react-native';
+import { Button, Text, View } from 'react-native';
+import { Drawer as DrawerLayout } from 'react-native-drawer-layout';
+
+import { router } from '../imperative-api';
+import { Drawer } from '../layouts/Drawer';
+import { Stack } from '../layouts/Stack';
+import { Tabs } from '../layouts/Tabs';
+import { NativeTabs } from '../native-tabs/NativeTabs';
+import { INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME } from '../navigationParams';
+import { DrawerActions } from '../react-navigation/native';
+import { renderRouter } from '../testing-library';
+import { TabList, TabSlot, TabTrigger, Tabs as HeadlessTabs } from '../ui';
+import { useNavigation } from '../useNavigation';
+
+jest.mock('react-native-drawer-layout', () => {
+  const { View }: typeof import('react-native') = jest.requireActual('react-native');
+  const actual = jest.requireActual(
+    'react-native-drawer-layout'
+  ) as typeof import('react-native-drawer-layout');
+  return {
+    ...actual,
+    Drawer: jest.fn(({ children, ...props }) => (
+      <View testID="drawer" {...props}>
+        {children}
+      </View>
+    )),
+  };
+});
+
+jest.mock('react-native-screens', () => {
+  const { View }: typeof import('react-native') = jest.requireActual('react-native');
+  const actual = jest.requireActual(
+    'react-native-screens'
+  ) as typeof import('react-native-screens');
+  return {
+    ...actual,
+    ScreenStackItem: jest.fn(({ children }) => <View>{children}</View>),
+    Tabs: {
+      ...actual.Tabs,
+      Host: jest.fn(({ children }) => <View>{children}</View>),
+      Screen: jest.fn(({ children }) => <View>{children}</View>),
+    },
+  };
+});
+
+const drawerOpen = () =>
+  (DrawerLayout as unknown as jest.Mock).mock.calls.at(-1)![0].open as boolean;
+
+let warn: jest.SpyInstance | undefined;
+
+afterEach(() => {
+  warn?.mockRestore();
+  warn = undefined;
+});
+
+it('push switches JS tabs without duplicating routes and follows back behavior', () => {
+  const result = renderRouter({
+    _layout: () => (
+      <Tabs backBehavior="history">
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+        <Tabs.Screen name="third" />
+      </Tabs>
+    ),
+    index: () => null,
+    second: () => null,
+    third: () => null,
+  });
+
+  act(() => router.push('/second'));
+  act(() => router.push('/third'));
+
+  const tabState = result.getRouterState()!.routes[0]!.state;
+  expect(tabState?.routes).toHaveLength(3);
+  expect(screen).toHavePathname('/third');
+
+  act(() => router.push('/third'));
+  const tabStateAfterDuplicatePush = result.getRouterState()!.routes[0]!.state;
+  expect(tabStateAfterDuplicatePush?.routes).toHaveLength(3);
+  expect(tabStateAfterDuplicatePush?.index).toBe(2);
+
+  act(() => router.back());
+  expect(screen).toHavePathname('/second');
+});
+
+it('push closes a drawer when switching routes', () => {
+  function Index() {
+    const navigation = useNavigation();
+    return (
+      <Button
+        testID="open-drawer"
+        title="Open drawer"
+        onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
+      />
+    );
+  }
+
+  renderRouter({
+    _layout: () => (
+      <Drawer>
+        <Drawer.Screen name="index" />
+        <Drawer.Screen name="second" />
+      </Drawer>
+    ),
+    index: Index,
+    second: () => null,
+  });
+
+  fireEvent.press(screen.getByTestId('open-drawer'));
+  expect(drawerOpen()).toBe(true);
+
+  act(() => router.push('/second'));
+  expect(screen).toHavePathname('/second');
+  expect(drawerOpen()).toBe(false);
+});
+
+it('push closes a parent drawer when switching nested tabs', () => {
+  function First() {
+    const navigation = useNavigation();
+    return (
+      <Button
+        testID="open-parent-drawer"
+        title="Open drawer"
+        onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
+      />
+    );
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Drawer>
+          <Drawer.Screen name="(tabs)" />
+        </Drawer>
+      ),
+      '(tabs)/_layout': () => (
+        <Tabs>
+          <Tabs.Screen name="first" />
+          <Tabs.Screen name="second" />
+        </Tabs>
+      ),
+      '(tabs)/first': First,
+      '(tabs)/second': () => null,
+    },
+    { initialUrl: '/first' }
+  );
+
+  fireEvent.press(screen.getByTestId('open-parent-drawer'));
+  expect(drawerOpen()).toBe(true);
+
+  act(() => router.push('/second'));
+  expect(screen).toHavePathname('/second');
+  expect(drawerOpen()).toBe(false);
+});
+
+it('push closes a parent drawer when switching a nested stack', () => {
+  function First() {
+    const navigation = useNavigation();
+    return (
+      <Button
+        testID="open-parent-drawer"
+        title="Open drawer"
+        onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
+      />
+    );
+  }
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Drawer>
+          <Drawer.Screen name="(stack)" />
+        </Drawer>
+      ),
+      '(stack)/_layout': () => <Stack />,
+      '(stack)/first': First,
+      '(stack)/second': () => null,
+    },
+    { initialUrl: '/first' }
+  );
+
+  fireEvent.press(screen.getByTestId('open-parent-drawer'));
+  expect(drawerOpen()).toBe(true);
+
+  act(() => router.push('/second'));
+  expect(screen).toHavePathname('/second');
+  expect(drawerOpen()).toBe(false);
+});
+
+it('push switches headless tabs to a nested route and anchors the target stack', () => {
+  const result = renderRouter({
+    _layout: () => (
+      <HeadlessTabs>
+        <TabList>
+          <TabTrigger name="index" href="/" />
+          <TabTrigger name="fruit" href="/fruit" />
+        </TabList>
+        <TabSlot />
+      </HeadlessTabs>
+    ),
+    index: () => null,
+    'fruit/_layout': {
+      default: () => <Stack />,
+      unstable_settings: { anchor: 'index' },
+    },
+    'fruit/index': () => <Text>Fruit</Text>,
+    'fruit/details': () => <Text>Details</Text>,
+  });
+
+  act(() => router.push('/fruit/details', { withAnchor: true }));
+
+  expect(screen).toHavePathname('/fruit/details');
+
+  const fruitRoute = result
+    .getRouterState()!
+    .routes[0]!.state!.routes.find((route) => route.name === 'fruit')!;
+  expect(fruitRoute.state!.routes.map((route) => route.name)).toEqual(['index', 'details']);
+});
+
+it('push switches native tabs and warns about zoom params', () => {
+  warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  renderRouter({
+    _layout: () => (
+      <NativeTabs>
+        <NativeTabs.Trigger name="index" />
+        <NativeTabs.Trigger name="second" />
+      </NativeTabs>
+    ),
+    index: () => <View />,
+    second: () => <View />,
+  });
+
+  act(() =>
+    router.push({
+      pathname: '/second',
+      params: {
+        [INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME]: 'source-id',
+      },
+    })
+  );
+
+  expect(screen).toHavePathname('/second');
+  expect(warn).toHaveBeenCalledWith(
+    'Zoom transition is not supported when navigating between tabs. Falling back to standard navigation transition.'
+  );
+});

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -165,7 +165,7 @@ describe(getNavigateAction, () => {
     );
   });
 
-  it('PUSH is downgraded to NAVIGATE when target navigator is not a stack', () => {
+  it('preserves PUSH when target navigator is tab', () => {
     mockFindDivergentState.mockReturnValue({
       actionState: { routes: [{ name: 'tab1' }] },
       navigationState: {
@@ -182,27 +182,27 @@ describe(getNavigateAction, () => {
 
     const result = getNavigateAction('/tab1', {}, 'PUSH');
 
-    expect(result!.type).toBe('NAVIGATE');
+    expect(result!.type).toBe('PUSH');
   });
 
-  it('type becomes JUMP_TO when target navigator is expo-tab', () => {
+  it('preserves PUSH when target navigator is drawer', () => {
     mockFindDivergentState.mockReturnValue({
-      actionState: { routes: [{ name: 'tab1' }] },
+      actionState: { routes: [{ name: 'screen1' }] },
       navigationState: {
-        key: 'expo-tab-key',
-        type: 'expo-tab',
-        routes: [{ key: 'tab1-key', name: 'tab1' }],
+        key: 'drawer-key',
+        type: 'drawer',
+        routes: [{ key: 'screen1-key', name: 'screen1' }],
         index: 0,
-        routeNames: ['tab1'],
+        routeNames: ['screen1'],
         stale: false,
       },
-      actionStateRoute: { name: 'tab1' },
+      actionStateRoute: { name: 'screen1' },
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/tab1', {});
+    const result = getNavigateAction('/screen1', {}, 'PUSH');
 
-    expect(result!.type).toBe('JUMP_TO');
+    expect(result!.type).toBe('PUSH');
   });
 
   it('preserves REPLACE when target navigator is drawer', () => {

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -74,12 +74,6 @@ export function getNavigateAction(
    */
   const rootPayload = getPayloadFromStateRoute(actionStateRoute || {});
 
-  if (type === 'PUSH' && navigationState.type !== 'stack') {
-    type = 'NAVIGATE';
-  } else if (navigationState.type === 'expo-tab') {
-    type = 'JUMP_TO';
-  }
-
   if (withAnchor) {
     if (rootPayload.params.initial) {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsRouter.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsRouter.tsx
@@ -28,6 +28,7 @@ export function NativeBottomTabsRouter(options: TabRouterOptions) {
     // @ts-expect-error TODO: For some reason this is not typed correctly
     getStateForAction: (state, action: TabActionType | CommonNavigationAction, options) => {
       switch (action.type) {
+        case 'PUSH':
         case 'NAVIGATE': {
           const newStateFromNavigation = tabRouter.getStateForAction(state, action, options);
 

--- a/packages/expo-router/src/react-navigation/routers/BaseRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/BaseRouter.tsx
@@ -1,6 +1,11 @@
 import { nanoid } from 'nanoid/non-secure';
 
-import type { CommonNavigationAction, NavigationState, PartialState } from './types';
+import type {
+  CommonNavigationAction,
+  NavigationAction,
+  NavigationState,
+  PartialState,
+} from './types';
 
 /**
  * Base router object that can be used when writing custom routers.
@@ -96,7 +101,9 @@ export const BaseRouter = {
     }
   },
 
-  shouldActionChangeFocus(action: CommonNavigationAction) {
-    return action.type === 'NAVIGATE' || action.type === 'NAVIGATE_DEPRECATED';
+  shouldActionChangeFocus(action: NavigationAction) {
+    return (
+      action.type === 'PUSH' || action.type === 'NAVIGATE' || action.type === 'NAVIGATE_DEPRECATED'
+    );
   },
 };

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -209,6 +209,7 @@ export function DrawerRouter({
 
           return addDrawerToHistory(state);
 
+        case 'PUSH':
         case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -26,6 +26,12 @@ export type TabActionType =
       payload: { name: string; params?: object };
       source?: string;
       target?: string;
+    }
+  | {
+      type: 'PUSH';
+      payload: { name: string; params?: object };
+      source?: string;
+      target?: string;
     };
 
 export type BackBehavior =
@@ -443,6 +449,7 @@ export function TabRouter({
           };
         }
 
+        case 'PUSH':
         case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE':


### PR DESCRIPTION
# Why

Instead of rewriting the navigation action from `PUSH` to `NAVIGATE` or `JUMP_TO`, we can handle this actions in routers. This makes the responsibilities clearer and removes the dependency of `getNavigateAction` on `state.type` - removed in a follow-up PR

```tsx
  if (type === 'PUSH' && navigationState.type !== 'stack') {
    type = 'NAVIGATE';
  } else if (navigationState.type === 'expo-tab') {
    type = 'JUMP_TO';
  }
```

# How

1. Add `PUSH` cases to `TabRouter` and `BaseRouter`
2. Update tests
3. Remove the condition

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
