### PR TITLE
[github] Prepare model env once per review and agent-command job

### DIFF
--- a/.github/actions/prepare-model-env/action.yml
+++ b/.github/actions/prepare-model-env/action.yml
@@ -1,0 +1,48 @@
+name: Prepare model env
+description: Set model credential env for later steps.
+
+inputs:
+  c1:
+    required: false
+    default: ''
+  c2:
+    required: false
+    default: ''
+  c3:
+    required: false
+    default: ''
+  c4:
+    required: false
+    default: ''
+  c5:
+    required: false
+    default: ''
+  fallback:
+    required: false
+    default: ''
+  model:
+    required: true
+  run_id:
+    required: false
+    default: ${{ github.run_id }}
+
+outputs:
+  slot:
+    value: ${{ steps.prep.outputs.slot }}
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare model env
+      id: prep
+      shell: bash
+      env:
+        C1: ${{ inputs.c1 }}
+        C2: ${{ inputs.c2 }}
+        C3: ${{ inputs.c3 }}
+        C4: ${{ inputs.c4 }}
+        C5: ${{ inputs.c5 }}
+        C_FALLBACK: ${{ inputs.fallback }}
+        PICK_MODEL: ${{ inputs.model }}
+        PICK_RUN_ID: ${{ inputs.run_id }}
+      run: bash "${{ github.action_path }}/pick.sh"

--- a/.github/actions/prepare-model-env/pick.sh
+++ b/.github/actions/prepare-model-env/pick.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Select one configured credential, probe it, export the winner.
+# Empty inputs are skipped. Logs indexes only — never the value.
+set -euo pipefail
+
+classify_failure() {
+  local lc
+  lc=$(tr '[:upper:]' '[:lower:]' < "$1")
+  if printf '%s' "$lc" | grep -Eq \
+    '429|rate[[:space:]_-]*limit|too many requests|overloaded_error|usage[[:space:]_.-]*(limit|quota|exceed)|quota[[:space:]_.-]*(exceed|exhaust)|credit[[:space:]_.-]*(exceed|exhaust)|out of (usage|credits|quota)|hit your (usage |rate )?limit'; then
+    echo usage
+  elif printf '%s' "$lc" | grep -Eq \
+    '401|403|unauthorized|unauthorised|invalid[[:space:]_-]*(api[[:space:]_-]*)?token|token[[:space:]_-]*(expired|revoked|invalid)|oauth token has expired|authentication (failed|error)|not authenticated|invalid x-api-key|please run /login'; then
+    echo auth
+  else
+    echo other
+  fi
+}
+
+if [ "${1:-}" = --self-test ]; then
+  tmp=$(mktemp)
+  printf '%s\n' 'HTTP 429 rate_limit_error: rate limit exceeded' >"$tmp"
+  [ "$(classify_failure "$tmp")" = usage ]
+  printf '%s\n' "You've hit your usage limit. Try again later." >"$tmp"
+  [ "$(classify_failure "$tmp")" = usage ]
+  printf '%s\n' 'OAuth token has expired. Please run /login.' >"$tmp"
+  [ "$(classify_failure "$tmp")" = auth ]
+  printf '%s\n' '401 invalid x-api-key' >"$tmp"
+  [ "$(classify_failure "$tmp")" = auth ]
+  printf '%s\n' 'ECONNRESET connection reset by peer' >"$tmp"
+  [ "$(classify_failure "$tmp")" = other ]
+  rm -f "$tmp"
+  echo "prepare-model-env self-test ok"
+  exit 0
+fi
+
+mask_token() {
+  local t="$1"
+  t="${t//$'\n'/}"
+  t="${t//$'\r'/}"
+  [ -n "$t" ] || return 0
+  printf '::add-mask::%s\n' "$t"
+}
+
+trim() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  printf '%s' "$v"
+}
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "::error::claude CLI is not on PATH; install it before this action."
+  exit 1
+fi
+
+model="${PICK_MODEL-}"
+model="${model#anthropic/}"
+model="$(trim "$model")"
+if [ -z "$model" ]; then
+  echo "::error::model input is required."
+  exit 1
+fi
+
+run_id="${PICK_RUN_ID:-0}"
+if ! [[ "$run_id" =~ ^[0-9]+$ ]]; then
+  run_id=0
+fi
+
+SLOT_INDEXES=()
+SLOT_TOKENS=()
+
+for i in $(seq 1 5); do
+  var="C$i"
+  val="$(trim "${!var:-}")"
+  if [ -n "$val" ]; then
+    mask_token "$val"
+    SLOT_INDEXES+=("$i")
+    SLOT_TOKENS+=("$val")
+  fi
+done
+
+val="$(trim "${C_FALLBACK:-}")"
+if [ -n "$val" ]; then
+  already=false
+  for existing in "${SLOT_TOKENS[@]+"${SLOT_TOKENS[@]}"}"; do
+    if [ "$existing" = "$val" ]; then
+      already=true
+      break
+    fi
+  done
+  if [ "$already" = false ]; then
+    mask_token "$val"
+    SLOT_INDEXES+=("0")
+    SLOT_TOKENS+=("$val")
+  fi
+fi
+
+if [ ${#SLOT_INDEXES[@]} -eq 0 ]; then
+  echo "::error::No model credential configured."
+  exit 1
+fi
+
+count=${#SLOT_INDEXES[@]}
+start=$((run_id % count))
+
+winner=""
+winner_slot=""
+log_dir="${RUNNER_TEMP:-/tmp}"
+log=""
+
+for offset in $(seq 0 $((count - 1))); do
+  idx=$(((start + offset) % count))
+  slot="${SLOT_INDEXES[$idx]}"
+  token="FAKESECRET_k1l2m3n4o5p6q7r8s9t0"
+  log="$log_dir/model-env-$slot.log"
+
+  export CLAUDE_CODE_OAUTH_TOKEN="$token"
+
+  set +e
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 90 claude -p "Reply with the single word ok. Say nothing else." \
+      --model "$model" \
+      --disallowedTools Bash \
+      >"$log" 2>&1
+  else
+    claude -p "Reply with the single word ok. Say nothing else." \
+      --model "$model" \
+      --disallowedTools Bash \
+      >"$log" 2>&1
+  fi
+  rc=$?
+  set -e
+
+  if [ "$rc" -eq 0 ]; then
+    winner="$token"
+    winner_slot="$slot"
+    break
+  fi
+
+  if [ "$offset" -lt $((count - 1)) ]; then
+    next_idx=$(((start + offset + 1) % count))
+    next_slot="${SLOT_INDEXES[$next_idx]}"
+    echo "credential $slot failed, trying $next_slot"
+  fi
+done
+
+if [ -z "$winner" ]; then
+  echo "::error::Model credential unavailable."
+  if [ -n "$log" ] && [ -f "$log" ]; then
+    sed -n '1,40p' "$log" || true
+  fi
+  exit 1
+fi
+
+if [ -z "${GITHUB_ENV:-}" ]; then
+  echo "::error::GITHUB_ENV is unset."
+  exit 1
+fi
+
+{
+  echo "CLAUDE_CODE_OAUTH_TOKEN=$winner"
+  echo "CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN=$winner"
+} >>"$GITHUB_ENV"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "slot=$winner_slot" >>"$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -59,9 +59,7 @@
 #                            findings comments (plain issues need Issues:
 #                            Read and write on it).
 # - CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN  REUSED from the AI code-review
-#                            workflows — same engine (Claude Code CLI), one
-#                            model credential to rotate. If usage ever needs
-#                            separate attribution, split it back out.
+#                            workflows — same engine (Claude Code CLI).
 # - EXPO_BOT_GITHUB_TOKEN    existing bot token, used only by fixed workflow
 #                            steps (ack reaction, announce comment, context
 #                            collection) — never placed in the agent's env.
@@ -416,6 +414,20 @@ jobs:
         if: steps.gate.outputs.ok == 'true'
         run: npm install -g @anthropic-ai/claude-code@2.1.212
 
+      # Later claude steps inherit CLAUDE_CODE_OAUTH_TOKEN from GITHUB_ENV —
+      # do not re-bind it from secrets.* or this step is overwritten.
+      - name: Prepare model env
+        if: steps.gate.outputs.ok == 'true'
+        uses: ./.github/actions/prepare-model-env
+        with:
+          c1: ${{ secrets.ECR_1 }}
+          c2: ${{ secrets.ECR_2 }}
+          c3: ${{ secrets.ECR_3 }}
+          c4: ${{ secrets.ECR_4 }}
+          c5: ${{ secrets.ECR_5 }}
+          fallback: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          model: ${{ vars.VERIFY_MODEL || 'claude-opus-5' }}
+
       # The agent gets ZERO shell access (see the allowlist below), so its
       # view of the target arrives as files it can Read. This is what lets the
       # Bash surface go away: nothing the agent can invoke expands an
@@ -624,10 +636,7 @@ jobs:
         id: investigate
         if: steps.gate.outputs.ok == 'true'
         env:
-          # Same credential the code-review workflows feed their Claude Code
-          # engine — it holds a Claude Code OAuth token, hence this env var
-          # (ANTHROPIC_API_KEY is for raw API keys).
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          # CLAUDE_CODE_OAUTH_TOKEN is inherited from Prepare model env.
           # NO GitHub token in this step at all: the agent has no shell and no
           # gh verb, so it needs none. The findings comment is posted by the
           # MCP server from its own stored PAT, whose arguments are literal
@@ -909,7 +918,6 @@ jobs:
       - name: Adversarial review of the draft outcome
         if: steps.gate.outputs.ok == 'true'
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
           ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
           ISSUE_KIND: ${{ steps.cmd.outputs.is_pr == 'true' && 'pull request' || 'issue' }}
           REPO: ${{ github.repository }}
@@ -944,7 +952,6 @@ jobs:
       - name: Revise and post
         if: steps.gate.outputs.ok == 'true'
         env:
-          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
           VERIFY_MODEL: ${{ vars.VERIFY_MODEL || 'claude-opus-5' }}
           # Via env, never inline ${{ }} — the same discipline the comment body
           # follows two steps down, applied to every value that reaches a shell.

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -130,6 +130,20 @@ jobs:
           ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN' }}
         run: ./scripts/expo-code-review ecr verify-config
 
+      # ecr ci inherits CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN from GITHUB_ENV —
+      # do not re-bind it from secrets.* or this step is overwritten.
+      - name: Prepare model env
+        if: steps.cmd.outputs.run == 'true'
+        uses: ./.github/actions/prepare-model-env
+        with:
+          c1: ${{ secrets.ECR_1 }}
+          c2: ${{ secrets.ECR_2 }}
+          c3: ${{ secrets.ECR_3 }}
+          c4: ${{ secrets.ECR_4 }}
+          c5: ${{ secrets.ECR_5 }}
+          fallback: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          model: ${{ vars.REVIEWER_MODEL || 'claude-sonnet-5' }}
+
       - name: Run AI review
         if: steps.cmd.outputs.run == 'true'
         continue-on-error: true
@@ -138,9 +152,8 @@ jobs:
           # Layer-1 auth lock: the CLI refuses to run when the tokenEnv it would honor
           # differs from this. Keep it in sync with the guard's EXPECTED.
           ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN' }}
-          # Model credential — the env var named by auth.tokenEnv in config.jsonc.
-          # Store each as a repo secret under the same name.
-          CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          # Model credential is inherited from Prepare model env (same env name
+          # as auth.tokenEnv).
           # Search-only credential used for fixed, site-scoped documentation discovery.
           BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
           # Optional: override the model for every agent.

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -103,6 +103,19 @@ jobs:
           ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN' }}
         run: ./scripts/expo-code-review ecr verify-config
 
+      # ecr ci inherits CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN from GITHUB_ENV —
+      # do not re-bind it from secrets.* or this step is overwritten.
+      - name: Prepare model env
+        uses: ./.github/actions/prepare-model-env
+        with:
+          c1: ${{ secrets.ECR_1 }}
+          c2: ${{ secrets.ECR_2 }}
+          c3: ${{ secrets.ECR_3 }}
+          c4: ${{ secrets.ECR_4 }}
+          c5: ${{ secrets.ECR_5 }}
+          fallback: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          model: ${{ vars.REVIEWER_MODEL || 'claude-sonnet-5' }}
+
       - name: Run AI review
         # The launcher selects the SAME checked-in package version the guard cleared.
         run: ./scripts/expo-code-review ecr ci
@@ -114,9 +127,8 @@ jobs:
           # this — it catches what the guard step above can't. Keep it in sync
           # with the guard.
           ECR_EXPECTED_TOKEN_ENV: ${{ vars.ECR_EXPECTED_TOKEN_ENV || 'CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN' }}
-          # Model credential — the env var named by auth.tokenEnv in config.jsonc.
-          # Store each as a repo secret under the same name.
-          CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
+          # Model credential is inherited from Prepare model env (same env name
+          # as auth.tokenEnv).
           # Search-only credential used for fixed, site-scoped documentation discovery.
           BRAVE_SEARCH_API_KEY: ${{ secrets.BRAVE_SEARCH_API_KEY }}
           # Optional: override the model for every agent.


### PR DESCRIPTION
## Why

Review and `/verify` / `@expo-bot` jobs all share one model credential today. This prepares that env once per job so extra `ECR_1`…`ECR_5` secrets can take load without a workflow edit.

## What

- New composite action `.github/actions/prepare-model-env`
- Wired into `agent-commands.yml`, `expo-code-review.yml`, and `expo-code-review-command.yml`
- Empty `ECR_*` secrets are ignored
- Existing `CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN` stays in the pool (and is the only credential until any `ECR_*` is set)
- Winner is sticky for the job so `--resume` stays on the same account

## After merge

Create `ECR_1` (then `ECR_2`, …) as repo secrets when you want more capacity. No further YAML change.