### PR TITLE
[verify] preflight should test the real model, and report what actually failed

### DIFF
--- a/.github/workflows/verify-command.yml
+++ b/.github/workflows/verify-command.yml
@@ -512,13 +512,31 @@ jobs:
           # This is unconditional now. Even outside fix mode the run depends on
           # writes: the draft the reviewer reads, and the review the last phase
           # reads back. An un-writable .verify-out means no findings at all.
+          #
+          # It runs on $VERIFY_MODEL, not a cheaper pinned one. The canary used
+          # claude-haiku-4-5-20251001 while the run used $VERIFY_MODEL, so it
+          # was proving a credential/model path the run never takes: a token
+          # with access to one but not the other fails here and blocks a run
+          # that would have worked, which is exactly what happened on
+          # 2026-08-11 after the CLAUDE_CODE_OAUTH_TOKEN secret was rotated.
+          # One trivial call on the real model is worth less than one wasted
+          # investigation.
+          #
+          # And it KEEPS THE CLI OUTPUT. Every cause — bad path rule, expired
+          # token, model not available, API outage — lands as the same missing
+          # file, so discarding stderr and then naming one of them was a guess
+          # printed as a diagnosis. That guess sent a maintainer to debug path
+          # rules that were correct. Report the symptom, show the output, let
+          # the reader conclude.
           mkdir -p .verify-out && rm -f .verify-out/.permcheck
           claude -p "Write the single word ok to .verify-out/.permcheck. Say nothing else." \
-            --model claude-haiku-4-5-20251001 \
+            --model "$VERIFY_MODEL" \
             --disallowedTools Bash --strict-mcp-config \
-            --allowedTools "$ALLOWED" >/dev/null 2>&1 || true
+            --allowedTools "$ALLOWED" > "$RUNNER_TEMP/permcheck.log" 2>&1 || true
           if [ ! -f .verify-out/.permcheck ]; then
-            echo "::error::The agent cannot write .verify-out — the --allowedTools file rules do not match. Fix them before this runs for real."
+            echo "::error::Preflight canary did not write .verify-out/.permcheck, so the run stopped before spending a sandbox. This is EITHER a file-permission rule that does not match OR the CLI failing to run at all (credential, model access, outage). The CLI output below says which:"
+            sed -n '1,40p' "$RUNNER_TEMP/permcheck.log" || true
+            echo "::error::--allowedTools was: $ALLOWED"
             exit 1
           fi
           rm -f .verify-out/.permcheck


### PR DESCRIPTION
`/verify` on #48780 died four seconds in, before the agent started:

```
##[error]The agent cannot write .verify-out — the --allowedTools file rules do not match.
```

**The file rules were correct.** `$ALLOWED` from that run's own environment dump:

```
Read(//home/runner/work/expo/expo/**),Glob(//…/**),Grep(//…/**),mcp__sandbox__create_sandbox,…
```

Well-formed, correct leading `//`, identical to the string that worked in the morning's successful runs. What had actually changed is that the `CLAUDE_CODE_OAUTH_TOKEN` secret was rotated.

## Two bugs, both about guessing

**The canary tested a model the run never uses.** It pinned `claude-haiku-4-5-20251001` while the run itself uses `$VERIFY_MODEL` (currently `claude-opus-5`). So it validated a credential/model path unrelated to the one the run depends on: a token with access to one but not the other fails the preflight and blocks a run that would have succeeded — and conversely a green canary said nothing about whether the real model was reachable. It now runs on `$VERIFY_MODEL`. One trivial call on the real model costs far less than one wasted investigation, and it now fails only when the run would have failed anyway.

**The error named a cause it had not established.** The canary sent stdout and stderr to `/dev/null`, so a bad path rule, an expired token, a model without access, and an API outage all arrived as the same missing file — and the message picked one of them and stated it as fact. That is what sent me to debug path rules that were fine. It now keeps the output, reports the symptom, prints the CLI's own error underneath, and echoes the `--allowedTools` string so both hypotheses can be checked at a glance:

```
::error::Preflight canary did not write .verify-out/.permcheck, so the run stopped
before spending a sandbox. This is EITHER a file-permission rule that does not match
OR the CLI failing to run at all (credential, model access, outage). The CLI output
below says which:
<first 40 lines of the CLI's own output>
::error::--allowedTools was: …
```

The preflight's purpose is unchanged and worth keeping: it catches an unmatched file rule before a run spends its one sandbox and several EAS builds. This only stops it from being confidently wrong about why it fired.

Nothing was spent on the failed run — the canary fires before the sandbox is created — so the only cost was the misdiagnosis.

YAML parses; the modified step passes `bash -n`.
