### PR TITLE
[docs] eas-cli observe docs

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/Consistency.yml
+++ b/docs/.vale/writing-styles/expo-docs/Consistency.yml
@@ -46,6 +46,7 @@ swap:
   sql: SQL
   tailwind css: Tailwind CSS
   tailwindcss: Tailwind CSS
+  transfer windows: transfer windows
   turtle cli: Turtle CLI
   typescript: TypeScript
   unix: Unix

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -634,6 +634,7 @@ export const eas = [
     makePage('eas/observe/introduction.mdx'),
     makePage('eas/observe/get-started.mdx'),
     makePage('eas/observe/dashboard.mdx'),
+    makePage('eas/observe/eas-cli.mdx'),
     makePage('eas/observe/eas-update.mdx'),
     makePage('eas/observe/events.mdx'),
     makePage('eas/observe/configuration.mdx'),

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -65,6 +65,8 @@ When something looks off, drill into individual sessions from the **Events** tab
 
 This helps you understand why specific users or devices experience slower performance, whether it's a particular OS version, network condition, or release.
 
+The same timeline is available from the terminal with `eas observe:session`. See [Querying with EAS CLI](/eas/observe/eas-cli/).
+
 ## Handoff to AI
 
 Use the **Handoff to AI** button in the page header to copy the current dashboard state as a structured prompt. Paste it into Claude or another AI assistant to ask questions about the metrics you're seeing, such as why a particular release regressed or which routes are slowest.

--- a/docs/pages/eas/observe/eas-cli.mdx
+++ b/docs/pages/eas/observe/eas-cli.mdx
@@ -1,17 +1,33 @@
 ---
 title: Querying with EAS CLI
+sidebar_title: EAS CLI
 description: Query EAS Observe metrics, events, and sessions from the terminal with the eas observe commands.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 Everything the [EAS Observe dashboard](/eas/observe/dashboard/) shows is also available from the terminal. Use the `eas observe` commands to compare releases, investigate slow sessions, and pipe results into scripts.
 
-## Before you start
+## Prerequisites
 
-Log in with `eas login`. By default, each command reads the project ID from the app config in the current directory. Pass `--project-id` to query a project from anywhere, using an account that has access to it:
+<Prerequisites>
+  <Requirement title="The EAS CLI">
+    Follow the [instructions for installing the CLI](/eas/cli#installation).
+  </Requirement>
+  <Requirement title="An app already using EAS Observe">
+    Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
+    build.
+  </Requirement>
+  <Requirement title="Authentication to the EAS CLI from your project directory">
+    Log in with `eas login`. By default, each command reads the project ID from the app config in
+    the current directory. Pass `--project-id` to query a project from anywhere, using an account
+    that has access to it:
+    <Terminal cmd={['$ eas observe:metrics-summary --project-id <project-id>']} />
+  </Requirement>
+</Prerequisites>
 
-<Terminal cmd={['$ eas observe:metrics-summary --project-id <project-id>']} />
+## EAS CLI help
 
 Run any command with `--help` to see the flags supported by your installed EAS CLI version.
 

--- a/docs/pages/eas/observe/eas-cli.mdx
+++ b/docs/pages/eas/observe/eas-cli.mdx
@@ -1,0 +1,242 @@
+---
+title: Querying with EAS CLI
+description: Query EAS Observe metrics, events, and sessions from the terminal with the eas observe commands.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+Everything the [EAS Observe dashboard](/eas/observe/dashboard/) shows is also available from the terminal. Use the `eas observe` commands to compare releases, investigate slow sessions, and pipe results into scripts.
+
+## Before you start
+
+Log in with `eas login`. By default, each command reads the project ID from the app config in the current directory. Pass `--project-id` to query a project from anywhere, using an account that has access to it:
+
+<Terminal cmd={['$ eas observe:metrics-summary --project-id <project-id>']} />
+
+Run any command with `--help` to see the flags supported by your installed EAS CLI version.
+
+## Commands
+
+| Command                       | What it shows                                                       |
+| ----------------------------- | ------------------------------------------------------------------- |
+| `eas observe:metrics-summary` | Aggregated statistics per app version, such as median, p90, and p99 |
+| `eas observe:metrics`         | Individual metric samples, ordered by value or time                 |
+| `eas observe:routes`          | Navigation metrics grouped by route name                            |
+| `eas observe:session`         | The full event timeline for one session                             |
+| `eas observe:events`          | User-defined events logged with `Observe.logEvent`                  |
+| `eas observe:versions`        | App versions with their build numbers and update IDs                |
+
+Every command accepts these flags:
+
+- `--platform android` or `--platform ios`: filter by platform. Both are included by default.
+- `--days <number>`: show data from the last N days.
+- `--start <ISO date>` and `--end <ISO date>`: set an explicit time range. Mutually exclusive with `--days`.
+- `--project-id <id>`: query a project without running inside its directory.
+- `--json`: machine-readable output. Implies `--non-interactive`.
+- `--non-interactive`: fail instead of prompting.
+
+When no time range is given, commands return the last 60 days.
+
+## Metric names
+
+Startup metrics are collected automatically once the app is instrumented. See the [Metrics reference](/eas/observe/reference/metrics/) for what each one measures.
+
+| Name              | Metric                                               |
+| ----------------- | ---------------------------------------------------- |
+| `tti`             | Time to interactive                                  |
+| `ttr`             | Time to first render                                 |
+| `cold_launch`     | Cold launch time                                     |
+| `warm_launch`     | Warm launch time                                     |
+| `bundle_load`     | Bundle load time                                     |
+| `update_download` | [EAS Update download time](/eas/observe/eas-update/) |
+
+Navigation metrics are per route. They require SDK 56 or later and one of the navigation integrations, either [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/).
+
+| Name           | Metric                        |
+| -------------- | ----------------------------- |
+| `nav_cold_ttr` | Per-route first render        |
+| `nav_warm_ttr` | Per-route warm render         |
+| `nav_tti`      | Per-route time to interactive |
+
+`observe:metrics` and `observe:metrics-summary` accept all nine names. `observe:routes` accepts the three navigation names.
+
+## `eas observe:metrics-summary`
+
+Shows aggregated statistics grouped by app version, with a separate table per platform. Use it to compare startup performance across releases.
+
+<Terminal
+  cmd={[
+    '# All metrics, last 60 days, both platforms',
+    '$ eas observe:metrics-summary',
+    '',
+    '# One metric, last 14 days, iOS only',
+    '$ eas observe:metrics-summary --metric tti --days 14 --platform ios',
+    '',
+    '# Several metrics, each in its own table',
+    '$ eas observe:metrics-summary --metric tti --metric cold_launch',
+    '',
+    '# Choose which statistics to display',
+    '$ eas observe:metrics-summary --metric tti --stat median --stat p90',
+  ]}
+/>
+
+Command flags:
+
+- `--metric <name>`: metric to display. Repeat the flag for several metrics.
+- `--stat <name>`: statistic to display per metric. One of `min`, `median`, `max`, `average`, `p80`, `p90`, `p99`, or `eventCount`.
+
+The table shows `median` and `eventCount` by default, and merges them into one cell, such as `0.45s (150)`. The App version column includes the build number in parentheses. Update IDs are omitted from the table to keep it readable, but `--json` returns them as an array per version.
+
+## `eas observe:metrics`
+
+Shows individual samples rather than aggregates. Use it to investigate outliers and to find the session behind a slow launch.
+
+<Terminal
+  cmd={[
+    '# Slowest time to interactive this week',
+    '$ eas observe:metrics tti --sort slowest --days 7 --limit 20',
+    '',
+    '# Samples from one release',
+    '$ eas observe:metrics tti --app-version 1.2.0',
+    '',
+    '# Next page of results',
+    '$ eas observe:metrics tti --after <cursor>',
+  ]}
+/>
+
+The metric is a positional argument. Omitting it prompts for a choice, and fails in non-interactive mode.
+
+Command flags:
+
+- `--sort <order>`: one of `oldest` (default), `newest`, `slowest`, or `fastest`.
+- `--limit <number>`: samples per page. Defaults to 10, capped at 100.
+- `--after <cursor>`: the `endCursor` from a previous run.
+- `--app-version <version>`: filter by app version.
+- `--update-id <id>`: filter by EAS Update ID.
+
+When more results are available, the command prints the flag needed to fetch the next page. JSON output adds `sessionId`, `easClientId`, and any custom params attached to the sample.
+
+## `eas observe:routes`
+
+Shows navigation metrics grouped by route name, with a separate section per platform. Use it to find the screens that are slowest to reach.
+
+<Terminal
+  cmd={[
+    '# All navigation metrics, last 7 days',
+    '$ eas observe:routes --days 7',
+    '',
+    '# Time to interactive per route, with percentiles',
+    '$ eas observe:routes --metric nav_tti --stat median --stat p90',
+    '',
+    '# Only the routes you care about',
+    '$ eas observe:routes --route-name /home --route-name /checkout',
+  ]}
+/>
+
+Command flags:
+
+- `--metric <name>`: one of `nav_cold_ttr`, `nav_warm_ttr`, or `nav_tti`. Repeat the flag for several metrics. Defaults to all three.
+- `--stat <name>`: one of `median`, `p90`, or `count`.
+- `--route-name <name>`: filter by route name. Repeat the flag for several routes.
+- `--app-version <version>` and `--build-number <number>`: filter to one release.
+- `--update-id <id>`: filter by EAS Update ID.
+- `--limit <number>`: routes per page. Defaults to 50, capped at 200.
+- `--after <cursor>`: the `endCursor` from a previous run.
+
+Route names are patterns, such as `/(tabs)/sessions/[sessionId]`, so distinct parameter values group together. Each platform paginates separately, so the next-page hint names the platform it applies to.
+
+## `eas observe:session`
+
+Shows every metric and log event recorded during one session, in order. Use it after `observe:metrics` surfaces a slow sample, to see what else happened during that launch.
+
+<Terminal
+  cmd={[
+    '# Inspect a known session',
+    '$ eas observe:session <session-id>',
+    '',
+    '# Pick a session from the slowest time to interactive events',
+    '$ eas observe:session --event-name tti --sort slowest --days 7',
+  ]}
+/>
+
+The session ID is a positional argument. Omitting it in interactive mode prompts you to pick from a list of candidate sessions. Session IDs are also included in the `--json` output of `observe:metrics` and `observe:events`.
+
+Command flags:
+
+- `--event-name <name>`: the metric or user-defined event used to build the candidate list, such as `tti` or `onboarding.completed`.
+- `--sort <order>`: orders the candidate events. One of `slowest`, `fastest`, `newest`, or `oldest`.
+
+## `eas observe:events`
+
+Shows [user-defined events](/eas/observe/events/) logged with `Observe.logEvent`. With no arguments, it lists event names and their counts.
+
+<Terminal
+  cmd={[
+    '# Which events is the app emitting',
+    '$ eas observe:events',
+    '',
+    '# Individual events with one name',
+    '$ eas observe:events report.exported --limit 50',
+    '',
+    '# Every event across all names',
+    '$ eas observe:events --all-events --days 7',
+    '',
+    '# Events from a single session',
+    '$ eas observe:events --all-events --session-id <session-id>',
+  ]}
+/>
+
+Command flags:
+
+- `--all-events`: list every event instead of the name summary. Cannot be combined with an event name.
+- `--session-id <id>`: filter to one session. For the full timeline, including metrics, use `observe:session`.
+- `--app-version <version>`: filter by app version.
+- `--update-id <id>`: filter by EAS Update ID.
+- `--limit <number>` and `--after <cursor>`: paginate the results.
+
+Querying a name that has no events prints the available names for the same time range, which makes typos easy to spot.
+
+## `eas observe:versions`
+
+Lists the app versions in the field with their build numbers, update IDs, and event counts. Use it to find the identifiers that the other commands filter by.
+
+<Terminal
+  cmd={[
+    '# Both platforms, last 60 days',
+    '$ eas observe:versions',
+    '',
+    '# iOS only, last 14 days',
+    '$ eas observe:versions --days 14 --platform ios',
+  ]}
+/>
+
+The table shows app version, first seen, events, users, builds, and updates. JSON output returns the full hierarchy, with EAS build and update details nested under each version.
+
+## Common workflows
+
+**Compare the current release against the previous one:**
+
+<Terminal cmd={['$ eas observe:metrics-summary --days 7 --stat median --stat p90']} />
+
+**Find and investigate the slowest launches:**
+
+<Terminal
+  cmd={[
+    '$ eas observe:metrics tti --sort slowest --days 7 --json',
+    '',
+    '# Then inspect one of the sessions returned above',
+    '$ eas observe:session <session-id>',
+  ]}
+/>
+
+**Check which screens are slowest to become interactive:**
+
+<Terminal cmd={['$ eas observe:routes --metric nav_tti --stat median --stat p90 --days 7']} />
+
+**Check how over-the-air updates download in the field:**
+
+<Terminal cmd={['$ eas observe:metrics-summary --metric update_download --days 7']} />
+
+**Gate a script or CI job on a metric:**
+
+<Terminal cmd={['$ eas observe:metrics-summary --metric tti --json --non-interactive']} />

--- a/docs/pages/eas/observe/eas-cli.mdx
+++ b/docs/pages/eas/observe/eas-cli.mdx
@@ -15,6 +15,8 @@ Log in with `eas login`. By default, each command reads the project ID from the 
 
 Run any command with `--help` to see the flags supported by your installed EAS CLI version.
 
+Some data is available only on certain plans. When your account's plan does not include what a command asks for, the command fails with an upgrade message that links to your billing page. Session timelines are checked before the interactive picker runs, so a blocked plan is reported immediately. See [Pricing](https://expo.dev/pricing) for what each plan includes.
+
 ## Commands
 
 | Command                       | What it shows                                                       |
@@ -28,7 +30,7 @@ Run any command with `--help` to see the flags supported by your installed EAS C
 
 Every command accepts these flags:
 
-- `--platform android` or `--platform ios`: filter by platform. Both are included by default.
+- `--platform android` or `--platform ios`: filter by platform. Both are included by default. Not available on `observe:session`, which already targets one session.
 - `--days <number>`: show data from the last N days.
 - `--start <ISO date>` and `--end <ISO date>`: set an explicit time range. Mutually exclusive with `--days`.
 - `--project-id <id>`: query a project without running inside its directory.
@@ -159,12 +161,14 @@ Shows every metric and log event recorded during one session, in order. Use it a
   ]}
 />
 
-The session ID is a positional argument. Omitting it in interactive mode prompts you to pick from a list of candidate sessions. Session IDs are also included in the `--json` output of `observe:metrics` and `observe:events`.
+The session ID is a positional argument. Omitting it in interactive mode prompts you to pick from a list of candidate sessions. In non-interactive mode, including under `--json`, the session ID is required. Session IDs are also included in the `--json` output of `observe:metrics` and `observe:events`.
 
 Command flags:
 
 - `--event-name <name>`: the metric or user-defined event used to build the candidate list, such as `tti` or `onboarding.completed`.
 - `--sort <order>`: orders the candidate events. One of `slowest`, `fastest`, `newest`, or `oldest`.
+
+> **info** The flags that build the candidate list — `--event-name`, `--sort`, `--days`, `--start`, and `--end` — describe how to _find_ a session, so they cannot be combined with a session ID. Pass the ID on its own to inspect a session you already have.
 
 ## `eas observe:events`
 

--- a/docs/pages/eas/observe/eas-cli.mdx
+++ b/docs/pages/eas/observe/eas-cli.mdx
@@ -214,7 +214,7 @@ Lists the app versions in the field with their build numbers, update IDs, and ev
   ]}
 />
 
-The table shows app version, first seen, events, users, builds, and updates. JSON output returns the full hierarchy, with EAS build and update details nested under each version.
+The table shows app version, first seen, events, users, builds, and updates. JSON output returns the full hierarchy, with EAS Build and update details nested under each version.
 
 ## Common workflows
 

--- a/docs/pages/eas/observe/eas-update.mdx
+++ b/docs/pages/eas/observe/eas-update.mdx
@@ -51,4 +51,4 @@ From the CLI:
   ]}
 />
 
-Run `eas observe:metrics-summary --help` or `eas observe:metrics --help` for the full list of flags (time range, platform, app version, update ID, and more).
+Run `eas observe:metrics-summary --help` or `eas observe:metrics --help` for the full list of flags (time range, platform, app version, update ID, and more). See [Querying with EAS CLI](/eas/observe/eas-cli/) for the other `eas observe` commands.

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -116,4 +116,4 @@ From the CLI:
   ]}
 />
 
-Run `eas observe:events --help` for the full list of flags (time range, platform, session ID, and more).
+Run `eas observe:events --help` for the full list of flags (time range, platform, session ID, and more). See [Querying with EAS CLI](/eas/observe/eas-cli/) for the other `eas observe` commands.

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -234,9 +234,10 @@ You can also query metrics from the terminal using the EAS CLI:
 - `eas observe:metrics-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
 - `eas observe:metrics`: Shows individual performance metric events ordered by value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
 - `eas observe:routes`: Shows navigation metrics (cold and warm time to first render, and time to interactive) grouped by route name. Requires the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/) integration.
+- `eas observe:session`: Shows the full event timeline for a single session.
 - `eas observe:events`: Shows individual events emitted by your app via `Observe.logEvent`. See [User-defined events](/eas/observe/events/) for details.
 
-Run any of these commands with `--help` to see the available flags and arguments.
+Run any of these commands with `--help` to see the available flags and arguments. For flags, metric names, and common workflows, see [Querying with EAS CLI](/eas/observe/eas-cli/).
 
 For the full library API, including configuration options and all available methods, see the [`expo-observe` API reference](/versions/latest/sdk/observe/).
 

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -151,7 +151,7 @@ In the CLI, you can run the following commands:
   ]}
 />
 
-Run `eas observe:routes --help` for the full list of flags (time range, platform, app version, and more).
+See [Querying with EAS CLI](/eas/observe/eas-cli/) for the full flag list.
 
 ## Notes and troubleshooting
 

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -151,7 +151,7 @@ In the CLI, you can run the following commands:
   ]}
 />
 
-See [Querying with EAS CLI](/eas/observe/eas-cli/) for the full flag list.
+Run `eas observe:routes --help` for the full list of flags (time range, platform, app version, and more).  See [Querying with EAS CLI](/eas/observe/eas-cli/) for the other `eas observe` commands.
 
 ## Notes and troubleshooting
 

--- a/docs/pages/eas/observe/integrations/react-navigation.mdx
+++ b/docs/pages/eas/observe/integrations/react-navigation.mdx
@@ -214,7 +214,7 @@ In the CLI, you can run the following commands:
   ]}
 />
 
-See [Querying with EAS CLI](/eas/observe/eas-cli/) for the full flag list.
+Run `eas observe:routes --help` for the full list of flags (time range, platform, app version, and more).  See [Querying with EAS CLI](/eas/observe/eas-cli/) for the other `eas observe` commands.
 
 ## Notes and troubleshooting
 

--- a/docs/pages/eas/observe/integrations/react-navigation.mdx
+++ b/docs/pages/eas/observe/integrations/react-navigation.mdx
@@ -214,7 +214,7 @@ In the CLI, you can run the following commands:
   ]}
 />
 
-Run `eas observe:routes --help` for the full list of flags (time range, platform, app version, and more).
+See [Querying with EAS CLI](/eas/observe/eas-cli/) for the full flag list.
 
 ## Notes and troubleshooting
 

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -152,12 +152,28 @@ Each TTI event includes extra params to help triage issues:
 - **`expo.device.thermalState`** (string): One of `nominal`, `fair`, `serious`, `critical`, `unknown`. Sustained `serious`/`critical` states cause the OS to throttle the CPU/GPU and can dramatically slow startup independent of any app change.
 - **`expo.network.connected`** (boolean): Whether the device had an internet-capable network at TTI. If TTI degrades only when this is `true`, the cause is likely a network-bound startup path; if it degrades when `false`, the app is doing more work than it should before showing cached content.
 - **`expo.network.type`** (string): One of `wifi`, `cellular`, `ethernet`, `none`, `other`, `unknown`. Use to compare cellular versus Wi-Fi populations — large gaps usually point to network-bound startup work. VPN traffic is reported as the underlying transport (typically `wifi` or `cellular`) since the VPN tunnels over it. The value set is intentionally the same on Android and iOS so dashboards don't need per-platform branching.
+- **`expo.network.isExpensive`** (boolean): Whether the OS considers the connection metered, such as cellular or a personal hotspot. Reported on both platforms, and only when a network is present.
+- **`expo.network.isConstrained`** (boolean, iOS only): Whether Low Data Mode is enabled for this path. The system defers background transfers in this mode, so a launch that waits on one can be slower than the same code on an unconstrained path.
+- **`expo.network.dataSaverEnabled`** (boolean, Android only): Whether Data Saver is enabled. It is the closest Android equivalent of Low Data Mode, but it is a process-wide setting rather than a per-path one, so it uses a separate key.
 
 **How to interpret them:**
 
 - **High TTI + low total delay:** startup is slow but smooth. Optimize what's blocking the launch sequence (bundle size, data fetching, initialization chains).
 - **High TTI + high total delay + many slow frames:** main thread contention. Offload work and simplify the initial render tree.
 - **High TTI + high delay + frozen frames:** something is blocking hard. Look for synchronous I/O, large JSON parsing, or blocking API calls.
+
+#### Network request params
+
+TTI events also summarize the HTTP requests the app made during launch, so you can tell a slow launch caused by the network from one caused by the app's own work. The window runs from the end of the native launch to the moment `markInteractive()` is called. Requests are observed automatically: `URLSession` traffic on iOS and `OkHttpClient` traffic on Android, which covers `fetch` in React Native. EAS Observe excludes its own telemetry uploads. These params are omitted when the window held no requests.
+
+- **`expo.network.requests.count`** (count): Requests started in the window.
+- **`expo.network.requests.failed`** (count): Requests that errored or returned a non-2xx status. This is the signal for a launch that stalled on a request that never arrived.
+- **`expo.network.requests.bytesReceived`** and **`expo.network.requests.bytesSent`** (bytes): Totals across the window, measured on the wire.
+- **`expo.network.requests.totalDuration`** (seconds): Sum of every request's duration, failures included. It can exceed wall-clock time when requests overlap, and a single timeout contributes the client's whole timeout interval.
+- **`expo.network.requests.throughputBytesPerSecond`** (bytes per second): Received bytes over the time those bytes were actually moving. The denominator is the union of transfer windows, measured from each first response byte, so DNS, connection setup, and server think time are excluded. Cache hits and failed requests are excluded. Omitted when nothing was received.
+- **`expo.network.requests.slowest.*`**: Facts about the single longest request that completed — `duration` (seconds), `host` (string), `statusCode` (number), `timeToFirstByte` (seconds), and `bytesReceived` (bytes). Read them together: a `duration` that is mostly `timeToFirstByte` means the server was slow to answer, while a small `timeToFirstByte` against a large `bytesReceived` means the transfer was. `statusCode` explains an empty response — a `bytesReceived` of 0 is routine on a 304 and a problem on a 200.
+
+> **info** The summary is bounded by an in-memory buffer of the 200 most recent requests. A launch that makes more than that undercounts, so read these params as a sample of a very busy window rather than a complete tally.
 
 #### Custom event params
 


### PR DESCRIPTION
# Why

Information on using EAS CLI observe commands was present in the docs, but was incomplete, and needed better organization.

# How

Create an `eas-cli` page in the EAS Observe docs, similar to the one in EAS Update, to organize all the docs on querying observe data with the CLI. Update other docs with links to the new page.

Now rebased against https://github.com/expo/expo/pull/48901

# Test Plan

Docs CI should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
