### PR TITLE
[submit-expo-feedback] Detect EAS Simulator sessions and split the bin/library entry points

### DIFF
--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -190,7 +190,9 @@ The stop mutation is idempotent.
 
 Send feedback about EAS Simulator to the Expo team:
 
-<Terminal cmd={['$ eas simulator:feedback "Sessions boot fast, but simulator:exec output is noisy"']} />
+<Terminal
+  cmd={['$ eas simulator:feedback "Sessions boot fast, but simulator:exec output is noisy"']}
+/>
 
 Omit the message to be prompted in an interactive terminal. The command submits through [`submit-expo-feedback`](https://www.npmjs.com/package/submit-expo-feedback) with the `simulator` category and attaches the active session ID from **.env.eas-simulator**, so feedback can be correlated with session events.
 

--- a/docs/pages/preview/eas-simulator/cli-reference.mdx
+++ b/docs/pages/preview/eas-simulator/cli-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: EAS Simulator CLI reference
 sidebar_title: CLI reference
-description: Reference for the experimental EAS CLI commands that create, inspect, monitor, control, list, and stop remote simulator sessions.
+description: Reference for the experimental EAS CLI commands that create, inspect, monitor, control, list, and stop remote simulator sessions, and send feedback.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
@@ -25,6 +25,7 @@ The `--help` flag displays the available options for `simulator:start`.
 | [`simulator:get`](#simulatorget)                   | Get status, connection details, dashboard URL, timestamps, and artifacts |
 | [`simulator:list`](#simulatorlist)                 | List and filter sessions for the current project                         |
 | [`simulator:stop`](#simulatorstop)                 | Stop a session                                                           |
+| [`simulator:feedback`](#simulatorfeedback)         | Send feedback about EAS Simulator to the Expo team                       |
 
 ## `simulator:availability`
 
@@ -184,6 +185,22 @@ Stop a specific session:
 <Terminal cmd={['$ eas simulator:stop --id <session-id>']} />
 
 The stop mutation is idempotent.
+
+## `simulator:feedback`
+
+Send feedback about EAS Simulator to the Expo team:
+
+<Terminal cmd={['$ eas simulator:feedback "Sessions boot fast, but simulator:exec output is noisy"']} />
+
+Omit the message to be prompted in an interactive terminal. The command submits through [`submit-expo-feedback`](https://www.npmjs.com/package/submit-expo-feedback) with the `simulator` category and attaches the active session ID from **.env.eas-simulator**, so feedback can be correlated with session events.
+
+| Flag                | Description                                                                       |
+| ------------------- | --------------------------------------------------------------------------------- |
+| `--id`              | Simulator session ID to attach. Defaults to the session in **.env.eas-simulator** |
+| `--subject`         | Simulator command or feature the feedback is about, such as `simulator:exec`      |
+| `--non-interactive` | Fail instead of prompting when the message is missing                             |
+
+Set `DO_NOT_TRACK=1` or `EXPO_NO_TELEMETRY=1` to omit automatically collected metadata, including the session ID.
 
 ## **.env.eas-simulator**
 

--- a/packages/submit-expo-feedback/bin/submit-expo-feedback.js
+++ b/packages/submit-expo-feedback/bin/submit-expo-feedback.js
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
 
-require('../build/index.js');
+const { logErrorAndExit, runExpoFeedbackAsync } = require('../build/index.js');
+
+runExpoFeedbackAsync().catch(logErrorAndExit);

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -85,6 +85,7 @@ describe('help output', () => {
       expect(helpOutput).toContain(
         'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected'
       );
+      expect(helpOutput).toContain('EAS Simulator session ID');
     } finally {
       process.argv = originalArgv;
       consoleLogSpy.mockRestore();
@@ -153,8 +154,14 @@ describe('feedback message resolution', () => {
 
   it('prompts for a category and message in interactive environments', async () => {
     const originalIsTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-    mockPrompts.mockResolvedValueOnce({ category: 'docs', feedback: 'Clarify this example.' });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: true,
+    });
+    mockPrompts.mockResolvedValueOnce({
+      category: 'docs',
+      feedback: 'Clarify this example.',
+    });
 
     try {
       await expect(resolveFeedbackAsync([])).resolves.toEqual({
@@ -178,7 +185,10 @@ describe('feedback message resolution', () => {
 
   it('requires a message without prompting in non-interactive environments', async () => {
     const originalIsTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: false });
+    Object.defineProperty(process.stdin, 'isTTY', {
+      configurable: true,
+      value: false,
+    });
 
     try {
       await expect(resolveFeedbackAsync([])).rejects.toThrow(
@@ -508,4 +518,110 @@ describe('feedback submission', () => {
       }
     }
   );
+});
+
+describe('simulator session metadata', () => {
+  const originalEnv = process.env;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = createTempDir();
+    const env: NodeJS.ProcessEnv = { ...originalEnv };
+    delete env.EAS_SIMULATOR_SESSION_ID;
+    delete env.DO_NOT_TRACK;
+    delete env.EXPO_NO_TELEMETRY;
+    process.env = env;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    rmSync(projectRoot, { force: true, recursive: true });
+  });
+
+  it('detects a session from the EAS_SIMULATOR_SESSION_ID environment variable', async () => {
+    process.env.EAS_SIMULATOR_SESSION_ID = 'session-from-env';
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+    expect(metadata).toMatchObject({
+      category: 'simulator',
+      simulatorEnvironment: {
+        detected: true,
+        simulator: { sessionId: 'session-from-env' },
+      },
+    });
+  });
+
+  it('falls back to the session ID written to .env.eas-simulator', async () => {
+    writeFileSync(
+      path.join(projectRoot, '.env.eas-simulator'),
+      '# Do not commit this file.\n' +
+        'EAS_SIMULATOR_SESSION_ID="session-from-dotenv"\n' +
+        'AGENT_DEVICE_DAEMON_BASE_URL="https://example.dev"\n' +
+        'AGENT_DEVICE_DAEMON_AUTH_TOKEN="super-secret-token"\n'
+    );
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+    expect(metadata).toMatchObject({
+      simulatorEnvironment: {
+        detected: true,
+        simulator: { sessionId: 'session-from-dotenv' },
+      },
+    });
+    expect(JSON.stringify(metadata)).not.toContain('super-secret-token');
+    expect(JSON.stringify(metadata)).not.toContain('example.dev');
+  });
+
+  it('prefers the environment variable over .env.eas-simulator', async () => {
+    process.env.EAS_SIMULATOR_SESSION_ID = 'session-from-env';
+    writeFileSync(
+      path.join(projectRoot, '.env.eas-simulator'),
+      'EAS_SIMULATOR_SESSION_ID="session-from-dotenv"\n'
+    );
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+    expect(metadata).toMatchObject({
+      simulatorEnvironment: {
+        detected: true,
+        simulator: { sessionId: 'session-from-env' },
+      },
+    });
+  });
+
+  it('reports no session when neither source has one', async () => {
+    writeFileSync(path.join(projectRoot, '.env.eas-simulator'), '# Do not commit this file.\n');
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+    expect(metadata).toMatchObject({
+      simulatorEnvironment: { detected: false },
+    });
+  });
+
+  it.each(['   ', 'contains spaces', 'a'.repeat(129)])(
+    'ignores invalid session ID %p',
+    async (sessionId) => {
+      process.env.EAS_SIMULATOR_SESSION_ID = sessionId;
+
+      const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+      expect(metadata).toMatchObject({
+        simulatorEnvironment: { detected: false },
+      });
+    }
+  );
+
+  it('omits the session ID when telemetry is disabled', async () => {
+    process.env.EAS_SIMULATOR_SESSION_ID = 'session-from-env';
+    process.env.DO_NOT_TRACK = '1';
+
+    const metadata = await createFeedbackMetadataAsync(projectRoot, null, 'simulator');
+
+    expect(metadata).toEqual({
+      category: 'simulator',
+      feedbackId: expect.stringMatching(/^[a-f0-9]{12}$/),
+    });
+  });
 });

--- a/packages/submit-expo-feedback/src/__tests__/index.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/index.test.ts
@@ -1,0 +1,11 @@
+describe('library entry point', () => {
+  it('exposes the submit interface without running the CLI', () => {
+    const index = require('../index');
+
+    expect(typeof index.sendFeedbackAsync).toBe('function');
+    expect(typeof index.runExpoFeedbackAsync).toBe('function');
+    expect(typeof index.logErrorAndExit).toBe('function');
+    expect(index.CLI_FEEDBACK_CATEGORIES).toContain('simulator');
+    expect(index.CLI_FEEDBACK_MAX_LENGTH).toBe(5_000);
+  });
+});

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -28,8 +28,11 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const EAS_SIMULATOR_SESSION_ID_VARIABLE = 'EAS_SIMULATOR_SESSION_ID';
+const EAS_SIMULATOR_DOTENV_FILE = '.env.eas-simulator';
+const MAX_SIMULATOR_SESSION_ID_LENGTH = 128;
 
-type UserSession = {
+export type UserSession = {
   sessionSecret?: string;
   userId?: string;
   username?: string;
@@ -212,6 +215,7 @@ export async function createFeedbackMetadataAsync(
     },
     agentEnvironment: getAgentEnvironment(),
     sandboxEnvironment: getSandboxEnvironment(),
+    simulatorEnvironment: getSimulatorEnvironment(projectRoot),
     ci: ciInfo.isCI
       ? {
           name: ciInfo.name ?? null,
@@ -251,6 +255,57 @@ function getSandboxEnvironment(): CliFeedbackTelemetryMetadata['sandboxEnvironme
         sandbox: result.sandbox,
       }
     : { detected: false };
+}
+
+function getSimulatorEnvironment(
+  projectRoot: string
+): CliFeedbackTelemetryMetadata['simulatorEnvironment'] {
+  const sessionId =
+    normalizeSimulatorSessionId(process.env[EAS_SIMULATOR_SESSION_ID_VARIABLE]) ??
+    normalizeSimulatorSessionId(readSimulatorSessionIdFromDotenvFile(projectRoot));
+
+  return sessionId
+    ? {
+        detected: true,
+        simulator: { sessionId },
+      }
+    : { detected: false };
+}
+
+// .env.eas-simulator is managed by eas-cli and also holds controller connection credentials;
+// read only the session ID line.
+function readSimulatorSessionIdFromDotenvFile(projectRoot: string): string | undefined {
+  let contents: string;
+  try {
+    contents = readFileSync(path.join(projectRoot, EAS_SIMULATOR_DOTENV_FILE), 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  const match = contents.match(new RegExp(`^${EAS_SIMULATOR_SESSION_ID_VARIABLE}=(.*)$`, 'm'));
+  if (!match) {
+    return undefined;
+  }
+
+  // eas-cli writes JSON-stringified values, but tolerate plain or single-quoted ones.
+  const value = match[1]?.trim();
+  if (!value) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return typeof parsed === 'string' ? parsed : undefined;
+  } catch {
+    return value.replace(/^['"]|['"]$/g, '');
+  }
+}
+
+function normalizeSimulatorSessionId(value: string | undefined): string | undefined {
+  const sessionId = value?.trim();
+  if (!sessionId || sessionId.length > MAX_SIMULATOR_SESSION_ID_LENGTH || /\s/.test(sessionId)) {
+    return undefined;
+  }
+  return sessionId;
 }
 
 export async function getUserMetadataAsync(
@@ -324,7 +379,10 @@ function hasExpoProjectConfig(paths: ConfigFilePaths, pkg: PackageJson | null): 
 }
 
 function getDependencyVersion(
-  pkg: { dependencies?: Record<string, unknown>; devDependencies?: Record<string, unknown> } | null,
+  pkg: {
+    dependencies?: Record<string, unknown>;
+    devDependencies?: Record<string, unknown>;
+  } | null,
   name: string
 ): string | undefined {
   if (!pkg) {
@@ -346,7 +404,9 @@ function getPackageJson(projectRoot: string): PackageJson | null {
 function getInstalledPackageVersion(projectRoot: string, packageName: string): string | undefined {
   try {
     const packageJsonPath = getResolvedPackageJsonPath(projectRoot, packageName);
-    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version?: unknown };
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      version?: unknown;
+    };
     return typeof pkg.version === 'string' ? pkg.version : undefined;
   } catch {
     return undefined;
@@ -474,7 +534,8 @@ function printHelp(): void {
 
   {bold Data collection}
     Feedback includes available agent/session identifiers, sandbox and environment
-    details, Expo project metadata, and Expo account identifiers.
+    details, the active EAS Simulator session ID, Expo project metadata, and Expo
+    account identifiers.
     Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected
     metadata and authentication.
 

--- a/packages/submit-expo-feedback/src/index.ts
+++ b/packages/submit-expo-feedback/src/index.ts
@@ -1,6 +1,6 @@
-#!/usr/bin/env node
-import { logErrorAndExit, runExpoFeedbackAsync } from './cli';
-
+export { logErrorAndExit, runExpoFeedbackAsync, sendFeedbackAsync } from './cli';
+export type { UserSession } from './cli';
+export { CLI_FEEDBACK_CATEGORIES, CLI_FEEDBACK_MAX_LENGTH } from './types';
 export type {
   CliFeedbackAgentEnvironment,
   CliFeedbackCategory,
@@ -9,8 +9,7 @@ export type {
   CliFeedbackProjectMetadata,
   CliFeedbackRequest,
   CliFeedbackSandboxEnvironment,
+  CliFeedbackSimulatorEnvironment,
   CliFeedbackTelemetryMetadata,
   CliFeedbackUserMetadata,
 } from './types';
-
-runExpoFeedbackAsync().catch(logErrorAndExit);

--- a/packages/submit-expo-feedback/src/types.ts
+++ b/packages/submit-expo-feedback/src/types.ts
@@ -39,6 +39,15 @@ export type CliFeedbackSandboxEnvironment =
       };
     };
 
+export type CliFeedbackSimulatorEnvironment =
+  | { detected: false }
+  | {
+      detected: true;
+      simulator: {
+        sessionId: string;
+      };
+    };
+
 export type CliFeedbackProjectMetadata =
   | { isExpoProject: false }
   | {
@@ -69,6 +78,7 @@ export type CliFeedbackTelemetryMetadata = {
   };
   agentEnvironment: CliFeedbackAgentEnvironment;
   sandboxEnvironment: CliFeedbackSandboxEnvironment;
+  simulatorEnvironment: CliFeedbackSimulatorEnvironment;
   ci?: {
     name: string | null;
     isPr: boolean | null;


### PR DESCRIPTION
# Why

EAS Simulator needs a feedback channel. The plan (with a companion eas-cli PR adding `eas simulator:feedback`) is to reuse `submit-expo-feedback` for simulator product feedback, with the active session ID attached automatically so feedback can be correlated with session events on expo.dev.

Two things blocked that:

1. The CLI collected agent/sandbox/project metadata but knew nothing about EAS Simulator sessions.
2. `src/index.ts` was simultaneously the bin entry and the package `main` — **importing the package ran the CLI** (and could fire a real submission with whatever was in `argv`), so nothing could safely consume it programmatically.

# How

- **Simulator session detection**, mirroring the existing `agentEnvironment`/`sandboxEnvironment` pattern: a new `simulatorEnvironment` field in the telemetry metadata reads `EAS_SIMULATOR_SESSION_ID` from the environment, falling back to reading **only the session-ID line** of `.env.eas-simulator` in the project root — never the controller credentials the file also holds. Invalid values (whitespace, >128 chars) are ignored, and telemetry opt-out (`DO_NOT_TRACK`/`EXPO_NO_TELEMETRY`) drops it like all other collected metadata. The dotenv parsing tolerates plain/single-quoted values since the file format is owned by eas-cli.
- **Entry-point split**: `src/index.ts` is now pure exports (`sendFeedbackAsync`, `runExpoFeedbackAsync`, `CLI_FEEDBACK_CATEGORIES`, all types, and the new `CliFeedbackSimulatorEnvironment`); the CLI invocation moved into `bin/submit-expo-feedback.js`. A regression test asserts that importing the entry point exposes the interface without running the CLI.
- Help text now discloses the session-ID collection, and the EAS Simulator preview docs got a `simulator:feedback` section for the upcoming eas-cli command.

# Test Plan

- `jest`: 35 tests pass (13 new — env-var detection, dotenv fallback, precedence, invalid IDs, telemetry opt-out, a credential-leak guard asserting the daemon token/URL never enter metadata, and the entry-point regression test).
- `tsc`, `oxlint`, `expo-module depscheck` clean; `ncc build` succeeds.
- Smoke-tested the built output: `bin/submit-expo-feedback.js --help`/`--version` work, and `require('build/index.js')` exposes the library without side effects.

# Checklist

- This package has no CHANGELOG.md, so no changelog entry.
- Built, type-checked, linted, and tested as above (`et check-packages` steps run individually).
- Not applicable to `npx expo prebuild` / EAS Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)