### PR TITLE
fix(require-utils): Fix Node 26 `stripTypeScriptTypes` fallback call

### DIFF
--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Node.js 26 fallback loading for TypeScript files when `typescript` is unavailable.
+
 ### 💡 Others
 
 ## 57.0.4 - 2026-07-22

--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### 🐛 Bug fixes
 
-- Fix Node.js 26 fallback loading for TypeScript files when `typescript` is unavailable.
-
 ### 💡 Others
+
+- Support Node 26's `stripTypeScriptTypes` and call without transform-mode, to fix the fallback when TypeScript isn't installed.
 
 ## 57.0.4 - 2026-07-22
 

--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- Support Node 26's `stripTypeScriptTypes` and call without transform-mode, to fix the fallback when TypeScript isn't installed.
+- Support Node 26's `stripTypeScriptTypes` and call without transform-mode, to fix the fallback when TypeScript isn't installed ([#48826](https://github.com/expo/expo/pull/48826) by [@kkkhs](https://github.com/kkkhs))
 
 ## 57.0.4 - 2026-07-22
 

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -5,7 +5,12 @@ import { evalModule } from '../load';
 const basepath = path.join(__dirname, 'fixtures');
 
 describe('evalModule', () => {
+  const actualNodeVersion = process.versions.node;
+
   afterEach(() => {
+    Object.defineProperty(process.versions, 'node', {
+      value: actualNodeVersion,
+    });
     jest.dontMock('node:module');
     jest.dontMock('typescript');
   });
@@ -127,19 +132,13 @@ describe('evalModule', () => {
     expect(caught).toEqual({ code: 'CUSTOM_THROW' });
   });
 
-  it('falls back to Node TypeScript stripping defaults when transform options are unsupported', () => {
+  it('uses Node TypeScript stripping defaults on Node 26', () => {
     jest.isolateModules(() => {
-      const actualNodeModule = jest.requireActual('node:module');
-      const stripTypeScriptTypes = jest.fn((code: string, options?: { mode?: string }) => {
-        if (options?.mode === 'transform') {
-          const error = new TypeError(
-            "The property 'options.mode' must be one of: 'strip'. Received 'transform'"
-          ) as NodeJS.ErrnoException;
-          error.code = 'ERR_INVALID_ARG_VALUE';
-          throw error;
-        }
-        return code.replace(' as string', '');
+      Object.defineProperty(process.versions, 'node', {
+        value: '26.0.0',
       });
+      const actualNodeModule = jest.requireActual('node:module');
+      const stripTypeScriptTypes = jest.fn((code: string) => code.replace(' as string', ''));
       const moduleNotFoundError = new Error(
         "Cannot find module 'typescript'"
       ) as NodeJS.ErrnoException;
@@ -160,12 +159,8 @@ describe('evalModule', () => {
       );
 
       expect(mod).toEqual({ value: 'test' });
-      expect(stripTypeScriptTypes).toHaveBeenCalledTimes(2);
-      expect(stripTypeScriptTypes).toHaveBeenNthCalledWith(1, expect.any(String), {
-        mode: 'transform',
-        sourceMap: true,
-      });
-      expect(stripTypeScriptTypes).toHaveBeenNthCalledWith(2, expect.any(String));
+      expect(stripTypeScriptTypes).toHaveBeenCalledTimes(1);
+      expect(stripTypeScriptTypes).toHaveBeenCalledWith(expect.any(String));
     });
   });
 });

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -5,6 +5,11 @@ import { evalModule } from '../load';
 const basepath = path.join(__dirname, 'fixtures');
 
 describe('evalModule', () => {
+  afterEach(() => {
+    jest.dontMock('node:module');
+    jest.dontMock('typescript');
+  });
+
   it('accepts .js code and turns it to CommonJS with default imports', () => {
     const mod = evalModule(
       `
@@ -120,5 +125,47 @@ describe('evalModule', () => {
     }
 
     expect(caught).toEqual({ code: 'CUSTOM_THROW' });
+  });
+
+  it('falls back to Node TypeScript stripping defaults when transform options are unsupported', () => {
+    jest.isolateModules(() => {
+      const actualNodeModule = jest.requireActual('node:module');
+      const stripTypeScriptTypes = jest.fn((code: string, options?: { mode?: string }) => {
+        if (options?.mode === 'transform') {
+          const error = new TypeError(
+            "The property 'options.mode' must be one of: 'strip'. Received 'transform'"
+          ) as NodeJS.ErrnoException;
+          error.code = 'ERR_INVALID_ARG_VALUE';
+          throw error;
+        }
+        return code.replace(' as string', '');
+      });
+      const moduleNotFoundError = new Error(
+        "Cannot find module 'typescript'"
+      ) as NodeJS.ErrnoException;
+      moduleNotFoundError.code = 'MODULE_NOT_FOUND';
+
+      jest.doMock('node:module', () => ({
+        ...actualNodeModule,
+        stripTypeScriptTypes,
+      }));
+      jest.doMock('typescript', () => {
+        throw moduleNotFoundError;
+      });
+
+      const { evalModule } = require('../load') as typeof import('../load');
+      const mod = evalModule(
+        `module.exports = { value: 'test' as string };`,
+        path.join(basepath, 'eval.ts')
+      );
+
+      expect(mod).toEqual({ value: 'test' });
+      expect(stripTypeScriptTypes).toHaveBeenCalledTimes(2);
+      expect(stripTypeScriptTypes).toHaveBeenNthCalledWith(1, expect.any(String), {
+        mode: 'transform',
+        sourceMap: true,
+      });
+      expect(stripTypeScriptTypes).toHaveBeenNthCalledWith(2, expect.any(String));
+    });
   });
 });

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -278,6 +278,28 @@ function containsModuleSyntax(code: string): boolean {
 
 const hasStripTypeScriptTypes = typeof nodeModule.stripTypeScriptTypes === 'function';
 
+function isInvalidStripTypeScriptOptionsError(error: any): boolean {
+  return (
+    error?.code === 'ERR_INVALID_ARG_VALUE' &&
+    typeof error?.message === 'string' &&
+    /\boptions\.(?:mode|sourceMap)\b/.test(error.message)
+  );
+}
+
+function stripTypeScriptTypes(code: string): string {
+  try {
+    return nodeModule.stripTypeScriptTypes(code, {
+      mode: 'transform',
+      sourceMap: true,
+    });
+  } catch (error: any) {
+    if (!isInvalidStripTypeScriptOptionsError(error)) {
+      throw error;
+    }
+    return nodeModule.stripTypeScriptTypes(code);
+  }
+}
+
 function evalModule(
   code: string,
   filename: string,
@@ -331,10 +353,7 @@ function evalModule(
 
     if (hasStripTypeScriptTypes && inputCode === code) {
       // This may throw its own error, but this contains a code-frame already
-      inputCode = nodeModule.stripTypeScriptTypes(code, {
-        mode: 'transform',
-        sourceMap: true,
-      });
+      inputCode = stripTypeScriptTypes(code);
       if (format.mode === 'commonjs-typescript') {
         inputCode = toCommonJS(filename, inputCode);
       }

--- a/packages/@expo/require-utils/src/load.ts
+++ b/packages/@expo/require-utils/src/load.ts
@@ -278,26 +278,19 @@ function containsModuleSyntax(code: string): boolean {
 
 const hasStripTypeScriptTypes = typeof nodeModule.stripTypeScriptTypes === 'function';
 
-function isInvalidStripTypeScriptOptionsError(error: any): boolean {
-  return (
-    error?.code === 'ERR_INVALID_ARG_VALUE' &&
-    typeof error?.message === 'string' &&
-    /\boptions\.(?:mode|sourceMap)\b/.test(error.message)
-  );
+function supportsStripTypeScriptTypesTransform(): boolean {
+  const nodeVersion = process.versions.node.split('.', 1).map(Number);
+  return nodeVersion[0]! < 26;
 }
 
 function stripTypeScriptTypes(code: string): string {
-  try {
-    return nodeModule.stripTypeScriptTypes(code, {
-      mode: 'transform',
-      sourceMap: true,
-    });
-  } catch (error: any) {
-    if (!isInvalidStripTypeScriptOptionsError(error)) {
-      throw error;
-    }
+  if (!supportsStripTypeScriptTypesTransform()) {
     return nodeModule.stripTypeScriptTypes(code);
   }
+  return nodeModule.stripTypeScriptTypes(code, {
+    mode: 'transform',
+    sourceMap: true,
+  });
 }
 
 function evalModule(


### PR DESCRIPTION
# Why
Fixes #48725. Node 26 rejects the TypeScript stripping fallback used when `typescript` is unavailable.

# How
Add `isInvalidStripTypeScriptOptionsError` and route fallback stripping through `stripTypeScriptTypes()`, which retries without the rejected options.

# Test Plan
Added Node 26 fallback rejection coverage.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to the contributing guide.
