### PR TITLE
[ios][expo-go] Track session expiry and resolve usernames for partner actors

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
@@ -35,6 +35,13 @@ import UIKit
       return
     }
 
+    if let expiredMessage = sessionExpiredMessage() {
+      AuthenticationService.clearSession()
+      showError(expiredMessage)
+      completion(false, nil)
+      return
+    }
+
     // Determine status text based on what we're opening
     let isLesson = (snackParams?["isLesson"] as? Bool) == true
     let isPlayground = (snackParams?["isPlayground"] as? Bool) == true
@@ -200,15 +207,33 @@ import UIKit
     return String(snackId[snackId.index(after: snackId.startIndex)..<slashIndex])
   }
 
+  static let expiredSessionMessage =
+    "Your Expo Go session has expired. Reload your project's preview and scan the new QR code to continue."
+
+  /// Non-nil when the stored session has expired, which only device auth sessions record.
+  @objc public func sessionExpiredMessage() -> String? {
+    return AuthenticationService.isSessionExpired() ? Self.expiredSessionMessage : nil
+  }
+
+  @objc public func showError(_ message: String) {
+    DispatchQueue.main.async { [weak self] in
+      self?.homeViewModel?.showError(message)
+    }
+  }
+
   @objc public func isAuthenticated() -> Bool {
-    return UserDefaults.standard.string(forKey: "expo-session-secret") != nil
+    guard !AuthenticationService.isSessionExpired() else {
+      return false
+    }
+    return UserDefaults.standard.string(forKey: AuthenticationService.sessionKey) != nil
   }
 
   @objc public func authenticatedUsername() -> String? {
-    guard UserDefaults.standard.string(forKey: "expo-session-secret") != nil else {
+    guard !AuthenticationService.isSessionExpired(),
+          UserDefaults.standard.string(forKey: AuthenticationService.sessionKey) != nil else {
       return nil
     }
-    return UserDefaults.standard.string(forKey: "expo-username")
+    return UserDefaults.standard.string(forKey: AuthenticationService.usernameKey)
   }
 
   @objc public func addHistoryItem(withUrl url: String, name: String, iconUrl: String?) {

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -18,12 +18,13 @@ struct GraphQLErrorLocation: Codable {
   let column: Int
 }
 
-struct MeUserActorResponse: Codable {
-  let data: MeUserActorData
+struct MeActorResponse: Codable {
+  let data: MeActorData
 }
 
-struct MeUserActorData: Codable {
-  let meUserActor: UserActor
+struct MeActorData: Codable {
+  /// Null for a `Robot`, which has no username, and for an unauthenticated request.
+  let meActor: UserActor?
 }
 
 struct HomeScreenDataResponse: Codable {

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
@@ -5,15 +5,10 @@ import Foundation
 struct Queries {
   static func getCurrentUser() -> String {
     return """
-    query Home_CurrentUserActor {
-      meUserActor {
+    query Home_CurrentActor {
+      meActor {
         __typename
         id
-        username
-        firstName
-        lastName
-        profilePhoto
-        bestContactEmail
         accounts {
           id
           name
@@ -26,6 +21,16 @@ struct Queries {
             fullName
             lastName
           }
+        }
+        ... on UserActor {
+          username
+          firstName
+          lastName
+          profilePhoto
+          bestContactEmail
+        }
+        ... on PartnerActor {
+          username
         }
       }
     }

--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -36,6 +36,10 @@ class HomeViewModel: ObservableObject {
   var selectedAccount: Account? { authService.selectedAccount }
   var isLoggedIn: Bool { authService.isLoggedIn }
 
+  var displayUsername: String? {
+    user?.username ?? UserDefaults.standard.string(forKey: AuthenticationService.usernameKey)
+  }
+
   var shakeToShowDevMenu: Bool { settingsManager.shakeToShowDevMenu }
   var threeFingerLongPressEnabled: Bool { settingsManager.threeFingerLongPressEnabled }
   var selectedTheme: Int { settingsManager.selectedTheme }

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -5,6 +5,10 @@ import AuthenticationServices
 import Combine
 import ExpoModulesCore
 
+extension Notification.Name {
+  static let expoSessionDidChange = Notification.Name("expo-session-did-change")
+}
+
 @MainActor
 class AuthenticationService: ObservableObject {
   @Published var user: UserActor?
@@ -12,13 +16,15 @@ class AuthenticationService: ObservableObject {
   @Published var isAuthenticating = false
   @Published var isAuthenticated = false
 
-  private let sessionKey = "expo-session-secret"
-  private let usernameKey = "expo-username"
-  private let selectedAccountKey = "expo-selected-account-id"
+  nonisolated static let sessionKey = "expo-session-secret"
+  nonisolated static let usernameKey = "expo-username"
+  nonisolated static let selectedAccountKey = "expo-selected-account-id"
+  nonisolated static let sessionExpiresAtKey = "expo-session-expires-at"
   private let presentationContext = AuthPresentationContextProvider()
+  private var cancellables = Set<AnyCancellable>()
 
   var sessionSecret: String? {
-    UserDefaults.standard.string(forKey: sessionKey)
+    UserDefaults.standard.string(forKey: Self.sessionKey)
   }
 
   var selectedAccount: Account? {
@@ -34,17 +40,23 @@ class AuthenticationService: ObservableObject {
   }
 
   init() {
-    selectedAccountId = UserDefaults.standard.string(forKey: selectedAccountKey)
+    selectedAccountId = UserDefaults.standard.string(forKey: Self.selectedAccountKey)
     checkAuthenticationStatus()
+    observeSessionChanges()
   }
 
   func checkAuthenticationStatus() {
-    let sessionSecret = UserDefaults.standard.string(forKey: sessionKey)
+    if Self.isPartnerSessionExpired() {
+      signOut()
+      return
+    }
+
+    let sessionSecret = UserDefaults.standard.string(forKey: Self.sessionKey)
     isAuthenticated = !(sessionSecret?.isEmpty ?? true)
 
     if isAuthenticated {
       if let sessionSecret {
-        synchronizeNativeSession(sessionSecret)
+        Self.saveNativeSession(sessionSecret)
       }
       Task {
         if let sessionSecret {
@@ -53,10 +65,20 @@ class AuthenticationService: ObservableObject {
         await loadUserInfo()
       }
     } else {
-      clearNativeSession()
+      Self.deleteNativeSession()
       user = nil
       selectedAccountId = nil
     }
+  }
+
+  private func observeSessionChanges() {
+    NotificationCenter.default.publisher(for: .expoSessionDidChange)
+      .sink { [weak self] _ in
+        Task { @MainActor in
+          self?.checkAuthenticationStatus()
+        }
+      }
+      .store(in: &cancellables)
   }
 
   func loadUserInfo() async {
@@ -70,7 +92,7 @@ class AuthenticationService: ObservableObject {
       user = response.data.meUserActor
 
       if let username = user?.username {
-        UserDefaults.standard.set(username, forKey: usernameKey)
+        UserDefaults.standard.set(username, forKey: Self.usernameKey)
       }
 
       if selectedAccountId == nil, let firstAccount = user?.accounts.first {
@@ -109,8 +131,9 @@ class AuthenticationService: ObservableObject {
   }
 
   func completeLogin(with sessionSecret: String) async {
-    UserDefaults.standard.set(sessionSecret, forKey: sessionKey)
-    synchronizeNativeSession(sessionSecret)
+    UserDefaults.standard.set(sessionSecret, forKey: Self.sessionKey)
+    UserDefaults.standard.removeObject(forKey: Self.sessionExpiresAtKey)
+    Self.saveNativeSession(sessionSecret)
     await APIClient.shared.setSession(sessionSecret)
     // Fetch user info before setting isAuthenticated so account data is ready
     // when the UI switches to the account selector
@@ -119,19 +142,13 @@ class AuthenticationService: ObservableObject {
   }
 
   func signOut() {
-    UserDefaults.standard.removeObject(forKey: sessionKey)
-    UserDefaults.standard.removeObject(forKey: usernameKey)
-    UserDefaults.standard.removeObject(forKey: selectedAccountKey)
-    clearNativeSession()
-    Task {
-      await APIClient.shared.setSession(nil)
-    }
+    Self.clearSession()
     user = nil
     selectedAccountId = nil
     isAuthenticated = false
   }
 
-  private func synchronizeNativeSession(_ sessionSecret: String) {
+  nonisolated private static func saveNativeSession(_ sessionSecret: String) {
     do {
       try Session.sharedInstance.saveSession(
         toKeychain: ["sessionSecret": sessionSecret] as NSDictionary
@@ -141,7 +158,7 @@ class AuthenticationService: ObservableObject {
     }
   }
 
-  private func clearNativeSession() {
+  nonisolated private static func deleteNativeSession() {
     do {
       try Session.sharedInstance.deleteSessionFromKeychain()
     } catch {
@@ -149,9 +166,47 @@ class AuthenticationService: ObservableObject {
     }
   }
 
+  nonisolated static func storePartnerSession(
+    sessionSecret: String,
+    username: String,
+    expiresAt: Date?
+  ) async {
+    let defaults = UserDefaults.standard
+    defaults.set(sessionSecret, forKey: sessionKey)
+    defaults.set(username, forKey: usernameKey)
+    if let expiresAt {
+      defaults.set(expiresAt.timeIntervalSince1970, forKey: sessionExpiresAtKey)
+    } else {
+      defaults.removeObject(forKey: sessionExpiresAtKey)
+    }
+    saveNativeSession(sessionSecret)
+    await APIClient.shared.setSession(sessionSecret)
+    NotificationCenter.default.post(name: .expoSessionDidChange, object: nil)
+  }
+
+  /// The stored expiry is the only local signal that a partner session died. Asking the server would
+  /// cost a round trip on every project open, and only partner sessions ever write this key.
+  nonisolated static func isPartnerSessionExpired() -> Bool {
+    guard let expiresAt = UserDefaults.standard.object(forKey: sessionExpiresAtKey) as? Double else {
+      return false
+    }
+    return Date().timeIntervalSince1970 >= expiresAt
+  }
+
+  nonisolated static func clearSession() {
+    let defaults = UserDefaults.standard
+    defaults.removeObject(forKey: sessionKey)
+    defaults.removeObject(forKey: usernameKey)
+    defaults.removeObject(forKey: selectedAccountKey)
+    defaults.removeObject(forKey: sessionExpiresAtKey)
+    deleteNativeSession()
+    Task { await APIClient.shared.setSession(nil) }
+    NotificationCenter.default.post(name: .expoSessionDidChange, object: nil)
+  }
+
   func selectAccount(accountId: String) {
     selectedAccountId = accountId
-    UserDefaults.standard.set(accountId, forKey: selectedAccountKey)
+    UserDefaults.standard.set(accountId, forKey: Self.selectedAccountKey)
   }
 
   private func performAuthentication(path: String) async throws -> String? {

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -88,18 +88,19 @@ class AuthenticationService: ObservableObject {
 
   private func fetchUserInfo() async {
     do {
-      let response: MeUserActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
-      user = response.data.meUserActor
-
-      if let username = user?.username {
-        UserDefaults.standard.set(username, forKey: Self.usernameKey)
+      let response: MeActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
+      guard let actor = response.data.meActor else {
+        print("[AuthenticationService] meActor was null. Signed in as an actor type Expo Go does not model.")
+        return
       }
+      user = actor
+      UserDefaults.standard.set(actor.username, forKey: Self.usernameKey)
 
-      if selectedAccountId == nil, let firstAccount = user?.accounts.first {
+      if selectedAccountId == nil, let firstAccount = actor.accounts.first {
         selectAccount(accountId: firstAccount.id)
       }
     } catch {
-      print("Failed to load user info: \(error)")
+      print("[AuthenticationService] Failed to load user info: \(error)")
     }
   }
 

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -46,8 +46,12 @@ class AuthenticationService: ObservableObject {
   }
 
   func checkAuthenticationStatus() {
-    if Self.isPartnerSessionExpired() {
-      signOut()
+    if Self.isSessionExpired() {
+      // The bridge reads this expiry to explain the failure, then clears it.
+      Self.deleteNativeSession()
+      user = nil
+      selectedAccountId = nil
+      isAuthenticated = false
       return
     }
 
@@ -167,7 +171,7 @@ class AuthenticationService: ObservableObject {
     }
   }
 
-  nonisolated static func storePartnerSession(
+  nonisolated static func storeDeviceAuthSession(
     sessionSecret: String,
     username: String,
     expiresAt: Date?
@@ -185,9 +189,8 @@ class AuthenticationService: ObservableObject {
     NotificationCenter.default.post(name: .expoSessionDidChange, object: nil)
   }
 
-  /// The stored expiry is the only local signal that a partner session died. Asking the server would
-  /// cost a round trip on every project open, and only partner sessions ever write this key.
-  nonisolated static func isPartnerSessionExpired() -> Bool {
+  /// The stored expiry is the only local signal that the session died, avoiding a round trip on every project open.
+  nonisolated static func isSessionExpired() -> Bool {
     guard let expiresAt = UserDefaults.standard.object(forKey: sessionExpiresAtKey) as? Double else {
       return false
     }

--- a/apps/expo-go/ios/Tests/ActorDecodingTests.swift
+++ b/apps/expo-go/ios/Tests/ActorDecodingTests.swift
@@ -1,0 +1,67 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class ActorDecodingTests: XCTestCase {
+  private func decode(_ json: String) throws -> MeActorResponse {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(MeActorResponse.self, from: data)
+  }
+
+  func testDecodesPartnerActorWithoutUserOnlyFields() throws {
+    let response = try decode("""
+    {"data":{"meActor":{
+      "__typename":"PartnerActor",
+      "id":"actor-1",
+      "username":"partner-private-test",
+      "accounts":[{"id":"acc-1","name":"partner-private-test","profileImageUrl":null,"ownerUserActor":null}]
+    }}}
+    """)
+
+    let actor = try XCTUnwrap(response.data.meActor)
+    XCTAssertEqual(actor.typename, "PartnerActor")
+    XCTAssertEqual(actor.username, "partner-private-test")
+    XCTAssertNil(actor.firstName)
+    XCTAssertNil(actor.profilePhoto)
+    XCTAssertNil(actor.bestContactEmail)
+    XCTAssertEqual(actor.accounts.count, 1)
+    XCTAssertEqual(actor.accounts[0].name, "partner-private-test")
+    XCTAssertNil(actor.accounts[0].ownerUserActor)
+  }
+
+  func testDecodesRegularUserActor() throws {
+    let response = try decode("""
+    {"data":{"meActor":{
+      "__typename":"User",
+      "id":"actor-2",
+      "username":"alanhughes",
+      "firstName":"Alan",
+      "lastName":"Hughes",
+      "profilePhoto":"https://example.test/a.png",
+      "bestContactEmail":"alan@expo.dev",
+      "accounts":[{"id":"acc-2","name":"alanhughes","profileImageUrl":"https://example.test/b.png",
+        "ownerUserActor":{"id":"actor-2","username":"alanhughes","profilePhoto":null,
+          "firstName":"Alan","fullName":"Alan Hughes","lastName":"Hughes"}}]
+    }}}
+    """)
+
+    let actor = try XCTUnwrap(response.data.meActor)
+    XCTAssertEqual(actor.username, "alanhughes")
+    XCTAssertEqual(actor.firstName, "Alan")
+    XCTAssertEqual(actor.accounts[0].ownerUserActor?.username, "alanhughes")
+  }
+
+  func testDecodesNullActor() throws {
+    let response = try decode(#"{"data":{"meActor":null}}"#)
+    XCTAssertNil(response.data.meActor)
+  }
+
+  func testQueryRequestsUsernameOnBothActorTypes() {
+    let query = Queries.getCurrentUser()
+    XCTAssertTrue(query.contains("meActor"))
+    XCTAssertTrue(query.contains("... on UserActor"))
+    XCTAssertTrue(query.contains("... on PartnerActor"))
+    XCTAssertFalse(query.contains("meUserActor"))
+  }
+}

--- a/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
@@ -1,0 +1,78 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class DeviceSessionExpiryTests: XCTestCase {
+  private let defaults = UserDefaults.standard
+
+  override func setUp() {
+    super.setUp()
+    AuthenticationService.clearSession()
+  }
+
+  override func tearDown() {
+    AuthenticationService.clearSession()
+    super.tearDown()
+  }
+
+  func testNoStoredExpiryIsNotExpired() {
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+  }
+
+  func testFutureExpiryIsNotExpired() async {
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: "secret",
+      username: "partner-private-test",
+      expiresAt: Date().addingTimeInterval(60)
+    )
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertEqual(defaults.string(forKey: AuthenticationService.sessionKey), "secret")
+    XCTAssertEqual(defaults.string(forKey: AuthenticationService.usernameKey), "partner-private-test")
+  }
+
+  func testPastExpiryIsExpired() async {
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: "secret",
+      username: "partner-private-test",
+      expiresAt: Date().addingTimeInterval(-1)
+    )
+    XCTAssertTrue(AuthenticationService.isPartnerSessionExpired())
+  }
+
+  func testNilExpiryIsNeverExpired() async {
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: "secret",
+      username: "partner-private-test",
+      expiresAt: nil
+    )
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertNil(defaults.object(forKey: AuthenticationService.sessionExpiresAtKey))
+  }
+
+  func testClearSessionRemovesEveryKey() async {
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: "secret",
+      username: "partner-private-test",
+      expiresAt: Date().addingTimeInterval(60)
+    )
+    defaults.set("acc1", forKey: AuthenticationService.selectedAccountKey)
+
+    AuthenticationService.clearSession()
+
+    XCTAssertNil(defaults.string(forKey: AuthenticationService.sessionKey))
+    XCTAssertNil(defaults.string(forKey: AuthenticationService.usernameKey))
+    XCTAssertNil(defaults.string(forKey: AuthenticationService.selectedAccountKey))
+    XCTAssertNil(defaults.object(forKey: AuthenticationService.sessionExpiresAtKey))
+  }
+
+  func testStoringPostsSessionDidChange() async {
+    let expectation = expectation(forNotification: .expoSessionDidChange, object: nil)
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: "secret",
+      username: "partner-private-test",
+      expiresAt: Date().addingTimeInterval(60)
+    )
+    await fulfillment(of: [expectation], timeout: 1)
+  }
+}

--- a/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
@@ -17,43 +17,43 @@ final class DeviceSessionExpiryTests: XCTestCase {
   }
 
   func testNoStoredExpiryIsNotExpired() {
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
   }
 
   func testFutureExpiryIsNotExpired() async {
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: "secret",
-      username: "partner-private-test",
+      username: "test-user",
       expiresAt: Date().addingTimeInterval(60)
     )
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
     XCTAssertEqual(defaults.string(forKey: AuthenticationService.sessionKey), "secret")
-    XCTAssertEqual(defaults.string(forKey: AuthenticationService.usernameKey), "partner-private-test")
+    XCTAssertEqual(defaults.string(forKey: AuthenticationService.usernameKey), "test-user")
   }
 
   func testPastExpiryIsExpired() async {
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: "secret",
-      username: "partner-private-test",
+      username: "test-user",
       expiresAt: Date().addingTimeInterval(-1)
     )
-    XCTAssertTrue(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertTrue(AuthenticationService.isSessionExpired())
   }
 
   func testNilExpiryIsNeverExpired() async {
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: "secret",
-      username: "partner-private-test",
+      username: "test-user",
       expiresAt: nil
     )
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
     XCTAssertNil(defaults.object(forKey: AuthenticationService.sessionExpiresAtKey))
   }
 
   func testClearSessionRemovesEveryKey() async {
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: "secret",
-      username: "partner-private-test",
+      username: "test-user",
       expiresAt: Date().addingTimeInterval(60)
     )
     defaults.set("acc1", forKey: AuthenticationService.selectedAccountKey)
@@ -68,9 +68,9 @@ final class DeviceSessionExpiryTests: XCTestCase {
 
   func testStoringPostsSessionDidChange() async {
     let expectation = expectation(forNotification: .expoSessionDidChange, object: nil)
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: "secret",
-      username: "partner-private-test",
+      username: "test-user",
       expiresAt: Date().addingTimeInterval(60)
     )
     await fulfillment(of: [expectation], timeout: 1)

--- a/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
+++ b/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
@@ -1,0 +1,57 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class ExpoGoHomeBridgeAuthTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+    AuthenticationService.clearSession()
+  }
+
+  override func tearDown() {
+    AuthenticationService.clearSession()
+    super.tearDown()
+  }
+
+  func testNoSessionIsNotAuthenticated() {
+    XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
+    XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
+    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
+  }
+
+  func testLiveSessionReportsUsername() async {
+    await AuthenticationService.storeDeviceAuthSession(
+      sessionSecret: "secret",
+      username: "test-user",
+      expiresAt: Date().addingTimeInterval(60)
+    )
+    XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
+    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
+  }
+
+  func testExpiredSessionReportsNeitherAuthNorUsername() async {
+    await AuthenticationService.storeDeviceAuthSession(
+      sessionSecret: "secret",
+      username: "test-user",
+      expiresAt: Date().addingTimeInterval(-1)
+    )
+    XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
+    XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
+    XCTAssertEqual(
+      ExpoGoHomeBridge.shared.sessionExpiredMessage(),
+      ExpoGoHomeBridge.expiredSessionMessage
+    )
+  }
+
+  func testSessionWithoutExpiryReportsUsername() async {
+    await AuthenticationService.storeDeviceAuthSession(
+      sessionSecret: "secret",
+      username: "test-user",
+      expiresAt: nil
+    )
+    XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
+  }
+}


### PR DESCRIPTION
# Why
Partner platforms can provision Expo accounts for their users, and those users never see the account credentials, so they cannot sign in to Expo Go and cannot open their previews since the manifest username check landed in SDK 57. This is the first of three PRs adding a device authorization sign in for those users.

# How
Sessions minted by the device grant carry an expiry, so AuthenticationService now stores one and treats an expired partner session as signed out. The current user query moves from meUserActor, which is null for partner actors, to meActor with a PartnerActor fragment, the same shape the cli uses. 

# Test Plan
New unit tests cover expiry storage and detection, actor decoding for partner, regular and null actors. Signed in with a regular account and confirmed the account sheet still lists accounts with avatars, which exercises the rewritten query against the real API.
