### PR TITLE
fix(metro-config): Add missing `countLines` helpers to modified serializer outputs

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
+- Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/environmentVariableSerializerPlugin.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/environmentVariableSerializerPlugin.test.ts
@@ -4,6 +4,7 @@ import {
   getEnvVarDevString,
   serverPreludeSerializerPlugin,
 } from '../environmentVariableSerializerPlugin';
+import { installPackedMap } from '../packedMap';
 
 describe(serverPreludeSerializerPlugin, () => {
   it('updates lineCount after modifying the server prelude', () => {
@@ -64,6 +65,36 @@ describe(environmentVariableSerializerPlugin, () => {
 
     expect(data.code).toBe(getEnvVarDevString());
     expect(data.lineCount).toBe(1);
+  });
+
+  it('discards the transformed map when replacing the environment prelude', () => {
+    const data = {
+      code: '(function (global) {\n//\n})(globalThis);',
+      lineCount: 3,
+      map: undefined,
+    };
+    installPackedMap(data, [
+      [2, 0, 1, 0],
+      [3, 0],
+    ]);
+    const previousPackedMap = (data as any).__packedMap;
+    const prelude = {
+      path: '\0polyfill:environment-variables',
+      output: [{ type: 'js/script', data }],
+    };
+
+    environmentVariableSerializerPlugin(
+      '/index.js',
+      [prelude] as any,
+      { transformOptions: { customTransformOptions: { environment: 'client' } } } as any,
+      { dev: true } as any
+    );
+
+    expect(data.code).toBe(getEnvVarDevString());
+    expect(data.lineCount).toBe(1);
+    expect((data as any).__packedMap).not.toBe(previousPackedMap);
+    expect((data as any).__packedMap.count).toBe(0);
+    expect(data.map).toEqual([]);
   });
 });
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/environmentVariableSerializerPlugin.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/environmentVariableSerializerPlugin.test.ts
@@ -1,7 +1,71 @@
 import {
+  environmentVariableSerializerPlugin,
   getTransformEnvironment,
   getEnvVarDevString,
+  serverPreludeSerializerPlugin,
 } from '../environmentVariableSerializerPlugin';
+
+describe(serverPreludeSerializerPlugin, () => {
+  it('updates lineCount after modifying the server prelude', () => {
+    const data = {
+      code: 'process=this.process||{},first\nsecond',
+      lineCount: 99,
+    };
+    const prelude = {
+      path: '__prelude__',
+      output: [{ type: 'js/script', data }],
+    };
+
+    serverPreludeSerializerPlugin(
+      '/index.js',
+      [prelude] as any,
+      { transformOptions: { customTransformOptions: { environment: 'node' } } } as any,
+      {} as any
+    );
+
+    expect(data).toEqual({
+      code: 'first\nsecond',
+      lineCount: 2,
+    });
+  });
+});
+
+describe(environmentVariableSerializerPlugin, () => {
+  it('sets lineCount when inserting the environment prelude', () => {
+    const preModules: any[] = [];
+
+    environmentVariableSerializerPlugin(
+      '/index.js',
+      preModules,
+      { transformOptions: { customTransformOptions: { environment: 'client' } } } as any,
+      { dev: true } as any
+    );
+
+    const data = preModules[0].output[0].data;
+    expect(data.lineCount).toBe(data.code.split(/\r\n?|\n|\u2028|\u2029/).length);
+  });
+
+  it('updates lineCount after replacing the environment prelude', () => {
+    const data = {
+      code: 'first\nsecond\nthird',
+      lineCount: 3,
+    };
+    const prelude = {
+      path: '\0polyfill:environment-variables',
+      output: [{ type: 'js/script', data }],
+    };
+
+    environmentVariableSerializerPlugin(
+      '/index.js',
+      [prelude] as any,
+      { transformOptions: { customTransformOptions: { environment: 'client' } } } as any,
+      { dev: true } as any
+    );
+
+    expect(data.code).toBe(getEnvVarDevString());
+    expect(data.lineCount).toBe(1);
+  });
+});
 
 describe(getTransformEnvironment, () => {
   [

--- a/packages/@expo/metro-config/src/serializer/environmentVariableSerializerPlugin.ts
+++ b/packages/@expo/metro-config/src/serializer/environmentVariableSerializerPlugin.ts
@@ -66,6 +66,7 @@ export function serverPreludeSerializerPlugin(
           /process\.env=process\.env\|\|{};process\.env\.NODE_ENV=process\.env\.NODE_ENV\|\|"\w+";/,
           ''
         );
+      data.lineCount = countLines(data.code);
     }
   }
   return [entryPoint, preModules, graph, options];
@@ -96,6 +97,7 @@ export function environmentVariableSerializerPlugin(
     const data = prelude.output[0]?.data as any;
     // !!MUST!! be one line in order to ensure Metro's asymmetric serializer system can handle it.
     data.code = code;
+    data.lineCount = countLines(data.code);
     return [entryPoint, preModules, graph, options];
   }
 
@@ -149,7 +151,7 @@ function getEnvPrelude(code: string): Module<MixedOutput> {
         type: 'js/script/virtual',
         data: {
           code,
-          lineCount: 1,
+          lineCount: countLines(code),
           map: [],
         },
       },

--- a/packages/@expo/metro-config/src/serializer/environmentVariableSerializerPlugin.ts
+++ b/packages/@expo/metro-config/src/serializer/environmentVariableSerializerPlugin.ts
@@ -13,6 +13,7 @@ import type {
 import CountingSet from '@expo/metro/metro/lib/CountingSet';
 import countLines from '@expo/metro/metro/lib/countLines';
 
+import { installPackedMap } from './packedMap';
 import type { SerializerParameters } from './withExpoSerializers';
 
 export function getTransformEnvironment(url: string): string | null {
@@ -98,6 +99,7 @@ export function environmentVariableSerializerPlugin(
     // !!MUST!! be one line in order to ensure Metro's asymmetric serializer system can handle it.
     data.code = code;
     data.lineCount = countLines(data.code);
+    installPackedMap(data, []);
     return [entryPoint, preModules, graph, options];
   }
 


### PR DESCRIPTION
# Why

Extracted from #48443

When the `environmentVariableSerializerPlugin` modifies outputs, it hardcodes the `lineCount` and doesn't adjust for cases where the number of lines in its output may be variable. This can cause subtle source-map offset bugs that are hard to track.

# How

- Invoke `countLines` on custom module output in `environmentVariableSerializerPlugin`
- Fix outdated/invalid packed map installation on dev-vars virtual module

# Test Plan

- Unit test added for this change; prior data clearly hard-coded

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
