### PR TITLE
[router] Make navigation state `type` optional

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Make navigation state `type` optional for custom routers. ([#48757](https://github.com/expo/expo/pull/48757) by [@Ubax](https://github.com/Ubax))
 - Handle `PUSH` in tab and drawer routers instead of coercing it to `NAVIGATE`. Custom routers must now handle the `PUSH` action in `getStateForAction`. ([#48752](https://github.com/expo/expo/pull/48752) by [@Ubax](https://github.com/Ubax))
 - Remove the `initialParams` prop from Expo Router screens and `routeParamList` from custom router action options. ([#48756](https://github.com/expo/expo/pull/48756) by [@Ubax](https://github.com/Ubax))
 - Remove the `initialRouteName` prop from Expo Router navigators. Configure the initial route with `unstable_settings.initialRouteName` in the route layout instead. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/global-state/router.ts
+++ b/packages/expo-router/src/global-state/router.ts
@@ -92,6 +92,8 @@ export function canDismiss(): boolean {
 
   // Keep traversing down the state tree until we find a stack navigator that we can pop
   while (state) {
+    // TODO(ENG-22019): Detect typeless stacks, including anchor/initialRouteName states that start
+    // with multiple routes.
     if (state.type === 'stack' && getHistoryLength(state) > 1) {
       return true;
     }

--- a/packages/expo-router/src/global-state/stateUtils.ts
+++ b/packages/expo-router/src/global-state/stateUtils.ts
@@ -59,6 +59,8 @@ export function findDivergentState(
   while (actionState && navigationState) {
     // TODO(@kitten): Review invalid indexed access into undefined
     actionStateRoute = actionState.routes[actionState.index ?? actionState.routes.length - 1]!;
+    // TODO(ENG-22021): Resolve navigator types independently of state for the tab checks in this loop.
+    // https://linear.app/expo/issue/ENG-22021/fix-link-preview-by-detecting-navigator-type-on-native
     const stateRoute = (() => {
       if (navigationState.type === 'tab' && lookThroughAllTabs) {
         return (

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -56,7 +56,8 @@ const Tabs = unstable_integrateWithRouter<
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),
     popNestedStackToTop: (routeKey) => {
       const nestedState = state.routes.find((route) => route.key === routeKey)?.state;
-      if (nestedState?.type === 'stack' && nestedState.key) {
+      // A targeted POP_TO_TOP is a no-op for nested navigators that are not stacks.
+      if (nestedState?.key) {
         dispatch({ ...StackActions.popToTop(), target: nestedState.key });
       }
     },

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -30,6 +30,7 @@ export function getTabPathFromRootStateByHref(
 
   const tabPath: TabPath[] = [];
   navigationRoutes.forEach((route, i, arr) => {
+    // TODO(ENG-22021): Fix link preview by detecting navigator type on native. https://linear.app/expo/issue/ENG-22021/fix-link-preview-by-detecting-navigator-type-on-native
     if (route.state?.type === 'tab') {
       const tabState = route.state as TabNavigationState<ParamListBase>;
       const oldTabKey = tabState.routes[tabState.index]!.key;

--- a/packages/expo-router/src/native-tabs/NativeTabTrigger.tsx
+++ b/packages/expo-router/src/native-tabs/NativeTabTrigger.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, type ReactElement, type ReactNode } from 'react';
+import { use, useCallback, type ReactElement, type ReactNode } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { useIsPreview } from '../link/preview/PreviewRouteContext';
+import { NavigatorTypeContext } from '../react-navigation/core';
 import { useNavigation, useRoute } from '../react-navigation/native';
 import { useFocusEffect } from '../useFocusEffect';
 import { filterAllowedChildrenElements, isChildOfType } from '../utils/children';
@@ -58,6 +59,7 @@ function NativeTabTriggerImpl(props: NativeTabTriggerProps) {
   const route = useRoute();
   const navigation = useNavigation();
   const isInPreview = useIsPreview();
+  const navigatorType = use(NavigatorTypeContext);
 
   useFocusEffect(
     useCallback(() => {
@@ -65,7 +67,7 @@ function NativeTabTriggerImpl(props: NativeTabTriggerProps) {
       // As long as all tabs are loaded at the start, we don't need this check.
       // It is here to ensure similar behavior to stack
       if (!isInPreview) {
-        if (navigation.getState()?.type !== 'tab') {
+        if (navigatorType !== 'tab') {
           throw new Error(
             `Trigger component can only be used in the tab screen. Current route: ${route.name}`
           );
@@ -73,7 +75,7 @@ function NativeTabTriggerImpl(props: NativeTabTriggerProps) {
         const options = convertTabPropsToOptions(props, true);
         navigation.setOptions(options);
       }
-    }, [props, isInPreview])
+    }, [props, isInPreview, navigatorType])
   );
 
   return null;

--- a/packages/expo-router/src/native-tabs/__tests__/NativeTabTrigger.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeTabTrigger.test.ios.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react-native';
+
+import { NavigatorTypeContext } from '../../react-navigation/core';
+import { NativeTabTrigger } from '../NativeTabTrigger';
+
+const mockNavigation = {
+  getState: jest.fn(() => ({ routes: [] })),
+  setOptions: jest.fn(),
+};
+
+jest.mock('../../react-navigation/native', () => {
+  const actualModule = jest.requireActual(
+    '../../react-navigation/native'
+  ) as typeof import('../../react-navigation/native');
+  return {
+    ...actualModule,
+    useNavigation: () => mockNavigation,
+    useRoute: () => ({ name: 'index' }),
+  };
+});
+
+jest.mock('../../useFocusEffect', () => ({
+  useFocusEffect: (effect: () => void) => effect(),
+}));
+
+test('uses the router type from context', () => {
+  render(
+    <NavigatorTypeContext.Provider value="tab">
+      <NativeTabTrigger unstable_nativeProps={{ title: 'Home' }} />
+    </NavigatorTypeContext.Provider>
+  );
+
+  expect(mockNavigation.getState).not.toHaveBeenCalled();
+  expect(mockNavigation.setOptions).toHaveBeenCalledWith({ nativeProps: { title: 'Home' } });
+});
+
+test('rejects a trigger rendered in a nested stack screen', () => {
+  expect(() =>
+    render(
+      <NavigatorTypeContext.Provider value="stack">
+        <NativeTabTrigger />
+      </NavigatorTypeContext.Provider>
+    )
+  ).toThrow('Trigger component can only be used in the tab screen. Current route: index');
+});

--- a/packages/expo-router/src/react-navigation/core/NavigatorTypeContext.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigatorTypeContext.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+import { createContext } from 'react';
+
+export const NavigatorTypeContext = createContext<string | undefined>(undefined);

--- a/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
@@ -1,0 +1,114 @@
+import { render, screen } from '@testing-library/react-native';
+import { use } from 'react';
+import { Text } from 'react-native';
+
+import type {
+  DefaultRouterOptions,
+  InitialState,
+  NavigationState,
+  ParamListBase,
+} from '../../routers';
+import { BaseNavigationContainer } from '../BaseNavigationContainer';
+import { NavigatorTypeContext } from '../NavigatorTypeContext';
+import { Screen } from '../Screen';
+import { createNavigationContainerRef } from '../createNavigationContainerRef';
+import { useNavigationBuilder } from '../useNavigationBuilder';
+import { MockRouter, MockRouterKey } from './__fixtures__/MockRouter';
+
+beforeEach(() => {
+  MockRouterKey.current = 0;
+});
+
+// `MockRouter` with `type` dropped from every state it produces.
+function StateWithoutTypeRouter(options: DefaultRouterOptions) {
+  const { getInitialState, getRehydratedState, ...router } = MockRouter(options);
+
+  // `MockRouter` always sets a type, so the result is only a `NavigationState` because `type` is optional.
+  const omitType = ({ type: _stateType, ...state }: NavigationState) => state as NavigationState;
+
+  return {
+    ...router,
+    getInitialState: (...args: Parameters<typeof getInitialState>) =>
+      omitType(getInitialState(...args)),
+    getRehydratedState: (...args: Parameters<typeof getRehydratedState>) =>
+      omitType(getRehydratedState(...args)),
+  };
+}
+
+// `MockRouter` with `type` dropped from the router and from every state it produces.
+function TypelessRouter(options: DefaultRouterOptions) {
+  const { type: _type, ...router } = StateWithoutTypeRouter(options);
+  return router;
+}
+
+function TestNavigator({ createRouter = TypelessRouter, ...props }: any): any {
+  const { state, descriptors, NavigationContent } = useNavigationBuilder(createRouter, props);
+
+  return (
+    <NavigationContent>
+      {state.routes.map((route) => descriptors[route.key]!.render())}
+    </NavigationContent>
+  );
+}
+
+/** Renders a navigator backed by `TypelessRouter` and returns the state it settles on. */
+function renderWithInitialState(initialState: InitialState) {
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={ref} initialState={initialState}>
+      <TestNavigator>
+        <Screen name="first">{() => null}</Screen>
+        <Screen name="second">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  return ref.current!.getRootState();
+}
+
+/** A persisted state focusing the second route, so a discarded state is visible as `index: 0`. */
+const persistedState = {
+  stale: false,
+  key: 'persisted',
+  index: 1,
+  routeNames: ['first', 'second'],
+  routes: [
+    { key: 'first', name: 'first' },
+    { key: 'second', name: 'second' },
+  ],
+};
+
+test('a persisted state without a type is accepted by a typeless router', () => {
+  const state = renderWithInitialState(persistedState);
+
+  expect(state.index).toBe(1);
+  expect(state).not.toHaveProperty('type');
+});
+
+test('a persisted state with a type is discarded by a typeless router', () => {
+  const state = renderWithInitialState({ ...persistedState, type: 'test' });
+
+  expect(state.index).toBe(0);
+  expect(state).not.toHaveProperty('type');
+});
+
+test('provides the router type when an accepted persisted state has no type', () => {
+  function RouterType() {
+    return <Text>{use(NavigatorTypeContext)}</Text>;
+  }
+
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  render(
+    <BaseNavigationContainer ref={ref} initialState={persistedState}>
+      <TestNavigator createRouter={StateWithoutTypeRouter}>
+        <Screen name="first" component={RouterType} />
+        <Screen name="second" component={RouterType} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(ref.current!.getRootState().index).toBe(1);
+  expect(screen.getAllByText('test')).toHaveLength(2);
+});

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
@@ -1,7 +1,12 @@
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
-import { CommonActions, type ParamListBase, StackRouter } from '../../routers';
+import {
+  CommonActions,
+  type NavigationState,
+  type ParamListBase,
+  StackRouter,
+} from '../../routers';
 import { BaseNavigationContainer } from '../BaseNavigationContainer';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
@@ -21,7 +26,7 @@ afterEach(() => {
 test('preserves reference for navigation objects', () => {
   expect.assertions(2);
 
-  const state = {
+  const state: NavigationState = {
     type: 'tab',
     stale: false as const,
     index: 1,
@@ -74,7 +79,7 @@ test('preserves reference for navigation objects', () => {
 test('preserves placeholder navigation after the route is created', () => {
   let routeNames = ['Foo', 'Bar'];
   let routes = [{ key: 'Foo-key', name: 'Foo' }];
-  const getState = () => ({
+  const getState = (): NavigationState => ({
     type: 'tab',
     stale: false as const,
     index: 0,

--- a/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
@@ -107,6 +107,34 @@ test("lets parent handle the action if child didn't", () => {
   });
 });
 
+test('handles an unsupported targeted action as a no-op without bubbling', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+  const onUnhandledAction = jest.fn();
+
+  const TestNavigator = (props: any) => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
+
+    return (
+      <NavigationContent>{descriptors[state.routes[state.index]!.key]!.render()}</NavigationContent>
+    );
+  };
+
+  render(
+    <BaseNavigationContainer ref={ref} onUnhandledAction={onUnhandledAction}>
+      <TestNavigator>
+        <Screen name="foo">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  const state = ref.current!.getRootState();
+
+  act(() => ref.dispatch({ type: 'POP_TO_TOP', target: state.key }));
+
+  expect(ref.current!.getRootState()).toBe(state);
+  expect(onUnhandledAction).not.toHaveBeenCalled();
+});
+
 test("lets children handle the action if parent didn't with navigationInChildEnabled", () => {
   const CurrentParentRouter = MockRouter;
 

--- a/packages/expo-router/src/react-navigation/core/getFocusedRouteNameFromRoute.tsx
+++ b/packages/expo-router/src/react-navigation/core/getFocusedRouteNameFromRoute.tsx
@@ -6,11 +6,12 @@ export function getFocusedRouteNameFromRoute(route: Partial<Route<string>>): str
   const state = route[CHILD_STATE] ?? route.state;
   const params = route.params as { screen?: unknown } | undefined;
 
+  // TODO(@ubax): https://github.com/expo/expo/pull/48757 - remove the stack.type check from here
   const routeName = state
     ? // Get the currently active route name in the nested navigator
       state.routes[
         // If we have a partial state without index, for tab/drawer, first screen will be focused one, and last for stack
-        // The type property will only exist for rehydrated state and not for state from deep link
+        // Deep-link partial states can omit both index and type; typeless full states still have an index
         state.index ??
           (typeof state.type === 'string' && state.type !== 'stack' ? 0 : state.routes.length - 1)
       ].name

--- a/packages/expo-router/src/react-navigation/core/index.tsx
+++ b/packages/expo-router/src/react-navigation/core/index.tsx
@@ -46,6 +46,7 @@ export { NavigationIndependentTree } from './NavigationIndependentTree';
  * @deprecated Will be removed in a future SDK.
  */
 export { NavigationMetaContext } from './NavigationMetaContext';
+export { NavigatorTypeContext } from './NavigatorTypeContext';
 export { NavigationProvider } from './NavigationProvider';
 /**
  * @deprecated Will be removed in a future SDK.

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -22,6 +22,7 @@ import { NavigationHelpersContext } from './NavigationHelpersContext';
 import { NavigationMetaContext } from './NavigationMetaContext';
 import { NavigationRouteContext } from './NavigationProvider';
 import { NavigationStateContext } from './NavigationStateContext';
+import { NavigatorTypeContext } from './NavigatorTypeContext';
 import { PreventRemoveContext } from './PreventRemoveContext';
 import { Screen } from './Screen';
 import { UnhandledActionContext } from './UnhandledActionContext';
@@ -798,7 +799,9 @@ export function useNavigationBuilder<
           <NavigationStateListenerProvider state={state}>
             <FocusedRouteKeyContext.Provider value={state.routes[state.index]?.key}>
               <PreventRemoveContext.Provider value={preventRemoveContextValue}>
-                {element}
+                <NavigatorTypeContext.Provider value={router.type}>
+                  {element}
+                </NavigatorTypeContext.Provider>
               </PreventRemoveContext.Provider>
             </FocusedRouteKeyContext.Provider>
           </NavigationStateListenerProvider>

--- a/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
@@ -28,6 +28,8 @@ export const getPreventableRoutes = (
   state: NavigationState | { type?: string; index?: number; routes: { key?: string }[] },
   type = state.type
 ) =>
+  // In order to preload routes in stack, an action needs to be dispatched, so the type will be always
+  // set when there are preloaded routes
   type === 'stack'
     ? state.routes.slice(0, (state.index ?? state.routes.length - 1) + 1)
     : state.routes;

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -94,7 +94,8 @@ function DrawerViewBase({
     ) {
       const prevRoute = state.routes.find((route) => route.key === previousRouteKey);
 
-      if (prevRoute?.state?.type === 'stack' && prevRoute.state.key) {
+      if (prevRoute?.state?.key) {
+        // A targeted POP_TO_TOP is a no-op for nested navigators that are not stacks.
         navigation.dispatch({
           ...StackActions.popToTop(),
           target: prevRoute.state.key,

--- a/packages/expo-router/src/react-navigation/native/useScrollToTop.tsx
+++ b/packages/expo-router/src/react-navigation/native/useScrollToTop.tsx
@@ -69,6 +69,8 @@ export function useScrollToTop(ref: React.RefObject<ScrollableWrapper>) {
     // If the screen is nested inside multiple tab navigators, we should scroll to top for any of them
     // So we need to find all the parent tab navigators and add the listeners there
     while (currentNavigation) {
+      // TODO: Resolve every ancestor's navigator type at render time, as NavigatorTypeContext does
+      // for the nearest navigator.
       if (currentNavigation.getState().type === 'tab') {
         tabNavigations.push(currentNavigation);
       }

--- a/packages/expo-router/src/react-navigation/routers/types.tsx
+++ b/packages/expo-router/src/react-navigation/routers/types.tsx
@@ -35,9 +35,11 @@ export type NavigationState<ParamList extends ParamListBase = ParamListBase> = R
   /**
    * Custom type for the state, whether it's for tab, stack, drawer etc.
    * During rehydration, the state will be discarded if type doesn't match with router type.
-   * It can also be used to detect the type of the navigator we're dealing with.
+   * It can also be used to detect the type of the navigator we're dealing with. Note that initial
+   * state does not include type, so an action needs to be dispatched in a navigator, in order
+   * for the type to be set
    */
-  type: string;
+  type?: string;
   /**
    * Whether the navigation state has been rehydrated.
    */
@@ -149,13 +151,20 @@ export type RouterConfigOptions = {
  */
 export type RouterActionOptions = Omit<RouterConfigOptions, 'routeParamList'>;
 
-export type Router<State extends NavigationState, Action extends NavigationAction> = {
-  /**
-   * Type of the router. Should match the `type` property in state.
-   * If the type doesn't match, the state will be discarded during rehydration.
-   */
-  type: State['type'];
+/**
+ * Type of the router. Should match the `type` property in state.
+ * If the type doesn't match, the state will be discarded during rehydration.
+ * Only routers whose state has no `type` may omit it, since a state without a `type`
+ * is accepted by every router.
+ */
+type RouterType<State extends NavigationState> = undefined extends State['type']
+  ? { type?: State['type'] }
+  : { type: State['type'] };
 
+export type Router<
+  State extends NavigationState,
+  Action extends NavigationAction,
+> = RouterType<State> & {
   /**
    * Initialize the navigation state.
    *

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -8,6 +8,11 @@ import {
 
 import type { CommonNavigationAction, ParamListBase } from '../../react-navigation/core';
 import {
+  type DefaultRouterOptions,
+  type NavigationAction,
+  type NavigationState,
+  type Router,
+  type RouterFactory,
   TabRouter,
   type TabNavigationState,
   type TabRouterOptions,
@@ -70,6 +75,43 @@ const Nav = unstable_createStandardRouterNavigator<
   { initialRouteName?: string },
   TabRouterOptions
 >(Content, TabRouter);
+
+type TypelessNavigationState = Readonly<{
+  key: string;
+  index: number;
+  routeNames: string[];
+  routes: { key: string; name: string; params?: object }[];
+  stale: false;
+}>;
+
+const TypelessRouter: RouterFactory<
+  TypelessNavigationState,
+  NavigationAction,
+  DefaultRouterOptions
+> = () => ({
+  getInitialState: () => {
+    throw new Error('Type test only');
+  },
+  getRehydratedState: () => {
+    throw new Error('Type test only');
+  },
+  getStateForDeclaredRoutes: (state) => state,
+  getStateForRouteFocus: (state) => state,
+  getStateForAction: (state) => state,
+  shouldActionChangeFocus: () => false,
+});
+
+unstable_createStandardRouterNavigator(Content, TypelessRouter);
+
+// A router may omit `type` only when its state has none. A router whose state declares a literal
+// type must still declare the same literal, otherwise every state it produces would be rejected
+// by the rehydration check and replaced with a fresh initial state.
+export type _BaseRouterTypeIsOptional = Expect<
+  Equal<Pick<Router<NavigationState, NavigationAction>, 'type'>, { type?: string }>
+>;
+export type _TypedRouterTypeIsRequired = Expect<
+  Equal<Pick<Router<TabNavigationState<ParamListBase>, NavigationAction>, 'type'>, { type: 'tab' }>
+>;
 
 export type _HasScreen = Expect<Equal<typeof Nav extends { Screen: unknown } ? true : false, true>>;
 export type _HasProtected = Expect<

--- a/packages/expo-router/src/utils/stack.ts
+++ b/packages/expo-router/src/utils/stack.ts
@@ -6,6 +6,8 @@ export function getHistoryLength(state: ReactNavigationState): number {
     return state.history.length;
   }
 
+  // This only matters for preloaded rotues, and in oreder to preload
+  // an action needs to be dispatched, so type will be set
   if (state.type === 'stack') {
     if (state.index === undefined) {
       return 1;
@@ -22,6 +24,7 @@ export function isRoutePreloadedInStack(
   navigationState: NavigationState | undefined,
   route: { key: string }
 ): boolean {
+  // A typeless stack cannot be detected here, including after PRELOAD preserves its missing type.
   if (!navigationState || navigationState.type !== 'stack') {
     return false;
   }


### PR DESCRIPTION
# Why

In order to be able to create initial state without knowing the unmounted navigator types first, we need to make the type optional and rework the cases where it is required.

# How

1. Make `state.type` type optional 
2. Add TODO for https://linear.app/expo/issue/ENG-22021/fix-link-preview-by-detecting-navigator-type-on-native in link preview logic
3. Add TODO for https://linear.app/expo/issue/ENG-22019/fix-candismiss-after-removing-the-navigation-state-type for `canDismiss` 
4. Remove the requirement for `stack` navigator type for `popToTop` actions - they can be safely dispatched to other navigators and will be ignored
5. Add `NavigatorTypeContext` to be able to check the navigator type from within content

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
