### PR TITLE
[github] Use the real model-env token in the probe loop

### DIFF
--- a/.github/actions/prepare-model-env/pick.sh
+++ b/.github/actions/prepare-model-env/pick.sh
@@ -17,6 +17,31 @@ classify_failure() {
   fi
 }
 
+token_shape() {
+  case "$1" in
+    sk-ant-oat*) echo oat ;;
+    sk-ant-api*) echo api ;;
+    *) echo other ;;
+  esac
+}
+
+# GitHub's secret editor is write-only; a paste that includes the assignment
+# or wrapping quotes is a common 401. Strip one layer. Never log the value.
+normalize_token() {
+  local v="$1"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  case "$v" in
+    \"*\"|\'*\') v="${v:1:${#v}-2}" ;;
+  esac
+  v="${v#CLAUDE_CODE_OAUTH_TOKEN=}"
+  v="${v#ANTHROPIC_API_KEY=}"
+  v="${v#ANTHROPIC_AUTH_TOKEN=}"
+  v="${v#"${v%%[![:space:]]*}"}"
+  v="${v%"${v##*[![:space:]]}"}"
+  printf '%s' "$v"
+}
+
 if [ "${1:-}" = --self-test ]; then
   tmp=$(mktemp)
   printf '%s\n' 'HTTP 429 rate_limit_error: rate limit exceeded' >"$tmp"
@@ -30,6 +55,12 @@ if [ "${1:-}" = --self-test ]; then
   printf '%s\n' 'ECONNRESET connection reset by peer' >"$tmp"
   [ "$(classify_failure "$tmp")" = other ]
   rm -f "$tmp"
+  [ "$(token_shape "sk-ant-oat01-aaaa")" = oat ]
+  [ "$(token_shape "sk-ant-api03-aaaa")" = api ]
+  [ "$(token_shape "not-a-token")" = other ]
+  [ "$(normalize_token "  sk-ant-oat01-x  ")" = "sk-ant-oat01-x" ]
+  [ "$(normalize_token "'sk-ant-oat01-x'")" = "sk-ant-oat01-x" ]
+  [ "$(normalize_token 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-x')" = "sk-ant-oat01-x" ]
   echo "prepare-model-env self-test ok"
   exit 0
 fi
@@ -72,7 +103,7 @@ SLOT_TOKENS=()
 
 for i in $(seq 1 5); do
   var="C$i"
-  val="$(trim "${!var:-}")"
+  val="$(normalize_token "${!var:-}")"
   if [ -n "$val" ]; then
     mask_token "$val"
     SLOT_INDEXES+=("$i")
@@ -80,7 +111,7 @@ for i in $(seq 1 5); do
   fi
 done
 
-val="$(trim "${C_FALLBACK:-}")"
+val="$(normalize_token "${C_FALLBACK:-}")"
 if [ -n "$val" ]; then
   already=false
   for existing in "${SLOT_TOKENS[@]+"${SLOT_TOKENS[@]}"}"; do
@@ -108,31 +139,45 @@ winner=""
 winner_slot=""
 log_dir="${RUNNER_TEMP:-/tmp}"
 log=""
+# Fresh config so a runner-image login cannot mask a bad secret, and so CI
+# matches a laptop canary that set CLAUDE_CONFIG_DIR.
+probe_cfg=$(mktemp -d)
+trap 'rm -rf "$probe_cfg"' EXIT
 
-for offset in $(seq 0 $((count - 1))); do
-  idx=$(((start + offset) % count))
-  slot="${SLOT_INDEXES[$idx]}"
-  token="FAKESECRET_k1l2m3n4o5p6q7r8s9t0"
-  log="$log_dir/model-env-$slot.log"
-
-  export CLAUDE_CODE_OAUTH_TOKEN="$token"
-
+probe_with_env() {
+  local env_name="$1"
+  local token="$2"
+  local out="$3"
+  unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_OAUTH_TOKEN
+  export CLAUDE_CONFIG_DIR="$probe_cfg"
+  export "$env_name=$token"
   set +e
   if command -v timeout >/dev/null 2>&1; then
     timeout 90 claude -p "Reply with the single word ok. Say nothing else." \
       --model "$model" \
       --disallowedTools Bash \
-      >"$log" 2>&1
+      >"$out" 2>&1
   else
     claude -p "Reply with the single word ok. Say nothing else." \
       --model "$model" \
       --disallowedTools Bash \
-      >"$log" 2>&1
+      >"$out" 2>&1
   fi
-  rc=$?
+  local rc=$?
   set -e
+  return "$rc"
+}
 
-  if [ "$rc" -eq 0 ]; then
+for offset in $(seq 0 $((count - 1))); do
+  idx=$(((start + offset) % count))
+  slot="${SLOT_INDEXES[$idx]}"
+  token="${SLOT_TOKENS[$idx]}"
+  log="$log_dir/model-env-$slot.log"
+  echo "credential $slot: shape=$(token_shape "$token") len=${#token}"
+
+  if probe_with_env CLAUDE_CODE_OAUTH_TOKEN "$token" "$log" \
+    || probe_with_env ANTHROPIC_AUTH_TOKEN "$token" "$log" \
+    || probe_with_env ANTHROPIC_API_KEY "$token" "$log"; then
     winner="$token"
     winner_slot="$slot"
     break
@@ -141,7 +186,7 @@ for offset in $(seq 0 $((count - 1))); do
   if [ "$offset" -lt $((count - 1)) ]; then
     next_idx=$(((start + offset + 1) % count))
     next_slot="${SLOT_INDEXES[$next_idx]}"
-    echo "credential $slot failed, trying $next_slot"
+    echo "credential $slot failed ($(classify_failure "$log")), trying $next_slot"
   fi
 done
 

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -120,7 +120,7 @@ jobs:
       # engine). Pinned exactly — see workflow.yml (expo-code-review.yml).
       - name: Install Claude Code CLI
         if: steps.cmd.outputs.run == 'true'
-        run: npm install -g @anthropic-ai/claude-code@2.1.212
+        run: npm install -g @anthropic-ai/claude-code@2.1.229
 
       # SECURITY: the base-ref checkout above includes every .expo-code-review/
       # config.jsonc + routing.jsonc, whose auth.tokenEnv names the env var the CLI
@@ -143,6 +143,7 @@ jobs:
       # ecr ci inherits CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN from GITHUB_ENV —
       # do not re-bind it from secrets.* or this step is overwritten.
       - name: Prepare model env
+        id: model-env
         if: steps.cmd.outputs.run == 'true'
         uses: ./.github/actions/prepare-model-env
         with:
@@ -153,6 +154,17 @@ jobs:
           c5: ${{ secrets.ECR_5 }}
           fallback: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
           model: ${{ vars.REVIEWER_MODEL || 'claude-sonnet-5' }}
+
+      # pick.sh used to fail the job before `ecr ci` could post its terminal
+      # "not reviewed" comment. Restore that notice here.
+      - name: Explain that the review did not start
+        if: always() && steps.cmd.outputs.run == 'true' && steps.model-env.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. This is not a fork limitation — the command path has secrets. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret) and re-set any slot that is not a \`claude setup-token\` value (\`sk-ant-oat…\`, 108 chars)."
 
       - name: Run AI review
         if: steps.cmd.outputs.run == 'true'

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -79,7 +79,7 @@ jobs:
       # would silently drift on every CI run; bump it deliberately. Remove this
       # step if you switch every model to an OpenCode-served provider.
       - name: Install Claude Code CLI
-        run: npm install -g @anthropic-ai/claude-code@2.1.212
+        run: npm install -g @anthropic-ai/claude-code@2.1.229
 
       # SECURITY: the TRUSTED BASE checkout above includes every
       # .expo-code-review/config.jsonc + routing.jsonc, whose auth.tokenEnv names the
@@ -106,6 +106,7 @@ jobs:
       # ecr ci inherits CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN from GITHUB_ENV —
       # do not re-bind it from secrets.* or this step is overwritten.
       - name: Prepare model env
+        id: model-env
         uses: ./.github/actions/prepare-model-env
         with:
           c1: ${{ secrets.ECR_1 }}
@@ -115,6 +116,15 @@ jobs:
           c5: ${{ secrets.ECR_5 }}
           fallback: ${{ secrets.CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN }}
           model: ${{ vars.REVIEWER_MODEL || 'claude-sonnet-5' }}
+
+      - name: Explain that the review did not start
+        if: always() && steps.model-env.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. Check the [run log]($RUN_URL) for each slot's shape/len and re-set any slot that is not a \`claude setup-token\` value (\`sk-ant-oat…\`, 108 chars)."
 
       - name: Run AI review
         # The launcher selects the SAME checked-in package version the guard cleared.


### PR DESCRIPTION
## Why

Every AI review / `@expo-bot review` job since #48848 fails in **Prepare model env** with `401 Invalid bearer token` on every slot, then skips `ecr ci` so the PR gets silence (eyes reaction only).

The picker writes credentials into `SLOT_TOKENS` and never reads them. The probe loop assigned a hardcoded placeholder string instead of `${SLOT_TOKENS[$idx]}`, so `claude` always authenticated with a fake bearer.

Seen on https://github.com/expo/expo/actions/runs/31658276453/job/94317432451 (and the auto-review job on the same PR).

## What

- Probe `${SLOT_TOKENS[$idx]}`.
- Log each slot's shape/len only (`oat` / `api` / `other`) so a real 401 is diagnosable.
- Strip wrapping quotes / `CLAUDE_CODE_OAUTH_TOKEN=` from a mangled secret paste.
- If every slot still fails, comment on the PR instead of going silent.
- Pin the review workflows' Claude CLI to 2.1.229 (the version that accepted a known-good `sk-ant-oat` canary).

`pick.sh --self-test` passes.

## Test plan

- [ ] Merge, then re-run `@expo-bot review` on a labeled PR (e.g. #48852).
- [ ] Prepare model env should log `credential N: shape=oat len=108` (or whatever is actually stored) and either start the review or post the new failure comment.