### PR TITLE
[docs] Fix escaping in docs code block

### DIFF
--- a/docs/pages/technical-specs/expo-updates-1.mdx
+++ b/docs/pages/technical-specs/expo-updates-1.mdx
@@ -87,8 +87,8 @@ The choice of update and headers are dependent on the values of the request head
 ```text
 expo-protocol-version: 1
 expo-sfv-version: 0
-expo-manifest-filters: &lt;expo-sfv&gt;
-expo-server-defined-headers: &lt;expo-sfv&gt;
+expo-manifest-filters: <expo-sfv>
+expo-server-defined-headers: <expo-sfv>
 cache-control: *
 content-type: *
 ```


### PR DESCRIPTION
# Why

Noticed the escaping of these on the rendered page was incorrect.

# How

Use unescaped chars.

# Test Plan

There's a test that should've caught this: https://github.com/expo/expo/blob/main/docs/scripts/generate-markdown-pages-utils.test.ts#L838 ? Maybe that function is no longer being used.

Either way, this seems to fix it.

Before:
<img width="399" height="176" alt="Screenshot 2026-08-12 at 12 26 16 PM" src="https://github.com/user-attachments/assets/9e5db40c-b811-4e93-a1cf-af901660b47a" />

After:
<img width="404" height="175" alt="Screenshot 2026-08-12 at 12 26 10 PM" src="https://github.com/user-attachments/assets/7324f86d-be1f-454f-a03c-71aca980a7a9" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)