### PR TITLE
fix(fingerprint): Set NODE_ENV before loading Expo config

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### 🐛 Bug fixes
 
+- Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
+
 ### 💡 Others
 
 - Hoisted the ignore-path Minimatch build out of the per-module filter in `ExpoConfigLoader`, avoiding O(modules × patterns) Minimatch constructions during config load. Byte-identical fingerprint hash. ([#48367](https://github.com/expo/expo/pull/48367) by [@alfonsocj](https://github.com/alfonsocj))

--- a/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
+++ b/packages/@expo/fingerprint/e2e/__tests__/default-ignore-paths-test.ts
@@ -92,6 +92,48 @@ export default ({ config }) => {
     expect(packageJsonSource).toBeUndefined();
     await fs.rm(appConfigPath, { force: true });
   });
+
+  it('loads development env files after inheriting dotenv values from a parent process', async () => {
+    const appConfigPath = path.join(projectRoot, 'app.config.js');
+    const envPath = path.join(projectRoot, '.env.development');
+    const appConfigContent = `\
+export default ({ config }) => ({
+  ...config,
+  extra: {
+    ...config.extra,
+    fingerprintDev: globalThis.__DEV__,
+    fingerprintConfigModeIsSet: process.env.__EXPO_CONFIG_MODE !== undefined,
+    fingerprintEnvValue: process.env.EXPO_PUBLIC_FINGERPRINT_MODE,
+  },
+});
+`;
+    await fs.writeFile(appConfigPath, appConfigContent);
+    await fs.writeFile(envPath, 'EXPO_PUBLIC_FINGERPRINT_MODE=development-value\n');
+    const originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: 'production',
+      __EXPO_CONFIG_MODE: 'production',
+      __EXPO_ENV_LOADED: JSON.stringify(['EXPO_PUBLIC_FINGERPRINT_MODE']),
+      EXPO_PUBLIC_FINGERPRINT_MODE: 'from-parent-dotenv',
+    };
+    try {
+      const fingerprint = await createFingerprintAsync(projectRoot);
+      const expoConfigSource = fingerprint.sources.find(
+        (source) => source.type === 'contents' && source.id === 'expoConfig'
+      );
+      expect(expoConfigSource?.type).toBe('contents');
+      if (expoConfigSource?.type === 'contents') {
+        const expoConfig = JSON.parse(expoConfigSource.contents.toString());
+        expect(expoConfig.extra.fingerprintDev).toBe(true);
+        expect(expoConfig.extra.fingerprintConfigModeIsSet).toBe(false);
+        expect(expoConfig.extra.fingerprintEnvValue).toBe('development-value');
+      }
+    } finally {
+      process.env = originalEnv;
+      await Promise.all([fs.rm(appConfigPath, { force: true }), fs.rm(envPath, { force: true })]);
+    }
+  });
 });
 
 macosDescribe('CocoaPods generated files', () => {

--- a/packages/@expo/fingerprint/src/ExpoConfig.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfig.ts
@@ -1,4 +1,5 @@
 import type { ProjectConfig } from '@expo/config';
+import { getOriginalEnv, setNodeEnv } from '@expo/env';
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
@@ -7,6 +8,8 @@ import resolveFrom from 'resolve-from';
 import { getExpoConfigLoaderPath, type LoadedModuleSource } from './ExpoConfigLoader';
 import type { NormalizedOptions } from './Fingerprint.types';
 import { spawnWithIpcAsync } from './utils/SpawnIPC';
+
+const FINGERPRINT_ENV_MODE = 'development';
 
 /**
  * An out-of-process `expo/config` loader that can be used to get the Expo config and loaded modules.
@@ -60,11 +63,19 @@ async function spawnConfigLoaderAsync(
   ignoredFile: string,
   skipPlugins: boolean
 ): Promise<{ config: ProjectConfig | null; loadedModules: LoadedModuleSource[] | null }> {
-  const args = [getExpoConfigLoaderPath(), path.resolve(projectRoot), ignoredFile];
+  const args = [
+    getExpoConfigLoaderPath(),
+    path.resolve(projectRoot),
+    ignoredFile,
+    '--mode',
+    FINGERPRINT_ENV_MODE,
+  ];
   if (skipPlugins) {
     args.push('--skipPlugins');
   }
-  const { message } = await spawnWithIpcAsync('node', args, { cwd: projectRoot });
+  const childEnv = setNodeEnv(FINGERPRINT_ENV_MODE, { systemEnv: getOriginalEnv() });
+  delete childEnv.EXPO_CONFIG_MODE;
+  const { message } = await spawnWithIpcAsync('node', args, { cwd: projectRoot, env: childEnv });
   return JSON.parse(message);
 }
 

--- a/packages/@expo/fingerprint/src/ExpoConfig.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfig.ts
@@ -74,7 +74,7 @@ async function spawnConfigLoaderAsync(
     args.push('--skipPlugins');
   }
   const childEnv = setNodeEnv(FINGERPRINT_ENV_MODE, { systemEnv: getOriginalEnv() });
-  delete childEnv.EXPO_CONFIG_MODE;
+  childEnv.__EXPO_CONFIG_MODE = FINGERPRINT_ENV_MODE;
   const { message } = await spawnWithIpcAsync('node', args, { cwd: projectRoot, env: childEnv });
   return JSON.parse(message);
 }

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -2,6 +2,7 @@
  * A helper script to load the Expo config and loaded plugins from a project
  */
 
+import { loadProjectEnv } from '@expo/env';
 import fs from 'fs/promises';
 import module from 'module';
 import process from 'node:process';
@@ -13,7 +14,9 @@ import { buildPathMatchObjects, isIgnoredPathWithMatchObjects, toPosixPath } fro
 
 async function runAsync(programName: string, args: string[] = []) {
   if (args[0] == null) {
-    console.log(`Usage: ${programName} <projectRoot> [ignoredFile] [--skipPlugins]`);
+    console.log(
+      `Usage: ${programName} <projectRoot> [ignoredFile] --mode <development|production> [--skipPlugins]`
+    );
     return;
   }
 
@@ -22,8 +25,16 @@ async function runAsync(programName: string, args: string[] = []) {
   const ignoredFileArg = args[1] && !args[1].startsWith('--') ? args[1] : null;
   const ignoredFile = ignoredFileArg ? path.resolve(ignoredFileArg) : null;
 
-  setNodeEnv('development');
-  require('@expo/env').load(projectRoot);
+  const modeFlagIndex = args.indexOf('--mode');
+  const mode = modeFlagIndex >= 0 ? args[modeFlagIndex + 1] : undefined;
+  if (mode !== 'development' && mode !== 'production') {
+    throw new Error(`Unsupported Expo config mode: ${mode}`);
+  }
+  try {
+    loadProjectEnv(projectRoot, { mode });
+  } finally {
+    delete process.env.EXPO_CONFIG_MODE;
+  }
 
   const { getCapturedModules, uninstall } = installModuleCaptureHook();
   let config;
@@ -201,18 +212,6 @@ export async function resolveLoadedModuleSourcesAsync(
  */
 export function getExpoConfigLoaderPath() {
   return path.join(__dirname, 'ExpoConfigLoader.js');
-}
-
-/**
- * Set the environment to production or development
- * Replicates the code from `@expo/cli` to ensure the same environment is set.
- */
-function setNodeEnv(mode: 'development' | 'production') {
-  process.env.NODE_ENV = process.env.NODE_ENV || mode;
-  process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
-
-  // @ts-expect-error: Add support for external React libraries being loaded in the same process.
-  globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
 }
 
 // Ignore known non-native packages loaded while applying config plugins, which the plugins-skipped

--- a/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
+++ b/packages/@expo/fingerprint/src/ExpoConfigLoader.ts
@@ -2,7 +2,7 @@
  * A helper script to load the Expo config and loaded plugins from a project
  */
 
-import { loadProjectEnv } from '@expo/env';
+import { consumeConfigEnvMode, loadProjectEnv } from '@expo/env';
 import fs from 'fs/promises';
 import module from 'module';
 import process from 'node:process';
@@ -11,6 +11,10 @@ import resolveFrom from 'resolve-from';
 
 import { DEFAULT_IGNORE_PATHS } from './Options';
 import { buildPathMatchObjects, isIgnoredPathWithMatchObjects, toPosixPath } from './utils/Path';
+
+declare namespace globalThis {
+  let __DEV__: boolean | undefined;
+}
 
 async function runAsync(programName: string, args: string[] = []) {
   if (args[0] == null) {
@@ -30,11 +34,9 @@ async function runAsync(programName: string, args: string[] = []) {
   if (mode !== 'development' && mode !== 'production') {
     throw new Error(`Unsupported Expo config mode: ${mode}`);
   }
-  try {
-    loadProjectEnv(projectRoot, { mode });
-  } finally {
-    delete process.env.EXPO_CONFIG_MODE;
-  }
+  consumeConfigEnvMode();
+  globalThis.__DEV__ = mode === 'development';
+  loadProjectEnv(projectRoot, { mode });
 
   const { getCapturedModules, uninstall } = installModuleCaptureHook();
   let config;

--- a/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
@@ -3,22 +3,63 @@ import resolveFrom from 'resolve-from';
 import { getExpoConfigAsync, diffLoadedModules } from '../ExpoConfig';
 import type { LoadedModuleSource } from '../ExpoConfigLoader';
 import { normalizeOptionsAsync } from '../Options';
+import { spawnWithIpcAsync } from '../utils/SpawnIPC';
 
 jest.mock('resolve-from');
 jest.mock('../ProjectWorkflow');
+jest.mock('../utils/SpawnIPC');
 
 describe(getExpoConfigAsync, () => {
-  it('should return null if the expo package is not found', async () => {
-    const result = await getExpoConfigAsync('/app', await normalizeOptionsAsync('/app'));
-    const mockedResolveFrom = resolveFrom.silent as jest.MockedFunction<typeof resolveFrom.silent>;
-    mockedResolveFrom.mockImplementationOnce((fromDirectory: string, moduleId: string) => {
-      const actualResolver = jest.requireActual('resolve-from').silent;
-      // To fake the case as no expo installed, trying to resolve as **nonexist/expo/config** module
-      return actualResolver(fromDirectory, 'nonexist/expo/config');
+  const originalEnv = process.env;
+  const actualResolveFromSilent = jest.requireActual('resolve-from').silent;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    jest
+      .mocked(resolveFrom.silent)
+      .mockImplementation((_fromDirectory, moduleId) =>
+        actualResolveFromSilent(__dirname, moduleId)
+      );
+    jest.mocked(spawnWithIpcAsync).mockResolvedValue({
+      output: [],
+      stdout: JSON.stringify({ config: null, loadedModules: [] }),
+      message: JSON.stringify({ config: null, loadedModules: [] }),
+      stderr: '',
+      signal: null,
+      status: 0,
     });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('should return null if the expo package is not found', async () => {
+    jest
+      .mocked(resolveFrom.silent)
+      .mockImplementation((_fromDirectory, moduleId) =>
+        moduleId === 'expo/config' ? undefined : actualResolveFromSilent(__dirname, moduleId)
+      );
+
+    const result = await getExpoConfigAsync('/app', await normalizeOptionsAsync('/app'));
 
     expect(result.config).toBeNull();
     expect(result.loadedModules).toBeNull();
+  });
+
+  it('uses development mode for the config loader', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.EXPO_CONFIG_MODE = 'production';
+
+    await getExpoConfigAsync('/app', await normalizeOptionsAsync('/app'));
+
+    expect(spawnWithIpcAsync).toHaveBeenCalledTimes(2);
+    for (const [, args, options] of jest.mocked(spawnWithIpcAsync).mock.calls) {
+      expect(args).toEqual(expect.arrayContaining(['--mode', 'development']));
+      expect(options?.env).toMatchObject({ NODE_ENV: 'development' });
+      expect(options?.env?.EXPO_CONFIG_MODE).toBeUndefined();
+    }
   });
 });
 

--- a/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ExpoConfig-test.ts
@@ -48,17 +48,18 @@ describe(getExpoConfigAsync, () => {
     expect(result.loadedModules).toBeNull();
   });
 
-  it('uses development mode for the config loader', async () => {
+  it('passes development mode to the config loader', async () => {
     process.env.NODE_ENV = 'production';
-    process.env.EXPO_CONFIG_MODE = 'production';
 
     await getExpoConfigAsync('/app', await normalizeOptionsAsync('/app'));
 
     expect(spawnWithIpcAsync).toHaveBeenCalledTimes(2);
     for (const [, args, options] of jest.mocked(spawnWithIpcAsync).mock.calls) {
       expect(args).toEqual(expect.arrayContaining(['--mode', 'development']));
-      expect(options?.env).toMatchObject({ NODE_ENV: 'development' });
-      expect(options?.env?.EXPO_CONFIG_MODE).toBeUndefined();
+      expect(options?.env).toMatchObject({
+        NODE_ENV: 'development',
+        __EXPO_CONFIG_MODE: 'development',
+      });
     }
   });
 });


### PR DESCRIPTION
# Why

Fingerprint can load different env files for the same project when `NODE_ENV` changes.

# How

I updated Fingerprint to use the shared API and set the mode to `development` before loading Expo config and env files.

# Test Plan

Tests and CI checks pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)