### PR TITLE
[app-metrics][iOS][Android] Add a spans table to the metrics database

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Add a generic `spans` table to the metrics database for trace telemetry. ([#48861](https://github.com/expo/expo/pull/48861) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
+- Add a generic `spans` table to the metrics database for trace telemetry. ([#48861](https://github.com/expo/expo/pull/48861) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -12,6 +12,8 @@ import androidx.room.Query
 import androidx.room.ForeignKey
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.room.Embedded
 import androidx.room.Relation
 import androidx.room.Transaction
@@ -22,9 +24,31 @@ object MetricsConstants {
   const val SECONDS_TO_REMOVE_OLD_METRICS: Long = 7 * 24 * 60 * 60 // 7 days in seconds
 }
 
+/**
+ * v16 -> v17: adds the `spans` table. Hand-written because schema export is off (so Room's
+ * auto-migrations aren't available); the DDL is copied verbatim from the KSP-generated
+ * `MetricsDatabase_Impl.createAllTables`, and Room validates the migrated schema against the
+ * entities on open, so any drift between this SQL and the `Span` entity fails fast instead of
+ * corrupting silently. Registered so existing installs keep their sessions, metrics, and logs
+ * on upgrade instead of hitting the destructive fallback.
+ */
+internal val MIGRATION_16_17 = object : Migration(16, 17) {
+  override fun migrate(db: SupportSQLiteDatabase) {
+    db.execSQL(
+      "CREATE TABLE IF NOT EXISTS `spans` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+        "`sessionId` TEXT NOT NULL, `traceId` TEXT NOT NULL, `spanId` TEXT NOT NULL, " +
+        "`parentSpanId` TEXT, `name` TEXT NOT NULL, `kind` INTEGER NOT NULL, " +
+        "`startTimestampMs` INTEGER NOT NULL, `endTimestampMs` INTEGER NOT NULL, " +
+        "`statusCode` INTEGER, `statusMessage` TEXT, `attributes` TEXT, `events` TEXT, " +
+        "FOREIGN KEY(`sessionId`) REFERENCES `sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+    )
+    db.execSQL("CREATE INDEX IF NOT EXISTS `index_spans_sessionId` ON `spans` (`sessionId`)")
+  }
+}
+
 @Database(
-  entities = [Metric::class, LogRecord::class, Session::class, CrashReportEntity::class],
-  version = 16,
+  entities = [Metric::class, LogRecord::class, Session::class, CrashReportEntity::class, Span::class],
+  version = 17,
   exportSchema = false
 )
 abstract class MetricsDatabase : RoomDatabase() {
@@ -35,6 +59,8 @@ abstract class MetricsDatabase : RoomDatabase() {
   abstract fun sessionDao(): SessionDao
 
   abstract fun crashReportDao(): CrashReportDao
+
+  abstract fun spanDao(): SpanDao
 
   companion object {
     @Volatile
@@ -48,7 +74,9 @@ abstract class MetricsDatabase : RoomDatabase() {
             MetricsDatabase::class.java,
             "app_metrics"
           )
-          // Allow destructive migration for schema changes during development. Replace with proper Migration if desired.
+          .addMigrations(MIGRATION_16_17)
+          // Destructive fallback for version jumps without a registered migration (pre-16
+          // installs, downgrades). Upgrades covered by a migration above keep their data.
           .fallbackToDestructiveMigration(false)
           .build()
         INSTANCE = instance

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -23,8 +23,8 @@ object MetricsConstants {
 }
 
 @Database(
-  entities = [Metric::class, LogRecord::class, Session::class, CrashReportEntity::class],
-  version = 17,
+  entities = [Metric::class, LogRecord::class, Session::class, CrashReportEntity::class, Span::class],
+  version = 18,
   exportSchema = false
 )
 abstract class MetricsDatabase : RoomDatabase() {
@@ -35,6 +35,8 @@ abstract class MetricsDatabase : RoomDatabase() {
   abstract fun sessionDao(): SessionDao
 
   abstract fun crashReportDao(): CrashReportDao
+
+  abstract fun spanDao(): SpanDao
 
   companion object {
     @Volatile
@@ -48,7 +50,8 @@ abstract class MetricsDatabase : RoomDatabase() {
             MetricsDatabase::class.java,
             "app_metrics"
           )
-          // Allow destructive migration for schema changes during development. Replace with proper Migration if desired.
+          // Version bumps drop the data instead of migrating: maintaining migrations costs more
+          // than losing local telemetry that is dispatched frequently anyway.
           .fallbackToDestructiveMigration(false)
           .build()
         INSTANCE = instance

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -153,6 +153,16 @@ class SessionManager(
 
   suspend fun getMaxMetricId(): Long? = database.metricDao().getMaxId()
 
+  suspend fun getSpansForSession(sessionId: String): List<Span> =
+    database.spanDao().getSpansForSession(sessionId)
+
+  suspend fun getSpans(afterId: Long, limit: Int): List<Span> =
+    database.spanDao().getSpans(afterId, limit)
+
+  suspend fun getMaxSpanId(): Long? = database.spanDao().getMaxId()
+
+  suspend fun deleteSpansUpTo(rowId: Long) = database.spanDao().deleteUpTo(rowId)
+
   suspend fun getLogsForSession(sessionId: String): List<LogRecord> =
     database.logDao().getLogsForSession(sessionId)
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/Span.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/Span.kt
@@ -1,0 +1,159 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.appmetrics.storage
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * Persistence-layer representation of one trace span, mirroring the OTLP `Span` shape. Spans are
+ * a generic signal: any producer (network requests today, navigation or custom spans later)
+ * converts its domain event into a `Span` at record time, and `expo-observe` exports pending rows
+ * to the OTLP traces endpoint without knowing what produced them. Mirrors the iOS `SpanRow`.
+ */
+@Entity(
+  tableName = "spans",
+  indices = [Index("sessionId")],
+  foreignKeys = [
+    ForeignKey(
+      entity = Session::class,
+      parentColumns = ["id"],
+      childColumns = ["sessionId"],
+      onDelete = ForeignKey.CASCADE
+    )
+  ]
+)
+data class Span(
+  /**
+   * Auto-incremented rowid. Unlike the other tables' UUID keys, spans use a monotonic id so the
+   * export layer can chunk in insertion order and delete consumed prefixes with one query.
+   */
+  @PrimaryKey(autoGenerate = true) val id: Long = 0,
+  val sessionId: String,
+
+  /**
+   * W3C trace/span identifiers as lowercase hex (32 and 16 characters). Generated once at
+   * record time and persisted, so a redelivered row (export is at-least-once) reaches the
+   * server byte-identical instead of becoming an untraceable duplicate.
+   */
+  val traceId: String = generateTraceId(),
+  val spanId: String = generateSpanId(),
+
+  /**
+   * Parent span id for in-app hierarchies, or `null` for a root span. No producer sets this yet;
+   * the column exists so adding nested spans later is not a schema change.
+   */
+  val parentSpanId: String? = null,
+
+  /** Span name per the semantic conventions of the producer (the HTTP method for network spans). */
+  val name: String,
+
+  /** `SpanKind` per the OTLP proto (`CLIENT_KIND` for network requests). */
+  val kind: Int = INTERNAL_KIND,
+
+  /**
+   * Unix-epoch milliseconds. Millisecond integers rather than the ISO strings the other tables
+   * use: a span's duration is routinely sub-second, and the house ISO format carries no
+   * fractional seconds, so a string timestamp would collapse every fast span to zero length.
+   */
+  val startTimestampMs: Long,
+  val endTimestampMs: Long,
+
+  /** OTLP status code (`STATUS_ERROR`), or `null` when the span completed without one (UNSET). */
+  val statusCode: Int? = null,
+  val statusMessage: String? = null,
+
+  /**
+   * JSON object of span attributes, keyed per the producer's semantic conventions. Stored as an
+   * opaque blob — nothing queries individual attributes locally, and the export layer converts
+   * them generically to the OTLP wire shape.
+   */
+  val attributes: String? = null,
+
+  /** JSON array of span events (`[{name, timeMs?, attributes}]`), or `null` when there are none. */
+  val events: String? = null
+) {
+  companion object {
+    /** `SpanKind` values from the OTLP proto, for producers picking a `kind`. */
+    const val INTERNAL_KIND = 1
+    const val CLIENT_KIND = 3
+
+    /** `Status.code` values from the OTLP proto. UNSET is expressed by a null `statusCode`. */
+    const val STATUS_ERROR = 2
+
+    /**
+     * A new random 16-byte trace id as 32 lowercase hex characters. There is no trace-context
+     * propagation yet, so every span starts its own trace.
+     */
+    fun generateTraceId(): String = generateHexId(words = 2)
+
+    /** A new random 8-byte span id as 16 lowercase hex characters. */
+    fun generateSpanId(): String = generateHexId(words = 1)
+
+    /**
+     * Random identifier built from 8-byte words, hex-encoded. The all-zero value is invalid per
+     * the OTLP spec (the server rejects the span), so it redraws — a branch that is hit once per
+     * 2^64 draws but keeps the invariant explicit.
+     */
+    private fun generateHexId(words: Int): String {
+      while (true) {
+        val drawn = List(words) { ThreadLocalRandom.current().nextLong() }
+        if (drawn.all { it == 0L }) {
+          continue
+        }
+        return drawn.joinToString(separator = "") { "%016x".format(it) }
+      }
+    }
+  }
+}
+
+@Dao
+interface SpanDao {
+  companion object {
+    /**
+     * Maximum number of rows retained in `spans`. Span producers (network requests especially)
+     * can outnumber metrics and logs by orders of magnitude, and when nothing consumes the rows
+     * (`expo-observe` not installed, or dispatch disabled) the session-retention prune alone
+     * would let a busy app accumulate a week of traffic. `insertCapped` prunes past the cap.
+     */
+    const val SPAN_CAP = 2_000
+  }
+
+  @Insert
+  suspend fun insert(span: Span): Long
+
+  /**
+   * Inserts a span and prunes rows older than `SPAN_CAP` in the same transaction — ids are
+   * monotonic, so "older" is simply everything at least `SPAN_CAP` ids behind the row just
+   * inserted.
+   */
+  @Transaction
+  suspend fun insertCapped(span: Span): Long {
+    val insertedId = insert(span)
+    deleteUpTo(insertedId - SPAN_CAP)
+    return insertedId
+  }
+
+  /** All spans in ascending rowid (insertion) order. */
+  @Query("SELECT * FROM spans ORDER BY id ASC")
+  suspend fun getAll(): List<Span>
+
+  /** The largest rowid currently in the table, or `null` when it's empty. */
+  @Query("SELECT MAX(id) FROM spans")
+  suspend fun getMaxId(): Long?
+
+  /**
+   * Deletes rows with `id <= rowId`. Called after a dispatch consumed (or deliberately dropped)
+   * a batch: unlike metrics and logs, no per-session API reads spans back, so dispatched rows
+   * are dead weight.
+   */
+  @Query("DELETE FROM spans WHERE id <= :rowId")
+  suspend fun deleteUpTo(rowId: Long)
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/Span.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/Span.kt
@@ -1,0 +1,180 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.appmetrics.storage
+
+import androidx.room.Dao
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Transaction
+import java.util.concurrent.ThreadLocalRandom
+
+/**
+ * Persistence-layer representation of one trace span, mirroring the OTLP `Span` shape
+ * (https://opentelemetry.io/docs/concepts/signals/traces/#spans). Spans are a generic signal:
+ * any producer (network requests today, navigation or custom spans later) converts its domain
+ * event into a `Span` at record time, and `expo-observe` exports pending rows to the OTLP traces
+ * endpoint without knowing what produced them. Mirrors the iOS `SpanRow`.
+ */
+@Entity(
+  tableName = "spans",
+  indices = [Index("sessionId")],
+  foreignKeys = [
+    ForeignKey(
+      entity = Session::class,
+      parentColumns = ["id"],
+      childColumns = ["sessionId"],
+      onDelete = ForeignKey.CASCADE
+    )
+  ]
+)
+data class Span(
+  /**
+   * Auto-incremented rowid, like `metrics` and `logs`: a monotonic id lets the export layer
+   * chunk in insertion order and delete consumed prefixes with one query.
+   */
+  @PrimaryKey(autoGenerate = true) val id: Long = 0,
+  val sessionId: String,
+
+  /**
+   * W3C trace/span identifiers as lowercase hex (32 and 16 characters). Generated once at
+   * record time and persisted, so a redelivered row (export is at-least-once) reaches the
+   * server byte-identical instead of becoming an untraceable duplicate.
+   */
+  val traceId: String = generateTraceId(),
+  val spanId: String = generateSpanId(),
+
+  /**
+   * Parent span id for in-app hierarchies, or `null` for a root span. Set by `SpanRecorder` when
+   * a custom span is started with a parent; the network producer always writes root spans.
+   */
+  val parentSpanId: String? = null,
+
+  /** Span name per the semantic conventions of the producer (the HTTP method for network spans). */
+  val name: String,
+
+  /** `SpanKind` per the OTLP proto (`CLIENT_KIND` for network requests). */
+  val kind: Int = INTERNAL_KIND,
+
+  /**
+   * Unix-epoch milliseconds. Millisecond integers rather than the ISO strings the other tables
+   * use: a span's duration is routinely sub-second, and the house ISO format carries no
+   * fractional seconds, so a string timestamp would collapse every fast span to zero length.
+   * Milliseconds is the OTel spec's minimal timestamp precision; the exporter converts to the
+   * wire format's `timeUnixNano`.
+   */
+  val startTimestampMs: Long,
+  val endTimestampMs: Long,
+
+  /** OTLP status code (`STATUS_ERROR`), or `null` when the span completed without one (UNSET). */
+  val statusCode: Int? = null,
+  val statusMessage: String? = null,
+
+  /**
+   * JSON object of span attributes, keyed per the producer's semantic conventions. Stored as an
+   * opaque blob: nothing queries individual attributes locally, and the export layer converts
+   * them generically to the OTLP wire shape.
+   */
+  val attributes: String? = null,
+
+  /** JSON array of span events (`[{name, timeMs?, attributes}]`), or `null` when there are none. */
+  val events: String? = null
+) {
+  companion object {
+    /** `SpanKind` values from the OTLP proto, for producers picking a `kind`. */
+    const val INTERNAL_KIND = 1
+    const val CLIENT_KIND = 3
+
+    /** `Status.code` values from the OTLP proto. UNSET is expressed by a null `statusCode`. */
+    const val STATUS_ERROR = 2
+
+    /**
+     * A new random 16-byte trace id as 32 lowercase hex characters. Called for a root span only:
+     * a child reuses its parent's trace id. There is no cross-process trace-context propagation,
+     * so a trace never extends beyond this app.
+     */
+    fun generateTraceId(): String = generateHexId(words = 2)
+
+    /** A new random 8-byte span id as 16 lowercase hex characters. */
+    fun generateSpanId(): String = generateHexId(words = 1)
+
+    /**
+     * Random identifier built from 8-byte words, hex-encoded. The all-zero value is invalid per
+     * the OTLP spec (the server rejects the span), so it redraws, a branch that is hit once per
+     * 2^64 draws but keeps the invariant explicit.
+     */
+    private fun generateHexId(words: Int): String {
+      while (true) {
+        val drawn = List(words) { ThreadLocalRandom.current().nextLong() }
+        if (drawn.all { it == 0L }) {
+          continue
+        }
+        return drawn.joinToString(separator = "") { "%016x".format(it) }
+      }
+    }
+  }
+}
+
+@Dao
+interface SpanDao {
+  companion object {
+    /**
+     * Maximum number of rows retained in `spans`. Span producers (network requests especially)
+     * can outnumber metrics and logs by orders of magnitude, and when nothing consumes the rows
+     * (`expo-observe` not installed, or dispatch disabled) the session-retention prune alone
+     * would let a busy app accumulate a week of traffic. `insert` prunes past the cap.
+     */
+    const val SPAN_CAP = 2_000
+  }
+
+  /**
+   * Raw row insert with no cap enforcement, the primitive `insert` builds on. Producers should
+   * call `insert`: picking this one silently loses the retention bound.
+   */
+  @Insert
+  suspend fun insertUncapped(span: Span): Long
+
+  /**
+   * Inserts a span and prunes rows older than `SPAN_CAP` in the same transaction. Ids are
+   * monotonic, so "older" is simply everything at least `SPAN_CAP` ids behind the row just
+   * inserted. The capped path is deliberately the default name, mirroring iOS where the only
+   * insert enforces the cap.
+   */
+  @Transaction
+  suspend fun insert(span: Span): Long {
+    val insertedId = insertUncapped(span)
+    deleteUpTo(insertedId - SPAN_CAP)
+    return insertedId
+  }
+
+  /**
+   * At most `limit` spans with `id > afterId`, in ascending rowid order. Mirrors the iOS
+   * `getSpans(afterId:limit:)` read so consumers can drain the table in chunks.
+   */
+  @Query("SELECT * FROM spans WHERE id > :afterId ORDER BY id ASC LIMIT :limit")
+  suspend fun getSpans(afterId: Long, limit: Int): List<Span>
+
+  /**
+   * The spans attributed to one session, in ascending rowid (insertion) order. This is the
+   * session-association read for a future session-inspection consumer. The exporter owns
+   * deletion today, so this sees only rows it hasn't dispatched yet, bounded also by the
+   * insert-time row cap.
+   */
+  @Query("SELECT * FROM spans WHERE sessionId = :sessionId ORDER BY id ASC")
+  suspend fun getSpansForSession(sessionId: String): List<Span>
+
+  /** The largest rowid currently in the table, or `null` when it's empty. */
+  @Query("SELECT MAX(id) FROM spans")
+  suspend fun getMaxId(): Long?
+
+  /**
+   * Deletes rows with `id <= rowId`. Called after a dispatch consumed (or deliberately dropped)
+   * a batch, and by the insert-time row cap. The exporter owns deletion: the per-session read
+   * (`getSpansForSession`) sees only rows not yet dispatched.
+   */
+  @Query("DELETE FROM spans WHERE id <= :rowId")
+  suspend fun deleteUpTo(rowId: Long)
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/MetricsDatabaseMigrationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/MetricsDatabaseMigrationTest.kt
@@ -1,0 +1,57 @@
+package expo.modules.appmetrics.storage
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class MetricsDatabaseMigrationTest {
+  @Test
+  fun `migration 16 to 17 creates the spans table and preserves existing data`() = runTest {
+    // Schema export is off, so Room's MigrationTestHelper isn't available. Instead, rewind a
+    // current-version database to the pre-migration shape by hand: drop `spans` and set the
+    // schema version back to 16. Reopening then runs MIGRATION_16_17, and Room validates the
+    // migrated table against the entity at open — wrong DDL fails this test loudly.
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val name = "migration-test.db"
+    context.deleteDatabase(name)
+    val fresh = Room
+      .databaseBuilder(context, MetricsDatabase::class.java, name)
+      .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+      .allowMainThreadQueries()
+      .build()
+    fresh.sessionDao().insert(Session(id = "s", startTimestamp = "2026-08-13T10:00:00.000Z"))
+    fresh.close()
+    SQLiteDatabase
+      .openDatabase(context.getDatabasePath(name).path, null, SQLiteDatabase.OPEN_READWRITE)
+      .use { raw ->
+        raw.execSQL("DROP TABLE `spans`")
+        raw.execSQL("PRAGMA user_version = 16")
+      }
+    val migrated = Room
+      .databaseBuilder(context, MetricsDatabase::class.java, name)
+      .addMigrations(MIGRATION_16_17)
+      .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+      .allowMainThreadQueries()
+      .build()
+    try {
+      // The session survived: the destructive fallback would have wiped it.
+      assertEquals("s", migrated.sessionDao().getById("s")?.id)
+      // The migrated table is fully usable, not just present.
+      migrated.spanDao().insert(Span(sessionId = "s", name = "GET", startTimestampMs = 1, endTimestampMs = 2))
+      assertEquals(1, migrated.spanDao().getAll().size)
+    } finally {
+      migrated.close()
+      context.deleteDatabase(name)
+    }
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SpanStorageTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SpanStorageTest.kt
@@ -1,0 +1,191 @@
+package expo.modules.appmetrics.storage
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class SpanStorageTest {
+  private lateinit var database: MetricsDatabase
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun insertSession(id: String) {
+    database.sessionDao().insert(
+      Session(id = id, startTimestamp = "2026-08-13T10:00:00.000Z")
+    )
+  }
+
+  private fun makeSpan(
+    sessionId: String,
+    name: String = "GET",
+    kind: Int = Span.CLIENT_KIND,
+    startTimestampMs: Long = 1_782_131_895_000,
+    endTimestampMs: Long = 1_782_131_895_250,
+    statusCode: Int? = null,
+    statusMessage: String? = null,
+    attributes: String? = null,
+    events: String? = null
+  ) = Span(
+    sessionId = sessionId,
+    name = name,
+    kind = kind,
+    startTimestampMs = startTimestampMs,
+    endTimestampMs = endTimestampMs,
+    statusCode = statusCode,
+    statusMessage = statusMessage,
+    attributes = attributes,
+    events = events
+  )
+
+  @Test
+  fun `insert assigns increasing row ids`() = runTest {
+    insertSession("s")
+    val firstId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    val secondId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    assertTrue(secondId > firstId)
+  }
+
+  @Test
+  fun `getAll returns rows in ascending row id order`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "a"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "b"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "c"))
+    val rows = database.spanDao().getAll()
+    assertEquals(listOf("a", "b", "c"), rows.map { it.name })
+    assertEquals(rows.map { it.id }.sorted(), rows.map { it.id })
+  }
+
+  @Test
+  fun `span round-trips its full payload`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(
+      Span(
+        sessionId = "s",
+        traceId = "a3ce929d0e0e4736a3ce929d0e0e4736",
+        spanId = "00f067aa0ba902b7",
+        parentSpanId = "abcdef0123456789",
+        name = "POST",
+        kind = Span.CLIENT_KIND,
+        startTimestampMs = 1_782_131_895_000,
+        endTimestampMs = 1_782_131_895_250,
+        statusCode = Span.STATUS_ERROR,
+        statusMessage = "went wrong",
+        attributes = """{"url.full":"https://example.com"}""",
+        events = """[{"name":"http.redirect"}]"""
+      )
+    )
+    val row = database.spanDao().getAll().single()
+    assertEquals("s", row.sessionId)
+    assertEquals("a3ce929d0e0e4736a3ce929d0e0e4736", row.traceId)
+    assertEquals("00f067aa0ba902b7", row.spanId)
+    assertEquals("abcdef0123456789", row.parentSpanId)
+    assertEquals("POST", row.name)
+    assertEquals(Span.CLIENT_KIND, row.kind)
+    assertEquals(1_782_131_895_000, row.startTimestampMs)
+    assertEquals(1_782_131_895_250, row.endTimestampMs)
+    assertEquals(Span.STATUS_ERROR, row.statusCode)
+    assertEquals("went wrong", row.statusMessage)
+    assertEquals("""{"url.full":"https://example.com"}""", row.attributes)
+    assertEquals("""[{"name":"http.redirect"}]""", row.events)
+  }
+
+  @Test
+  fun `span round-trips absent optionals as null`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val row = database.spanDao().getAll().single()
+    assertNull(row.parentSpanId)
+    assertNull(row.statusCode)
+    assertNull(row.statusMessage)
+    assertNull(row.attributes)
+    assertNull(row.events)
+  }
+
+  @Test
+  fun `getMaxId reflects the newest row and null when empty`() = runTest {
+    assertNull(database.spanDao().getMaxId())
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val lastId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    assertEquals(lastId, database.spanDao().getMaxId())
+  }
+
+  @Test
+  fun `deleteUpTo removes rows up to and including the given row id`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val secondId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    val thirdId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    database.spanDao().deleteUpTo(secondId)
+    assertEquals(listOf(thirdId), database.spanDao().getAll().map { it.id })
+  }
+
+  @Test
+  fun `spans are deleted when their session is deleted`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    database.sessionDao().deleteAll()
+    assertTrue(database.spanDao().getAll().isEmpty())
+  }
+
+  @Test
+  fun `insertCapped prunes the oldest rows past the retention cap`() = runTest {
+    // Span producers (network requests especially) can record orders of magnitude more rows
+    // than metrics or logs. The cap bounds the table when nothing consumes (and deletes) the rows.
+    insertSession("s")
+    repeat(SpanDao.SPAN_CAP + 10) {
+      database.spanDao().insertCapped(makeSpan(sessionId = "s"))
+    }
+    val rows = database.spanDao().getAll()
+    assertTrue(rows.size <= SpanDao.SPAN_CAP)
+    // The newest rows survive.
+    val maxId = rows.maxOf { it.id }
+    assertEquals(maxId, rows.last().id)
+  }
+
+  @Test
+  fun `generated identifiers are lowercase hex of the required lengths`() {
+    // The ingestion endpoint rejects a span whose ids aren't exactly 32 and 16 hex characters.
+    val span = makeSpan(sessionId = "s")
+    assertEquals(32, span.traceId.length)
+    assertEquals(16, span.spanId.length)
+    assertTrue(span.traceId.all { it.isDigit() || it in 'a'..'f' })
+    assertTrue(span.spanId.all { it.isDigit() || it in 'a'..'f' })
+    assertNotEquals("0".repeat(32), span.traceId)
+    assertNotEquals("0".repeat(16), span.spanId)
+  }
+
+  @Test
+  fun `each new span receives distinct identifiers`() {
+    // Ids are assigned once at record time and persisted, so a redelivered row (export is
+    // at-least-once) reaches the server byte-identical instead of becoming a fresh duplicate.
+    val ids = (0 until 128).map { makeSpan(sessionId = "s").traceId }.toSet()
+    assertEquals(128, ids.size)
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SpanStorageTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SpanStorageTest.kt
@@ -1,0 +1,215 @@
+package expo.modules.appmetrics.storage
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class SpanStorageTest {
+  private lateinit var database: MetricsDatabase
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun insertSession(id: String) {
+    database.sessionDao().insert(
+      Session(id = id, startTimestamp = "2026-08-13T10:00:00.000Z")
+    )
+  }
+
+  private suspend fun allSpans() = database.spanDao().getSpans(afterId = -1, limit = Int.MAX_VALUE)
+
+  private fun makeSpan(
+    sessionId: String,
+    name: String = "GET",
+    kind: Int = Span.CLIENT_KIND,
+    startTimestampMs: Long = 1_782_131_895_000,
+    endTimestampMs: Long = 1_782_131_895_250,
+    statusCode: Int? = null,
+    statusMessage: String? = null,
+    attributes: String? = null,
+    events: String? = null
+  ) = Span(
+    sessionId = sessionId,
+    name = name,
+    kind = kind,
+    startTimestampMs = startTimestampMs,
+    endTimestampMs = endTimestampMs,
+    statusCode = statusCode,
+    statusMessage = statusMessage,
+    attributes = attributes,
+    events = events
+  )
+
+  @Test
+  fun `insert assigns increasing row ids`() = runTest {
+    insertSession("s")
+    val firstId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    val secondId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    assertTrue(secondId > firstId)
+  }
+
+  @Test
+  fun `getSpans from the start returns rows in ascending row id order`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "a"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "b"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "c"))
+    val rows = allSpans()
+    assertEquals(listOf("a", "b", "c"), rows.map { it.name })
+    assertEquals(rows.map { it.id }.sorted(), rows.map { it.id })
+  }
+
+  @Test
+  fun `span round-trips its full payload`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(
+      Span(
+        sessionId = "s",
+        traceId = "a3ce929d0e0e4736a3ce929d0e0e4736",
+        spanId = "00f067aa0ba902b7",
+        parentSpanId = "abcdef0123456789",
+        name = "POST",
+        kind = Span.CLIENT_KIND,
+        startTimestampMs = 1_782_131_895_000,
+        endTimestampMs = 1_782_131_895_250,
+        statusCode = Span.STATUS_ERROR,
+        statusMessage = "went wrong",
+        attributes = """{"url.full":"https://example.com"}""",
+        events = """[{"name":"http.redirect"}]"""
+      )
+    )
+    val row = allSpans().single()
+    assertEquals("s", row.sessionId)
+    assertEquals("a3ce929d0e0e4736a3ce929d0e0e4736", row.traceId)
+    assertEquals("00f067aa0ba902b7", row.spanId)
+    assertEquals("abcdef0123456789", row.parentSpanId)
+    assertEquals("POST", row.name)
+    assertEquals(Span.CLIENT_KIND, row.kind)
+    assertEquals(1_782_131_895_000, row.startTimestampMs)
+    assertEquals(1_782_131_895_250, row.endTimestampMs)
+    assertEquals(Span.STATUS_ERROR, row.statusCode)
+    assertEquals("went wrong", row.statusMessage)
+    assertEquals("""{"url.full":"https://example.com"}""", row.attributes)
+    assertEquals("""[{"name":"http.redirect"}]""", row.events)
+  }
+
+  @Test
+  fun `span round-trips absent optionals as null`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val row = allSpans().single()
+    assertNull(row.parentSpanId)
+    assertNull(row.statusCode)
+    assertNull(row.statusMessage)
+    assertNull(row.attributes)
+    assertNull(row.events)
+  }
+
+  @Test
+  fun `getSpans returns rows past the cursor in ascending order`() = runTest {
+    insertSession("s")
+    val firstId = database.spanDao().insert(makeSpan(sessionId = "s", name = "a"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "b"))
+    database.spanDao().insert(makeSpan(sessionId = "s", name = "c"))
+    assertEquals(listOf("b", "c"), database.spanDao().getSpans(firstId, limit = 10).map { it.name })
+    assertEquals(listOf("b"), database.spanDao().getSpans(firstId, limit = 1).map { it.name })
+  }
+
+  @Test
+  fun `getSpansForSession returns only that session's rows in insertion order`() = runTest {
+    insertSession("a")
+    insertSession("b")
+    database.spanDao().insert(makeSpan(sessionId = "a", name = "a1"))
+    database.spanDao().insert(makeSpan(sessionId = "b", name = "b1"))
+    database.spanDao().insert(makeSpan(sessionId = "a", name = "a2"))
+    assertEquals(listOf("a1", "a2"), database.spanDao().getSpansForSession("a").map { it.name })
+    assertTrue(database.spanDao().getSpansForSession("missing").isEmpty())
+  }
+
+  @Test
+  fun `getMaxId reflects the newest row and null when empty`() = runTest {
+    assertNull(database.spanDao().getMaxId())
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val lastId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    assertEquals(lastId, database.spanDao().getMaxId())
+  }
+
+  @Test
+  fun `deleteUpTo removes rows up to and including the given row id`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    val secondId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    val thirdId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    database.spanDao().deleteUpTo(secondId)
+    assertEquals(listOf(thirdId), allSpans().map { it.id })
+  }
+
+  @Test
+  fun `spans are deleted when their session is deleted`() = runTest {
+    insertSession("s")
+    database.spanDao().insert(makeSpan(sessionId = "s"))
+    database.sessionDao().deleteAll()
+    assertTrue(allSpans().isEmpty())
+  }
+
+  @Test
+  fun `insert prunes the oldest rows past the retention cap`() = runTest {
+    // Span producers (network requests especially) can record orders of magnitude more rows
+    // than metrics or logs. The cap bounds the table when nothing consumes (and deletes) the rows.
+    insertSession("s")
+    var lastId = 0L
+    repeat(SpanDao.SPAN_CAP + 10) {
+      lastId = database.spanDao().insert(makeSpan(sessionId = "s"))
+    }
+    val rows = allSpans()
+    assertEquals(SpanDao.SPAN_CAP, rows.size)
+    assertEquals(lastId - SpanDao.SPAN_CAP + 1, rows.first().id)
+    assertEquals(lastId, rows.last().id)
+  }
+
+  @Test
+  fun `generated identifiers are lowercase hex of the required lengths`() {
+    // The ingestion endpoint rejects a span whose ids aren't exactly 32 and 16 hex characters.
+    val span = makeSpan(sessionId = "s")
+    assertEquals(32, span.traceId.length)
+    assertEquals(16, span.spanId.length)
+    assertTrue(span.traceId.all { it.isDigit() || it in 'a'..'f' })
+    assertTrue(span.spanId.all { it.isDigit() || it in 'a'..'f' })
+    assertNotEquals("0".repeat(32), span.traceId)
+    assertNotEquals("0".repeat(16), span.spanId)
+  }
+
+  @Test
+  fun `each new span receives distinct identifiers`() {
+    // Ids are assigned once at record time and persisted, so a redelivered row (export is
+    // at-least-once) reaches the server byte-identical instead of becoming a fresh duplicate.
+    val spans = (0 until 128).map { makeSpan(sessionId = "s") }
+    assertEquals(128, spans.mapTo(mutableSetOf()) { it.traceId }.size)
+    assertEquals(128, spans.mapTo(mutableSetOf()) { it.spanId }.size)
+  }
+}

--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -102,6 +102,27 @@ public struct AppMetrics {
     return try database?.getMaxLogId() ?? nil
   }
 
+  /// Returns span rows whose `id` is greater than `cursor`, in ascending id order. Empty when
+  /// the database failed to open.
+  @AppMetricsActor
+  public static func getSpans(afterId cursor: Int64) throws -> [SpanRow] {
+    return try database?.getSpans(afterId: cursor) ?? []
+  }
+
+  /// The largest span id currently in the database, or `nil` if the table is empty.
+  @AppMetricsActor
+  public static func getMaxSpanId() throws -> Int64? {
+    return try database?.getMaxSpanId() ?? nil
+  }
+
+  /// Deletes span rows with `id <= upToId`. Consumers call this after dispatching (or
+  /// deliberately dropping) a batch — nothing else reads these rows back, so retaining them past
+  /// the dispatch cursor only grows the database.
+  @AppMetricsActor
+  public static func deleteSpans(upToId: Int64) throws {
+    try database?.deleteSpans(upToId: upToId)
+  }
+
   // MARK: - Environment
 
   @AppMetricsActor

--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -102,6 +102,33 @@ public struct AppMetrics {
     return try database?.getMaxLogId() ?? nil
   }
 
+  /// Returns span rows whose `id` is greater than `cursor`, in ascending id order, at most
+  /// `limit` of them (all when `nil`). Empty when the database failed to open.
+  @AppMetricsActor
+  public static func getSpans(afterId cursor: Int64, limit: Int? = nil) throws -> [SpanRow] {
+    return try database?.getSpans(afterId: cursor, limit: limit) ?? []
+  }
+
+  /// The largest span id currently in the database, or `nil` if the table is empty.
+  @AppMetricsActor
+  public static func getMaxSpanId() throws -> Int64? {
+    return try database?.getMaxSpanId() ?? nil
+  }
+
+  /// Returns the spans attributed to `sessionId`, in ascending id order. Empty when the
+  /// database failed to open.
+  @AppMetricsActor
+  public static func getSpans(forSessionId sessionId: String) throws -> [SpanRow] {
+    return try database?.getSpans(forSessionId: sessionId) ?? []
+  }
+
+  /// Deletes span rows with `id <= upToId`. The exporter owns deletion; the per-session read
+  /// (`getSpans(forSessionId:)`) sees only rows not yet dispatched.
+  @AppMetricsActor
+  public static func deleteSpans(upToId: Int64) throws {
+    try database?.deleteSpans(upToId: upToId)
+  }
+
   // MARK: - Environment
 
   @AppMetricsActor

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -559,6 +559,73 @@ final class MetricsDatabase: Sendable {
     try statement.run()
   }
 
+  // MARK: - Spans
+
+  /// Maximum number of rows retained in `spans`. Span producers (network requests especially)
+  /// can outnumber metrics and logs by orders of magnitude, and when nothing consumes the rows
+  /// (`expo-observe` not installed, or dispatch disabled) the session-retention prune alone
+  /// would let a busy app accumulate a week of traffic. Inserts prune anything older than the cap.
+  static let spanCap = 2_000
+
+  /// Inserts a single span and returns its rowid (the auto-incremented `id`). Also prunes rows
+  /// older than `spanCap` — ids are monotonic, so "older" is simply everything at least
+  /// `spanCap` ids behind the row just inserted. Insert and prune share one transaction, so the
+  /// per-span hot path pays a single commit.
+  @AppMetricsActor
+  @discardableResult
+  func insert(span: SpanRow) throws -> Int64 {
+    return try database.transaction {
+      let statement = try database.prepare(
+        """
+        INSERT INTO spans (
+          sessionId, traceId, spanId, parentSpanId, name, kind,
+          startTimestampMs, endTimestampMs, statusCode, statusMessage, attributes, events
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+        """
+      )
+      try statement.bindAll([
+        span.sessionId, span.traceId, span.spanId, span.parentSpanId, span.name, span.kind,
+        span.startTimestampMs, span.endTimestampMs, span.statusCode, span.statusMessage,
+        span.attributes, span.events,
+      ])
+      try statement.run()
+      let insertedId = database.lastInsertRowid()
+      try deleteSpans(upToId: insertedId - Int64(Self.spanCap))
+      return insertedId
+    }
+  }
+
+  /// Returns span rows whose `id` is greater than `cursor`, in ascending id order.
+  @AppMetricsActor
+  func getSpans(afterId cursor: Int64) throws -> [SpanRow] {
+    let statement = try database.prepare(
+      """
+      SELECT \(spanColumns) FROM spans WHERE id > ?1 ORDER BY id ASC
+      """
+    )
+    try statement.bindAll([cursor])
+    var rows: [SpanRow] = []
+    try statement.forEachRow { row in
+      rows.append(SpanRow(row: row))
+    }
+    return rows
+  }
+
+  @AppMetricsActor
+  func getMaxSpanId() throws -> Int64? {
+    return try selectMaxId(table: "spans")
+  }
+
+  /// Deletes rows with `id <= upToId`. Called after a dispatch consumed (or deliberately
+  /// dropped) a batch: unlike metrics and logs, no per-session API reads spans back, so
+  /// dispatched rows are dead weight.
+  @AppMetricsActor
+  func deleteSpans(upToId: Int64) throws {
+    let statement = try database.prepare("DELETE FROM spans WHERE id <= ?1")
+    try statement.bindAll([upToId])
+    try statement.run()
+  }
+
   // MARK: - Schema
 
   /// Creates the schema (tables, indexes, version row) atomically. Wrapping the whole bootstrap in a
@@ -575,14 +642,20 @@ final class MetricsDatabase: Sendable {
     }
   }
 
-  /// Creates the four data tables plus `schema_version`. Relationships:
+  /// Creates the five data tables plus `schema_version`. Relationships:
   ///
   /// - `sessions` is the root. Every other table keys off `sessions.id` (a UUID string).
-  /// - `metrics` and `logs` each have a `sessionId` FK with `ON DELETE CASCADE`. Their `id` is
-  /// `INTEGER PRIMARY KEY AUTOINCREMENT` so `expo-observe` can dispatch with a monotonic cursor.
+  /// - `metrics`, `logs` and `spans` each have a `sessionId` FK with `ON DELETE CASCADE`. Their
+  /// `id` is `INTEGER PRIMARY KEY AUTOINCREMENT` so `expo-observe` can dispatch with a monotonic
+  /// cursor.
   /// - `crash_reports` is keyed by `sessionId`. There's no FK constraint; the relationship is
   /// informational, and deletes cascade manually (see `deleteSession`, `deleteAllSessions`,
   /// `cleanupSessions`).
+  ///
+  /// Because this runs with `IF NOT EXISTS` on every open, a table added in a newer build appears
+  /// in an existing database without a schema-version bump — older data is preserved. Bump
+  /// `currentSchemaVersion` only for changes an older or newer build couldn't operate on (altered
+  /// columns, changed semantics).
   private func createSchemaTables() throws {
     try database.execute(
       """
@@ -642,6 +715,23 @@ final class MetricsDatabase: Sendable {
         sessionId TEXT PRIMARY KEY NOT NULL,
         payload TEXT NOT NULL
       );
+
+      CREATE TABLE IF NOT EXISTS spans (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sessionId TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        traceId TEXT NOT NULL,
+        spanId TEXT NOT NULL,
+        parentSpanId TEXT,
+        name TEXT NOT NULL,
+        kind INTEGER NOT NULL,
+        startTimestampMs INTEGER NOT NULL,
+        endTimestampMs INTEGER NOT NULL,
+        statusCode INTEGER,
+        statusMessage TEXT,
+        attributes TEXT,
+        events TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_spans_sessionId ON spans(sessionId);
       """
     )
   }
@@ -683,5 +773,10 @@ final class MetricsDatabase: Sendable {
     appUpdateId, appUpdateRuntimeVersion, appUpdateRequestHeaders, appEasBuildId,
     deviceOs, deviceOsVersion, deviceModel, deviceName,
     expoSdkVersion, reactNativeVersion, clientVersion, languageTag
+    """
+
+  private let spanColumns = """
+    id, sessionId, traceId, spanId, parentSpanId, name, kind,
+    startTimestampMs, endTimestampMs, statusCode, statusMessage, attributes, events
     """
 }

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -574,6 +574,102 @@ final class MetricsDatabase: Sendable {
     try statement.run()
   }
 
+  // MARK: - Spans
+
+  /// Maximum number of rows retained in `spans`. Span producers (network requests especially)
+  /// can outnumber metrics and logs by orders of magnitude, and when nothing consumes the rows
+  /// (`expo-observe` not installed, or dispatch disabled) the session-retention prune alone
+  /// would let a busy app accumulate a week of traffic. Inserts prune anything older than the cap.
+  static let spanCap = 2_000
+
+  /// Inserts a single span and returns its rowid (the auto-incremented `id`). Also prunes rows
+  /// older than `spanCap`. Ids are monotonic, so "older" is simply everything at least
+  /// `spanCap` ids behind the row just inserted. Insert and prune share one transaction, so the
+  /// per-span hot path pays a single commit.
+  @AppMetricsActor
+  @discardableResult
+  func insert(span: SpanRow) throws -> Int64 {
+    return try database.transaction {
+      let insertedId = try insertUncapped(span: span)
+      try deleteSpans(upToId: insertedId - Int64(Self.spanCap))
+      return insertedId
+    }
+  }
+
+  /// Raw row insert with no cap enforcement and no transaction of its own, the primitive
+  /// `insert(span:)` builds on. `database.transaction` issues a plain `BEGIN` and doesn't nest,
+  /// so a future batch path (`insertAll(spans:)`) can call this inside one outer transaction.
+  @AppMetricsActor
+  private func insertUncapped(span: SpanRow) throws -> Int64 {
+    let statement = try database.prepare(
+      """
+      INSERT INTO spans (
+        sessionId, traceId, spanId, parentSpanId, name, kind,
+        startTimestampMs, endTimestampMs, statusCode, statusMessage, attributes, events
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+      """
+    )
+    try statement.bindAll([
+      span.sessionId, span.traceId, span.spanId, span.parentSpanId, span.name, span.kind,
+      span.startTimestampMs, span.endTimestampMs, span.statusCode, span.statusMessage,
+      span.attributes, span.events,
+    ])
+    try statement.run()
+    return database.lastInsertRowid()
+  }
+
+  /// Returns span rows whose `id` is greater than `cursor`, in ascending id order, at most
+  /// `limit` of them (all when `nil`). Mirrors `getMetrics(afterId:limit:)` so consumers can
+  /// drain the table in chunks.
+  @AppMetricsActor
+  func getSpans(afterId cursor: Int64, limit: Int? = nil) throws -> [SpanRow] {
+    let statement = try database.prepare(
+      """
+      SELECT \(spanColumns) FROM spans WHERE id > ?1 ORDER BY id ASC LIMIT ?2
+      """
+    )
+    try statement.bindAll([cursor, limit ?? -1])
+    var rows: [SpanRow] = []
+    try statement.forEachRow { row in
+      rows.append(SpanRow(row: row))
+    }
+    return rows
+  }
+
+  /// Returns the spans attributed to `sessionId`, in ascending id (insertion) order. This is
+  /// the session-association read for a future session-inspection consumer. The exporter owns
+  /// deletion today, so this sees only rows it hasn't dispatched yet, bounded also by the
+  /// insert-time row cap.
+  @AppMetricsActor
+  func getSpans(forSessionId sessionId: String) throws -> [SpanRow] {
+    let statement = try database.prepare(
+      """
+      SELECT \(spanColumns) FROM spans WHERE sessionId = ?1 ORDER BY id ASC
+      """
+    )
+    try statement.bindAll([sessionId])
+    var rows: [SpanRow] = []
+    try statement.forEachRow { row in
+      rows.append(SpanRow(row: row))
+    }
+    return rows
+  }
+
+  @AppMetricsActor
+  func getMaxSpanId() throws -> Int64? {
+    return try selectMaxId(table: "spans")
+  }
+
+  /// Deletes rows with `id <= upToId`. Called after a dispatch consumed (or deliberately
+  /// dropped) a batch, and by the insert-time row cap. The exporter owns deletion: the
+  /// per-session read (`getSpans(forSessionId:)`) sees only rows not yet dispatched.
+  @AppMetricsActor
+  func deleteSpans(upToId: Int64) throws {
+    let statement = try database.prepare("DELETE FROM spans WHERE id <= ?1")
+    try statement.bindAll([upToId])
+    try statement.run()
+  }
+
   // MARK: - Schema
 
   /// Creates the schema (tables, indexes, version row) atomically. Wrapping the whole bootstrap in a
@@ -590,14 +686,20 @@ final class MetricsDatabase: Sendable {
     }
   }
 
-  /// Creates the four data tables plus `schema_version`. Relationships:
+  /// Creates the five data tables plus `schema_version`. Relationships:
   ///
   /// - `sessions` is the root. Every other table keys off `sessions.id` (a UUID string).
-  /// - `metrics` and `logs` each have a `sessionId` FK with `ON DELETE CASCADE`. Their `id` is
-  /// `INTEGER PRIMARY KEY AUTOINCREMENT` so `expo-observe` can dispatch with a monotonic cursor.
+  /// - `metrics`, `logs` and `spans` each have a `sessionId` FK with `ON DELETE CASCADE`. Their
+  /// `id` is `INTEGER PRIMARY KEY AUTOINCREMENT` so `expo-observe` can dispatch with a monotonic
+  /// cursor.
   /// - `crash_reports` is keyed by `sessionId`. There's no FK constraint; the relationship is
   /// informational, and deletes cascade manually (see `deleteSession`, `deleteAllSessions`,
   /// `cleanupSessions`).
+  ///
+  /// Because this runs with `IF NOT EXISTS` on every open, a table added in a newer build appears
+  /// in an existing database without a schema-version bump, and older data is preserved. Bump
+  /// `currentSchemaVersion` only for changes an older or newer build couldn't operate on (altered
+  /// columns, changed semantics).
   private func createSchemaTables() throws {
     try database.execute(
       """
@@ -657,6 +759,23 @@ final class MetricsDatabase: Sendable {
         sessionId TEXT PRIMARY KEY NOT NULL,
         payload TEXT NOT NULL
       );
+
+      CREATE TABLE IF NOT EXISTS spans (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sessionId TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+        traceId TEXT NOT NULL,
+        spanId TEXT NOT NULL,
+        parentSpanId TEXT,
+        name TEXT NOT NULL,
+        kind INTEGER NOT NULL,
+        startTimestampMs INTEGER NOT NULL,
+        endTimestampMs INTEGER NOT NULL,
+        statusCode INTEGER,
+        statusMessage TEXT,
+        attributes TEXT,
+        events TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_spans_sessionId ON spans(sessionId);
       """
     )
   }
@@ -682,8 +801,8 @@ final class MetricsDatabase: Sendable {
 
   @AppMetricsActor
   private func selectMaxId(table: String) throws -> Int64? {
-    // The table name is a literal we control (`metrics` / `logs`), so interpolating into the SQL
-    // text is safe — SQLite has no parameter placeholder for identifiers.
+    // The table name is a literal we control (`metrics` / `logs` / `spans`), so interpolating into
+    // the SQL text is safe, and SQLite has no parameter placeholder for identifiers.
     let statement = try database.prepare("SELECT MAX(id) FROM \(table)")
     var maxId: Int64?
     try statement.forEachRow { row in
@@ -698,5 +817,10 @@ final class MetricsDatabase: Sendable {
     appUpdateId, appUpdateRuntimeVersion, appUpdateRequestHeaders, appEasBuildId,
     deviceOs, deviceOsVersion, deviceModel, deviceName,
     expoSdkVersion, reactNativeVersion, clientVersion, languageTag
+    """
+
+  private let spanColumns = """
+    id, sessionId, traceId, spanId, parentSpanId, name, kind,
+    startTimestampMs, endTimestampMs, statusCode, statusMessage, attributes, events
     """
 }

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabaseRows.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabaseRows.swift
@@ -219,3 +219,129 @@ extension LogRow {
     )
   }
 }
+
+/// Persistence-layer representation of one trace span, mirroring the OTLP `Span` shape. Spans are
+/// a generic signal: any producer (network requests today, navigation or custom spans later)
+/// converts its domain event into a `SpanRow` at record time, and `expo-observe` exports rows past
+/// a cursor to the OTLP traces endpoint without knowing what produced them.
+public struct SpanRow: Sendable {
+  /// `SpanKind` values from the OTLP proto, for producers picking a `kind`.
+  public static let internalKind = 1
+  public static let clientKind = 3
+
+  /// `Status.code` values from the OTLP proto. UNSET is expressed by a `nil` `statusCode`.
+  public static let statusError = 2
+
+  public let id: Int64?
+  public let sessionId: String
+
+  /// W3C trace/span identifiers as lowercase hex (32 and 16 characters). Generated once at
+  /// record time and persisted, so a redelivered row (export is at-least-once) reaches the
+  /// server byte-identical instead of becoming an untraceable duplicate.
+  public let traceId: String
+  public let spanId: String
+
+  /// Parent span id for in-app hierarchies, or `nil` for a root span. No producer sets this yet;
+  /// the column exists so adding nested spans later is not a schema change.
+  public let parentSpanId: String?
+
+  /// Span name per the semantic conventions of the producer (the HTTP method for network
+  /// request spans).
+  public let name: String
+
+  /// `SpanKind` per the OTLP proto (`clientKind` for network requests).
+  public let kind: Int
+
+  /// Unix-epoch milliseconds. Stored as integers rather than the ISO strings the other tables use:
+  /// a span's duration is routinely sub-second, and the house ISO format carries no fractional
+  /// seconds, so a string timestamp would collapse every fast span to zero length.
+  public let startTimestampMs: Int64
+  public let endTimestampMs: Int64
+
+  /// OTLP status code (`statusError`), or `nil` when the span completed without one (UNSET).
+  public let statusCode: Int?
+  public let statusMessage: String?
+
+  /// JSON object of span attributes, keyed per the producer's semantic conventions. Stored as an
+  /// opaque blob — nothing queries individual attributes locally, and the export layer converts
+  /// them generically to the OTLP wire shape.
+  public let attributes: String?
+
+  /// JSON array of span events (`[{name, timeMs?, attributes}]`). Stored as an opaque blob for
+  /// the same reason as `attributes`.
+  public let events: String?
+
+  public init(
+    id: Int64? = nil,
+    sessionId: String,
+    traceId: String = SpanRow.generateTraceId(),
+    spanId: String = SpanRow.generateSpanId(),
+    parentSpanId: String? = nil,
+    name: String,
+    kind: Int = SpanRow.internalKind,
+    startTimestampMs: Int64,
+    endTimestampMs: Int64,
+    statusCode: Int? = nil,
+    statusMessage: String? = nil,
+    attributes: String? = nil,
+    events: String? = nil
+  ) {
+    self.id = id
+    self.sessionId = sessionId
+    self.traceId = traceId
+    self.spanId = spanId
+    self.parentSpanId = parentSpanId
+    self.name = name
+    self.kind = kind
+    self.startTimestampMs = startTimestampMs
+    self.endTimestampMs = endTimestampMs
+    self.statusCode = statusCode
+    self.statusMessage = statusMessage
+    self.attributes = attributes
+    self.events = events
+  }
+
+  /// A new random 16-byte trace id as 32 lowercase hex characters. There is no trace-context
+  /// propagation yet, so every span starts its own trace.
+  public static func generateTraceId() -> String {
+    return generateHexId(words: 2)
+  }
+
+  /// A new random 8-byte span id as 16 lowercase hex characters.
+  public static func generateSpanId() -> String {
+    return generateHexId(words: 1)
+  }
+
+  /// Random identifier built from 8-byte words, hex-encoded. The all-zero value is invalid per
+  /// the OTLP spec (the server rejects the span), so it redraws — a branch that is hit once per
+  /// 2^64 draws but keeps the invariant explicit.
+  private static func generateHexId(words: Int) -> String {
+    while true {
+      let drawn = (0..<words).map { _ in UInt64.random(in: .min ... .max) }
+      guard drawn.contains(where: { $0 != 0 }) else {
+        continue
+      }
+      return drawn.map { String(format: "%016llx", $0) }.joined()
+    }
+  }
+}
+
+extension SpanRow {
+  init(row: SQLiteRow) {
+    self.init(
+      id: row.int64(at: 0),
+      sessionId: row.string(at: 1) ?? "",
+      traceId: row.string(at: 2) ?? "",
+      spanId: row.string(at: 3) ?? "",
+      parentSpanId: row.string(at: 4),
+      name: row.string(at: 5) ?? "",
+      kind: row.int(at: 6) ?? SpanRow.internalKind,
+      startTimestampMs: row.int64(at: 7) ?? 0,
+      endTimestampMs: row.int64(at: 8) ?? 0,
+      statusCode: row.int(at: 9),
+      statusMessage: row.string(at: 10),
+      attributes: row.string(at: 11),
+      events: row.string(at: 12)
+    )
+  }
+}

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabaseRows.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabaseRows.swift
@@ -219,3 +219,139 @@ extension LogRow {
     )
   }
 }
+
+/// Persistence-layer representation of one trace span, mirroring the OTLP `Span` shape
+/// (https://opentelemetry.io/docs/concepts/signals/traces/#spans). Spans are a generic signal:
+/// any producer (network requests today, navigation or custom spans later) converts its domain
+/// event into a `SpanRow` at record time, and `expo-observe` exports rows past a cursor to the
+/// OTLP traces endpoint without knowing what produced them.
+public struct SpanRow: Sendable {
+  /// `SpanKind` values from the OTLP proto, for producers picking a `kind`.
+  public static let internalKind = 1
+  public static let clientKind = 3
+
+  /// `Status.code` values from the OTLP proto. UNSET is expressed by a `nil` `statusCode`.
+  public static let statusError = 2
+
+  public let id: Int64?
+  public let sessionId: String
+
+  /// W3C trace/span identifiers as lowercase hex (32 and 16 characters). Generated once at
+  /// record time and persisted, so a redelivered row (export is at-least-once) reaches the
+  /// server byte-identical instead of becoming an untraceable duplicate.
+  public let traceId: String
+  public let spanId: String
+
+  /// Parent span id for in-app hierarchies, or `nil` for a root span. Set by `SpanRecorder` when
+  /// a custom span is started with a parent; the network producer always writes root spans.
+  public let parentSpanId: String?
+
+  /// Span name per the semantic conventions of the producer (the HTTP method for network
+  /// request spans).
+  public let name: String
+
+  /// `SpanKind` per the OTLP proto (`clientKind` for network requests).
+  public let kind: Int
+
+  /// Unix-epoch milliseconds. Stored as integers rather than the ISO strings the other tables use:
+  /// a span's duration is routinely sub-second, and the house ISO format carries no fractional
+  /// seconds, so a string timestamp would collapse every fast span to zero length. Milliseconds
+  /// is the OTel spec's minimal timestamp precision; the exporter converts to the wire format's
+  /// `timeUnixNano`.
+  public let startTimestampMs: Int64
+  public let endTimestampMs: Int64
+
+  /// OTLP status code (`statusError`), or `nil` when the span completed without one (UNSET).
+  public let statusCode: Int?
+  public let statusMessage: String?
+
+  /// JSON object of span attributes, keyed per the producer's semantic conventions. Stored as an
+  /// opaque blob: nothing queries individual attributes locally, and the export layer converts
+  /// them generically to the OTLP wire shape.
+  public let attributes: String?
+
+  /// JSON array of span events (`[{name, timeMs?, attributes}]`). Stored as an opaque blob for
+  /// the same reason as `attributes`.
+  public let events: String?
+
+  public init(
+    id: Int64? = nil,
+    sessionId: String,
+    traceId: String = SpanRow.generateTraceId(),
+    spanId: String = SpanRow.generateSpanId(),
+    parentSpanId: String? = nil,
+    name: String,
+    kind: Int = SpanRow.internalKind,
+    startTimestampMs: Int64,
+    endTimestampMs: Int64,
+    statusCode: Int? = nil,
+    statusMessage: String? = nil,
+    attributes: String? = nil,
+    events: String? = nil
+  ) {
+    self.id = id
+    self.sessionId = sessionId
+    self.traceId = traceId
+    self.spanId = spanId
+    self.parentSpanId = parentSpanId
+    self.name = name
+    self.kind = kind
+    self.startTimestampMs = startTimestampMs
+    self.endTimestampMs = endTimestampMs
+    self.statusCode = statusCode
+    self.statusMessage = statusMessage
+    self.attributes = attributes
+    self.events = events
+  }
+
+  /// A new random 16-byte trace id as 32 lowercase hex characters. Called for a root span only:
+  /// a child reuses its parent's trace id. There is no cross-process trace-context propagation,
+  /// so a trace never extends beyond this app.
+  public static func generateTraceId() -> String {
+    return generateHexId(words: 2)
+  }
+
+  /// A new random 8-byte span id as 16 lowercase hex characters.
+  public static func generateSpanId() -> String {
+    return generateHexId(words: 1)
+  }
+
+  private static func generateHexId(words: Int) -> String {
+    var generator = SystemRandomNumberGenerator()
+    return generateHexId(words: words, using: &generator)
+  }
+
+  /// Random identifier built from 8-byte words, hex-encoded. The all-zero value is invalid per
+  /// the OTLP spec (the server rejects the span), so it redraws, a branch that is hit once per
+  /// 2^64 draws but keeps the invariant explicit. The generator is injectable so a test can
+  /// force the zero draw and prove the redraw happens.
+  static func generateHexId(words: Int, using generator: inout some RandomNumberGenerator) -> String {
+    while true {
+      let drawn = (0..<words).map { _ in generator.next() }
+      guard drawn.contains(where: { $0 != 0 }) else {
+        continue
+      }
+      return drawn.map { String(format: "%016llx", $0) }.joined()
+    }
+  }
+}
+
+extension SpanRow {
+  init(row: SQLiteRow) {
+    self.init(
+      id: row.int64(at: 0),
+      sessionId: row.string(at: 1) ?? "",
+      traceId: row.string(at: 2) ?? "",
+      spanId: row.string(at: 3) ?? "",
+      parentSpanId: row.string(at: 4),
+      name: row.string(at: 5) ?? "",
+      kind: row.int(at: 6) ?? SpanRow.internalKind,
+      startTimestampMs: row.int64(at: 7) ?? 0,
+      endTimestampMs: row.int64(at: 8) ?? 0,
+      statusCode: row.int(at: 9),
+      statusMessage: row.string(at: 10),
+      attributes: row.string(at: 11),
+      events: row.string(at: 12)
+    )
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
@@ -562,6 +562,158 @@ struct MetricsDatabaseTests {
     }
   }
 
+  // MARK: - Spans
+
+  @Test
+  func `insert span returns auto-incremented id`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let firstId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let secondId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      #expect(secondId > firstId)
+    }
+  }
+
+  @Test
+  func `getSpans returns rows past the cursor in ascending id order`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let firstId = try database.insert(span: makeSpanRow(sessionId: "s", name: "a"))
+      try database.insert(span: makeSpanRow(sessionId: "s", name: "b"))
+      try database.insert(span: makeSpanRow(sessionId: "s", name: "c"))
+      let rows = try database.getSpans(afterId: firstId)
+      #expect(rows.map(\.name) == ["b", "c"])
+      #expect(rows.compactMap(\.id) == rows.compactMap(\.id).sorted())
+    }
+  }
+
+  @Test
+  func `span round-trips its full payload`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(
+        span: makeSpanRow(
+          sessionId: "s",
+          traceId: "a3ce929d0e0e4736a3ce929d0e0e4736",
+          spanId: "00f067aa0ba902b7",
+          parentSpanId: "abcdef0123456789",
+          name: "POST",
+          kind: SpanRow.clientKind,
+          startTimestampMs: 1_782_131_895_000,
+          endTimestampMs: 1_782_131_895_250,
+          statusCode: SpanRow.statusError,
+          statusMessage: "went wrong",
+          attributes: "{\"url.full\":\"https://example.com\"}",
+          events: "[{\"name\":\"http.redirect\"}]"
+        )
+      )
+      let row = try #require(try database.getSpans(afterId: -1).first)
+      #expect(row.id != nil)
+      #expect(row.sessionId == "s")
+      #expect(row.traceId == "a3ce929d0e0e4736a3ce929d0e0e4736")
+      #expect(row.spanId == "00f067aa0ba902b7")
+      #expect(row.parentSpanId == "abcdef0123456789")
+      #expect(row.name == "POST")
+      #expect(row.kind == SpanRow.clientKind)
+      #expect(row.startTimestampMs == 1_782_131_895_000)
+      #expect(row.endTimestampMs == 1_782_131_895_250)
+      #expect(row.statusCode == SpanRow.statusError)
+      #expect(row.statusMessage == "went wrong")
+      #expect(row.attributes == "{\"url.full\":\"https://example.com\"}")
+      #expect(row.events == "[{\"name\":\"http.redirect\"}]")
+    }
+  }
+
+  @Test
+  func `span round-trips absent optionals as nil`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let row = try #require(try database.getSpans(afterId: -1).first)
+      #expect(row.parentSpanId == nil)
+      #expect(row.statusCode == nil)
+      #expect(row.statusMessage == nil)
+      #expect(row.attributes == nil)
+      #expect(row.events == nil)
+    }
+  }
+
+  @Test
+  func `getMaxSpanId reflects the newest row and nil when empty`() throws {
+    try withTemporaryDatabase { database in
+      let emptyMaxId = try database.getMaxSpanId()
+      #expect(emptyMaxId == nil)
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let lastId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let maxId = try database.getMaxSpanId()
+      #expect(maxId == lastId)
+    }
+  }
+
+  @Test
+  func `deleteSpans removes rows up to and including the given id`() throws {
+    // Dispatched rows are deleted rather than retained: unlike metrics and logs, no
+    // per-session JS API reads them back, and spans are high-volume.
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let secondId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let thirdId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      try database.deleteSpans(upToId: secondId)
+      let remaining = try database.getSpans(afterId: -1)
+      #expect(remaining.compactMap(\.id) == [thirdId])
+    }
+  }
+
+  @Test
+  func `spans are deleted when their session is deleted`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      try database.deleteSession(id: "s")
+      let remaining = try database.getSpans(afterId: -1)
+      #expect(remaining.isEmpty)
+    }
+  }
+
+  @Test
+  func `insert span prunes the oldest rows past the retention cap`() throws {
+    // Span producers (network requests especially) can record orders of magnitude more rows
+    // than metrics or logs. The cap bounds the table when nothing consumes (and deletes) the rows.
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      for _ in 0..<(MetricsDatabase.spanCap + 10) {
+        try database.insert(span: makeSpanRow(sessionId: "s"))
+      }
+      let count = try countRows(database: database, table: "spans")
+      #expect(count <= MetricsDatabase.spanCap)
+      let rows = try database.getSpans(afterId: -1)
+      let maxId = try #require(try database.getMaxSpanId())
+      #expect(rows.compactMap(\.id).max() == maxId)
+    }
+  }
+
+  @Test
+  func `adding the spans table preserves an existing database`() throws {
+    // The table ships without a schema-version bump, so a database created by a build
+    // that predates it must keep its rows when this build opens the file. This models
+    // that by dropping the table and re-opening.
+    try withTemporaryDirectory { directoryUrl in
+      do {
+        let database = try MetricsDatabase(directoryUrl: directoryUrl)
+        try database.insert(session: makeSessionRow(id: "kept"))
+        try database.database.execute("DROP TABLE spans;")
+      }
+      let database = try MetricsDatabase(directoryUrl: directoryUrl)
+      let session = try database.getSession(id: "kept")
+      #expect(session != nil)
+      try database.insert(span: makeSpanRow(sessionId: "kept"))
+      let requests = try database.getSpans(afterId: -1)
+      #expect(requests.count == 1)
+    }
+  }
+
   // MARK: - Helpers
 }
 
@@ -668,6 +820,36 @@ private func makeLogRow(
     body: body,
     attributes: attributes,
     droppedAttributesCount: droppedAttributesCount
+  )
+}
+
+private func makeSpanRow(
+  sessionId: String,
+  traceId: String = SpanRow.generateTraceId(),
+  spanId: String = SpanRow.generateSpanId(),
+  parentSpanId: String? = nil,
+  name: String = "GET",
+  kind: Int = SpanRow.clientKind,
+  startTimestampMs: Int64 = 1_782_131_895_000,
+  endTimestampMs: Int64 = 1_782_131_895_250,
+  statusCode: Int? = nil,
+  statusMessage: String? = nil,
+  attributes: String? = nil,
+  events: String? = nil
+) -> SpanRow {
+  return SpanRow(
+    sessionId: sessionId,
+    traceId: traceId,
+    spanId: spanId,
+    parentSpanId: parentSpanId,
+    name: name,
+    kind: kind,
+    startTimestampMs: startTimestampMs,
+    endTimestampMs: endTimestampMs,
+    statusCode: statusCode,
+    statusMessage: statusMessage,
+    attributes: attributes,
+    events: events
   )
 }
 

--- a/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
@@ -618,6 +618,172 @@ struct MetricsDatabaseTests {
     }
   }
 
+  // MARK: - Spans
+
+  @Test
+  func `insert span returns auto-incremented id`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let firstId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let secondId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      #expect(secondId > firstId)
+    }
+  }
+
+  @Test
+  func `getSpans returns rows past the cursor in ascending id order`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let firstId = try database.insert(span: makeSpanRow(sessionId: "s", name: "a"))
+      try database.insert(span: makeSpanRow(sessionId: "s", name: "b"))
+      try database.insert(span: makeSpanRow(sessionId: "s", name: "c"))
+      let rows = try database.getSpans(afterId: firstId)
+      let limited = try database.getSpans(afterId: firstId, limit: 1)
+      #expect(limited.map(\.name) == ["b"])
+      #expect(rows.map(\.name) == ["b", "c"])
+      #expect(rows.compactMap(\.id) == rows.compactMap(\.id).sorted())
+    }
+  }
+
+  @Test
+  func `getSpans by session returns only that session's rows in insertion order`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "a"))
+      try database.insert(session: makeSessionRow(id: "b"))
+      try database.insert(span: makeSpanRow(sessionId: "a", name: "a1"))
+      try database.insert(span: makeSpanRow(sessionId: "b", name: "b1"))
+      try database.insert(span: makeSpanRow(sessionId: "a", name: "a2"))
+      let rows = try database.getSpans(forSessionId: "a")
+      #expect(rows.map(\.name) == ["a1", "a2"])
+      #expect(try database.getSpans(forSessionId: "missing").isEmpty)
+    }
+  }
+
+  @Test
+  func `span round-trips its full payload`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(
+        span: makeSpanRow(
+          sessionId: "s",
+          traceId: "a3ce929d0e0e4736a3ce929d0e0e4736",
+          spanId: "00f067aa0ba902b7",
+          parentSpanId: "abcdef0123456789",
+          name: "POST",
+          kind: SpanRow.clientKind,
+          startTimestampMs: 1_782_131_895_000,
+          endTimestampMs: 1_782_131_895_250,
+          statusCode: SpanRow.statusError,
+          statusMessage: "went wrong",
+          attributes: "{\"url.full\":\"https://example.com\"}",
+          events: "[{\"name\":\"http.redirect\"}]"
+        )
+      )
+      let row = try #require(try database.getSpans(afterId: -1).first)
+      #expect(row.id != nil)
+      #expect(row.sessionId == "s")
+      #expect(row.traceId == "a3ce929d0e0e4736a3ce929d0e0e4736")
+      #expect(row.spanId == "00f067aa0ba902b7")
+      #expect(row.parentSpanId == "abcdef0123456789")
+      #expect(row.name == "POST")
+      #expect(row.kind == SpanRow.clientKind)
+      #expect(row.startTimestampMs == 1_782_131_895_000)
+      #expect(row.endTimestampMs == 1_782_131_895_250)
+      #expect(row.statusCode == SpanRow.statusError)
+      #expect(row.statusMessage == "went wrong")
+      #expect(row.attributes == "{\"url.full\":\"https://example.com\"}")
+      #expect(row.events == "[{\"name\":\"http.redirect\"}]")
+    }
+  }
+
+  @Test
+  func `span round-trips absent optionals as nil`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let row = try #require(try database.getSpans(afterId: -1).first)
+      #expect(row.parentSpanId == nil)
+      #expect(row.statusCode == nil)
+      #expect(row.statusMessage == nil)
+      #expect(row.attributes == nil)
+      #expect(row.events == nil)
+    }
+  }
+
+  @Test
+  func `getMaxSpanId reflects the newest row and nil when empty`() throws {
+    try withTemporaryDatabase { database in
+      let emptyMaxId = try database.getMaxSpanId()
+      #expect(emptyMaxId == nil)
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let lastId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let maxId = try database.getMaxSpanId()
+      #expect(maxId == lastId)
+    }
+  }
+
+  @Test
+  func `deleteSpans removes rows up to and including the given id`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      let secondId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      let thirdId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      try database.deleteSpans(upToId: secondId)
+      let remaining = try database.getSpans(afterId: -1)
+      #expect(remaining.compactMap(\.id) == [thirdId])
+    }
+  }
+
+  @Test
+  func `spans are deleted when their session is deleted`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      try database.insert(span: makeSpanRow(sessionId: "s"))
+      try database.deleteSession(id: "s")
+      let remaining = try database.getSpans(afterId: -1)
+      #expect(remaining.isEmpty)
+    }
+  }
+
+  @Test
+  func `insert span prunes the oldest rows past the retention cap`() throws {
+    // Span producers (network requests especially) can record orders of magnitude more rows
+    // than metrics or logs. The cap bounds the table when nothing consumes (and deletes) the rows.
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      var lastId: Int64 = 0
+      for _ in 0..<(MetricsDatabase.spanCap + 10) {
+        lastId = try database.insert(span: makeSpanRow(sessionId: "s"))
+      }
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.count == MetricsDatabase.spanCap)
+      #expect(rows.first?.id == lastId - Int64(MetricsDatabase.spanCap) + 1)
+      #expect(rows.last?.id == lastId)
+    }
+  }
+
+  @Test
+  func `adding the spans table preserves an existing database`() throws {
+    // The table ships without a schema-version bump, so a database created by a build
+    // that predates it must keep its rows when this build opens the file. This models
+    // that by dropping the table and re-opening.
+    try withTemporaryDirectory { directoryUrl in
+      do {
+        let database = try MetricsDatabase(directoryUrl: directoryUrl)
+        try database.insert(session: makeSessionRow(id: "kept"))
+        try database.database.execute("DROP TABLE spans;")
+      }
+      let database = try MetricsDatabase(directoryUrl: directoryUrl)
+      let session = try database.getSession(id: "kept")
+      #expect(session != nil)
+      try database.insert(span: makeSpanRow(sessionId: "kept"))
+      let spans = try database.getSpans(afterId: -1)
+      #expect(spans.count == 1)
+    }
+  }
+
   // MARK: - Helpers
 }
 
@@ -724,6 +890,36 @@ private func makeLogRow(
     body: body,
     attributes: attributes,
     droppedAttributesCount: droppedAttributesCount
+  )
+}
+
+private func makeSpanRow(
+  sessionId: String,
+  traceId: String = SpanRow.generateTraceId(),
+  spanId: String = SpanRow.generateSpanId(),
+  parentSpanId: String? = nil,
+  name: String = "GET",
+  kind: Int = SpanRow.clientKind,
+  startTimestampMs: Int64 = 1_782_131_895_000,
+  endTimestampMs: Int64 = 1_782_131_895_250,
+  statusCode: Int? = nil,
+  statusMessage: String? = nil,
+  attributes: String? = nil,
+  events: String? = nil
+) -> SpanRow {
+  return SpanRow(
+    sessionId: sessionId,
+    traceId: traceId,
+    spanId: spanId,
+    parentSpanId: parentSpanId,
+    name: name,
+    kind: kind,
+    startTimestampMs: startTimestampMs,
+    endTimestampMs: endTimestampMs,
+    statusCode: statusCode,
+    statusMessage: statusMessage,
+    attributes: attributes,
+    events: events
   )
 }
 

--- a/packages/expo-app-metrics/ios/Tests/SpanRowTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/SpanRowTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("SpanRow identifiers")
+struct SpanRowIdentifierTests {
+  @Test
+  func `generates a 32-character lowercase hex trace id`() {
+    // The ingestion endpoint rejects any span whose trace id isn't exactly 32 hex characters.
+    let traceId = SpanRow.generateTraceId()
+    #expect(traceId.count == 32)
+    #expect(traceId.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+  }
+
+  @Test
+  func `generates a 16-character lowercase hex span id`() {
+    let spanId = SpanRow.generateSpanId()
+    #expect(spanId.count == 16)
+    #expect(spanId.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+  }
+
+  @Test
+  func `never generates an all-zero identifier`() {
+    // An all-zero id is invalid per the OTLP spec and the server rejects the span outright.
+    // A single draw can legitimately contain zero bytes, so this asserts across many draws
+    // that the fully-zero degenerate value never appears.
+    for _ in 0..<512 {
+      #expect(SpanRow.generateTraceId() != String(repeating: "0", count: 32))
+      #expect(SpanRow.generateSpanId() != String(repeating: "0", count: 16))
+    }
+  }
+
+  @Test
+  func `generates distinct identifiers on each call`() {
+    var seen = Set<String>()
+    for _ in 0..<128 {
+      seen.insert(SpanRow.generateTraceId())
+    }
+    #expect(seen.count == 128)
+  }
+
+  @Test
+  func `a new row receives generated identifiers by default`() {
+    // Ids are assigned once at record time and persisted, so a redelivered row (export is
+    // at-least-once) reaches the server byte-identical instead of becoming a fresh duplicate.
+    let first = SpanRow(sessionId: "s", name: "GET", startTimestampMs: 0, endTimestampMs: 1)
+    let second = SpanRow(sessionId: "s", name: "GET", startTimestampMs: 0, endTimestampMs: 1)
+    #expect(first.traceId.count == 32)
+    #expect(first.spanId.count == 16)
+    #expect(first.traceId != second.traceId)
+    #expect(first.spanId != second.spanId)
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/SpanRowTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/SpanRowTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+/// Yields the scripted values in order, then a fixed non-zero fallback.
+private struct ScriptedGenerator: RandomNumberGenerator {
+  var values: [UInt64]
+  private var index = 0
+
+  init(values: [UInt64]) {
+    self.values = values
+  }
+
+  mutating func next() -> UInt64 {
+    defer {
+      index += 1
+    }
+    return index < values.count ? values[index] : 42
+  }
+}
+
+@Suite("SpanRow identifiers")
+struct SpanRowIdentifierTests {
+  @Test
+  func `generates a 32-character lowercase hex trace id`() {
+    // The ingestion endpoint rejects any span whose trace id isn't exactly 32 hex characters.
+    let traceId = SpanRow.generateTraceId()
+    #expect(traceId.count == 32)
+    #expect(traceId.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+  }
+
+  @Test
+  func `generates a 16-character lowercase hex span id`() {
+    let spanId = SpanRow.generateSpanId()
+    #expect(spanId.count == 16)
+    #expect(spanId.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+  }
+
+  @Test
+  func `redraws when the generator produces the all-zero identifier`() {
+    // An all-zero id is invalid per the OTLP spec and the server rejects the span outright.
+    // A real generator hits the zero draw once per 2^64 draws, so this injects one that yields
+    // zeros first and proves the redraw branch produces the next non-zero value instead.
+    var generator = ScriptedGenerator(values: [0, 0, 1, 2])
+    let id = SpanRow.generateHexId(words: 2, using: &generator)
+    #expect(id == String(format: "%016llx%016llx", UInt64(1), UInt64(2)))
+  }
+
+  @Test
+  func `generates distinct identifiers on each call`() {
+    var traceIds = Set<String>()
+    var spanIds = Set<String>()
+    for _ in 0..<128 {
+      traceIds.insert(SpanRow.generateTraceId())
+      spanIds.insert(SpanRow.generateSpanId())
+    }
+    #expect(traceIds.count == 128)
+    #expect(spanIds.count == 128)
+  }
+
+  @Test
+  func `a new row receives generated identifiers by default`() {
+    // Ids are assigned once at record time and persisted, so a redelivered row (export is
+    // at-least-once) reaches the server byte-identical instead of becoming a fresh duplicate.
+    let first = SpanRow(sessionId: "s", name: "GET", startTimestampMs: 0, endTimestampMs: 1)
+    let second = SpanRow(sessionId: "s", name: "GET", startTimestampMs: 0, endTimestampMs: 1)
+    #expect(first.traceId.count == 32)
+    #expect(first.spanId.count == 16)
+    #expect(first.traceId != second.traceId)
+    #expect(first.spanId != second.spanId)
+  }
+}


### PR DESCRIPTION
# Why

The Observe backend can ingest OTLP traces now (expo/universe#29872, expo/universe#29874), but the SDK has nowhere to store spans locally. This adds the storage layer only; producers and export sit on top.

Part of ENG-25894.

# How

Adds a generic `spans` table mirroring the OTLP span shape, plus the read/delete facade the exporter consumes. Spans are attributed to the session that produced them and stay readable per session, so a session's trace activity can be inspected alongside its metrics and logs; consumers delete only rows no reader still needs. Trace and span ids are generated at record time, so redelivery after a crash stays byte-identical on the server. The table is capped at 2000 rows in the same transaction as the insert. Timestamps are millisecond integers rather than the house ISO strings, which carry no fractional seconds and would collapse sub-second spans.

On iOS the table is created with `IF NOT EXISTS` on every open, no schema-version bump, so existing data survives. On Android, Room bumps to v18 and relies on the existing destructive fallback: maintaining a migration costs more than losing local telemetry that is dispatched frequently anyway.

# Test Plan

Unit suites on both platforms cover id generation, storage round-trips, ordering, the per-session read, the cap, cascade deletion, and the iOS no-wipe upgrade path. `et native-unit-tests` passes on both platforms with only this layer present.

