### PR TITLE
[github] Add @expo-bot aliases for review, dismiss, verify, and help

### DIFF
--- a/.github/expo-bot.md
+++ b/.github/expo-bot.md
@@ -1,0 +1,35 @@
+# expo-bot
+
+These commands run on the [expo/expo](https://github.com/expo/expo) repository — Expo’s open-source SDK, apps, and docs. Mention `@expo-bot` on an [issue](https://github.com/expo/expo/issues) or [pull request](https://github.com/expo/expo/pulls) there, or use the slash form. They do nothing on other repos. Only people with write access on expo/expo (OWNER / MEMBER / COLLABORATOR) can trigger them.
+
+Comment `@expo-bot help` on an expo/expo thread for a short list. That command also publishes this file to the [expo-bot profile](https://github.com/expo-bot) when the copy there is behind.
+
+## Commands
+
+| Mention | Slash | Where | What it does |
+| --- | --- | --- | --- |
+| `@expo-bot help` | — | issue or PR | Post a short command list and a link here |
+| `@expo-bot verify` | `/verify` | issue or PR | Investigate and post attested findings |
+| `@expo-bot verify --fix` | `/verify --fix` | PR (on an issue, fix is already the default) | Also attempt a fix pull request |
+| `@expo-bot verify --no-fix` | `/verify --no-fix` | issue or PR | Report only; never open a PR |
+| `@expo-bot review` | `/review`, `/expo-review` | PR | One-shot AI review; router picks agents |
+| `@expo-bot review all` | `/review all` | PR | Review with every agent |
+| `@expo-bot review <agents>` | `/review <agents>` | PR | Review with a named subset (`correctness security`, …) |
+| `@expo-bot dismiss <id>…` | `/dismiss <id>…` | PR | Hide reviewer finding(s); optional `-- reason` |
+| `@expo-bot undismiss <id>…` | `/undismiss <id>…` | PR | Restore finding(s) |
+| `@expo-bot <task>` | — | open PR **authored by expo-bot** | Carry out that follow-up and push to the same PR |
+
+A bare `@expo-bot` is the same as `@expo-bot help`.
+
+Incidental mentions in the middle of a comment do nothing. The command has to start the comment.
+
+## Notes
+
+- **Review / dismiss / work** are pull-request only.
+- **Verify and help** also run on issues. On an issue, `/verify` will open a fix PR when it can; on a pull request it reports only unless you pass `--fix`.
+- **Work mode** (`@expo-bot <task>`) only updates PRs expo-bot itself opened. It will not push to a contributor branch.
+- Reserved verbs (`help`, `verify`, `review`, `dismiss`, `undismiss`) are never treated as a work-mode task.
+
+## Continuous review
+
+Label a same-repo PR `ai-review` to run the reviewer on every push. That label cannot start a review on a fork PR (GitHub withholds secrets). Comment `@expo-bot review` instead.

--- a/.github/scripts/sync-expo-bot-manpage.sh
+++ b/.github/scripts/sync-expo-bot-manpage.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Publish .github/expo-bot.md to the expo-bot profile README (expo-bot/expo-bot)
+# when the copy there is missing or differs. No-op when already current.
+set -euo pipefail
+
+SRC="${SRC:-.github/expo-bot.md}"
+DEST_REPO="${DEST_REPO:-expo-bot/expo-bot}"
+DEST_PATH="${DEST_PATH:-README.md}"
+
+b64encode() {
+  openssl base64 -A
+}
+
+b64decode() {
+  openssl base64 -d -A
+}
+
+if [ "${1:-}" = --self-test ]; then
+  sample=$'hello\nworld\n'
+  [ "$(printf '%s' "$sample" | b64encode | b64decode)" = "$sample" ]
+  echo "sync-expo-bot-manpage self-test ok"
+  exit 0
+fi
+
+if [ ! -f "$SRC" ]; then
+  echo "::error::Manpage source missing: $SRC"
+  exit 1
+fi
+
+login=$(gh api user --jq .login)
+if [ "$login" != "expo-bot" ]; then
+  echo "::error::Manpage sync must run as expo-bot (authenticated as $login)."
+  exit 1
+fi
+
+desired_b64=$(b64encode < "$SRC")
+
+if ! gh api "repos/$DEST_REPO" >/dev/null 2>&1; then
+  echo "Creating $DEST_REPO"
+  gh repo create "$DEST_REPO" --public \
+    --description "Maintainer commands for expo/expo" \
+    --homepage "https://github.com/expo/expo"
+fi
+
+sha=""
+current_tmp=$(mktemp)
+trap 'rm -f "$current_tmp"' EXIT
+if meta=$(gh api "repos/$DEST_REPO/contents/$DEST_PATH" --jq '{sha:.sha,content:.content}' 2>/dev/null); then
+  sha=$(printf '%s' "$meta" | jq -r .sha)
+  printf '%s' "$meta" | jq -r .content | tr -d '\n' | b64decode >"$current_tmp" || true
+fi
+
+if [ -n "$sha" ] && cmp -s "$SRC" "$current_tmp"; then
+  echo "Manpage already current on $DEST_REPO"
+  exit 0
+fi
+
+args=(
+  -X PUT "repos/$DEST_REPO/contents/$DEST_PATH"
+  -f message="Sync manpage from expo/expo"
+  -f content="$desired_b64"
+)
+if [ -n "$sha" ]; then
+  args+=(-f sha="$sha")
+fi
+
+gh api "${args[@]}" --jq .content.html_url
+echo "Updated $DEST_REPO/$DEST_PATH"

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -1,12 +1,17 @@
 # Maintainer-directed agent commands. One workflow owns the security and
 # publishing machinery for both modes:
-#   /verify           investigate the report and post findings with attested evidence.
-#                     On an ISSUE this also opens a pull request when it can verify a
-#                     fix; on a PULL REQUEST it reports only.
-#   /verify --fix     also attempt a fix pull request (needed only on a pull request).
-#   /verify --no-fix  report only, never open a pull request.
-#   @expo-bot <task>  on an open PR authored by expo-bot, carry out a concrete
-#                     follow-up task and push the checked commit to that PR.
+#   /verify                  investigate the report and post findings with attested evidence.
+#   @expo-bot verify         same as /verify (mention form).
+#                            On an ISSUE this also opens a pull request when it can verify a
+#                            fix; on a PULL REQUEST it reports only.
+#   /verify --fix            also attempt a fix pull request (needed only on a pull request).
+#   @expo-bot verify --fix   same as /verify --fix.
+#   /verify --no-fix         report only, never open a pull request.
+#   @expo-bot verify --no-fix  same as /verify --no-fix.
+#   @expo-bot <task>         on an open PR authored by expo-bot, carry out a concrete
+#                            follow-up task and push the checked commit to that PR.
+#   Reserved verbs (handled by other workflows, never work mode):
+#     review, dismiss, undismiss, help.
 #
 # The agent is headless Claude Code connected to the expo-sandbox-mcp server
 # (hosted E2B sandboxes, proxied EAS builds, hosted iOS simulators). It
@@ -130,8 +135,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       ((startsWith(github.event.comment.body, '/verify') ||
-      github.event.comment.body == '@expo-bot' ||
-      startsWith(github.event.comment.body, '@expo-bot ')) &&
+      startsWith(github.event.comment.body, '@expo-bot verify') ||
+      (startsWith(github.event.comment.body, '@expo-bot ') &&
+      !startsWith(github.event.comment.body, '@expo-bot review') &&
+      !startsWith(github.event.comment.body, '@expo-bot dismiss') &&
+      !startsWith(github.event.comment.body, '@expo-bot undismiss') &&
+      !startsWith(github.event.comment.body, '@expo-bot help'))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     outputs:
@@ -189,6 +198,9 @@ jobs:
     # not trigger. Deliberate: matching a bare `@expo-bot` prefix would fire
     # on `@expo-bot!` and similar asides, and each false fire ends in a
     # public parse-failure comment.
+    # `@expo-bot verify` is /verify, so it must run on issues as well as PRs.
+    # Other `@expo-bot …` forms stay PR-only (work mode), except reserved
+    # verbs (review, dismiss, undismiss, help) which other workflows own.
     # Excluding expo-bot itself prevents a result comment from forming a loop.
     # The authoritative write-access check is the step below.
     # (Runs are backed by the expo-verification-bot service account.)
@@ -196,9 +208,13 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.comment.user.login != 'expo-bot' &&
       (startsWith(github.event.comment.body, '/verify') ||
+      startsWith(github.event.comment.body, '@expo-bot verify') ||
       (github.event.issue.pull_request != null &&
-      (github.event.comment.body == '@expo-bot' ||
-      startsWith(github.event.comment.body, '@expo-bot ')))) &&
+      startsWith(github.event.comment.body, '@expo-bot ') &&
+      !startsWith(github.event.comment.body, '@expo-bot review') &&
+      !startsWith(github.event.comment.body, '@expo-bot dismiss') &&
+      !startsWith(github.event.comment.body, '@expo-bot undismiss') &&
+      !startsWith(github.event.comment.body, '@expo-bot help'))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # ONE budget, in one place, and the ordering is the point:
@@ -288,9 +304,19 @@ jobs:
           else
             line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
             first=$(printf '%s' "$line" | awk '{print tolower($1)}')
+            second=$(printf '%s' "$line" | awk '{print tolower($2)}')
             case "$first" in
-              @expo-bot) mode=work ;;
               /verify) mode=verify ;;
+              @expo-bot)
+                case "$second" in
+                  verify) mode=verify ;;
+                  review|dismiss|undismiss|help)
+                    echo "This mention is handled by another workflow."
+                    exit 0
+                    ;;
+                  *) mode=work ;;
+                esac
+                ;;
               *)
                 echo "::error::The first token must be /verify or @expo-bot."
                 exit 1

--- a/.github/workflows/expo-bot-help.yml
+++ b/.github/workflows/expo-bot-help.yml
@@ -1,0 +1,61 @@
+name: expo-bot help
+
+# Maintainer comment `@expo-bot help` (or a bare `@expo-bot`) posts a short
+# command list and publishes .github/expo-bot.md to the expo-bot profile
+# README when that copy is behind. No model, no model credential.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  help:
+    if: >-
+      github.event.comment.user.login != 'expo-bot' &&
+      (github.event.comment.body == '@expo-bot' ||
+      github.event.comment.body == '@expo-bot help' ||
+      startsWith(github.event.comment.body, '@expo-bot help')) &&
+      contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Default branch only — the manpage on main is what we publish, never
+      # a PR-head edit of .github/expo-bot.md.
+      - name: Checkout (default branch)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Publish manpage if stale
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+        run: bash .github/scripts/sync-expo-bot-manpage.sh
+
+      - name: Post command list
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          cat > /tmp/expo-bot-help.md <<'MARKDOWN'
+          <!-- expo-bot:help -->
+          **@expo-bot** — maintainer commands on [expo/expo](https://github.com/expo/expo). Full manpage: https://github.com/expo-bot
+
+          | Command | What it does |
+          | --- | --- |
+          | `@expo-bot help` | This list (and refresh the manpage if it is behind) |
+          | `@expo-bot verify` | Investigate an issue or PR (`/verify`) |
+          | `@expo-bot review` | One-shot AI review on a PR (`/review`) |
+          | `@expo-bot dismiss` / `undismiss` | Hide or restore a finding |
+          | `@expo-bot <task>` | Follow-up on an open expo-bot PR |
+
+          Review, dismiss, and work are pull-request only. Verify and help also run on issues.
+          MARKDOWN
+          gh issue comment "$NUMBER" -R "$REPO" --body-file /tmp/expo-bot-help.md

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -2,9 +2,9 @@
 name: AI code review (command)
 
 # On-demand, ONE-SHOT reviewer triggered by a PR comment (maintainers only):
-#   /review (or /expo-review)                       run once; router picks agents
-#   /review all (or /expo-review all)               run once with every agent
-#   /review correctness security (either command)  run with just those agents
+#   /review (or /expo-review, or @expo-bot review)  run once; router picks agents
+#   /review all (or /expo-review all, or @expo-bot review all)
+#   /review correctness security (either command, or @expo-bot review …)
 # This never changes configuration. CONTINUOUS review is configured in
 # expo-code-review.yml (the `pull_request` workflow) via the `review.trigger`
 # policy in .expo-code-review/config.jsonc and the `ai-review:skip` label.
@@ -25,11 +25,14 @@ concurrency:
 
 jobs:
   command:
-    # Only PR comments starting with /review or /expo-review, from a maintainer.
+    # Only PR comments starting with /review, /expo-review, or @expo-bot review.
     # @ref LLP 0009#workflow-security-posture [implements] — gate controls who triggers, not what code runs
     if: >-
       github.event.issue.pull_request != null &&
-      (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/expo-review')) &&
+      github.event.comment.user.login != 'expo-bot' &&
+      (startsWith(github.event.comment.body, '/review') ||
+      startsWith(github.event.comment.body, '/expo-review') ||
+      startsWith(github.event.comment.body, '@expo-bot review')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     # Bound the run so a slow/stalled review fails fast rather than hanging. Keep it
@@ -47,14 +50,21 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         run: |
           line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
-          verb=$(printf '%s' "$line" | awk '{print $1}')
-          rest=$(printf '%s' "$line" | cut -s -d' ' -f2-)
-          # Only /review or /expo-review (one-shot). Continuous review is
-          # policy/label-driven; neither command changes configuration.
-          case "$verb" in
-            /review|/expo-review) ;;
-            *) echo "run=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
-          esac
+          first=$(printf '%s' "$line" | awk '{print tolower($1)}')
+          second=$(printf '%s' "$line" | awk '{print tolower($2)}')
+          # /review, /expo-review, or @expo-bot review (one-shot). Continuous
+          # review is policy/label-driven; none of these change configuration.
+          if [ "$first" = "@expo-bot" ]; then
+            if [ "$second" != "review" ]; then
+              echo "run=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            rest=$(printf '%s' "$line" | awk '{for (i=3;i<=NF;i++) printf "%s%s", $i, (i<NF?" ":"")}')
+          else
+            case "$first" in
+              /review|/expo-review) rest=$(printf '%s' "$line" | cut -s -d' ' -f2-) ;;
+              *) echo "run=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+            esac
+          fi
           # A bare command -> router picks; "all" -> every agent; names -> subset.
           # Sanitize agent ids to [a-zA-Z0-9,_-] to keep the value shell-safe.
           agents=""

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -3,8 +3,9 @@ name: AI code review (dismiss)
 
 # Maintainer PR-comment command to hide/restore a reviewer finding on this PR:
 #   /dismiss <id> [<id> …] [-- reason]   hide finding(s); they move to a collapsed
-#                                        "Dismissed" section and stay there on re-review
+#   @expo-bot dismiss <id> …             "Dismissed" section and stay there on re-review
 #   /undismiss <id> [<id> …]             restore finding(s)
+#   @expo-bot undismiss <id> …
 # <id> is the short `id:` shown on each finding in the reviewer comment. This only
 # edits the reviewer's comment (no review run, no model secret).
 
@@ -23,10 +24,14 @@ concurrency:
 
 jobs:
   dismiss:
-    # PR comments starting with /dismiss or /undismiss, from a maintainer only.
+    # PR comments starting with /dismiss, /undismiss, or the @expo-bot forms.
     if: >-
       github.event.issue.pull_request != null &&
-      (startsWith(github.event.comment.body, '/dismiss') || startsWith(github.event.comment.body, '/undismiss')) &&
+      github.event.comment.user.login != 'expo-bot' &&
+      (startsWith(github.event.comment.body, '/dismiss') ||
+      startsWith(github.event.comment.body, '/undismiss') ||
+      startsWith(github.event.comment.body, '@expo-bot dismiss') ||
+      startsWith(github.event.comment.body, '@expo-bot undismiss')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     # @ref LLP 0009#guard-step-ordering-and-job-budgets [constrained-by] — no review budget to cover; capped low regardless
@@ -41,13 +46,23 @@ jobs:
           COMMENT: ${{ github.event.comment.body }}
         run: |
           line=$(printf '%s' "$COMMENT" | head -n1 | tr -d '\r')
-          verb=$(printf '%s' "$line" | awk '{print $1}')
-          case "$verb" in
-            /dismiss) sub=dismiss ;;
-            /undismiss) sub=undismiss ;;
-            *) echo "run=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
-          esac
-          rest=$(printf '%s' "$line" | cut -s -d' ' -f2-)
+          first=$(printf '%s' "$line" | awk '{print tolower($1)}')
+          second=$(printf '%s' "$line" | awk '{print tolower($2)}')
+          if [ "$first" = "@expo-bot" ]; then
+            case "$second" in
+              dismiss) sub=dismiss ;;
+              undismiss) sub=undismiss ;;
+              *) echo "run=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+            esac
+            rest=$(printf '%s' "$line" | awk '{for (i=3;i<=NF;i++) printf "%s%s", $i, (i<NF?" ":"")}')
+          else
+            case "$first" in
+              /dismiss) sub=dismiss ;;
+              /undismiss) sub=undismiss ;;
+              *) echo "run=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+            esac
+            rest=$(printf '%s' "$line" | cut -s -d' ' -f2-)
+          fi
           # Optional reason after ' -- '.
           reason=""
           ids_part="$rest"

--- a/.github/workflows/expo-code-review-fork-hint.yml
+++ b/.github/workflows/expo-code-review-fork-hint.yml
@@ -59,7 +59,7 @@ jobs:
 
           With the exception of a read-only `GITHUB_TOKEN`, [GitHub does not pass secrets to a workflow triggered from a forked repository](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull-request-events-for-forked-repositories), so the reviewer cannot reach its model credential there. This is a platform rule, not a setting we can change.
 
-          **A maintainer can comment `/review` or `/expo-review` on this PR instead.** That path runs in the base repository's context, so it has the credential and works normally.
+          **A maintainer can comment `/review`, `/expo-review`, or `@expo-bot review` on this PR instead.** That path runs in the base repository's context, so it has the credential and works normally.
 
           Running it does not execute anything from the pull request: the branch is never checked out, and no dependency install, build, or script from it runs. The reviewer reads the diff and the changed files. Treat the result as advisory — a pull request's own code and description are part of what the reviewer reads, so a review that finds nothing is not evidence that the change is safe to merge.
           MARKDOWN

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -31,7 +31,7 @@ jobs:
     # read-only, so this job cannot reach the model credential AND cannot post a comment —
     # not even to explain itself. Without this guard, labeling an external PR produced a
     # failed run and total silence. `expo-code-review-fork-hint.yml` now posts the
-    # review-command pointer for that case, and the `/review` or `/expo-review`
+    # review-command pointer for that case, and the `/review`, `/expo-review`, or `@expo-bot review`
     # command path (issue_comment) is what actually reviews a fork PR: it runs in
     # base-repo context with full secrets.
     # @ref LLP 0009#guard-step-ordering-and-job-budgets [explains] — spin-up avoidance only; real policy is config.jsonc review.trigger


### PR DESCRIPTION
## Why

Maintainers who prefer tagging the bot should get the same commands as the slash forms. `@expo-bot review` must not fall through into work mode.

## What

- `@expo-bot review` / `review all` / `review <agents>` → `/review`
- `@expo-bot dismiss` / `undismiss` → `/dismiss` / `/undismiss`
- `@expo-bot verify` / `--fix` / `--no-fix` → `/verify` (this alias was never on main)
- `@expo-bot help` or a bare `@expo-bot` → short command list
- Reserved verbs are excluded from agent-commands work mode
- Help publishes `.github/expo-bot.md` to the expo-bot profile README when that copy is behind

Slash commands are unchanged.