### PR TITLE
[docs] Note that barcodeScannerEnabled requires building expo-camera from source

### DIFF
--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -70,7 +70,7 @@ Configure Expo Autolinking with `buildFromSource` in **package.json**. Use `".*"
 }
 ```
 
-This is typically only needed when you're modifying module source code yourself, or when you use a config plugin option that controls native compilation. Prebuilt artifacts ship with each module's default build options, so options that add or remove native dependencies (such as `expo-camera`'s [`barcodeScannerEnabled`](/versions/latest/sdk/camera/#configuration-in-app-config)) only take effect when the module builds from source.
+This is typically only needed when you're modifying module source code yourself, or when you use a config plugin option that controls native compilation. Prebuilt artifacts ship with each module's default build options, so options that add or remove native dependencies (such as `expo-camera`'s [`barcodeScannerEnabled`](/versions/latest/sdk/camera/#configuration-in-app-config) on Android) only take effect when the module builds from source.
 
 </Collapsible>
 

--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -70,7 +70,7 @@ Configure Expo Autolinking with `buildFromSource` in **package.json**. Use `".*"
 }
 ```
 
-This is typically only needed when you're modifying module source code yourself.
+This is typically only needed when you're modifying module source code yourself, or when you use a config plugin option that controls native compilation. Prebuilt artifacts ship with each module's default build options, so options that add or remove native dependencies (such as `expo-camera`'s [`barcodeScannerEnabled`](/versions/latest/sdk/camera/#configuration-in-app-config)) only take effect when the module builds from source.
 
 </Collapsible>
 

--- a/docs/pages/versions/unversioned/sdk/camera.mdx
+++ b/docs/pages/versions/unversioned/sdk/camera.mdx
@@ -77,7 +77,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
     {
       name: 'barcodeScannerEnabled',
       description:
-        'A boolean that determines whether to enable barcode scanning support. Disabling this reduces app size when barcode scanning is not needed.',
+        'A boolean that determines whether to enable barcode scanning support. Disabling this reduces app size when barcode scanning is not needed. On Android, this option only takes effect when `expo-camera` builds from source. [Prebuilt modules](/guides/prebuilt-expo-modules/) already include the barcode scanning libraries. To make this option apply, add `expo-camera` to `buildFromSource` in **package.json**.',
       default: 'true',
     },
   ]}

--- a/docs/pages/versions/v57.0.0/sdk/camera.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/camera.mdx
@@ -77,7 +77,7 @@ You can configure `expo-camera` using its built-in [config plugin](/config-plugi
     {
       name: 'barcodeScannerEnabled',
       description:
-        'A boolean that determines whether to enable barcode scanning support. Disabling this reduces app size when barcode scanning is not needed.',
+        'A boolean that determines whether to enable barcode scanning support. Disabling this reduces app size when barcode scanning is not needed. On Android, this option only takes effect when `expo-camera` builds from source. [Prebuilt modules](/guides/prebuilt-expo-modules/) already include the barcode scanning libraries. To make this option apply, add `expo-camera` to `buildFromSource` in **package.json**.',
       default: 'true',
     },
   ]}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25851

# How

<!--
How did you build this feature or fix this bug and why?
-->

Note that `barcodeScannerEnabled` requires building `expo-camera` from source in the config plugin definition. Also, note a general guidance about the same in prebuilt modules FAQ.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
