### PR TITLE
verify: silence the did-not-finish notice in quiet mode, and fix dispatch fix-mode defaults

### DIFF
--- a/.github/workflows/verify-command.yml
+++ b/.github/workflows/verify-command.yml
@@ -1018,7 +1018,7 @@ jobs:
       # with no result. The job also runs continue-on-error, so nothing else
       # signals it either.
       - name: Report a run that did not finish
-        if: always() && steps.gate.outputs.ok == 'true' && (failure() || cancelled())
+        if: always() && steps.gate.outputs.ok == 'true' && env.QUIET != 'true' && (failure() || cancelled())
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}

--- a/.github/workflows/verify-command.yml
+++ b/.github/workflows/verify-command.yml
@@ -74,9 +74,10 @@ on:
         required: true
         type: string
       fix:
-        description: "Attempt a fix pull request (issues default to yes on the comment path; here it is explicit)"
-        type: boolean
-        default: false
+        description: "Fix mode. auto = same rule as the comment path (issue yes, pull request no)"
+        type: choice
+        options: ["auto", "yes", "no"]
+        default: "auto"
 
 # Scopes the automatic workflow token, which is what the AGENT step gets:
 # issue comments yes, repository contents never. The agent therefore cannot
@@ -176,7 +177,16 @@ jobs:
             # Dispatch carries no comment, and nothing tells us whether the
             # number is an issue or a pull request — ask.
             IS_PR=$(gh api "repos/${{ github.repository }}/issues/$TARGET_NUMBER" --jq '.pull_request != null' 2>/dev/null || echo false)
-            fix=$INPUT_FIX
+            # 'auto' MUST resolve the same way the comment path does, or the
+            # same target behaves differently depending on how it was
+            # triggered — which is the kind of difference nobody remembers at
+            # the moment they need to. yes/no are the explicit overrides,
+            # equivalent to --fix and --no-fix.
+            case "$INPUT_FIX" in
+              yes) fix=true ;;
+              no)  fix=false ;;
+              *)   if [ "$IS_PR" = "true" ]; then fix=false; else fix=true; fi ;;
+            esac
           else
             line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
             if [ "$IS_PR" = "true" ]; then fix=false; else fix=true; fi


### PR DESCRIPTION
One-line follow-up to #48805, which I got wrong.

`env.QUIET` gated `Acknowledge` and `Announce run` but not `Report a run that did not finish`, so a quiet dispatch that fails or is cancelled still comments — the exact thing quiet mode exists to prevent.

Reproduced within a minute of merging: I dispatched a run against #48780 while testing, cancelled it a few seconds later, and it posted `⚠️ /verify was cancelled before it could post findings` onto a thread that had been successfully verified an hour earlier.

In quiet mode the person who dispatched is watching the Actions tab, which already shows the outcome.