### PR TITLE
[cli] Fall back to index.html for client-side routes in single-page web exports

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
 - Serve one virtual Metro asset registry to every consumer on React Native 0.87 — Metro's generated asset modules, `react-native/asset-registry` and legacy `@react-native/assets-registry` imports, and React Native core's internal registry imports — so Metro-registered assets and React Native's `<Image>` share one registry instance. ([#49444](https://github.com/expo/expo/pull/49444) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Depend on `@react-native/js-polyfills` directly for the web polyfills instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Serve `index.html` for client-side routes with `expo serve` on `web.output: 'single'` exports, instead of returning 404 for every route except `/` ([#48879](https://github.com/expo/expo/pull/48879) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/serve/__tests__/serveAsync-test.ts
+++ b/packages/@expo/cli/src/serve/__tests__/serveAsync-test.ts
@@ -1,0 +1,161 @@
+import { vol } from 'memfs';
+import { once } from 'node:events';
+import http from 'node:http';
+
+import { serveAsync } from '../serveAsync';
+
+jest.mock('../../utils/nodeEnv', () => ({ loadEnvFiles: jest.fn() }));
+jest.mock('../../utils/port', () => ({
+  // Bind to port 0 so the OS assigns a free ephemeral port to every test server.
+  resolveMetroPortAsync: jest.fn(async () => 0),
+}));
+
+const indexHtml = `<!DOCTYPE html><html><body><div id="root">single-page shell</div></body></html>`;
+const exploreHtml = `<!DOCTYPE html><html><body><div id="root">prerendered explore</div></body></html>`;
+
+/** A `web.output: 'single'` export: only `index.html`, no `_expo/.routes.json`. */
+function singlePageExport(projectRoot: string) {
+  return {
+    [`${projectRoot}/package.json`]: JSON.stringify({ name: 'single-app' }),
+    [`${projectRoot}/dist/index.html`]: indexHtml,
+    [`${projectRoot}/dist/_expo/static/js/web/entry-abc123.js`]: `console.log('entry')`,
+  };
+}
+
+/** A `web.output: 'static'` export: one HTML file per route, plus `_expo/.routes.json`. */
+function staticExport(projectRoot: string) {
+  return {
+    [`${projectRoot}/package.json`]: JSON.stringify({ name: 'static-app' }),
+    [`${projectRoot}/dist/index.html`]: indexHtml,
+    [`${projectRoot}/dist/explore.html`]: exploreHtml,
+    [`${projectRoot}/dist/_expo/.routes.json`]: JSON.stringify({}),
+    [`${projectRoot}/dist/_expo/static/js/web/entry-abc123.js`]: `console.log('entry')`,
+  };
+}
+
+const servers: http.Server[] = [];
+const createServer = http.createServer;
+
+beforeEach(() => {
+  vol.reset();
+  jest.spyOn(http, 'createServer').mockImplementation((...args: any[]) => {
+    const server = (createServer as any)(...args);
+    servers.push(server);
+    return server;
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map((server) => new Promise((resolve) => server.close(resolve)))
+  );
+});
+
+/** Serve `<projectRoot>/dist` and return the ephemeral port it is listening on. */
+async function serveFixtureAsync(projectRoot: string): Promise<number> {
+  await serveAsync(projectRoot, { isDefaultDirectory: true });
+
+  const server = servers[servers.length - 1];
+  if (!server) {
+    throw new Error('Expected `serveAsync` to have created an HTTP server');
+  }
+  if (!server.listening) {
+    await once(server, 'listening');
+  }
+
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error(`Expected the server to be listening on a TCP port, found: ${address}`);
+  }
+  return address.port;
+}
+
+/** Request a URL the way a browser requests a document, e.g. a reload or a deep link. */
+function navigateAsync(port: number, pathname: string) {
+  return fetch(`http://127.0.0.1:${port}${pathname}`, {
+    headers: { accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' },
+  });
+}
+
+describe(serveAsync, () => {
+  describe(`web.output: 'single'`, () => {
+    it(`serves index.html for a client-side route`, async () => {
+      vol.fromJSON(singlePageExport('/single-app'));
+
+      const port = await serveFixtureAsync('/single-app');
+      const response = await navigateAsync(port, '/explore');
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('content-type')).toMatch(/text\/html/);
+      await expect(response.text()).resolves.toBe(indexHtml);
+    });
+
+    it(`serves index.html for a nested client-side route`, async () => {
+      vol.fromJSON(singlePageExport('/single-app'));
+
+      const port = await serveFixtureAsync('/single-app');
+      const response = await navigateAsync(port, '/products/42?ref=email');
+
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe(indexHtml);
+    });
+
+    it(`returns 404 for a missing asset instead of the HTML shell`, async () => {
+      vol.fromJSON(singlePageExport('/single-app'));
+
+      const port = await serveFixtureAsync('/single-app');
+      const response = await fetch(
+        `http://127.0.0.1:${port}/_expo/static/js/web/entry-missing.js`,
+        { headers: { accept: '*/*' } }
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.text()).resolves.toBe('Not Found');
+    });
+
+    it(`serves existing files as-is`, async () => {
+      vol.fromJSON(singlePageExport('/single-app'));
+
+      const port = await serveFixtureAsync('/single-app');
+      const response = await fetch(`http://127.0.0.1:${port}/_expo/static/js/web/entry-abc123.js`);
+
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe(`console.log('entry')`);
+    });
+  });
+
+  describe(`web.output: 'static'`, () => {
+    it(`returns 404 for an unknown route`, async () => {
+      vol.fromJSON(staticExport('/static-app'));
+
+      const port = await serveFixtureAsync('/static-app');
+      const response = await navigateAsync(port, '/does-not-exist');
+
+      expect(response.status).toBe(404);
+      await expect(response.text()).resolves.toBe('Not Found');
+    });
+
+    it(`serves the prerendered HTML file for a known route`, async () => {
+      vol.fromJSON(staticExport('/static-app'));
+
+      const port = await serveFixtureAsync('/static-app');
+      const response = await navigateAsync(port, '/explore');
+
+      expect(response.status).toBe(200);
+      await expect(response.text()).resolves.toBe(exploreHtml);
+    });
+  });
+
+  it(`returns 404 when the export has no index.html`, async () => {
+    vol.fromJSON({
+      '/native-app/package.json': JSON.stringify({ name: 'native-app' }),
+      '/native-app/dist/_expo/static/js/ios/entry-abc123.hbc': `native bundle`,
+    });
+
+    const port = await serveFixtureAsync('/native-app');
+    const response = await navigateAsync(port, '/explore');
+
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe('Not Found');
+  });
+});

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -110,7 +110,7 @@ async function startStaticServerAsync(dist: string, options: Options) {
 
 /**
  * Whether the request is a document navigation, such as opening a URL or reloading a page.
- * Only navigations may fall back to the single-page app shell — a missing script, stylesheet,
+ * Only navigations may fall back to the single-page app shell. A missing script, stylesheet,
  * or image must still 404 instead of resolving to HTML.
  */
 function isNavigationRequest(req: http.IncomingMessage): boolean {

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -58,6 +58,10 @@ export async function serveAsync(inputDir: string, options: Options) {
 
 async function startStaticServerAsync(dist: string, options: Options) {
   const staticManifest = await loadStaticManifestAsync(dist);
+  // Only `web.output: 'static'` exports write `_expo/.routes.json`, and they emit one HTML file per
+  // route, so a missing file there is a genuine 404. A `web.output: 'single'` export emits nothing
+  // but `index.html`, so client-side routes have to fall back to it to survive a reload or deep link.
+  const useSpaFallback = !staticManifest && (await fileExistsAsync(path.join(dist, 'index.html')));
 
   const server = http.createServer((req, res) => {
     // Remove query strings and decode URI
@@ -82,6 +86,15 @@ async function startStaticServerAsync(dist: string, options: Options) {
       })
       .on('error', (err: any) => {
         if (err.status === 404) {
+          if (useSpaFallback && isNavigationRequest(req)) {
+            send(req, '/index.html', { root: dist })
+              .on('error', (fallbackError: any) => {
+                res.statusCode = fallbackError.status || 500;
+                res.end('Internal Server Error');
+              })
+              .pipe(res);
+            return;
+          }
           res.statusCode = 404;
           res.end('Not Found');
           return;
@@ -93,6 +106,18 @@ async function startStaticServerAsync(dist: string, options: Options) {
   });
 
   server.listen(options.port!);
+}
+
+/**
+ * Whether the request is a document navigation, such as opening a URL or reloading a page.
+ * Only navigations may fall back to the single-page app shell — a missing script, stylesheet,
+ * or image must still 404 instead of resolving to HTML.
+ */
+function isNavigationRequest(req: http.IncomingMessage): boolean {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return false;
+  }
+  return !!req.headers.accept?.includes('text/html');
 }
 
 async function startDynamicServerAsync(dist: string, options: Options) {


### PR DESCRIPTION
# Why

Fixes #39477.

`expo serve` on a `web.output: 'single'` export returns **404 for every route except `/`**. Reloading a page or opening a deep link breaks, which in turn breaks auth redirects and e2e testing of exported web builds.

Reproduced on `main` with the reporter's minimal repro ([davidjbng/expo-serve-spa](https://github.com/davidjbng/expo-serve-spa)):

```
$ npx expo export -p web && npx expo serve --port 8099
$ curl -o /dev/null -w '%{http_code}\n' -H 'Accept: text/html' http://localhost:8099/
200
$ curl -i -H 'Accept: text/html' http://localhost:8099/explore
HTTP/1.1 404 Not Found
Not Found
```

`startStaticServerAsync()` pipes through `send()` and ends the response with a literal `Not Found` on a 404. A `single` export contains only `dist/index.html` plus assets — there is no `explore.html` — so there is no SPA history fallback. `startDynamicServerAsync()` already falls through to the server handler; only the static path lacks an equivalent.

This picks up #38230 by @davidjbng, which was closed unreviewed by a bulk sweep of stale PRs. That PR identified the fix correctly; what it flagged as missing was the discriminator against `web.output: 'static'` and a test. Both are addressed here.

# How

In the static path, a request that 404s falls back to `dist/index.html` — but only when both of these hold:

**1. The export is a single-page export.** The discriminator is `_expo/.routes.json`, which `startStaticServerAsync()` already loads via `loadStaticManifestAsync()`. Only `web.output: 'static'` writes it (`exportStaticAsync.ts`, the `if (!exportServer)` branch); a `single` export never calls `exportFromServerAsync()` at all. The repo's own e2e tests pin this both ways — `e2e/__tests__/export/static-rendering.test.ts` asserts `_expo/.routes.json` is present for a static export, and the exhaustive file list in `e2e/__tests__/export.test.ts` for a default (`single`) export contains `index.html` and no routes manifest.

I chose this over reading `exp.web.output` from the app config because `expo serve` is already artifact-driven — `isStaticExportAsync()` discriminates static from server output by looking for `dist/server/_expo/routes.json`, not by reading the config. The dist being served is the ground truth; the app config can have drifted since the export, and `expo serve <dir>` may point at a dist that does not belong to the resolved project root. `web.output` also defaults to `single` when unset, so a config-based check fails open on exactly the case where it should fail closed.

The fallback additionally requires `dist/index.html` to exist, so pointing `expo serve` at a native-only export still 404s rather than 500s.

**2. The request is a document navigation** — `GET`/`HEAD` with `text/html` in `Accept`. This matters: a blanket fallback would answer a missing script or image with the HTML shell at 200, which is the classic `Uncaught SyntaxError: Unexpected token '<'` failure and hides real broken-asset bugs. Missing assets keep returning 404.

# Test Plan

New `packages/@expo/cli/src/serve/__tests__/serveAsync-test.ts` boots the real server on an ephemeral port over in-memory `dist/` fixtures and asserts over HTTP:

| fixture | request | expected |
| --- | --- | --- |
| `single` | `GET /explore` (navigation) | 200, `index.html` |
| `single` | `GET /products/42?ref=email` | 200, `index.html` |
| `single` | `GET /_expo/.../entry-missing.js` (`Accept: */*`) | **404** |
| `single` | `GET /_expo/.../entry-abc123.js` | 200, the real file |
| `static` | `GET /does-not-exist` (navigation) | **404** |
| `static` | `GET /explore` (navigation) | 200, `explore.html` |
| no `index.html` | `GET /explore` (navigation) | **404** |

Counterfactual — with the source change reverted and the test kept, exactly the two SPA-fallback cases fail and every 404 assertion still passes:

```
✓ returns 404 when the export has no index.html
✕ serves index.html for a client-side route      Expected: 200  Received: 404
✕ serves index.html for a nested client-side route   Expected: 200  Received: 404
✓ returns 404 for a missing asset instead of the HTML shell
✓ serves existing files as-is
✓ returns 404 for an unknown route
✓ serves the prerendered HTML file for a known route

Tests: 2 failed, 5 passed, 7 total
```

Restored, all 7 pass.

End-to-end against a real export, serving the reporter's repro with this build of the CLI:

```
# web.output: 'single'
GET /explore            Accept: text/html   -> 200, 1424 bytes, Content-Type: text/html   (index.html)
GET /_expo/static/js/web/missing.js  Accept: */*  -> 404
GET /_expo/static/js/web/entry-<hash>.js          -> 200, 1969181 bytes

# web.output: 'static' (same app re-exported)
GET /explore            Accept: text/html   -> 200, 24731 bytes  (prerendered explore.html)
GET /does-not-exist     Accept: text/html   -> 404 Not Found
GET /                   Accept: text/html   -> 200
```

Package checks: `et check-packages @expo/cli` passes. `pnpm test` in `packages/@expo/cli` goes from 243 suites / 1925 passing to 244 suites / 1932 passing, no regressions.

## One caveat worth flagging

`_expo/.routes.json` for static exports is itself unreleased (#47429 / #47781, still under **Unpublished**). I verified that a static export produced by the currently released CLI (SDK 54) does **not** contain it, so serving that older dist with a newer CLI would take the SPA path and answer an unknown route with the shell at 200 instead of 404. Known routes are unaffected, and the shell hydrates expo-router which then client-renders `+not-found`, so the degradation is limited to the status code. Within a single release the exporter and the server always agree. I left it at the single clean discriminator rather than stacking heuristics, but I'm happy to add a guard if you'd rather be strict about older dists.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
