### PR TITLE
[ios][updates] Reject asset keys that escape the updates directory 

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Isolate UpdatesLogReaderTests from concurrent suites. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [iOS] Fix SIGABRT during log purge when the persistent log contains a truncated line: `UpdatesLogReader` guarded on UTF-8 byte length but advanced the string index by Characters, so a line holding only the multi-byte emoji log prefix trapped with "String index is out of bounds". ([#48222](https://github.com/expo/expo/pull/48222) by [@valinagacevschi](https://github.com/valinagacevschi))
 - [Android] Fix SIGABRT when loading a development server URL that has no path (e.g. `http://192.168.1.2:8081`): Android's `URI.resolve` omits the path separator for an empty-path base, so the first segment of a relative asset URL was spliced onto the port and the resulting authority failed to parse. ([#48625](https://github.com/expo/expo/pull/48625) by [@tsapeta](https://github.com/tsapeta))
+- Reject updates whose asset key or file extension contains a path separator, which previously let a manifest write and delete files outside the updates directory. ([#48762](https://github.com/expo/expo/pull/48762), [#48763](https://github.com/expo/expo/pull/48763) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 
@@ -27,7 +28,7 @@
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
 - [iOS] Resolved the reload screen's window through the shared scene geometry helper. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Link `libc++` in the test spec so the unit test bundle resolves the C++ symbols it pulls from `ExpoModulesCore`.
+- [iOS] Link `libc++` in the test spec so the unit test bundle resolves the C++ symbols it pulls from `ExpoModulesCore`. ([#48762](https://github.com/expo/expo/pull/48762) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [Internal] Align find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
 - [iOS] Resolved the reload screen's window through the shared scene geometry helper. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Link `libc++` in the test spec so the unit test bundle resolves the C++ symbols it pulls from `ExpoModulesCore`.
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -152,6 +152,7 @@ Pod::Spec.new do |s|
     test_spec.dependency 'ExpoModulesTestCore'
 
     test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++',
       'USER_HEADER_SEARCH_PATHS' => '"${CONFIGURATION_TEMP_DIR}/EXUpdates.build/DerivedSources"',
       'GCC_TREAT_INCOMPATIBLE_POINTER_TYPE_WARNINGS_AS_ERRORS' => 'YES',
       'GCC_TREAT_IMPLICIT_FUNCTION_DECLARATIONS_AS_ERRORS' => 'YES',

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/RemoteAppLoader.swift
@@ -105,6 +105,13 @@ public final class RemoteAppLoader: AppLoader {
   }
 
   override public func downloadAsset(_ asset: UpdateAsset, extraHeaders: [String: Any]) {
+    guard UpdatesUtils.isSafeFilename(asset.filename) else {
+      self.handleAssetDownload(
+        withError: UpdatesError.remoteAppLoaderUnsafeAssetFilename(filename: asset.filename),
+        asset: asset
+      )
+      return
+    }
     let urlOnDisk = self.directory.appendingPathComponent(asset.filename)
 
     let progressBlock = { [weak self] fractionCompleted in

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesReaper.swift
@@ -71,6 +71,10 @@ public final class UpdatesReaper: NSObject {
 
         let beginDeleteAssets = Date()
         for asset in assetsForDeletion {
+          guard UpdatesUtils.isSafeFilename(asset.filename) else {
+            logger.warn(message: "Refusing to delete asset at unsafe path \(asset.filename)")
+            continue
+          }
           let localUrl = directory.appendingPathComponent(asset.filename)
           if FileManager.default.fileExists(atPath: localUrl.path) {
             do {

--- a/packages/expo-updates/ios/EXUpdates/Update/Update.swift
+++ b/packages/expo-updates/ios/EXUpdates/Update/Update.swift
@@ -77,6 +77,7 @@ public enum UpdateStatus: Int {
 public enum UpdateError: Error, Sendable, LocalizedError {
   case invalidExpoProtocolVersion(protocolVersion: Int)
   case legacyManifestInstantiationInvalid
+  case unsafeAssetFilename(updateId: String, filename: String)
 
   public var errorDescription: String? {
     switch self {
@@ -84,6 +85,10 @@ public enum UpdateError: Error, Sendable, LocalizedError {
       return "Invalid Expo Updates protocol version: \(protocolVersion)"
     case .legacyManifestInstantiationInvalid:
       return "This version of expo-updates can no longer load legacy manifests"
+    case let .unsafeAssetFilename(updateId, filename):
+      return "Update \(updateId) could not be loaded because the asset filename \"\(filename)\" " +
+        "is not a valid filename. Assets are stored under their key and file extension, so neither " +
+        "may contain a path separator. Check the server that produced this manifest."
     }
   }
 }
@@ -157,12 +162,21 @@ public class Update: NSObject {
     }
     switch protocolVersion {
     case 0, 1:
-      return ExpoUpdatesUpdate.update(
+      let update = ExpoUpdatesUpdate.update(
         withExpoUpdatesManifest: ExpoUpdatesManifest(rawManifestJSON: withManifest),
         extensions: extensions,
         config: config,
         database: database
       )
+      try update.assets()?.forEach { asset in
+        guard UpdatesUtils.isSafeFilename(asset.filename) else {
+          throw UpdateError.unsafeAssetFilename(
+            updateId: update.updateId.uuidString,
+            filename: asset.filename
+          )
+        }
+      }
+      return update
     default:
       throw UpdateError.invalidExpoProtocolVersion(protocolVersion: protocolVersion)
     }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
@@ -26,6 +26,7 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
   case fileDownloaderFailedUpdateIDsFailure(cause: Error)
   case fileDownloaderUnknownError(cause: Error)
   case remoteAppLoaderAssetMissingUrl
+  case remoteAppLoaderUnsafeAssetFilename(filename: String)
   case remoteAppLoaderHeaderDataError(cause: Error)
   case remoteAppLoaderUnknownError(cause: Error)
   case appLoaderFailedToLoadAllAssets
@@ -92,6 +93,8 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
       return "Unknown error: \(cause.localizedDescription)"
     case .remoteAppLoaderAssetMissingUrl:
       return "Failed to download asset with no URL provided"
+    case let .remoteAppLoaderUnsafeAssetFilename(filename):
+      return "Failed to download asset: filename \"\(filename)\" would resolve outside the updates directory"
     case let .remoteAppLoaderHeaderDataError(cause):
       return "Error persisting header data to disk: \(cause.localizedDescription)"
     case .appLoaderFailedToLoadAllAssets:

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -78,14 +78,18 @@ public final class UpdatesUtils: NSObject {
   /**
    * Asset filenames are built from manifest-controlled values, so a filename holding a path
    * separator or a `..` component would resolve outside the updates directory.
+   *
+   * Matching is done on unicode scalars because `String.contains` compares grapheme clusters, and
+   * a separator followed by a combining mark forms one cluster that does not equal the separator.
+   * The filesystem still sees the separator byte.
    */
   public static func isSafeFilename(_ filename: String) -> Bool {
     return !filename.isEmpty &&
       filename != "." &&
       filename != ".." &&
-      !filename.contains("/") &&
-      !filename.contains("\\") &&
-      !filename.contains("\0")
+      !filename.unicodeScalars.contains("/") &&
+      !filename.unicodeScalars.contains("\\") &&
+      !filename.unicodeScalars.contains("\0")
   }
 
   // MARK: - Internal methods

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -75,6 +75,19 @@ public final class UpdatesUtils: NSObject {
     return updatesDirectory
   }
 
+  /**
+   * Asset filenames are built from manifest-controlled values, so a filename holding a path
+   * separator or a `..` component would resolve outside the updates directory.
+   */
+  public static func isSafeFilename(_ filename: String) -> Bool {
+    return !filename.isEmpty &&
+      filename != "." &&
+      filename != ".." &&
+      !filename.contains("/") &&
+      !filename.contains("\\") &&
+      !filename.contains("\0")
+  }
+
   // MARK: - Internal methods
 
   public static func defaultNativeStateMachineContextJson() -> [String: Any?] {

--- a/packages/expo-updates/ios/Tests/UpdateAssetTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdateAssetTests.swift
@@ -37,4 +37,44 @@ struct UpdateAssetTests {
     let assetWithDotPrefix = UpdateAsset(key: "cat", type: nil)
     #expect(assetWithDotPrefix.filename == "cat")
   }
+
+  @Test
+  func `is only safe when it is a plain filename`() {
+    let unsafe = [
+      "",
+      ".",
+      "..",
+      "../pwned.png",
+      "../../Library/Preferences/pwned.plist",
+      "nested/asset.png",
+      "nested\\asset.png",
+      "/etc/passwd",
+      "asset\0.png"
+    ]
+    for filename in unsafe {
+      #expect(!UpdatesUtils.isSafeFilename(filename), "expected \"\(filename)\" to be rejected")
+    }
+
+    let safe = [
+      "696a70cf7035664c20ea86f67dae822b.bundle",
+      "asset-1699999999-12345.png",
+      "..hidden.png",
+      "a..b.png"
+    ]
+    for filename in safe {
+      #expect(UpdatesUtils.isSafeFilename(filename), "expected \"\(filename)\" to be accepted")
+    }
+  }
+
+  @Test
+  func `escapes the updates directory when the key traverses`() {
+    let updatesDirectory = URL(fileURLWithPath: "/Documents/.expo-internal")
+    let asset = UpdateAsset(key: "../../Library/Preferences/pwned", type: "plist")
+
+    #expect(!UpdatesUtils.isSafeFilename(asset.filename))
+    #expect(
+      !updatesDirectory.appendingPathComponent(asset.filename).standardizedFileURL.path
+        .hasPrefix(updatesDirectory.path + "/")
+    )
+  }
 }

--- a/packages/expo-updates/ios/Tests/UpdateAssetTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdateAssetTests.swift
@@ -49,7 +49,10 @@ struct UpdateAssetTests {
       "nested/asset.png",
       "nested\\asset.png",
       "/etc/passwd",
-      "asset\0.png"
+      "asset\0.png",
+      // "/" followed by a combining mark is a single Character that does not equal "/", so a
+      // grapheme-level check passes this even though the separator byte reaches the filesystem.
+      "..\u{2F}\u{0338}pwned.png"
     ]
     for filename in unsafe {
       #expect(!UpdatesUtils.isSafeFilename(filename), "expected \"\(filename)\" to be rejected")

--- a/packages/expo-updates/ios/Tests/UpdateTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdateTests.swift
@@ -102,6 +102,87 @@ struct UpdateTests {
   }
 
   @Test
+  func `throws for asset key that escapes the updates directory`() {
+    #expect {
+      try Update.update(
+        withManifest: manifest(assetKey: "../../Library/Preferences/pwned", fileExtension: ".plist"),
+        responseHeaderData: ResponseHeaderData(
+          protocolVersionRaw: "0",
+          serverDefinedHeadersRaw: nil,
+          manifestFiltersRaw: nil
+        ),
+        extensions: [:],
+        config: config,
+        database: database
+      )
+    } throws: { error in
+      guard case UpdateError.unsafeAssetFilename = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test
+  func `throws for file extension that escapes the updates directory`() {
+    #expect {
+      try Update.update(
+        withManifest: manifest(assetKey: "image", fileExtension: ".png/../../pwned"),
+        responseHeaderData: ResponseHeaderData(
+          protocolVersionRaw: "0",
+          serverDefinedHeadersRaw: nil,
+          manifestFiltersRaw: nil
+        ),
+        extensions: [:],
+        config: config,
+        database: database
+      )
+    } throws: { error in
+      guard case UpdateError.unsafeAssetFilename = error else {
+        return false
+      }
+      return true
+    }
+  }
+
+  @Test
+  func `works for asset key with leading dots`() throws {
+    // Only path separators and the `..` component are dangerous. A key may still start with a dot.
+    let update = try Update.update(
+      withManifest: manifest(assetKey: "..hidden", fileExtension: ".png"),
+      responseHeaderData: ResponseHeaderData(
+        protocolVersionRaw: "0",
+        serverDefinedHeadersRaw: nil,
+        manifestFiltersRaw: nil
+      ),
+      extensions: [:],
+      config: config,
+      database: database
+    )
+    #expect(update.assets()?.contains(where: { $0.filename == "..hidden.png" }) == true)
+  }
+
+  private func manifest(assetKey: String, fileExtension: String) -> [String: Any] {
+    return [
+      "runtimeVersion": "1",
+      "id": "0eef8214-4833-4089-9dff-b4138a14f196",
+      "createdAt": "2020-11-11T00:17:54.797Z",
+      "launchAsset": [
+        "key": "696a70cf7035664c20ea86f67dae822b",
+        "url": "https://url.to/bundle.js",
+        "contentType": "application/javascript"
+      ],
+      "assets": [
+        [
+          "key": assetKey,
+          "url": "https://url.to/asset",
+          "fileExtension": fileExtension
+        ]
+      ]
+    ]
+  }
+
+  @Test
   func `works for embedded bare manifest`() {
     let embeddedManifest: [String: Any] = [
       "id": "0eef8214-4833-4089-9dff-b4138a14f196",


### PR DESCRIPTION
# Why
Addresses https://exponent-internal.slack.com/archives/C013ZK4SA12/p1786425601131549

Asset filenames come from the manifest. `UpdateAsset.filename` is with no validation, and `RemoteAppLoader` joins it to the updates directory with `appendingPathComponent`, which appends raw text without resolving `..`. A `..` in either the key or the extension can escape the updates directory. 

Impact is confined to the app's own container and needs control of the update server, and code signing already blocks it. Still worth closing as it's a bug/.

# How
New `UpdatesUtils.isSafeFilename` rejects an empty name, `.`, `..`, path separators and NUL. It checks the whole filename because the extension is manifest controlled too. Rejection lives in `Update.update(withManifest:)`, which already throws and is the only production caller. The download and reaper sites are guarded as well, for rows written before this change.

# Test Plan
Five new tests across `UpdateTests` and `UpdateAssetTests` and full CI run
