### PR TITLE
[docs] Add llms.txt in page head and HTTP response headers

### DIFF
--- a/docs/components/DocumentationHead.tsx
+++ b/docs/components/DocumentationHead.tsx
@@ -60,6 +60,7 @@ const DocumentationHead = ({
       />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
       {markdownPath && <link rel="alternate" type="text/markdown" href={markdownPath} />}
+      <link rel="llms-txt" href="/llms.txt" />
 
       <meta name="description" content={resolvedDescription} />
       <meta property="og:title" content={title} />

--- a/docs/public/_headers
+++ b/docs/public/_headers
@@ -1,3 +1,8 @@
 # Next.js hashed assets - immutable, cache forever
 /_next/*
   Cache-Control: public, max-age=31536000, immutable
+
+# llms.txt discovery for AI agents that fetch pages without content negotiation
+/*
+  Link: </llms.txt>; rel="llms-txt"
+  X-Llms-Txt: /llms.txt


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25770

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `/llms.txt` in every page head (`<link rel="llms-txt">`) and in response headers (Link, X-Llms-Txt) so agents that fetch HTML without content negotiation can find it.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->



N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
