### PR TITLE
[verify] quiet dispatch trigger, and stop double-commenting a withdrawal

### DIFF
--- a/.github/workflows/verify-command.yml
+++ b/.github/workflows/verify-command.yml
@@ -59,6 +59,24 @@ name: Verify issue (command)
 on:
   issue_comment:
     types: [created]
+  # Quiet path. Dispatching from the Actions tab runs a verification that
+  # posts NOTHING to the thread until the findings themselves — no eyes
+  # reaction, no "started" comment, no failure notice. That matters on a
+  # pull request, where every bot comment lands in a contributor's inbox
+  # and an experiment that finds nothing should leave no trace at all.
+  # workflow_dispatch is inherently gated: GitHub only lets accounts with
+  # write access dispatch a workflow, which is the same bar the comment
+  # path checks for explicitly.
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Issue or pull request number"
+        required: true
+        type: string
+      fix:
+        description: "Attempt a fix pull request (issues default to yes on the comment path; here it is explicit)"
+        type: boolean
+        default: false
 
 # Scopes the automatic workflow token, which is what the AGENT step gets:
 # issue comments yes, repository contents never. The agent therefore cannot
@@ -77,14 +95,15 @@ jobs:
     # its sandboxes and EAS builds. cancel-in-progress:false queues a second
     # /verify instead of killing the first.
     concurrency:
-      group: verify-${{ github.event.issue.number }}
+      group: verify-${{ github.event.issue.number || inputs.target }}
       cancel-in-progress: false
     # Comments starting with /verify, on issues or PRs, from maintainer
     # associations. The authoritative write-access check is the step below.
     # (Runs are backed by the expo-verification-bot service account.)
     if: >-
-      startsWith(github.event.comment.body, '/verify') &&
-      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+      github.event_name == 'workflow_dispatch' ||
+      (startsWith(github.event.comment.body, '/verify') &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # ONE budget, in one place, and the ordering is the point:
     #   scoped-token TTL (180m) > job timeout (150m) > sum of the phase
@@ -107,6 +126,12 @@ jobs:
     # honest answer there is fewer arms, not more clock.
     timeout-minutes: 150
     continue-on-error: true
+    # Resolved once, for both trigger paths, so no step has to know which
+    # event it is running under.
+    env:
+      TARGET_NUMBER: ${{ github.event.issue.number || inputs.target }}
+      TRIGGER_ACTOR: ${{ github.event.comment.user.login || github.actor }}
+      QUIET: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       # author_association MEMBER does not imply write on THIS repo; the
       # requirement is write access or higher, checked against the
@@ -115,7 +140,7 @@ jobs:
         id: gate
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
-          ACTOR: ${{ github.event.comment.user.login }}
+          ACTOR: ${{ github.event.comment.user.login || github.actor }}
         run: |
           perm=$(gh api "repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq .permission || echo none)
           case "$perm" in
@@ -142,18 +167,28 @@ jobs:
         id: cmd
         if: steps.gate.outputs.ok == 'true'
         env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           COMMENT: ${{ github.event.comment.body }}
           IS_PR: ${{ github.event.issue.pull_request != null }}
+          INPUT_FIX: ${{ inputs.fix }}
         run: |
-          line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
-          if [ "$IS_PR" = "true" ]; then fix=false; else fix=true; fi
-          case " $line " in *" --fix "*) fix=true ;; esac
-          case " $line " in *" --no-fix "*) fix=false ;; esac
+          if [ "$QUIET" = "true" ]; then
+            # Dispatch carries no comment, and nothing tells us whether the
+            # number is an issue or a pull request — ask.
+            IS_PR=$(gh api "repos/${{ github.repository }}/issues/$TARGET_NUMBER" --jq '.pull_request != null' 2>/dev/null || echo false)
+            fix=$INPUT_FIX
+          else
+            line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
+            if [ "$IS_PR" = "true" ]; then fix=false; else fix=true; fi
+            case " $line " in *" --fix "*) fix=true ;; esac
+            case " $line " in *" --no-fix "*) fix=false ;; esac
+          fi
           echo "fix=$fix" >> "$GITHUB_OUTPUT"
-          echo "fix mode: $fix (target is $([ "$IS_PR" = true ] && echo 'a pull request' || echo 'an issue'))"
+          echo "is_pr=$IS_PR" >> "$GITHUB_OUTPUT"
+          echo "fix mode: $fix (target is $([ "$IS_PR" = true ] && echo 'a pull request' || echo 'an issue')${QUIET:+, quiet dispatch})"
 
       - name: Acknowledge
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && env.QUIET != 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         run: gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
@@ -162,12 +197,12 @@ jobs:
       # progress, so the thread gets that link the moment work begins (the
       # findings comment lands separately when the investigation completes).
       - name: Announce run
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && env.QUIET != 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         run: |
-          gh issue comment "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
-            --body "🔍 \`/verify\` started for @${{ github.event.comment.user.login }} — [watch the investigation run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Findings will be posted here when it completes."
+          gh issue comment "$TARGET_NUMBER" -R "${{ github.repository }}" \
+            --body "🔍 \`/verify\` started for @$TRIGGER_ACTOR — [watch the investigation run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Findings will be posted here when it completes."
 
       # Base ref only — the prompt file must come from the trusted branch,
       # and no PR-head code may ever run on this runner.
@@ -200,7 +235,7 @@ jobs:
         if: steps.gate.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
-          IS_PR: ${{ github.event.issue.pull_request != null }}
+          IS_PR: ${{ steps.cmd.outputs.is_pr }}
         run: |
           mkdir -p "$GITHUB_WORKSPACE/.verify-context"
           cd "$GITHUB_WORKSPACE/.verify-context"
@@ -210,7 +245,7 @@ jobs:
           # single line. Pretty-print so paging works, and bound it the same
           # way the diff below is bounded, with the status in a header the
           # agent cannot read past.
-          gh issue view "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
+          gh issue view "$TARGET_NUMBER" -R "${{ github.repository }}" \
             --comments --json number,title,state,labels,body,comments \
             | jq . > "$RUNNER_TEMP/full-target.json"
           t_lines=$(wc -l < "$RUNNER_TEMP/full-target.json" | tr -d ' ')
@@ -238,7 +273,7 @@ jobs:
             # fetches of a MUTABLE ref: a contributor pushing mid-run makes the
             # agent reason from revision A, test revision B, and publish a
             # verdict about neither.
-            gh pr view "${{ github.event.issue.number }}" -R "${{ github.repository }}" \
+            gh pr view "$TARGET_NUMBER" -R "${{ github.repository }}" \
               --json number,title,state,headRefName,baseRefName,headRefOid,baseRefOid,files,body > pull-request.json
             head_oid=$(jq -r .headRefOid pull-request.json)
             base_oid=$(jq -r .baseRefOid pull-request.json)
@@ -321,7 +356,7 @@ jobs:
         env:
           EXPO_SANDBOX_MCP_TOKEN: ${{ secrets.EXPO_SANDBOX_MCP_TOKEN }}
           MCP_URL: https://agile-minnow-543.convex.site
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
         run: |
           umask 077
           scoped=$(curl -sf -m 30 "$MCP_URL/tokens/scoped" \
@@ -383,9 +418,8 @@ jobs:
           # gh verb, so it needs none. The findings comment is posted by the
           # MCP server from its own stored PAT, whose arguments are literal
           # JSON — never a shell-expanded string.
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_KIND: ${{ github.event.issue.pull_request != null && 'pull request' || 'issue' }}
-          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
+          ISSUE_KIND: ${{ steps.cmd.outputs.is_pr == 'true' && 'pull request' || 'issue' }}
           REPO: ${{ github.repository }}
           # Pinned to Opus explicitly; override with a VERIFY_MODEL repo
           # variable (mirrors the code-review workflows' REVIEWER_MODEL).
@@ -640,8 +674,8 @@ jobs:
         if: steps.gate.outputs.ok == 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_KIND: ${{ github.event.issue.pull_request != null && 'pull request' || 'issue' }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
+          ISSUE_KIND: ${{ steps.cmd.outputs.is_pr == 'true' && 'pull request' || 'issue' }}
           REPO: ${{ github.repository }}
           VERIFY_MODEL: ${{ vars.VERIFY_MODEL || 'claude-opus-5' }}
         run: |
@@ -710,11 +744,11 @@ jobs:
       # revision the PR no longer has — say so on the thread rather than
       # leaving a stale conclusion standing unqualified.
       - name: Note if the PR moved under the run
-        if: steps.gate.outputs.ok == 'true' && github.event.issue.pull_request != null
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.is_pr == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           TESTED: ${{ steps.ctx.outputs.head_oid }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           now=$(gh pr view "$ISSUE_NUMBER" -R "${{ github.repository }}" --json headRefOid --jq .headRefOid)
@@ -739,8 +773,7 @@ jobs:
         if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.fix == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          TRIGGER_ACTOR: ${{ github.event.comment.user.login }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -o pipefail
@@ -768,8 +801,19 @@ jobs:
           fi
           if [ "$declined" = "yes" ] || [ -z "$changed" ]; then
             if [ "$declined" = "yes" ]; then
-              reason=$(sed -n '2,12p' .verify-out/pr.md | tr -d '\r' | sed '/^$/d' | head -c 900)
-              gh issue comment "$ISSUE_NUMBER" --body "$(printf '🔧 `/verify --fix` deliberately did NOT open a pull request. The run says why:\n\n%s\n\n[Findings comment and run log](%s)' "$reason" "$RUN_URL")"
+              # Say nothing here. The agent decided this, and the prompt
+              # requires it to say so in the findings comment it just posted,
+              # so a second comment restating the same reasoning is pure
+              # duplication in a thread other people are subscribed to.
+              # Observed on #48780: findings landed at 21:43:43 and this
+              # comment repeated the withdrawal 16 seconds later.
+              #
+              # The rule: the workflow comments only about outcomes the AGENT
+              # could not have stated itself — a pull-request URL it never
+              # sees, a denylist or size refusal made after it stopped, a push
+              # that failed. Its own decisions are its own to report.
+              echo "::notice::The run declined to open a pull request; its reasoning is in the findings comment."
+              sed -n '2,12p' .verify-out/pr.md | tr -d '\r' | sed '/^$/d' | head -c 900
             else
               gh issue comment "$ISSUE_NUMBER" --body "🔧 \`/verify --fix\` ran but proposed no code change — see the [findings comment and run log]($RUN_URL)."
             fi
@@ -950,7 +994,7 @@ jobs:
         if: always() && steps.gate.outputs.ok == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: verify-run-log-${{ github.event.issue.number }}
+          name: verify-run-log-${{ env.TARGET_NUMBER }}
           # All three phases, plus the draft and the review that passed
           # between them — the review is deliberately not published to the
           # thread, so this artifact is where it can be audited.
@@ -977,7 +1021,7 @@ jobs:
         if: always() && steps.gate.outputs.ok == 'true' && (failure() || cancelled())
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # job.status, NOT cancelled(): status check functions are valid only
           # in an `if:`, and one in an `env:` makes the whole workflow file


### PR DESCRIPTION
Two changes, both about thread noise.

## 1. A quiet trigger

`workflow_dispatch` with a target number and a fix toggle. Dispatching from the Actions tab posts **nothing** to the thread until the findings themselves — no 👀 reaction, no "started" comment, no failure notice.

That matters most on a pull request, where every bot comment lands in a contributor's inbox, and where an experiment that finds nothing should leave no trace at all.

Safety is unchanged: `workflow_dispatch` is inherently gated, since GitHub only lets accounts with write access dispatch a workflow — the same bar the comment path checks for explicitly, and that explicit check still runs.

The mechanics: target number, triggering actor and quietness resolve **once** into job-level `env`, so no individual step has to know which event it is running under. On the dispatch path fix mode comes from the input, and whether the target is a PR is looked up via the API, because a dispatch carries no issue payload.

```
Actions → Verify issue (command) → Run workflow
  target: 48780
  fix:    ☐
```

## 2. Stop double-commenting a withdrawal

When the agent decides *not* to propose a fix, the workflow posted a comment restating why. But the prompt already requires the agent to say that in the findings comment it just posted, so this was pure duplication in a thread other people are subscribed to.

Observed on #48780: findings landed at `21:43:43`, and this comment repeated the same withdrawal reasoning at `21:43:59` — 16 seconds later.

The rule it now follows: **the workflow comments only about outcomes the agent could not have stated itself** — a pull-request URL it never sees, a denylist or size refusal made after it stopped, a push that failed. The agent's own decisions are its own to report. The reasoning still goes to the run log as a `::notice::`.

## Validation

YAML parses with both triggers present and the expected inputs; the modified `Parse command` and `Open fix pull request` steps pass `bash -n`. The quiet path is only fully exercised by an actual dispatch — worth doing once on a low-stakes target before relying on it.
