### PR TITLE
[docs] Fix SDK reference prop cards render a double border and shadow

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -373,7 +373,7 @@ for more details.
       </p>
     </div>
     <div
-      class="mb-5 overflow-hidden rounded-lg border border-palette-gray4 shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none [&>*:last-child]:mb-0!"
+      class="overflow-hidden border-palette-gray4 [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:px-4 [&_th]:text-tertiary [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:shadow-none mb-0 rounded-none border-0 shadow-none [&>*:last-child]:mb-0!"
     >
       <div
         class="border-t border-palette-gray4 first:border-t-0"

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -117,7 +117,11 @@ const renderProps = (
   return (
     <div
       key={`props-definition-${def.name}`}
-      className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:mb-0!')}>
+      className={mergeClasses(
+        STYLES_APIBOX,
+        !exposeInSidebar && 'mb-0 rounded-none border-0 shadow-none',
+        '[&>*:last-child]:mb-0!'
+      )}>
       {propsDeclarations?.map(prop =>
         prop
           ? renderProp(


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25786

<img width="2232" height="644" alt="CleanShot 2026-08-12 at 17 24 41@2x" src="https://github.com/user-attachments/assets/5734ace7-7821-43d3-9923-62b9dd3426b5" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix SDK reference prop cards render a double border and shadow.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2202" height="594" alt="CleanShot 2026-08-12 at 17 25 11@2x" src="https://github.com/user-attachments/assets/140cc4d4-d74c-49aa-ab8f-6f24f7090fbd" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
