### PR TITLE
[github] Create bot-fork branches at the upstream SHA

### DIFF
--- a/.github/scripts/ensure-fork-branch.sh
+++ b/.github/scripts/ensure-fork-branch.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Point a new branch on a fork at a commit GitHub already has (the parent
+# network). Does not merge-upstream and does not send a pack.
+#
+# merge-upstream (and `git push` of a SHA that is  N workflow-changing
+# commits ahead of the fork's default branch) needs the `workflow` scope.
+# Creating a ref at that SHA, then pushing one commit that does not touch
+# .github/workflows/**, does not.
+set -euo pipefail
+
+if [ "${1:-}" = --self-test ]; then
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' EXIT
+  # Valid sha / branch are accepted by the arg checks; we cannot hit the API
+  # here. Invalid inputs must die before any gh call.
+  if "$0" 2>"$tmp"; then echo "expected usage error"; exit 1; fi
+  grep -q usage "$tmp"
+  if "$0" owner/repo 'bad branch' "$(printf 'a%.0s' {1..40})" 2>"$tmp"; then
+    echo "expected bad branch error"; exit 1
+  fi
+  grep -q 'odd branch name' "$tmp"
+  if "$0" owner/repo ok-branch notasha 2>"$tmp"; then
+    echo "expected bad sha error"; exit 1
+  fi
+  grep -q '40-hex' "$tmp"
+  echo "ensure-fork-branch self-test ok"
+  exit 0
+fi
+
+fork=${1:-}
+branch=${2:-}
+sha=${3:-}
+if [ -z "$fork" ] || [ -z "$branch" ] || [ -z "$sha" ]; then
+  echo "usage: ensure-fork-branch.sh <owner/repo> <branch> <sha>" >&2
+  exit 2
+fi
+if ! [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "sha must be a 40-hex commit: $sha" >&2
+  exit 2
+fi
+if ! [[ "$branch" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "refusing odd branch name: $branch" >&2
+  exit 2
+fi
+
+# The SHA must already live in the fork's object store (shared with the
+# parent). If it does not, a later git push would send the whole gap —
+# including workflow files — and a public_repo PAT would be refused.
+if ! gh api "repos/$fork/git/commits/$sha" --jq .sha >/dev/null; then
+  echo "::error::$sha is not in $fork's object store; cannot create a branch without sending a pack."
+  exit 1
+fi
+
+existing=$(gh api "repos/$fork/git/ref/heads/$branch" --jq .object.sha 2>/dev/null || true)
+if [ "$existing" = "$sha" ]; then
+  echo "fork branch $branch already at $sha"
+  exit 0
+fi
+if [ -n "$existing" ]; then
+  echo "::error::$fork already has $branch at $existing; not moving it."
+  exit 1
+fi
+
+if ! out=$(gh api -X POST "repos/$fork/git/refs" -f ref="refs/heads/$branch" -f sha="$sha" 2>&1); then
+  echo "::error::Could not create refs/heads/$branch on $fork at $sha."
+  printf '%s\n' "$out"
+  exit 1
+fi
+echo "created $fork $branch at $sha"

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -695,21 +695,30 @@ jobs:
               echo "::error::Could not resolve or create the bot fork $fork; fix mode refuses to use a secret-bearing same-repository branch."
               exit 1
             fi
-            fork_default=$(gh api "repos/$fork" --jq .default_branch)
-            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
-              echo "::error::Could not synchronize $fork with upstream; refusing a push that may include stale workflow commits."
-              exit 1
-            fi
+            # Do NOT merge-upstream. That fast-forwards the fork's default
+            # branch through every missing workflow file and needs the
+            # `workflow` scope this token deliberately lacks (run 31664540660).
+            # Point a throwaway ref at THIS checkout SHA instead — GitHub
+            # already has the object via the parent network — then dry-run a
+            # push that introduces no new commit.
+            base_sha=$(git rev-parse HEAD)
+            probe="agent-preflight-$GITHUB_RUN_ID"
+            bash .github/scripts/ensure-fork-branch.sh "$fork" "$probe" "$base_sha"
             gh auth setup-git
             # No pipe here: `git ... | tail` would report tail's exit status and
             # the check would pass no matter what git did.
-            if ! git push --dry-run "https://github.com/$fork.git" "HEAD:refs/heads/agent-preflight-$GITHUB_RUN_ID"; then
+            if ! git push --dry-run "https://github.com/$fork.git" "HEAD:refs/heads/$probe"; then
               echo "::error::EXPO_BOT_GITHUB_TOKEN cannot push to the bot fork $fork, so fix mode could not open a pull request."
+              gh api -X DELETE "repos/$fork/git/refs/heads/$probe" >/dev/null 2>&1 || true
               exit 1
             fi
-            echo "BOT_FORK_OWNER=$fork_owner" >> "$GITHUB_ENV"
-            echo "BOT_FORK=$fork" >> "$GITHUB_ENV"
-            echo "preflight: push credentials work for $fork; fix mode can open a fork pull request"
+            gh api -X DELETE "repos/$fork/git/refs/heads/$probe" >/dev/null 2>&1 || true
+            {
+              echo "BOT_FORK_OWNER=$fork_owner"
+              echo "BOT_FORK=$fork"
+              echo "FORK_BASE_SHA=$base_sha"
+            } >> "$GITHUB_ENV"
+            echo "preflight: fork accepts a branch at $base_sha; fix mode can open a fork pull request"
           fi
 
       - name: Run agent command
@@ -1405,32 +1414,23 @@ jobs:
           # agent-authored change with repository secrets available.
           fork_owner=${BOT_FORK_OWNER:-}
           fork=${BOT_FORK:-}
-          # SYNC THE FORK FIRST. A branch pushed to a stale fork introduces
-          # every upstream commit between the fork's tip and this checkout —
-          # including any that touch .github/workflows/** — and a classic PAT
-          # carrying public_repo (which deliberately excludes `workflow`) is
-          # refused outright. Observed on run 31540508035:
-          #
-          #   ! [remote rejected] HEAD -> verify/48804-31540508035 (refusing to
-          #     allow a Personal Access Token to create or update workflow
-          #     `.github/workflows/verify-command.yml` without `workflow` scope)
-          #
-          # The path denylist above already refuses an agent patch that touches
-          # .github/**, so once the fork is level with upstream the push carries
-          # only the agent's own commit and there is no workflow file in it.
-          # Note this gets WORSE the staler the fork is, so it is not optional.
-          if [ -n "$fork" ]; then
-            fork_default=$(gh api "repos/$fork" --jq .default_branch 2>/dev/null || echo main)
-            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
-              gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not synchronize the bot fork. It refused to push a branch that might include stale workflow commits, and refused the secret-bearing same-repository fallback. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
-              echo "::error::could not sync $fork with upstream; refusing to push."
-              exit 1
-            fi
-            echo "synced $fork ($fork_default) with upstream before pushing"
-          fi
+          # Do not merge-upstream (needs `workflow` to move .github/workflows
+          # on a stale fork). Create the publish branch at the checkout SHA
+          # GitHub already has, then push only the agent commit. Observed
+          # merge-upstream failure: run 31664540660. Observed workflow-scope
+          # push failure without a parent ref: run 31540508035.
           if [ -z "$fork" ]; then
             gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not resolve or create the bot fork. It refused to use a same-repository branch because that would run agent-authored code with CI secrets. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
             echo "::error::could not resolve or create the bot fork; refusing unsafe same-repository fallback."
+            exit 1
+          fi
+          base_sha=${FORK_BASE_SHA:-}
+          if [ -z "$base_sha" ]; then
+            base_sha=$(git rev-parse HEAD^)
+          fi
+          if ! bash .github/scripts/ensure-fork-branch.sh "$fork" "$branch" "$base_sha"; then
+            gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not create the bot-fork branch at the trusted checkout. It refused to merge-upstream (that needs the \`workflow\` scope) and refused the secret-bearing same-repository fallback. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
+            echo "::error::could not create $fork $branch at $base_sha; refusing to push."
             exit 1
           fi
           if ! git push -q "https://github.com/$fork.git" "HEAD:refs/heads/$branch"; then


### PR DESCRIPTION
## Summary

`POST /repos/expo-bot/expo/merge-upstream` cannot work with a `public_repo` PAT that lacks `workflow`. The fork is 43 commits behind, those commits include `.github/workflows/**`, and syncing `main` is exactly the update GitHub refuses (run [31664540660](https://github.com/expo/expo/actions/runs/31664540660)).

This stops moving the fork's default branch. The runner already has current `expo/expo` `main`; that SHA is already in the fork's object store (parent network). We create the publish branch at that SHA via `POST /git/refs`, then `git push` only the agent commit (path-denylisted from `.github/**`).

Preflight does the same with a throwaway `agent-preflight-$RUN_ID` ref and deletes it.

Supersedes the diagnostic-only approach in #48856 for this failure.

## Test plan

- [ ] `bash .github/scripts/ensure-fork-branch.sh --self-test`
- [ ] With an expo-bot PAT that can write `expo-bot/expo` and does **not** have `workflow`:
  - `GET /repos/expo-bot/expo/git/commits/<current expo/expo main>` succeeds
  - `POST /git/refs` creating `refs/heads/agent-probe-<n>` at that SHA succeeds
  - `DELETE` that ref
  - a `git push` of one non-workflow commit onto a branch created that way succeeds
- [ ] After merge, `verify <issue>` (fix mode) gets past preflight

Do **not** add `workflow` to `EXPO_BOT_GITHUB_TOKEN` to make this pass.