### PR TITLE
[android][updates] Reject asset keys that escape the updates directory

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesUtils.kt
@@ -166,6 +166,17 @@ object UpdatesUtils {
     }
   }
 
+  /**
+   * Asset filenames are built from manifest-controlled values, so a filename holding a path
+   * separator or a `..` component would resolve outside the updates directory.
+   */
+  fun isSafeFilename(filename: String): Boolean {
+    return filename.isNotEmpty() &&
+      filename != "." &&
+      filename != ".." &&
+      filename.none { it == '/' || it == '\\' || it == '\u0000' }
+  }
+
   fun shouldCheckForUpdateOnLaunch(
     updatesConfiguration: UpdatesConfiguration,
     logger: UpdatesLogger,

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.kt
@@ -7,6 +7,7 @@ import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.manifest.ManifestMetadata
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.utils.AndroidResourceAssetUtils
 import java.io.File
 
 /**
@@ -48,9 +49,13 @@ object Reaper {
         )
         continue
       }
-      // A row written before asset filenames were validated may point outside the updates directory.
       val relativePath = asset.relativePath
-      if (relativePath == null || !UpdatesUtils.isSafeFilename(relativePath)) {
+      // Embedded assets are served from the APK, so there is no file here to delete.
+      if (relativePath == null || AndroidResourceAssetUtils.isAndroidResourceAsset(relativePath)) {
+        continue
+      }
+      // A row written before asset filenames were validated may point outside the updates directory.
+      if (!UpdatesUtils.isSafeFilename(relativePath)) {
         Log.e(
           TAG,
           "Refusing to delete asset with URL " + asset.url + " at unsafe path " + relativePath

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/Reaper.kt
@@ -2,6 +2,7 @@ package expo.modules.updates.db
 
 import android.util.Log
 import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.UpdatesUtils
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
 import expo.modules.updates.manifest.ManifestMetadata
@@ -47,7 +48,16 @@ object Reaper {
         )
         continue
       }
-      val path = File(updatesDirectory, asset.relativePath)
+      // A row written before asset filenames were validated may point outside the updates directory.
+      val relativePath = asset.relativePath
+      if (relativePath == null || !UpdatesUtils.isSafeFilename(relativePath)) {
+        Log.e(
+          TAG,
+          "Refusing to delete asset with URL " + asset.url + " at unsafe path " + relativePath
+        )
+        continue
+      }
+      val path = File(updatesDirectory, relativePath)
       try {
         if (path.exists() && !path.delete()) {
           Log.e(TAG, "Failed to delete asset with URL " + asset.url + " at path " + path.toString())

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -688,6 +688,12 @@ class FileDownloader(
     }
 
     val filename = UpdatesUtils.createFilenameForAsset(asset)
+    if (!UpdatesUtils.isSafeFilename(filename)) {
+      val message = "Failed to download asset ${asset.key}"
+      val error = IOException("Asset filename \"$filename\" would resolve outside the updates directory")
+      logger.error(message, error, UpdatesErrorCode.AssetsFailedToLoad)
+      throw IOException(message, error)
+    }
     val path = File(destinationDirectory, filename)
 
     if (path.exists()) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/manifest/ExpoUpdatesUpdate.kt
@@ -14,6 +14,7 @@ import expo.modules.updates.db.enums.UpdateStatus
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
+import java.io.IOException
 import java.net.URI
 import java.text.ParseException
 import java.util.*
@@ -96,7 +97,7 @@ class ExpoUpdatesUpdate private constructor(
   companion object {
     private val TAG = Update::class.java.simpleName
 
-    @Throws(JSONException::class)
+    @Throws(Exception::class)
     fun fromExpoUpdatesManifest(
       manifest: ExpoUpdatesManifest,
       extensions: JSONObject?,
@@ -105,7 +106,7 @@ class ExpoUpdatesUpdate private constructor(
       val resolvedManifest = ExpoUpdatesManifest(
         resolveManifestAssetUrls(manifest.getRawJson(), configuration.updateUrl)
       )
-      return ExpoUpdatesUpdate(
+      val update = ExpoUpdatesUpdate(
         resolvedManifest,
         id = UUID.fromString(resolvedManifest.getID()),
         configuration.scopeKey,
@@ -122,6 +123,20 @@ class ExpoUpdatesUpdate private constructor(
         url = configuration.updateUrl,
         requestHeaders = configuration.requestHeaders
       )
+
+      update.assetEntityList.forEach { asset ->
+        val filename = UpdatesUtils.createFilenameForAsset(asset)
+        if (!UpdatesUtils.isSafeFilename(filename)) {
+          throw IOException(
+            "Update ${resolvedManifest.getID()} could not be loaded because the asset filename " +
+              "\"$filename\" is not a valid filename. Assets are stored under their key and file " +
+              "extension, so neither may contain a path separator. Check the server that produced " +
+              "this manifest."
+          )
+        }
+      }
+
+      return update
     }
 
     private fun resolveManifestAssetUrls(manifestJson: JSONObject, baseUrl: Uri): JSONObject {

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -5,6 +5,7 @@ import expo.modules.updates.db.entity.AssetEntity
 import io.mockk.mockk
 import junit.framework.TestCase
 import org.junit.Assert
+import java.io.File
 
 class UpdatesUtilsTest : TestCase() {
   fun testCreateFilenameForAsset() {
@@ -32,6 +33,44 @@ class UpdatesUtilsTest : TestCase() {
     )
     val asset1Name = UpdatesUtils.createFilenameForAsset(asset1)
     Assert.assertEquals(asset1Name.substring(asset1Name.length - 7), ".bundle")
+  }
+
+  fun testIsSafeFilename() {
+    val unsafe = listOf(
+      "",
+      ".",
+      "..",
+      "../pwned.png",
+      "../../shared_prefs/pwned.xml",
+      "nested/asset.png",
+      "nested\\asset.png",
+      "/etc/passwd",
+      "asset\u0000.png"
+    )
+    unsafe.forEach {
+      Assert.assertFalse("expected \"$it\" to be rejected", UpdatesUtils.isSafeFilename(it))
+    }
+
+    val safe = listOf(
+      "696a70cf7035664c20ea86f67dae822b.bundle",
+      "asset-1699999999-12345.png",
+      "..hidden.png",
+      "a..b.png"
+    )
+    safe.forEach {
+      Assert.assertTrue("expected \"$it\" to be accepted", UpdatesUtils.isSafeFilename(it))
+    }
+  }
+
+  fun testIsSafeFilename_everySafeNameStaysInsideItsDirectory() {
+    val updatesDirectory = File("/data/data/com.example/files/.expo-internal")
+    val filename = UpdatesUtils.createFilenameForAsset(AssetEntity("../../shared_prefs/pwned", "xml"))
+
+    Assert.assertFalse(UpdatesUtils.isSafeFilename(filename))
+    Assert.assertFalse(
+      File(updatesDirectory, filename).canonicalPath
+        .startsWith(updatesDirectory.canonicalPath + File.separator)
+    )
   }
 
   fun testGetRuntimeVersion() {

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/UpdatesUtilsTest.kt
@@ -45,7 +45,10 @@ class UpdatesUtilsTest : TestCase() {
       "nested/asset.png",
       "nested\\asset.png",
       "/etc/passwd",
-      "asset\u0000.png"
+      "asset\u0000.png",
+      // A separator followed by a combining mark. Kotlin compares UTF-16 code units so this is
+      // caught here, unlike Swift, where the two form one Character that does not equal "/".
+      "..\u002F\u0338pwned.png"
     )
     unsafe.forEach {
       Assert.assertFalse("expected \"$it\" to be rejected", UpdatesUtils.isSafeFilename(it))
@@ -62,7 +65,7 @@ class UpdatesUtilsTest : TestCase() {
     }
   }
 
-  fun testIsSafeFilename_everySafeNameStaysInsideItsDirectory() {
+  fun testIsSafeFilename_rejectedNameEscapesItsDirectory() {
     val updatesDirectory = File("/data/data/com.example/files/.expo-internal")
     val filename = UpdatesUtils.createFilenameForAsset(AssetEntity("../../shared_prefs/pwned", "xml"))
 

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/db/ReaperTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/db/ReaperTest.kt
@@ -1,0 +1,92 @@
+package expo.modules.updates.db
+
+import android.util.Log
+import expo.modules.updates.UpdatesConfiguration
+import expo.modules.updates.db.entity.AssetEntity
+import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.selectionpolicy.SelectionPolicy
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowLog
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class ReaperTest {
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
+  private fun asset(relativePath: String?) = AssetEntity("key-$relativePath", "png").apply {
+    this.relativePath = relativePath
+    markedForDeletion = true
+  }
+
+  private fun reap(updatesDirectory: File, assetsToDelete: List<AssetEntity>) {
+    val database = mockk<UpdatesDatabase>(relaxed = true)
+    every { database.assetDao().deleteUnusedAssets() } returns assetsToDelete
+    every { database.updateDao().loadAllUpdates() } returns listOf()
+
+    val selectionPolicy = mockk<SelectionPolicy>(relaxed = true)
+    every { selectionPolicy.selectUpdatesToDelete(any(), any(), any()) } returns listOf()
+
+    Reaper.reapUnusedUpdates(
+      mockk<UpdatesConfiguration>(relaxed = true),
+      database,
+      updatesDirectory,
+      mockk<UpdateEntity>(relaxed = true),
+      selectionPolicy
+    )
+  }
+
+  @Test
+  fun testReap_deletesAssetInsideUpdatesDirectory() {
+    val updatesDirectory = temporaryFolder.newFolder(".expo-internal")
+    val target = File(updatesDirectory, "abc.png").apply { writeText("asset") }
+
+    reap(updatesDirectory, listOf(asset("abc.png")))
+
+    Assert.assertFalse(target.exists())
+  }
+
+  @Test
+  fun testReap_refusesToDeleteOutsideUpdatesDirectory() {
+    // A row written before asset filenames were validated can still point outside the directory.
+    val root = temporaryFolder.newFolder()
+    val updatesDirectory = File(root, ".expo-internal").apply { mkdirs() }
+    val outside = File(root, "keep-me.xml").apply { writeText("not the reaper's to delete") }
+
+    reap(updatesDirectory, listOf(asset("../keep-me.xml")))
+
+    Assert.assertTrue(outside.exists())
+  }
+
+  @Test
+  fun testReap_skipsEmbeddedAssetsServedFromTheApk() {
+    // Embedded assets store a resource URL rather than a filename, and there is nothing on disk to
+    // delete. Their slashes must not be reported as an unsafe path, which is only visible in the
+    // log because the delete is a no-op either way.
+    val updatesDirectory = temporaryFolder.newFolder(".expo-internal")
+    ShadowLog.clear()
+
+    reap(
+      updatesDirectory,
+      listOf(
+        asset("file:///android_asset/app.bundle"),
+        asset("file:///android_res/drawable-xxhdpi/icon.png")
+      )
+    )
+
+    val unsafePathErrors = ShadowLog.getLogs()
+      .filter { it.type == Log.ERROR && it.msg.contains("unsafe path") }
+    Assert.assertEquals(
+      "embedded assets reported as unsafe: ${unsafePathErrors.map { it.msg }}",
+      0,
+      unsafePathErrors.size
+    )
+  }
+}

--- a/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
+++ b/packages/expo-updates/android/src/test/java/expo/modules/updates/loader/FileDownloaderManifestParsingTest.kt
@@ -115,6 +115,73 @@ class FileDownloaderManifestParsingTest {
   }
 
   @Test
+  fun testManifestParsing_RejectsAssetKeyEscapingUpdatesDirectory() = runTest {
+    val manifestBody = manifestBodyWithAsset(key = "../../shared_prefs/pwned", fileExtension = ".xml")
+    val response = manifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
+    val fileDownloader = createFileDownloader(configurationWithUpdateUrl())
+
+    val exception = Assert.assertThrows(Exception::class.java) {
+      fileDownloader.parseRemoteUpdateResponse(response)
+    }
+    Assert.assertTrue(
+      exception.localizedMessageWithCauseLocalizedMessage().contains("../../shared_prefs/pwned")
+    )
+  }
+
+  @Test
+  fun testManifestParsing_RejectsFileExtensionEscapingUpdatesDirectory() = runTest {
+    val manifestBody = manifestBodyWithAsset(key = "image", fileExtension = ".png/../../pwned")
+    val response = manifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
+    val fileDownloader = createFileDownloader(configurationWithUpdateUrl())
+
+    Assert.assertThrows(Exception::class.java) {
+      fileDownloader.parseRemoteUpdateResponse(response)
+    }
+  }
+
+  @Test
+  fun testManifestParsing_AcceptsAssetKeyWithLeadingDots() = runTest {
+    // Only path separators and the `..` component are dangerous. A key may still start with a dot.
+    val manifestBody = manifestBodyWithAsset(key = "..hidden", fileExtension = ".png")
+    val response = manifestBody.asJSONResponse(mapOf("expo-protocol-version" to "0").toHeaders())
+    val fileDownloader = createFileDownloader(configurationWithUpdateUrl())
+
+    val resultUpdate = fileDownloader.parseRemoteUpdateResponse(response).manifestUpdateResponsePart?.update
+    Assert.assertNotNull(resultUpdate)
+    Assert.assertEquals("..hidden", resultUpdate!!.assetEntityList.first { !it.isLaunchAsset }.key)
+  }
+
+  private fun configurationWithUpdateUrl() = UpdatesConfiguration(
+    null,
+    mapOf(
+      UpdatesConfiguration.UPDATES_CONFIGURATION_UPDATE_URL_KEY to Uri.parse("https://exp.host/@test/test")
+    )
+  )
+
+  private fun manifestBodyWithAsset(key: String, fileExtension: String) = """
+    {
+      "id": "0754dad0-d200-d634-113c-ef1f26106028",
+      "createdAt": "2021-11-23T00:57:14.437Z",
+      "runtimeVersion": "1",
+      "assets": [{
+        "hash": "cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d",
+        "key": "$key",
+        "contentType": "image/png",
+        "url": "https://url.to/asset",
+        "fileExtension": "$fileExtension"
+      }],
+      "launchAsset": {
+        "hash": "323ddd1968ee76d4ddbb16b04fb2c3f1b6d1ab9b637d819699fecd6fa0ffb1a8",
+        "key": "696a70cf7035664c20ea86f67dae822b.bundle",
+        "contentType": "application/javascript",
+        "url": "https://url.to/bundle",
+        "fileExtension": ".bundle"
+      },
+      "extra": { "scopeKey": "@test/app" }
+    }
+  """.trimIndent()
+
+  @Test
   fun testManifestParsing_RelativeUrlsAgainstNonHttpBase() = runTest {
     // Normalizing the base must not narrow which schemes resolve: `exp://` URLs still reach here.
     val manifestBody = """


### PR DESCRIPTION
# Why
Same bug as the PR below, on Android.

Android is the worse of the two. The write path calls `parentFile?.mkdirs()` and copies with `overwrite = true`, so a manifest can create directories and overwrite files anywhere the app's uid can write. On iOS, the write fails unless the target directory already exists.

# How
`UpdatesUtils.isSafeFilename` mirrors the iOS helper.

# Test Plan
Five new tests across `FileDownloaderManifestParsingTest, `UpdatesUtilsTest` and full CI run
