### PR TITLE
[ios][expo-go] Add the device authorization sign in flow

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
@@ -1,0 +1,62 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+struct DeviceLoginCodeView: View {
+  let userCode: String
+  let origin: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Your code")
+          .font(.headline)
+        Text(userCode)
+          .font(.system(size: 34, weight: .bold, design: .monospaced))
+          .textSelection(.enabled)
+          .accessibilityLabel(spelledOut(userCode))
+      }
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Enter it on the page that showed you the QR code:")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+        // Plain text on purpose. This address comes from a scanned QR code, so Expo Go never opens it.
+        Text(origin)
+          .font(.system(.body, design: .monospaced))
+          .foregroundColor(.primary)
+      }
+
+      Button {
+        UIPasteboard.general.string = userCode
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+      } label: {
+        Text("Copy code")
+          .font(.headline)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 12)
+      }
+      .background(Color.expoSystemBackground)
+      .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.secondary.opacity(0.3)))
+      .cornerRadius(12)
+
+      HStack(spacing: 8) {
+        ProgressView()
+        Text("Waiting for you to approve this sign-in")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+      }
+
+      Text("This code stops working after 10 minutes.")
+        .font(.footnote)
+        .foregroundColor(.secondary)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  /// VoiceOver reads "BCDFGHJK" as a word. Spelling it out makes it transcribable.
+  private func spelledOut(_ code: String) -> String {
+    code.map { $0 == "-" ? "dash" : String($0) }.joined(separator: " ")
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginErrorView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginErrorView.swift
@@ -1,0 +1,75 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DeviceLoginErrorView: View {
+  let failure: DeviceLoginFailure
+  let onRetry: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: 8) {
+        Text(title)
+          .font(.headline)
+        Text(explanation)
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+      }
+
+      Button {
+        onRetry()
+      } label: {
+        Text(retryLabel)
+          .font(.headline)
+          .foregroundColor(.white)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 12)
+      }
+      .background(Color.black)
+      .cornerRadius(12)
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+
+  private var title: String {
+    switch failure {
+    case .wrongNumber: return "That was the wrong number"
+    case .denied: return "The sign in was declined"
+    case .expired: return "The code expired"
+    case .invalid: return "Expo couldn't finish signing you in"
+    case .network: return "Couldn't reach Expo"
+    case .server: return "Expo turned down the request"
+    }
+  }
+
+  private var explanation: String {
+    switch failure {
+    case .wrongNumber:
+      return "For your security, a wrong number cancels the whole attempt. Get a new code and try again, matching the number on your other screen exactly."
+    case .denied:
+      return "Someone chose Deny on the page where you entered the code. Get a new code if that wasn't what you meant to do."
+    case .expired:
+      return "A code only works for ten minutes. Get a new one to carry on."
+    case .invalid:
+      return "This code has already been used, or Expo returned something unexpected. Get a new code, and contact support@expo.dev if it keeps happening."
+    case .network:
+      return "Check your connection and try again. Your code was not used."
+    case .server(let message):
+      return "\(sentence(from: message)) Wait a moment before trying again."
+    }
+  }
+
+  // The API's message may not end in punctuation.
+  private func sentence(from message: String) -> String {
+    let trimmed = message.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let last = trimmed.last else {
+      return "Expo turned down the request."
+    }
+    return ".!?".contains(last) ? trimmed : trimmed + "."
+  }
+
+  /// A network failure never reached the server, so the same attempt can simply be retried.
+  private var retryLabel: String {
+    failure == .network ? "Try again" : "Get a new code"
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginLink.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginLink.swift
@@ -1,0 +1,47 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// The QR a partner renders is the dev server URL with one extra query parameter naming the page that
+/// hosts the code text box. Expo Go on iOS has no scanner, so the parameter arrives on a URL handed
+/// over by the system Camera app and there is no chance to add UI at scan time.
+@objc(EXDeviceLoginLink)
+public final class DeviceLoginLink: NSObject {
+  @objc public static let queryParamName = "verification_uri_override"
+
+  private override init() {
+    super.init()
+  }
+
+  /// Only https with a real host is accepted, because the value is shown inside Expo Go's own UI.
+  /// A rejected value falls back to the `verification_uri` the server returns.
+  @objc(verificationURIFromURL:)
+  public static func verificationURI(from url: URL) -> URL? {
+    guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+          let value = queryItems.first(where: { $0.name == queryParamName })?.value,
+          !value.isEmpty,
+          let candidate = URL(string: value),
+          candidate.scheme?.lowercased() == "https",
+          let host = candidate.host,
+          !host.isEmpty else {
+      return nil
+    }
+    return candidate
+  }
+
+  @objc(urlByRemovingOverrideFromURL:)
+  public static func urlByRemovingOverride(from url: URL) -> URL {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let queryItems = components.percentEncodedQueryItems else {
+      return url
+    }
+
+    let remaining = queryItems.filter { $0.name != queryParamName }
+    guard remaining.count != queryItems.count else {
+      return url
+    }
+
+    components.percentEncodedQueryItems = remaining.isEmpty ? nil : remaining
+    return components.url ?? url
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginLink.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginLink.swift
@@ -2,23 +2,26 @@
 
 import Foundation
 
-/// The QR a partner renders is the dev server URL with one extra query parameter naming the page that
-/// hosts the code text box. Expo Go on iOS has no scanner, so the parameter arrives on a URL handed
-/// over by the system Camera app and there is no chance to add UI at scan time.
+/// The QR is the dev server URL plus device auth params, since iOS has no scanner to add UI at scan time.
 @objc(EXDeviceLoginLink)
 public final class DeviceLoginLink: NSObject {
-  @objc public static let queryParamName = "verification_uri_override"
+  @objc public static let promptParamName = "expo_go_prompt_device_auth"
+  @objc public static let overrideParamName = "expo_go_device_auth_verification_uri_override"
 
   private override init() {
     super.init()
   }
 
+  @objc(promptRequestedInURL:)
+  public static func promptRequested(in url: URL) -> Bool {
+    decodedQueryItems(of: url)?.first { $0.name == promptParamName }?.value == "1"
+  }
+
   /// Only https with a real host is accepted, because the value is shown inside Expo Go's own UI.
-  /// A rejected value falls back to the `verification_uri` the server returns.
+  /// A rejected or absent override leaves the flow on the server's own verification page.
   @objc(verificationURIFromURL:)
   public static func verificationURI(from url: URL) -> URL? {
-    guard let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
-          let value = queryItems.first(where: { $0.name == queryParamName })?.value,
+    guard let value = decodedQueryItems(of: url)?.first(where: { $0.name == overrideParamName })?.value,
           !value.isEmpty,
           let candidate = URL(string: value),
           candidate.scheme?.lowercased() == "https",
@@ -29,19 +32,23 @@ public final class DeviceLoginLink: NSObject {
     return candidate
   }
 
-  @objc(urlByRemovingOverrideFromURL:)
-  public static func urlByRemovingOverride(from url: URL) -> URL {
+  @objc(urlByRemovingDeviceAuthParamsFromURL:)
+  public static func urlByRemovingDeviceAuthParams(from url: URL) -> URL {
     guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
           let queryItems = components.percentEncodedQueryItems else {
       return url
     }
 
-    let remaining = queryItems.filter { $0.name != queryParamName }
+    let remaining = queryItems.filter { $0.name != promptParamName && $0.name != overrideParamName }
     guard remaining.count != queryItems.count else {
       return url
     }
 
     components.percentEncodedQueryItems = remaining.isEmpty ? nil : remaining
     return components.url ?? url
+  }
+
+  private static func decodedQueryItems(of url: URL) -> [URLQueryItem]? {
+    URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginMatchView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginMatchView.swift
@@ -1,0 +1,40 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+struct DeviceLoginMatchView: View {
+  let options: [String]
+  let onPick: (String) -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 24) {
+      VStack(alignment: .leading, spacing: 8) {
+        Text("Tap the number shown on your other screen")
+          .font(.headline)
+        Text("You only get one try. A wrong number cancels this attempt, and you will need a new code.")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+      }
+
+      VStack(spacing: 12) {
+        ForEach(options, id: \.self) { option in
+          Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            onPick(option)
+          } label: {
+            Text(option)
+              .font(.system(size: 28, weight: .bold, design: .monospaced))
+              .frame(maxWidth: .infinity)
+              .padding(.vertical, 16)
+          }
+          .background(Color.expoSystemBackground)
+          .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.secondary.opacity(0.3)))
+          .cornerRadius(12)
+          .accessibilityLabel("Number \(option)")
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
@@ -1,0 +1,139 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+// MARK: - Requests
+
+struct DeviceAuthorizationRequest: Encodable {
+  let clientId: String
+  let deviceName: String?
+  let devicePlatform: String?
+  let deviceOsVersion: String?
+  let deviceAppVersion: String?
+
+  enum CodingKeys: String, CodingKey {
+    case clientId = "client_id"
+    case deviceName = "device_name"
+    case devicePlatform = "device_platform"
+    case deviceOsVersion = "device_os_version"
+    case deviceAppVersion = "device_app_version"
+  }
+}
+
+struct DeviceTokenRequest: Encodable {
+  let grantType = "urn:ietf:params:oauth:grant-type:device_code"
+  let clientId: String
+  let deviceCode: String
+  let matchValue: String?
+
+  enum CodingKeys: String, CodingKey {
+    case grantType = "grant_type"
+    case clientId = "client_id"
+    case deviceCode = "device_code"
+    case matchValue = "match_value"
+  }
+}
+
+// MARK: - Responses
+
+struct DeviceAuthorizationResponse: Decodable {
+  let data: DeviceAuthorization
+}
+
+struct DeviceAuthorization: Decodable {
+  let deviceCode: String
+  let userCode: String
+  let verificationURI: URL
+  let expiresIn: Int
+  let interval: Int
+
+  enum CodingKeys: String, CodingKey {
+    case deviceCode = "device_code"
+    case userCode = "user_code"
+    case verificationURI = "verification_uri"
+    case expiresIn = "expires_in"
+    case interval = "interval"
+  }
+}
+
+struct DeviceTokenResponse: Decodable {
+  let data: DeviceTokenPayload
+}
+
+/// The token endpoint reports in-flight and terminal states as HTTP 200 with an `error` string rather
+/// than an HTTP error code, so success and failure share one shape.
+struct DeviceTokenPayload: Decodable {
+  let sessionSecret: String?
+  let expiresAt: String?
+  let error: String?
+  let matchOptions: [String]?
+
+  enum CodingKeys: String, CodingKey {
+    case sessionSecret = "session_secret"
+    case expiresAt = "expires_at"
+    case error
+    case matchOptions = "match_options"
+  }
+}
+
+// MARK: - Outcome
+
+enum TokenOutcome: Equatable {
+  case session(secret: String, expiresAt: Date?)
+  case pending
+  case slowDown
+  case matchRequired([String])
+  case denied
+  case expired
+  case invalid
+
+  init(payload: DeviceTokenPayload) {
+    if let secret = payload.sessionSecret {
+      // A session with an unreadable expiry is still a working session. Dropping the expiry only
+      // costs us the local staleness check, which is better than discarding a valid credential.
+      let expiresAt = payload.expiresAt.flatMap(DeviceLoginDates.parseExpiry)
+      if payload.expiresAt != nil, expiresAt == nil {
+        print("[DeviceLogin] Could not parse expires_at: \(payload.expiresAt ?? "")")
+      }
+      self = .session(secret: secret, expiresAt: expiresAt)
+      return
+    }
+
+    switch payload.error {
+    case "authorization_pending":
+      self = .pending
+    case "slow_down":
+      self = .slowDown
+    case "matching_required":
+      guard let options = payload.matchOptions, !options.isEmpty else {
+        print("[DeviceLogin] matching_required arrived with no match_options")
+        self = .invalid
+        return
+      }
+      self = .matchRequired(options)
+    case "access_denied":
+      self = .denied
+    case "expired_token":
+      self = .expired
+    default:
+      self = .invalid
+    }
+  }
+}
+
+// MARK: - Dates
+
+enum DeviceLoginDates {
+  /// The API sends fractional seconds, which `JSONDecoder`'s `.iso8601` strategy rejects.
+  static func parseExpiry(_ value: String) -> Date? {
+    let withFractionalSeconds = ISO8601DateFormatter()
+    withFractionalSeconds.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = withFractionalSeconds.date(from: value) {
+      return date
+    }
+
+    let withoutFractionalSeconds = ISO8601DateFormatter()
+    withoutFractionalSeconds.formatOptions = [.withInternetDateTime]
+    return withoutFractionalSeconds.date(from: value)
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
@@ -60,8 +60,7 @@ struct DeviceTokenResponse: Decodable {
   let data: DeviceTokenPayload
 }
 
-/// The token endpoint reports in-flight and terminal states as HTTP 200 with an `error` string rather
-/// than an HTTP error code, so success and failure share one shape.
+/// The token endpoint reports in-flight and terminal states as HTTP 200 with an `error` string, not an HTTP error code.
 struct DeviceTokenPayload: Decodable {
   let sessionSecret: String?
   let expiresAt: String?
@@ -89,8 +88,7 @@ enum TokenOutcome: Equatable {
 
   init(payload: DeviceTokenPayload) {
     if let secret = payload.sessionSecret {
-      // A session with an unreadable expiry is still a working session. Dropping the expiry only
-      // costs us the local staleness check, which is better than discarding a valid credential.
+      // A session with an unreadable expiry is still valid. Drop the expiry, not the credential.
       let expiresAt = payload.expiresAt.flatMap(DeviceLoginDates.parseExpiry)
       if payload.expiresAt != nil, expiresAt == nil {
         print("[DeviceLogin] Could not parse expires_at: \(payload.expiresAt ?? "")")

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginService.swift
@@ -1,0 +1,47 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import UIKit
+
+/// The two calls Expo Go makes during a device authorization grant. Both are unauthenticated.
+enum DeviceLoginService {
+  static let clientId = "expo-go"
+
+  static func requestAuthorization() async throws -> DeviceAuthorization {
+    let info = deviceInfo()
+    let response: DeviceAuthorizationResponse = try await RESTClient.shared.post(
+      path: "auth/device_authorization",
+      body: DeviceAuthorizationRequest(
+        clientId: clientId,
+        deviceName: info.name,
+        devicePlatform: info.platform,
+        deviceOsVersion: info.osVersion,
+        deviceAppVersion: info.appVersion
+      )
+    )
+    return response.data
+  }
+
+  static func poll(deviceCode: String, matchValue: String?) async throws -> TokenOutcome {
+    let response: DeviceTokenResponse = try await RESTClient.shared.post(
+      path: "auth/token",
+      body: DeviceTokenRequest(
+        clientId: clientId,
+        deviceCode: deviceCode,
+        matchValue: matchValue
+      )
+    )
+    return TokenOutcome(payload: response.data)
+  }
+
+  /// Shown on the partner's page so the user can confirm the device asking to sign in is theirs.
+  /// `UIDevice.current.name` returns a generic model name on iOS 16 and later without entitlement.
+  static func deviceInfo() -> (name: String?, platform: String, osVersion: String, appVersion: String?) {
+    return (
+      name: UIDevice.current.name,
+      platform: "ios",
+      osVersion: UIDevice.current.systemVersion,
+      appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+    )
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginService.swift
@@ -3,7 +3,7 @@
 import Foundation
 import UIKit
 
-/// The two calls Expo Go makes during a device authorization grant. Both are unauthenticated.
+/// Both calls are unauthenticated.
 enum DeviceLoginService {
   static let clientId = "expo-go"
 
@@ -34,8 +34,7 @@ enum DeviceLoginService {
     return TokenOutcome(payload: response.data)
   }
 
-  /// Shown on the partner's page so the user can confirm the device asking to sign in is theirs.
-  /// `UIDevice.current.name` returns a generic model name on iOS 16 and later without entitlement.
+  /// Shown on the verification page to confirm the device asking to sign in. `UIDevice.current.name` returns a generic name on iOS 16+ without the entitlement.
   static func deviceInfo() -> (name: String?, platform: String, osVersion: String, appVersion: String?) {
     return (
       name: UIDevice.current.name,

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
@@ -1,0 +1,77 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct DeviceLoginSheet: View {
+  let onFinished: (Bool) -> Void
+
+  @StateObject private var viewModel: DeviceLoginViewModel
+  @Environment(\.dismiss) private var dismiss
+
+  init(verificationURI: URL?, onFinished: @escaping (Bool) -> Void) {
+    self.onFinished = onFinished
+    _viewModel = StateObject(wrappedValue: DeviceLoginViewModel(verificationURI: verificationURI))
+  }
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        content
+          .padding(.horizontal, 16)
+          .padding(.top, 24)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(Color.expoSystemBackground)
+      .navigationTitle("Sign in to Expo Go")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .topBarLeading) {
+          Button {
+            viewModel.cancel()
+            onFinished(false)
+            dismiss()
+          } label: {
+            Image(systemName: "xmark")
+              .font(.system(size: 16, weight: .medium))
+              .foregroundColor(.primary)
+          }
+          .accessibilityLabel("Cancel")
+        }
+      }
+    }
+    .task {
+      viewModel.onSignedIn = {
+        onFinished(true)
+        dismiss()
+      }
+      await viewModel.start()
+    }
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch viewModel.phase {
+    case .requesting:
+      ProgressView("Getting a code")
+        .frame(maxWidth: .infinity)
+        .padding(.top, 48)
+    case .awaitingBrowser:
+      DeviceLoginCodeView(
+        userCode: viewModel.userCode ?? "",
+        origin: viewModel.displayOrigin
+      )
+    case .matching(let options):
+      DeviceLoginMatchView(options: options) { value in
+        viewModel.pick(value)
+      }
+    case .completing:
+      ProgressView("Signing you in")
+        .frame(maxWidth: .infinity)
+        .padding(.top, 48)
+    case .failed(let failure):
+      DeviceLoginErrorView(failure: failure) {
+        Task { await viewModel.restart() }
+      }
+    }
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
@@ -1,0 +1,79 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+enum DeviceLoginFailure: Equatable {
+  case denied
+  case wrongNumber
+  case expired
+  case invalid
+  case network
+  /// The API refused the request and said why. Carries its message so a rate limit does not get
+  /// reported as a connection problem.
+  case server(String)
+}
+
+/// Every timing rule the polling loop depends on, as a pure function of the previous response. `now`
+/// is injected so the deadline is testable without waiting.
+struct DeviceLoginStateMachine {
+  enum Step: Equatable {
+    case poll(after: TimeInterval, matchValue: String?)
+    case awaitMatch([String])
+    case signedIn(secret: String, expiresAt: Date?)
+    case failed(DeviceLoginFailure)
+  }
+
+  private let deadline: Date
+  private var delay: TimeInterval
+  private var matchValue: String?
+  private var hasSentMatch = false
+
+  init(interval: Int, expiresIn: Int, now: Date) {
+    self.delay = TimeInterval(interval)
+    self.deadline = now.addingTimeInterval(TimeInterval(expiresIn))
+  }
+
+  /// The first poll waits out `interval` rather than firing immediately, so a fast browser approval
+  /// cannot trip the server's three-polls-per-five-seconds limit.
+  var firstStep: Step {
+    .poll(after: delay, matchValue: nil)
+  }
+
+  mutating func advance(with outcome: TokenOutcome, now: Date) -> Step {
+    if now >= deadline {
+      return .failed(.expired)
+    }
+
+    switch outcome {
+    case .session(let secret, let expiresAt):
+      return .signedIn(secret: secret, expiresAt: expiresAt)
+    case .pending:
+      return .poll(after: delay, matchValue: matchValue)
+    case .slowDown:
+      // RFC 8628 section 3.5.
+      delay += 5
+      return .poll(after: delay, matchValue: matchValue)
+    case .matchRequired(let options):
+      guard !hasSentMatch else {
+        return .failed(.invalid)
+      }
+      return .awaitMatch(options)
+    case .denied:
+      // The server sends access_denied both for a user denial and for a failed match. Only we know
+      // whether a number was sent.
+      return .failed(hasSentMatch ? .wrongNumber : .denied)
+    case .expired:
+      return .failed(.expired)
+    case .invalid:
+      return .failed(.invalid)
+    }
+  }
+
+  /// The pick goes out immediately. It is also the only one the user gets, because a wrong value is
+  /// terminal server-side.
+  mutating func pick(_ value: String) -> Step {
+    matchValue = value
+    hasSentMatch = true
+    return .poll(after: 0, matchValue: value)
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
@@ -8,13 +8,11 @@ enum DeviceLoginFailure: Equatable {
   case expired
   case invalid
   case network
-  /// The API refused the request and said why. Carries its message so a rate limit does not get
-  /// reported as a connection problem.
+  /// The API refused the request and said why, so a rate limit isn't reported as a connection problem.
   case server(String)
 }
 
-/// Every timing rule the polling loop depends on, as a pure function of the previous response. `now`
-/// is injected so the deadline is testable without waiting.
+/// Every timing rule the polling loop depends on, as a pure function of the previous response.
 struct DeviceLoginStateMachine {
   enum Step: Equatable {
     case poll(after: TimeInterval, matchValue: String?)
@@ -33,8 +31,7 @@ struct DeviceLoginStateMachine {
     self.deadline = now.addingTimeInterval(TimeInterval(expiresIn))
   }
 
-  /// The first poll waits out `interval` rather than firing immediately, so a fast browser approval
-  /// cannot trip the server's three-polls-per-five-seconds limit.
+  /// The first poll waits out `interval` rather than firing immediately, to avoid tripping the server's rate limit.
   var firstStep: Step {
     .poll(after: delay, matchValue: nil)
   }
@@ -59,8 +56,7 @@ struct DeviceLoginStateMachine {
       }
       return .awaitMatch(options)
     case .denied:
-      // The server sends access_denied both for a user denial and for a failed match. Only we know
-      // whether a number was sent.
+      // access_denied covers both a user denial and a failed match. Only we know which happened.
       return .failed(hasSentMatch ? .wrongNumber : .denied)
     case .expired:
       return .failed(.expired)
@@ -69,8 +65,7 @@ struct DeviceLoginStateMachine {
     }
   }
 
-  /// The pick goes out immediately. It is also the only one the user gets, because a wrong value is
-  /// terminal server-side.
+  /// The pick goes out immediately, and it's the only one the user gets. A wrong value is terminal server-side.
   mutating func pick(_ value: String) -> Step {
     matchValue = value
     hasSentMatch = true

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
@@ -29,7 +29,7 @@ final class DeviceLoginViewModel: ObservableObject {
     self.verificationURI = verificationURI
   }
 
-  /// The partner's own page when the QR supplied one, otherwise whatever the server told us to use.
+  /// The override page when the QR supplied one, otherwise whatever the server told us to use.
   var displayURI: URL? {
     verificationURI ?? serverVerificationURI
   }
@@ -53,8 +53,6 @@ final class DeviceLoginViewModel: ObservableObject {
       self.authorization = authorization
       self.serverVerificationURI = authorization.verificationURI
       self.userCode = authorization.userCode
-      // `let`, not `var`: `firstStep` is a non-mutating computed property, so a `var` here earns a
-      // "never mutated" warning.
       let machine = DeviceLoginStateMachine(
         interval: authorization.interval,
         expiresIn: authorization.expiresIn,
@@ -125,9 +123,7 @@ final class DeviceLoginViewModel: ObservableObject {
         deviceCode: authorization.deviceCode,
         matchValue: matchValue
       )
-      // Cancellation is checked again here, not only before the request. A task cancelled while this
-      // await was in flight would otherwise still write `phase`, stomping the state a fresh restart()
-      // had just set up.
+      // Re-checked after the await so a cancelled poll cannot write phase.
       guard !Task.isCancelled else {
         return
       }
@@ -149,7 +145,7 @@ final class DeviceLoginViewModel: ObservableObject {
       phase = .failed(.invalid)
       return
     }
-    await AuthenticationService.storePartnerSession(
+    await AuthenticationService.storeDeviceAuthSession(
       sessionSecret: secret,
       username: username,
       expiresAt: expiresAt
@@ -157,8 +153,7 @@ final class DeviceLoginViewModel: ObservableObject {
     onSignedIn?()
   }
 
-  /// The token response carries no username, and `meUserActor` is null for a partner actor, so the
-  /// username has to come from `meActor`.
+  /// The token response carries no username, and `meUserActor` is null for some actor types, so username comes from `meActor`.
   private func resolveUsername(sessionSecret: String) async -> String? {
     await APIClient.shared.setSession(sessionSecret)
     do {
@@ -174,12 +169,7 @@ final class DeviceLoginViewModel: ObservableObject {
     }
   }
 
-  /// A transport failure is worth retrying in place. Anything the API actively refused, such as the ten
-  /// device authorizations per minute per IP limit, needs its own message rather than being reported as
-  /// a connection problem.
-  ///
-  /// `LoginError` shadows rather than overrides `localizedDescription`, because it does not conform to
-  /// `LocalizedError`. A bare `error.localizedDescription` would lose the API's message.
+  /// A transport failure can be retried in place. An API refusal, like a rate limit, needs its own message.
   private func failure(for error: Error) -> DeviceLoginFailure {
     guard let loginError = error as? LoginError else {
       return .network

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
@@ -1,0 +1,196 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+import Combine
+
+@MainActor
+final class DeviceLoginViewModel: ObservableObject {
+  enum Phase: Equatable {
+    case requesting
+    case awaitingBrowser
+    case matching([String])
+    case completing
+    case failed(DeviceLoginFailure)
+  }
+
+  @Published private(set) var phase: Phase = .requesting
+  @Published private(set) var userCode: String?
+
+  /// Called once a session has been stored, so the caller can resume whatever it was doing.
+  var onSignedIn: (() -> Void)?
+
+  private let verificationURI: URL?
+  private var serverVerificationURI: URL?
+  private var authorization: DeviceAuthorization?
+  private var machine: DeviceLoginStateMachine?
+  private var pollTask: Task<Void, Never>?
+
+  init(verificationURI: URL?) {
+    self.verificationURI = verificationURI
+  }
+
+  /// The partner's own page when the QR supplied one, otherwise whatever the server told us to use.
+  var displayURI: URL? {
+    verificationURI ?? serverVerificationURI
+  }
+
+  var displayOrigin: String {
+    guard let host = displayURI?.host else {
+      return ""
+    }
+    guard let path = displayURI?.path, path != "/", !path.isEmpty else {
+      return host
+    }
+    return host + path
+  }
+
+  func start() async {
+    phase = .requesting
+    userCode = nil
+
+    do {
+      let authorization = try await DeviceLoginService.requestAuthorization()
+      self.authorization = authorization
+      self.serverVerificationURI = authorization.verificationURI
+      self.userCode = authorization.userCode
+      // `let`, not `var`: `firstStep` is a non-mutating computed property, so a `var` here earns a
+      // "never mutated" warning.
+      let machine = DeviceLoginStateMachine(
+        interval: authorization.interval,
+        expiresIn: authorization.expiresIn,
+        now: Date()
+      )
+      let first = machine.firstStep
+      self.machine = machine
+      phase = .awaitingBrowser
+      schedule(first)
+    } catch {
+      let failure = failure(for: error)
+      print("[DeviceLogin] Could not start: \(failure)")
+      phase = .failed(failure)
+    }
+  }
+
+  func pick(_ value: String) {
+    guard var machine else {
+      return
+    }
+    let step = machine.pick(value)
+    self.machine = machine
+    phase = .completing
+    schedule(step)
+  }
+
+  func restart() async {
+    pollTask?.cancel()
+    pollTask = nil
+    await start()
+  }
+
+  func cancel() {
+    pollTask?.cancel()
+    pollTask = nil
+  }
+
+  private func schedule(_ step: DeviceLoginStateMachine.Step) {
+    switch step {
+    case .poll(let after, let matchValue):
+      pollTask?.cancel()
+      pollTask = Task { [weak self] in
+        if after > 0 {
+          try? await Task.sleep(nanoseconds: UInt64(after * 1_000_000_000))
+        }
+        guard !Task.isCancelled else {
+          return
+        }
+        await self?.pollOnce(matchValue: matchValue)
+      }
+    case .awaitMatch(let options):
+      phase = .matching(options)
+    case .signedIn(let secret, let expiresAt):
+      Task { [weak self] in
+        await self?.finish(secret: secret, expiresAt: expiresAt)
+      }
+    case .failed(let failure):
+      phase = .failed(failure)
+    }
+  }
+
+  private func pollOnce(matchValue: String?) async {
+    guard let authorization, var machine else {
+      return
+    }
+    do {
+      let outcome = try await DeviceLoginService.poll(
+        deviceCode: authorization.deviceCode,
+        matchValue: matchValue
+      )
+      // Cancellation is checked again here, not only before the request. A task cancelled while this
+      // await was in flight would otherwise still write `phase`, stomping the state a fresh restart()
+      // had just set up.
+      guard !Task.isCancelled else {
+        return
+      }
+      let step = machine.advance(with: outcome, now: Date())
+      self.machine = machine
+      schedule(step)
+    } catch {
+      guard !Task.isCancelled else {
+        return
+      }
+      let failure = failure(for: error)
+      print("[DeviceLogin] Poll failed: \(failure)")
+      phase = .failed(failure)
+    }
+  }
+
+  private func finish(secret: String, expiresAt: Date?) async {
+    guard let username = await resolveUsername(sessionSecret: secret) else {
+      phase = .failed(.invalid)
+      return
+    }
+    await AuthenticationService.storePartnerSession(
+      sessionSecret: secret,
+      username: username,
+      expiresAt: expiresAt
+    )
+    onSignedIn?()
+  }
+
+  /// The token response carries no username, and `meUserActor` is null for a partner actor, so the
+  /// username has to come from `meActor`.
+  private func resolveUsername(sessionSecret: String) async -> String? {
+    await APIClient.shared.setSession(sessionSecret)
+    do {
+      let response: MeActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
+      guard let username = response.data.meActor?.username else {
+        print("[DeviceLogin] meActor was null after signing in")
+        return nil
+      }
+      return username
+    } catch {
+      print("[DeviceLogin] Could not resolve the username: \(error)")
+      return nil
+    }
+  }
+
+  /// A transport failure is worth retrying in place. Anything the API actively refused, such as the ten
+  /// device authorizations per minute per IP limit, needs its own message rather than being reported as
+  /// a connection problem.
+  ///
+  /// `LoginError` shadows rather than overrides `localizedDescription`, because it does not conform to
+  /// `LocalizedError`. A bare `error.localizedDescription` would lose the API's message.
+  private func failure(for error: Error) -> DeviceLoginFailure {
+    guard let loginError = error as? LoginError else {
+      return .network
+    }
+    switch loginError {
+    case .networkError:
+      return .network
+    case .apiError(let message), .invalidCredentials(let message):
+      return .server(message)
+    case .otpRequired:
+      return .invalid
+    }
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
@@ -1,0 +1,36 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Carries the verification URI from `EXKernelLinkingManager.openUrl:`, which reads it, to
+/// `ExpoGoHomeBridge` and `EXAppLoaderExpoUpdates`, which act on it.
+///
+/// Deliberately not persisted. A device code lives ten minutes, so a pending sign in that survived a
+/// relaunch would only produce a confusing `expired_token`.
+@objc(EXPendingDeviceLogin)
+public final class PendingDeviceLogin: NSObject {
+  @objc public static let shared = PendingDeviceLogin()
+
+  private let lock = NSLock()
+  private var storedURI: URL?
+
+  private override init() {
+    super.init()
+  }
+
+  @objc public var current: URL? {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedURI
+  }
+
+  @objc public func set(_ uri: URL?) {
+    lock.lock()
+    defer { lock.unlock() }
+    storedURI = uri
+  }
+
+  @objc public func clear() {
+    set(nil)
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
@@ -2,11 +2,7 @@
 
 import Foundation
 
-/// Carries the verification URI from `EXKernelLinkingManager.openUrl:`, which reads it, to
-/// `ExpoGoHomeBridge` and `EXAppLoaderExpoUpdates`, which act on it.
-///
-/// Deliberately not persisted. A device code lives ten minutes, so a pending sign in that survived a
-/// relaunch would only produce a confusing `expired_token`.
+/// Not persisted: a device code lives ten minutes, so a stale pending sign in would only produce `expired_token`.
 @objc(EXPendingDeviceLogin)
 public final class PendingDeviceLogin: NSObject {
   @objc public static let shared = PendingDeviceLogin()

--- a/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
@@ -1,0 +1,106 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class DeviceLoginLinkTests: XCTestCase {
+  private func url(_ string: String) throws -> URL {
+    try XCTUnwrap(URL(string: string))
+  }
+
+  // MARK: reading
+
+  func testReadsHTTPSOverride() throws {
+    let parsed = DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2Fpartner.dev%2Fp%2F123")
+    )
+    XCTAssertEqual(parsed?.absoluteString, "https://partner.dev/p/123")
+  }
+
+  func testReadsOverrideAlongsideOtherParams() throws {
+    let parsed = DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?snack-channel=abc&verification_uri_override=https%3A%2F%2Fpartner.dev")
+    )
+    XCTAssertEqual(parsed?.absoluteString, "https://partner.dev")
+  }
+
+  func testReturnsNilWhenParameterAbsent() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(from: try url("exp://10.0.0.5:8081/")))
+  }
+
+  func testReturnsNilForEmptyValue() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=")
+    ))
+  }
+
+  func testRejectsPlainHTTP() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=http%3A%2F%2Fpartner.dev")
+    ))
+  }
+
+  func testRejectsSchemelessValue() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=partner.dev%2Fp")
+    ))
+  }
+
+  func testRejectsHostlessValue() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2F%2Fjust-a-path")
+    ))
+  }
+
+  func testRejectsCustomScheme() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=javascript%3Aalert(1)")
+    ))
+  }
+
+  // MARK: stripping
+
+  func testStripRemovesOnlyTheOverride() throws {
+    let stripped = DeviceLoginLink.urlByRemovingOverride(
+      from: try url("exp://10.0.0.5:8081/?a=1&verification_uri_override=https%3A%2F%2Fp.dev&b=2")
+    )
+    XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?a=1&b=2")
+  }
+
+  func testStripPreservesEncodingOfOtherItems() throws {
+    let stripped = DeviceLoginLink.urlByRemovingOverride(
+      from: try url("exp://10.0.0.5:8081/?snack-channel=a%2Bb&verification_uri_override=https%3A%2F%2Fp.dev")
+    )
+    XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?snack-channel=a%2Bb")
+  }
+
+  func testStripDropsTheQueryEntirelyWhenNothingRemains() throws {
+    let stripped = DeviceLoginLink.urlByRemovingOverride(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2Fp.dev")
+    )
+    XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/")
+  }
+
+  func testStripIsIdentityWhenAbsent() throws {
+    let original = try url("exp://10.0.0.5:8081/?a=1")
+    XCTAssertEqual(DeviceLoginLink.urlByRemovingOverride(from: original).absoluteString, original.absoluteString)
+  }
+
+  func testStripLeavesAnInvalidOverrideValueRemoved() throws {
+    // Validation and stripping are independent. A rejected value must still not reach the dev server.
+    let stripped = DeviceLoginLink.urlByRemovingOverride(
+      from: try url("exp://10.0.0.5:8081/?verification_uri_override=http%3A%2F%2Fp.dev&a=1")
+    )
+    XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?a=1")
+  }
+
+  // MARK: pending holder
+
+  func testPendingHolderStoresAndClears() throws {
+    let uri = try url("https://partner.dev/p/123")
+    PendingDeviceLogin.shared.set(uri)
+    XCTAssertEqual(PendingDeviceLogin.shared.current, uri)
+    PendingDeviceLogin.shared.clear()
+    XCTAssertNil(PendingDeviceLogin.shared.current)
+  }
+}

--- a/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
@@ -8,88 +8,120 @@ final class DeviceLoginLinkTests: XCTestCase {
     try XCTUnwrap(URL(string: string))
   }
 
-  // MARK: reading
+  // MARK: prompt
+
+  func testPromptRequestedWhenTriggerIsOne() throws {
+    XCTAssertTrue(DeviceLoginLink.promptRequested(
+      in: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=1")
+    ))
+  }
+
+  func testPromptNotRequestedWhenTriggerIsZero() throws {
+    XCTAssertFalse(DeviceLoginLink.promptRequested(
+      in: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=0")
+    ))
+  }
+
+  func testPromptNotRequestedWhenTriggerAbsent() throws {
+    XCTAssertFalse(DeviceLoginLink.promptRequested(in: try url("exp://10.0.0.5:8081/")))
+  }
+
+  func testOverrideAloneDoesNotPrompt() throws {
+    XCTAssertFalse(DeviceLoginLink.promptRequested(
+      in: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=https%3A%2F%2Fverify.example")
+    ))
+  }
+
+  // MARK: reading the override
 
   func testReadsHTTPSOverride() throws {
     let parsed = DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2Fpartner.dev%2Fp%2F123")
+      from: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=1&expo_go_device_auth_verification_uri_override=https%3A%2F%2Fverify.example%2Fp%2F123")
     )
-    XCTAssertEqual(parsed?.absoluteString, "https://partner.dev/p/123")
+    XCTAssertEqual(parsed?.absoluteString, "https://verify.example/p/123")
   }
 
   func testReadsOverrideAlongsideOtherParams() throws {
     let parsed = DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?snack-channel=abc&verification_uri_override=https%3A%2F%2Fpartner.dev")
+      from: try url("exp://10.0.0.5:8081/?snack-channel=abc&expo_go_device_auth_verification_uri_override=https%3A%2F%2Fverify.example")
     )
-    XCTAssertEqual(parsed?.absoluteString, "https://partner.dev")
+    XCTAssertEqual(parsed?.absoluteString, "https://verify.example")
   }
 
-  func testReturnsNilWhenParameterAbsent() throws {
-    XCTAssertNil(DeviceLoginLink.verificationURI(from: try url("exp://10.0.0.5:8081/")))
+  func testReturnsNilWhenOverrideAbsent() throws {
+    XCTAssertNil(DeviceLoginLink.verificationURI(
+      from: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=1")
+    ))
   }
 
   func testReturnsNilForEmptyValue() throws {
     XCTAssertNil(DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=")
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=")
     ))
   }
 
   func testRejectsPlainHTTP() throws {
     XCTAssertNil(DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=http%3A%2F%2Fpartner.dev")
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=http%3A%2F%2Fverify.example")
     ))
   }
 
   func testRejectsSchemelessValue() throws {
     XCTAssertNil(DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=partner.dev%2Fp")
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=verify.example%2Fp")
     ))
   }
 
   func testRejectsHostlessValue() throws {
     XCTAssertNil(DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2F%2Fjust-a-path")
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=https%3A%2F%2F%2Fjust-a-path")
     ))
   }
 
   func testRejectsCustomScheme() throws {
     XCTAssertNil(DeviceLoginLink.verificationURI(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=javascript%3Aalert(1)")
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=javascript%3Aalert(1)")
     ))
   }
 
   // MARK: stripping
 
-  func testStripRemovesOnlyTheOverride() throws {
-    let stripped = DeviceLoginLink.urlByRemovingOverride(
-      from: try url("exp://10.0.0.5:8081/?a=1&verification_uri_override=https%3A%2F%2Fp.dev&b=2")
+  func testStripRemovesBothParams() throws {
+    let stripped = DeviceLoginLink.urlByRemovingDeviceAuthParams(
+      from: try url("exp://10.0.0.5:8081/?a=1&expo_go_prompt_device_auth=1&expo_go_device_auth_verification_uri_override=https%3A%2F%2Fverify.example&b=2")
     )
     XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?a=1&b=2")
   }
 
+  func testStripRemovesTriggerAlone() throws {
+    let stripped = DeviceLoginLink.urlByRemovingDeviceAuthParams(
+      from: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=1&a=1")
+    )
+    XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?a=1")
+  }
+
   func testStripPreservesEncodingOfOtherItems() throws {
-    let stripped = DeviceLoginLink.urlByRemovingOverride(
-      from: try url("exp://10.0.0.5:8081/?snack-channel=a%2Bb&verification_uri_override=https%3A%2F%2Fp.dev")
+    let stripped = DeviceLoginLink.urlByRemovingDeviceAuthParams(
+      from: try url("exp://10.0.0.5:8081/?snack-channel=a%2Bb&expo_go_prompt_device_auth=1")
     )
     XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?snack-channel=a%2Bb")
   }
 
   func testStripDropsTheQueryEntirelyWhenNothingRemains() throws {
-    let stripped = DeviceLoginLink.urlByRemovingOverride(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=https%3A%2F%2Fp.dev")
+    let stripped = DeviceLoginLink.urlByRemovingDeviceAuthParams(
+      from: try url("exp://10.0.0.5:8081/?expo_go_prompt_device_auth=1")
     )
     XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/")
   }
 
   func testStripIsIdentityWhenAbsent() throws {
     let original = try url("exp://10.0.0.5:8081/?a=1")
-    XCTAssertEqual(DeviceLoginLink.urlByRemovingOverride(from: original).absoluteString, original.absoluteString)
+    XCTAssertEqual(DeviceLoginLink.urlByRemovingDeviceAuthParams(from: original).absoluteString, original.absoluteString)
   }
 
-  func testStripLeavesAnInvalidOverrideValueRemoved() throws {
-    // Validation and stripping are independent. A rejected value must still not reach the dev server.
-    let stripped = DeviceLoginLink.urlByRemovingOverride(
-      from: try url("exp://10.0.0.5:8081/?verification_uri_override=http%3A%2F%2Fp.dev&a=1")
+  func testStripRemovesAnInvalidOverride() throws {
+    let stripped = DeviceLoginLink.urlByRemovingDeviceAuthParams(
+      from: try url("exp://10.0.0.5:8081/?expo_go_device_auth_verification_uri_override=http%3A%2F%2Fverify.example&a=1")
     )
     XCTAssertEqual(stripped.absoluteString, "exp://10.0.0.5:8081/?a=1")
   }
@@ -97,7 +129,7 @@ final class DeviceLoginLinkTests: XCTestCase {
   // MARK: pending holder
 
   func testPendingHolderStoresAndClears() throws {
-    let uri = try url("https://partner.dev/p/123")
+    let uri = try url("https://verify.example/p/123")
     PendingDeviceLogin.shared.set(uri)
     XCTAssertEqual(PendingDeviceLogin.shared.current, uri)
     PendingDeviceLogin.shared.clear()

--- a/apps/expo-go/ios/Tests/DeviceLoginModelsTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginModelsTests.swift
@@ -80,8 +80,7 @@ final class DeviceLoginModelsTests: XCTestCase {
   }
 
   func testMapsMatchingRequiredWithNoOptionsToInvalid() throws {
-    // Three options are always sent. Their absence means the contract changed, not that we should
-    // show an empty picker.
+    // Their absence means the contract changed, not that we should show an empty picker.
     XCTAssertEqual(try outcome(#"{"data":{"error":"matching_required"}}"#), .invalid)
   }
 

--- a/apps/expo-go/ios/Tests/DeviceLoginModelsTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginModelsTests.swift
@@ -1,0 +1,130 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class DeviceLoginModelsTests: XCTestCase {
+  private func payload(_ json: String) throws -> DeviceTokenPayload {
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    return try JSONDecoder().decode(DeviceTokenResponse.self, from: data).data
+  }
+
+  private func outcome(_ json: String) throws -> TokenOutcome {
+    TokenOutcome(payload: try payload(json))
+  }
+
+  // MARK: authorization response
+
+  func testDecodesAuthorizationResponse() throws {
+    let json = """
+    {"data":{"device_code":"Aag-CvhX","user_code":"FRCK-VFRN",
+      "verification_uri":"https://expo.dev/oauth/device","expires_in":599,"interval":5}}
+    """
+    let data = try XCTUnwrap(json.data(using: .utf8))
+    let authorization = try JSONDecoder().decode(DeviceAuthorizationResponse.self, from: data).data
+
+    XCTAssertEqual(authorization.deviceCode, "Aag-CvhX")
+    XCTAssertEqual(authorization.userCode, "FRCK-VFRN")
+    XCTAssertEqual(authorization.verificationURI.absoluteString, "https://expo.dev/oauth/device")
+    XCTAssertEqual(authorization.expiresIn, 599)
+    XCTAssertEqual(authorization.interval, 5)
+  }
+
+  // MARK: expiry parsing
+
+  func testParsesExpiryWithFractionalSeconds() {
+    let date = DeviceLoginDates.parseExpiry("2026-08-11T12:34:56.789Z")
+    XCTAssertNotNil(date)
+  }
+
+  func testParsesExpiryWithoutFractionalSeconds() {
+    let date = DeviceLoginDates.parseExpiry("2026-08-11T12:34:56Z")
+    XCTAssertNotNil(date)
+  }
+
+  func testRejectsUnparseableExpiry() {
+    XCTAssertNil(DeviceLoginDates.parseExpiry("not a date"))
+  }
+
+  // MARK: outcome mapping
+
+  func testMapsSuccessWithExpiry() throws {
+    let result = try outcome("""
+    {"data":{"session_secret":"secret","expires_at":"2026-08-11T12:34:56.789Z"}}
+    """)
+    guard case .session(let secret, let expiresAt) = result else {
+      return XCTFail("expected .session, got \(result)")
+    }
+    XCTAssertEqual(secret, "secret")
+    XCTAssertNotNil(expiresAt)
+  }
+
+  func testMapsSuccessWithUnparseableExpiryToASessionWithNoExpiry() throws {
+    let result = try outcome(#"{"data":{"session_secret":"secret","expires_at":"garbage"}}"#)
+    XCTAssertEqual(result, .session(secret: "secret", expiresAt: nil))
+  }
+
+  func testMapsAuthorizationPending() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"authorization_pending"}}"#), .pending)
+  }
+
+  func testMapsSlowDown() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"slow_down"}}"#), .slowDown)
+  }
+
+  func testMapsMatchingRequiredWithOptions() throws {
+    XCTAssertEqual(
+      try outcome(#"{"data":{"error":"matching_required","match_options":["42","17","93"]}}"#),
+      .matchRequired(["42", "17", "93"])
+    )
+  }
+
+  func testMapsMatchingRequiredWithNoOptionsToInvalid() throws {
+    // Three options are always sent. Their absence means the contract changed, not that we should
+    // show an empty picker.
+    XCTAssertEqual(try outcome(#"{"data":{"error":"matching_required"}}"#), .invalid)
+  }
+
+  func testMapsAccessDenied() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"access_denied"}}"#), .denied)
+  }
+
+  func testMapsExpiredToken() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"expired_token"}}"#), .expired)
+  }
+
+  func testMapsInvalidGrant() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"invalid_grant"}}"#), .invalid)
+  }
+
+  func testMapsUnknownErrorToInvalid() throws {
+    XCTAssertEqual(try outcome(#"{"data":{"error":"something_new"}}"#), .invalid)
+  }
+
+  func testMapsEmptyPayloadToInvalid() throws {
+    XCTAssertEqual(try outcome(#"{"data":{}}"#), .invalid)
+  }
+
+  // MARK: request encoding
+
+  func testEncodesTokenRequestWithSnakeCaseKeys() throws {
+    let request = DeviceTokenRequest(clientId: "expo-go", deviceCode: "abc", matchValue: "42")
+    let encoded = try JSONEncoder().encode(request)
+    let object = try XCTUnwrap(
+      try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    XCTAssertEqual(object["grant_type"] as? String, "urn:ietf:params:oauth:grant-type:device_code")
+    XCTAssertEqual(object["client_id"] as? String, "expo-go")
+    XCTAssertEqual(object["device_code"] as? String, "abc")
+    XCTAssertEqual(object["match_value"] as? String, "42")
+  }
+
+  func testOmitsMatchValueWhenAbsent() throws {
+    let request = DeviceTokenRequest(clientId: "expo-go", deviceCode: "abc", matchValue: nil)
+    let encoded = try JSONEncoder().encode(request)
+    let object = try XCTUnwrap(
+      try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+    )
+    XCTAssertNil(object["match_value"])
+  }
+}

--- a/apps/expo-go/ios/Tests/DeviceLoginStateMachineTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginStateMachineTests.swift
@@ -1,0 +1,94 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class DeviceLoginStateMachineTests: XCTestCase {
+  private let start = Date(timeIntervalSince1970: 1_786_000_000)
+
+  private func machine(interval: Int = 5, expiresIn: Int = 600) -> DeviceLoginStateMachine {
+    DeviceLoginStateMachine(interval: interval, expiresIn: expiresIn, now: start)
+  }
+
+  func testFirstStepWaitsOutTheInterval() {
+    XCTAssertEqual(machine().firstStep, .poll(after: 5, matchValue: nil))
+  }
+
+  func testPendingKeepsTheInterval() {
+    var subject = machine()
+    XCTAssertEqual(subject.advance(with: .pending, now: start), .poll(after: 5, matchValue: nil))
+    XCTAssertEqual(subject.advance(with: .pending, now: start), .poll(after: 5, matchValue: nil))
+  }
+
+  func testSlowDownAddsFiveSecondsEachTime() {
+    var subject = machine()
+    XCTAssertEqual(subject.advance(with: .slowDown, now: start), .poll(after: 10, matchValue: nil))
+    XCTAssertEqual(subject.advance(with: .slowDown, now: start), .poll(after: 15, matchValue: nil))
+    XCTAssertEqual(subject.advance(with: .pending, now: start), .poll(after: 15, matchValue: nil))
+  }
+
+  func testDeadlineExpiresLocally() {
+    var subject = machine(expiresIn: 600)
+    let past = start.addingTimeInterval(601)
+    XCTAssertEqual(subject.advance(with: .pending, now: past), .failed(.expired))
+  }
+
+  func testMatchRequiredMovesToMatching() {
+    var subject = machine()
+    XCTAssertEqual(
+      subject.advance(with: .matchRequired(["42", "17", "93"]), now: start),
+      .awaitMatch(["42", "17", "93"])
+    )
+  }
+
+  func testPickPollsImmediatelyWithTheValue() {
+    var subject = machine()
+    _ = subject.advance(with: .matchRequired(["42", "17", "93"]), now: start)
+    XCTAssertEqual(subject.pick("42"), .poll(after: 0, matchValue: "42"))
+  }
+
+  func testPendingAfterAPickKeepsSendingTheValue() {
+    var subject = machine()
+    _ = subject.advance(with: .matchRequired(["42", "17", "93"]), now: start)
+    _ = subject.pick("42")
+    XCTAssertEqual(subject.advance(with: .pending, now: start), .poll(after: 5, matchValue: "42"))
+  }
+
+  func testDeniedBeforeAPickIsADenial() {
+    var subject = machine()
+    XCTAssertEqual(subject.advance(with: .denied, now: start), .failed(.denied))
+  }
+
+  func testDeniedAfterAPickIsAWrongNumber() {
+    var subject = machine()
+    _ = subject.advance(with: .matchRequired(["42", "17", "93"]), now: start)
+    _ = subject.pick("17")
+    XCTAssertEqual(subject.advance(with: .denied, now: start), .failed(.wrongNumber))
+  }
+
+  func testSecondMatchRequiredAfterAPickIsInvalid() {
+    var subject = machine()
+    _ = subject.advance(with: .matchRequired(["42", "17", "93"]), now: start)
+    _ = subject.pick("42")
+    XCTAssertEqual(subject.advance(with: .matchRequired(["42", "17", "93"]), now: start), .failed(.invalid))
+  }
+
+  func testSessionSignsIn() {
+    var subject = machine()
+    let expiry = start.addingTimeInterval(3600)
+    XCTAssertEqual(
+      subject.advance(with: .session(secret: "secret", expiresAt: expiry), now: start),
+      .signedIn(secret: "secret", expiresAt: expiry)
+    )
+  }
+
+  func testExpiredTokenFails() {
+    var subject = machine()
+    XCTAssertEqual(subject.advance(with: .expired, now: start), .failed(.expired))
+  }
+
+  func testInvalidGrantFails() {
+    var subject = machine()
+    XCTAssertEqual(subject.advance(with: .invalid, now: start), .failed(.invalid))
+  }
+}


### PR DESCRIPTION
# Why
Adds the UI necessary for the feature.

# How

The flow follows RFC 8628 with the number match step the server added in [expo/universe#29795](https://github.com/expo/universe/issues/29795). A partner's QR is the dev server URL plus one query parameter. DeviceLoginLink validates and strips it.

The sheet has three steps, the code with a copy button and an in-app browser so a single device user can finish the flow, the number match, and error states which describe the recovery the app actually offers. The browser dismisses itself shortly after a poll sees the approval.

# Test Plan
Unit tests cover the URL parsing and stripping, every shape the token endpoint returns including expires_at with and without fractional seconds, and each timing rule in the state machine.