### PR TITLE
fix(ios,android): worklets bridge calling removed executeSync API

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `WorkletsAdapter` calling `WorkletRuntime::executeSync`, which is deprecated and removed in `react-native-worklets` 0.12.0. ([#48818](https://github.com/expo/expo/pull/48818) by [@kimchi-developer](https://github.com/kimchi-developer))
+- Fixed the worklets bridge calling `WorkletRuntime::executeSync`, which is deprecated and removed in `react-native-worklets` 0.12.0. ([#48818](https://github.com/expo/expo/pull/48818) by [@kimchi-developer](https://github.com/kimchi-developer))
 - [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `WorkletsAdapter` calling `WorkletRuntime::executeSync`, which is deprecated and removed in `react-native-worklets` 0.12.0. ([#48818](https://github.com/expo/expo/pull/48818) by [@kimchi-developer](https://github.com/kimchi-developer))
 - [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp
@@ -22,7 +22,7 @@ namespace expo {
       return;
     }
 
-    workletRuntime->executeSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
+    workletRuntime->runSync([func = std::move(func)](jsi::Runtime &rt) -> jsi::Value {
       func(rt);
       return jsi::Value::undefined();
     });

--- a/packages/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm
+++ b/packages/expo-modules-core/ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm
@@ -233,7 +233,7 @@ static jsi::Value callWorklet(jsi::Runtime &rt, std::shared_ptr<worklets::Serial
     return;
   }
 
-  workletRuntime->executeSync([worklet, arguments](jsi::Runtime &rt) -> jsi::Value {
+  workletRuntime->runSync([worklet, arguments](jsi::Runtime &rt) -> jsi::Value {
     return callWorklet(rt, worklet, arguments);
   });
 }


### PR DESCRIPTION
# Why

`expo-modules-core` calls `worklets::WorkletRuntime::executeSync` from both the iOS and the Android worklets bridge. That method was deprecated in favour of `runSync` and **removed in `react-native-worklets` 0.12.0**, so both platforms fail to compile against it:

```
# iOS
ios/WorkletsAdapter/ExpoWorkletsBridgeProvider.mm:236
no member named 'executeSync' in 'worklets::WorkletRuntime'

# Android
android/src/main/cpp/worklets/WorkletJSCallInvoker.cpp:25:21
no member named 'executeSync' in 'worklets::WorkletRuntime'
```

On iOS, `ExpoModulesWorkletsAdapter` is a companion pod that builds whenever `react-native-worklets` is installed; on Android the worklets bridge is compiled into `expo-modules-core`'s C++ target. Either way, an app pairing `expo-modules-core` with worklets 0.11+ cannot build.

`expo-modules-core` currently declares `"react-native-worklets": "^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0"`, so 0.12 is outside the supported range today — but these call sites use a deprecated API regardless, and moving off it is both correct now and forward-compatible.

# How

One line per platform, `executeSync` → `runSync`.

`react-native-worklets` itself names the replacement. In 0.7.2 — the lowest version in the declared peer range — the overload used here is annotated:

```cpp
/** @deprecated Use `runSync` instead. */
jsi::Value executeSync(std::function<jsi::Value(jsi::Runtime &)> &&job) const;
```

I deliberately did **not** use `runSyncAndDrainMicrotasks`: it runs a microtask checkpoint on completion, so it is not semantically equivalent to the old `executeSync`.

**Backward compatible.** The `runSync(lambda)` overload already exists in 0.7.2:

```cpp
template <typename TCallable>
std::invoke_result_t<TCallable, jsi::Runtime &> runSync(TCallable &&job) const;
```

and in 0.12.0 as the concept-constrained equivalent. So this compiles across the entire declared peer range as well as 0.11/0.12 — it does not require bumping `peerDependencies`.

# Test Plan

Reproduced and verified in a real app (Expo SDK 58 canary, React Native 0.87.0, `react-native-worklets` 0.12.0).

**iOS** — iPhone 17 simulator, iOS 26.5, Xcode 26.6:

| | |
|---|---|
| Before | `** BUILD FAILED **`, exactly one error — the one above |
| After | `** BUILD SUCCEEDED **`, 0 errors |

**Android** — `./gradlew assembleDebug`:

| | |
|---|---|
| Before | `BUILD FAILED`, C++ compile step, same error |
| After | `BUILD SUCCESSFUL`, `app-debug.apk` produced |

Both verified twice — once by editing `node_modules` directly, then again from a clean install with the change applied as a package patch — and confirmed by build artifact (`.app` / `.apk`) rather than the exit status alone, since the Gradle wrapper returned 0 on a failed run.

I have not run this repo's own test suites against worklets 0.7.2; the backward-compatibility claim rests on the header showing the same `runSync(lambda)` overload in that version.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — N/A, no docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
