### PR TITLE
[docs] State that Free plan accounts cannot incur overage charges

### DIFF
--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -34,6 +34,10 @@ To upgrade from the Free plan to the Starter plan, see [Upgrade to a new plan](/
 
 To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manage/#cancel-a-plan).
 
+### What happens when I use up the Free plan's monthly quota?
+
+Free plan accounts are not charged for overage. Once you use your monthly quota of free builds, new builds are unavailable until the quota resets on the first day of the next calendar month. To keep building without waiting for the reset, upgrade to the [Starter plan](/billing/plans/) or [run builds locally](/build-reference/local-builds/).
+
 ### I've run out of paid plan's EAS Build credits. Can I downgrade to the Free plan to use the free build credits?
 
 No. If you are subscribed to a paid plan and use up your included EAS Build credits, additional builds are billed using [usage-based pricing](/billing/usage-based-pricing/).

--- a/docs/pages/billing/faq.mdx
+++ b/docs/pages/billing/faq.mdx
@@ -36,7 +36,7 @@ To downgrade from the Starter to a Free plan, see [Cancel a plan](/billing/manag
 
 ### What happens when I use up the Free plan's monthly quota?
 
-Free plan accounts are not charged for overage. Once you use your monthly quota of free builds, new builds are unavailable until the quota resets on the first day of the next calendar month. To keep building without waiting for the reset, upgrade to the [Starter plan](/billing/plans/) or [run builds locally](/build-reference/local-builds/).
+Free plan accounts do not incur overage charges. Once you use your monthly quota of free builds, new builds are unavailable until the quota resets on the first day of the next calendar month. To keep building without waiting for the reset, upgrade to the [Starter plan](/billing/plans/) or [run builds locally](/build-reference/local-builds/).
 
 ### I've run out of paid plan's EAS Build credits. Can I downgrade to the Free plan to use the free build credits?
 

--- a/docs/pages/billing/plans.mdx
+++ b/docs/pages/billing/plans.mdx
@@ -30,7 +30,7 @@ We also offer annual contracts on an as-needed basis. Contact our [customer supp
 
 ## Plans
 
-Each plan has specific limits. However, subscribers can exceed them and pay for additional usage with [usage-based billing](/billing/usage-based-pricing/).
+Each plan has specific limits. Paid plan subscribers can exceed them and pay for additional usage with [usage-based billing](/billing/usage-based-pricing/). Free plan accounts cannot incur overage charges. See [what happens when the Free plan's monthly quota is used up](/billing/faq/#what-happens-when-i-use-up-the-free-plans-monthly-quota) for details.
 
 <BoxLink
   title="Pricing"
@@ -75,7 +75,7 @@ If you exceed the limits or use up your monthly credits, any further usage will 
 
 ## Usage-based billing
 
-Usage-based billing is applied to customers who exceed their plan limits. It enables you to use our services without worrying about limitations or any contractual obligations.
+Usage-based billing is applied to customers on paid plans who exceed their plan limits. It enables you to use our services without worrying about limitations or any contractual obligations.
 
 Usage-based billing is billed monthly and is currently enabled for EAS Build and EAS Update. We provide an estimate of your existing usage and any overage charges on [your account's Billing](https://expo.dev/settings/billing). Expo also sends [email notifications](/billing/usage-based-pricing/#usage-notifications) when your account reaches 80% and 100% of your plan's included EAS Build credits.
 

--- a/docs/pages/billing/usage-based-pricing.mdx
+++ b/docs/pages/billing/usage-based-pricing.mdx
@@ -5,7 +5,7 @@ description: Learn how Expo applies usage-based billing for customers who exceed
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-Expo applies usage-based billing for customers who exceed their [plan](/billing/plans/) allowances. This enables our customers to use what they need without worrying about limitations or requiring contractual obligations.
+Expo applies usage-based billing for customers on paid plans who exceed their [plan](/billing/plans/) allowances. This enables our customers to use what they need without worrying about limitations or requiring contractual obligations.
 
 Usage-based billing is enabled for EAS Build and EAS Update and is billed monthly. We provide an estimate of your existing usage and any overage charges on your [account's Billing](https://expo.dev/settings/billing).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25825

# How

<!--
How did you build this feature or fix this bug and why?
-->

State that Free plan accounts cannot incur overage charges in relevant places in Billing docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
