### PR TITLE
[github] Note that @expo-bot verify may open a fix PR on issues

### DIFF
--- a/.github/expo-bot.md
+++ b/.github/expo-bot.md
@@ -9,7 +9,7 @@ Comment `@expo-bot help` on an expo/expo thread for a short list. That command a
 | Mention | Slash | Where | What it does |
 | --- | --- | --- | --- |
 | `@expo-bot help` | — | issue or PR | Post a short command list and a link here |
-| `@expo-bot verify` | `/verify` | issue or PR | Investigate and post attested findings |
+| `@expo-bot verify` | `/verify` | issue or PR | Investigate and post attested findings. On an issue, also opens a fix PR when it can. On a PR, report only unless `--fix`. |
 | `@expo-bot verify --fix` | `/verify --fix` | PR (on an issue, fix is already the default) | Also attempt a fix pull request |
 | `@expo-bot verify --no-fix` | `/verify --no-fix` | issue or PR | Report only; never open a PR |
 | `@expo-bot review` | `/review`, `/expo-review` | PR | One-shot AI review; router picks agents |

--- a/.github/workflows/expo-bot-help.yml
+++ b/.github/workflows/expo-bot-help.yml
@@ -60,7 +60,7 @@ jobs:
           | Command | What it does |
           | --- | --- |
           | `@expo-bot help` | This list (and refresh the manpage if it is behind) |
-          | `@expo-bot verify` | Investigate an issue or PR (`/verify`) |
+          | `@expo-bot verify` | Investigate; on an issue may also open a fix PR (`/verify`) |
           | `@expo-bot review` | One-shot AI review on a PR (`/review`) |
           | `@expo-bot dismiss` / `undismiss` | Hide or restore a finding |
           | `@expo-bot <task>` | Follow-up on an open expo-bot PR |


### PR DESCRIPTION
Help and the manpage said verify only investigates. On an issue it also opens a fix PR when it can; on a PR it reports only unless `--fix`.