### PR TITLE
chore: migrate from @expo/vector-icons

### DIFF
--- a/apps/native-component-list/app.json
+++ b/apps/native-component-list/app.json
@@ -61,7 +61,7 @@
         "googleMobileAdsAppId": "ca-app-pub-3940256099942544~1458002511"
       }
     },
-    "assetBundlePatterns": ["assets/**", "node_modules/@expo/vector-icons/fonts/*.ttf"],
+    "assetBundlePatterns": ["assets/**"],
     "plugins": [
       "expo-router",
       [

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -34,6 +34,8 @@
     "@react-native-masked-view/masked-view": "0.3.2",
     "@react-native-picker/picker": "2.11.4",
     "@react-native-segmented-control/segmented-control": "2.5.7",
+    "@react-native-vector-icons/ionicons": "^13.1.2",
+    "@react-native-vector-icons/material-design-icons": "^13.1.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/react-native-skia": "2.6.2",
     "canvaskit-wasm": "^0.40.0",

--- a/apps/native-component-list/src/components/HeaderIconButton.tsx
+++ b/apps/native-component-list/src/components/HeaderIconButton.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { StyleSheet, TouchableOpacity, TouchableOpacityProps } from 'react-native';
 
 type Props = TouchableOpacityProps & {

--- a/apps/native-component-list/src/components/SearchBar.ios.tsx
+++ b/apps/native-component-list/src/components/SearchBar.ios.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { useNavigation } from 'expo-router';
 import React from 'react';
 import {

--- a/apps/native-component-list/src/components/SearchBar.tsx
+++ b/apps/native-component-list/src/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import React from 'react';
 import { StyleSheet, TextInput, TouchableOpacity, View, Platform } from 'react-native';
 

--- a/apps/native-component-list/src/components/ShowActionSheetButton.tsx
+++ b/apps/native-component-list/src/components/ShowActionSheetButton.tsx
@@ -1,6 +1,6 @@
 import { ActionSheetOptions } from '@expo/react-native-action-sheet';
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { Text, TextStyle, View } from 'react-native';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
+import { Pressable, StyleSheet, Text, TextStyle, View } from 'react-native';
 
 const icon = (name: string) => <MaterialCommunityIcons key={name} name={name as any} size={24} />;
 
@@ -77,18 +77,26 @@ export default function ShowActionSheetButton({
 
   return (
     <View style={{ margin: 6 }}>
-      <MaterialCommunityIcons.Button
-        name="code-tags"
-        backgroundColor="#3e3e3e"
-        onPress={showActionSheet}>
-        <Text
-          style={{
-            fontSize: 15,
-            color: '#fff',
-          }}>
-          {title}
-        </Text>
-      </MaterialCommunityIcons.Button>
+      <Pressable style={styles.button} onPress={showActionSheet}>
+        <MaterialCommunityIcons name="code-tags" size={20} color="#fff" />
+        <Text style={styles.label}>{title}</Text>
+      </Pressable>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  button: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#3e3e3e',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 4,
+    gap: 8,
+  },
+  label: {
+    fontSize: 15,
+    color: '#fff',
+  },
+});

--- a/apps/native-component-list/src/components/TabIcon.tsx
+++ b/apps/native-component-list/src/components/TabIcon.tsx
@@ -1,4 +1,4 @@
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import { useTheme } from 'ThemeProvider';
 import React from 'react';
 import { Platform } from 'react-native';

--- a/apps/native-component-list/src/navigation/StackConfig.tsx
+++ b/apps/native-component-list/src/navigation/StackConfig.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { ThemeType, useTheme } from 'ThemeProvider';
 import { Stack, router, type NativeStackNavigationOptions, useRouter } from 'expo-router';
 import * as React from 'react';

--- a/apps/native-component-list/src/screens/Audio/Player.tsx
+++ b/apps/native-component-list/src/screens/Audio/Player.tsx
@@ -1,6 +1,6 @@
-import Ionicons from '@expo/vector-icons/build/Ionicons';
 import Slider from '@react-native-community/slider';
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { AudioMetadata } from 'expo-audio';
 import React from 'react';
 import {

--- a/apps/native-component-list/src/screens/Audio/Recorder.tsx
+++ b/apps/native-component-list/src/screens/Audio/Recorder.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/build/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { useAudioRecorder, useAudioRecorderState, AudioModule, RecordingPresets } from 'expo-audio';
 import type { RecordingDirectory, RecordingOptions, RecordingStatus } from 'expo-audio';
 import React, { useEffect } from 'react';

--- a/apps/native-component-list/src/screens/Audio/RecordingStreamScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/RecordingStreamScreen.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/build/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import {
   useAudioStream,
   useAudioPlayer,

--- a/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewScrollScreen.tsx
@@ -1,13 +1,13 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { BlurTargetView, BlurView } from 'expo-blur';
 import { Image } from 'expo-image';
 import { useRef } from 'react';
 import { View, FlatList, StyleSheet, TouchableOpacity } from 'react-native';
 
-function TouchableIcon({ name }: { name: 'home' | 'heart' | 'gear' }) {
+function TouchableIcon({ name }: { name: 'home' | 'heart' | 'settings' }) {
   return (
     <TouchableOpacity>
-      <FontAwesome name={name} size={48} color="rgba(255, 255, 255, 0.85)" />
+      <Ionicons name={name} size={48} color="rgba(255, 255, 255, 0.85)" />
     </TouchableOpacity>
   );
 }
@@ -46,7 +46,7 @@ export default function BlurScrollScreen() {
           intensity={40}>
           <TouchableIcon name="home" />
           <TouchableIcon name="heart" />
-          <TouchableIcon name="gear" />
+          <TouchableIcon name="settings" />
         </BlurView>
       </View>
     </View>

--- a/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenFull.tsx
@@ -1,7 +1,6 @@
-import AntDesign from '@expo/vector-icons/AntDesign';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import Slider from '@react-native-community/slider';
+import Ionicons from '@react-native-vector-icons/ionicons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import {
   BarcodeScanningResult,
   CameraView,
@@ -375,9 +374,9 @@ export default function CameraScreen() {
       </TouchableOpacity>
       <TouchableOpacity style={styles.toggleButton} onPress={updatePreviewState}>
         {state.previewPaused ? (
-          <AntDesign name="play-circle" size={24} color="white" />
+          <Ionicons name="play-circle" size={24} color="white" />
         ) : (
-          <AntDesign name="pause-circle" size={24} color="white" />
+          <Ionicons name="pause-circle" size={24} color="white" />
         )}
       </TouchableOpacity>
       <TouchableOpacity style={styles.toggleButton} onPress={toggleMoreOptions}>

--- a/apps/native-component-list/src/screens/Camera/CameraScreenLenses.tsx
+++ b/apps/native-component-list/src/screens/Camera/CameraScreenLenses.tsx
@@ -1,7 +1,6 @@
-import { Ionicons } from '@expo/vector-icons';
-import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import Slider from '@react-native-community/slider';
+import Ionicons from '@react-native-vector-icons/ionicons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import {
   Camera,
   CameraMode,
@@ -124,7 +123,7 @@ export default function CameraScreenLenses() {
           </TouchableOpacity>
         </View>
         <TouchableOpacity style={styles.bottomButton} onPress={clearSelectedLens}>
-          <MaterialIcons name="clear" size={32} color="white" />
+          <Ionicons name="close" size={32} color="white" />
         </TouchableOpacity>
       </View>
       <Slider

--- a/apps/native-component-list/src/screens/Camera/GalleryScreen.tsx
+++ b/apps/native-component-list/src/screens/Camera/GalleryScreen.tsx
@@ -1,4 +1,4 @@
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { CameraCapturedPicture } from 'expo-camera';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as MediaLibrary from 'expo-media-library/legacy';
@@ -130,7 +130,7 @@ function LoadedGalleryScreen(
     <View style={styles.container}>
       <View style={styles.navbar}>
         <TouchableOpacity style={styles.button} onPress={props.onPress}>
-          <MaterialIcons name="arrow-back" size={25} color="white" />
+          <Ionicons name="arrow-back" size={25} color="white" />
         </TouchableOpacity>
         <TouchableOpacity style={styles.button} onPress={saveToGallery}>
           <Text style={styles.whiteText}>Save selected to gallery</Text>

--- a/apps/native-component-list/src/screens/Camera/Photo.tsx
+++ b/apps/native-component-list/src/screens/Camera/Photo.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { Image } from 'expo-image';
 import * as VideoThumbnails from 'expo-video-thumbnails';
 import React, { useEffect } from 'react';

--- a/apps/native-component-list/src/screens/Camera/Photo.web.tsx
+++ b/apps/native-component-list/src/screens/Camera/Photo.web.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import React from 'react';
 import { Image, StyleSheet, TouchableOpacity } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { useObserve } from 'expo-observe';
 import { Link } from 'expo-router';
 import React from 'react';

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailList.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailList.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import * as React from 'react';
 import {
   SectionList,

--- a/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactDetailScreen.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import * as Contacts from 'expo-contacts/legacy';
 import * as ImagePicker from 'expo-image-picker';
 import * as Linking from 'expo-linking';

--- a/apps/native-component-list/src/screens/Contacts/ContactsListItem.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsListItem.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import * as React from 'react';
 import { StyleSheet, TouchableHighlight, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ExpoVectorIconsCompatibilitySection.tsx
+++ b/apps/native-component-list/src/screens/ExpoVectorIconsCompatibilitySection.tsx
@@ -1,0 +1,18 @@
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { View } from 'react-native';
+
+import { Section } from '../components/Page';
+
+// Keep all legacy @expo/vector-icons usage isolated here. To remove compatibility coverage,
+// delete this file, its single usage in FontScreen, and the package dependency.
+export function ExpoVectorIconsCompatibilitySection({ color }: { color: string }) {
+  return (
+    <Section title="@expo/vector-icons compatibility">
+      <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
+        <FontAwesome name="camera" size={25} color={color} />
+        <FontAwesome name="map" size={25} color={color} />
+        <FontAwesome name="github" size={25} color={color} />
+      </View>
+    </Section>
+  );
+}

--- a/apps/native-component-list/src/screens/FontScreen.tsx
+++ b/apps/native-component-list/src/screens/FontScreen.tsx
@@ -1,8 +1,5 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
-import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
-import FoundationIcons from '@expo/vector-icons/Foundation';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import Ionicons from '@react-native-vector-icons/ionicons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import { useTheme } from 'ThemeProvider';
 import * as Font from 'expo-font';
 import { RenderToImageResult } from 'expo-font';
@@ -12,20 +9,13 @@ import { Platform, ScrollView, StyleSheet, View, Image as CoreImage } from 'reac
 
 import { BodyText } from '../components/BodyText';
 import { Page, Section } from '../components/Page';
+import { ExpoVectorIconsCompatibilitySection } from './ExpoVectorIconsCompatibilitySection';
 
 const round = (num: number) => Math.round(num * 100) / 100;
 
 export default function FontScreen() {
   const { theme } = useTheme();
   const color = theme.text.default;
-
-  const renderedFontAwesomeImage = useLoadIcon(() =>
-    Font.renderToImageAsync(String.fromCodePoint(62491), {
-      fontFamily: 'FontAwesome5Free-Brand',
-      color: '#61dafb',
-      size: 172,
-    })
-  );
 
   const renderedFontAsImage = useLoadIcon(() =>
     Font.renderToImageAsync('ÅBÇD', {
@@ -101,32 +91,25 @@ export default function FontScreen() {
             <Ionicons name="alarm" size={25} color={color} />
           </View>
         </Section>
-        <Section title="FontAwesome5">
+        <Section title="Material Design Icons">
           <View style={styles.vectorIconsRow}>
-            <FontAwesome5 name="laugh-wink" size={25} color={color} />
-            <FontAwesome5 name="smile-beam" size={25} color={color} />
-            <FontAwesome5 name="map" size={25} color={color} />
-            <FontAwesome5 name="bacon" size={25} color={color} />
-            <FontAwesome5 name="basketball-ball" size={25} color={color} />
-            <FontAwesome5 name="biking" size={25} color={color} />
+            <MaterialCommunityIcons name="emoticon-wink" size={25} color={color} />
+            <MaterialCommunityIcons name="map" size={25} color={color} />
+            <MaterialCommunityIcons name="food-drumstick" size={25} color={color} />
+            <MaterialCommunityIcons name="basketball" size={25} color={color} />
+            <MaterialCommunityIcons name="bike" size={25} color={color} />
+            <MaterialCommunityIcons name="home" size={25} color={color} />
           </View>
           <View style={styles.vectorIconsRow}>
-            <FontAwesome5 name="home" size={25} color={color} />
-            <FontAwesome5 name="paw" size={25} color={color} />
-            <FontAwesome5 name="map" size={25} solid color={color} />
-            <FontAwesome5 name="camera" size={25} color={color} />
-            <FontAwesome5 name="cat" size={25} color={color} />
-            <FontAwesome5 name="horse" size={25} color={color} />
-          </View>
-          <View style={styles.vectorIconsRow}>
-            <FontAwesome5 name="react" size={25} color={color} />
-            <FontAwesome5 name="aws" size={25} color={color} />
-            <FontAwesome5 name="swift" size={25} color={color} />
-            <FontAwesome5 name="facebook" size={25} color={color} />
-            <FontAwesome5 name="twitter" size={25} color={color} />
-            <FontAwesome5 name="apple" size={25} color={color} />
+            <MaterialCommunityIcons name="paw" size={25} color={color} />
+            <MaterialCommunityIcons name="camera" size={25} color={color} />
+            <MaterialCommunityIcons name="cat" size={25} color={color} />
+            <MaterialCommunityIcons name="horse" size={25} color={color} />
+            <MaterialCommunityIcons name="react" size={25} color={color} />
+            <MaterialCommunityIcons name="apple" size={25} color={color} />
           </View>
         </Section>
+        <ExpoVectorIconsCompatibilitySection color={color} />
         <Section title="Custom Fonts">
           <View style={styles.customFonts}>
             <View style={{ flex: 1 }}>
@@ -180,23 +163,6 @@ export default function FontScreen() {
         <VectorIconSection />
 
         <Section title="renderToImageAsync" gap={5}>
-          {renderedFontAwesomeImage && (
-            <>
-              <BodyText>
-                FontAwesome5Free rendered to image
-                {round(renderedFontAwesomeImage.width)}x{round(renderedFontAwesomeImage.height)}
-              </BodyText>
-              <Image
-                source={{ uri: renderedFontAwesomeImage.uri }}
-                style={{
-                  height: renderedFontAwesomeImage.height,
-                  width: renderedFontAwesomeImage.width,
-                  backgroundColor: 'grey',
-                }}
-                contentFit="cover"
-              />
-            </>
-          )}
           {renderedFontAsImage && (
             <>
               <BodyText>
@@ -323,10 +289,8 @@ function useLoadIcon(getImage: () => Promise<RenderToImageResult | null>) {
 
 function VectorIconSection() {
   const icons = [
-    useLoadIcon(() => MaterialIcons.getImageSource('camera', size, 'yellow')),
-    useLoadIcon(() => FontAwesome.getImageSource('book', size, 'yellow')),
+    useLoadIcon(() => MaterialCommunityIcons.getImageSource('camera', size, 'yellow')),
     useLoadIcon(() => Ionicons.getImageSource('camera', size, 'yellow')),
-    useLoadIcon(() => FoundationIcons.getImageSource('book', size, 'yellow')),
   ];
 
   return (

--- a/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
+++ b/apps/native-component-list/src/screens/GestureHandler/GmailStyleSwipeableRow.tsx
@@ -1,4 +1,4 @@
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import React, { useRef } from 'react';
 import { StyleSheet } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
@@ -10,7 +10,7 @@ import Animated, {
   useAnimatedStyle,
 } from 'react-native-reanimated';
 
-const AnimatedIcon = Animated.createAnimatedComponent(MaterialIcons);
+const AnimatedIcon = Animated.createAnimatedComponent(MaterialCommunityIcons);
 
 function ActionIcon({
   name,

--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { Asset } from 'expo-asset';
 import { ImageResult, FlipType, useImageManipulator, SaveFormat } from 'expo-image-manipulator';
 import * as ImagePicker from 'expo-image-picker';

--- a/apps/native-component-list/src/screens/ImageManipulatorScreenLegacy.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreenLegacy.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { Asset } from 'expo-asset';
 import * as ImageManipulator from 'expo-image-manipulator';
 import * as ImagePicker from 'expo-image-picker';

--- a/apps/native-component-list/src/screens/Location/BackgroundLocationMapScreen.tsx
+++ b/apps/native-component-list/src/screens/Location/BackgroundLocationMapScreen.tsx
@@ -1,6 +1,5 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import * as Location from 'expo-location';
 import { useFocusEffect } from 'expo-router';
 import { type NativeStackNavigationProp } from 'expo-router';
@@ -301,7 +300,7 @@ function BackgroundLocationMapView() {
                     {state.showsBackgroundLocationIndicator ? 'Hide' : 'Show'}
                   </Text>
                   <Text style={styles.text}> background </Text>
-                  <FontAwesome name="location-arrow" size={20} color="white" />
+                  <MaterialCommunityIcons name="near-me" size={20} color="white" />
                   <Text style={styles.text}> indicator</Text>
                 </View>
               </Button>
@@ -325,7 +324,7 @@ function BackgroundLocationMapView() {
           </View>
           <View style={styles.buttonsColumn}>
             <Button style={styles.button} onPress={onCenterMap}>
-              <MaterialIcons name="my-location" size={20} color="white" />
+              <MaterialCommunityIcons name="crosshairs-gps" size={20} color="white" />
             </Button>
           </View>
         </View>

--- a/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary/MediaLibraryCell.tsx
@@ -1,4 +1,4 @@
-import FontAwesome from '@expo/vector-icons/FontAwesome';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { Image } from 'expo-image';
 import * as MediaLibrary from 'expo-media-library/legacy';
 import React from 'react';
@@ -19,19 +19,19 @@ export default function MediaLibraryCell({
     switch (asset.mediaType) {
       case MediaLibrary.MediaType.photo:
         return {
-          icon: 'photo',
+          icon: 'image',
           description: `${asset.width}x${asset.height}`,
           preview: <Image style={styles.preview} source={{ uri: asset.uri }} resizeMode="cover" />,
         };
       case MediaLibrary.MediaType.video:
         return {
-          icon: 'video-camera',
+          icon: 'videocam',
           description: `${Math.round(asset.duration)}s`,
           preview: <Image style={styles.preview} source={{ uri: asset.uri }} resizeMode="cover" />,
         };
       case MediaLibrary.MediaType.audio:
         return {
-          icon: 'music',
+          icon: 'musical-notes',
           description: `${Math.round(asset.duration)}s`,
           preview: (
             <View style={[styles.preview, styles.audioPreview]}>
@@ -49,7 +49,7 @@ export default function MediaLibraryCell({
       {data && data.preview}
       {data && (
         <View style={styles.cellFooter}>
-          <FontAwesome name={data.icon as any} size={12} color="white" />
+          <Ionicons name={data.icon as any} size={12} color="white" />
           <BodyText style={styles.description}>{data.description}</BodyText>
         </View>
       )}

--- a/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
+++ b/apps/native-component-list/src/screens/SVG/SVGScreen.tsx
@@ -1,4 +1,4 @@
-import Ionicons from '@expo/vector-icons/Ionicons';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { router } from 'expo-router';
 import { FlatList, PixelRatio, StyleSheet, TouchableHighlight, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlashListScreen.tsx
@@ -1,4 +1,4 @@
-import Entypo from '@expo/vector-icons/Entypo';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { FlashList } from '@shopify/flash-list';
 import { VideoView, VideoSource, useVideoPlayer } from 'expo-video';
 import { useEffect, useState } from 'react';
@@ -62,16 +62,16 @@ function RenderItem({ item, index, viewSize, visibleIndex }: RenderItemProps) {
       />
       <View style={styles.overlayContainer}>
         <View style={styles.controlsContainer}>
-          <Entypo
-            name={heart ? 'heart' : 'heart-outlined'}
+          <Ionicons
+            name={heart ? 'heart' : 'heart-outline'}
             size={50}
             color="white"
             onPress={() => {
               setHeart(!heart);
             }}
           />
-          <Entypo name="message" size={50} color="white" />
-          <Entypo name="upload-to-cloud" size={50} color="white" />
+          <Ionicons name="chatbubble" size={50} color="white" />
+          <Ionicons name="cloud-upload" size={50} color="white" />
         </View>
       </View>
     </View>

--- a/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFlatListScreen.tsx
@@ -1,4 +1,4 @@
-import Entypo from '@expo/vector-icons/Entypo';
+import Ionicons from '@react-native-vector-icons/ionicons';
 import { VideoView, VideoPlayer, createVideoPlayer, VideoSource } from 'expo-video';
 import { useEffect, useRef, useState } from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
@@ -56,16 +56,16 @@ function RenderItem({ item, index, playerPool, viewSize }: RenderItemProps) {
       />
       <View style={styles.overlayContainer}>
         <View style={styles.controlsContainer}>
-          <Entypo
-            name={heart ? 'heart' : 'heart-outlined'}
+          <Ionicons
+            name={heart ? 'heart' : 'heart-outline'}
             size={50}
             color="white"
             onPress={() => {
               setHeart(!heart);
             }}
           />
-          <Entypo name="message" size={50} color="white" />
-          <Entypo name="upload-to-cloud" size={50} color="white" />
+          <Ionicons name="chatbubble" size={50} color="white" />
+          <Ionicons name="cloud-upload" size={50} color="white" />
         </View>
       </View>
     </View>

--- a/apps/native-component-list/src/utilities/loadAssetsAsync.ts
+++ b/apps/native-component-list/src/utilities/loadAssetsAsync.ts
@@ -4,8 +4,6 @@ import {
   Inter_800ExtraBold,
   Inter_900Black,
 } from '@expo-google-fonts/inter';
-import Ionicons from '@expo/vector-icons/Ionicons';
-import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { Asset } from 'expo-asset';
 import * as Font from 'expo-font';
 import { Assets as StackAssets } from 'expo-router/react-navigation';
@@ -15,8 +13,6 @@ async function loadAssetsAsync() {
   const assetPromises: Promise<any>[] = [
     // The assets are `require` results, so they are numbers at runtime.
     Asset.loadAsync(StackAssets as number[]),
-    Font.loadAsync(Ionicons.font),
-    Font.loadAsync(MaterialIcons.font),
     Font.loadAsync({
       'space-mono': require('../../assets/fonts/SpaceMono-Regular.ttf'),
     }),

--- a/apps/test-suite/navigationConfig.tsx
+++ b/apps/test-suite/navigationConfig.tsx
@@ -1,4 +1,4 @@
-import MaterialCommunityIcons from '@expo/vector-icons/build/MaterialCommunityIcons';
+import MaterialCommunityIcons from '@react-native-vector-icons/material-design-icons';
 import { type NativeStackNavigationOptions } from 'expo-router';
 import * as React from 'react';
 import { View } from 'react-native';

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@expo/html-elements": "workspace:*",
     "@expo/styleguide-base": "^1.0.1",
-    "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-vector-icons/material-design-icons": "^13.1.2",
     "async-retry": "^1.1.4",
     "expo": "workspace:*",
     "expo-app-metrics": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,12 @@ importers:
       '@react-native-segmented-control/segmented-control':
         specifier: 2.5.7
         version: 2.5.7(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      '@react-native-vector-icons/ionicons':
+        specifier: ^13.1.2
+        version: 13.1.2(@expo/config-plugins@packages+@expo+config-plugins)(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      '@react-native-vector-icons/material-design-icons':
+        specifier: ^13.1.2
+        version: 13.1.2(@expo/config-plugins@packages+@expo+config-plugins)(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@shopify/flash-list':
         specifier: 2.0.2
         version: 2.0.2(@babel/runtime@7.29.7)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -1564,12 +1570,12 @@ importers:
       '@expo/styleguide-base':
         specifier: ^1.0.1
         version: 1.0.1(react@19.2.3)
-      '@expo/vector-icons':
-        specifier: ^15.0.2
-        version: 15.1.1(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))
+      '@react-native-vector-icons/material-design-icons':
+        specifier: ^13.1.2
+        version: 13.1.2(@expo/config-plugins@packages+@expo+config-plugins)(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       async-retry:
         specifier: ^1.1.4
         version: 1.3.3
@@ -8786,6 +8792,46 @@ packages:
       react: '>=16.0'
       react-native: 0.86.0
 
+  '@react-native-vector-icons/common@13.0.1':
+    resolution: {integrity: sha512-UPC6L3tW5rXCjBn4kgw9RPURUILIg8tFpEY2uaYwU8aCjEHkywNCMcAO8+PvMCDkR6aICPeHYA0OXvMgrjsF4g==}
+    engines: {node: '>=20.19.0 <21.0.0 || >=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@react-native-vector-icons/get-image': ^13.0.0
+      '@react-native/assets-registry': '*'
+      expo-font: '*'
+      react: '*'
+      react-native: 0.86.0
+    peerDependenciesMeta:
+      '@react-native-vector-icons/get-image':
+        optional: true
+      '@react-native/assets-registry':
+        optional: true
+      expo-font:
+        optional: true
+
+  '@react-native-vector-icons/ionicons@13.1.2':
+    resolution: {integrity: sha512-8TaXKw41MgKADeesrrbUpA3FR81JNy96ogiGRjWgtE1djSEevDsOKMij7Jq/3TfiGaE0prEshU0TcW5qwsf0Ug==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      '@expo/config-plugins': '>=10.0.0'
+      react: '*'
+      react-native: 0.86.0
+    peerDependenciesMeta:
+      '@expo/config-plugins':
+        optional: true
+
+  '@react-native-vector-icons/material-design-icons@13.1.2':
+    resolution: {integrity: sha512-Qc8IQCxbnHOk8CvTAb+dLzYgRMbJOLiZ8Up7TRsNixY6EqwPx9/W3DeK5niKtNQ4dIfbALeYz41yyvDM7w7mag==}
+    engines: {node: '>= 18.0.0'}
+    peerDependencies:
+      '@expo/config-plugins': '>=10.0.0'
+      react: '*'
+      react-native: 0.86.0
+    peerDependenciesMeta:
+      '@expo/config-plugins':
+        optional: true
+
   '@react-native/assets-registry@0.86.0':
     resolution: {integrity: sha512-nIaXbm2jX1OTYp0qbviJ3O6KZivoE8z3BnhUQ2LsqfZSWRoOK/n1qsiAr6oALiNKWnXY3j2KPwtYORnZzp8xew==}
     engines: {node: ^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0}
@@ -11324,6 +11370,10 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  find-up@8.0.0:
+    resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
+    engines: {node: '>=20'}
+
   flat-cache@3.2.0:
     resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -12440,6 +12490,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@8.0.0:
+    resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
+    engines: {node: '>=20'}
+
   lodash._baseflatten@3.1.4:
     resolution: {integrity: sha512-fESngZd+X4k+GbTxdMutf8ohQa0s3sJEHIcwtu4/LsIQ2JTDzdRxDCMQjW+ezzwRitLmHnacVVmosCbxifefbw==}
 
@@ -13071,6 +13125,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
     engines: {node: '>=6'}
@@ -13082,6 +13140,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -14557,6 +14619,10 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
+
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
@@ -15092,6 +15158,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -17405,6 +17475,41 @@ snapshots:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
 
+  '@react-native-vector-icons/common@13.0.1(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      find-up: 8.0.0
+      picocolors: 1.1.1
+      plist: 3.1.0
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@react-native/assets-registry': 0.86.0
+      expo-font: link:packages/expo-font
+
+  '@react-native-vector-icons/ionicons@13.1.2(@expo/config-plugins@packages+@expo+config-plugins)(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@react-native-vector-icons/common': 13.0.1(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@expo/config-plugins': link:packages/@expo/config-plugins
+    transitivePeerDependencies:
+      - '@react-native-vector-icons/get-image'
+      - '@react-native/assets-registry'
+      - expo-font
+
+  '@react-native-vector-icons/material-design-icons@13.1.2(@expo/config-plugins@packages+@expo+config-plugins)(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@react-native-vector-icons/common': 13.0.1(@react-native/assets-registry@0.86.0)(expo-font@packages+expo-font)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@expo/config-plugins': link:packages/@expo/config-plugins
+    transitivePeerDependencies:
+      - '@react-native-vector-icons/get-image'
+      - '@react-native/assets-registry'
+      - expo-font
+
   '@react-native/assets-registry@0.86.0': {}
 
   '@react-native/babel-plugin-codegen@0.86.0(@babel/core@7.29.7)':
@@ -17541,7 +17646,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -20384,6 +20491,11 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  find-up@8.0.0:
+    dependencies:
+      locate-path: 8.0.0
+      unicorn-magic: 0.3.0
+
   flat-cache@3.2.0:
     dependencies:
       flatted: 3.4.2
@@ -21708,6 +21820,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  locate-path@8.0.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash._baseflatten@3.1.4:
     dependencies:
       lodash.isarguments: 3.1.0
@@ -22443,6 +22559,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-locate@3.0.0:
     dependencies:
       p-limit: 2.3.0
@@ -22454,6 +22574,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   p-try@2.2.0: {}
 
@@ -24017,6 +24141,8 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
@@ -24664,6 +24790,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  yocto-queue@1.2.2: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
# Why

we're recommending people to use the community vector icons library (https://expo.dev/blog/moving-away-from-expo-vector-icons) but we're not using it ourselves; this replaces most of our `@expo/vector-icons` usages with usages of the community lib. A few examples of `@expo/vector-icons` remain (in one isolated place) so we have some visibility into that package too, but those examples can be dropped later.

# How

add 

```
"@react-native-vector-icons/ionicons": "^13.1.2",
"@react-native-vector-icons/material-design-icons": "^13.1.2",
```

# Test Plan

bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
