### PR TITLE
fix(expo-doctor): Use the same mode for env config

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
+- Use an explicit mode for `.env` files and Expo config.
 
 ### 🎉 New features
 
@@ -13,6 +14,7 @@
 ### 🐛 Bug fixes
 
 - [Internal] Prevent `ncc` from removing dynamic requires where we need them ([#48887](https://github.com/expo/expo/pull/48887) by [@kitten](https://github.com/kitten))
+- Keep loaded `.env` values out of `expo install --check`.
 
 ### 💡 Others
 

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Raise minimum Node.js version to `^22.13.0` ([#47202](https://github.com/expo/expo/pull/47202) by [@kitten](https://github.com/kitten))
-- Use an explicit mode for `.env` files and Expo config.
+- Use an explicit mode for `.env` files and Expo config. ([#48845](https://github.com/expo/expo/pull/48845) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 🎉 New features
 
@@ -14,7 +14,7 @@
 ### 🐛 Bug fixes
 
 - [Internal] Prevent `ncc` from removing dynamic requires where we need them ([#48887](https://github.com/expo/expo/pull/48887) by [@kitten](https://github.com/kitten))
-- Keep loaded `.env` values out of `expo install --check`.
+- Keep loaded `.env` values out of `expo install --check`. ([#48845](https://github.com/expo/expo/pull/48845) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/src/__tests__/doctor.test.ts
+++ b/packages/expo-doctor/src/__tests__/doctor.test.ts
@@ -1,14 +1,23 @@
+import { loadProjectEnv } from '@expo/env';
+
 import { InstalledDependencyVersionCheck } from '../checks/InstalledDependencyVersionCheck';
 import { VectorIconsCheck } from '../checks/VectorIconsCheck';
 import type { DoctorCheck } from '../checks/checks.types';
 import {
+  actionAsync,
   printCheckResultSummaryOnComplete,
   printFailedCheckIssueAndAdvice,
   runChecksAsync,
 } from '../doctor';
+import * as CheckResolver from '../utils/checkResolver';
 import { resolveChecksInScope } from '../utils/checkResolver';
+import * as ProjectConfig from '../utils/getProjectConfig';
 import { Log } from '../utils/log';
 
+jest.mock('@expo/env', () => ({
+  ...jest.requireActual('@expo/env'),
+  loadProjectEnv: jest.fn(),
+}));
 jest.mock(`../utils/log`);
 
 jest.mock('../utils/ora', () => ({
@@ -50,6 +59,34 @@ class MockUnexpectedThrowCheck implements DoctorCheck {
   sdkVersionRange = '*';
   runAsync = jest.fn(() => Promise.reject(new Error('Unexpected error thrown from check.')));
 }
+
+describe(actionAsync, () => {
+  afterEach(() => {
+    delete process.env.EXPO_CONFIG_MODE;
+    jest.mocked(loadProjectEnv).mockReset();
+    jest.restoreAllMocks();
+  });
+
+  it('removes EXPO_CONFIG_MODE loaded from .env before Expo config runs', async () => {
+    let configModeAtConfig: string | undefined;
+
+    jest.mocked(loadProjectEnv).mockImplementation(() => {
+      process.env.EXPO_CONFIG_MODE = 'development';
+      return { result: 'skipped', loaded: [] };
+    });
+    jest.spyOn(ProjectConfig, 'getProjectConfigAsync').mockImplementation(async () => {
+      configModeAtConfig = process.env.EXPO_CONFIG_MODE;
+      return additionalProjectProps;
+    });
+    jest.spyOn(CheckResolver, 'resolveChecksInScope').mockReturnValue([]);
+
+    await actionAsync('/app', false, 'production');
+
+    expect(loadProjectEnv).toHaveBeenCalledWith('/app', { mode: 'production' });
+    expect(ProjectConfig.getProjectConfigAsync).toHaveBeenCalledWith('/app', 'production');
+    expect(configModeAtConfig).toBeUndefined();
+  });
+});
 
 describe(resolveChecksInScope, () => {
   beforeEach(() => {

--- a/packages/expo-doctor/src/__tests__/doctor.test.ts
+++ b/packages/expo-doctor/src/__tests__/doctor.test.ts
@@ -61,30 +61,51 @@ class MockUnexpectedThrowCheck implements DoctorCheck {
 }
 
 describe(actionAsync, () => {
+  const devGlobal = globalThis as typeof globalThis & { __DEV__?: boolean };
+  const originalDev = devGlobal.__DEV__;
+  const originalConfigMode = process.env.__EXPO_CONFIG_MODE;
+
   afterEach(() => {
-    delete process.env.EXPO_CONFIG_MODE;
+    devGlobal.__DEV__ = originalDev;
+    if (originalConfigMode === undefined) {
+      delete process.env.__EXPO_CONFIG_MODE;
+    } else {
+      process.env.__EXPO_CONFIG_MODE = originalConfigMode;
+    }
     jest.mocked(loadProjectEnv).mockReset();
+    jest.mocked(Log.exception).mockReset();
     jest.restoreAllMocks();
   });
 
-  it('removes EXPO_CONFIG_MODE loaded from .env before Expo config runs', async () => {
-    let configModeAtConfig: string | undefined;
-
-    jest.mocked(loadProjectEnv).mockImplementation(() => {
-      process.env.EXPO_CONFIG_MODE = 'development';
-      return { result: 'skipped', loaded: [] };
-    });
-    jest.spyOn(ProjectConfig, 'getProjectConfigAsync').mockImplementation(async () => {
-      configModeAtConfig = process.env.EXPO_CONFIG_MODE;
-      return additionalProjectProps;
-    });
+  it('uses the same mode for env files and Expo config', async () => {
+    process.env.__EXPO_CONFIG_MODE = 'production';
+    jest.spyOn(ProjectConfig, 'getProjectConfigAsync').mockResolvedValue(additionalProjectProps);
     jest.spyOn(CheckResolver, 'resolveChecksInScope').mockReturnValue([]);
 
-    await actionAsync('/app', false, 'production');
+    await actionAsync('/app', false);
 
     expect(loadProjectEnv).toHaveBeenCalledWith('/app', { mode: 'production' });
     expect(ProjectConfig.getProjectConfigAsync).toHaveBeenCalledWith('/app', 'production');
-    expect(configModeAtConfig).toBeUndefined();
+    expect(devGlobal.__DEV__).toBe(false);
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('reports an invalid config mode', async () => {
+    process.env.__EXPO_CONFIG_MODE = 'staging';
+    const getProjectConfigSpy = jest
+      .spyOn(ProjectConfig, 'getProjectConfigAsync')
+      .mockResolvedValue(additionalProjectProps);
+
+    await actionAsync('/app', false);
+
+    expect(Log.exception).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Invalid __EXPO_CONFIG_MODE value: "staging". Use "development" or "production".',
+      })
+    );
+    expect(loadProjectEnv).not.toHaveBeenCalled();
+    expect(getProjectConfigSpy).not.toHaveBeenCalled();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 });
 

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -41,7 +41,7 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       try {
         commandResult = await spawnExpoCLI(projectRoot, ['install', '--check', '--json'], {
           stdio: 'pipe',
-          env: { ...process.env, CI: '1', EXPO_DEBUG: '0' },
+          env: { CI: '1', EXPO_DEBUG: '0' },
         });
       } catch (error: any) {
         if (isSpawnResult(error) && error.status === 1) {
@@ -61,7 +61,7 @@ export class InstalledDependencyVersionCheck implements DoctorCheck {
       try {
         await spawnExpoCLI(projectRoot, ['install', '--check'], {
           stdio: 'pipe',
-          env: { ...process.env, CI: '1', EXPO_DEBUG: '0' },
+          env: { CI: '1', EXPO_DEBUG: '0' },
         });
       } catch (error: any) {
         if (isSpawnResult(error)) {

--- a/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/InstalledDependencyVersionCheck.test.ts
@@ -1,7 +1,11 @@
+import { loadProjectEnv } from '@expo/env';
 import spawnAsync from '@expo/spawn-async';
+import { vol } from 'memfs';
 
 import { mockSpawnPromise } from '../../__tests__/spawn-utils';
 import { InstalledDependencyVersionCheck } from '../InstalledDependencyVersionCheck';
+
+jest.mock('fs');
 
 // required by runAsync
 const additionalProjectProps = {
@@ -46,6 +50,33 @@ describe('runAsync', () => {
     expect(mockSpawnAsync.mock.calls[0]![0]).toBe('npx');
     expect(mockSpawnAsync.mock.calls[0]![1]).toEqual(['expo', 'install', '--check']);
     expect(mockSpawnAsync.mock.calls[0]![2]).toMatchObject({ env: { CI: '1' } });
+  });
+
+  it('does not pass loaded env values to expo install', async () => {
+    const originalEnv = process.env;
+    process.env = { ...originalEnv };
+    delete process.env.EXPO_PUBLIC_DOCTOR_TEST;
+    vol.fromJSON({ '/path/to/project/.env': 'EXPO_PUBLIC_DOCTOR_TEST=from-env' });
+
+    try {
+      loadProjectEnv('/path/to/project', { mode: 'development', silent: true });
+
+      const mockSpawnAsync = jest.mocked(spawnAsync).mockImplementation(() =>
+        mockSpawnPromise(
+          Promise.resolve({
+            stdout: '',
+          })
+        )
+      );
+      const check = new InstalledDependencyVersionCheck();
+      await check.runAsync({ projectRoot: '/path/to/project', ...additionalProjectProps });
+
+      expect(mockSpawnAsync.mock.calls[0]![2]?.env).not.toHaveProperty('EXPO_PUBLIC_DOCTOR_TEST');
+      expect(mockSpawnAsync.mock.calls[0]![2]?.env).not.toHaveProperty('__EXPO_ENV_LOADED');
+    } finally {
+      process.env = originalEnv;
+      vol.reset();
+    }
   });
 
   it('returns result with isSuccessful = false if check fails', async () => {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -1,4 +1,4 @@
-import { load as loadEnv } from '@expo/env';
+import { loadProjectEnv, type EnvMode } from '@expo/env';
 import chalk from 'chalk';
 
 import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/checks.types';
@@ -8,7 +8,6 @@ import { isNetworkError } from './utils/errors';
 import { getProjectConfigAsync } from './utils/getProjectConfig';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
-import { setNodeEnv } from './utils/nodeEnv';
 import { logNewSection } from './utils/ora';
 import { endTimer, formatMilliseconds, startTimer } from './utils/timer';
 import { ltSdkVersion } from './utils/versions';
@@ -123,12 +122,14 @@ export async function runChecksAsync(
   );
 }
 
-function maybeLoadEnv(projectRoot: string) {
+function maybeLoadEnv(projectRoot: string, mode: EnvMode) {
   try {
-    loadEnv(projectRoot);
+    loadProjectEnv(projectRoot, { mode });
   } catch {
     // NOTE(@kitten): It's unclear why we load env files here in expo-doctor, and it's likely optional, even with us loading the project config
     // If this fails, e.g. because the Node.js version is too out of date, ignore the error
+  } finally {
+    delete process.env.EXPO_CONFIG_MODE;
   }
 }
 
@@ -136,13 +137,17 @@ function maybeLoadEnv(projectRoot: string) {
  * Run the expo-doctor checks on the project.
  * @param projectRoot The root of the project to check.
  * @param showVerboseTestResults if true, show passes and failures; otherwise show number of tests passed and failure details only
+ * @param mode The mode to use for .env files and Expo config.
  */
-export async function actionAsync(projectRoot: string, showVerboseTestResults: boolean) {
+export async function actionAsync(
+  projectRoot: string,
+  showVerboseTestResults: boolean,
+  mode: EnvMode
+) {
   try {
-    setNodeEnv('development');
-    maybeLoadEnv(projectRoot);
+    maybeLoadEnv(projectRoot, mode);
 
-    const projectConfig = await getProjectConfigAsync(projectRoot);
+    const projectConfig = await getProjectConfigAsync(projectRoot, mode);
 
     // expo-doctor relies on versioned CLI, which is only available for 44+
     if (ltSdkVersion(projectConfig.exp, '46.0.0')) {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -8,9 +8,14 @@ import { isNetworkError } from './utils/errors';
 import { getProjectConfigAsync } from './utils/getProjectConfig';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
+import { getConfigEnvMode } from './utils/nodeEnv';
 import { logNewSection } from './utils/ora';
 import { endTimer, formatMilliseconds, startTimer } from './utils/timer';
 import { ltSdkVersion } from './utils/versions';
+
+declare namespace globalThis {
+  let __DEV__: boolean | undefined;
+}
 
 interface DoctorCheckRunnerJob {
   check: DoctorCheck;
@@ -128,8 +133,6 @@ function maybeLoadEnv(projectRoot: string, mode: EnvMode) {
   } catch {
     // NOTE(@kitten): It's unclear why we load env files here in expo-doctor, and it's likely optional, even with us loading the project config
     // If this fails, e.g. because the Node.js version is too out of date, ignore the error
-  } finally {
-    delete process.env.EXPO_CONFIG_MODE;
   }
 }
 
@@ -137,14 +140,11 @@ function maybeLoadEnv(projectRoot: string, mode: EnvMode) {
  * Run the expo-doctor checks on the project.
  * @param projectRoot The root of the project to check.
  * @param showVerboseTestResults if true, show passes and failures; otherwise show number of tests passed and failure details only
- * @param mode The mode to use for .env files and Expo config.
  */
-export async function actionAsync(
-  projectRoot: string,
-  showVerboseTestResults: boolean,
-  mode: EnvMode
-) {
+export async function actionAsync(projectRoot: string, showVerboseTestResults: boolean) {
   try {
+    const mode = getConfigEnvMode();
+    globalThis.__DEV__ = mode === 'development';
     maybeLoadEnv(projectRoot, mode);
 
     const projectConfig = await getProjectConfigAsync(projectRoot, mode);

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -6,6 +6,7 @@ import { boolish } from 'getenv';
 import path from 'path';
 
 import { actionAsync } from './doctor';
+import { getConfigEnvMode } from './utils/nodeEnv';
 
 // Check Node.js version and issue a loud warning if it's too outdated
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
@@ -64,7 +65,7 @@ async function run() {
   if (showVerboseTestResults) {
     console.log(`expo-doctor: v${packageJson().version}`);
   }
-  await actionAsync(projectRoot, showVerboseTestResults);
+  await actionAsync(projectRoot, showVerboseTestResults, getConfigEnvMode());
 }
 
 function logVersionAndExit() {

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -6,7 +6,6 @@ import { boolish } from 'getenv';
 import path from 'path';
 
 import { actionAsync } from './doctor';
-import { getConfigEnvMode } from './utils/nodeEnv';
 
 // Check Node.js version and issue a loud warning if it's too outdated
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
@@ -65,7 +64,7 @@ async function run() {
   if (showVerboseTestResults) {
     console.log(`expo-doctor: v${packageJson().version}`);
   }
-  await actionAsync(projectRoot, showVerboseTestResults, getConfigEnvMode());
+  await actionAsync(projectRoot, showVerboseTestResults);
 }
 
 function logVersionAndExit() {

--- a/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
@@ -27,7 +27,7 @@ describe(getProjectConfigAsync, () => {
       pid: 1234,
     });
 
-    const result = await getProjectConfigAsync('/project');
+    const result = await getProjectConfigAsync('/project', 'production');
 
     expect(result).toEqual({
       exp: configOutput.exp,
@@ -37,14 +37,10 @@ describe(getProjectConfigAsync, () => {
       dynamicConfigPath: null,
     });
 
-    expect(mockSpawnExpoCLI).toHaveBeenCalledWith(
-      '/project',
-      ['config', '--json', '--full'],
-      expect.objectContaining({
-        stdio: 'pipe',
-        env: expect.objectContaining({ EXPO_DEBUG: '0' }),
-      })
-    );
+    expect(mockSpawnExpoCLI).toHaveBeenCalledWith('/project', ['config', '--json', '--full'], {
+      stdio: 'pipe',
+      env: { EXPO_CONFIG_MODE: 'production', EXPO_DEBUG: '0' },
+    });
   });
 
   it('throws on invalid JSON output', async () => {
@@ -57,7 +53,9 @@ describe(getProjectConfigAsync, () => {
       pid: 1234,
     });
 
-    await expect(getProjectConfigAsync('/project')).rejects.toThrow(/Failed to parse JSON output/);
+    await expect(getProjectConfigAsync('/project', 'development')).rejects.toThrow(
+      /Failed to parse JSON output/
+    );
   });
 
   it('throws when exp or pkg fields are missing', async () => {
@@ -70,7 +68,7 @@ describe(getProjectConfigAsync, () => {
       pid: 1234,
     });
 
-    await expect(getProjectConfigAsync('/project')).rejects.toThrow(
+    await expect(getProjectConfigAsync('/project', 'development')).rejects.toThrow(
       /missing 'exp' or 'pkg' fields/
     );
   });
@@ -90,7 +88,7 @@ describe(getProjectConfigAsync, () => {
       pid: 1234,
     });
 
-    const result = await getProjectConfigAsync('/project');
+    const result = await getProjectConfigAsync('/project', 'development');
 
     expect(result.hasUnusedStaticConfig).toBe(false);
     expect(result.staticConfigPath).toBeNull();
@@ -110,7 +108,7 @@ describe(getProjectConfigAsync, () => {
       pid: 1234,
     });
 
-    await expect(getProjectConfigAsync('/project')).rejects.toThrow(
+    await expect(getProjectConfigAsync('/project', 'development')).rejects.toThrow(
       /Cannot determine the project's Expo SDK version/
     );
   });

--- a/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
@@ -39,7 +39,7 @@ describe(getProjectConfigAsync, () => {
 
     expect(mockSpawnExpoCLI).toHaveBeenCalledWith('/project', ['config', '--json', '--full'], {
       stdio: 'pipe',
-      env: { EXPO_CONFIG_MODE: 'production', EXPO_DEBUG: '0' },
+      env: { __EXPO_CONFIG_MODE: 'production', EXPO_DEBUG: '0' },
     });
   });
 

--- a/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
@@ -1,0 +1,28 @@
+import { getConfigEnvMode } from '../nodeEnv';
+
+describe(getConfigEnvMode, () => {
+  afterEach(() => {
+    delete process.env.EXPO_CONFIG_MODE;
+  });
+
+  it('reads and removes EXPO_CONFIG_MODE', () => {
+    process.env.EXPO_CONFIG_MODE = 'production';
+
+    expect(getConfigEnvMode()).toBe('production');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('uses development when EXPO_CONFIG_MODE is not set', () => {
+    expect(getConfigEnvMode()).toBe('development');
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('rejects an invalid EXPO_CONFIG_MODE value', () => {
+    process.env.EXPO_CONFIG_MODE = 'staging';
+
+    expect(() => getConfigEnvMode()).toThrow(
+      'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
+    );
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+});

--- a/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
@@ -2,27 +2,34 @@ import { getConfigEnvMode } from '../nodeEnv';
 
 describe(getConfigEnvMode, () => {
   afterEach(() => {
-    delete process.env.EXPO_CONFIG_MODE;
+    delete process.env.EAS_BUILD;
+    delete process.env.__EXPO_CONFIG_MODE;
   });
 
-  it('reads and removes EXPO_CONFIG_MODE', () => {
-    process.env.EXPO_CONFIG_MODE = 'production';
+  it('reads and removes __EXPO_CONFIG_MODE', () => {
+    process.env.__EXPO_CONFIG_MODE = 'production';
 
     expect(getConfigEnvMode()).toBe('production');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('uses development when EXPO_CONFIG_MODE is not set', () => {
+  it('uses development when __EXPO_CONFIG_MODE is not set', () => {
     expect(getConfigEnvMode()).toBe('development');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('rejects an invalid EXPO_CONFIG_MODE value', () => {
-    process.env.EXPO_CONFIG_MODE = 'staging';
+  it('uses production in EAS Build when __EXPO_CONFIG_MODE is not set', () => {
+    process.env.EAS_BUILD = 'true';
+
+    expect(getConfigEnvMode()).toBe('production');
+  });
+
+  it('rejects an invalid __EXPO_CONFIG_MODE value', () => {
+    process.env.__EXPO_CONFIG_MODE = 'staging';
 
     expect(() => getConfigEnvMode()).toThrow(
-      'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
+      'Invalid __EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
     );
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 });

--- a/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/nodeEnv.test.ts
@@ -6,30 +6,17 @@ describe(getConfigEnvMode, () => {
     delete process.env.__EXPO_CONFIG_MODE;
   });
 
-  it('reads and removes __EXPO_CONFIG_MODE', () => {
-    process.env.__EXPO_CONFIG_MODE = 'production';
+  it('uses development outside EAS Build when __EXPO_CONFIG_MODE is not set', () => {
+    delete process.env.EAS_BUILD;
+    delete process.env.__EXPO_CONFIG_MODE;
 
-    expect(getConfigEnvMode()).toBe('production');
-    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
-  });
-
-  it('uses development when __EXPO_CONFIG_MODE is not set', () => {
     expect(getConfigEnvMode()).toBe('development');
-    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
   it('uses production in EAS Build when __EXPO_CONFIG_MODE is not set', () => {
+    delete process.env.__EXPO_CONFIG_MODE;
     process.env.EAS_BUILD = 'true';
 
     expect(getConfigEnvMode()).toBe('production');
-  });
-
-  it('rejects an invalid __EXPO_CONFIG_MODE value', () => {
-    process.env.__EXPO_CONFIG_MODE = 'staging';
-
-    expect(() => getConfigEnvMode()).toThrow(
-      'Invalid __EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
-    );
-    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 });

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -35,7 +35,7 @@ class Env {
     return boolish('EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS', false);
   }
 
-  /** Whether Expo Doctor runs in EAS Build. */
+  /** Is running in EAS Build */
   get EAS_BUILD() {
     return boolish('EAS_BUILD', false);
   }

--- a/packages/expo-doctor/src/utils/env.ts
+++ b/packages/expo-doctor/src/utils/env.ts
@@ -35,6 +35,11 @@ class Env {
     return boolish('EXPO_DOCTOR_WARN_ON_NETWORK_ERRORS', false);
   }
 
+  /** Whether Expo Doctor runs in EAS Build. */
+  get EAS_BUILD() {
+    return boolish('EAS_BUILD', false);
+  }
+
   /** EAS Build Platform */
   get EAS_BUILD_PLATFORM(): 'android' | 'ios' | null {
     const easPlatform = process.env.EAS_BUILD_PLATFORM;

--- a/packages/expo-doctor/src/utils/getProjectConfig.ts
+++ b/packages/expo-doctor/src/utils/getProjectConfig.ts
@@ -1,12 +1,17 @@
+import type { EnvMode } from '@expo/env';
+
 import type { DoctorCheckParams } from '../checks/checks.types';
 import { spawnExpoCLI } from './spawnExpoCLI';
 
 type ProjectConfig = Omit<DoctorCheckParams, 'projectRoot'>;
 
-export async function getProjectConfigAsync(projectRoot: string): Promise<ProjectConfig> {
+export async function getProjectConfigAsync(
+  projectRoot: string,
+  mode: EnvMode
+): Promise<ProjectConfig> {
   const result = await spawnExpoCLI(projectRoot, ['config', '--json', '--full'], {
     stdio: 'pipe',
-    env: { ...process.env, EXPO_DEBUG: '0' },
+    env: { EXPO_CONFIG_MODE: mode, EXPO_DEBUG: '0' },
   });
 
   let parsed: any;

--- a/packages/expo-doctor/src/utils/getProjectConfig.ts
+++ b/packages/expo-doctor/src/utils/getProjectConfig.ts
@@ -11,7 +11,7 @@ export async function getProjectConfigAsync(
 ): Promise<ProjectConfig> {
   const result = await spawnExpoCLI(projectRoot, ['config', '--json', '--full'], {
     stdio: 'pipe',
-    env: { EXPO_CONFIG_MODE: mode, EXPO_DEBUG: '0' },
+    env: { __EXPO_CONFIG_MODE: mode, EXPO_DEBUG: '0' },
   });
 
   let parsed: any;

--- a/packages/expo-doctor/src/utils/nodeEnv.ts
+++ b/packages/expo-doctor/src/utils/nodeEnv.ts
@@ -1,11 +1,16 @@
-/**
- * Set the environment to production or development
- * lots of tools use this to determine if they should run in a dev mode.
- */
-export function setNodeEnv(mode: 'development' | 'production') {
-  process.env.NODE_ENV = process.env.NODE_ENV || mode;
-  process.env.BABEL_ENV = process.env.BABEL_ENV || process.env.NODE_ENV;
+import type { EnvMode } from '@expo/env';
 
-  // @ts-expect-error: Add support for external React libraries being loaded in the same process.
-  globalThis.__DEV__ = process.env.NODE_ENV !== 'production';
+export function getConfigEnvMode(): EnvMode {
+  const mode = process.env.EXPO_CONFIG_MODE;
+  delete process.env.EXPO_CONFIG_MODE;
+
+  if (!mode) {
+    return 'development';
+  }
+  if (mode !== 'development' && mode !== 'production') {
+    throw new Error(
+      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
+    );
+  }
+  return mode;
 }

--- a/packages/expo-doctor/src/utils/nodeEnv.ts
+++ b/packages/expo-doctor/src/utils/nodeEnv.ts
@@ -1,16 +1,7 @@
-import type { EnvMode } from '@expo/env';
+import { consumeConfigEnvMode, type EnvMode } from '@expo/env';
+
+import { env } from './env';
 
 export function getConfigEnvMode(): EnvMode {
-  const mode = process.env.EXPO_CONFIG_MODE;
-  delete process.env.EXPO_CONFIG_MODE;
-
-  if (!mode) {
-    return 'development';
-  }
-  if (mode !== 'development' && mode !== 'production') {
-    throw new Error(
-      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
-    );
-  }
-  return mode;
+  return consumeConfigEnvMode() ?? (env.EAS_BUILD ? 'production' : 'development');
 }


### PR DESCRIPTION
# Why

Expo Doctor can use different modes for env files and Expo config, and it also passes loaded env values to `expo install --check`.

# How

I updated Expo Doctor to use the shared API with the same mode for both, and stopped passing loaded env values.

# Test Plan

Tests and CI checks pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)