### PR TITLE
[docs] Fix observe:metrics sort flag on EAS Update page

### DIFF
--- a/docs/pages/eas/observe/eas-update.mdx
+++ b/docs/pages/eas/observe/eas-update.mdx
@@ -47,7 +47,7 @@ From the CLI:
     '$ eas observe:metrics-summary --metric update_download',
     '',
     '# Slowest individual update downloads',
-    '$ eas observe:metrics update_download --order desc',
+    '$ eas observe:metrics update_download --sort slowest',
   ]}
 />
 


### PR DESCRIPTION
Fixes an error in the docs for `eas observe:metrics` usage.
