### PR TITLE
[ui] use `useReleasingSharedObjectWithLifecycle` for WorkletCallback

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [universal] Fix `Cannot use shared object that was already released` when a worklet callback prop closes over an unstable value. ([#48819](https://github.com/expo/expo/pull/48819) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
 - [iOS] Fix `community/bottom-sheet` close callbacks firing before the sheet finished dismissing. ([#48389](https://github.com/expo/expo/issues/48389) by [@nicklamont](https://github.com/nicklamont)) ([#48436](https://github.com/expo/expo/pull/48436) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -79,6 +79,13 @@ class ExpoUIModule : Module() {
         callback
       }
 
+      Function("setWorklet") { callback: WorkletCallback, worklet: Worklet ->
+        // Dispatch on main thread as callback is read on the main thread
+        appContext.mainQueue.launch {
+          callback.worklet = worklet
+        }
+      }
+
       Property("__expo_ui_shared_object__") { _: WorkletCallback ->
         true
       }

--- a/packages/expo-ui/ios/State/WorkletCallbackClassDef.swift
+++ b/packages/expo-ui/ios/State/WorkletCallbackClassDef.swift
@@ -18,6 +18,13 @@ internal func makeWorkletCallbackClass() -> ClassDefinition {
       return callback
     }
 
+    Function("setWorklet") { (callback: WorkletCallback, worklet: Worklet) in
+      // Dispatch on main thread as callback is read on the main thread
+      DispatchQueue.main.async {
+        callback.worklet = worklet
+      }
+    }
+
     Property("__expo_ui_shared_object__") { (_: WorkletCallback) -> Bool in
       true
     }

--- a/packages/expo-ui/src/State/useWorkletProp.ts
+++ b/packages/expo-ui/src/State/useWorkletProp.ts
@@ -1,8 +1,25 @@
-import { requireNativeModule, type SharedObject, useReleasingSharedObject } from 'expo';
+import {
+  requireNativeModule,
+  type SharedObject,
+  useReleasingSharedObjectWithLifecycle,
+} from 'expo';
 
 import { worklets } from './optionalWorklets';
 
 const ExpoUI = requireNativeModule('ExpoUI');
+
+function createSerializable(callback?: (...args: any[]) => void, propName?: string) {
+  if (!callback || !worklets) {
+    return null;
+  }
+  if (!worklets.isWorkletFunction(callback)) {
+    const name = propName ? `'${propName}'` : 'The callback';
+    throw new Error(
+      `${name} must be a worklet function. Add the 'worklet' directive as the first statement in your callback.`
+    );
+  }
+  return worklets.createSerializable(callback);
+}
 
 /**
  * Creates a `WorkletCallback` SharedObject that wraps a worklet function.
@@ -15,17 +32,21 @@ export function useWorkletProp(
   callback?: (...args: any[]) => void,
   propName?: string
 ): SharedObject | null {
-  return useReleasingSharedObject(() => {
-    if (!callback || !worklets) {
-      return null;
-    }
-    try {
-      return new ExpoUI.WorkletCallback(worklets.createSerializable(callback));
-    } catch {
-      const name = propName ? `'${propName}'` : 'The callback';
-      throw new Error(
-        `${name} must be a worklet function. Add the 'worklet' directive as the first statement in your callback.`
-      );
-    }
-  }, [callback]);
+  return useReleasingSharedObjectWithLifecycle(
+    {
+      factory: () => {
+        const serializable = createSerializable(callback, propName);
+        return serializable ? new ExpoUI.WorkletCallback(serializable) : null;
+      },
+      // Only removing the callback needs a different object.
+      shouldRecreate: () => !callback,
+      update: (object) => {
+        const serializable = createSerializable(callback, propName);
+        if (serializable) {
+          object.setWorklet(serializable);
+        }
+      },
+    },
+    [callback]
+  );
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 💡 Others
 
+- Re-export `useReleasingSharedObjectWithLifecycle` from `expo-modules-core`. ([#48819](https://github.com/expo/expo/pull/48819) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] `ExpoReactHostFactory` now passes host handlers' `DevSupportManagerFactory` to `ReactHostImpl`. ([#47637](https://github.com/expo/expo/pull/47637) by [@alanjhughes](https://github.com/alanjhughes))
 - [macOS] Fix build by guarding the `bundleConfiguration` override, which requires react-native 0.84+. ([#48494](https://github.com/expo/expo/pull/48494) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - Restore RCTHostRuntimeDelegate conformance for react-native-macos ([#46420](https://github.com/expo/expo/pull/46420) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo/src/Expo.ts
+++ b/packages/expo/src/Expo.ts
@@ -29,6 +29,7 @@ export {
   uuid,
   createSnapshotFriendlyRef,
   useReleasingSharedObject,
+  useReleasingSharedObjectWithLifecycle,
 } from 'expo-modules-core';
 
 export type {


### PR DESCRIPTION


# Why

Fixes https://github.com/expo/expo/issues/48803

When worklet callback identity changes, it leads to creation of worklet shared objects. The re-creation of worklet on each keystroke causes race condition where JS frees the old object and native tries to access it.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Instead of re-creating new shared object on each callback change we instead change the callback property on it. This preserves the shared object identity across re-renders. It uses `useReleasingSharedObjectWithLifecycle` helper hook.
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the user shared repro and existing NCL examples

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
