### PR TITLE
[ios][expo-go] Sign in before opening a partner project

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
@@ -6,6 +6,7 @@ import UIKit
 struct DeviceLoginCodeView: View {
   let userCode: String
   let origin: String
+  let onOpenBrowser: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 24) {
@@ -22,24 +23,41 @@ struct DeviceLoginCodeView: View {
         Text("Enter it on the page that showed you the QR code:")
           .font(.subheadline)
           .foregroundColor(.secondary)
-        // Plain text on purpose. This address comes from a scanned QR code, so Expo Go never opens it.
         Text(origin)
           .font(.system(.body, design: .monospaced))
           .foregroundColor(.primary)
       }
 
-      Button {
-        UIPasteboard.general.string = userCode
-        UIImpactFeedbackGenerator(style: .light).impactOccurred()
-      } label: {
-        Text("Copy code")
-          .font(.headline)
-          .frame(maxWidth: .infinity)
-          .padding(.vertical, 12)
+      VStack(alignment: .leading, spacing: 12) {
+        Text("After you approve on that page, it will show you a two-digit number. Remember that number, because you will pick it here once the browser closes.")
+          .font(.subheadline)
+          .foregroundColor(.secondary)
+
+        Button {
+          copyCode()
+          onOpenBrowser()
+        } label: {
+          Text("Copy code and open page")
+            .font(.headline)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+        }
+        .background(Color.black)
+        .cornerRadius(12)
+
+        Button {
+          copyCode()
+        } label: {
+          Text("Copy code")
+            .font(.subheadline)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+        }
+        .background(Color.expoSystemBackground)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.secondary.opacity(0.3)))
+        .cornerRadius(12)
       }
-      .background(Color.expoSystemBackground)
-      .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.secondary.opacity(0.3)))
-      .cornerRadius(12)
 
       HStack(spacing: 8) {
         ProgressView()
@@ -56,6 +74,11 @@ struct DeviceLoginCodeView: View {
   }
 
   /// VoiceOver reads "BCDFGHJK" as a word. Spelling it out makes it transcribable.
+  private func copyCode() {
+    UIPasteboard.general.string = userCode
+    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+  }
+
   private func spelledOut(_ code: String) -> String {
     code.map { $0 == "-" ? "dash" : String($0) }.joined(separator: " ")
   }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginCodeView.swift
@@ -73,12 +73,12 @@ struct DeviceLoginCodeView: View {
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
-  /// VoiceOver reads "BCDFGHJK" as a word. Spelling it out makes it transcribable.
   private func copyCode() {
     UIPasteboard.general.string = userCode
     UIImpactFeedbackGenerator(style: .light).impactOccurred()
   }
 
+  /// VoiceOver reads "BCDFGHJK" as a word. Spelling it out makes it transcribable.
   private func spelledOut(_ code: String) -> String {
     code.map { $0 == "-" ? "dash" : String($0) }.joined(separator: " ")
   }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginErrorView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginErrorView.swift
@@ -19,7 +19,7 @@ struct DeviceLoginErrorView: View {
       Button {
         onRetry()
       } label: {
-        Text(retryLabel)
+        Text("Get a new code")
           .font(.headline)
           .foregroundColor(.white)
           .frame(maxWidth: .infinity)
@@ -53,7 +53,7 @@ struct DeviceLoginErrorView: View {
     case .invalid:
       return "This code has already been used, or Expo returned something unexpected. Get a new code, and contact support@expo.dev if it keeps happening."
     case .network:
-      return "Check your connection and try again. Your code was not used."
+      return "Expo Go couldn't reach the server. Check your connection and get a new code."
     case .server(let message):
       return "\(sentence(from: message)) Wait a moment before trying again."
     }
@@ -66,10 +66,5 @@ struct DeviceLoginErrorView: View {
       return "Expo turned down the request."
     }
     return ".!?".contains(last) ? trimmed : trimmed + "."
-  }
-
-  /// A network failure never reached the server, so the same attempt can simply be retried.
-  private var retryLabel: String {
-    failure == .network ? "Try again" : "Get a new code"
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginModels.swift
@@ -124,14 +124,6 @@ enum TokenOutcome: Equatable {
 enum DeviceLoginDates {
   /// The API sends fractional seconds, which `JSONDecoder`'s `.iso8601` strategy rejects.
   static func parseExpiry(_ value: String) -> Date? {
-    let withFractionalSeconds = ISO8601DateFormatter()
-    withFractionalSeconds.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    if let date = withFractionalSeconds.date(from: value) {
-      return date
-    }
-
-    let withoutFractionalSeconds = ISO8601DateFormatter()
-    withoutFractionalSeconds.formatOptions = [.withInternetDateTime]
-    return withoutFractionalSeconds.date(from: value)
+    parseISO8601Date(value)
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
@@ -49,7 +49,7 @@ struct DeviceLoginSheet: View {
       case .awaitingBrowser:
         break
       case .matching:
-        // The number the user has to pick is on the page behind this, so leave it readable.
+        // The number to pick is on the browser page, so leave it readable a moment before dismissing.
         Task {
           try? await Task.sleep(nanoseconds: 3_000_000_000)
           browserURL = nil

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginSheet.swift
@@ -7,10 +7,11 @@ struct DeviceLoginSheet: View {
 
   @StateObject private var viewModel: DeviceLoginViewModel
   @Environment(\.dismiss) private var dismiss
+  @State private var browserURL: URL?
 
-  init(verificationURI: URL?, onFinished: @escaping (Bool) -> Void) {
+  init(authService: AuthenticationService, verificationURI: URL?, onFinished: @escaping (Bool) -> Void) {
     self.onFinished = onFinished
-    _viewModel = StateObject(wrappedValue: DeviceLoginViewModel(verificationURI: verificationURI))
+    _viewModel = StateObject(wrappedValue: DeviceLoginViewModel(authService: authService, verificationURI: verificationURI))
   }
 
   var body: some View {
@@ -39,6 +40,24 @@ struct DeviceLoginSheet: View {
         }
       }
     }
+    .sheet(item: $browserURL) { url in
+      SafariView(url: url)
+        .ignoresSafeArea()
+    }
+    .onChange(of: viewModel.phase) { newPhase in
+      switch newPhase {
+      case .awaitingBrowser:
+        break
+      case .matching:
+        // The number the user has to pick is on the page behind this, so leave it readable.
+        Task {
+          try? await Task.sleep(nanoseconds: 3_000_000_000)
+          browserURL = nil
+        }
+      default:
+        browserURL = nil
+      }
+    }
     .task {
       viewModel.onSignedIn = {
         onFinished(true)
@@ -58,7 +77,8 @@ struct DeviceLoginSheet: View {
     case .awaitingBrowser:
       DeviceLoginCodeView(
         userCode: viewModel.userCode ?? "",
-        origin: viewModel.displayOrigin
+        origin: viewModel.displayOrigin,
+        onOpenBrowser: { browserURL = viewModel.displayURI }
       )
     case .matching(let options):
       DeviceLoginMatchView(options: options) { value in

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginStateMachine.swift
@@ -27,7 +27,7 @@ struct DeviceLoginStateMachine {
   private var hasSentMatch = false
 
   init(interval: Int, expiresIn: Int, now: Date) {
-    self.delay = TimeInterval(interval)
+    self.delay = TimeInterval(max(interval, 1))
     self.deadline = now.addingTimeInterval(TimeInterval(expiresIn))
   }
 
@@ -37,13 +37,17 @@ struct DeviceLoginStateMachine {
   }
 
   mutating func advance(with outcome: TokenOutcome, now: Date) -> Step {
+    if case .session(let secret, let expiresAt) = outcome {
+      return .signedIn(secret: secret, expiresAt: expiresAt)
+    }
+
     if now >= deadline {
       return .failed(.expired)
     }
 
     switch outcome {
-    case .session(let secret, let expiresAt):
-      return .signedIn(secret: secret, expiresAt: expiresAt)
+    case .session:
+      return .failed(.expired)
     case .pending:
       return .poll(after: delay, matchValue: matchValue)
     case .slowDown:

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
@@ -19,17 +19,20 @@ final class DeviceLoginViewModel: ObservableObject {
   /// Called once a session has been stored, so the caller can resume whatever it was doing.
   var onSignedIn: (() -> Void)?
 
+  private let authService: AuthenticationService
   private let verificationURI: URL?
   private var serverVerificationURI: URL?
   private var authorization: DeviceAuthorization?
   private var machine: DeviceLoginStateMachine?
   private var pollTask: Task<Void, Never>?
+  private var finishTask: Task<Void, Never>?
 
-  init(verificationURI: URL?) {
+  init(authService: AuthenticationService, verificationURI: URL?) {
+    self.authService = authService
     self.verificationURI = verificationURI
   }
 
-  /// The override page when the QR supplied one, otherwise whatever the server told us to use.
+  /// The partner's own page when the QR supplied one, otherwise whatever the server told us to use.
   var displayURI: URL? {
     verificationURI ?? serverVerificationURI
   }
@@ -88,6 +91,8 @@ final class DeviceLoginViewModel: ObservableObject {
   func cancel() {
     pollTask?.cancel()
     pollTask = nil
+    finishTask?.cancel()
+    finishTask = nil
   }
 
   private func schedule(_ step: DeviceLoginStateMachine.Step) {
@@ -106,7 +111,7 @@ final class DeviceLoginViewModel: ObservableObject {
     case .awaitMatch(let options):
       phase = .matching(options)
     case .signedIn(let secret, let expiresAt):
-      Task { [weak self] in
+      finishTask = Task { [weak self] in
         await self?.finish(secret: secret, expiresAt: expiresAt)
       }
     case .failed(let failure):
@@ -141,32 +146,18 @@ final class DeviceLoginViewModel: ObservableObject {
   }
 
   private func finish(secret: String, expiresAt: Date?) async {
-    guard let username = await resolveUsername(sessionSecret: secret) else {
+    await authService.completeLogin(with: secret, expiresAt: expiresAt)
+    // Re-checked after the await so a cancelled sign-in cannot still call onSignedIn.
+    guard !Task.isCancelled else {
+      return
+    }
+    guard authService.user != nil else {
+      // No actor means no username, which the manifest check needs, so this is not a usable session.
+      authService.signOut()
       phase = .failed(.invalid)
       return
     }
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: secret,
-      username: username,
-      expiresAt: expiresAt
-    )
     onSignedIn?()
-  }
-
-  /// The token response carries no username, and `meUserActor` is null for some actor types, so username comes from `meActor`.
-  private func resolveUsername(sessionSecret: String) async -> String? {
-    await APIClient.shared.setSession(sessionSecret)
-    do {
-      let response: MeActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
-      guard let username = response.data.meActor?.username else {
-        print("[DeviceLogin] meActor was null after signing in")
-        return nil
-      }
-      return username
-    } catch {
-      print("[DeviceLogin] Could not resolve the username: \(error)")
-      return nil
-    }
   }
 
   /// A transport failure can be retried in place. An API refusal, like a rate limit, needs its own message.
@@ -177,7 +168,9 @@ final class DeviceLoginViewModel: ObservableObject {
     switch loginError {
     case .networkError:
       return .network
-    case .apiError(let message), .invalidCredentials(let message):
+    case .apiError(let message):
+      return RESTClient.isClientAuthoredMessage(message) ? .invalid : .server(message)
+    case .invalidCredentials(let message):
       return .server(message)
     case .otpRequired:
       return .invalid

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/DeviceLoginViewModel.swift
@@ -32,7 +32,7 @@ final class DeviceLoginViewModel: ObservableObject {
     self.verificationURI = verificationURI
   }
 
-  /// The partner's own page when the QR supplied one, otherwise whatever the server told us to use.
+  /// The override page when the QR supplied one, otherwise whatever the server told us to use.
   var displayURI: URL? {
     verificationURI ?? serverVerificationURI
   }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
@@ -8,57 +8,59 @@ public final class PendingDeviceLogin: NSObject {
   @objc public static let shared = PendingDeviceLogin()
 
   private let lock = NSLock()
+  private var pendingProjectURL: URL?
   private var storedURI: URL?
-  private var storedProjectURL: URL?
   private var hasOffered = false
 
   private override init() {
     super.init()
   }
 
-  /// The URI while it is stored, offered or not. The mismatch error reads this after the sheet has
-  /// already been declined.
-  @objc(currentForProjectURL:)
-  public func current(forProjectURL projectURL: URL) -> URL? {
+  @objc(hasPendingForProjectURL:)
+  public func hasPending(forProjectURL projectURL: URL) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return matches(projectURL)
+  }
+
+  /// Nil either when nothing is pending for this project or when the prompt came without an override.
+  @objc(verificationURIForProjectURL:)
+  public func verificationURI(forProjectURL projectURL: URL) -> URL? {
     lock.lock()
     defer { lock.unlock() }
     return matches(projectURL) ? storedURI : nil
   }
 
-  /// The URI the first time only. Returning it once is what stops the open loop from re-presenting.
+  /// True the first time only. Answering once is what stops the open loop from re-presenting.
   @objc(offerOnceForProjectURL:)
-  public func offerOnce(forProjectURL projectURL: URL) -> URL? {
+  public func offerOnce(forProjectURL projectURL: URL) -> Bool {
     lock.lock()
     defer { lock.unlock() }
-    guard matches(projectURL), !hasOffered, let storedURI else {
-      return nil
+    guard matches(projectURL), !hasOffered else {
+      return false
     }
     hasOffered = true
-    return storedURI
+    return true
   }
 
-  @objc(setURI:forProjectURL:)
-  public func set(_ uri: URL?, forProjectURL projectURL: URL) {
-    guard let uri else {
-      clear()
-      return
-    }
+  @objc(setPending:verificationURI:forProjectURL:)
+  public func setPending(_ pending: Bool, verificationURI uri: URL?, forProjectURL projectURL: URL) {
     lock.lock()
     defer { lock.unlock() }
     hasOffered = false
-    storedURI = uri
-    storedProjectURL = projectURL
+    pendingProjectURL = pending ? projectURL : nil
+    storedURI = pending ? uri : nil
   }
 
   @objc public func clear() {
     lock.lock()
     defer { lock.unlock() }
+    pendingProjectURL = nil
     storedURI = nil
-    storedProjectURL = nil
     hasOffered = false
   }
 
   private func matches(_ projectURL: URL) -> Bool {
-    storedProjectURL?.absoluteString == projectURL.absoluteString
+    pendingProjectURL?.absoluteString == projectURL.absoluteString
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
@@ -2,31 +2,46 @@
 
 import Foundation
 
-/// Not persisted: a device code lives ten minutes, so a stale pending sign in would only produce `expired_token`.
+/// Not persisted: a device code lives ten minutes. Keyed by project URL so a cancelled sign in cannot resurface on a different project.
 @objc(EXPendingDeviceLogin)
 public final class PendingDeviceLogin: NSObject {
   @objc public static let shared = PendingDeviceLogin()
 
   private let lock = NSLock()
   private var storedURI: URL?
+  private var storedProjectURL: URL?
 
   private override init() {
     super.init()
   }
 
-  @objc public var current: URL? {
+  @objc(currentForProjectURL:)
+  public func current(forProjectURL projectURL: URL) -> URL? {
     lock.lock()
     defer { lock.unlock() }
+    guard storedProjectURL?.absoluteString == projectURL.absoluteString else {
+      return nil
+    }
     return storedURI
   }
 
-  @objc public func set(_ uri: URL?) {
+  @objc(setURI:forProjectURL:)
+  public func set(_ uri: URL?, forProjectURL projectURL: URL) {
     lock.lock()
     defer { lock.unlock() }
+    guard let uri else {
+      storedURI = nil
+      storedProjectURL = nil
+      return
+    }
     storedURI = uri
+    storedProjectURL = projectURL
   }
 
   @objc public func clear() {
-    set(nil)
+    lock.lock()
+    defer { lock.unlock() }
+    storedURI = nil
+    storedProjectURL = nil
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/DeviceLogin/PendingDeviceLogin.swift
@@ -10,30 +10,42 @@ public final class PendingDeviceLogin: NSObject {
   private let lock = NSLock()
   private var storedURI: URL?
   private var storedProjectURL: URL?
+  private var hasOffered = false
 
   private override init() {
     super.init()
   }
 
+  /// The URI while it is stored, offered or not. The mismatch error reads this after the sheet has
+  /// already been declined.
   @objc(currentForProjectURL:)
   public func current(forProjectURL projectURL: URL) -> URL? {
     lock.lock()
     defer { lock.unlock() }
-    guard storedProjectURL?.absoluteString == projectURL.absoluteString else {
+    return matches(projectURL) ? storedURI : nil
+  }
+
+  /// The URI the first time only. Returning it once is what stops the open loop from re-presenting.
+  @objc(offerOnceForProjectURL:)
+  public func offerOnce(forProjectURL projectURL: URL) -> URL? {
+    lock.lock()
+    defer { lock.unlock() }
+    guard matches(projectURL), !hasOffered, let storedURI else {
       return nil
     }
+    hasOffered = true
     return storedURI
   }
 
   @objc(setURI:forProjectURL:)
   public func set(_ uri: URL?, forProjectURL projectURL: URL) {
-    lock.lock()
-    defer { lock.unlock() }
     guard let uri else {
-      storedURI = nil
-      storedProjectURL = nil
+      clear()
       return
     }
+    lock.lock()
+    defer { lock.unlock() }
+    hasOffered = false
     storedURI = uri
     storedProjectURL = projectURL
   }
@@ -43,5 +55,10 @@ public final class PendingDeviceLogin: NSObject {
     defer { lock.unlock() }
     storedURI = nil
     storedProjectURL = nil
+    hasOffered = false
+  }
+
+  private func matches(_ projectURL: URL) -> Bool {
+    storedProjectURL?.absoluteString == projectURL.absoluteString
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
@@ -35,36 +35,14 @@ import UIKit
       return
     }
 
-    let expiredMessage = expiredPartnerSessionMessage()
-    if expiredMessage != nil {
-      AuthenticationService.clearSession()
-    }
+    let expiredMessage = consumeExpiredSessionMessage()
 
-    let pendingVerificationURI = PendingDeviceLogin.shared.current(forProjectURL: appUrl)
-    let alreadyGranted = pendingVerificationURI?.host.map {
-      AuthenticationService.isDeviceLoginAlreadyGranted(forVerificationHost: $0)
-    } ?? false
-
-    if !alreadyGranted, let verificationURI = PendingDeviceLogin.shared.offerOnce(forProjectURL: appUrl) {
-      UserDefaults.standard.set(true, forKey: "ExpoGoOnboardingFinished")
-
-      Task { @MainActor in
-        guard let homeViewModel = self.homeViewModel else {
-          // Home is not up yet, so leave the pending sign in for the next attempt.
-          print("[DeviceLogin] Home is not ready, so the sign in sheet could not be presented yet.")
-          completion(false, nil)
-          return
-        }
-
-        // Declining still opens the project. The mismatch error then explains why it failed.
-        if await homeViewModel.presentDeviceLogin(verificationURI: verificationURI) {
-          if let host = verificationURI.host, let username = AuthenticationService.currentUsername {
-            AuthenticationService.recordDeviceLoginGrant(username: username, forVerificationHost: host)
-          }
-          PendingDeviceLogin.shared.clear()
-        }
-        self.openApp(url: url, snackParams: snackParams, completion: completion)
-      }
+    if presentDeviceLoginIfPending(
+      appUrl: appUrl,
+      url: url,
+      snackParams: snackParams,
+      completion: completion
+    ) {
       return
     }
 
@@ -186,6 +164,52 @@ import UIKit
       EXKernel.sharedInstance().createNewApp(with: appUrl, initialProps: nil)
       completion(true, nil)
     }
+  }
+
+  private func consumeExpiredSessionMessage() -> String? {
+    guard let message = expiredPartnerSessionMessage() else {
+      return nil
+    }
+    AuthenticationService.clearSession()
+    return message
+  }
+
+  /// True when a sign in has taken over the open, so the caller should stop and let it finish.
+  private func presentDeviceLoginIfPending(
+    appUrl: URL,
+    url: String,
+    snackParams: NSDictionary?,
+    completion: @escaping (Bool, String?) -> Void
+  ) -> Bool {
+    let alreadyGranted = PendingDeviceLogin.shared.current(forProjectURL: appUrl)?.host.map {
+      AuthenticationService.isDeviceLoginAlreadyGranted(forVerificationHost: $0)
+    } ?? false
+
+    guard !alreadyGranted,
+          let verificationURI = PendingDeviceLogin.shared.offerOnce(forProjectURL: appUrl) else {
+      return false
+    }
+
+    UserDefaults.standard.set(true, forKey: "ExpoGoOnboardingFinished")
+
+    Task { @MainActor in
+      guard let homeViewModel else {
+        // Home is not up yet, so leave the pending sign in for the next attempt.
+        print("[DeviceLogin] Home is not ready, so the sign in sheet could not be presented yet.")
+        completion(false, nil)
+        return
+      }
+
+      // Declining still opens the project. The mismatch error then explains why it failed.
+      if await homeViewModel.presentDeviceLogin(verificationURI: verificationURI) {
+        if let host = verificationURI.host, let username = AuthenticationService.currentUsername {
+          AuthenticationService.recordDeviceLoginGrant(username: username, forVerificationHost: host)
+        }
+        PendingDeviceLogin.shared.clear()
+      }
+      self.openApp(url: url, snackParams: snackParams, completion: completion)
+    }
+    return true
   }
 
   /// Convenience overload for non-snack apps (no session setup needed)

--- a/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
@@ -167,7 +167,7 @@ import UIKit
   }
 
   private func consumeExpiredSessionMessage() -> String? {
-    guard let message = expiredPartnerSessionMessage() else {
+    guard let message = sessionExpiredMessage() else {
       return nil
     }
     AuthenticationService.clearSession()
@@ -181,12 +181,12 @@ import UIKit
     snackParams: NSDictionary?,
     completion: @escaping (Bool, String?) -> Void
   ) -> Bool {
-    let alreadyGranted = PendingDeviceLogin.shared.current(forProjectURL: appUrl)?.host.map {
+    let verificationURI = PendingDeviceLogin.shared.verificationURI(forProjectURL: appUrl)
+    let alreadyGranted = verificationURI?.host.map {
       AuthenticationService.isDeviceLoginAlreadyGranted(forVerificationHost: $0)
     } ?? false
 
-    guard !alreadyGranted,
-          let verificationURI = PendingDeviceLogin.shared.offerOnce(forProjectURL: appUrl) else {
+    guard !alreadyGranted, PendingDeviceLogin.shared.offerOnce(forProjectURL: appUrl) else {
       return false
     }
 
@@ -202,7 +202,7 @@ import UIKit
 
       // Declining still opens the project. The mismatch error then explains why it failed.
       if await homeViewModel.presentDeviceLogin(verificationURI: verificationURI) {
-        if let host = verificationURI.host, let username = AuthenticationService.currentUsername {
+        if let host = verificationURI?.host, let username = AuthenticationService.currentUsername {
           AuthenticationService.recordDeviceLoginGrant(username: username, forVerificationHost: host)
         }
         PendingDeviceLogin.shared.clear()
@@ -260,9 +260,9 @@ import UIKit
   static let expiredSessionMessage =
     "Your Expo Go session has expired. Reload your project's preview and scan the new QR code to continue."
 
-  /// Non-nil when a stored partner session has expired. Partner-provisioned users have no password to fall back on.
-  @objc public func expiredPartnerSessionMessage() -> String? {
-    return AuthenticationService.isPartnerSessionExpired() ? Self.expiredSessionMessage : nil
+  /// Non-nil when the stored session has expired, which only device auth sessions record.
+  @objc public func sessionExpiredMessage() -> String? {
+    return AuthenticationService.isSessionExpired() ? Self.expiredSessionMessage : nil
   }
 
   @objc public func showError(_ message: String) {
@@ -273,10 +273,13 @@ import UIKit
 
   /// Only signs in. The error screen's Try Again is what reloads the project.
   @objc(offerDeviceLoginWithVerificationURI:)
-  public func offerDeviceLogin(verificationURI: URL) {
+  public func offerDeviceLogin(verificationURI: URL?) {
     Task { @MainActor in
       let signedIn = await self.homeViewModel?.presentDeviceLogin(verificationURI: verificationURI) ?? false
       if signedIn {
+        if let host = verificationURI?.host, let username = AuthenticationService.currentUsername {
+          AuthenticationService.recordDeviceLoginGrant(username: username, forVerificationHost: host)
+        }
         PendingDeviceLogin.shared.clear()
       }
     }

--- a/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
@@ -35,14 +35,17 @@ import UIKit
       return
     }
 
-    if let expiredMessage = sessionExpiredMessage() {
+    let expiredMessage = expiredPartnerSessionMessage()
+    if expiredMessage != nil {
       AuthenticationService.clearSession()
-      showError(expiredMessage)
-      completion(false, nil)
-      return
     }
 
-    if let verificationURI = PendingDeviceLogin.shared.current(forProjectURL: appUrl), !isAuthenticated() {
+    let pendingVerificationURI = PendingDeviceLogin.shared.current(forProjectURL: appUrl)
+    let alreadyGranted = pendingVerificationURI?.host.map {
+      AuthenticationService.isDeviceLoginAlreadyGranted(forVerificationHost: $0)
+    } ?? false
+
+    if !alreadyGranted, let verificationURI = PendingDeviceLogin.shared.offerOnce(forProjectURL: appUrl) {
       UserDefaults.standard.set(true, forKey: "ExpoGoOnboardingFinished")
 
       Task { @MainActor in
@@ -53,14 +56,21 @@ import UIKit
           return
         }
 
-        let signedIn = await homeViewModel.presentDeviceLogin(verificationURI: verificationURI)
-        guard signedIn else {
-          completion(false, nil)
-          return
+        // Declining still opens the project. The mismatch error then explains why it failed.
+        if await homeViewModel.presentDeviceLogin(verificationURI: verificationURI) {
+          if let host = verificationURI.host, let username = AuthenticationService.currentUsername {
+            AuthenticationService.recordDeviceLoginGrant(username: username, forVerificationHost: host)
+          }
+          PendingDeviceLogin.shared.clear()
         }
-        PendingDeviceLogin.shared.clear()
         self.openApp(url: url, snackParams: snackParams, completion: completion)
       }
+      return
+    }
+
+    if let expiredMessage {
+      showError(expiredMessage)
+      completion(false, nil)
       return
     }
 
@@ -103,9 +113,7 @@ import UIKit
       // Not an embedded snack — require login at minimum
       guard let currentUser = authenticatedUsername() else {
         EXKernel.sharedInstance().browserController.hideAppLoadingOverlay()
-        DispatchQueue.main.async { [weak self] in
-          self?.homeViewModel?.showError("Sign in to Expo Go to open your Snack playgrounds.")
-        }
+        showError("Sign in to Expo Go to open your Snack playgrounds.")
         completion(false, nil)
         return
       }
@@ -115,11 +123,7 @@ import UIKit
          let owner = ownerUsername(fromSnackId: snackId),
          owner != currentUser {
         EXKernel.sharedInstance().browserController.hideAppLoadingOverlay()
-        DispatchQueue.main.async { [weak self] in
-          self?.homeViewModel?.showError(
-            "This playground belongs to @\(owner). Sign in as @\(owner) to open it, or open one of your own."
-          )
-        }
+        showError("This playground belongs to @\(owner). Sign in as @\(owner) to open it, or open one of your own.")
         completion(false, nil)
         return
       }
@@ -232,9 +236,9 @@ import UIKit
   static let expiredSessionMessage =
     "Your Expo Go session has expired. Reload your project's preview and scan the new QR code to continue."
 
-  /// Non-nil when the stored session has expired, which only device auth sessions record.
-  @objc public func sessionExpiredMessage() -> String? {
-    return AuthenticationService.isSessionExpired() ? Self.expiredSessionMessage : nil
+  /// Non-nil when a stored partner session has expired. Partner-provisioned users have no password to fall back on.
+  @objc public func expiredPartnerSessionMessage() -> String? {
+    return AuthenticationService.isPartnerSessionExpired() ? Self.expiredSessionMessage : nil
   }
 
   @objc public func showError(_ message: String) {
@@ -243,19 +247,23 @@ import UIKit
     }
   }
 
-  @objc public func isAuthenticated() -> Bool {
-    guard !AuthenticationService.isSessionExpired() else {
-      return false
+  /// Only signs in. The error screen's Try Again is what reloads the project.
+  @objc(offerDeviceLoginWithVerificationURI:)
+  public func offerDeviceLogin(verificationURI: URL) {
+    Task { @MainActor in
+      let signedIn = await self.homeViewModel?.presentDeviceLogin(verificationURI: verificationURI) ?? false
+      if signedIn {
+        PendingDeviceLogin.shared.clear()
+      }
     }
-    return UserDefaults.standard.string(forKey: AuthenticationService.sessionKey) != nil
+  }
+
+  @objc public func isAuthenticated() -> Bool {
+    AuthenticationService.currentUsername != nil
   }
 
   @objc public func authenticatedUsername() -> String? {
-    guard !AuthenticationService.isSessionExpired(),
-          UserDefaults.standard.string(forKey: AuthenticationService.sessionKey) != nil else {
-      return nil
-    }
-    return UserDefaults.standard.string(forKey: AuthenticationService.usernameKey)
+    AuthenticationService.currentUsername
   }
 
   @objc public func addHistoryItem(withUrl url: String, name: String, iconUrl: String?) {

--- a/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/ExpoGoHomeBridge.swift
@@ -42,6 +42,28 @@ import UIKit
       return
     }
 
+    if let verificationURI = PendingDeviceLogin.shared.current(forProjectURL: appUrl), !isAuthenticated() {
+      UserDefaults.standard.set(true, forKey: "ExpoGoOnboardingFinished")
+
+      Task { @MainActor in
+        guard let homeViewModel = self.homeViewModel else {
+          // Home is not up yet, so leave the pending sign in for the next attempt.
+          print("[DeviceLogin] Home is not ready, so the sign in sheet could not be presented yet.")
+          completion(false, nil)
+          return
+        }
+
+        let signedIn = await homeViewModel.presentDeviceLogin(verificationURI: verificationURI)
+        guard signedIn else {
+          completion(false, nil)
+          return
+        }
+        PendingDeviceLogin.shared.clear()
+        self.openApp(url: url, snackParams: snackParams, completion: completion)
+      }
+      return
+    }
+
     // Determine status text based on what we're opening
     let isLesson = (snackParams?["isLesson"] as? Bool) == true
     let isPlayground = (snackParams?["isPlayground"] as? Bool) == true

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -23,7 +23,7 @@ struct MeActorResponse: Codable {
 }
 
 struct MeActorData: Codable {
-  /// Null for a `Robot`, which has no username, and for an unauthenticated request.
+  /// Null for an unauthenticated request.
   let meActor: UserActor?
 }
 

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/RESTClient.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/RESTClient.swift
@@ -80,3 +80,17 @@ actor RESTClient {
     return .apiError(firstError.message)
   }
 }
+
+extension RESTClient {
+  private static let clientAuthoredMessages: Set<String> = [
+    "Invalid URL",
+    "Failed to encode request",
+    "Invalid response from server",
+    "Failed to decode response"
+  ]
+
+  /// True for a message this client wrote itself rather than one relayed from the server.
+  static func isClientAuthoredMessage(_ message: String) -> Bool {
+    clientAuthoredMessages.contains(message) || message.hasPrefix("Server error (")
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -88,6 +88,12 @@ struct HomeRootView: View {
         AccountSheet()
           .environmentObject(viewModel)
       }
+      .sheet(item: $viewModel.deviceLoginRequest) { request in
+        DeviceLoginSheet(verificationURI: request.verificationURI) { signedIn in
+          request.completion(signedIn)
+          viewModel.deviceLoginRequest = nil
+        }
+      }
       .alert(item: $viewModel.errorToShow) { error in
         Alert(
           title: Text("Error"),

--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -89,9 +89,13 @@ struct HomeRootView: View {
           .environmentObject(viewModel)
       }
       .sheet(item: $viewModel.deviceLoginRequest) { request in
-        DeviceLoginSheet(verificationURI: request.verificationURI) { signedIn in
-          request.completion(signedIn)
+        DeviceLoginSheet(authService: viewModel.authService, verificationURI: request.verificationURI) { signedIn in
+          request.completion.resolve(signedIn)
           viewModel.deviceLoginRequest = nil
+        }
+        // Catches swipe-to-dismiss, which never calls the content closure above.
+        .onDisappear {
+          request.completion.resolve(false)
         }
       }
       .alert(item: $viewModel.errorToShow) { error in

--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -37,10 +37,6 @@ class HomeViewModel: ObservableObject {
   var selectedAccount: Account? { authService.selectedAccount }
   var isLoggedIn: Bool { authService.isLoggedIn }
 
-  var displayUsername: String? {
-    user?.username ?? UserDefaults.standard.string(forKey: AuthenticationService.usernameKey)
-  }
-
   var shakeToShowDevMenu: Bool { settingsManager.shakeToShowDevMenu }
   var threeFingerLongPressEnabled: Bool { settingsManager.threeFingerLongPressEnabled }
   var selectedTheme: Int { settingsManager.selectedTheme }
@@ -226,9 +222,13 @@ class HomeViewModel: ObservableObject {
   /// Presents the device login sheet and resolves once the user signs in or backs out.
   func presentDeviceLogin(verificationURI: URL?) async -> Bool {
     await withCheckedContinuation { continuation in
-      deviceLoginRequest = DeviceLoginRequest(verificationURI: verificationURI) { signedIn in
-        continuation.resume(returning: signedIn)
-      }
+      deviceLoginRequest?.completion.resolve(false)
+      deviceLoginRequest = DeviceLoginRequest(
+        verificationURI: verificationURI,
+        completion: DeviceLoginCompletion { signedIn in
+          continuation.resume(returning: signedIn)
+        }
+      )
     }
   }
 
@@ -343,5 +343,21 @@ enum ExpoGoError: Error {
 struct DeviceLoginRequest: Identifiable {
   let id = UUID()
   let verificationURI: URL?
-  let completion: (Bool) -> Void
+  let completion: DeviceLoginCompletion
+}
+
+/// Wraps a device login result so success, cancel, and dismiss paths can each call it without a double resume.
+@MainActor
+final class DeviceLoginCompletion {
+  private var handler: ((Bool) -> Void)?
+
+  init(_ handler: @escaping (Bool) -> Void) {
+    self.handler = handler
+  }
+
+  func resolve(_ signedIn: Bool) {
+    guard let handler else { return }
+    self.handler = nil
+    handler(signedIn)
+  }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -15,6 +15,7 @@ class HomeViewModel: ObservableObject {
   @Published var showingFeedbackForm = false
   @Published var errorToShow: ErrorInfo?
   @Published var isNetworkAvailable = true
+  @Published var deviceLoginRequest: DeviceLoginRequest?
 
   @Published var user: UserActor?
   @Published var selectedAccountId: String?
@@ -222,6 +223,15 @@ class HomeViewModel: ObservableObject {
     errorToShow = ErrorInfo(message: message, apiError: apiError)
   }
 
+  /// Presents the device login sheet and resolves once the user signs in or backs out.
+  func presentDeviceLogin(verificationURI: URL?) async -> Bool {
+    await withCheckedContinuation { continuation in
+      deviceLoginRequest = DeviceLoginRequest(verificationURI: verificationURI) { signedIn in
+        continuation.resume(returning: signedIn)
+      }
+    }
+  }
+
   private func setupSubscriptions() {
     authService.$user
       .sink { [weak self] in self?.user = $0 }
@@ -328,4 +338,10 @@ enum ExpoGoError: Error {
   case noSessionSecret
   case notImplemented(String)
   case missingURLScheme
+}
+
+struct DeviceLoginRequest: Identifiable {
+  let id = UUID()
+  let verificationURI: URL?
+  let completion: (Bool) -> Void
 }

--- a/apps/expo-go/ios/Client/SwiftUI/Rows/BranchRow.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Rows/BranchRow.swift
@@ -59,31 +59,12 @@ struct BranchRowContent: View {
   }
 
   private func formattedDate(_ value: String) -> String {
-    let formatters = [
-      isoFormatter(withFractionalSeconds: true),
-      isoFormatter(withFractionalSeconds: false)
-    ]
-    for formatter in formatters {
-      if let date = formatter.date(from: value) {
-        let display = DateFormatter()
-        display.locale = Locale(identifier: "en_US_POSIX")
-        display.dateFormat = "MMM d, yyyy h:mm a"
-        return display.string(from: date)
-      }
+    guard let date = parseISO8601Date(value) else {
+      return value
     }
-    return value
-  }
-
-  private func isoFormatter(withFractionalSeconds: Bool) -> ISO8601DateFormatter {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [
-      .withInternetDateTime,
-      .withDashSeparatorInDate,
-      .withColonSeparatorInTime
-    ]
-    if withFractionalSeconds {
-      formatter.formatOptions.insert(.withFractionalSeconds)
-    }
-    return formatter
+    let display = DateFormatter()
+    display.locale = Locale(identifier: "en_US_POSIX")
+    display.dateFormat = "MMM d, yyyy h:mm a"
+    return display.string(from: date)
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/Rows/UpdateRow.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Rows/UpdateRow.swift
@@ -58,19 +58,13 @@ struct UpdateRow: View {
   }
 
   private func formattedDate(_ value: String) -> String {
-    let formatters = [
-      isoFormatter(withFractionalSeconds: true),
-      isoFormatter(withFractionalSeconds: false)
-    ]
-    for formatter in formatters {
-      if let date = formatter.date(from: value) {
-        let display = DateFormatter()
-        display.locale = Locale(identifier: "en_US_POSIX")
-        display.dateFormat = "MMM d, yyyy h:mm a"
-        return display.string(from: date)
-      }
+    guard let date = parseISO8601Date(value) else {
+      return value
     }
-    return value
+    let display = DateFormatter()
+    display.locale = Locale(identifier: "en_US_POSIX")
+    display.dateFormat = "MMM d, yyyy h:mm a"
+    return display.string(from: date)
   }
 
   private func updateTitle(_ update: AppUpdate) -> String {
@@ -78,18 +72,5 @@ struct UpdateRow: View {
       return "\"\(message)\""
     }
     return update.id
-  }
-
-  private func isoFormatter(withFractionalSeconds: Bool) -> ISO8601DateFormatter {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [
-      .withInternetDateTime,
-      .withDashSeparatorInDate,
-      .withColonSeparatorInTime
-    ]
-    if withFractionalSeconds {
-      formatter.formatOptions.insert(.withFractionalSeconds)
-    }
-    return formatter
   }
 }

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -47,7 +47,7 @@ class AuthenticationService: ObservableObject {
   }
 
   func checkAuthenticationStatus() {
-    if Self.isPartnerSessionExpired() {
+    if Self.isSessionExpired() {
       // The bridge reads this expiry to explain the failure, then clears it.
       Self.deleteNativeSession()
       user = nil
@@ -188,8 +188,8 @@ class AuthenticationService: ObservableObject {
     }
   }
 
-  /// The stored expiry is the only local signal that a partner session died, avoiding a round trip on every project open.
-  nonisolated static func isPartnerSessionExpired() -> Bool {
+  /// The stored expiry is the only local signal that the session died, avoiding a round trip on every project open.
+  nonisolated static func isSessionExpired() -> Bool {
     guard let expiresAt = UserDefaults.standard.object(forKey: sessionExpiresAtKey) as? Double else {
       return false
     }
@@ -199,13 +199,13 @@ class AuthenticationService: ObservableObject {
   /// The signed-in username, or nil if there is no live, unexpired session.
   nonisolated static var currentUsername: String? {
     guard UserDefaults.standard.string(forKey: sessionKey) != nil,
-          !isPartnerSessionExpired() else {
+          !isSessionExpired() else {
       return nil
     }
     return UserDefaults.standard.string(forKey: usernameKey)
   }
 
-  /// Remembers which account a device login granted for a partner host, so rescanning a project behind that
+  /// Remembers which account a device login granted for a verification host, so rescanning a project behind that
   /// host does not ask again when the user is already signed in as that account.
   nonisolated static func recordDeviceLoginGrant(username: String, forVerificationHost host: String) {
     var grants = UserDefaults.standard.dictionary(forKey: deviceLoginGrantsKey) as? [String: String] ?? [:]

--- a/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/AuthenticationService.swift
@@ -20,6 +20,7 @@ class AuthenticationService: ObservableObject {
   nonisolated static let usernameKey = "expo-username"
   nonisolated static let selectedAccountKey = "expo-selected-account-id"
   nonisolated static let sessionExpiresAtKey = "expo-session-expires-at"
+  nonisolated static let deviceLoginGrantsKey = "expo-device-login-grants"
   private let presentationContext = AuthPresentationContextProvider()
   private var cancellables = Set<AnyCancellable>()
 
@@ -46,7 +47,7 @@ class AuthenticationService: ObservableObject {
   }
 
   func checkAuthenticationStatus() {
-    if Self.isSessionExpired() {
+    if Self.isPartnerSessionExpired() {
       // The bridge reads this expiry to explain the failure, then clears it.
       Self.deleteNativeSession()
       user = nil
@@ -87,25 +88,29 @@ class AuthenticationService: ObservableObject {
 
   func loadUserInfo() async {
     guard isAuthenticated else { return }
-    await fetchUserInfo()
-  }
-
-  private func fetchUserInfo() async {
     do {
-      let response: MeActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
-      guard let actor = response.data.meActor else {
-        print("[AuthenticationService] meActor was null. Signed in as an actor type Expo Go does not model.")
-        return
-      }
-      user = actor
-      UserDefaults.standard.set(actor.username, forKey: Self.usernameKey)
-
-      if selectedAccountId == nil, let firstAccount = actor.accounts.first {
-        selectAccount(accountId: firstAccount.id)
+      if try await fetchUserInfo() == false {
+        signOut()
       }
     } catch {
       print("[AuthenticationService] Failed to load user info: \(error)")
     }
+  }
+
+  /// Returns false only when the actor is definitively null, not when the request merely failed.
+  private func fetchUserInfo() async throws -> Bool {
+    let response: MeActorResponse = try await APIClient.shared.request(Queries.getCurrentUser())
+    guard let actor = response.data.meActor else {
+      print("[AuthenticationService] meActor was null. Signed in as an actor type Expo Go does not model.")
+      return false
+    }
+    user = actor
+    UserDefaults.standard.set(actor.username, forKey: Self.usernameKey)
+
+    if selectedAccountId == nil, let firstAccount = actor.accounts.first {
+      selectAccount(accountId: firstAccount.id)
+    }
+    return true
   }
 
   func signUp() async throws {
@@ -135,15 +140,27 @@ class AuthenticationService: ObservableObject {
     }
   }
 
-  func completeLogin(with sessionSecret: String) async {
+  func completeLogin(with sessionSecret: String, expiresAt: Date? = nil) async {
     UserDefaults.standard.set(sessionSecret, forKey: Self.sessionKey)
-    UserDefaults.standard.removeObject(forKey: Self.sessionExpiresAtKey)
+    if let expiresAt {
+      UserDefaults.standard.set(expiresAt.timeIntervalSince1970, forKey: Self.sessionExpiresAtKey)
+    } else {
+      UserDefaults.standard.removeObject(forKey: Self.sessionExpiresAtKey)
+    }
     Self.saveNativeSession(sessionSecret)
     await APIClient.shared.setSession(sessionSecret)
-    // Fetch user info before setting isAuthenticated so account data is ready
-    // when the UI switches to the account selector
-    await fetchUserInfo()
-    isAuthenticated = true
+    do {
+      // Fetch user info before setting isAuthenticated so account data is ready
+      // when the UI switches to the account selector
+      guard try await fetchUserInfo() else {
+        signOut()
+        return
+      }
+      isAuthenticated = true
+    } catch {
+      print("[AuthenticationService] Failed to load user info: \(error)")
+      isAuthenticated = true
+    }
   }
 
   func signOut() {
@@ -171,30 +188,37 @@ class AuthenticationService: ObservableObject {
     }
   }
 
-  nonisolated static func storeDeviceAuthSession(
-    sessionSecret: String,
-    username: String,
-    expiresAt: Date?
-  ) async {
-    let defaults = UserDefaults.standard
-    defaults.set(sessionSecret, forKey: sessionKey)
-    defaults.set(username, forKey: usernameKey)
-    if let expiresAt {
-      defaults.set(expiresAt.timeIntervalSince1970, forKey: sessionExpiresAtKey)
-    } else {
-      defaults.removeObject(forKey: sessionExpiresAtKey)
-    }
-    saveNativeSession(sessionSecret)
-    await APIClient.shared.setSession(sessionSecret)
-    NotificationCenter.default.post(name: .expoSessionDidChange, object: nil)
-  }
-
-  /// The stored expiry is the only local signal that the session died, avoiding a round trip on every project open.
-  nonisolated static func isSessionExpired() -> Bool {
+  /// The stored expiry is the only local signal that a partner session died, avoiding a round trip on every project open.
+  nonisolated static func isPartnerSessionExpired() -> Bool {
     guard let expiresAt = UserDefaults.standard.object(forKey: sessionExpiresAtKey) as? Double else {
       return false
     }
     return Date().timeIntervalSince1970 >= expiresAt
+  }
+
+  /// The signed-in username, or nil if there is no live, unexpired session.
+  nonisolated static var currentUsername: String? {
+    guard UserDefaults.standard.string(forKey: sessionKey) != nil,
+          !isPartnerSessionExpired() else {
+      return nil
+    }
+    return UserDefaults.standard.string(forKey: usernameKey)
+  }
+
+  /// Remembers which account a device login granted for a partner host, so rescanning a project behind that
+  /// host does not ask again when the user is already signed in as that account.
+  nonisolated static func recordDeviceLoginGrant(username: String, forVerificationHost host: String) {
+    var grants = UserDefaults.standard.dictionary(forKey: deviceLoginGrantsKey) as? [String: String] ?? [:]
+    grants[host] = username
+    UserDefaults.standard.set(grants, forKey: deviceLoginGrantsKey)
+  }
+
+  nonisolated static func isDeviceLoginAlreadyGranted(forVerificationHost host: String) -> Bool {
+    guard let username = currentUsername else {
+      return false
+    }
+    let grants = UserDefaults.standard.dictionary(forKey: deviceLoginGrantsKey) as? [String: String] ?? [:]
+    return grants[host] == username
   }
 
   nonisolated static func clearSession() {

--- a/apps/expo-go/ios/Client/SwiftUI/Utils/DateUtils.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Utils/DateUtils.swift
@@ -1,0 +1,23 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+private let iso8601Lock = NSLock()
+private let iso8601WithFractionalSeconds: ISO8601DateFormatter = {
+  let formatter = ISO8601DateFormatter()
+  formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+  return formatter
+}()
+private let iso8601WithoutFractionalSeconds: ISO8601DateFormatter = {
+  let formatter = ISO8601DateFormatter()
+  formatter.formatOptions = [.withInternetDateTime]
+  return formatter
+}()
+
+/// Tries fractional seconds first, then falls back without them, since callers may see either.
+/// `ISO8601DateFormatter` is not safe for concurrent use, so parsing is serialized behind a lock.
+func parseISO8601Date(_ value: String) -> Date? {
+  iso8601Lock.lock()
+  defer { iso8601Lock.unlock() }
+  return iso8601WithFractionalSeconds.date(from: value) ?? iso8601WithoutFractionalSeconds.date(from: value)
+}

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -253,13 +253,23 @@ static BOOL isEASUpdateHost(NSString * _Nullable host)
   }
   if (isDevServer && (expoGoUsername == nil || ![manifestUsername isEqualToString:expoGoUsername])) {
     // _manifestUrl is what createNewApp was given, so it matches the key the linking manager set.
-    NSURL *verificationURI = [[EXPendingDeviceLogin shared] currentForProjectURL:_manifestUrl];
+    BOOL hasPendingDeviceAuth = [[EXPendingDeviceLogin shared] hasPendingForProjectURL:_manifestUrl];
+    NSURL *verificationURI = [[EXPendingDeviceLogin shared] verificationURIForProjectURL:_manifestUrl];
     NSString *message;
-    if (verificationURI != nil) {
+    if (hasPendingDeviceAuth) {
       // The QR asked for a sign in, so the account can be switched here rather than on a computer.
-      message = [NSString stringWithFormat:
-        @"This project belongs to \"%@\", and you're signed in to Expo Go as \"%@\". Sign in as \"%@\" to open it. Expo Go will show you a code to enter at %@, then tap Try Again.",
-        manifestUsername, expoGoUsername ?: @"someone else", manifestUsername, verificationURI.host];
+      NSString *codeSentence = verificationURI.host
+        ? [NSString stringWithFormat:@"Expo Go will show you a code to enter at %@, then tap Try Again.", verificationURI.host]
+        : @"Expo Go will show you a code and where to enter it, then tap Try Again.";
+      if (expoGoUsername != nil && [expoGoUsername length] > 0) {
+        message = [NSString stringWithFormat:
+          @"This project belongs to \"%@\", and you're signed in to Expo Go as \"%@\". Sign in as \"%@\" to open it. %@",
+          manifestUsername, expoGoUsername, manifestUsername, codeSentence];
+      } else {
+        message = [NSString stringWithFormat:
+          @"This project belongs to \"%@\", and you're not signed in to Expo Go. Sign in as \"%@\" to open it. %@",
+          manifestUsername, manifestUsername, codeSentence];
+      }
       [[ExpoGoHomeBridge shared] offerDeviceLoginWithVerificationURI:verificationURI];
     } else if (expoGoUsername == nil || [expoGoUsername length] == 0) {
       message = [NSString stringWithFormat:

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -252,8 +252,16 @@ static BOOL isEASUpdateHost(NSString * _Nullable host)
     return;
   }
   if (isDevServer && (expoGoUsername == nil || ![manifestUsername isEqualToString:expoGoUsername])) {
+    // _manifestUrl is what createNewApp was given, so it matches the key the linking manager set.
+    NSURL *verificationURI = [[EXPendingDeviceLogin shared] currentForProjectURL:_manifestUrl];
     NSString *message;
-    if (expoGoUsername == nil || [expoGoUsername length] == 0) {
+    if (verificationURI != nil) {
+      // The QR asked for a sign in, so the account can be switched here rather than on a computer.
+      message = [NSString stringWithFormat:
+        @"This project belongs to \"%@\", and you're signed in to Expo Go as \"%@\". Sign in as \"%@\" to open it. Expo Go will show you a code to enter at %@, then tap Try Again.",
+        manifestUsername, expoGoUsername ?: @"someone else", manifestUsername, verificationURI.host];
+      [[ExpoGoHomeBridge shared] offerDeviceLoginWithVerificationURI:verificationURI];
+    } else if (expoGoUsername == nil || [expoGoUsername length] == 0) {
       message = [NSString stringWithFormat:
         @"You're signed in to Expo CLI as \"%@\", but not signed in to Expo Go. Sign in to Expo Go as \"%@\" to open this project.",
         manifestUsername, manifestUsername];

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -37,6 +37,14 @@ EX_REGISTER_SINGLETON_MODULE(KernelLinkingManager);
   EXKernelAppRecord *destinationApp = nil;
   NSURL *urlToRoute = [[self class] uriTransformedForLinking:url isUniversalLink:isUniversalLink];
 
+  // Strip on any change, so an override that failed validation is cleared too.
+  NSURL *verificationURI = [EXDeviceLoginLink verificationURIFromURL:urlToRoute];
+  NSURL *strippedUrl = [EXDeviceLoginLink urlByRemovingOverrideFromURL:urlToRoute];
+  if (![strippedUrl isEqual:urlToRoute]) {
+    [[EXPendingDeviceLogin shared] setURI:verificationURI forProjectURL:strippedUrl];
+    urlToRoute = strippedUrl;
+  }
+
   for (NSString *recordId in [appRegistry appEnumerator]) {
     EXKernelAppRecord *appRecord = [appRegistry recordForId:recordId];
     if (!appRecord || appRecord.status != kEXKernelAppRecordStatusRunning) {

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -37,11 +37,12 @@ EX_REGISTER_SINGLETON_MODULE(KernelLinkingManager);
   EXKernelAppRecord *destinationApp = nil;
   NSURL *urlToRoute = [[self class] uriTransformedForLinking:url isUniversalLink:isUniversalLink];
 
-  // Strip on any change, so an override that failed validation is cleared too.
+  // Strip on any change, so stray or invalid device auth params are cleared too.
+  BOOL promptRequested = [EXDeviceLoginLink promptRequestedInURL:urlToRoute];
   NSURL *verificationURI = [EXDeviceLoginLink verificationURIFromURL:urlToRoute];
-  NSURL *strippedUrl = [EXDeviceLoginLink urlByRemovingOverrideFromURL:urlToRoute];
+  NSURL *strippedUrl = [EXDeviceLoginLink urlByRemovingDeviceAuthParamsFromURL:urlToRoute];
   if (![strippedUrl isEqual:urlToRoute]) {
-    [[EXPendingDeviceLogin shared] setURI:verificationURI forProjectURL:strippedUrl];
+    [[EXPendingDeviceLogin shared] setPending:promptRequested verificationURI:verificationURI forProjectURL:strippedUrl];
     urlToRoute = strippedUrl;
   }
 

--- a/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
@@ -130,9 +130,28 @@ final class DeviceLoginLinkTests: XCTestCase {
 
   func testPendingHolderStoresAndClears() throws {
     let uri = try url("https://verify.example/p/123")
-    PendingDeviceLogin.shared.set(uri)
-    XCTAssertEqual(PendingDeviceLogin.shared.current, uri)
+    let project = try url("exp://10.0.0.5:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: project), uri)
     PendingDeviceLogin.shared.clear()
-    XCTAssertNil(PendingDeviceLogin.shared.current)
+    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: project))
+  }
+
+  func testPendingHolderDoesNotLeakToAnotherProject() throws {
+    let uri = try url("https://verify.example/p/123")
+    let scanned = try url("exp://10.0.0.5:8081/")
+    let unrelated = try url("exp://10.0.0.9:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: scanned)
+    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: unrelated))
+    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: scanned), uri)
+    PendingDeviceLogin.shared.clear()
+  }
+
+  func testPendingHolderSettingNilClearsTheRecord() throws {
+    let uri = try url("https://verify.example/p/123")
+    let project = try url("exp://10.0.0.5:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    PendingDeviceLogin.shared.set(nil, forProjectURL: project)
+    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: project))
   }
 }

--- a/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
@@ -131,64 +131,63 @@ final class DeviceLoginLinkTests: XCTestCase {
   func testPendingHolderStoresAndClears() throws {
     let uri = try url("https://verify.example/p/123")
     let project = try url("exp://10.0.0.5:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
-    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: project), uri)
+    PendingDeviceLogin.shared.setPending(true, verificationURI: uri, forProjectURL: project)
+    XCTAssertTrue(PendingDeviceLogin.shared.hasPending(forProjectURL: project))
+    XCTAssertEqual(PendingDeviceLogin.shared.verificationURI(forProjectURL: project), uri)
     PendingDeviceLogin.shared.clear()
-    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: project))
+    XCTAssertFalse(PendingDeviceLogin.shared.hasPending(forProjectURL: project))
+    XCTAssertNil(PendingDeviceLogin.shared.verificationURI(forProjectURL: project))
+  }
+
+  func testPendingHolderAcceptsANilOverride() throws {
+    let project = try url("exp://10.0.0.5:8081/")
+    PendingDeviceLogin.shared.setPending(true, verificationURI: nil, forProjectURL: project)
+    XCTAssertTrue(PendingDeviceLogin.shared.hasPending(forProjectURL: project))
+    XCTAssertNil(PendingDeviceLogin.shared.verificationURI(forProjectURL: project))
+    XCTAssertTrue(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
+    PendingDeviceLogin.shared.clear()
   }
 
   func testPendingHolderDoesNotLeakToAnotherProject() throws {
     let uri = try url("https://verify.example/p/123")
     let scanned = try url("exp://10.0.0.5:8081/")
     let unrelated = try url("exp://10.0.0.9:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: scanned)
-    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: unrelated))
-    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: scanned), uri)
+    PendingDeviceLogin.shared.setPending(true, verificationURI: uri, forProjectURL: scanned)
+    XCTAssertFalse(PendingDeviceLogin.shared.hasPending(forProjectURL: unrelated))
+    XCTAssertFalse(PendingDeviceLogin.shared.offerOnce(forProjectURL: unrelated))
+    XCTAssertTrue(PendingDeviceLogin.shared.offerOnce(forProjectURL: scanned))
     PendingDeviceLogin.shared.clear()
   }
 
   func testPendingHolderOffersOnlyOnce() throws {
-    let uri = try url("https://partner.dev/p/123")
     let project = try url("exp://10.0.0.5:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    PendingDeviceLogin.shared.setPending(true, verificationURI: nil, forProjectURL: project)
 
-    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: project), uri)
-    XCTAssertNil(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
-    // Still readable after being offered, which is what the mismatch error uses.
-    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: project), uri)
+    XCTAssertTrue(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
+    XCTAssertFalse(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
+    // Still pending after being offered, which is what the mismatch error reads.
+    XCTAssertTrue(PendingDeviceLogin.shared.hasPending(forProjectURL: project))
 
     PendingDeviceLogin.shared.clear()
   }
 
   func testPendingHolderOffersAgainAfterANewScan() throws {
-    let uri = try url("https://partner.dev/p/123")
     let project = try url("exp://10.0.0.5:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    PendingDeviceLogin.shared.setPending(true, verificationURI: nil, forProjectURL: project)
     _ = PendingDeviceLogin.shared.offerOnce(forProjectURL: project)
 
-    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
-    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: project), uri)
+    PendingDeviceLogin.shared.setPending(true, verificationURI: nil, forProjectURL: project)
+    XCTAssertTrue(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
 
     PendingDeviceLogin.shared.clear()
   }
 
-  func testPendingHolderDoesNotOfferForAnotherProject() throws {
-    let uri = try url("https://partner.dev/p/123")
-    let scanned = try url("exp://10.0.0.5:8081/")
-    let unrelated = try url("exp://10.0.0.9:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: scanned)
-
-    XCTAssertNil(PendingDeviceLogin.shared.offerOnce(forProjectURL: unrelated))
-    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: scanned), uri)
-
-    PendingDeviceLogin.shared.clear()
-  }
-
-  func testPendingHolderSettingNilClearsTheRecord() throws {
+  func testPendingHolderClearsWhenNotPending() throws {
     let uri = try url("https://verify.example/p/123")
     let project = try url("exp://10.0.0.5:8081/")
-    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
-    PendingDeviceLogin.shared.set(nil, forProjectURL: project)
-    XCTAssertNil(PendingDeviceLogin.shared.current(forProjectURL: project))
+    PendingDeviceLogin.shared.setPending(true, verificationURI: uri, forProjectURL: project)
+    PendingDeviceLogin.shared.setPending(false, verificationURI: nil, forProjectURL: project)
+    XCTAssertFalse(PendingDeviceLogin.shared.hasPending(forProjectURL: project))
+    XCTAssertNil(PendingDeviceLogin.shared.verificationURI(forProjectURL: project))
   }
 }

--- a/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginLinkTests.swift
@@ -147,6 +147,43 @@ final class DeviceLoginLinkTests: XCTestCase {
     PendingDeviceLogin.shared.clear()
   }
 
+  func testPendingHolderOffersOnlyOnce() throws {
+    let uri = try url("https://partner.dev/p/123")
+    let project = try url("exp://10.0.0.5:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+
+    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: project), uri)
+    XCTAssertNil(PendingDeviceLogin.shared.offerOnce(forProjectURL: project))
+    // Still readable after being offered, which is what the mismatch error uses.
+    XCTAssertEqual(PendingDeviceLogin.shared.current(forProjectURL: project), uri)
+
+    PendingDeviceLogin.shared.clear()
+  }
+
+  func testPendingHolderOffersAgainAfterANewScan() throws {
+    let uri = try url("https://partner.dev/p/123")
+    let project = try url("exp://10.0.0.5:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    _ = PendingDeviceLogin.shared.offerOnce(forProjectURL: project)
+
+    PendingDeviceLogin.shared.set(uri, forProjectURL: project)
+    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: project), uri)
+
+    PendingDeviceLogin.shared.clear()
+  }
+
+  func testPendingHolderDoesNotOfferForAnotherProject() throws {
+    let uri = try url("https://partner.dev/p/123")
+    let scanned = try url("exp://10.0.0.5:8081/")
+    let unrelated = try url("exp://10.0.0.9:8081/")
+    PendingDeviceLogin.shared.set(uri, forProjectURL: scanned)
+
+    XCTAssertNil(PendingDeviceLogin.shared.offerOnce(forProjectURL: unrelated))
+    XCTAssertEqual(PendingDeviceLogin.shared.offerOnce(forProjectURL: scanned), uri)
+
+    PendingDeviceLogin.shared.clear()
+  }
+
   func testPendingHolderSettingNilClearsTheRecord() throws {
     let uri = try url("https://verify.example/p/123")
     let project = try url("exp://10.0.0.5:8081/")

--- a/apps/expo-go/ios/Tests/DeviceLoginStateMachineTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceLoginStateMachineTests.swift
@@ -14,6 +14,11 @@ final class DeviceLoginStateMachineTests: XCTestCase {
     XCTAssertEqual(machine().firstStep, .poll(after: 5, matchValue: nil))
   }
 
+  func testNonPositiveIntervalIsClampedToOneSecond() {
+    XCTAssertEqual(machine(interval: 0).firstStep, .poll(after: 1, matchValue: nil))
+    XCTAssertEqual(machine(interval: -5).firstStep, .poll(after: 1, matchValue: nil))
+  }
+
   func testPendingKeepsTheInterval() {
     var subject = machine()
     XCTAssertEqual(subject.advance(with: .pending, now: start), .poll(after: 5, matchValue: nil))
@@ -31,6 +36,16 @@ final class DeviceLoginStateMachineTests: XCTestCase {
     var subject = machine(expiresIn: 600)
     let past = start.addingTimeInterval(601)
     XCTAssertEqual(subject.advance(with: .pending, now: past), .failed(.expired))
+  }
+
+  func testSessionAfterTheDeadlineStillSignsIn() {
+    var subject = machine(expiresIn: 600)
+    let past = start.addingTimeInterval(601)
+    let expiry = start.addingTimeInterval(3600)
+    XCTAssertEqual(
+      subject.advance(with: .session(secret: "secret", expiresAt: expiry), now: past),
+      .signedIn(secret: "secret", expiresAt: expiry)
+    )
   }
 
   func testMatchRequiredMovesToMatching() {

--- a/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
@@ -17,27 +17,27 @@ final class DeviceSessionExpiryTests: XCTestCase {
   }
 
   func testNoStoredExpiryIsNotExpired() {
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
   }
 
   func testFutureExpiryIsNotExpired() {
     defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
   }
 
   func testPastExpiryIsExpired() {
     defaults.set(Date().addingTimeInterval(-1).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
-    XCTAssertTrue(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertTrue(AuthenticationService.isSessionExpired())
   }
 
   func testNilExpiryIsNeverExpired() {
     defaults.removeObject(forKey: AuthenticationService.sessionExpiresAtKey)
-    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
+    XCTAssertFalse(AuthenticationService.isSessionExpired())
   }
 
   func testClearSessionRemovesEveryKey() {
     defaults.set("secret", forKey: AuthenticationService.sessionKey)
-    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set("test-user", forKey: AuthenticationService.usernameKey)
     defaults.set("acc1", forKey: AuthenticationService.selectedAccountKey)
     defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
 

--- a/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
+++ b/apps/expo-go/ios/Tests/DeviceSessionExpiryTests.swift
@@ -17,46 +17,29 @@ final class DeviceSessionExpiryTests: XCTestCase {
   }
 
   func testNoStoredExpiryIsNotExpired() {
-    XCTAssertFalse(AuthenticationService.isSessionExpired())
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
   }
 
-  func testFutureExpiryIsNotExpired() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(60)
-    )
-    XCTAssertFalse(AuthenticationService.isSessionExpired())
-    XCTAssertEqual(defaults.string(forKey: AuthenticationService.sessionKey), "secret")
-    XCTAssertEqual(defaults.string(forKey: AuthenticationService.usernameKey), "test-user")
+  func testFutureExpiryIsNotExpired() {
+    defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
   }
 
-  func testPastExpiryIsExpired() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(-1)
-    )
-    XCTAssertTrue(AuthenticationService.isSessionExpired())
+  func testPastExpiryIsExpired() {
+    defaults.set(Date().addingTimeInterval(-1).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
+    XCTAssertTrue(AuthenticationService.isPartnerSessionExpired())
   }
 
-  func testNilExpiryIsNeverExpired() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: nil
-    )
-    XCTAssertFalse(AuthenticationService.isSessionExpired())
-    XCTAssertNil(defaults.object(forKey: AuthenticationService.sessionExpiresAtKey))
+  func testNilExpiryIsNeverExpired() {
+    defaults.removeObject(forKey: AuthenticationService.sessionExpiresAtKey)
+    XCTAssertFalse(AuthenticationService.isPartnerSessionExpired())
   }
 
-  func testClearSessionRemovesEveryKey() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(60)
-    )
+  func testClearSessionRemovesEveryKey() {
+    defaults.set("secret", forKey: AuthenticationService.sessionKey)
+    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
     defaults.set("acc1", forKey: AuthenticationService.selectedAccountKey)
+    defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
 
     AuthenticationService.clearSession()
 
@@ -66,13 +49,9 @@ final class DeviceSessionExpiryTests: XCTestCase {
     XCTAssertNil(defaults.object(forKey: AuthenticationService.sessionExpiresAtKey))
   }
 
-  func testStoringPostsSessionDidChange() async {
+  func testClearSessionPostsSessionDidChange() {
     let expectation = expectation(forNotification: .expoSessionDidChange, object: nil)
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(60)
-    )
-    await fulfillment(of: [expectation], timeout: 1)
+    AuthenticationService.clearSession()
+    wait(for: [expectation], timeout: 1)
   }
 }

--- a/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
+++ b/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
@@ -19,37 +19,37 @@ final class ExpoGoHomeBridgeAuthTests: XCTestCase {
   func testNoSessionIsNotAuthenticated() {
     XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
     XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
-    XCTAssertNil(ExpoGoHomeBridge.shared.expiredPartnerSessionMessage())
+    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
   }
 
   func testLiveSessionReportsUsername() {
     defaults.set("secret", forKey: AuthenticationService.sessionKey)
-    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set("test-user", forKey: AuthenticationService.usernameKey)
     defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
 
     XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
-    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "partner-private-test")
-    XCTAssertNil(ExpoGoHomeBridge.shared.expiredPartnerSessionMessage())
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
+    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
   }
 
   func testExpiredSessionReportsNeitherAuthNorUsername() {
     defaults.set("secret", forKey: AuthenticationService.sessionKey)
-    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set("test-user", forKey: AuthenticationService.usernameKey)
     defaults.set(Date().addingTimeInterval(-1).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
 
     XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
     XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
     XCTAssertEqual(
-      ExpoGoHomeBridge.shared.expiredPartnerSessionMessage(),
+      ExpoGoHomeBridge.shared.sessionExpiredMessage(),
       ExpoGoHomeBridge.expiredSessionMessage
     )
   }
 
   func testSessionWithoutExpiryReportsUsername() {
     defaults.set("secret", forKey: AuthenticationService.sessionKey)
-    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set("test-user", forKey: AuthenticationService.usernameKey)
 
     XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
-    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "partner-private-test")
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
   }
 }

--- a/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
+++ b/apps/expo-go/ios/Tests/ExpoGoHomeBridgeAuthTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @testable import Expo_Go
 
 final class ExpoGoHomeBridgeAuthTests: XCTestCase {
+  private let defaults = UserDefaults.standard
+
   override func setUp() {
     super.setUp()
     AuthenticationService.clearSession()
@@ -17,41 +19,37 @@ final class ExpoGoHomeBridgeAuthTests: XCTestCase {
   func testNoSessionIsNotAuthenticated() {
     XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
     XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
-    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
+    XCTAssertNil(ExpoGoHomeBridge.shared.expiredPartnerSessionMessage())
   }
 
-  func testLiveSessionReportsUsername() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(60)
-    )
+  func testLiveSessionReportsUsername() {
+    defaults.set("secret", forKey: AuthenticationService.sessionKey)
+    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set(Date().addingTimeInterval(60).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
+
     XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
-    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
-    XCTAssertNil(ExpoGoHomeBridge.shared.sessionExpiredMessage())
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "partner-private-test")
+    XCTAssertNil(ExpoGoHomeBridge.shared.expiredPartnerSessionMessage())
   }
 
-  func testExpiredSessionReportsNeitherAuthNorUsername() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: Date().addingTimeInterval(-1)
-    )
+  func testExpiredSessionReportsNeitherAuthNorUsername() {
+    defaults.set("secret", forKey: AuthenticationService.sessionKey)
+    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+    defaults.set(Date().addingTimeInterval(-1).timeIntervalSince1970, forKey: AuthenticationService.sessionExpiresAtKey)
+
     XCTAssertFalse(ExpoGoHomeBridge.shared.isAuthenticated())
     XCTAssertNil(ExpoGoHomeBridge.shared.authenticatedUsername())
     XCTAssertEqual(
-      ExpoGoHomeBridge.shared.sessionExpiredMessage(),
+      ExpoGoHomeBridge.shared.expiredPartnerSessionMessage(),
       ExpoGoHomeBridge.expiredSessionMessage
     )
   }
 
-  func testSessionWithoutExpiryReportsUsername() async {
-    await AuthenticationService.storeDeviceAuthSession(
-      sessionSecret: "secret",
-      username: "test-user",
-      expiresAt: nil
-    )
+  func testSessionWithoutExpiryReportsUsername() {
+    defaults.set("secret", forKey: AuthenticationService.sessionKey)
+    defaults.set("partner-private-test", forKey: AuthenticationService.usernameKey)
+
     XCTAssertTrue(ExpoGoHomeBridge.shared.isAuthenticated())
-    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "test-user")
+    XCTAssertEqual(ExpoGoHomeBridge.shared.authenticatedUsername(), "partner-private-test")
   }
 }


### PR DESCRIPTION
# Why
Finalized feature

# How
`openUrl` reads the override, strips it before the routing decision so it never becomes part of the project identity or reaches the dev server, and records it keyed by the stripped project URL. `openApp` then offers the sheet before any load when a pending sign in exists. Declining still opens the project, and the manifest mismatch error then explains why it failed and re-offers the sheet.

Successful sign ins record a grant keyed by the partner's verification host, so rescanning a preview QR does not prompt again while the same account is signed in. Users arriving through a partner QR skip the onboarding.

# Test Plan
Verified end to end on a physical device
  <table>
    <tr>
      <td><img width="225" alt="IMG_0549" src="https://github.com/user-attachments/assets/7923be63-e43d-4960-b55e-1dd74cc49fc2" /></td>
      <td><img width="225" alt="IMG_0548" src="https://github.com/user-attachments/assets/f557c3b1-be20-462b-a883-e874df81534f" /></td>
    </tr>
    <tr>
      <td><img width="225" alt="IMG_0550" src="https://github.com/user-attachments/assets/3ad32500-501f-463d-ade9-56e56483a008" /></td>
      <td><img width="225" alt="IMG_0551" src="https://github.com/user-attachments/assets/696e61f5-7028-434d-bf87-f427a69c4009" /></td>
    </tr>
  </table>


