### PR TITLE
[docs] show a variable font in the expo-font config plugin example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -50,6 +50,19 @@ On Android and iOS, the plugin allows you to embed font files at build time whic
                     "weight": 800
                   }
                 ]
+              },
+              {
+                "fontFamily": "Roboto Flex",
+                /* @info A variable font file. It backs every definition below, so the path is shared. */
+                "path": "./path/to/RobotoFlex.ttf",
+                /* @end */
+                "fontDefinitions": [
+                  { "weight": 400 },
+                  { "weight": 700 },
+                  /* @info The `slnt` axis draws the italic out of the same file. */
+                  { "weight": 400, "style": "italic", "axes": { "slnt": -10 } }
+                  /* @end */
+                ]
               }
             ]
           },
@@ -147,6 +160,10 @@ const styles = StyleSheet.create({
 ```
 
 </SnackInline>
+
+### Variable fonts
+
+The `Roboto Flex` entry in the example above is a variable font: one file that holds many faces, which you select with the `fontWeight` and `fontStyle` style props. Variable fonts also work with [`useFonts`](#usefonts). To learn more, see [Variable fonts](/develop/user-interface/fonts/#variable-fonts) in the Fonts guide.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/font.mdx
+++ b/docs/pages/versions/unversioned/sdk/font.mdx
@@ -163,7 +163,7 @@ const styles = StyleSheet.create({
 
 ### Variable fonts
 
-The `Roboto Flex` entry in the example above is a variable font: one file that holds many faces, which you select with the `fontWeight` and `fontStyle` style props. Variable fonts also work with [`useFonts`](#usefonts). To learn more, see [Variable fonts](/develop/user-interface/fonts/#variable-fonts) in the Fonts guide.
+The `Roboto Flex` entry in the example above is a variable font: one file that holds many faces. You select a face with the `fontWeight` and `fontStyle` style props. Variable fonts also work with [`useFonts`](#usefonts). To learn more, see [Variable fonts](/develop/user-interface/fonts/#variable-fonts) in the Fonts guide.
 
 ## API
 


### PR DESCRIPTION
# Why

SDK 58 adds variable font support to `expo-font`: #48129 and #48621 (config plugin on Android), #48432 (`useFonts` on iOS). The API reference does not mention that yet.

First PR of a stack of 3. This one updates the versioned reference for SDK 58 and can merge right away.

# How

Adds an example of configuring the config plugin with variable fonts on Android, along with a short paragraph linking to an existing paragraph in the Fonts guide.

# Test Plan

- docs preview

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

