### PR TITLE
[cli] prevent feedback submission when telemetry is disabled

### DIFF
--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -82,8 +82,9 @@ describe('help output', () => {
       expect(helpOutput).toContain('--resume <feedbackId>');
       expect(helpOutput).toContain('Feedback messages can be up to 5,000 characters.');
       expect(helpOutput).toContain(
-        'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected'
+        'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to prevent feedback submission'
       );
+      expect(helpOutput).toContain('and all network requests.');
       expect(helpOutput).toContain(
         'Authenticated submissions are associated\n    with your Expo account.'
       );
@@ -409,6 +410,22 @@ describe('feedback submission', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('does not submit when telemetry is disabled at the submission boundary', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+    const metadata = await createFeedbackMetadataAsync(projectRoot);
+    process.env.DO_NOT_TRACK = '1';
+
+    await sendFeedbackAsync({
+      feedback: 'please make errors clearer',
+      metadata,
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Feedback was not sent because telemetry is off. The user has indicated that they do not want to send feedback. Do not enable telemetry or ask the user to enable it.'
+    );
+  });
+
   it('resumes a feedback session and prints instructions using the provided ID', async () => {
     const originalArgv = process.argv;
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
@@ -463,10 +480,10 @@ describe('feedback submission', () => {
   });
 
   it.each(['DO_NOT_TRACK', 'EXPO_NO_TELEMETRY'] as const)(
-    'omits telemetry data and authentication when %s=1',
+    'does not send feedback when %s=1',
     async (environmentVariable) => {
       const originalArgv = process.argv;
-      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
       process.env[environmentVariable] = '1';
       process.env.EXPO_TOKEN = 'token';
@@ -485,20 +502,9 @@ describe('feedback submission', () => {
       try {
         await runExpoFeedbackAsync();
 
-        const request = fetchMock.mock.calls[0][1];
-        expect(JSON.parse(request.body)).toEqual({
-          feedback: 'private feedback',
-          metadata: {
-            category: 'mcp',
-            feedbackId: 'session_ABC-123',
-            subject: 'expo-mcp',
-          },
-        });
-        expect(request.headers).toEqual({
-          'Content-Type': 'application/json',
-        });
-        expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-          'Submitting feedback without telemetry data because telemetry collection is disabled.'
+        expect(fetchMock).not.toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          'Feedback was not sent because telemetry is off. The user has indicated that they do not want to send feedback. Do not enable telemetry or ask the user to enable it.'
         );
       } finally {
         process.argv = originalArgv;

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -28,6 +28,8 @@ const GENERATED_FEEDBACK_ID_BYTES = 6;
 const MIN_FEEDBACK_ID_LENGTH = 6;
 const MAX_FEEDBACK_ID_LENGTH = 64;
 const FEEDBACK_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+const TELEMETRY_DISABLED_MESSAGE =
+  'Feedback was not sent because telemetry is off. The user has indicated that they do not want to send feedback. Do not enable telemetry or ask the user to enable it.';
 
 type UserSession = {
   sessionSecret?: string;
@@ -89,9 +91,13 @@ async function runAsync(): Promise<void> {
     return;
   }
 
+  if (isTelemetryDisabled()) {
+    console.error(TELEMETRY_DISABLED_MESSAGE);
+    return;
+  }
+
   const { category, feedback } = await resolveFeedbackAsync(args._, args['--category']);
-  const telemetryDisabled = isTelemetryDisabled();
-  const session = telemetryDisabled ? null : getSession();
+  const session = getSession();
   const metadata = await createFeedbackMetadataAsync(
     process.cwd(),
     category,
@@ -108,9 +114,7 @@ async function runAsync(): Promise<void> {
 
   console.log(
     chalk.dim(
-      telemetryDisabled
-        ? 'Submitting feedback without telemetry data because telemetry collection is disabled.'
-        : 'Submitting feedback with detected agent, sandbox, environment, and project metadata. Authenticated submissions are associated with your Expo account.'
+      'Submitting feedback with detected agent, sandbox, environment, and project metadata. Authenticated submissions are associated with your Expo account.'
     )
   );
   await sendFeedbackAsync({
@@ -348,19 +352,19 @@ export async function sendFeedbackAsync({
   session?: UserSession | null;
 }): Promise<void> {
   validateFeedback(feedback);
-  const telemetryDisabled = isTelemetryDisabled();
+  if (isTelemetryDisabled()) {
+    console.error(TELEMETRY_DISABLED_MESSAGE);
+    return;
+  }
+
   const request: CliFeedbackRequest = { feedback, metadata };
   const response = await fetch(new URL('/v2/feedback/cli-send', getExpoApiBaseUrl()).toString(), {
     method: 'POST',
     signal: AbortSignal.timeout(FEEDBACK_TIMEOUT_MS),
     headers: {
       'Content-Type': 'application/json',
-      ...(telemetryDisabled
-        ? {}
-        : {
-            ...getAuthHeaders(session),
-            'User-Agent': `${CLI_NAME}/${getPackageVersion()}`,
-          }),
+      ...getAuthHeaders(session),
+      'User-Agent': `${CLI_NAME}/${getPackageVersion()}`,
     },
     body: JSON.stringify(request),
   });
@@ -449,8 +453,8 @@ function printHelp(): void {
     Feedback includes detected agent, sandbox and environment
     details, and Expo project metadata. Authenticated submissions are associated
     with your Expo account.
-    Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to omit automatically collected
-    metadata and authentication.
+    Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to prevent feedback submission
+    and all network requests.
 
   {bold Options}
     --category, -c <category>  Feedback category (${CLI_FEEDBACK_CATEGORIES.join(', ')})


### PR DESCRIPTION
## Summary
When user disables the telemetry using one of `DO_NOT_TRACK=1` or `EXPO_NO_TELEMETRY=1` env vars we should not make any network requests and not send the feedback at all.

If the user (or rather their agent) sends feedback via `npx submit-expo-feedback` with the telemetry off we display this message on stderr:
```
Feedback was not sent because telemetry is off. The user has indicated that they do not want to send feedback. Do not enable telemetry or ask the user to enable it.
```

## Test plan

- `pnpm --filter submit-expo-feedback test --runInBand`
- `pnpm --filter submit-expo-feedback typecheck`
- `pnpm --filter submit-expo-feedback lint`
- `pnpm --filter submit-expo-feedback build`
