### PR TITLE
fix(cli,create-expo,create-expo-module): Update `npm pack --json` usage for npm@12's dictionary format

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Ignore an invalid `--port` or an out-of-range `RCT_METRO_PORT` and start on the preferred port instead of prompting to use port `null` ([#48300](https://github.com/expo/expo/pull/48300) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Resolve the signed-in username for partner provisioned actors so Expo Go can verify the account match ([#48354](https://github.com/expo/expo/pull/48354) by [@davidko604](https://github.com/davidko604))
 - Switch `ManifestMiddleware` to `expo-server`'s response helpers to avoid cancellations being surfaced as exceptions ([#48700](https://github.com/expo/expo/pull/48700) by [@kitten](https://github.com/kitten))
+- Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/__tests__/npm-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/npm-test.ts
@@ -1,4 +1,21 @@
-import { sanitizeNpmPackageName } from '../npm';
+import { normalizeNpmPackResult, sanitizeNpmPackageName } from '../npm';
+
+describe(normalizeNpmPackResult, () => {
+  const packageInfo = { name: 'expo', filename: 'expo.tgz' };
+
+  it('supports the npm 11 and earlier array format', () => {
+    expect(normalizeNpmPackResult([packageInfo])).toEqual([packageInfo]);
+  });
+
+  it('supports the npm 12 package-keyed object format', () => {
+    expect(normalizeNpmPackResult({ expo: packageInfo })).toEqual([packageInfo]);
+  });
+
+  it('rejects non-container values', () => {
+    expect(normalizeNpmPackResult(null)).toBeNull();
+    expect(normalizeNpmPackResult('expo.tgz')).toBeNull();
+  });
+});
 
 describe(sanitizeNpmPackageName, () => {
   it(`leaves valid names`, () => {

--- a/packages/@expo/cli/src/utils/npm.ts
+++ b/packages/@expo/cli/src/utils/npm.ts
@@ -176,16 +176,31 @@ export async function packNpmTarballAsync(packageDir: string): Promise<string> {
     })
   ).stdout?.trim();
   try {
-    const [json] = JSON.parse(results) as { filename: string }[];
+    const packages = normalizeNpmPackResult(JSON.parse(results));
+    const packageInfo = packages?.[0];
     assert(
-      typeof json?.filename === 'string',
-      'Expected filename property on JSON array of type "string"'
+      packageInfo &&
+        typeof packageInfo === 'object' &&
+        'filename' in packageInfo &&
+        typeof packageInfo.filename === 'string',
+      'Expected filename property in npm pack JSON output of type "string"'
     );
-    return path.resolve(packageDir, json.filename);
+    return path.resolve(packageDir, packageInfo.filename);
   } catch (error: any) {
     const cmdString = `npm ${cmdArgs.join(' ')}`;
     throw new Error(
       `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
     );
+  }
+}
+
+/** Normalize the npm pack JSON formats used before and after npm 12 */
+export function normalizeNpmPackResult(result: unknown): unknown[] | null {
+  if (Array.isArray(result)) {
+    return result;
+  } else if (result && typeof result === 'object') {
+    return Object.values(result);
+  } else {
+    return null;
   }
 }

--- a/packages/create-expo-module/src/__tests__/templateUtils-test.ts
+++ b/packages/create-expo-module/src/__tests__/templateUtils-test.ts
@@ -2,7 +2,12 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getGeneratedWebStubSentinel, getTemplateDistTag, updateWebStub } from '../templateUtils';
+import {
+  getGeneratedWebStubSentinel,
+  getTemplateDistTag,
+  normalizeNpmPackResult,
+  updateWebStub,
+} from '../templateUtils';
 import type { SubstitutionData } from '../types';
 
 const mockData: SubstitutionData = {
@@ -36,6 +41,25 @@ async function writeMinimalWebTemplate(templateDir: string) {
     'export default class <%- project.moduleName %> {}\n'
   );
 }
+
+describe(normalizeNpmPackResult, () => {
+  const packageInfo = { name: 'create-expo-module-template', filename: 'template.tgz' };
+
+  it('supports the npm 11 and earlier array format', () => {
+    expect(normalizeNpmPackResult([packageInfo])).toEqual([packageInfo]);
+  });
+
+  it('supports the npm 12 package-keyed object format', () => {
+    expect(normalizeNpmPackResult({ 'create-expo-module-template': packageInfo })).toEqual([
+      packageInfo,
+    ]);
+  });
+
+  it('rejects non-container values', () => {
+    expect(normalizeNpmPackResult(null)).toBeNull();
+    expect(normalizeNpmPackResult('template.tgz')).toBeNull();
+  });
+});
 
 describe('getTemplateDistTag', () => {
   it('maps an SDK-aligned version to its `sdk-<major>` tag', () => {

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -135,14 +135,32 @@ async function npmPackAsync(packageName: string, cwd: string): Promise<string> {
 
   try {
     const json = JSON.parse(results);
-    if (!Array.isArray(json) || !json[0]?.filename) {
+    const packages = normalizeNpmPackResult(json);
+    const packageInfo = packages?.[0];
+    if (
+      !packageInfo ||
+      typeof packageInfo !== 'object' ||
+      !('filename' in packageInfo) ||
+      typeof packageInfo.filename !== 'string'
+    ) {
       throw new Error(`Invalid response from npm: ${results}`);
     }
-    return json[0].filename;
+    return packageInfo.filename;
   } catch (error: any) {
     throw new Error(
       `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
     );
+  }
+}
+
+/** Normalize the npm pack JSON formats used before and after npm 12 */
+export function normalizeNpmPackResult(result: unknown): unknown[] | null {
+  if (Array.isArray(result)) {
+    return result;
+  } else if (result && typeof result === 'object') {
+    return Object.values(result);
+  } else {
+    return null;
   }
 }
 

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 5.0.0 - 2026-06-25

--- a/packages/create-expo/src/utils/__tests__/npm.test.ts
+++ b/packages/create-expo/src/utils/__tests__/npm.test.ts
@@ -1,4 +1,26 @@
-import { applyBetaTag, getResolvedTemplateName, splitNpmNameAndTag } from '../npm';
+import {
+  applyBetaTag,
+  getResolvedTemplateName,
+  normalizeNpmPackResult,
+  splitNpmNameAndTag,
+} from '../npm';
+
+describe(normalizeNpmPackResult, () => {
+  const packageInfo = { name: 'expo-template-default', filename: 'template.tgz' };
+
+  it('supports the npm 11 and earlier array format', () => {
+    expect(normalizeNpmPackResult([packageInfo])).toEqual([packageInfo]);
+  });
+
+  it('supports the npm 12 package-keyed object format', () => {
+    expect(normalizeNpmPackResult({ 'expo-template-default': packageInfo })).toEqual([packageInfo]);
+  });
+
+  it('rejects non-container values', () => {
+    expect(normalizeNpmPackResult(null)).toBeNull();
+    expect(normalizeNpmPackResult('template.tgz')).toBeNull();
+  });
+});
 
 describe(applyBetaTag, () => {
   const originalEnv = process.env;

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -162,8 +162,9 @@ async function npmPackAsync(
 
   try {
     const json = JSON.parse(results);
-    if (Array.isArray(json) && json.every(isNpmPackageInfo)) {
-      return json.map(sanitizeNpmPackageFilename);
+    const packages = normalizeNpmPackResult(json);
+    if (packages?.every(isNpmPackageInfo)) {
+      return packages.map(sanitizeNpmPackageFilename);
     } else {
       throw new Error(`Invalid response from npm: ${results}`);
     }
@@ -171,6 +172,17 @@ async function npmPackAsync(
     throw new Error(
       `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
     );
+  }
+}
+
+/** Normalize the npm pack JSON formats used before and after npm 12 */
+export function normalizeNpmPackResult(result: unknown): unknown[] | null {
+  if (Array.isArray(result)) {
+    return result;
+  } else if (result && typeof result === 'object') {
+    return Object.values(result);
+  } else {
+    return null;
   }
 }
 


### PR DESCRIPTION
# Why

Resolves #48091

In npm@12, the return `npm pack --json` format has changed to use dictionaries instead of arrays. The core logic and how we use it doesn't change much, so the fix is just a normalisation of the JSON output.

# How

- Add normalisation for JSON output (cli, create-expo, create-expo-module)

# Test Plan

- Unit tests added demonstrating the change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
