### PR TITLE
fix(patch-project): Use development mode for env files

### DIFF
--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Use development mode when loading Expo config and `.env` files. ([#48882](https://github.com/expo/expo/pull/48882) by [@ramonclaudio](https://github.com/ramonclaudio))
+
 ### 💡 Others
 
 ## 57.0.9 - 2026-07-29

--- a/packages/patch-project/src/cli/__tests__/patchProjectAsync-test.ts
+++ b/packages/patch-project/src/cli/__tests__/patchProjectAsync-test.ts
@@ -1,0 +1,53 @@
+import { loadProjectEnv, logLoadedEnv } from '@expo/env';
+import { getConfig } from 'expo/config';
+
+import { patchProjectAsync } from '../patchProjectAsync';
+
+jest.mock('@expo/env', () => ({
+  loadProjectEnv: jest.fn(),
+  logLoadedEnv: jest.fn(),
+}));
+jest.mock('expo/config', () => ({
+  getConfig: jest.fn(),
+}));
+jest.mock('../resolveFromExpoCli', () => ({
+  resolveFromExpoCli: jest.fn(() => 'patch-project-resolve-options'),
+}));
+jest.mock(
+  'patch-project-resolve-options',
+  () => ({
+    ensureValidPlatforms: jest.fn(() => []),
+  }),
+  { virtual: true }
+);
+
+describe(patchProjectAsync, () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, EXPO_CONFIG_MODE: 'production' };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('loads and logs development env before Expo config', async () => {
+    const envInfo = { result: 'skipped' as const, loaded: [] };
+    jest.mocked(loadProjectEnv).mockReturnValue(envInfo);
+    let configMode: string | undefined = 'not loaded';
+    jest.mocked(getConfig).mockImplementation(() => {
+      configMode = process.env.EXPO_CONFIG_MODE;
+      return { exp: {} } as ReturnType<typeof getConfig>;
+    });
+
+    await patchProjectAsync('/app', { platforms: [] });
+
+    expect(loadProjectEnv).toHaveBeenCalledWith('/app', { mode: 'development' });
+    expect(logLoadedEnv).toHaveBeenCalledWith(envInfo);
+    expect(jest.mocked(loadProjectEnv).mock.invocationCallOrder[0]).toBeLessThan(
+      jest.mocked(getConfig).mock.invocationCallOrder[0]!
+    );
+    expect(configMode).toBeUndefined();
+  });
+});

--- a/packages/patch-project/src/cli/__tests__/patchProjectAsync-test.ts
+++ b/packages/patch-project/src/cli/__tests__/patchProjectAsync-test.ts
@@ -4,6 +4,7 @@ import { getConfig } from 'expo/config';
 import { patchProjectAsync } from '../patchProjectAsync';
 
 jest.mock('@expo/env', () => ({
+  ...jest.requireActual('@expo/env'),
   loadProjectEnv: jest.fn(),
   logLoadedEnv: jest.fn(),
 }));
@@ -22,24 +23,27 @@ jest.mock(
 );
 
 describe(patchProjectAsync, () => {
-  const originalEnv = process.env;
+  const devGlobal = globalThis as typeof globalThis & { __DEV__?: boolean };
+  const originalDev = devGlobal.__DEV__;
+  const originalConfigMode = process.env.__EXPO_CONFIG_MODE;
 
   beforeEach(() => {
-    process.env = { ...originalEnv, EXPO_CONFIG_MODE: 'production' };
+    process.env.__EXPO_CONFIG_MODE = 'production';
   });
 
-  afterAll(() => {
-    process.env = originalEnv;
+  afterEach(() => {
+    devGlobal.__DEV__ = originalDev;
+    if (originalConfigMode === undefined) {
+      delete process.env.__EXPO_CONFIG_MODE;
+    } else {
+      process.env.__EXPO_CONFIG_MODE = originalConfigMode;
+    }
   });
 
   it('loads and logs development env before Expo config', async () => {
     const envInfo = { result: 'skipped' as const, loaded: [] };
     jest.mocked(loadProjectEnv).mockReturnValue(envInfo);
-    let configMode: string | undefined = 'not loaded';
-    jest.mocked(getConfig).mockImplementation(() => {
-      configMode = process.env.EXPO_CONFIG_MODE;
-      return { exp: {} } as ReturnType<typeof getConfig>;
-    });
+    jest.mocked(getConfig).mockReturnValue({ exp: {} } as ReturnType<typeof getConfig>);
 
     await patchProjectAsync('/app', { platforms: [] });
 
@@ -48,6 +52,7 @@ describe(patchProjectAsync, () => {
     expect(jest.mocked(loadProjectEnv).mock.invocationCallOrder[0]).toBeLessThan(
       jest.mocked(getConfig).mock.invocationCallOrder[0]!
     );
-    expect(configMode).toBeUndefined();
+    expect(devGlobal.__DEV__).toBe(true);
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 });

--- a/packages/patch-project/src/cli/patchProjectAsync.ts
+++ b/packages/patch-project/src/cli/patchProjectAsync.ts
@@ -44,6 +44,7 @@ export async function patchProjectAsync(
     const envInfo = loadProjectEnv(projectRoot, { mode: 'development' });
     logLoadedEnv(envInfo);
   } finally {
+    // Prevents an inherited mode from reaching the app config.
     delete process.env.EXPO_CONFIG_MODE;
   }
 

--- a/packages/patch-project/src/cli/patchProjectAsync.ts
+++ b/packages/patch-project/src/cli/patchProjectAsync.ts
@@ -1,3 +1,4 @@
+import { loadProjectEnv, logLoadedEnv } from '@expo/env';
 import chalk from 'chalk';
 import { getConfig, type ExpoConfig } from 'expo/config';
 import { type ModPlatform } from 'expo/config-plugins';
@@ -39,12 +40,12 @@ export async function patchProjectAsync(
   const { ensureValidPlatforms } = require(
     resolveFromExpoCli(projectRoot, 'build/src/prebuild/resolveOptions')
   ) as typeof import('@expo/cli/src/prebuild/resolveOptions');
-  const { setNodeEnv } = require(
-    resolveFromExpoCli(projectRoot, 'build/src/utils/nodeEnv')
-  ) as typeof import('@expo/cli/src/utils/nodeEnv');
-
-  setNodeEnv('development');
-  require('@expo/env').load(projectRoot);
+  try {
+    const envInfo = loadProjectEnv(projectRoot, { mode: 'development' });
+    logLoadedEnv(envInfo);
+  } finally {
+    delete process.env.EXPO_CONFIG_MODE;
+  }
 
   const { exp } = await getConfig(projectRoot);
   const patchRoot = options.patchRoot || 'cng-patches';

--- a/packages/patch-project/src/cli/patchProjectAsync.ts
+++ b/packages/patch-project/src/cli/patchProjectAsync.ts
@@ -1,4 +1,4 @@
-import { loadProjectEnv, logLoadedEnv } from '@expo/env';
+import { consumeConfigEnvMode, loadProjectEnv, logLoadedEnv } from '@expo/env';
 import chalk from 'chalk';
 import { getConfig, type ExpoConfig } from 'expo/config';
 import { type ModPlatform } from 'expo/config-plugins';
@@ -16,6 +16,10 @@ import {
 } from './normalizeNativeProjects';
 import { resolveFromExpoCli } from './resolveFromExpoCli';
 import { createWorkingDirectoriesAsync, type WorkingDirectories } from './workingDirectories';
+
+declare namespace globalThis {
+  let __DEV__: boolean | undefined;
+}
 
 const debug = require('debug')('patch-project') as typeof console.log;
 
@@ -40,13 +44,10 @@ export async function patchProjectAsync(
   const { ensureValidPlatforms } = require(
     resolveFromExpoCli(projectRoot, 'build/src/prebuild/resolveOptions')
   ) as typeof import('@expo/cli/src/prebuild/resolveOptions');
-  try {
-    const envInfo = loadProjectEnv(projectRoot, { mode: 'development' });
-    logLoadedEnv(envInfo);
-  } finally {
-    // Prevents an inherited mode from reaching the app config.
-    delete process.env.EXPO_CONFIG_MODE;
-  }
+  consumeConfigEnvMode();
+  globalThis.__DEV__ = true;
+  const envInfo = loadProjectEnv(projectRoot, { mode: 'development' });
+  logLoadedEnv(envInfo);
 
   const { exp } = await getConfig(projectRoot);
   const patchRoot = options.patchRoot || 'cng-patches';


### PR DESCRIPTION
# Why

Patch Project gets `setNodeEnv` from Expo CLI and then loads env files in a separate step, which can cause inconsistencies.

# How

I updated it to use the shared API with `development` mode for both env files and config.

# Test Plan

Tests and CI checks pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)