### PR TITLE
[expo-image] fixed image's internal dataSet marker being overwritten by a user-provided dataSet

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`.
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Replaced the deprecated RenderScript-based `blurRadius` blur with a software stack blur to fix a use-after-free crash under concurrent image loads (aborts under GrapheneOS hardened_malloc). ([#PR](https://github.com/expo/expo/pull/PR) by [@DimitrisTzimikas](https://github.com/DimitrisTzimikas))
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`.
+- [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Replaced the deprecated RenderScript-based `blurRadius` blur with a software stack blur to fix a use-after-free crash under concurrent image loads (aborts under GrapheneOS hardened_malloc). ([#PR](https://github.com/expo/expo/pull/PR) by [@DimitrisTzimikas](https://github.com/DimitrisTzimikas))
 

--- a/packages/expo-image/src/ExpoImage.web.tsx
+++ b/packages/expo-image/src/ExpoImage.web.tsx
@@ -12,7 +12,7 @@ import useSourceSelection from './web/useSourceSelection';
 loadStyle();
 
 type ExpoImageWebProps = ImageNativeProps & {
-  dataSet?: Record<string, unknown>;
+  dataSet?: Record<string, string | undefined>;
 };
 
 function onLoadAdapter(onLoad?: (event: ImageLoadEventData) => void) {
@@ -176,7 +176,7 @@ export default function ExpoImage({
     <View
       ref={containerViewRef}
       // @ts-expect-error: TODO(@kitten): This is related to react-native-web presumably
-      dataSet={{ ...dataSet, expoimage: true }}
+      dataSet={{ ...dataSet, expoimage: 'true' }}
       style={[{ overflow: 'hidden' }, style]}
       {...props}>
       <AnimationManager transition={transition} recyclingKey={recyclingKey} initial={initialNode}>

--- a/packages/expo-image/src/ExpoImage.web.tsx
+++ b/packages/expo-image/src/ExpoImage.web.tsx
@@ -11,6 +11,10 @@ import useSourceSelection from './web/useSourceSelection';
 
 loadStyle();
 
+type ExpoImageWebProps = ImageNativeProps & {
+  dataSet?: Record<string, unknown>;
+};
+
 function onLoadAdapter(onLoad?: (event: ImageLoadEventData) => void) {
   return (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
     const target = event.target as HTMLImageElement;
@@ -81,8 +85,9 @@ export default function ExpoImage({
   tintColor,
   containerViewRef,
   draggable,
+  dataSet,
   ...props
-}: ImageNativeProps) {
+}: ExpoImageWebProps) {
   const imagePlaceholderContentFit = placeholderContentFit || 'scale-down';
   const imageHashStyle = {
     objectFit: placeholderContentFit || contentFit,
@@ -171,7 +176,7 @@ export default function ExpoImage({
     <View
       ref={containerViewRef}
       // @ts-expect-error: TODO(@kitten): This is related to react-native-web presumably
-      dataSet={{ expoimage: true }}
+      dataSet={{ ...dataSet, expoimage: true }}
       style={[{ overflow: 'hidden' }, style]}
       {...props}>
       <AnimationManager transition={transition} recyclingKey={recyclingKey} initial={initialNode}>

--- a/packages/expo-image/src/__tests__/ExpoImage.test.web.tsx
+++ b/packages/expo-image/src/__tests__/ExpoImage.test.web.tsx
@@ -1,0 +1,13 @@
+import ExpoImage from '../ExpoImage.web';
+
+jest.mock('../web/useSourceSelection', () => () => undefined);
+
+describe('ExpoImage', () => {
+  it('merges a user-provided dataSet while preserving the Expo Image marker', () => {
+    const element = ExpoImage({
+      dataSet: { test: 'value' },
+    });
+
+    expect(element.props.dataSet).toEqual({ test: 'value', expoimage: true });
+  });
+});

--- a/packages/expo-image/src/__tests__/ExpoImage.test.web.tsx
+++ b/packages/expo-image/src/__tests__/ExpoImage.test.web.tsx
@@ -8,6 +8,6 @@ describe('ExpoImage', () => {
       dataSet: { test: 'value' },
     });
 
-    expect(element.props.dataSet).toEqual({ test: 'value', expoimage: true });
+    expect(element.props.dataSet).toEqual({ test: 'value', expoimage: 'true' });
   });
 });


### PR DESCRIPTION
# Why

 Expo Image’s internal `expoimage` data-set marker could be overwritten when consumers passed a `dataSet` prop.

# How

Added a web-only `dataSet` prop type and merge user-provided values with Expo Image’s internal marker, ensuring `expoimage: true` is retained.

# Test Plan

- Added a web unit test verifying that Expo Image preserves user-provided `dataSet` entries and retains its internal `expoimage: true` marker.
- Ran:
```sh
   pnpm --filter expo-image test -- ExpoImage.test.web.tsx --runInBand
   pnpm --filter expo-image run build
   pnpm --filter expo-image run typecheck
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
