### PR TITLE
[github] Harden agent command workflows

### DIFF
--- a/.github/actions/prepare-model-env/pick.sh
+++ b/.github/actions/prepare-model-env/pick.sh
@@ -195,15 +195,26 @@ for offset in $(seq 0 $((count - 1))); do
     fi
   done
 
+  # Classify on EVERY slot, not only the ones that have a successor: the last
+  # slot's verdict is the one a caller reports.
+  reason=$(classify_failure "$log")
+
   if [ "$offset" -lt $((count - 1)) ]; then
     next_idx=$(((start + offset + 1) % count))
     next_slot="${SLOT_INDEXES[$next_idx]}"
-    echo "credential $slot failed ($(classify_failure "$log")), trying $next_slot"
+    echo "credential $slot failed ($reason), trying $next_slot"
   fi
 done
 
 if [ -z "$winner" ]; then
-  echo "::error::Model credential unavailable."
+  # A FILE, not a step output. This step is failing, so a caller must not have
+  # to rely on outputs propagating out of a failed composite action. The file's
+  # ABSENCE is itself the useful signal: it means no probe ever ran, so the
+  # failure is not about the credentials at all — a missing local action, a bad
+  # input, a runner fault. Callers that blame the secrets unconditionally send
+  # maintainers off to rotate five working tokens.
+  printf '%s\n' "${reason:-other}" >"$log_dir/model-env-reason" || true
+  echo "::error::Model credential unavailable (${reason:-other})."
   if [ -n "$log" ] && [ -f "$log" ]; then
     sed -n '1,40p' "$log" || true
   fi

--- a/.github/actions/prepare-model-env/pick.sh
+++ b/.github/actions/prepare-model-env/pick.sh
@@ -25,6 +25,14 @@ token_shape() {
   esac
 }
 
+probe_order() {
+  case "$(token_shape "$1")" in
+    oat) echo "CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY" ;;
+    api) echo "ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_OAUTH_TOKEN" ;;
+    *) echo "CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY" ;;
+  esac
+}
+
 # GitHub's secret editor is write-only; a paste that includes the assignment
 # or wrapping quotes is a common 401. Strip one layer. Never log the value.
 normalize_token() {
@@ -58,6 +66,8 @@ if [ "${1:-}" = --self-test ]; then
   [ "$(token_shape "sk-ant-oat01-aaaa")" = oat ]
   [ "$(token_shape "sk-ant-api03-aaaa")" = api ]
   [ "$(token_shape "not-a-token")" = other ]
+  [ "$(probe_order "sk-ant-oat01-aaaa")" = "CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY" ]
+  [ "$(probe_order "sk-ant-api03-aaaa")" = "ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN CLAUDE_CODE_OAUTH_TOKEN" ]
   [ "$(normalize_token "  sk-ant-oat01-x  ")" = "sk-ant-oat01-x" ]
   [ "$(normalize_token "'sk-ant-oat01-x'")" = "sk-ant-oat01-x" ]
   [ "$(normalize_token 'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-x')" = "sk-ant-oat01-x" ]
@@ -137,6 +147,7 @@ start=$((run_id % count))
 
 winner=""
 winner_slot=""
+winner_env=""
 log_dir="${RUNNER_TEMP:-/tmp}"
 log=""
 # Fresh config so a runner-image login cannot mask a bad secret, and so CI
@@ -175,13 +186,14 @@ for offset in $(seq 0 $((count - 1))); do
   log="$log_dir/model-env-$slot.log"
   echo "credential $slot: shape=$(token_shape "$token") len=${#token}"
 
-  if probe_with_env CLAUDE_CODE_OAUTH_TOKEN "$token" "$log" \
-    || probe_with_env ANTHROPIC_AUTH_TOKEN "$token" "$log" \
-    || probe_with_env ANTHROPIC_API_KEY "$token" "$log"; then
-    winner="$token"
-    winner_slot="$slot"
-    break
-  fi
+  for env_name in $(probe_order "$token"); do
+    if probe_with_env "$env_name" "$token" "$log"; then
+      winner="$token"
+      winner_slot="$slot"
+      winner_env="$env_name"
+      break 2
+    fi
+  done
 
   if [ "$offset" -lt $((count - 1)) ]; then
     next_idx=$(((start + offset + 1) % count))
@@ -204,7 +216,7 @@ if [ -z "${GITHUB_ENV:-}" ]; then
 fi
 
 {
-  echo "CLAUDE_CODE_OAUTH_TOKEN=$winner"
+  echo "$winner_env=$winner"
   echo "CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN=$winner"
 } >>"$GITHUB_ENV"
 

--- a/.github/scripts/cleanup-agent-sandboxes.sh
+++ b/.github/scripts/cleanup-agent-sandboxes.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Destroy every sandbox created under one scoped expo-sandbox-mcp token.
+set -euo pipefail
+
+extract_session_ids() {
+  jq -r '.result.content[]? | select(.type == "text") | .text' |
+    while IFS= read -r line; do
+      case "$line" in
+        *" — "*) printf '%s\n' "${line%% *}" ;;
+      esac
+    done
+}
+
+if [ "${1:-}" = --self-test ]; then
+  actual=$(printf '%s\n' '{"result":{"content":[{"type":"text","text":"abc123456789 — active; project demo\ndef987654321 — paused; project other"}]}}' | extract_session_ids)
+  expected=$'abc123456789\ndef987654321'
+  [ "$actual" = "$expected" ]
+  [ -z "$(printf '%s\n' '{"result":{"content":[{"type":"text","text":"No sandbox sessions. Use create_sandbox to start one."}]}}' | extract_session_ids)" ]
+  echo "cleanup-agent-sandboxes self-test ok"
+  exit 0
+fi
+
+config=${1:-}
+if [ -z "$config" ] || [ ! -f "$config" ]; then
+  echo "No scoped MCP config exists; no sandbox cleanup is needed."
+  exit 0
+fi
+
+url=$(jq -er '.mcpServers.sandbox.url' "$config")
+authorization=$(jq -er '.mcpServers.sandbox.headers.Authorization' "$config")
+response=$(mktemp)
+sessions=$(mktemp)
+trap 'rm -f "$response" "$sessions"' EXIT
+
+mcp_call() {
+  local id=$1
+  local name=$2
+  local arguments=$3
+  jq -cn --argjson id "$id" --arg name "$name" --argjson arguments "$arguments" \
+    '{jsonrpc:"2.0", id:$id, method:"tools/call", params:{name:$name, arguments:$arguments}}' |
+    curl -fsS --max-time 180 "$url" \
+      -H "Authorization: $authorization" \
+      -H 'Content-Type: application/json' \
+      --data-binary @-
+}
+
+if ! mcp_call 1 list_sandboxes '{}' >"$response"; then
+  echo "::error::Could not list scoped sandbox sessions for cleanup."
+  exit 1
+fi
+if ! jq -e '.error == null and .result.isError != true' "$response" >/dev/null; then
+  echo "::error::The MCP server refused the scoped sandbox list call."
+  jq -r '.error.message // .result.content[]?.text // empty' "$response"
+  exit 1
+fi
+extract_session_ids <"$response" >"$sessions"
+
+if [ ! -s "$sessions" ]; then
+  echo "No leftover scoped sandbox sessions."
+  exit 0
+fi
+
+failed=0
+call_id=1
+while IFS= read -r session_id; do
+  call_id=$((call_id + 1))
+  args=$(jq -cn --arg sessionId "$session_id" '{sessionId:$sessionId}')
+  if mcp_call "$call_id" destroy_sandbox "$args" >"$response" &&
+    jq -e '.error == null and .result.isError != true' "$response" >/dev/null; then
+    echo "Destroyed leftover sandbox session $session_id."
+  else
+    echo "::error::Could not destroy leftover sandbox session $session_id."
+    jq -r '.error.message // .result.content[]?.text // empty' "$response" || true
+    failed=1
+  fi
+done <"$sessions"
+
+exit "$failed"

--- a/.github/scripts/cleanup-agent-sandboxes.sh
+++ b/.github/scripts/cleanup-agent-sandboxes.sh
@@ -38,14 +38,19 @@ mcp_call() {
   local arguments=$3
   jq -cn --argjson id "$id" --arg name "$name" --argjson arguments "$arguments" \
     '{jsonrpc:"2.0", id:$id, method:"tools/call", params:{name:$name, arguments:$arguments}}' |
-    curl -fsS --max-time 180 "$url" \
+    curl -sS --fail-with-body --max-time 45 --connect-timeout 10 \
+      --retry 2 --retry-connrefused "$url" \
       -H "Authorization: $authorization" \
       -H 'Content-Type: application/json' \
       --data-binary @-
 }
 
 if ! mcp_call 1 list_sandboxes '{}' >"$response"; then
+  # --fail-with-body keeps the server's body on an HTTP error, so a 401 from an
+  # expired token, a 429, and a 502 are distinguishable. Plain `curl -f`
+  # discarded it and made all three print this one indistinguishable line.
   echo "::error::Could not list scoped sandbox sessions for cleanup."
+  sed -n '1,10p' "$response" || true
   exit 1
 fi
 if ! jq -e '.error == null and .result.isError != true' "$response" >/dev/null; then

--- a/.github/scripts/cleanup-agent-sandboxes.sh
+++ b/.github/scripts/cleanup-agent-sandboxes.sh
@@ -32,20 +32,25 @@ response=$(mktemp)
 sessions=$(mktemp)
 trap 'rm -f "$response" "$sessions"' EXIT
 
+# Extra curl flags after the three positional args. list_sandboxes is
+# idempotent and short; retry transient faults. destroy_sandbox stops
+# simulators and then e2b.kill — that can exceed 45s, and retrying a
+# timeout races the in-flight first call (usually harmless, always noisy).
 mcp_call() {
   local id=$1
   local name=$2
   local arguments=$3
+  shift 3
   jq -cn --argjson id "$id" --arg name "$name" --argjson arguments "$arguments" \
     '{jsonrpc:"2.0", id:$id, method:"tools/call", params:{name:$name, arguments:$arguments}}' |
-    curl -sS --fail-with-body --max-time 45 --connect-timeout 10 \
-      --retry 2 --retry-connrefused "$url" \
+    curl -sS --fail-with-body --connect-timeout 10 "$@" \
+      "$url" \
       -H "Authorization: $authorization" \
       -H 'Content-Type: application/json' \
       --data-binary @-
 }
 
-if ! mcp_call 1 list_sandboxes '{}' >"$response"; then
+if ! mcp_call 1 list_sandboxes '{}' --max-time 45 --retry 2 --retry-connrefused >"$response"; then
   # --fail-with-body keeps the server's body on an HTTP error, so a 401 from an
   # expired token, a 429, and a 502 are distinguishable. Plain `curl -f`
   # discarded it and made all three print this one indistinguishable line.
@@ -70,7 +75,7 @@ call_id=1
 while IFS= read -r session_id; do
   call_id=$((call_id + 1))
   args=$(jq -cn --arg sessionId "$session_id" '{sessionId:$sessionId}')
-  if mcp_call "$call_id" destroy_sandbox "$args" >"$response" &&
+  if mcp_call "$call_id" destroy_sandbox "$args" --max-time 180 >"$response" &&
     jq -e '.error == null and .result.isError != true' "$response" >/dev/null; then
     echo "Destroyed leftover sandbox session $session_id."
   else

--- a/.github/scripts/sync-expo-bot-manpage.sh
+++ b/.github/scripts/sync-expo-bot-manpage.sh
@@ -16,8 +16,12 @@ b64decode() {
 }
 
 if [ "${1:-}" = --self-test ]; then
-  sample=$'hello\nworld\n'
-  [ "$(printf '%s' "$sample" | b64encode | b64decode)" = "$sample" ]
+  source_file=$(mktemp)
+  decoded_file=$(mktemp)
+  trap 'rm -f "$source_file" "$decoded_file"' EXIT
+  printf 'hello\nworld\n' >"$source_file"
+  b64encode <"$source_file" | b64decode >"$decoded_file"
+  cmp -s "$source_file" "$decoded_file"
   echo "sync-expo-bot-manpage self-test ok"
   exit 0
 fi

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -145,7 +145,8 @@ jobs:
       !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
       github.event.comment.body != '@expo-bot undismiss' &&
       !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
-      github.event.comment.body != '@expo-bot help')) &&
+      github.event.comment.body != '@expo-bot help' &&
+      !startsWith(github.event.comment.body, '@expo-bot help '))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     outputs:
@@ -224,7 +225,8 @@ jobs:
       !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
       github.event.comment.body != '@expo-bot undismiss' &&
       !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
-      github.event.comment.body != '@expo-bot help')) &&
+      github.event.comment.body != '@expo-bot help' &&
+      !startsWith(github.event.comment.body, '@expo-bot help '))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # ONE budget, in one place, and the ordering is the point:
@@ -324,6 +326,18 @@ jobs:
                     echo "This mention is handled by another workflow."
                     exit 0
                     ;;
+                  # A word that merely BEGINS with a reserved verb is prose,
+                  # not a command: "reviewers", "dismissing", "verified",
+                  # "verify-fix", "helpful". Treating it as a work task made
+                  # every such aside either fail loudly in public or, worse,
+                  # fall through to a full verify investigation. Decline
+                  # quietly instead — the maintainer did not ask for anything.
+                  # `verif*`, not `verify*`: "verified" is verif+ied and does
+                  # not start with "verify" at all.
+                  verif*|review*|dismiss*|undismiss*|help*)
+                    echo "'$second' begins with a reserved verb but is not one; treating the comment as prose."
+                    exit 0
+                    ;;
                   *) mode=work ;;
                 esac
                 ;;
@@ -333,6 +347,14 @@ jobs:
                 ;;
             esac
           fi
+          # route=true means "this comment really is a command for THIS
+          # workflow". Every later step gates on it, so any `exit 0` above —
+          # a mention another workflow owns, or prose that merely starts with
+          # a reserved verb — leaves it unset and stops the job dead. Without
+          # it, `exit 0` counted as success and the run continued with an
+          # empty mode, which the prompt selector reads as verify: a comment
+          # asking for help launched a full investigation.
+          echo "route=true" >> "$GITHUB_OUTPUT"
           # Write mode before validating the task so the always-run failure
           # reporter still names an empty @expo-bot request correctly.
           echo "mode=$mode" >> "$GITHUB_OUTPUT"
@@ -396,7 +418,7 @@ jobs:
           echo "mode: $mode; fix mode: $fix (target is $([ "$IS_PR" = true ] && echo 'a pull request' || echo 'an issue'))"
 
       - name: Acknowledge
-        if: steps.gate.outputs.ok == 'true' && env.QUIET != 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && env.QUIET != 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
         run: gh api -X POST "repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions" -f content=eyes
@@ -405,7 +427,7 @@ jobs:
       # progress, so the thread gets that link the moment work begins (the
       # findings comment lands separately when the investigation completes).
       - name: Announce run
-        if: steps.gate.outputs.ok == 'true' && env.QUIET != 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && env.QUIET != 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           MODE: ${{ steps.cmd.outputs.mode }}
@@ -420,7 +442,7 @@ jobs:
       # Base ref only — the prompt file must come from the trusted branch,
       # and no PR-head code may ever run on this runner.
       - name: Checkout (base ref only — never the PR head)
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
@@ -430,7 +452,7 @@ jobs:
       # every prompt and executable renderer before granting that capability;
       # later phases must never read their policy back from mutable files.
       - name: Pin trusted agent policy
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         run: |
           mkdir -p "$RUNNER_TEMP/agent-policy"
           cp .github/verify/prompt.md "$RUNNER_TEMP/agent-policy/prompt.md"
@@ -439,7 +461,7 @@ jobs:
           cp .github/verify/render.jq "$RUNNER_TEMP/agent-policy/render.jq"
 
       - name: Set up Node
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
@@ -447,13 +469,13 @@ jobs:
 
       # Pinned exactly, like the code-review workflows.
       - name: Install Claude Code CLI
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         run: npm install -g @anthropic-ai/claude-code@2.1.212
 
       # Later claude steps inherit CLAUDE_CODE_OAUTH_TOKEN from GITHUB_ENV —
       # do not re-bind it from secrets.* or this step is overwritten.
       - name: Prepare model env
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         uses: ./.github/actions/prepare-model-env
         with:
           c1: ${{ secrets.ECR_1 }}
@@ -471,7 +493,7 @@ jobs:
       # credential anywhere.
       - name: Collect target context
         id: ctx
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           IS_PR: ${{ steps.cmd.outputs.is_pr }}
@@ -603,7 +625,7 @@ jobs:
       # deliberate: job outputs and artifacts are readable by anyone who can
       # read the run, which on a public repository is everyone.)
       - name: Mint scoped token
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         env:
           EXPO_SANDBOX_MCP_TOKEN: ${{ secrets.EXPO_SANDBOX_MCP_TOKEN }}
           MCP_URL: https://agile-minnow-543.convex.site
@@ -644,7 +666,7 @@ jobs:
       # Its own step on purpose: "Run agent command" holds NO GitHub token, and
       # that is a property worth keeping.
       - name: Preflight push credentials
-        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.fix == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && steps.cmd.outputs.fix == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           MODE: ${{ steps.cmd.outputs.mode }}
@@ -690,7 +712,7 @@ jobs:
 
       - name: Run agent command
         id: investigate
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         env:
           # The canonical Claude credential variable selected by Prepare
           # model env is inherited through GITHUB_ENV.
@@ -976,7 +998,7 @@ jobs:
       # what checking a citation actually needs; what it can no longer do is
       # go exploring a very large tree.
       - name: Adversarial review of the draft outcome
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         env:
           ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
           ISSUE_KIND: ${{ steps.cmd.outputs.is_pr == 'true' && 'pull request' || 'issue' }}
@@ -1010,7 +1032,7 @@ jobs:
       # tear the sandbox down — both capabilities are added here and nowhere
       # else.
       - name: Revise and post
-        if: steps.gate.outputs.ok == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         env:
           VERIFY_MODEL: ${{ vars.VERIFY_MODEL || 'claude-opus-5' }}
           # Via env, never inline ${{ }} — the same discipline the comment body
@@ -1058,7 +1080,7 @@ jobs:
       # revision the PR no longer has — say so on the thread rather than
       # leaving a stale conclusion standing unqualified.
       - name: Note if the PR moved under the run
-        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.mode == 'verify' && steps.cmd.outputs.is_pr == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && steps.cmd.outputs.mode == 'verify' && steps.cmd.outputs.is_pr == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           TESTED: ${{ steps.ctx.outputs.head_oid }}
@@ -1084,7 +1106,7 @@ jobs:
       # work. Nothing auto-merges; branch protection and CODEOWNERS still
       # apply, and CI on the PR runs it exactly as it runs any contributor's.
       - name: Publish agent-authored change
-        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.fix == 'true'
+        if: steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && steps.cmd.outputs.fix == 'true'
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}
@@ -1443,14 +1465,6 @@ jobs:
           }
           gh issue comment "$ISSUE_NUMBER" --body "🔧 Opened $url with the $change_name — agent-authored, unreviewed, and queued for AI review. [$run_name]($RUN_URL)"
 
-      # The resumed agent is asked to destroy its sandboxes, but cancellation,
-      # timeout, or a failed model call can prevent that turn from running.
-      # This fixed backstop uses the scoped child token, whose list_sandboxes
-      # view contains only sessions created by this job.
-      - name: Destroy leftover sandboxes
-        if: always() && steps.gate.outputs.ok == 'true'
-        run: bash .github/scripts/cleanup-agent-sandboxes.sh "$RUNNER_TEMP/mcp.json"
-
       # Last line of defence against a total loss. `if: always()` genuinely
       # runs on step failure AND on cancellation — verified on real runs
       # (31505614243 failed, 31463049146 cancelled; the upload succeeded in
@@ -1469,7 +1483,7 @@ jobs:
       # thread". That is a real handoff to a maintainer instead of silence.
       - name: Salvage a partial report if the run died before writing one
         id: salvage
-        if: always() && steps.gate.outputs.ok == 'true'
+        if: always() && steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         run: |
           set -o pipefail
           mkdir -p .verify-out
@@ -1501,7 +1515,7 @@ jobs:
       # Raw engine transcript, kept like the code-review workflows keep
       # their run log — the console rendering above is lossy by design.
       - name: Upload run log
-        if: always() && steps.gate.outputs.ok == 'true'
+        if: always() && steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-command-run-log-${{ env.TARGET_NUMBER }}
@@ -1518,6 +1532,28 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+      # The resumed agent is asked to destroy its sandboxes, but cancellation,
+      # timeout, or a failed model call can prevent that turn from running.
+      # This fixed backstop uses the scoped child token, whose list_sandboxes
+      # view contains only sessions created by this job.
+      #
+      # AFTER the artifact upload, and isolated, both deliberately:
+      #  - Ordering: each MCP call can stall for its full --max-time, and on a
+      #    cancelled job the grace window is finite. Ahead of the upload, a
+      #    slow server could eat the window and lose the transcript — the very
+      #    total loss the salvage step above exists to prevent.
+      #  - continue-on-error: a leftover sandbox is not permanent (the server's
+      #    reaper kills sessions past TTL), so failing to tidy up must not be
+      #    reported as the COMMAND failing. Without this, a transient MCP error
+      #    made failure() true and the reporter below told the thread the work
+      #    was "not complete" and to try again — directly under the outcome
+      #    comment and the PR this run had already opened.
+      - name: Destroy leftover sandboxes
+        if: always() && steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true'
+        continue-on-error: true
+        timeout-minutes: 3
+        run: bash .github/scripts/cleanup-agent-sandboxes.sh "$RUNNER_TEMP/mcp.json"
+
       # The announce comment promises "findings will be posted here when it
       # completes". Every path that breaks that promise ends here.
       #
@@ -1528,7 +1564,7 @@ jobs:
       # with no result. The job also runs continue-on-error, so nothing else
       # signals it either.
       - name: Report a run that did not finish
-        if: always() && steps.gate.outputs.ok == 'true' && env.QUIET != 'true' && (failure() || cancelled())
+        if: always() && steps.gate.outputs.ok == 'true' && steps.cmd.outputs.route == 'true' && env.QUIET != 'true' && (failure() || cancelled())
         env:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ env.TARGET_NUMBER }}

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -145,8 +145,8 @@ jobs:
       !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
       github.event.comment.body != '@expo-bot undismiss' &&
       !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
-      github.event.comment.body != '@expo-bot help' &&
-      !startsWith(github.event.comment.body, '@expo-bot help '))) &&
+      !startsWith(github.event.comment.body, '@expo-bot help') &&
+      !startsWith(github.event.comment.body, '@expo-bot  help'))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     outputs:
@@ -207,6 +207,8 @@ jobs:
     # `@expo-bot verify` is /verify, so it must run on issues as well as PRs.
     # Other `@expo-bot …` forms stay PR-only (work mode), except reserved
     # verbs (review, dismiss, undismiss, help) which other workflows own.
+    # Help is excluded as a prefix (`@expo-bot help…`, plus the two-space
+    # typo) so a newline after `help` cannot start this job.
     # Excluding expo-bot itself prevents a result comment from forming a loop.
     # The authoritative write-access check is the step below.
     # (Runs are backed by the expo-verification-bot service account.)
@@ -225,8 +227,8 @@ jobs:
       !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
       github.event.comment.body != '@expo-bot undismiss' &&
       !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
-      github.event.comment.body != '@expo-bot help' &&
-      !startsWith(github.event.comment.body, '@expo-bot help '))) &&
+      !startsWith(github.event.comment.body, '@expo-bot help') &&
+      !startsWith(github.event.comment.body, '@expo-bot  help'))) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # ONE budget, in one place, and the ordering is the point:
@@ -326,16 +328,16 @@ jobs:
                     echo "This mention is handled by another workflow."
                     exit 0
                     ;;
-                  # A word that merely BEGINS with a reserved verb is prose,
-                  # not a command: "reviewers", "dismissing", "verified",
-                  # "verify-fix", "helpful". Treating it as a work task made
-                  # every such aside either fail loudly in public or, worse,
-                  # fall through to a full verify investigation. Decline
-                  # quietly instead — the maintainer did not ask for anything.
-                  # `verif*`, not `verify*`: "verified" is verif+ied and does
-                  # not start with "verify" at all.
-                  verif*|review*|dismiss*|undismiss*|help*)
-                    echo "'$second' begins with a reserved verb but is not one; treating the comment as prose."
+                  # Named inflections of reserved verbs, not an open prefix.
+                  # `review-feedback` and `help-text` are real work tasks;
+                  # `verif*|review*` also swallowed them. `verified` is
+                  # verif+ied (it does not start with `verify`). `verify-*`
+                  # is a mangled verify (`verify-fix`), not work. `help*`
+                  # covers `@expo-bot  helpful` (double space), which the
+                  # job `if:` cannot exclude — `startsWith('@expo-bot help')`
+                  # is false there, and help.yml may not have started.
+                  reviewers|reviewing|reviewed|dismissing|dismissed|dismissal|dismissals|verified|verifying|helpful|helping|helper|helpers|undismissed|undismissing|verify-*|help*)
+                    echo "'$second' is a reserved-verb inflection, not a command; treating the comment as prose."
                     exit 0
                     ;;
                   *) mode=work ;;

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -134,13 +134,18 @@ jobs:
     name: Assign queue slot
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      ((startsWith(github.event.comment.body, '/verify') ||
-      startsWith(github.event.comment.body, '@expo-bot verify') ||
+      ((github.event.comment.body == '/verify' ||
+      startsWith(github.event.comment.body, '/verify ') ||
+      github.event.comment.body == '@expo-bot verify' ||
+      startsWith(github.event.comment.body, '@expo-bot verify ') ||
       (startsWith(github.event.comment.body, '@expo-bot ') &&
-      !startsWith(github.event.comment.body, '@expo-bot review') &&
-      !startsWith(github.event.comment.body, '@expo-bot dismiss') &&
-      !startsWith(github.event.comment.body, '@expo-bot undismiss') &&
-      !startsWith(github.event.comment.body, '@expo-bot help'))) &&
+      github.event.comment.body != '@expo-bot review' &&
+      !startsWith(github.event.comment.body, '@expo-bot review ') &&
+      github.event.comment.body != '@expo-bot dismiss' &&
+      !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
+      github.event.comment.body != '@expo-bot undismiss' &&
+      !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
+      github.event.comment.body != '@expo-bot help')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     outputs:
@@ -207,14 +212,19 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.comment.user.login != 'expo-bot' &&
-      (startsWith(github.event.comment.body, '/verify') ||
-      startsWith(github.event.comment.body, '@expo-bot verify') ||
+      (github.event.comment.body == '/verify' ||
+      startsWith(github.event.comment.body, '/verify ') ||
+      github.event.comment.body == '@expo-bot verify' ||
+      startsWith(github.event.comment.body, '@expo-bot verify ') ||
       (github.event.issue.pull_request != null &&
       startsWith(github.event.comment.body, '@expo-bot ') &&
-      !startsWith(github.event.comment.body, '@expo-bot review') &&
-      !startsWith(github.event.comment.body, '@expo-bot dismiss') &&
-      !startsWith(github.event.comment.body, '@expo-bot undismiss') &&
-      !startsWith(github.event.comment.body, '@expo-bot help'))) &&
+      github.event.comment.body != '@expo-bot review' &&
+      !startsWith(github.event.comment.body, '@expo-bot review ') &&
+      github.event.comment.body != '@expo-bot dismiss' &&
+      !startsWith(github.event.comment.body, '@expo-bot dismiss ') &&
+      github.event.comment.body != '@expo-bot undismiss' &&
+      !startsWith(github.event.comment.body, '@expo-bot undismiss ') &&
+      github.event.comment.body != '@expo-bot help')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     # ONE budget, in one place, and the ordering is the point:
@@ -648,21 +658,42 @@ jobs:
             fi
             echo "preflight: bot token can update $WORK_HEAD_REPO"
           else
+            fork_owner=$(gh api user --jq .login)
+            fork="$fork_owner/${GITHUB_REPOSITORY#*/}"
+            if ! gh repo view "$fork" >/dev/null 2>&1; then
+              gh repo fork "$GITHUB_REPOSITORY" --clone=false --default-branch-only >/dev/null 2>&1 || true
+              for _ in $(seq 1 30); do
+                gh repo view "$fork" >/dev/null 2>&1 && break
+                sleep 2
+              done
+            fi
+            if ! gh repo view "$fork" >/dev/null 2>&1; then
+              echo "::error::Could not resolve or create the bot fork $fork; fix mode refuses to use a secret-bearing same-repository branch."
+              exit 1
+            fi
+            fork_default=$(gh api "repos/$fork" --jq .default_branch)
+            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
+              echo "::error::Could not synchronize $fork with upstream; refusing a push that may include stale workflow commits."
+              exit 1
+            fi
             gh auth setup-git
             # No pipe here: `git ... | tail` would report tail's exit status and
             # the check would pass no matter what git did.
-            if ! git push --dry-run origin "HEAD:refs/heads/agent-preflight-$GITHUB_RUN_ID"; then
-              echo "::error::EXPO_BOT_GITHUB_TOKEN cannot push to this repository, so fix mode could not open a pull request. Fix the credential before re-running."
+            if ! git push --dry-run "https://github.com/$fork.git" "HEAD:refs/heads/agent-preflight-$GITHUB_RUN_ID"; then
+              echo "::error::EXPO_BOT_GITHUB_TOKEN cannot push to the bot fork $fork, so fix mode could not open a pull request."
               exit 1
             fi
-            echo "preflight: push credentials work; fix mode can open a pull request"
+            echo "BOT_FORK_OWNER=$fork_owner" >> "$GITHUB_ENV"
+            echo "BOT_FORK=$fork" >> "$GITHUB_ENV"
+            echo "preflight: push credentials work for $fork; fix mode can open a fork pull request"
           fi
 
       - name: Run agent command
         id: investigate
         if: steps.gate.outputs.ok == 'true'
         env:
-          # CLAUDE_CODE_OAUTH_TOKEN is inherited from Prepare model env.
+          # The canonical Claude credential variable selected by Prepare
+          # model env is inherited through GITHUB_ENV.
           # NO GitHub token in this step at all: the agent has no shell and no
           # gh verb, so it needs none. The findings comment is posted by the
           # MCP server from its own stored PAT, whose arguments are literal
@@ -755,6 +786,9 @@ jobs:
               "mcp__sandbox__simulator_ui"
               "mcp__sandbox__simulator_tap"
               "mcp__sandbox__simulator_type"
+              "mcp__sandbox__simulator_wait"
+              "mcp__sandbox__simulator_scroll"
+              "mcp__sandbox__simulator_query"
               "mcp__sandbox__simulator_open"
               "mcp__sandbox__simulator_boot_app"
               "mcp__sandbox__simulator_install_build"
@@ -1341,27 +1375,12 @@ jobs:
           # is exactly the posture this repository already grants every
           # drive-by contributor.
           #
-          # Falling back to a same-repo branch is deliberate and VISIBLE.
-          # Losing a verified fix over fork plumbing would be the worse
-          # failure, so the push still happens — but the pull request itself
-          # carries a note saying so, because a silent downgrade of a security
-          # property is how it stays downgraded, and a ::warning:: buried in a
-          # run log is not something a reviewer of that PR will ever see.
-          fork_owner=$(gh api user --jq .login 2>/dev/null || true)
-          fork=""
-          if [ -n "$fork_owner" ]; then
-            fork="$fork_owner/${GITHUB_REPOSITORY#*/}"
-            if ! gh repo view "$fork" >/dev/null 2>&1; then
-              # --default-branch-only keeps the fork small. Forking is async,
-              # so wait for it to become addressable before pushing into it.
-              gh repo fork "$GITHUB_REPOSITORY" --clone=false --default-branch-only >/dev/null 2>&1 || true
-              for _ in $(seq 1 30); do
-                gh repo view "$fork" >/dev/null 2>&1 && break
-                sleep 2
-              done
-            fi
-            gh repo view "$fork" >/dev/null 2>&1 || fork=""
-          fi
+          # Fork isolation is a hard boundary, not a best-effort preference.
+          # If fork creation, synchronization, or push fails, do not fall back
+          # to a same-repository branch: pull_request CI would execute the
+          # agent-authored change with repository secrets available.
+          fork_owner=${BOT_FORK_OWNER:-}
+          fork=${BOT_FORK:-}
           # SYNC THE FORK FIRST. A branch pushed to a stale fork introduces
           # every upstream commit between the fork's tip and this checkout —
           # including any that touch .github/workflows/** — and a classic PAT
@@ -1378,28 +1397,24 @@ jobs:
           # Note this gets WORSE the staler the fork is, so it is not optional.
           if [ -n "$fork" ]; then
             fork_default=$(gh api "repos/$fork" --jq .default_branch 2>/dev/null || echo main)
-            if gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
-              echo "synced $fork ($fork_default) with upstream before pushing"
-            else
-              echo "::warning::could not sync $fork with upstream; the push may be rejected for workflow scope"
-            fi
-          fi
-          if [ -n "$fork" ] && git push -q "https://github.com/$fork.git" "HEAD:refs/heads/$branch"; then
-            head_ref="$fork_owner:$branch"
-          else
-            if [ -n "$fork" ]; then
-              echo "::warning::push to fork $fork failed; falling back to a same-repo branch"
-            else
-              echo "::warning::could not resolve or create the bot fork; falling back to a same-repo branch"
-            fi
-            fork=""
-            if ! git push -q origin "HEAD:refs/heads/$branch"; then
-              gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not push the branch, so no pull request was opened. The outcome comment still stands and the change is described there. [Run log]($RUN_URL)"
-              echo "::error::git push failed; no pull request was opened."
+            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
+              gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not synchronize the bot fork. It refused to push a branch that might include stale workflow commits, and refused the secret-bearing same-repository fallback. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
+              echo "::error::could not sync $fork with upstream; refusing to push."
               exit 1
             fi
-            head_ref="$branch"
+            echo "synced $fork ($fork_default) with upstream before pushing"
           fi
+          if [ -z "$fork" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not resolve or create the bot fork. It refused to use a same-repository branch because that would run agent-authored code with CI secrets. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
+            echo "::error::could not resolve or create the bot fork; refusing unsafe same-repository fallback."
+            exit 1
+          fi
+          if ! git push -q "https://github.com/$fork.git" "HEAD:refs/heads/$branch"; then
+            gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not push it to the bot fork. It refused to use a same-repository branch because that would run agent-authored code with CI secrets. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
+            echo "::error::push to fork $fork failed; refusing unsafe same-repository fallback."
+            exit 1
+          fi
+          head_ref="$fork_owner:$branch"
           {
             # ONE LINE PER PARAGRAPH, however long. GitHub renders a newline
             # inside a comment or pull-request body as a hard <br>, unlike a
@@ -1412,11 +1427,6 @@ jobs:
             echo "> **Agent-authored and NOT human-reviewed.** An automated \`$command_name\` run for #$ISSUE_NUMBER wrote this change and checked it in a sandbox; the reasoning and evidence are in the outcome comment on that issue. Review it as you would any external contribution."
             echo ""
             echo "Requested by @$TRIGGER_ACTOR · [$run_name]($RUN_URL) · refs #$ISSUE_NUMBER"
-            if [ -z "$fork" ]; then
-              echo ""
-              echo "> [!NOTE]"
-              echo "> This branch lives on \`$GITHUB_REPOSITORY\` rather than the bot's fork, because the fork push failed. A fork pull request runs CI without secrets; this one runs with them, over agent-authored code. Treat it accordingly, and see the run log for why the fork was unavailable."
-            fi
             echo ""
             tail -n +2 .verify-out/pr.md 2>/dev/null || echo "_No description was provided by the run._"
           } > "$RUNNER_TEMP/pr-body.md"
@@ -1432,6 +1442,14 @@ jobs:
             exit 1
           }
           gh issue comment "$ISSUE_NUMBER" --body "🔧 Opened $url with the $change_name — agent-authored, unreviewed, and queued for AI review. [$run_name]($RUN_URL)"
+
+      # The resumed agent is asked to destroy its sandboxes, but cancellation,
+      # timeout, or a failed model call can prevent that turn from running.
+      # This fixed backstop uses the scoped child token, whose list_sandboxes
+      # view contains only sessions created by this job.
+      - name: Destroy leftover sandboxes
+        if: always() && steps.gate.outputs.ok == 'true'
+        run: bash .github/scripts/cleanup-agent-sandboxes.sh "$RUNNER_TEMP/mcp.json"
 
       # Last line of defence against a total loss. `if: always()` genuinely
       # runs on step failure AND on cancellation — verified on real runs

--- a/.github/workflows/expo-bot-help.yml
+++ b/.github/workflows/expo-bot-help.yml
@@ -25,7 +25,8 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.comment.user.login != 'expo-bot' &&
       (github.event.comment.body == '@expo-bot' ||
-      github.event.comment.body == '@expo-bot help') &&
+      github.event.comment.body == '@expo-bot help' ||
+      startsWith(github.event.comment.body, '@expo-bot help ')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -36,7 +37,10 @@ jobs:
           GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
           ACTOR: ${{ github.event.comment.user.login }}
         run: |
-          permission=$(gh api "repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq .permission)
+          # `|| echo none` on purpose: a non-collaborator gets a 404, and under
+          # `bash -e` a bare assignment would kill the step before the error
+          # below could name the reason. Same pattern as agent-commands.yml.
+          permission=$(gh api "repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq .permission 2>/dev/null || echo none)
           case "$permission" in
             admin|maintain|write) ;;
             *) echo "::error::$ACTOR has '$permission' permission; write access is required."; exit 1 ;;

--- a/.github/workflows/expo-bot-help.yml
+++ b/.github/workflows/expo-bot-help.yml
@@ -25,12 +25,23 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.comment.user.login != 'expo-bot' &&
       (github.event.comment.body == '@expo-bot' ||
-      github.event.comment.body == '@expo-bot help' ||
-      startsWith(github.event.comment.body, '@expo-bot help')) &&
+      github.event.comment.body == '@expo-bot help') &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Require write access
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_GITHUB_TOKEN }}
+          ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          permission=$(gh api "repos/${{ github.repository }}/collaborators/$ACTOR/permission" --jq .permission)
+          case "$permission" in
+            admin|maintain|write) ;;
+            *) echo "::error::$ACTOR has '$permission' permission; write access is required."; exit 1 ;;
+          esac
+
       # Default branch only — the manpage on main is what we publish, never
       # a PR-head edit of .github/expo-bot.md.
       - name: Checkout (default branch)

--- a/.github/workflows/expo-bot-help.yml
+++ b/.github/workflows/expo-bot-help.yml
@@ -20,13 +20,17 @@ permissions:
 
 jobs:
   help:
+    # `startsWith('@expo-bot help')` (no trailing space) so a newline or tab
+    # after `help` still matches — expression literals cannot name those
+    # characters. The two-space form is a separate prefix because
+    # `startsWith('@expo-bot help')` is false for `@expo-bot  help`.
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event.comment.user.login != 'expo-bot' &&
       (github.event.comment.body == '@expo-bot' ||
-      github.event.comment.body == '@expo-bot help' ||
-      startsWith(github.event.comment.body, '@expo-bot help ')) &&
+      startsWith(github.event.comment.body, '@expo-bot help') ||
+      startsWith(github.event.comment.body, '@expo-bot  help')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -168,7 +168,19 @@ jobs:
           PR: ${{ github.event.issue.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. This is not a fork limitation — the command path has secrets. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret), then rotate or correct the failed setup token or API key."
+          # See the matching step in expo-code-review.yml: pick.sh writes this
+          # file only after it has probed a credential, so its absence means the
+          # step failed before any probe and the secrets are not the cause.
+          reason=$(cat "$RUNNER_TEMP/model-env-reason" 2>/dev/null || echo unprobed)
+          slots="\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`"
+          forks="This is not a fork limitation — the command path has secrets."
+          case "$reason" in
+            auth)  body="⚠️ The AI reviewer did not start: every configured model credential ($slots) was rejected as invalid. $forks Check the [run log]($RUN_URL) for each slot's shape/len (never the secret), then rotate or correct the failed setup token or API key." ;;
+            usage) body="⚠️ The AI reviewer did not start: every configured model credential ($slots) is over its usage or rate limit. $forks The credentials are valid — nothing to rotate. Re-run later, or configure a spare slot. [Run log]($RUN_URL)" ;;
+            other) body="⚠️ The AI reviewer did not start: every configured model credential ($slots) failed for a reason that is neither authentication nor usage — a network fault, a timeout, or a model outage. $forks [Run log]($RUN_URL) has each slot's error." ;;
+            *)     body="⚠️ The AI reviewer did not start: the model-env step failed **before it tested any credential**, so this is not a credential problem and there is nothing to rotate. $forks [Run log]($RUN_URL) has the error." ;;
+          esac
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "$body"
 
       - name: Run AI review
         if: steps.cmd.outputs.run == 'true'

--- a/.github/workflows/expo-code-review-command.yml
+++ b/.github/workflows/expo-code-review-command.yml
@@ -19,10 +19,6 @@ permissions:
   pull-requests: write
   issues: write
 
-concurrency:
-  group: ai-code-review-cmd-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   command:
     # Only PR comments starting with /review, /expo-review, or @expo-bot review.
@@ -30,11 +26,19 @@ jobs:
     if: >-
       github.event.issue.pull_request != null &&
       github.event.comment.user.login != 'expo-bot' &&
-      (startsWith(github.event.comment.body, '/review') ||
-      startsWith(github.event.comment.body, '/expo-review') ||
-      startsWith(github.event.comment.body, '@expo-bot review')) &&
+      (github.event.comment.body == '/review' ||
+      startsWith(github.event.comment.body, '/review ') ||
+      github.event.comment.body == '/expo-review' ||
+      startsWith(github.event.comment.body, '/expo-review ') ||
+      github.event.comment.body == '@expo-bot review' ||
+      startsWith(github.event.comment.body, '@expo-bot review ')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    # Job-level so a prose comment that the gate rejects cannot claim this
+    # group at workflow creation and cancel a real review already in flight.
+    concurrency:
+      group: ai-code-review-cmd-${{ github.event.issue.number }}
+      cancel-in-progress: true
     # Bound the run so a slow/stalled review fails fast rather than hanging. Keep it
     # above the passes budget (budget.totalPassesMinutes, 55m) + coordinator (10m) +
     # verification + setup, like the auto-review workflow's cap.
@@ -164,7 +168,7 @@ jobs:
           PR: ${{ github.event.issue.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. This is not a fork limitation — the command path has secrets. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret) and re-set any slot that is not a \`claude setup-token\` value (\`sk-ant-oat…\`, 108 chars)."
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. This is not a fork limitation — the command path has secrets. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret), then rotate or correct the failed setup token or API key."
 
       - name: Run AI review
         if: steps.cmd.outputs.run == 'true'

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -18,10 +18,6 @@ permissions:
   pull-requests: write
   issues: write
 
-concurrency:
-  group: ai-code-review-dismiss-${{ github.event.issue.number }}
-  cancel-in-progress: false
-
 jobs:
   dismiss:
     # PR comments starting with /dismiss, /undismiss, or the @expo-bot forms.
@@ -38,6 +34,13 @@ jobs:
       startsWith(github.event.comment.body, '@expo-bot undismiss ')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    # Job-level, NOT workflow-level: `issue_comment` fires for EVERY comment in
+    # the repository, and a workflow-level group is claimed at run creation,
+    # before the `if:` above can skip the job. A group holds one pending run, so
+    # unrelated chatter on a PR could displace a real /dismiss waiting its turn.
+    concurrency:
+      group: ai-code-review-dismiss-${{ github.event.issue.number }}
+      cancel-in-progress: false
     # @ref LLP 0009#guard-step-ordering-and-job-budgets [constrained-by] — no review budget to cover; capped low regardless
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/expo-code-review-dismiss.yml
+++ b/.github/workflows/expo-code-review-dismiss.yml
@@ -28,10 +28,14 @@ jobs:
     if: >-
       github.event.issue.pull_request != null &&
       github.event.comment.user.login != 'expo-bot' &&
-      (startsWith(github.event.comment.body, '/dismiss') ||
-      startsWith(github.event.comment.body, '/undismiss') ||
-      startsWith(github.event.comment.body, '@expo-bot dismiss') ||
-      startsWith(github.event.comment.body, '@expo-bot undismiss')) &&
+      (github.event.comment.body == '/dismiss' ||
+      startsWith(github.event.comment.body, '/dismiss ') ||
+      github.event.comment.body == '/undismiss' ||
+      startsWith(github.event.comment.body, '/undismiss ') ||
+      github.event.comment.body == '@expo-bot dismiss' ||
+      startsWith(github.event.comment.body, '@expo-bot dismiss ') ||
+      github.event.comment.body == '@expo-bot undismiss' ||
+      startsWith(github.event.comment.body, '@expo-bot undismiss ')) &&
       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     # @ref LLP 0009#guard-step-ordering-and-job-budgets [constrained-by] — no review budget to cover; capped low regardless

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -124,7 +124,7 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. Check the [run log]($RUN_URL) for each slot's shape/len and re-set any slot that is not a \`claude setup-token\` value (\`sk-ant-oat…\`, 108 chars)."
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret), then rotate or correct the failed setup token or API key."
 
       - name: Run AI review
         # The launcher selects the SAME checked-in package version the guard cleared.

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -58,7 +58,7 @@ jobs:
       # the only line. persist-credentials off — the CLI's own git fetches
       # authenticate through `gh` from GH_TOKEN, so the token never lands in
       # .git/config.
-      # @ref LLP 0009#workflow-security-posture [implements] — immutable base commit, never PR head/merge ref
+      # @ref LLP 0009#workflow-security-posture [implements] — trusted base branch, never PR head/merge ref
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # base.REF, not base.SHA. The security property is "never the PR head

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -49,15 +49,15 @@ jobs:
     # A reviewer failure must never fail the PR's checks.
     continue-on-error: true
     steps:
-      # SECURITY: check out the PR's immutable BASE commit, never the PR head or
+      # SECURITY: check out the PR's trusted base branch tip, never the PR head or
       # merge ref. Everything security-sensitive on this runner (`ecr verify-config`'s
-      # sweep, and any ambient files) therefore comes from a commit that already
-      # merged. `ecr ci` additionally enforces this itself: it materializes the base
-      # commit via the GitHub API for configuration and the head commit (scrubbed of
-      # runtime config) for source reads, so this checkout is defense in depth, not
-      # the only line. persist-credentials off — the CLI's own git fetches
-      # authenticate through `gh` from GH_TOKEN, so the token never lands in
-      # .git/config.
+      # sweep, and any ambient files) therefore comes from a branch only maintainers
+      # can land on. `ecr ci` additionally enforces this itself: it materializes the
+      # PR's immutable base commit via the GitHub API for configuration and the head
+      # commit (scrubbed of runtime config) for source reads, so this checkout is
+      # defense in depth, not the only line. persist-credentials off — the CLI's own
+      # git fetches authenticate through `gh` from GH_TOKEN, so the token never lands
+      # in .git/config.
       # @ref LLP 0009#workflow-security-posture [implements] — trusted base branch, never PR head/merge ref
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/expo-code-review.yml
+++ b/.github/workflows/expo-code-review.yml
@@ -61,7 +61,15 @@ jobs:
       # @ref LLP 0009#workflow-security-posture [implements] — immutable base commit, never PR head/merge ref
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          # base.REF, not base.SHA. The security property is "never the PR head
+          # or the merge ref", and the base branch tip satisfies it — only
+          # maintainers land there. base.sha additionally FROZE the tree at
+          # whenever the PR was last synchronized, which broke this job outright:
+          # a PR based before .github/actions/prepare-model-env existed checked
+          # out a tree without it, so `uses: ./…` could not resolve and the run
+          # died before reviewing anything. base.sha does not advance on its own,
+          # so every such PR stayed broken until someone pushed to it.
+          ref: ${{ github.event.pull_request.base.ref }}
           # Shallow is enough — the reviewer gets the diff from the API (`gh`).
           fetch-depth: 1
           persist-credentials: false
@@ -124,7 +132,20 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR" --repo "${{ github.repository }}" --body "⚠️ The AI reviewer did not start: every configured model credential (\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`) failed authentication. Check the [run log]($RUN_URL) for each slot's shape/len (not the secret), then rotate or correct the failed setup token or API key."
+          # pick.sh writes this file only once it has actually probed a
+          # credential, so its absence means the step died BEFORE any probe.
+          # Do not blame the secrets in that case: this comment used to assert
+          # an authentication failure unconditionally, and told maintainers to
+          # rotate five perfectly good tokens after a missing-action failure.
+          reason=$(cat "$RUNNER_TEMP/model-env-reason" 2>/dev/null || echo unprobed)
+          slots="\`ECR_1\`…\`ECR_5\` and \`CLAUDE_CODE_REVIEW_EXPO_OSS_API_TOKEN\`"
+          case "$reason" in
+            auth)  body="⚠️ The AI reviewer did not start: every configured model credential ($slots) was rejected as invalid. Check the [run log]($RUN_URL) for each slot's shape/len (never the secret), then rotate or correct the failed setup token or API key." ;;
+            usage) body="⚠️ The AI reviewer did not start: every configured model credential ($slots) is over its usage or rate limit. The credentials are valid — nothing to rotate. Re-run later, or configure a spare slot. [Run log]($RUN_URL)" ;;
+            other) body="⚠️ The AI reviewer did not start: every configured model credential ($slots) failed for a reason that is neither authentication nor usage — a network fault, a timeout, or a model outage. [Run log]($RUN_URL) has each slot's error." ;;
+            *)     body="⚠️ The AI reviewer did not start: the model-env step failed **before it tested any credential**, so this is not a credential problem and there is nothing to rotate. [Run log]($RUN_URL) has the error." ;;
+          esac
+          gh pr comment "$PR" --repo "${{ github.repository }}" --body "$body"
 
       - name: Run AI review
         # The launcher selects the SAME checked-in package version the guard cleared.


### PR DESCRIPTION
## Summary

Hardens the recently added agent-command and AI-review workflows after a joint audit.

- fail closed when the bot fork cannot be created, synchronized, or pushed instead of publishing agent-authored code from a secret-bearing same-repository branch
- preflight the actual bot-fork push path
- move command-review concurrency to job scope and make command gates respect token boundaries
- preserve the canonical Claude credential environment that actually passed the probe, with token-shape-aware probe ordering
- deterministically destroy scoped-token sandboxes from an `always()` runner step
- require authoritative write access for `@expo-bot help`
- grant the three missing simulator query/wait tools
- repair the manpage round-trip self-test

The documented modulo queueing tradeoff is intentionally unchanged.

## Validation

- `actionlint` on every changed workflow
- `shellcheck` on all changed/new shell scripts
- `prepare-model-env/pick.sh --self-test`
- `sync-expo-bot-manpage.sh --self-test`
- `cleanup-agent-sandboxes.sh --self-test`
- behavioral credential handoff checks for both `sk-ant-api…` and `sk-ant-oat…` shapes
- `git diff --check`
