### PR TITLE
[github] Sync expo-bot/expo on every push to main

### DIFF
--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -696,7 +696,24 @@ jobs:
               exit 1
             fi
             fork_default=$(gh api "repos/$fork" --jq .default_branch)
-            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
+            # The dedicated sync-expo-bot-fork workflow (EXPO_BOT_FORK_SYNC_TOKEN)
+            # is what is allowed to move workflow files. This token is not.
+            # Retry a few times: a verify that starts on the same push as a
+            # workflow change can land before that job finishes. Keep the API
+            # body — 422 is workflow scope, 404 is "cannot write this repo".
+            synced=
+            for attempt in 1 2 3 4; do
+              if sync_out=$(gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" 2>&1); then
+                synced=1
+                printf '%s\n' "$sync_out"
+                break
+              fi
+              echo "merge-upstream attempt $attempt failed:"
+              printf '%s\n' "$sync_out"
+              [ "$attempt" -eq 4 ] && break
+              sleep 20
+            done
+            if [ -z "$synced" ]; then
               echo "::error::Could not synchronize $fork with upstream; refusing a push that may include stale workflow commits."
               exit 1
             fi
@@ -1421,9 +1438,10 @@ jobs:
           # Note this gets WORSE the staler the fork is, so it is not optional.
           if [ -n "$fork" ]; then
             fork_default=$(gh api "repos/$fork" --jq .default_branch 2>/dev/null || echo main)
-            if ! gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" >/dev/null 2>&1; then
+            if ! sync_out=$(gh api -X POST "repos/$fork/merge-upstream" -f branch="$fork_default" 2>&1); then
               gh issue comment "$ISSUE_NUMBER" --body "⛔ \`$command_name\` prepared the $change_name but could not synchronize the bot fork. It refused to push a branch that might include stale workflow commits, and refused the secret-bearing same-repository fallback. The outcome comment still stands and describes the change. [Run log]($RUN_URL)"
               echo "::error::could not sync $fork with upstream; refusing to push."
+              printf '%s\n' "$sync_out"
               exit 1
             fi
             echo "synced $fork ($fork_default) with upstream before pushing"

--- a/.github/workflows/agent-commands.yml
+++ b/.github/workflows/agent-commands.yml
@@ -696,7 +696,7 @@ jobs:
               exit 1
             fi
             fork_default=$(gh api "repos/$fork" --jq .default_branch)
-            # The dedicated sync-expo-bot-fork workflow (EXPO_BOT_FORK_SYNC_TOKEN)
+            # The dedicated sync-expo-bot-fork workflow (DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN)
             # is what is allowed to move workflow files. This token is not.
             # Retry a few times: a verify that starts on the same push as a
             # workflow change can land before that job finishes. Keep the API

--- a/.github/workflows/sync-expo-bot-fork.yml
+++ b/.github/workflows/sync-expo-bot-fork.yml
@@ -1,0 +1,51 @@
+# Fast-forward expo-bot/expo's default branch after every land on main.
+#
+# /verify --fix pushes to that fork with EXPO_BOT_GITHUB_TOKEN, which is
+# public_repo and must NOT have the `workflow` scope. merge-upstream (and
+# creating a branch at a SHA whose tree has newer .github/workflows/** than
+# the fork default) is refused without that scope — run 31664540660, PAT
+# probe 2026-08-13. A dedicated token that MAY update workflow files lives
+# only in this job: one API call, no checkout of untrusted code, no agent.
+#
+# Add the secret BEFORE merging this workflow:
+#   EXPO_BOT_FORK_SYNC_TOKEN
+# Fine-grained, resource expo-bot/expo only: Contents write + Workflows write.
+# Classic fallback: public_repo + workflow, owned by expo-bot.
+# Do not reuse EXPO_BOT_GITHUB_TOKEN.
+
+name: Sync expo-bot fork
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-expo-bot-fork
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fast-forward expo-bot/expo
+        env:
+          GH_TOKEN: ${{ secrets.EXPO_BOT_FORK_SYNC_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::EXPO_BOT_FORK_SYNC_TOKEN is not set. Add it (Contents + Workflows write on expo-bot/expo) before this job can run."
+            exit 1
+          fi
+          fork="expo-bot/${GITHUB_REPOSITORY#*/}"
+          branch=$(gh api "repos/$fork" --jq .default_branch)
+          if ! out=$(gh api -X POST "repos/$fork/merge-upstream" -f branch="$branch" 2>&1); then
+            echo "::error::Could not sync $fork ($branch) with ${GITHUB_REPOSITORY}."
+            printf '%s\n' "$out"
+            exit 1
+          fi
+          printf '%s\n' "$out"
+          echo "synced $fork ($branch)"

--- a/.github/workflows/sync-expo-bot-fork.yml
+++ b/.github/workflows/sync-expo-bot-fork.yml
@@ -8,7 +8,7 @@
 # only in this job: one API call, no checkout of untrusted code, no agent.
 #
 # Add the secret BEFORE merging this workflow:
-#   EXPO_BOT_FORK_SYNC_TOKEN
+#   DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN
 # Fine-grained, resource expo-bot/expo only: Contents write + Workflows write.
 # Classic fallback: public_repo + workflow, owned by expo-bot.
 # Do not reuse EXPO_BOT_GITHUB_TOKEN.
@@ -34,10 +34,10 @@ jobs:
     steps:
       - name: Fast-forward expo-bot/expo
         env:
-          GH_TOKEN: ${{ secrets.EXPO_BOT_FORK_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
-            echo "::error::EXPO_BOT_FORK_SYNC_TOKEN is not set. Add it (Contents + Workflows write on expo-bot/expo) before this job can run."
+            echo "::error::DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN is not set. Add it (Contents + Workflows write on expo-bot/expo) before this job can run."
             exit 1
           fi
           fork="expo-bot/${GITHUB_REPOSITORY#*/}"


### PR DESCRIPTION
## Summary

`/verify --fix` pushes to `expo-bot/expo` with `EXPO_BOT_GITHUB_TOKEN` (`public_repo`, no `workflow`). A PAT probe as expo-bot showed:

- write on the fork works
- `merge-upstream` is **422** `refusing to … update workflow … without workflow scope` when the fork is behind on `.github/workflows/**`
- `POST /git/refs` at current `expo/expo` main is **404** for the same reason

So the agent token cannot catch the fork up. This adds a tiny `push`/`workflow_dispatch` job that uses a **separate** secret, `DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN`, and only calls `merge-upstream`. No checkout of untrusted code, no agent.

Agent-command preflight still syncs with the public_repo token (a no-op once the fork is current), prints the API body, and retries for ~1 minute so a verify that starts on the same push can wait.

Closes the approach in #48857 (create-ref at upstream SHA) — that is the same GitHub check.

## Secret (add before merge)

`DO_NOT_USE_EXPO_BOT_FORK_SYNC_TOKEN` on `expo/expo`:

- Preferred: fine-grained, **expo-bot/expo only**, Contents: write + Workflows: write
- Classic fallback: expo-bot PAT with `public_repo` + `workflow`

Do **not** put `workflow` on `EXPO_BOT_GITHUB_TOKEN`.

After the secret exists, either **Sync fork** once in the UI as expo-bot, or run this workflow via **workflow_dispatch**, so the 43-commit gap is closed before the next `/verify --fix`.

## Test plan

- [ ] Secret added
- [ ] `workflow_dispatch` this workflow → log shows `merge_type: fast-forward` or `none`
- [ ] `expo-bot/expo` default branch matches `expo/expo` `main`
- [ ] `verify <issue>` (fix mode) gets past preflight
