### PR TITLE
[sqlite] Fix kv-store permanently losing the storage table on a raced first launch

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
+- Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -372,6 +372,9 @@ export class SQLiteStorage {
   }
 
   private getDbSync(): SQLiteDatabase {
+    // NOTE: Unlike `getDbAsync()`, this cannot acquire `awaitLock` because the lock is
+    // promise-based and this method is synchronous. The migration is idempotent instead,
+    // so racing it with `getDbAsync()` cannot leave the database without a `storage` table.
     if (!this.db) {
       const db = openDatabaseSync(this.databaseName);
       this.maybeMigrateDbSync(db);
@@ -383,30 +386,26 @@ export class SQLiteStorage {
   private maybeMigrateDbAsync(db: SQLiteDatabase) {
     return db.withTransactionAsync(async () => {
       const result = await db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
-      let currentDbVersion = result?.user_version ?? 0;
-      if (currentDbVersion >= DATABASE_VERSION) {
-        return;
+      const currentDbVersion = result?.user_version ?? 0;
+      // `MIGRATION_STATEMENT_0` uses `CREATE TABLE IF NOT EXISTS`, so it is a no-op when the
+      // table is already there. Running it unconditionally rather than only when the version is
+      // still 0 also repairs a database left at `user_version = 1` without a `storage` table.
+      await db.execAsync(MIGRATION_STATEMENT_0);
+      if (currentDbVersion < DATABASE_VERSION) {
+        await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
       }
-      if (currentDbVersion === 0) {
-        await db.execAsync(MIGRATION_STATEMENT_0);
-        currentDbVersion = 1;
-      }
-      await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 
   private maybeMigrateDbSync(db: SQLiteDatabase) {
     db.withTransactionSync(() => {
       const result = db.getFirstSync<{ user_version: number }>('PRAGMA user_version');
-      let currentDbVersion = result?.user_version ?? 0;
-      if (currentDbVersion >= DATABASE_VERSION) {
-        return;
+      const currentDbVersion = result?.user_version ?? 0;
+      // See the comment in `maybeMigrateDbAsync()`.
+      db.execSync(MIGRATION_STATEMENT_0);
+      if (currentDbVersion < DATABASE_VERSION) {
+        db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
       }
-      if (currentDbVersion === 0) {
-        db.execSync(MIGRATION_STATEMENT_0);
-        currentDbVersion = 1;
-      }
-      db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 

--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -394,7 +394,10 @@ export class SQLiteStorage {
       // A new column has to be added here as well, so fresh and repaired databases also get it.
       await db.execAsync(MIGRATION_STATEMENT_0);
 
-      // Version ladder: add each new migration below, gated on `currentDbVersion`.
+      // Version ladder: add each new migration below, gated on `currentDbVersion`. Since the
+      // baseline above already carries every column, a ladder entry that adds one has to
+      // tolerate it already being there — gate it on `PRAGMA table_info(storage)`, or a fresh
+      // database fails the migration with `duplicate column name`.
       if (currentDbVersion >= DATABASE_VERSION) {
         return;
       }

--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -387,13 +387,18 @@ export class SQLiteStorage {
     return db.withTransactionAsync(async () => {
       const result = await db.getFirstAsync<{ user_version: number }>('PRAGMA user_version');
       const currentDbVersion = result?.user_version ?? 0;
-      // `MIGRATION_STATEMENT_0` uses `CREATE TABLE IF NOT EXISTS`, so it is a no-op when the
-      // table is already there. Running it unconditionally rather than only when the version is
-      // still 0 also repairs a database left at `user_version = 1` without a `storage` table.
+
+      // Baseline schema, deliberately outside the version ladder below. It is a
+      // `CREATE TABLE IF NOT EXISTS`, so it is a no-op on a healthy database and it also repairs
+      // one that a raced first-run migration left at `user_version >= 1` with no `storage` table.
+      // A new column has to be added here as well, so fresh and repaired databases also get it.
       await db.execAsync(MIGRATION_STATEMENT_0);
-      if (currentDbVersion < DATABASE_VERSION) {
-        await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
+
+      // Version ladder: add each new migration below, gated on `currentDbVersion`.
+      if (currentDbVersion >= DATABASE_VERSION) {
+        return;
       }
+      await db.execAsync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 
@@ -401,11 +406,14 @@ export class SQLiteStorage {
     db.withTransactionSync(() => {
       const result = db.getFirstSync<{ user_version: number }>('PRAGMA user_version');
       const currentDbVersion = result?.user_version ?? 0;
-      // See the comment in `maybeMigrateDbAsync()`.
+
+      // Keep in sync with `maybeMigrateDbAsync()`, which documents the two steps below.
       db.execSync(MIGRATION_STATEMENT_0);
-      if (currentDbVersion < DATABASE_VERSION) {
-        db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
+
+      if (currentDbVersion >= DATABASE_VERSION) {
+        return;
       }
+      db.execSync(`PRAGMA user_version = ${DATABASE_VERSION}`);
     });
   }
 

--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -374,7 +374,7 @@ export class SQLiteStorage {
   private getDbSync(): SQLiteDatabase {
     // NOTE: Unlike `getDbAsync()`, this cannot acquire `awaitLock` because the lock is
     // promise-based and this method is synchronous. The migration is idempotent instead,
-    // so racing it with `getDbAsync()` cannot leave the database without a `storage` table.
+    // so the next open repairs a database left without a `storage` table by a race.
     if (!this.db) {
       const db = openDatabaseSync(this.databaseName);
       this.maybeMigrateDbSync(db);

--- a/packages/expo-sqlite/src/Storage.ts
+++ b/packages/expo-sqlite/src/Storage.ts
@@ -396,7 +396,7 @@ export class SQLiteStorage {
 
       // Version ladder: add each new migration below, gated on `currentDbVersion`. Since the
       // baseline above already carries every column, a ladder entry that adds one has to
-      // tolerate it already being there — gate it on `PRAGMA table_info(storage)`, or a fresh
+      // tolerate it already being there. Gate it on `PRAGMA table_info(storage)`, or a fresh
       // database fails the migration with `duplicate column name`.
       if (currentDbVersion >= DATABASE_VERSION) {
         return;

--- a/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
@@ -1,7 +1,9 @@
 // @ts-ignore-next-line: no @types/node
 import fs from 'fs/promises';
 
+import { openDatabaseSync } from '../SQLiteDatabase';
 import { SQLiteStorage } from '../Storage';
+import { createDatabasePath } from '../pathUtils';
 
 jest.mock('expo/devtools', () => ({
   getDevToolsPluginClientAsync: jest.fn(),
@@ -322,5 +324,101 @@ describe('react-native-async-storage API compatibility', () => {
     const value2 = await storage.getItem('key2');
     expect(value1).toBe(JSON.stringify({ a: 1, b: 3, c: 4 }));
     expect(value2).toBe(JSON.stringify({ x: 10, y: 30, z: 40 }));
+  });
+});
+
+describe('SQLiteStorage migration', () => {
+  const databaseName = 'TestStorageMigration';
+
+  async function removeDatabaseFile() {
+    await fs.unlink(createDatabasePath(databaseName)).catch(() => {});
+  }
+
+  /**
+   * Seeds a database file that is already at `user_version = 1` but has no `storage` table.
+   * This is the state a device is left in when `getDbSync()` migrates on a second connection
+   * while `getDbAsync()` is migrating on the first one. See https://github.com/expo/expo/issues/47448.
+   */
+  function seedDatabaseWithoutStorageTable() {
+    const db = openDatabaseSync(databaseName);
+    db.execSync('PRAGMA user_version = 1');
+    db.closeSync();
+  }
+
+  function readUserVersion(): number {
+    const db = openDatabaseSync(databaseName);
+    const result = db.getFirstSync<{ user_version: number }>('PRAGMA user_version');
+    db.closeSync();
+    return result?.user_version ?? 0;
+  }
+
+  function tableExists(): boolean {
+    const db = openDatabaseSync(databaseName);
+    const result = db.getFirstSync<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'storage'"
+    );
+    db.closeSync();
+    return result != null;
+  }
+
+  beforeEach(removeDatabaseFile);
+  afterEach(removeDatabaseFile);
+
+  it('should recreate the storage table when the database is at the current version but the table is missing (sync)', () => {
+    seedDatabaseWithoutStorageTable();
+    expect(tableExists()).toBe(false);
+
+    const storage = new SQLiteStorage(databaseName);
+    try {
+      expect(storage.getItemSync('key1')).toBeNull();
+      storage.setItemSync('key1', 'value1');
+      expect(storage.getItemSync('key1')).toBe('value1');
+    } finally {
+      storage.closeSync();
+    }
+    expect(tableExists()).toBe(true);
+  });
+
+  it('should recreate the storage table when the database is at the current version but the table is missing (async)', async () => {
+    seedDatabaseWithoutStorageTable();
+    expect(tableExists()).toBe(false);
+
+    const storage = new SQLiteStorage(databaseName);
+    try {
+      await expect(storage.getItemAsync('key1')).resolves.toBeNull();
+      await storage.setItemAsync('key1', 'value1');
+      await expect(storage.getItemAsync('key1')).resolves.toBe('value1');
+    } finally {
+      await storage.closeAsync();
+    }
+    expect(tableExists()).toBe(true);
+  });
+
+  it('should migrate a fresh database and bump the user version', () => {
+    const storage = new SQLiteStorage(databaseName);
+    try {
+      storage.setItemSync('key1', 'value1');
+    } finally {
+      storage.closeSync();
+    }
+    expect(tableExists()).toBe(true);
+    expect(readUserVersion()).toBe(1);
+  });
+
+  it('should keep existing data when reopening an already migrated database', () => {
+    const storage = new SQLiteStorage(databaseName);
+    storage.setItemSync('key1', 'value1');
+    storage.setItemSync('key2', 'value2');
+    storage.closeSync();
+
+    const reopened = new SQLiteStorage(databaseName);
+    try {
+      expect(reopened.getItemSync('key1')).toBe('value1');
+      expect(reopened.getItemSync('key2')).toBe('value2');
+      expect(reopened.getLengthSync()).toBe(2);
+    } finally {
+      reopened.closeSync();
+    }
+    expect(readUserVersion()).toBe(1);
   });
 });

--- a/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
@@ -336,8 +336,8 @@ describe('SQLiteStorage migration', () => {
 
   /**
    * Seeds a database file that is already at `user_version = 1` but has no `storage` table.
-   * This is the state a device is left in when `getDbSync()` migrates on a second connection
-   * while `getDbAsync()` is migrating on the first one. See https://github.com/expo/expo/issues/47448.
+   * This is the state a device can be left in when `getDbSync()` races with an in-progress
+   * `getDbAsync()` migration on the same cached native connection. See https://github.com/expo/expo/issues/47448.
    */
   function seedDatabaseWithoutStorageTable() {
     const db = openDatabaseSync(databaseName);

--- a/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/Storage-test.ios.ts
@@ -329,6 +329,8 @@ describe('react-native-async-storage API compatibility', () => {
 
 describe('SQLiteStorage migration', () => {
   const databaseName = 'TestStorageMigration';
+  // Any version above the `DATABASE_VERSION` the source is currently at.
+  const FUTURE_DATABASE_VERSION = 99;
 
   async function removeDatabaseFile() {
     await fs.unlink(createDatabasePath(databaseName)).catch(() => {});
@@ -403,6 +405,24 @@ describe('SQLiteStorage migration', () => {
     }
     expect(tableExists()).toBe(true);
     expect(readUserVersion()).toBe(1);
+  });
+
+  it('should leave a database from a newer version untouched', () => {
+    const db = openDatabaseSync(databaseName);
+    db.execSync('CREATE TABLE IF NOT EXISTS storage (key TEXT PRIMARY KEY NOT NULL, value TEXT);');
+    db.execSync("INSERT INTO storage (key, value) VALUES ('key1', 'value1');");
+    db.execSync(`PRAGMA user_version = ${FUTURE_DATABASE_VERSION}`);
+    db.closeSync();
+
+    const storage = new SQLiteStorage(databaseName);
+    try {
+      expect(storage.getItemSync('key1')).toBe('value1');
+    } finally {
+      storage.closeSync();
+    }
+    // The migration must never downgrade `user_version`, otherwise the next launch would replay
+    // migrations that have already run.
+    expect(readUserVersion()).toBe(FUTURE_DATABASE_VERSION);
   });
 
   it('should keep existing data when reopening an already migrated database', () => {


### PR DESCRIPTION
# Why

Fixes #47448.

`SQLiteStorage` (`expo-sqlite/kv-store`) can permanently lose its `storage` table on a raced first launch, after which every `getItemSync`/`setItemSync`/`getItemAsync` throws `no such table: storage` forever — the bad state survives an app reinstall, because the database file is restored from backup.

`getDbAsync()` serializes its init through `awaitLock` (added in #33834 for #33754), but `getDbSync()` has no shared lock with it, so both paths can run the first-run migration concurrently on the same cached native connection:

https://github.com/expo/expo/blob/main/packages/expo-sqlite/src/Storage.ts#L360-L381

Both `maybeMigrateDbAsync()` and `maybeMigrateDbSync()` returned early once `user_version >= DATABASE_VERSION`, so any raced launch that ended at the current version without the `storage` table became permanently unrecoverable. The version guard guaranteed the migration was never retried.

Credit to @tsushanth, who diagnosed this and proposed the same fix in #47540 before closing it themselves for inactivity ("Happy to reopen or resubmit if there's still interest"). This PR carries that fix forward on current `main` and adds regression tests and a changelog entry.

# How

Run `MIGRATION_STATEMENT_0` unconditionally instead of only when `user_version === 0`, and keep the `PRAGMA user_version` write conditional.

**Why self-heal rather than a lock.** The issue suggests either guarding `getDbSync()` with a lock or making the migration idempotent. A lock is not actually available on the sync path: `awaitLock` is promise-based and `getDbSync()` is synchronous, so it cannot wait on it, and JS has no synchronous mutex to fall back on. More importantly, a lock only prevents *future* corruption — it does nothing for the users already stuck, who cannot recover by reinstalling. The idempotent migration does not prevent the race, but it makes the resulting broken state self-healing and repairs already-affected databases the next time the app opens them. I left a `NOTE` on `getDbSync()` recording why it does not take the lock and that recovery happens on the next open, so the asymmetry with `getDbAsync()` does not read as an oversight.

This cannot lose data. `MIGRATION_STATEMENT_0` is `CREATE TABLE IF NOT EXISTS storage (...)` — on a healthy database it is a no-op, and there is no `DROP`, `DELETE`, or `CREATE TABLE` without `IF NOT EXISTS` anywhere on this path. The two "normal path" tests below assert that explicitly.

# Test Plan

Four tests added to `packages/expo-sqlite/src/__tests__/Storage-test.ios.ts`. They run against a real file-backed SQLite database through the existing `src/__mocks__/ExpoSQLite` (node:sqlite), and they are deterministic — the broken state is seeded directly rather than reproduced by racing, so there is no timing dependency.

Two reproduce the bug: seed a database at `user_version = 1` with no `storage` table (exactly the state the race leaves behind), then assert that `getItemSync` / `getItemAsync` recreate the table instead of throwing, and that a subsequent write/read round-trips. This is the user-visible path — an app already stuck in the broken state starts working again after upgrading.

Two guard the normal paths: a fresh database still migrates and ends at `user_version = 1`, and reopening an already-migrated database preserves its rows and its version.

Red — new tests against unmodified `Storage.ts` (the two control tests already pass, only the two self-heal tests fail):

```
FAIL iOS src/__tests__/Storage-test.ios.ts
  ● SQLiteStorage migration › should recreate the storage table when the database is at
    the current version but the table is missing (sync)

    no such table: storage

      at SQLiteStorage.getFirstSync [as getItemSync] (src/Storage.ts:147:23)

  ● SQLiteStorage migration › should recreate the storage table when the database is at
    the current version but the table is missing (async)

    Received promise rejected instead of resolved
    Rejected to value: [Error: no such table: storage]

Test Suites: 1 failed, 1 passed, 2 total
Tests:       2 failed, 34 passed, 36 total
```

Green — full `expo-sqlite` suite with the fix applied (baseline on `main` is 190 passing; the 4 added tests take it to 194):

```
Test Suites: 10 passed, 10 total
Tests:       1 skipped, 194 passed, 195 total
```

`et check-packages expo-sqlite` (build, typecheck, depscheck, test, lint, format):

```
expo-sqlite:lint: Found 0 warnings and 0 errors.
expo-sqlite:format: All matched files use the correct format.
🏁 All checks passed.
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

