### PR TITLE
[expo][jest-expo] Prefer the engine's native TextDecoder over the polyfill

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Prefer the engine's native `TextDecoder` (shipped in Hermes 260318099.0.0 and newer) over the JS polyfill. ([#48790](https://github.com/expo/expo/pull/48790) by [@tomekzaw](https://github.com/tomekzaw))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -10,7 +10,12 @@ import { installFormDataPatch } from './FormData';
 import { installGlobal as install } from './installGlobal';
 
 // https://encoding.spec.whatwg.org/#textdecoder
-install('TextDecoder', () => require('./TextDecoder').TextDecoder);
+// Hermes ships a native, WHATWG-conformant `TextDecoder` as of engine release
+// 260318099.0.0. Prefer it over the JS polyfill when available - it is faster
+// and supports more encodings than the UTF-8-only polyfill.
+if (typeof globalThis.TextDecoder === 'undefined') {
+  install('TextDecoder', () => require('./TextDecoder').TextDecoder);
+}
 // https://encoding.spec.whatwg.org/#interface-textdecoderstream
 install('TextDecoderStream', () => require('./TextDecoderStream').TextDecoderStream);
 // https://encoding.spec.whatwg.org/#interface-textencoderstream

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Remove Node's built-in `TextDecoder` before installing the `expo` winter runtime, simulating the native runtimes where the polyfill is used. ([#48790](https://github.com/expo/expo/pull/48790) by [@tomekzaw](https://github.com/tomekzaw))
+
 ## 57.0.3 - 2026-07-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -362,6 +362,10 @@ jest.doMock('expo/src/winter/FormData', () => ({
   // so we don't need to patch `FormData` for the jest runtime.
   installFormDataPatch: jest.fn(),
 }));
+// Simulate the native runtime, where no engine-provided `TextDecoder` exists
+// yet: the winter runtime only installs its polyfill when the global is
+// absent, and the tests exercise the polyfill rather than Node's built-in.
+delete globalThis.TextDecoder;
 // Ensure the environment globals are installed before the first test runs.
 require('expo/src/winter');
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was authored by AI with [Argent](https://argent.swmansion.com) on behalf of @tomekzaw.

# Why

Hermes ships a native, WHATWG-conformant `TextDecoder` as of engine release [260318099.0.0](https://github.com/facebook/hermes/blob/static_h/doc/blog/2026-06-05-new-hermes-stable-release.md) ("TextDecoder now ships with the engine (no polyfill needed)"). The extension is installed by the engine itself at runtime creation, so on any React Native version that adopts that Hermes release, `globalThis.TextDecoder` exists before any JS runs.

However, the winter runtime installs its `TextDecoder` polyfill **unconditionally** — `installGlobal` explicitly replaces an existing global. This means Expo apps would silently keep running the UTF-8-only JS polyfill (which decodes at roughly 0.5 ms per KB on Hermes, see https://github.com/expo/expo/pull/48791) over the engine's native implementation.

# How

- `packages/expo`: only install the `TextDecoder` polyfill when the global doesn't already exist. Deferring to the engine is a strict superset in functionality: the polyfill supports only UTF-8 (and throws `RangeError` for other labels), while the native implementation also covers the single-byte encodings.
- `packages/jest-expo`: the jest preset now deletes Node's built-in `TextDecoder` before requiring `expo/src/winter`, simulating the native runtimes the polyfill targets (where no engine `TextDecoder` exists yet). The existing suites keep exercising the polyfill, unchanged.

This is a zero-behavior-change on every engine Expo runs on today (verified on current Hermes: no engine-provided `TextDecoder` exists when the winter runtime executes, so the polyfill still installs). `TextDecoderStream` is untouched — no engine ships it, and it picks up whichever `TextDecoder` global is installed.

# Test Plan

- `packages/expo`: `TextDecoder.test.native.ts` + `TextDecoderStream.test.ios.ts` — 96/96 pass on iOS and Android jest projects.
- Runtime probe on Hermes (Android): before this change the polyfill replaces nothing (`originalTextDecoder` is `undefined` in dev), after this change the polyfill still installs — confirming no behavior change on current engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
