### PR TITLE
[observe][iOS][Android] Export spans as OTLP traces

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Expose `ObserveErrorBoundary`, a React error boundary that records render-phase errors. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Add `reportError` to report caught, non-fatal errors from your own `try`/`catch` blocks. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
 - Add an `errorHandlingEnabled` option to `configure` to opt out of recording unhandled JavaScript errors. ([#48506](https://github.com/expo/expo/pull/48506) by [@tsapeta](https://github.com/tsapeta))
+- Export network requests as OTLP traces. ([#48883](https://github.com/expo/expo/pull/48883) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -11,10 +11,12 @@
 - Add `reportError` to report caught, non-fatal errors from your own `try`/`catch` blocks. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
 - Add an `errorHandlingEnabled` option to `configure` to opt out of recording unhandled JavaScript errors. ([#48506](https://github.com/expo/expo/pull/48506) by [@tsapeta](https://github.com/tsapeta))
 - Add `Observe.clientId`, the EAS client id recorded on every event, so apps can correlate Observe data with other services. ([#49599](https://github.com/expo/expo/pull/49599) by [@kadikraman](https://github.com/kadikraman))
+- Export network requests as OTLP traces. ([#48883](https://github.com/expo/expo/pull/48883) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 
 - Fix OTel date conversion ([#48161](https://github.com/expo/expo/pull/48161) by [@Ubax](https://github.com/Ubax))
+- [iOS] Stop overlapping dispatches from sending the same pending rows twice. `dispatchEvents()` now waits for a dispatch already in progress instead of overlapping with it. ([#48883](https://github.com/expo/expo/pull/48883) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
@@ -145,3 +145,13 @@ data class Event(
   val metrics: List<EASMetric>,
   val logs: List<LogEvent> = emptyList()
 )
+
+/**
+ * One session's spans paired with the event carrying that session's resource metadata, ready
+ * for the traces dispatch. Spans travel separately from `Event` because they aren't part of
+ * the payload shape the metrics/logs signals share.
+ */
+data class SpanBatch(
+  val event: Event,
+  val spans: List<OTSpan>
+)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -27,6 +27,8 @@ class EventDispatcher(
 
   private fun logsEndpointUrl(): String = "$baseProjectUrl/v1/logs"
 
+  private fun tracesEndpointUrl(): String = "$baseProjectUrl/v1/traces"
+
   /**
    * POSTs `events` to the metrics endpoint and classifies the response per the OTLP retry
    * spec. Non-throwing: payload-encoding errors collapse to `NonRetryable` (same bytes will
@@ -74,6 +76,30 @@ class EventDispatcher(
         return@suspendCancellableCoroutine Unit
       }
       executePost(continuation, logsEndpointUrl(), body)
+    }
+
+  /**
+   * Dispatches span batches to `{baseUrl}/{projectId}/v1/traces`. Each batch carries one
+   * session's spans plus the event holding that session's resource metadata.
+   */
+  suspend fun dispatchSpans(batches: List<SpanBatch>): DispatchResult =
+    suspendCancellableCoroutine { continuation ->
+      if (batches.isEmpty()) {
+        // Empty input isn't a server response - signal success.
+        continuation.resume(DispatchResult.Success)
+        return@suspendCancellableCoroutine Unit
+      }
+      val easId = EASClientID(context).uuid.toString()
+      val body = try {
+        OTTracesRequestBody(
+          resourceSpans = batches.map { it.event.toOTResourceSpans(easId, it.spans) }
+        ).toJson(prettyPrint = true)
+      } catch (e: Exception) {
+        Log.w(OBSERVE_TAG, "Encoding traces request body failed: ${e.message}")
+        continuation.resume(DispatchResult.NonRetryableFailure("encoding error: ${e.message}"))
+        return@suspendCancellableCoroutine Unit
+      }
+      executePost(continuation, tracesEndpointUrl(), body)
     }
 
   private fun executePost(

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -17,6 +17,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
+import expo.modules.appmetrics.storage.MetricsDatabase
 import expo.modules.appmetrics.storage.SessionManager
 
 /**
@@ -52,7 +53,8 @@ class ObservabilityBackgroundWorker(
       pendingMetricsManager = pendingMetricsManager,
       pendingLogsManager = pendingLogsManager,
       baseUrl = baseUrl,
-      isDebugBuild = BuildConfig.DEBUG
+      isDebugBuild = BuildConfig.DEBUG,
+      spanDao = MetricsDatabase.getDatabase(context).spanDao()
     )
   }
 
@@ -83,6 +85,7 @@ class ObservabilityBackgroundWorker(
       observabilityManager.cleanup()
       observabilityManager.dispatchUnsentMetrics()
       observabilityManager.dispatchUnsentLogs()
+      observabilityManager.dispatchUnsentSpans()
       Log.d(OBSERVE_TAG, "Successfully dispatched unsent metrics and logs")
       Result.success()
     } catch (e: Exception) {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -18,7 +18,7 @@ import androidx.work.workDataOf
 import expo.modules.appmetrics.storage.SessionManager
 
 /**
- * Background worker that dispatches stored metrics and logs to EAS Observe.
+ * Background worker that dispatches stored metrics, logs, and spans to EAS Observe.
  */
 class ObservabilityBackgroundWorker(
   context: Context,
@@ -72,10 +72,11 @@ class ObservabilityBackgroundWorker(
       observabilityManager.cleanup()
       observabilityManager.dispatchUnsentMetrics()
       observabilityManager.dispatchUnsentLogs()
-      Log.d(OBSERVE_TAG, "Successfully dispatched unsent metrics and logs")
+      observabilityManager.dispatchUnsentSpans()
+      Log.d(OBSERVE_TAG, "Successfully dispatched unsent metrics, logs, and spans")
       Result.success()
     } catch (e: Exception) {
-      Log.e(OBSERVE_TAG, "Failed to dispatch metrics", e)
+      Log.e(OBSERVE_TAG, "Failed to dispatch metrics, logs, and spans", e)
       // Retry with exponential backoff
       Result.retry()
     }
@@ -108,7 +109,7 @@ class ObservabilityBackgroundWorker(
         .getInstance(context)
         .enqueueUniqueWork(
           WORK_NAME,
-          // Keep an in-flight dispatch; cancelling it can duplicate a request the server received.
+          // Keep an in-flight dispatch; canceling it can duplicate a request the server received.
           ExistingWorkPolicy.KEEP,
           periodicWork
         )

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -5,7 +5,9 @@ import android.util.Log
 import expo.modules.easclient.EASClientID
 import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
+import expo.modules.appmetrics.storage.MetricsDatabase
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.storage.SpanDao
 import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.interfaces.constants.ConstantsInterface
 import kotlinx.coroutines.sync.Mutex
@@ -42,7 +44,8 @@ class ObservabilityManager(
       pendingLogsManager = pendingLogsManager,
       projectId = projectId,
       baseUrl = baseUrl,
-      isDebugBuild = BuildConfig.DEBUG
+      isDebugBuild = BuildConfig.DEBUG,
+      spanDao = MetricsDatabase.getDatabase(context).spanDao()
     )
 
     sessionManager.addMetricsInsertListener { metricIds ->
@@ -59,6 +62,10 @@ class ObservabilityManager(
 
   suspend fun dispatchUnsentLogs() {
     baseManager.dispatchUnsentLogs()
+  }
+
+  suspend fun dispatchUnsentSpans() {
+    baseManager.dispatchUnsentSpans()
   }
 
   fun scheduleBackgroundDispatch() {
@@ -81,8 +88,20 @@ class BaseObservabilityManager(
   private val deterministicUniformValueProvider: () -> Double = {
     EASClientID.deterministicUniformValue(EASClientID(context).uuid)
   },
-  private val currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() }
+  private val currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() },
+  /**
+   * Source of persisted spans, or `null` to disable the traces signal (kept optional so
+   * existing constructions and tests that don't exercise spans stay valid).
+   */
+  private val spanDao: SpanDao? = null
 ) {
+  companion object {
+    /**
+     * Maximum spans per request accepted by the ingestion endpoint; it rejects everything past
+     * this count within one POST, so larger backlogs are sent as sequential chunks.
+     */
+    const val MAX_SPANS_PER_REQUEST = 512
+  }
   private val eventDispatcher = EventDispatcher(
     context = context,
     projectId = projectId,
@@ -104,6 +123,7 @@ class BaseObservabilityManager(
    */
   private var metricsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
   private var logsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
+  private var spansRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
 
   /**
    * Per-signal mutexes that serialize same-signal dispatch calls. Two `dispatchEvents`
@@ -118,6 +138,7 @@ class BaseObservabilityManager(
    */
   private val metricsDispatchMutex = Mutex()
   private val logsDispatchMutex = Mutex()
+  private val spansDispatchMutex = Mutex()
 
   /**
    * Returns true and logs when an active retry gate suppresses this dispatch round. Called
@@ -267,6 +288,71 @@ class BaseObservabilityManager(
           "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
         )
       is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+    }
+  }
+
+  /**
+   * Dispatches persisted spans to `/v1/traces`.
+   *
+   * Unlike metrics and logs there is no pending-ids store: nothing else reads the `spans` rows
+   * back, so a consumed (or deliberately dropped) batch is deleted outright and the table
+   * itself acts as the queue. Rows survive on a retryable failure and go out on the next
+   * dispatch. Batches are chunked at the server's per-request span limit.
+   */
+  suspend fun dispatchUnsentSpans(): Unit = spansDispatchMutex.withLock {
+    val spanDao = spanDao ?: return
+
+    if (retryGateBlocks(spansRetryGate, "spans")) {
+      return
+    }
+
+    if (!shouldDispatch()) {
+      // Drop the backlog without materializing it; one MAX query is enough to know how far to
+      // delete. Mirrors metrics/logs removing pending ids they won't send.
+      spanDao.getMaxId()?.let { spanDao.deleteUpTo(it) }
+      return
+    }
+
+    val pendingSpans = spanDao.getAll()
+    if (pendingSpans.isEmpty()) {
+      return
+    }
+
+    // Rows arrive ordered by id; a chunk that fails retryably stops the loop and leaves its
+    // rows (and everything after them) for the next dispatch.
+    for (chunk in pendingSpans.chunked(MAX_SPANS_PER_REQUEST)) {
+      val batches = chunk.groupBy { it.sessionId }.mapNotNull { (sessionId, spans) ->
+        // Spans whose session row no longer exists are skipped — their rows are about to be
+        // deleted below anyway.
+        val session = sessionManager.getSessionRow(sessionId) ?: return@mapNotNull null
+        SpanBatch(
+          event = Event(metadata = Metadata.fromSessionMetadata(session), metrics = emptyList()),
+          spans = spans.map { it.toOTSpan() }
+        )
+      }
+      val highestId = chunk.last().id
+      if (batches.isEmpty()) {
+        spanDao.deleteUpTo(highestId)
+        continue
+      }
+      val result = eventDispatcher.dispatchSpans(batches)
+      spansRetryGate = nextGate(spansRetryGate, result)
+      when (result) {
+        is DispatchResult.PartialSuccess ->
+          Log.w(
+            OBSERVE_TAG,
+            "Partial success on batch of ${chunk.size} span(s): " +
+              "server rejected ${result.partial.rejectedCount} " +
+              "(${result.partial.errorMessage ?: "no error message"})"
+          )
+        is DispatchResult.NonRetryableFailure ->
+          Log.w(OBSERVE_TAG, "Dropping batch of ${chunk.size} span(s): ${result.reason}")
+        is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+      }
+      if (!DispatchUtils.shouldRemovePending(result)) {
+        return
+      }
+      spanDao.deleteUpTo(highestId)
     }
   }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import expo.modules.easclient.EASClientID
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.storage.Span
 import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.interfaces.constants.ConstantsInterface
 import kotlinx.coroutines.currentCoroutineContext
@@ -49,6 +50,10 @@ class ObservabilityManager(
     baseManager.dispatchUnsentLogs()
   }
 
+  suspend fun dispatchUnsentSpans() {
+    baseManager.dispatchUnsentSpans()
+  }
+
   fun scheduleBackgroundDispatch() {
     ObservabilityBackgroundWorker.scheduleBackgroundDispatch(
       context = context,
@@ -91,6 +96,7 @@ class BaseObservabilityManager(
    */
   private var metricsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
   private var logsRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
+  private var spansRetryGate: DispatchUtils.RetryGateState = DispatchUtils.RetryGateState.initial
 
   /**
    * Returns true and logs when an active retry gate suppresses this dispatch round. Called
@@ -276,6 +282,90 @@ class BaseObservabilityManager(
     }
   }
 
+  /**
+   * Dispatches persisted spans to `/v1/traces`.
+   *
+   * Unlike metrics and logs there is no persisted cursor yet: a consumed (or deliberately
+   * dropped) batch is deleted outright and the table itself acts as the queue. Rows survive
+   * on a retryable failure and go out on the next dispatch. Batches are chunked at the
+   * server's per-request span limit.
+   */
+  suspend fun dispatchUnsentSpans(): Unit = spansDispatchMutex.withLock {
+    if (retryGateBlocks(spansRetryGate, "spans")) {
+      return
+    }
+
+    if (!shouldDispatch()) {
+      // Mirrors metrics/logs advancing the cursor past rows they won't send.
+      sessionManager.getMaxSpanId()?.let { sessionManager.deleteSpansUpTo(it) }
+      return
+    }
+
+    // Rows are read in id order one server-sized chunk at a time; a chunk that fails retryably
+    // stops the loop and leaves its rows (and everything after them) for the next dispatch. An
+    // oversized chunk is split in half and retried, so one huge span doesn't drop its whole
+    // chunk.
+    var readCursor = -1L
+    val chunks = ArrayDeque<List<Span>>()
+    while (currentCoroutineContext().isActive) {
+      if (chunks.isEmpty()) {
+        val nextChunk = sessionManager.getSpans(readCursor, MAX_SPANS_PER_REQUEST)
+        if (nextChunk.isEmpty()) {
+          return
+        }
+        readCursor = nextChunk.last().id
+        chunks.addLast(nextChunk)
+      }
+      val chunk = chunks.removeFirst()
+      val spansBySessionId = chunk.groupBy { it.sessionId }
+      // Batched because an offline backlog spans many sessions, and each halving retry would
+      // otherwise re-run every lookup.
+      val sessions = sessionManager.getSessions(spansBySessionId.keys).associateBy { it.id }
+      val batches = spansBySessionId.mapNotNull { (sessionId, spans) ->
+        // Spans whose session row no longer exists are skipped, because their rows are about to be
+        // deleted below anyway.
+        val session = sessions[sessionId] ?: return@mapNotNull null
+        SpanBatch(
+          event = Event(metadata = Metadata.fromSessionMetadata(session), metrics = emptyList()),
+          spans = spans.map { it.toOTSpan() }
+        )
+      }
+      val highestId = chunk.last().id
+      if (batches.isEmpty()) {
+        sessionManager.deleteSpansUpTo(highestId)
+        continue
+      }
+      val result = eventDispatcher.dispatchSpans(batches)
+      spansRetryGate = nextGate(spansRetryGate, result)
+      when (result) {
+        is DispatchResult.PartialSuccess ->
+          Log.w(
+            OBSERVE_TAG,
+            "Partial success on batch of ${chunk.size} span(s): " +
+              "server rejected ${result.partial.rejectedCount} " +
+              "(${result.partial.errorMessage ?: "no error message"})"
+          )
+        is DispatchResult.NonRetryableFailure ->
+          Log.w(OBSERVE_TAG, "Dropping batch of ${chunk.size} span(s): ${result.reason}")
+        DispatchResult.PayloadTooLarge -> if (chunk.size == 1) {
+          Log.w(OBSERVE_TAG, "Dropping span that exceeds the server's payload limit")
+        }
+        DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+      }
+      when (spanDispatchDisposition(result, chunk.size)) {
+        SpanDispatchDisposition.HALVE_AND_RETRY -> {
+          // `toList()` rather than the `subList` views: nested views would keep the whole
+          // original chunk (up to 512 rows with their JSON blobs) reachable until every
+          // descendant had been processed. Matches iOS, which materializes with `Array`.
+          chunks.addFirst(chunk.subList(chunk.size / 2, chunk.size).toList())
+          chunks.addFirst(chunk.subList(0, chunk.size / 2).toList())
+        }
+        SpanDispatchDisposition.DELETE_AND_CONTINUE -> sessionManager.deleteSpansUpTo(highestId)
+        SpanDispatchDisposition.KEEP_AND_STOP -> return
+      }
+    }
+  }
+
   private fun isInSample(): Boolean {
     val rate = ObservePreferences.getConfig(context)?.sampleRate ?: return true
     val clamped = rate.coerceIn(0.0, 1.0)
@@ -303,8 +393,15 @@ class BaseObservabilityManager(
   }
 
   companion object {
+    /**
+     * Maximum spans per request accepted by the ingestion endpoint; it rejects everything past
+     * this count within one POST, so larger backlogs are sent as sequential chunks.
+     */
+    const val MAX_SPANS_PER_REQUEST = 512
+
     // Serialize foreground and background dispatches without blocking the other signal.
     private val metricsDispatchMutex = Mutex()
     private val logsDispatchMutex = Mutex()
+    private val spansDispatchMutex = Mutex()
   }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
@@ -61,6 +61,7 @@ class ObserveModule : Module() {
       AsyncFunction("dispatchEvents") Coroutine { ->
         observabilityManager.dispatchUnsentMetrics()
         observabilityManager.dispatchUnsentLogs()
+        observabilityManager.dispatchUnsentSpans()
       }
 
       Function("configure") { config: Config ->

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
@@ -66,6 +66,7 @@ class ObserveModule : Module() {
       AsyncFunction("dispatchEvents") Coroutine { ->
         observabilityManager.dispatchUnsentMetrics()
         observabilityManager.dispatchUnsentLogs()
+        observabilityManager.dispatchUnsentSpans()
       }
 
       Function("configure") { config: Config ->

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -6,6 +6,7 @@ import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.utils.TimeUtils.timestampToDateNS
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -134,6 +135,58 @@ data class OTResourceLogs(
   val schemaUrl: String
 )
 
+/**
+ * One OTLP span. Nullable fields with defaults (`parentSpanId`, `status`) rely on
+ * kotlinx-serialization omitting defaults: the ingestion endpoint rejects a span whose present
+ * `parentSpanId` isn't valid hex, so a root span must omit the key entirely rather than send
+ * null or "".
+ */
+@Serializable
+data class OTSpan(
+  val traceId: String,
+  val spanId: String,
+  val parentSpanId: String? = null,
+  val name: String,
+  val kind: Int,
+  val startTimeUnixNano: Long,
+  val endTimeUnixNano: Long,
+  val attributes: List<OTAttribute>,
+  val events: List<OTSpanEvent>,
+  val droppedEventsCount: Int = 0,
+  val status: OTSpanStatus? = null
+)
+
+/** `Span.Event` per the OTLP proto — used for redirect hops. */
+@Serializable
+data class OTSpanEvent(
+  val timeUnixNano: Long,
+  val name: String,
+  val attributes: List<OTAttribute>
+)
+
+/**
+ * `Status` per the OTLP proto. Only attached when the span represents a failure; a successful
+ * client span stays UNSET by omitting the status entirely, per the semantic conventions.
+ */
+@Serializable
+data class OTSpanStatus(
+  val code: Int,
+  val message: String? = null
+)
+
+@Serializable
+data class OTScopeSpans(
+  val scope: OTScope,
+  val spans: List<OTSpan>
+)
+
+@Serializable
+data class OTResourceSpans(
+  val resource: OTMetadata,
+  val scopeSpans: List<OTScopeSpans>,
+  val schemaUrl: String
+)
+
 // MARK: -- Request body for Open Telemetry events
 
 @Serializable
@@ -160,6 +213,18 @@ data class OTLogsRequestBody(
   }
 }
 
+@Serializable
+data class OTTracesRequestBody(
+  val resourceSpans: List<OTResourceSpans>
+) {
+  fun toJson(prettyPrint: Boolean = false): String {
+    val json = Json {
+      this.prettyPrint = prettyPrint
+    }
+    return json.encodeToString(serializer(), this)
+  }
+}
+
 // MARK: -- Response shapes
 
 /**
@@ -177,10 +242,11 @@ data class OTLogsRequestBody(
 data class OTPartialSuccess(
   val rejectedDataPoints: Int? = null,
   val rejectedLogRecords: Int? = null,
+  val rejectedSpans: Int? = null,
   val errorMessage: String? = null
 ) {
   val rejectedCount: Int
-    get() = (rejectedDataPoints ?: 0) + (rejectedLogRecords ?: 0)
+    get() = (rejectedDataPoints ?: 0) + (rejectedLogRecords ?: 0) + (rejectedSpans ?: 0)
 }
 
 @Serializable
@@ -396,6 +462,99 @@ fun Event.toOTResourceLogs(easClientId: String): OTResourceLogs {
       )
     ),
     schemaUrl = SEMCONV_SCHEMA_URL
+  )
+}
+
+/**
+ * Wraps already-mapped spans in this event's resource envelope. Spans are passed in rather than
+ * derived from the event because they come from `spans` rows, which are not part of the `Event`
+ * payload shape the metrics/logs signals share.
+ */
+fun Event.toOTResourceSpans(easClientId: String, spans: List<OTSpan>): OTResourceSpans {
+  return OTResourceSpans(
+    resource = toOTMetadata(easClientId),
+    scopeSpans = listOf(
+      OTScopeSpans(
+        scope = OTScope(name = "expo-observe", version = BuildConfig.EXPO_OBSERVE_VERSION),
+        spans = spans
+      )
+    ),
+    schemaUrl = SEMCONV_SCHEMA_URL
+  )
+}
+
+/**
+ * Maximum span events the ingestion endpoint keeps per span; anything past it is counted as
+ * dropped server-side, so the SDK truncates locally and reports the loss itself instead of
+ * shipping payload that is guaranteed to be discarded.
+ */
+private const val MAX_SPAN_EVENT_COUNT = 32
+
+/**
+ * Converts a persisted unix-epoch millisecond timestamp to nanoseconds, saturating instead of
+ * overflowing: a corrupt row or a device clock set far into the future must never wrap into a
+ * negative timestamp.
+ */
+private fun spanNanosecondsFromMilliseconds(milliseconds: Long): Long {
+  val maxRepresentableMs = Long.MAX_VALUE / 1_000_000
+  return milliseconds.coerceIn(0, maxRepresentableMs) * 1_000_000
+}
+
+/**
+ * Maps one persisted span row onto the OTLP wire shape. The mapping is producer-agnostic:
+ * attributes and events were shaped by whichever producer recorded the row (per its own
+ * semantic conventions), and this conversion only handles the generic concerns — timestamps,
+ * the session attribute, the event cap, and the JSON-to-`AnyValue` typing. Mirrors the iOS
+ * `SpanRow.toOTSpan`.
+ */
+fun expo.modules.appmetrics.storage.Span.toOTSpan(): OTSpan {
+  // Millisecond precision matches the backend's DateTime64(3) storage. A clock adjustment
+  // mid-span can invert the two wall-clock timestamps, and the server rejects a span whose end
+  // precedes its start, so the end clamps to the start.
+  val startNs = spanNanosecondsFromMilliseconds(startTimestampMs)
+  val endNs = maxOf(startNs, spanNanosecondsFromMilliseconds(endTimestampMs))
+
+  val otAttributes = mutableListOf(
+    OTAttribute.of(key = "session.id", rawValue = sessionId)
+  )
+  attributes
+    ?.let { json -> runCatching { Json.decodeFromString<JsonObject>(json) }.getOrNull() }
+    ?.let { obj -> otAttributes.addAll(otAttributesFromJsonObject(obj).first) }
+
+  // The ingestion endpoint keeps at most `MAX_SPAN_EVENT_COUNT` events per span and counts the
+  // rest as dropped; truncating locally reports the same loss without shipping payload that is
+  // guaranteed to be discarded.
+  val allEvents = events
+    ?.let { json -> runCatching { Json.decodeFromString<JsonArray>(json) }.getOrNull() }
+    ?: JsonArray(emptyList())
+  val otEvents = allEvents.take(MAX_SPAN_EVENT_COUNT).mapNotNull { element ->
+    val obj = element as? JsonObject ?: return@mapNotNull null
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    val name = (obj["name"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+      ?: return@mapNotNull null
+    val eventAttributes = (obj["attributes"] as? JsonObject)
+      ?.let { otAttributesFromJsonObject(it).first }
+      ?: emptyList()
+    // Producers may record a per-event timestamp; without one the event anchors to the span
+    // start, which keeps it inside the span window.
+    val timeNs = (obj["timeMs"] as? JsonPrimitive)?.longOrNull
+      ?.let { spanNanosecondsFromMilliseconds(it) }
+      ?: startNs
+    OTSpanEvent(timeUnixNano = timeNs, name = name, attributes = eventAttributes)
+  }
+
+  return OTSpan(
+    traceId = traceId,
+    spanId = spanId,
+    parentSpanId = parentSpanId,
+    name = name,
+    kind = kind,
+    startTimeUnixNano = startNs,
+    endTimeUnixNano = endNs,
+    attributes = otAttributes,
+    events = otEvents,
+    droppedEventsCount = maxOf(0, allEvents.size - MAX_SPAN_EVENT_COUNT),
+    status = statusCode?.let { OTSpanStatus(code = it, message = statusMessage) }
   )
 }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -6,6 +6,7 @@ import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.utils.TimeUtils.timestampToDateNS
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -134,6 +135,59 @@ data class OTResourceLogs(
   val schemaUrl: String
 )
 
+/**
+ * One OTLP span, per https://opentelemetry.io/docs/concepts/signals/traces/#spans.
+ *
+ * Nullable fields with defaults (`parentSpanId`, `status`) rely on kotlinx-serialization omitting
+ * defaults: the ingestion endpoint rejects a span whose present `parentSpanId` isn't valid hex, so
+ * a root span must omit the key entirely rather than send null or "".
+ */
+@Serializable
+data class OTSpan(
+  val traceId: String,
+  val spanId: String,
+  val parentSpanId: String? = null,
+  val name: String,
+  val kind: Int,
+  val startTimeUnixNano: Long,
+  val endTimeUnixNano: Long,
+  val attributes: List<OTAttribute>,
+  val events: List<OTSpanEvent>,
+  val droppedEventsCount: Int = 0,
+  val status: OTSpanStatus? = null
+)
+
+/** `Span.Event` per the OTLP proto, used for redirect hops. */
+@Serializable
+data class OTSpanEvent(
+  val timeUnixNano: Long,
+  val name: String,
+  val attributes: List<OTAttribute>
+)
+
+/**
+ * `Status` per the OTLP proto. Only attached when the span represents a failure; a successful
+ * client span stays UNSET by omitting the status entirely, per the semantic conventions.
+ */
+@Serializable
+data class OTSpanStatus(
+  val code: Int,
+  val message: String? = null
+)
+
+@Serializable
+data class OTScopeSpans(
+  val scope: OTScope,
+  val spans: List<OTSpan>
+)
+
+@Serializable
+data class OTResourceSpans(
+  val resource: OTMetadata,
+  val scopeSpans: List<OTScopeSpans>,
+  val schemaUrl: String
+)
+
 // MARK: -- Request body for Open Telemetry events
 
 @Serializable
@@ -160,6 +214,18 @@ data class OTLogsRequestBody(
   }
 }
 
+@Serializable
+data class OTTracesRequestBody(
+  val resourceSpans: List<OTResourceSpans>
+) {
+  fun toJson(prettyPrint: Boolean = false): String {
+    val json = Json {
+      this.prettyPrint = prettyPrint
+    }
+    return json.encodeToString(serializer(), this)
+  }
+}
+
 // MARK: -- Response shapes
 
 /**
@@ -177,10 +243,11 @@ data class OTLogsRequestBody(
 data class OTPartialSuccess(
   val rejectedDataPoints: Int? = null,
   val rejectedLogRecords: Int? = null,
+  val rejectedSpans: Int? = null,
   val errorMessage: String? = null
 ) {
   val rejectedCount: Int
-    get() = (rejectedDataPoints ?: 0) + (rejectedLogRecords ?: 0)
+    get() = (rejectedDataPoints ?: 0) + (rejectedLogRecords ?: 0) + (rejectedSpans ?: 0)
 }
 
 @Serializable
@@ -396,6 +463,99 @@ fun Event.toOTResourceLogs(easClientId: String): OTResourceLogs {
       )
     ),
     schemaUrl = SEMCONV_SCHEMA_URL
+  )
+}
+
+/**
+ * Wraps already-mapped spans in this event's resource envelope. Spans are passed in rather than
+ * derived from the event because they come from `spans` rows, which are not part of the `Event`
+ * payload shape the metrics/logs signals share.
+ */
+fun Event.toOTResourceSpans(easClientId: String, spans: List<OTSpan>): OTResourceSpans {
+  return OTResourceSpans(
+    resource = toOTMetadata(easClientId),
+    scopeSpans = listOf(
+      OTScopeSpans(
+        scope = OTScope(name = "expo-observe", version = BuildConfig.EXPO_OBSERVE_VERSION),
+        spans = spans
+      )
+    ),
+    schemaUrl = SEMCONV_SCHEMA_URL
+  )
+}
+
+/**
+ * Maximum span events the ingestion endpoint keeps per span; anything past it is counted as
+ * dropped server-side, so the SDK truncates locally and reports the loss itself instead of
+ * shipping payload that is guaranteed to be discarded.
+ */
+private const val MAX_SPAN_EVENT_COUNT = 32
+
+/**
+ * Converts a persisted unix-epoch millisecond timestamp to nanoseconds, saturating instead of
+ * overflowing: a corrupt row or a device clock set far into the future must never wrap into a
+ * negative timestamp.
+ */
+private fun spanNanosecondsFromMilliseconds(milliseconds: Long): Long {
+  val maxRepresentableMs = Long.MAX_VALUE / 1_000_000
+  return milliseconds.coerceIn(0, maxRepresentableMs) * 1_000_000
+}
+
+/**
+ * Maps one persisted span row onto the OTLP wire shape. The mapping is producer-agnostic:
+ * attributes and events were shaped by whichever producer recorded the row (per its own
+ * semantic conventions), and this conversion only handles the generic concerns: timestamps,
+ * the session attribute, the event cap, and the JSON-to-`AnyValue` typing. Mirrors the iOS
+ * `SpanRow.toOTSpan`.
+ */
+fun expo.modules.appmetrics.storage.Span.toOTSpan(): OTSpan {
+  // Millisecond precision matches the backend's DateTime64(3) storage. A clock adjustment
+  // mid-span can invert the two wall-clock timestamps, and the server rejects a span whose end
+  // precedes its start, so the end clamps to the start.
+  val startNs = spanNanosecondsFromMilliseconds(startTimestampMs)
+  val endNs = maxOf(startNs, spanNanosecondsFromMilliseconds(endTimestampMs))
+
+  val otAttributes = mutableListOf(
+    OTAttribute.of(key = "session.id", rawValue = sessionId)
+  )
+  attributes
+    ?.let { json -> runCatching { Json.decodeFromString<JsonObject>(json) }.getOrNull() }
+    ?.let { obj -> otAttributes.addAll(otAttributesFromJsonObject(obj).first) }
+
+  // The ingestion endpoint keeps at most `MAX_SPAN_EVENT_COUNT` events per span and counts the
+  // rest as dropped; truncating locally reports the same loss without shipping payload that is
+  // guaranteed to be discarded.
+  val allEvents = events
+    ?.let { json -> runCatching { Json.decodeFromString<JsonArray>(json) }.getOrNull() }
+    ?: JsonArray(emptyList())
+  val otEvents = allEvents.take(MAX_SPAN_EVENT_COUNT).mapNotNull { element ->
+    val obj = element as? JsonObject ?: return@mapNotNull null
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    val name = (obj["name"] as? JsonPrimitive)?.takeIf { it.isString }?.content
+      ?: return@mapNotNull null
+    val eventAttributes = (obj["attributes"] as? JsonObject)
+      ?.let { otAttributesFromJsonObject(it).first }
+      ?: emptyList()
+    // Producers may record a per-event timestamp; without one the event anchors to the span
+    // start, which keeps it inside the span window.
+    val timeNs = (obj["timeMs"] as? JsonPrimitive)?.longOrNull
+      ?.let { spanNanosecondsFromMilliseconds(it) }
+      ?: startNs
+    OTSpanEvent(timeUnixNano = timeNs, name = name, attributes = eventAttributes)
+  }
+
+  return OTSpan(
+    traceId = traceId,
+    spanId = spanId,
+    parentSpanId = parentSpanId,
+    name = name,
+    kind = kind,
+    startTimeUnixNano = startNs,
+    endTimeUnixNano = endNs,
+    attributes = otAttributes,
+    events = otEvents,
+    droppedEventsCount = maxOf(0, allEvents.size - MAX_SPAN_EVENT_COUNT),
+    status = statusCode?.let { OTSpanStatus(code = it, message = statusMessage) }
   )
 }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/SpanDispatchOutcome.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/SpanDispatchOutcome.kt
@@ -1,0 +1,43 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.observe
+
+/**
+ * What the span dispatch loop does with a chunk once the server has answered. Mirrors the iOS
+ * `SpanDispatchLoop.Disposition`.
+ *
+ * Spans deliberately do not reuse the metrics and logs loop: that one owns a persisted cursor and
+ * stops after a batch it cannot advance past, whereas spans have no cursor (the table is the
+ * queue) and delete a dropped chunk before continuing with the next one.
+ */
+internal enum class SpanDispatchDisposition {
+  /** Delete the chunk's rows and continue with the next chunk. */
+  DELETE_AND_CONTINUE,
+
+  /** Leave every remaining row in place and stop, so the next dispatch retries them. */
+  KEEP_AND_STOP,
+
+  /** Too large to send but still splittable: retry the halves before anything after them. */
+  HALVE_AND_RETRY
+}
+
+/**
+ * Maps a send outcome onto what the loop does next. Pure, so every branch is assertable without
+ * a database, a network, or a coroutine scope.
+ *
+ * @param chunkCount how many spans were in the chunk that produced [result].
+ */
+internal fun spanDispatchDisposition(result: DispatchResult, chunkCount: Int): SpanDispatchDisposition =
+  when (result) {
+    DispatchResult.Success, is DispatchResult.PartialSuccess ->
+      SpanDispatchDisposition.DELETE_AND_CONTINUE
+    is DispatchResult.RetryableFailure -> SpanDispatchDisposition.KEEP_AND_STOP
+    is DispatchResult.NonRetryableFailure -> SpanDispatchDisposition.DELETE_AND_CONTINUE
+    // A single row cannot be split, so it is dropped: keeping it would block every span behind
+    // it on every future dispatch.
+    DispatchResult.PayloadTooLarge -> if (chunkCount > 1) {
+      SpanDispatchDisposition.HALVE_AND_RETRY
+    } else {
+      SpanDispatchDisposition.DELETE_AND_CONTINUE
+    }
+  }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -5,6 +5,7 @@ import expo.modules.appmetrics.storage.LogRecord
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.Session
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.storage.Span
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -826,6 +827,180 @@ class BaseObservabilityManagerTest {
     coEvery { eventDispatcher.dispatchLogs(any()) } returns result
   }
 
+  // region Span dispatch tests
+
+  @Test
+  fun `disabled dispatch drops the whole span backlog without reading it`() = runTest {
+    // Spans have no persisted cursor, so "advancing past" a backlog means deleting it. One
+    // SELECT MAX is enough; materializing rows the SDK will not send would be wasted work.
+    every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = false)
+    coEvery { sessionManager.getMaxSpanId() } returns 42
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(42) }
+    coVerify(exactly = 0) { sessionManager.getSpans(any(), any()) }
+    coVerify(exactly = 0) { eventDispatcher.dispatchSpans(any()) }
+  }
+
+  @Test
+  fun `an empty span table sends nothing and deletes nothing`() = runTest {
+    stubSpanDispatch(spans = emptyList())
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 0) { eventDispatcher.dispatchSpans(any()) }
+    coVerify(exactly = 0) { sessionManager.deleteSpansUpTo(any()) }
+  }
+
+  @Test
+  fun `a successful chunk is deleted up to its highest id`() = runTest {
+    stubSpanDispatch(spans = spans(1..3), result = DispatchResult.Success)
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 1) { eventDispatcher.dispatchSpans(any()) }
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(3) }
+  }
+
+  @Test
+  fun `a retryable failure keeps the rows for the next dispatch`() = runTest {
+    // The table is the queue: leaving the rows is the only way a retry can find them again.
+    stubSpanDispatch(
+      spans = spans(1..3),
+      result = DispatchResult.RetryableFailure(retryAfterMs = null)
+    )
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 1) { eventDispatcher.dispatchSpans(any()) }
+    coVerify(exactly = 0) { sessionManager.deleteSpansUpTo(any()) }
+  }
+
+  @Test
+  fun `a non-retryable failure drops the chunk instead of retrying it forever`() = runTest {
+    stubSpanDispatch(
+      spans = spans(1..3),
+      result = DispatchResult.NonRetryableFailure(reason = "malformed")
+    )
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(3) }
+  }
+
+  @Test
+  fun `partial success deletes the chunk including the rows the server rejected`() = runTest {
+    // A rejection is permanent (a malformed id, a session id that is not a UUID), so retrying
+    // the same bytes would fail identically. The count is logged and the rows go.
+    stubSpanDispatch(
+      spans = spans(1..3),
+      result = DispatchResult.PartialSuccess(
+        partial = OTPartialSuccess(rejectedSpans = 2, errorMessage = "2 invalid spans")
+      )
+    )
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(3) }
+  }
+
+  @Test
+  fun `an oversized chunk is halved and both halves are sent`() = runTest {
+    // The server rejected the payload by size, not content, so the same rows can succeed in
+    // smaller batches. Without halving, one huge span would take its whole chunk down with it.
+    val rows = spans(1..4)
+    stubSpanDispatch(spans = rows)
+    val sentSizes = mutableListOf<Int>()
+    coEvery { eventDispatcher.dispatchSpans(any()) } answers {
+      val batches = firstArg<List<SpanBatch>>()
+      sentSizes.add(batches.sumOf { it.spans.size })
+      if (sentSizes.size == 1) DispatchResult.PayloadTooLarge else DispatchResult.Success
+    }
+
+    createManager().dispatchUnsentSpans()
+
+    assertEquals(listOf(4, 2, 2), sentSizes)
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(2) }
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(4) }
+  }
+
+  @Test
+  fun `halving stops at a single span, which is dropped rather than retried`() = runTest {
+    // Two rows halve to one each. A single row that is still too large cannot be split, so it
+    // is dropped: keeping it would block every span behind it forever.
+    stubSpanDispatch(spans = spans(1..2), result = DispatchResult.PayloadTooLarge)
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 3) { eventDispatcher.dispatchSpans(any()) }
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(1) }
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(2) }
+  }
+
+  @Test
+  fun `a retryable failure after halving leaves every row of the original chunk`() = runTest {
+    val sentSizes = mutableListOf<Int>()
+    stubSpanDispatch(spans = spans(1..4))
+    coEvery { eventDispatcher.dispatchSpans(any()) } answers {
+      val batches = firstArg<List<SpanBatch>>()
+      sentSizes.add(batches.sumOf { it.spans.size })
+      if (sentSizes.size == 1) {
+        DispatchResult.PayloadTooLarge
+      } else {
+        DispatchResult.RetryableFailure(retryAfterMs = null)
+      }
+    }
+
+    createManager().dispatchUnsentSpans()
+
+    assertEquals(listOf(4, 2), sentSizes)
+    coVerify(exactly = 0) { sessionManager.deleteSpansUpTo(any()) }
+  }
+
+  @Test
+  fun `spans whose session row is gone are deleted without being sent`() = runTest {
+    // The session was pruned, so its resource metadata is unrecoverable and the rows are about
+    // to be deleted anyway. Sending them without an envelope is not an option.
+    val rows = spans(1..2)
+    coEvery { sessionManager.getSpans(-1, any()) } returns rows
+    coEvery { sessionManager.getSpans(2, any()) } returns emptyList()
+    coEvery { sessionManager.getSessions(any()) } returns emptyList()
+
+    createManager().dispatchUnsentSpans()
+
+    coVerify(exactly = 0) { eventDispatcher.dispatchSpans(any()) }
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(2) }
+  }
+
+  @Test
+  fun `spans are grouped into one batch per session`() = runTest {
+    // Each batch carries its own session's resource metadata, so a chunk spanning two sessions
+    // must not be sent under a single envelope.
+    val rows = listOf(
+      span(id = 1, sessionId = "a"),
+      span(id = 2, sessionId = "b"),
+      span(id = 3, sessionId = "a")
+    )
+    coEvery { sessionManager.getSpans(-1, any()) } returns rows
+    coEvery { sessionManager.getSpans(3, any()) } returns emptyList()
+    coEvery { sessionManager.getSessions(any()) } answers {
+      firstArg<Collection<String>>().map { session(id = it) }
+    }
+    var batchSizes: List<Int> = emptyList()
+    coEvery { eventDispatcher.dispatchSpans(any()) } answers {
+      batchSizes = firstArg<List<SpanBatch>>().map { it.spans.size }
+      DispatchResult.Success
+    }
+
+    createManager().dispatchUnsentSpans()
+
+    assertEquals(listOf(2, 1), batchSizes)
+    coVerify(exactly = 1) { sessionManager.deleteSpansUpTo(3) }
+  }
+
+  // endregion
+
   private fun createManager(
     chunkSize: Int = DISPATCH_CHUNK_SIZE,
     currentTimeMs: () -> Long = { 0 },
@@ -863,6 +1038,35 @@ class BaseObservabilityManagerTest {
     expoSdkVersion = "55",
     reactNativeVersion = "0.81"
   )
+
+  private fun span(id: Long, sessionId: String = "session") = Span(
+    sessionId = sessionId,
+    name = "GET",
+    kind = Span.CLIENT_KIND,
+    startTimestampMs = 1_782_131_895_000,
+    endTimestampMs = 1_782_131_895_250,
+    id = id
+  )
+
+  private fun spans(ids: IntRange) = ids.map { span(id = it.toLong()) }
+
+  /**
+   * Stubs a single-chunk span read plus its session lookup. The second read returns empty so the
+   * loop terminates instead of re-reading the same rows.
+   */
+  private fun stubSpanDispatch(
+    spans: List<Span>,
+    result: DispatchResult = DispatchResult.Success
+  ) {
+    coEvery { sessionManager.getSpans(-1, any()) } returns spans
+    if (spans.isNotEmpty()) {
+      coEvery { sessionManager.getSpans(spans.last().id, any()) } returns emptyList()
+    }
+    coEvery { sessionManager.getSessions(any()) } answers {
+      firstArg<Collection<String>>().map { session(id = it) }
+    }
+    coEvery { eventDispatcher.dispatchSpans(any()) } returns result
+  }
 
   private fun metric(id: Long, name: String, sessionId: String = "session") = Metric(
     sessionId = sessionId,

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanDispatchOutcomeTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanDispatchOutcomeTest.kt
@@ -1,0 +1,62 @@
+package expo.modules.observe
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The outcome mapping behind span dispatch. Pure, so each branch is asserted directly rather
+ * than inferred from the loop's database side effects. Mirrors the iOS
+ * `SpanDispatchLoopTests.every outcome maps to a disposition`.
+ */
+class SpanDispatchOutcomeTest {
+  @Test
+  fun `a delivered chunk is deleted and the loop continues`() {
+    assertEquals(
+      SpanDispatchDisposition.DELETE_AND_CONTINUE,
+      spanDispatchDisposition(DispatchResult.Success, chunkCount = 2)
+    )
+  }
+
+  @Test
+  fun `partial success still deletes the chunk`() {
+    // A rejection is permanent (a malformed id, a session id that is not a UUID), so resending
+    // the same bytes would fail identically.
+    val partial = OTPartialSuccess(rejectedSpans = 1)
+    assertEquals(
+      SpanDispatchDisposition.DELETE_AND_CONTINUE,
+      spanDispatchDisposition(DispatchResult.PartialSuccess(partial), chunkCount = 2)
+    )
+  }
+
+  @Test
+  fun `a non-retryable failure drops the chunk rather than retrying it forever`() {
+    assertEquals(
+      SpanDispatchDisposition.DELETE_AND_CONTINUE,
+      spanDispatchDisposition(DispatchResult.NonRetryableFailure("malformed"), chunkCount = 2)
+    )
+  }
+
+  @Test
+  fun `a retryable failure keeps every remaining row`() {
+    assertEquals(
+      SpanDispatchDisposition.KEEP_AND_STOP,
+      spanDispatchDisposition(DispatchResult.RetryableFailure(retryAfterMs = null), chunkCount = 2)
+    )
+  }
+
+  @Test
+  fun `an oversized multi-span chunk is halved`() {
+    assertEquals(
+      SpanDispatchDisposition.HALVE_AND_RETRY,
+      spanDispatchDisposition(DispatchResult.PayloadTooLarge, chunkCount = 2)
+    )
+  }
+
+  @Test
+  fun `an oversized single span is dropped because it cannot be split`() {
+    assertEquals(
+      SpanDispatchDisposition.DELETE_AND_CONTINUE,
+      spanDispatchDisposition(DispatchResult.PayloadTooLarge, chunkCount = 1)
+    )
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanOpenTelemetryTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanOpenTelemetryTest.kt
@@ -1,0 +1,244 @@
+package expo.modules.observe
+
+import expo.modules.appmetrics.storage.Span
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val START_MS = 1_782_131_895_000
+private const val END_MS = 1_782_131_895_250
+
+private fun makeRow(
+  sessionId: String = "0f8fad5b-d9cb-469f-a165-70867728950e",
+  traceId: String = "a3ce929d0e0e4736a3ce929d0e0e4736",
+  spanId: String = "00f067aa0ba902b7",
+  parentSpanId: String? = null,
+  name: String = "GET",
+  kind: Int = Span.CLIENT_KIND,
+  startTimestampMs: Long = START_MS,
+  endTimestampMs: Long = END_MS,
+  statusCode: Int? = null,
+  statusMessage: String? = null,
+  attributes: String? = null,
+  events: String? = null
+) = Span(
+  sessionId = sessionId,
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  name = name,
+  kind = kind,
+  startTimestampMs = startTimestampMs,
+  endTimestampMs = endTimestampMs,
+  statusCode = statusCode,
+  statusMessage = statusMessage,
+  attributes = attributes,
+  events = events
+)
+
+private fun attribute(span: OTSpan, key: String): OTAnyValue? =
+  span.attributes.firstOrNull { it.key == key }?.value
+
+class SpanToOTSpanMappingTest {
+  @Test
+  fun `passes the persisted identity through to the wire shape`() {
+    // Ids are generated at record time and persisted precisely so that the export layer never
+    // invents new ones — a redelivered row must stay byte-identical on the server.
+    val span = makeRow(name = "POST", kind = 5).toOTSpan()
+    assertEquals("a3ce929d0e0e4736a3ce929d0e0e4736", span.traceId)
+    assertEquals("00f067aa0ba902b7", span.spanId)
+    assertEquals("POST", span.name)
+    assertEquals(5, span.kind)
+    assertNull(span.parentSpanId)
+  }
+
+  @Test
+  fun `passes a present parent span id through`() {
+    val span = makeRow(parentSpanId = "abcdef0123456789").toOTSpan()
+    assertEquals("abcdef0123456789", span.parentSpanId)
+  }
+
+  @Test
+  fun `converts the start and end timestamps to unix nanoseconds`() {
+    val span = makeRow().toOTSpan()
+    assertEquals(1_782_131_895_000_000_000, span.startTimeUnixNano)
+    assertEquals(1_782_131_895_250_000_000, span.endTimeUnixNano)
+  }
+
+  @Test
+  fun `never reports an end that precedes the start`() {
+    // The server rejects a span whose end is before its start. A clock adjustment mid-span
+    // can invert the two wall-clock timestamps, so the mapping has to clamp.
+    val span = makeRow(startTimestampMs = START_MS, endTimestampMs = START_MS - 5_000).toOTSpan()
+    assertTrue(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  fun `clamps a far-future timestamp instead of overflowing`() {
+    // A corrupt row or a device clock set far into the future must never overflow the
+    // nanosecond conversion into a negative timestamp; it saturates instead.
+    val span = makeRow(startTimestampMs = Long.MAX_VALUE, endTimestampMs = Long.MAX_VALUE).toOTSpan()
+    assertTrue(span.startTimeUnixNano > 0)
+    assertTrue(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  fun `attaches the session id as an attribute`() {
+    val span = makeRow(sessionId = "session-uuid").toOTSpan()
+    assertEquals(OTAnyValue.Str("session-uuid"), attribute(span, "session.id"))
+  }
+
+  @Test
+  fun `decodes the attributes blob into typed wire attributes`() {
+    val json =
+      """{"http.request.method":"GET","http.response.status_code":200,"http.request.size":412,"retried":false,"sampling.rate":0.5}"""
+    val span = makeRow(attributes = json).toOTSpan()
+    assertEquals(OTAnyValue.Str("GET"), attribute(span, "http.request.method"))
+    assertEquals(OTAnyValue.Int64(200), attribute(span, "http.response.status_code"))
+    assertEquals(OTAnyValue.Int64(412), attribute(span, "http.request.size"))
+    assertEquals(OTAnyValue.Bln(false), attribute(span, "retried"))
+    assertEquals(OTAnyValue.Dbl(0.5), attribute(span, "sampling.rate"))
+  }
+
+  @Test
+  fun `tolerates an absent or malformed attributes blob`() {
+    // Only the session attribute remains; a bad blob must not fail the whole span.
+    for (blob in listOf(null, "not json", "[1,2,3]")) {
+      val span = makeRow(attributes = blob).toOTSpan()
+      assertEquals(1, span.attributes.size)
+      assertEquals("session.id", span.attributes.single().key)
+    }
+  }
+
+  @Test
+  fun `passes the error status and message through`() {
+    val span = makeRow(statusCode = 2, statusMessage = "offline").toOTSpan()
+    assertEquals(2, span.status?.code)
+    assertEquals("offline", span.status?.message)
+  }
+
+  @Test
+  fun `omits the status when the row has none`() {
+    // UNSET is expressed by omitting the status object entirely, per the conventions.
+    assertNull(makeRow(statusCode = null).toOTSpan().status)
+  }
+}
+
+class SpanEventDecodingTest {
+  private fun eventsJson(count: Int): String {
+    val events = (0 until count).joinToString(separator = ",") { index ->
+      """{"name":"http.redirect","attributes":{"from":"https://example.com/$index","statusCode":302}}"""
+    }
+    return "[$events]"
+  }
+
+  @Test
+  fun `decodes events with their attributes`() {
+    val span = makeRow(events = eventsJson(count = 2)).toOTSpan()
+    assertEquals(2, span.events.size)
+    assertTrue(span.events.all { it.name == "http.redirect" })
+    val first = span.events.first()
+    val attributes = first.attributes.associate { it.key to it.value }
+    assertEquals(OTAnyValue.Str("https://example.com/0"), attributes["from"])
+    assertEquals(OTAnyValue.Int64(302), attributes["statusCode"])
+  }
+
+  @Test
+  fun `anchors events without a timestamp to the span start`() {
+    // Producers may omit per-event timestamps; an out-of-window event is meaningless in a
+    // trace waterfall, so the fallback is the span start.
+    val span = makeRow(events = eventsJson(count = 2)).toOTSpan()
+    assertTrue(span.events.all { it.timeUnixNano == span.startTimeUnixNano })
+  }
+
+  @Test
+  fun `uses a per-event timestamp when the producer recorded one`() {
+    val json = """[{"name":"checkpoint","timeMs":${START_MS + 100}}]"""
+    val span = makeRow(events = json).toOTSpan()
+    assertEquals(1_782_131_895_100_000_000, span.events.single().timeUnixNano)
+  }
+
+  @Test
+  fun `drops an event without a name`() {
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    val json = """[{"attributes":{"orphan":true}},{"name":"kept"}]"""
+    val span = makeRow(events = json).toOTSpan()
+    assertEquals(listOf("kept"), span.events.map { it.name })
+  }
+
+  @Test
+  fun `emits no events when the row has none`() {
+    val span = makeRow().toOTSpan()
+    assertTrue(span.events.isEmpty())
+    assertEquals(0, span.droppedEventsCount)
+  }
+
+  @Test
+  fun `caps the number of emitted events at the server limit`() {
+    // The server keeps at most 32 events per span and counts the rest as dropped. Sending
+    // more just wastes payload, so the SDK truncates and reports the loss itself.
+    val span = makeRow(events = eventsJson(count = 40)).toOTSpan()
+    assertEquals(32, span.events.size)
+    assertEquals(8, span.droppedEventsCount)
+  }
+}
+
+class TracesRequestBodyTest {
+  private fun encode(spans: List<OTSpan>): String {
+    val event = Event(
+      metadata = Metadata(
+        appName = null,
+        appIdentifier = "dev.expo.test",
+        appVersion = null,
+        appBuildNumber = null,
+        appEasBuildId = null,
+        appUpdatesInfo = null,
+        languageTag = null,
+        deviceOs = null,
+        deviceOsVersion = null,
+        deviceModel = null,
+        deviceName = null,
+        expoSdkVersion = "55.0.0",
+        reactNativeVersion = "0.85.0",
+        clientVersion = null
+      ),
+      metrics = emptyList()
+    )
+    return OTTracesRequestBody(
+      resourceSpans = listOf(event.toOTResourceSpans("eas-client-id", spans))
+    ).toJson()
+  }
+
+  @Test
+  fun `encodes the resourceSpans envelope the endpoint expects`() {
+    val body = encode(listOf(makeRow().toOTSpan()))
+    assertTrue(body.contains("\"resourceSpans\""))
+    assertTrue(body.contains("\"scopeSpans\""))
+    assertTrue(body.contains("\"traceId\":\"a3ce929d0e0e4736a3ce929d0e0e4736\""))
+    assertTrue(body.contains("\"kind\":3"))
+  }
+
+  @Test
+  fun `omits an absent parent span id from the encoded span`() {
+    // The server rejects a span carrying a present-but-invalid parent id, so a root span
+    // must leave the key out entirely rather than encode null or an empty string.
+    val body = encode(listOf(makeRow().toOTSpan()))
+    assertFalse(body.contains("parentSpanId"))
+  }
+}
+
+class TracesPartialSuccessTest {
+  @Test
+  fun `counts rejected spans from a traces partial success`() {
+    // The traces endpoint reports `rejectedSpans`, a field neither the metrics nor the logs
+    // response carries. Without it the shared decoder reads a rejection as a clean success.
+    val json = """{"partialSuccess":{"rejectedSpans":3,"errorMessage":"bad span"}}"""
+    val response = Json { ignoreUnknownKeys = true }.decodeFromString(OTServiceResponse.serializer(), json)
+    val partial = checkNotNull(response.partialSuccess)
+    assertEquals(3, partial.rejectedCount)
+    assertEquals("bad span", partial.errorMessage)
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanOpenTelemetryTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/SpanOpenTelemetryTest.kt
@@ -1,0 +1,244 @@
+package expo.modules.observe
+
+import expo.modules.appmetrics.storage.Span
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private const val START_MS = 1_782_131_895_000
+private const val END_MS = 1_782_131_895_250
+
+private fun makeRow(
+  sessionId: String = "0f8fad5b-d9cb-469f-a165-70867728950e",
+  traceId: String = "a3ce929d0e0e4736a3ce929d0e0e4736",
+  spanId: String = "00f067aa0ba902b7",
+  parentSpanId: String? = null,
+  name: String = "GET",
+  kind: Int = Span.CLIENT_KIND,
+  startTimestampMs: Long = START_MS,
+  endTimestampMs: Long = END_MS,
+  statusCode: Int? = null,
+  statusMessage: String? = null,
+  attributes: String? = null,
+  events: String? = null
+) = Span(
+  sessionId = sessionId,
+  traceId = traceId,
+  spanId = spanId,
+  parentSpanId = parentSpanId,
+  name = name,
+  kind = kind,
+  startTimestampMs = startTimestampMs,
+  endTimestampMs = endTimestampMs,
+  statusCode = statusCode,
+  statusMessage = statusMessage,
+  attributes = attributes,
+  events = events
+)
+
+private fun attribute(span: OTSpan, key: String): OTAnyValue? =
+  span.attributes.firstOrNull { it.key == key }?.value
+
+class SpanToOTSpanMappingTest {
+  @Test
+  fun `passes the persisted identity through to the wire shape`() {
+    // Ids are generated at record time and persisted precisely so that the export layer never
+    // invents new ones, because a redelivered row must stay byte-identical on the server.
+    val span = makeRow(name = "POST", kind = 5).toOTSpan()
+    assertEquals("a3ce929d0e0e4736a3ce929d0e0e4736", span.traceId)
+    assertEquals("00f067aa0ba902b7", span.spanId)
+    assertEquals("POST", span.name)
+    assertEquals(5, span.kind)
+    assertNull(span.parentSpanId)
+  }
+
+  @Test
+  fun `passes a present parent span id through`() {
+    val span = makeRow(parentSpanId = "abcdef0123456789").toOTSpan()
+    assertEquals("abcdef0123456789", span.parentSpanId)
+  }
+
+  @Test
+  fun `converts the start and end timestamps to unix nanoseconds`() {
+    val span = makeRow().toOTSpan()
+    assertEquals(1_782_131_895_000_000_000, span.startTimeUnixNano)
+    assertEquals(1_782_131_895_250_000_000, span.endTimeUnixNano)
+  }
+
+  @Test
+  fun `never reports an end that precedes the start`() {
+    // The server rejects a span whose end is before its start. A clock adjustment mid-span
+    // can invert the two wall-clock timestamps, so the mapping has to clamp.
+    val span = makeRow(startTimestampMs = START_MS, endTimestampMs = START_MS - 5_000).toOTSpan()
+    assertTrue(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  fun `clamps a far-future timestamp instead of overflowing`() {
+    // A corrupt row or a device clock set far into the future must never overflow the
+    // nanosecond conversion into a negative timestamp; it saturates instead.
+    val span = makeRow(startTimestampMs = Long.MAX_VALUE, endTimestampMs = Long.MAX_VALUE).toOTSpan()
+    assertTrue(span.startTimeUnixNano > 0)
+    assertTrue(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  fun `attaches the session id as an attribute`() {
+    val span = makeRow(sessionId = "session-uuid").toOTSpan()
+    assertEquals(OTAnyValue.Str("session-uuid"), attribute(span, "session.id"))
+  }
+
+  @Test
+  fun `decodes the attributes blob into typed wire attributes`() {
+    val json =
+      """{"http.request.method":"GET","http.response.status_code":200,"http.request.size":412,"retried":false,"sampling.rate":0.5}"""
+    val span = makeRow(attributes = json).toOTSpan()
+    assertEquals(OTAnyValue.Str("GET"), attribute(span, "http.request.method"))
+    assertEquals(OTAnyValue.Int64(200), attribute(span, "http.response.status_code"))
+    assertEquals(OTAnyValue.Int64(412), attribute(span, "http.request.size"))
+    assertEquals(OTAnyValue.Bln(false), attribute(span, "retried"))
+    assertEquals(OTAnyValue.Dbl(0.5), attribute(span, "sampling.rate"))
+  }
+
+  @Test
+  fun `tolerates an absent or malformed attributes blob`() {
+    // Only the session attribute remains; a bad blob must not fail the whole span.
+    for (blob in listOf(null, "not json", "[1,2,3]")) {
+      val span = makeRow(attributes = blob).toOTSpan()
+      assertEquals(1, span.attributes.size)
+      assertEquals("session.id", span.attributes.single().key)
+    }
+  }
+
+  @Test
+  fun `passes the error status and message through`() {
+    val span = makeRow(statusCode = 2, statusMessage = "offline").toOTSpan()
+    assertEquals(2, span.status?.code)
+    assertEquals("offline", span.status?.message)
+  }
+
+  @Test
+  fun `omits the status when the row has none`() {
+    // UNSET is expressed by omitting the status object entirely, per the conventions.
+    assertNull(makeRow(statusCode = null).toOTSpan().status)
+  }
+}
+
+class SpanEventDecodingTest {
+  private fun eventsJson(count: Int): String {
+    val events = (0 until count).joinToString(separator = ",") { index ->
+      """{"name":"http.redirect","attributes":{"from":"https://example.com/$index","statusCode":302}}"""
+    }
+    return "[$events]"
+  }
+
+  @Test
+  fun `decodes events with their attributes`() {
+    val span = makeRow(events = eventsJson(count = 2)).toOTSpan()
+    assertEquals(2, span.events.size)
+    assertTrue(span.events.all { it.name == "http.redirect" })
+    val first = span.events.first()
+    val attributes = first.attributes.associate { it.key to it.value }
+    assertEquals(OTAnyValue.Str("https://example.com/0"), attributes["from"])
+    assertEquals(OTAnyValue.Int64(302), attributes["statusCode"])
+  }
+
+  @Test
+  fun `anchors events without a timestamp to the span start`() {
+    // Producers may omit per-event timestamps; an out-of-window event is meaningless in a
+    // trace waterfall, so the fallback is the span start.
+    val span = makeRow(events = eventsJson(count = 2)).toOTSpan()
+    assertTrue(span.events.all { it.timeUnixNano == span.startTimeUnixNano })
+  }
+
+  @Test
+  fun `uses a per-event timestamp when the producer recorded one`() {
+    val json = """[{"name":"checkpoint","timeMs":${START_MS + 100}}]"""
+    val span = makeRow(events = json).toOTSpan()
+    assertEquals(1_782_131_895_100_000_000, span.events.single().timeUnixNano)
+  }
+
+  @Test
+  fun `drops an event without a name`() {
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    val json = """[{"attributes":{"orphan":true}},{"name":"kept"}]"""
+    val span = makeRow(events = json).toOTSpan()
+    assertEquals(listOf("kept"), span.events.map { it.name })
+  }
+
+  @Test
+  fun `emits no events when the row has none`() {
+    val span = makeRow().toOTSpan()
+    assertTrue(span.events.isEmpty())
+    assertEquals(0, span.droppedEventsCount)
+  }
+
+  @Test
+  fun `caps the number of emitted events at the server limit`() {
+    // The server keeps at most 32 events per span and counts the rest as dropped. Sending
+    // more just wastes payload, so the SDK truncates and reports the loss itself.
+    val span = makeRow(events = eventsJson(count = 40)).toOTSpan()
+    assertEquals(32, span.events.size)
+    assertEquals(8, span.droppedEventsCount)
+  }
+}
+
+class TracesRequestBodyTest {
+  private fun encode(spans: List<OTSpan>): String {
+    val event = Event(
+      metadata = Metadata(
+        appName = null,
+        appIdentifier = "dev.expo.test",
+        appVersion = null,
+        appBuildNumber = null,
+        appEasBuildId = null,
+        appUpdatesInfo = null,
+        languageTag = null,
+        deviceOs = null,
+        deviceOsVersion = null,
+        deviceModel = null,
+        deviceName = null,
+        expoSdkVersion = "55.0.0",
+        reactNativeVersion = "0.85.0",
+        clientVersion = null
+      ),
+      metrics = emptyList()
+    )
+    return OTTracesRequestBody(
+      resourceSpans = listOf(event.toOTResourceSpans("eas-client-id", spans))
+    ).toJson()
+  }
+
+  @Test
+  fun `encodes the resourceSpans envelope the endpoint expects`() {
+    val body = encode(listOf(makeRow().toOTSpan()))
+    assertTrue(body.contains("\"resourceSpans\""))
+    assertTrue(body.contains("\"scopeSpans\""))
+    assertTrue(body.contains("\"traceId\":\"a3ce929d0e0e4736a3ce929d0e0e4736\""))
+    assertTrue(body.contains("\"kind\":3"))
+  }
+
+  @Test
+  fun `omits an absent parent span id from the encoded span`() {
+    // The server rejects a span carrying a present-but-invalid parent id, so a root span
+    // must leave the key out entirely rather than encode null or an empty string.
+    val body = encode(listOf(makeRow().toOTSpan()))
+    assertFalse(body.contains("parentSpanId"))
+  }
+}
+
+class TracesPartialSuccessTest {
+  @Test
+  fun `counts rejected spans from a traces partial success`() {
+    // The traces endpoint reports `rejectedSpans`, a field neither the metrics nor the logs
+    // response carries. Without it the shared decoder reads a rejection as a clean success.
+    val json = """{"partialSuccess":{"rejectedSpans":3,"errorMessage":"bad span"}}"""
+    val response = Json { ignoreUnknownKeys = true }.decodeFromString(OTServiceResponse.serializer(), json)
+    val partial = checkNotNull(response.partialSuccess)
+    assertEquals(3, partial.rejectedCount)
+    assertEquals("bad span", partial.errorMessage)
+  }
+}

--- a/packages/expo-observe/ios/DispatchSerializer.swift
+++ b/packages/expo-observe/ios/DispatchSerializer.swift
@@ -1,0 +1,40 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoAppMetrics
+
+/// Runs dispatch passes one at a time, so a later caller waits for the pass ahead of it instead
+/// of overlapping with it.
+///
+/// `ObservabilityManager` is actor-isolated but reentrant at every network `await`, so two
+/// overlapping passes would read and send the same pending rows before either advanced its cursor
+/// or deleted its batch. Serializing also lets a JS `dispatchEvents()` promise mean the queue was
+/// drained, matching Android's per-signal mutexes.
+@AppMetricsActor
+internal final class DispatchSerializer {
+  private var inFlight: Task<Void, Never>?
+  private var generation = 0
+  private var inFlightGeneration = 0
+
+  /// Waits for any pass already running, then runs `work` as the new in-flight pass.
+  internal func run(_ work: @escaping () async -> Void) async {
+    // The predecessor is captured and awaited *inside* the new task, not before creating it.
+    // Awaiting first would suspend, letting two callers both observe a finished pass and start
+    // work concurrently. Chaining publishes this task synchronously, so the next caller links
+    // behind it.
+    let predecessor = inFlight
+    generation += 1
+    let ownGeneration = generation
+    let task = Task {
+      await predecessor?.value
+      await work()
+    }
+    inFlight = task
+    inFlightGeneration = ownGeneration
+    await task.value
+    // Cleared only when still the current pass, so a caller resuming late cannot orphan the pass
+    // that replaced it.
+    if inFlightGeneration == ownGeneration {
+      inFlight = nil
+    }
+  }
+}

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -7,7 +7,12 @@ internal struct ObservabilityManager {
   private static let easClientId = EASClientID.uuid().uuidString
   private static var metricsEndpointUrl: URL? = nil
   private static var logsEndpointUrl: URL? = nil
+  private static var tracesEndpointUrl: URL? = nil
   private static var projectId: String? = nil
+
+  /// Maximum spans per request accepted by the ingestion endpoint; it rejects everything past
+  /// this count within one POST, so larger backlogs are sent as sequential chunks.
+  internal static let maxSpansPerRequest = 512
 
   /// In-memory retry-gate state, kept independently per OTLP endpoint. The `/v1/metrics` and
   /// `/v1/logs` endpoints fail independently in practice (e.g., one schema validation
@@ -22,14 +27,31 @@ internal struct ObservabilityManager {
   /// mean a UserDefaults write per retryable response.
   private static var metricsRetryGate: DispatchUtils.RetryGateState = .initial
   private static var logsRetryGate: DispatchUtils.RetryGateState = .initial
+  private static var tracesRetryGate: DispatchUtils.RetryGateState = .initial
+
+  /// Whether a dispatch pass is currently running. The actor is reentrant at every network
+  /// `await`, so overlapping `dispatch()` calls (a JS `dispatchEvents` racing the resign-active
+  /// app delegate hook) would otherwise read — and send — the same pending rows twice before
+  /// either pass advances its cursor or deletes its batch.
+  private static var isDispatching = false
 
   internal static func dispatch() async {
-    // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` rather than
-    // here, so a backoff on one endpoint doesn't suppress the other's traffic.
+    if isDispatching {
+      observeLogger.debug("[EAS Observe] Dispatch already in progress; skipping")
+      return
+    }
+    isDispatching = true
+    defer {
+      isDispatching = false
+    }
+
+    // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` / `dispatchTraces`
+    // rather than here, so a backoff on one endpoint doesn't suppress the others' traffic.
     let shouldDispatch = Self.shouldDispatch()
 
     await dispatchMetrics(shouldDispatch: shouldDispatch)
     await dispatchLogs(shouldDispatch: shouldDispatch)
+    await dispatchTraces(shouldDispatch: shouldDispatch)
   }
 
   /// Whether a per-signal retry gate currently blocks dispatch on that signal. Logs a debug
@@ -190,29 +212,139 @@ internal struct ObservabilityManager {
     }
   }
 
-  /// Groups `metrics` by `sessionId`, hydrates the matching session rows, and emits one `Event` per
-  /// session in the same shape Android dispatches: each event carries the session's metadata and only
-  /// the metrics that belong to it.
-  private static func buildEvents(forMetrics metrics: [MetricRow]) throws -> [Event] {
-    let metricsBySession = Dictionary(grouping: metrics, by: \.sessionId)
-    let sessionIds = Array(metricsBySession.keys)
-    let sessions = try AppMetrics.getSessions(ids: sessionIds)
+  /// Dispatches persisted spans to `/v1/traces`.
+  ///
+  /// Unlike metrics and logs there is no persisted cursor: nothing else reads the `spans` rows
+  /// back, so a consumed (or deliberately dropped) batch is deleted outright and the table
+  /// itself acts as the queue. Rows survive on a retryable failure and go out on the next
+  /// dispatch.
+  private static func dispatchTraces(shouldDispatch: Bool) async {
+    guard let endpointUrl = tracesEndpointUrl else {
+      // Without a project id there is nowhere to send spans, so skip even the table read —
+      // this path runs on every resign-active in apps without EAS config, and the pending
+      // rows are already bounded by the insert-time cap.
+      return
+    }
+    if retryGateBlocks(tracesRetryGate, signal: "traces") {
+      return
+    }
+    if !shouldDispatch {
+      // Drop the backlog without materializing it; one SELECT MAX is enough to know how far
+      // to delete. Mirrors metrics/logs advancing their cursor past rows they won't send.
+      do {
+        if let maxId = try AppMetrics.getMaxSpanId() {
+          try AppMetrics.deleteSpans(upToId: maxId)
+        }
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to drop undispatched spans: \(error.localizedDescription)")
+      }
+      return
+    }
+
+    let pendingSpans: [SpanRow]
+    do {
+      pendingSpans = try AppMetrics.getSpans(afterId: -1)
+    } catch {
+      observeLogger.warn("[EAS Observe] Failed to read pending spans: \(error.localizedDescription)")
+      return
+    }
+    guard !pendingSpans.isEmpty else {
+      observeLogger.debug("[EAS Observe] No new spans to dispatch")
+      return
+    }
+
+    // The endpoint rejects spans past `maxSpansPerRequest` per POST, so a larger backlog goes
+    // out as sequential chunks. Rows arrive ordered by id; a chunk that fails retryably stops
+    // the loop and leaves its rows (and everything after them) for the next dispatch.
+    for chunkStart in stride(from: 0, to: pendingSpans.count, by: maxSpansPerRequest) {
+      let chunk = Array(pendingSpans[chunkStart..<min(chunkStart + maxSpansPerRequest, pendingSpans.count)])
+      let resourceSpans: [OTResourceSpans]
+      do {
+        resourceSpans = try buildResourceSpans(forSpans: chunk)
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to assemble trace events: \(error.localizedDescription)")
+        return
+      }
+      if resourceSpans.isEmpty {
+        deleteDispatchedSpans(upToId: chunk.last?.id)
+        continue
+      }
+      let body = OTTracesRequestBody(resourceSpans: resourceSpans)
+      let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+      applyRetryOutcome(result, to: &tracesRetryGate)
+      switch result {
+      case .success:
+        ObserveUserDefaults.lastDispatchDate = Date.now
+      case .partialSuccess(let partial):
+        ObserveUserDefaults.lastDispatchDate = Date.now
+        observeLogger.warn(
+          "[EAS Observe] Partial success on batch of \(chunk.count) span(s): "
+            + "server rejected \(partial.rejectedCount) "
+            + "(\(partial.errorMessage ?? "no error message"))"
+        )
+      case .retryableFailure:
+        return
+      case .nonRetryableFailure(let reason):
+        observeLogger.warn(
+          "[EAS Observe] Dropping batch of \(chunk.count) span(s): \(reason)"
+        )
+      }
+      // Reached on success, partial success, and non-retryable failure — all outcomes after
+      // which the batch must not be sent again.
+      deleteDispatchedSpans(upToId: chunk.last?.id)
+    }
+  }
+
+  private static func deleteDispatchedSpans(upToId: Int64?) {
+    guard let upToId else {
+      return
+    }
+    do {
+      try AppMetrics.deleteSpans(upToId: upToId)
+    } catch {
+      observeLogger.warn("[EAS Observe] Failed to delete dispatched spans: \(error.localizedDescription)")
+    }
+  }
+
+  /// Groups `rows` by session id, hydrates the matching session rows, and emits one value per
+  /// session via `transform`. Shared by the metrics, logs, and traces builders so session
+  /// hydration behaves identically across the three signals. Rows whose session no longer
+  /// exists are skipped.
+  private static func buildPerSession<Row, T>(
+    _ rows: [Row],
+    sessionId: (Row) -> String,
+    transform: (SessionRow, [Row]) -> T?
+  ) throws -> [T] {
+    let rowsBySession = Dictionary(grouping: rows, by: sessionId)
+    let sessions = try AppMetrics.getSessions(ids: Array(rowsBySession.keys))
     return sessions.compactMap { session in
-      guard let sessionMetrics = metricsBySession[session.id] else {
+      guard let sessionRows = rowsBySession[session.id] else {
         return nil
       }
+      return transform(session, sessionRows)
+    }
+  }
+
+  /// Emits one `OTResourceSpans` per session, mirroring how metrics and logs attach their
+  /// session's resource metadata. Spans whose session row no longer exists are skipped — their
+  /// rows are about to be deleted by the caller anyway.
+  private static func buildResourceSpans(forSpans spans: [SpanRow]) throws -> [OTResourceSpans] {
+    return try buildPerSession(spans, sessionId: \.sessionId) { session, sessionSpans in
+      let event = Event.from(session: session, metrics: [], logs: [])
+      return event.toOTResourceSpans(easClientId, spans: sessionSpans.map { $0.toOTSpan() })
+    }
+  }
+
+  /// Emits one `Event` per session in the same shape Android dispatches: each event carries the
+  /// session's metadata and only the metrics that belong to it.
+  private static func buildEvents(forMetrics metrics: [MetricRow]) throws -> [Event] {
+    return try buildPerSession(metrics, sessionId: \.sessionId) { session, sessionMetrics in
       return Event.from(session: session, metrics: sessionMetrics, logs: [])
     }
   }
 
   private static func buildEvents(forLogs logs: [LogRow]) throws -> [Event] {
-    let logsBySession = Dictionary(grouping: logs, by: \.sessionId)
-    let sessionIds = Array(logsBySession.keys)
-    let sessions = try AppMetrics.getSessions(ids: sessionIds)
-    return sessions.compactMap { session in
-      guard let sessionLogs = logsBySession[session.id] else {
-        return nil
-      }
+    return try buildPerSession(logs, sessionId: \.sessionId) { session, sessionLogs in
       return Event.from(session: session, metrics: [], logs: sessionLogs)
     }
   }
@@ -228,6 +360,7 @@ internal struct ObservabilityManager {
     AppMetricsActor.isolated {
       self.metricsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/metrics")
       self.logsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/logs")
+      self.tracesEndpointUrl = url.appendingPathComponent("\(projectId)/v1/traces")
     }
   }
 

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -7,7 +7,12 @@ internal struct ObservabilityManager {
   private static let easClientId = EASClientID.uuid().uuidString
   private static var metricsEndpointUrl: URL? = nil
   private static var logsEndpointUrl: URL? = nil
+  private static var tracesEndpointUrl: URL? = nil
   private static var projectId: String? = nil
+
+  /// Maximum spans per request accepted by the ingestion endpoint; it rejects everything past
+  /// this count within one POST, so larger backlogs are sent as sequential chunks.
+  internal static let maxSpansPerRequest = 512
 
   /// In-memory retry-gate state, kept independently per OTLP endpoint. The `/v1/metrics` and
   /// `/v1/logs` endpoints fail independently in practice (e.g., one schema validation
@@ -22,14 +27,23 @@ internal struct ObservabilityManager {
   /// mean a UserDefaults write per retryable response.
   private static var metricsRetryGate: DispatchUtils.RetryGateState = .initial
   private static var logsRetryGate: DispatchUtils.RetryGateState = .initial
+  private static var tracesRetryGate: DispatchUtils.RetryGateState = .initial
+
+  /// Serializes dispatch passes, so a JS `dispatchEvents` racing the resign-active app delegate
+  /// hook waits its turn rather than sending the same rows twice.
+  private static let serializer = DispatchSerializer()
 
   internal static func dispatch() async {
-    // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` rather than
-    // here, so a backoff on one endpoint doesn't suppress the other's traffic.
-    let shouldDispatch = Self.shouldDispatch()
+    await serializer.run {
+      // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` /
+      // `dispatchTraces` rather than here, so a backoff on one endpoint doesn't suppress the
+      // others' traffic.
+      let shouldDispatch = Self.shouldDispatch()
 
-    await dispatchMetrics(shouldDispatch: shouldDispatch)
-    await dispatchLogs(shouldDispatch: shouldDispatch)
+      await dispatchMetrics(shouldDispatch: shouldDispatch)
+      await dispatchLogs(shouldDispatch: shouldDispatch)
+      await dispatchTraces(shouldDispatch: shouldDispatch)
+    }
   }
 
   /// Whether a per-signal retry gate currently blocks dispatch on that signal. Logs a debug
@@ -206,29 +220,127 @@ internal struct ObservabilityManager {
     )
   }
 
-  /// Groups `metrics` by `sessionId`, hydrates the matching session rows, and emits one `Event` per
-  /// session in the same shape Android dispatches: each event carries the session's metadata and only
-  /// the metrics that belong to it.
-  private static func buildEvents(forMetrics metrics: [MetricRow]) throws -> [Event] {
-    let metricsBySession = Dictionary(grouping: metrics, by: \.sessionId)
-    let sessionIds = Array(metricsBySession.keys)
-    let sessions = try AppMetrics.getSessions(ids: sessionIds)
+  /// Dispatches persisted spans to `/v1/traces`.
+  ///
+  /// Unlike metrics and logs there is no persisted cursor: nothing else reads the `spans` rows
+  /// back, so a consumed (or deliberately dropped) batch is deleted outright and the table
+  /// itself acts as the queue. Rows survive on a retryable failure and go out on the next
+  /// dispatch.
+  private static func dispatchTraces(shouldDispatch: Bool) async {
+    guard let endpointUrl = tracesEndpointUrl else {
+      // Without a project id there is nowhere to send spans, so skip even the table read:
+      // this path runs on every resign-active in apps without EAS config, and the pending
+      // rows are already bounded by the insert-time cap.
+      return
+    }
+    if retryGateBlocks(tracesRetryGate, signal: "traces") {
+      return
+    }
+    if !shouldDispatch {
+      // Drop the backlog without materializing it; one SELECT MAX is enough to know how far
+      // to delete. Mirrors metrics/logs advancing their cursor past rows they won't send.
+      do {
+        if let maxId = try AppMetrics.getMaxSpanId() {
+          try AppMetrics.deleteSpans(upToId: maxId)
+        }
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to drop undispatched spans: \(error.localizedDescription)")
+      }
+      return
+    }
+
+    // The endpoint rejects spans past `maxSpansPerRequest` per POST, so a larger backlog goes
+    // out as sequential chunks, read one chunk at a time. `SpanDispatchLoop` owns the reading,
+    // the chunking, the halving of an oversized chunk, and which outcomes delete their rows;
+    // these closures only fetch and send.
+    await SpanDispatchLoop.drain(
+      chunkSize: maxSpansPerRequest,
+      fetchChunk: { afterId, limit in
+        return try AppMetrics.getSpans(afterId: afterId, limit: limit)
+      },
+      send: { chunk in
+        let resourceSpans = try buildResourceSpans(forSpans: chunk)
+        if resourceSpans.isEmpty {
+          return nil
+        }
+        let body = OTTracesRequestBody(resourceSpans: resourceSpans)
+        let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+        applyRetryOutcome(result, to: &tracesRetryGate)
+        switch result {
+        case .success:
+          ObserveUserDefaults.lastDispatchDate = Date.now
+        case .partialSuccess(let partial):
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          observeLogger.warn(
+            "[EAS Observe] Partial success on batch of \(chunk.count) span(s): "
+              + "server rejected \(partial.rejectedCount) "
+              + "(\(partial.errorMessage ?? "no error message"))"
+          )
+        case .nonRetryableFailure(let reason):
+          observeLogger.warn(
+            "[EAS Observe] Dropping batch of \(chunk.count) span(s): \(reason)"
+          )
+        case .payloadTooLarge where chunk.count == 1:
+          observeLogger.warn("[EAS Observe] Dropping a span that exceeds the server payload limit")
+        case .retryableFailure, .payloadTooLarge:
+          break
+        }
+        return result
+      },
+      deleteUpTo: { deleteDispatchedSpans(upToId: $0) }
+    )
+  }
+
+  private static func deleteDispatchedSpans(upToId: Int64?) {
+    guard let upToId else {
+      return
+    }
+    do {
+      try AppMetrics.deleteSpans(upToId: upToId)
+    } catch {
+      observeLogger.warn("[EAS Observe] Failed to delete dispatched spans: \(error.localizedDescription)")
+    }
+  }
+
+  /// Groups `rows` by session id, hydrates the matching session rows, and emits one value per
+  /// session via `transform`. Shared by the metrics, logs, and traces builders so session
+  /// hydration behaves identically across the three signals. Rows whose session no longer
+  /// exists are skipped.
+  private static func buildPerSession<Row, T>(
+    _ rows: [Row],
+    sessionId: (Row) -> String,
+    transform: (SessionRow, [Row]) -> T?
+  ) throws -> [T] {
+    let rowsBySession = Dictionary(grouping: rows, by: sessionId)
+    let sessions = try AppMetrics.getSessions(ids: Array(rowsBySession.keys))
     return sessions.compactMap { session in
-      guard let sessionMetrics = metricsBySession[session.id] else {
+      guard let sessionRows = rowsBySession[session.id] else {
         return nil
       }
+      return transform(session, sessionRows)
+    }
+  }
+
+  /// Emits one `OTResourceSpans` per session, mirroring how metrics and logs attach their
+  /// session's resource metadata. Spans whose session row no longer exists are skipped: their
+  /// rows are about to be deleted by the caller anyway.
+  private static func buildResourceSpans(forSpans spans: [SpanRow]) throws -> [OTResourceSpans] {
+    return try buildPerSession(spans, sessionId: \.sessionId) { session, sessionSpans in
+      let event = Event.from(session: session, metrics: [], logs: [])
+      return event.toOTResourceSpans(easClientId, spans: sessionSpans.map { $0.toOTSpan() })
+    }
+  }
+
+  /// Emits one `Event` per session in the same shape Android dispatches: each event carries the
+  /// session's metadata and only the metrics that belong to it.
+  private static func buildEvents(forMetrics metrics: [MetricRow]) throws -> [Event] {
+    return try buildPerSession(metrics, sessionId: \.sessionId) { session, sessionMetrics in
       return Event.from(session: session, metrics: sessionMetrics, logs: [])
     }
   }
 
   private static func buildEvents(forLogs logs: [LogRow]) throws -> [Event] {
-    let logsBySession = Dictionary(grouping: logs, by: \.sessionId)
-    let sessionIds = Array(logsBySession.keys)
-    let sessions = try AppMetrics.getSessions(ids: sessionIds)
-    return sessions.compactMap { session in
-      guard let sessionLogs = logsBySession[session.id] else {
-        return nil
-      }
+    return try buildPerSession(logs, sessionId: \.sessionId) { session, sessionLogs in
       return Event.from(session: session, metrics: [], logs: sessionLogs)
     }
   }
@@ -244,6 +356,7 @@ internal struct ObservabilityManager {
     AppMetricsActor.isolated {
       self.metricsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/metrics")
       self.logsEndpointUrl = url.appendingPathComponent("\(projectId)/v1/logs")
+      self.tracesEndpointUrl = url.appendingPathComponent("\(projectId)/v1/traces")
     }
   }
 

--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -156,6 +156,48 @@ struct OTResourceLogs: Codable, Sendable {
   let schemaUrl: String
 }
 
+/// One OTLP span. Optionals (`parentSpanId`, `status`) rely on synthesized Codable's
+/// `encodeIfPresent`: the ingestion endpoint rejects a span whose present `parentSpanId` isn't
+/// valid hex, so a root span must omit the key entirely rather than send null or "".
+struct OTSpan: Codable, Sendable {
+  let traceId: String
+  let spanId: String
+  let parentSpanId: String?
+  let name: String
+  let kind: Int
+  let startTimeUnixNano: UInt64
+  let endTimeUnixNano: UInt64
+  let attributes: [OTAttribute]
+  let events: [OTSpanEvent]
+  let droppedEventsCount: Int
+  let status: OTSpanStatus?
+}
+
+/// `Span.Event` per the OTLP proto — used for redirect hops.
+struct OTSpanEvent: Codable, Sendable {
+  let timeUnixNano: UInt64
+  let name: String
+  let attributes: [OTAttribute]
+}
+
+/// `Status` per the OTLP proto. Only attached when the span represents a failure; a successful
+/// client span stays UNSET by omitting the status entirely, per the semantic conventions.
+struct OTSpanStatus: Codable, Sendable {
+  let code: Int
+  let message: String?
+}
+
+struct OTScopeSpans: Codable, Sendable {
+  let scope: OTScope
+  let spans: [OTSpan]
+}
+
+struct OTResourceSpans: Codable, Sendable {
+  let resource: OTMetadata
+  let scopeSpans: [OTScopeSpans]
+  let schemaUrl: String
+}
+
 // MARK: -- Event extensions for Open Telemetry
 
 /// OpenTelemetry Semantic Conventions schema URL referenced by the resource on
@@ -263,6 +305,87 @@ extension Event.Log {
       droppedAttributesCount: totalDrops > 0 ? totalDrops : nil
     )
   }
+}
+
+/// Maximum span events the ingestion endpoint keeps per span; anything past it is counted as
+/// dropped server-side, so the SDK truncates locally and reports the loss itself instead of
+/// shipping payload that is guaranteed to be discarded.
+private let maxSpanEventCount = 32
+
+/// Converts a persisted unix-epoch millisecond timestamp to nanoseconds, saturating instead of
+/// trapping: a corrupt row or a device clock set far into the future must never crash the host
+/// app from inside the telemetry library.
+private func spanNanoseconds(fromMilliseconds milliseconds: Int64) -> UInt64 {
+  let maxRepresentableMs = Int64(UInt64.max / 1_000_000)
+  return UInt64(min(max(0, milliseconds), maxRepresentableMs)) * 1_000_000
+}
+
+extension SpanRow {
+  /// Maps one persisted span row onto the OTLP wire shape. The mapping is producer-agnostic:
+  /// attributes and events were shaped by whichever producer recorded the row (per its own
+  /// semantic conventions), and this conversion only handles the generic concerns — timestamps,
+  /// the session attribute, the event cap, and the JSON-to-`AnyValue` typing.
+  func toOTSpan() -> OTSpan {
+    // Millisecond precision matches the backend's DateTime64(3) storage. A clock adjustment
+    // mid-span can invert the two wall-clock timestamps, and the server rejects a span whose
+    // end precedes its start, so the end clamps to the start.
+    let startNs = spanNanoseconds(fromMilliseconds: startTimestampMs)
+    let endNs = max(startNs, spanNanoseconds(fromMilliseconds: endTimestampMs))
+
+    var otAttributes: [OTAttribute] = [
+      OTAttribute(key: "session.id", rawValue: sessionId)
+    ]
+    if let attributesDict = decodeJSONObject(attributes) {
+      otAttributes.append(contentsOf: otAttributesFromUserDict(attributesDict).attributes)
+    }
+
+    // The ingestion endpoint keeps at most `maxSpanEventCount` events per span and counts the
+    // rest as dropped; truncating locally reports the same loss without shipping payload that
+    // is guaranteed to be discarded.
+    let allEvents = decodeJSONArray(events) ?? []
+    let otEvents = allEvents.prefix(maxSpanEventCount).compactMap { event -> OTSpanEvent? in
+      guard let name = event["name"] as? String else {
+        return nil
+      }
+      let eventAttributes = (event["attributes"] as? [String: Any]).map {
+        otAttributesFromUserDict($0).attributes
+      }
+      // Producers may record a per-event timestamp; without one the event anchors to the span
+      // start, which keeps it inside the span window.
+      let timeNs = (event["timeMs"] as? Int64).map(spanNanoseconds(fromMilliseconds:)) ?? startNs
+      return OTSpanEvent(timeUnixNano: timeNs, name: name, attributes: eventAttributes ?? [])
+    }
+
+    return OTSpan(
+      traceId: traceId,
+      spanId: spanId,
+      parentSpanId: parentSpanId,
+      name: name,
+      kind: kind,
+      startTimeUnixNano: startNs,
+      endTimeUnixNano: endNs,
+      attributes: otAttributes,
+      events: otEvents,
+      droppedEventsCount: max(0, allEvents.count - maxSpanEventCount),
+      status: statusCode.map { OTSpanStatus(code: $0, message: statusMessage) }
+    )
+  }
+}
+
+/// Decodes a JSON-object column into a dictionary, or `nil` when absent or malformed.
+private func decodeJSONObject(_ json: String?) -> [String: Any]? {
+  guard let json, let data = json.data(using: .utf8) else {
+    return nil
+  }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+}
+
+/// Decodes a JSON-array column into an array of objects, or `nil` when absent or malformed.
+private func decodeJSONArray(_ json: String?) -> [[String: Any]]? {
+  guard let json, let data = json.data(using: .utf8) else {
+    return nil
+  }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
 }
 
 /// Maps a caller-supplied attribute dictionary to typed `OTAttribute`s. Returns the
@@ -417,6 +540,22 @@ extension Event {
       schemaUrl: semConvSchemaUrl
     )
   }
+
+  /// Wraps already-mapped spans in this event's resource envelope. Spans are passed in rather
+  /// than derived from the event because they come from `spans` rows, which are not part of the
+  /// `Event` payload shape the metrics/logs signals share.
+  func toOTResourceSpans(_ easClientId: String, spans: [OTSpan]) -> OTResourceSpans {
+    OTResourceSpans(
+      resource: toOTMetadata(easClientId),
+      scopeSpans: [
+        OTScopeSpans(
+          scope: OTScope(name: "expo-observe", version: ObserveVersions.clientVersion),
+          spans: spans
+        )
+      ],
+      schemaUrl: semConvSchemaUrl
+    )
+  }
 }
 
 // MARK: -- Request body for Open Telemetry events
@@ -429,19 +568,24 @@ internal struct OTLogsRequestBody: Codable, Sendable {
   let resourceLogs: [OTResourceLogs]
 }
 
+internal struct OTTracesRequestBody: Codable, Sendable {
+  let resourceSpans: [OTResourceSpans]
+}
+
 // MARK: -- Response shapes for Open Telemetry endpoints
 
-/// Per OTLP/HTTP, both `/v1/metrics` and `/v1/logs` return an `ExportXServiceResponse` with an
-/// optional `partial_success` object. Our server emits it (with camelCase JSON keys — no
-/// snake_case translation) only when there were actual rejections, e.g.
+/// Per OTLP/HTTP, the `/v1/metrics`, `/v1/logs` and `/v1/traces` endpoints return an
+/// `ExportXServiceResponse` with an optional `partial_success` object. Our server emits it (with
+/// camelCase JSON keys — no snake_case translation) only when there were actual rejections, e.g.
 /// `{ "partialSuccess": { "rejectedDataPoints": 3, "errorMessage": "..." } }`. We model the
-/// union — `rejectedDataPoints` for metrics responses, `rejectedLogRecords` for logs responses
-/// — so a single decoder works for either endpoint.
+/// union — `rejectedDataPoints` for metrics, `rejectedLogRecords` for logs, `rejectedSpans` for
+/// traces — so a single decoder works for any of the endpoints.
 ///
 /// Spec: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
 internal struct OTPartialSuccess: Codable, Equatable, Sendable {
   let rejectedDataPoints: Int64?
   let rejectedLogRecords: Int64?
+  let rejectedSpans: Int64?
   let errorMessage: String?
 
   /// Count of records the server says it rejected from this batch. The OTLP spec also allows
@@ -449,7 +593,7 @@ internal struct OTPartialSuccess: Codable, Equatable, Sendable {
   /// `errorMessage`); the dispatch classifier treats that as a successful send with a logged
   /// warning rather than a batch drop.
   var rejectedCount: Int64 {
-    (rejectedDataPoints ?? 0) + (rejectedLogRecords ?? 0)
+    (rejectedDataPoints ?? 0) + (rejectedLogRecords ?? 0) + (rejectedSpans ?? 0)
   }
 }
 

--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -156,6 +156,48 @@ struct OTResourceLogs: Codable, Sendable {
   let schemaUrl: String
 }
 
+/// One OTLP span. Optionals (`parentSpanId`, `status`) rely on synthesized Codable's
+/// `encodeIfPresent`: the ingestion endpoint rejects a span whose present `parentSpanId` isn't
+/// valid hex, so a root span must omit the key entirely rather than send null or "".
+struct OTSpan: Codable, Sendable {
+  let traceId: String
+  let spanId: String
+  let parentSpanId: String?
+  let name: String
+  let kind: Int
+  let startTimeUnixNano: UInt64
+  let endTimeUnixNano: UInt64
+  let attributes: [OTAttribute]
+  let events: [OTSpanEvent]
+  let droppedEventsCount: Int
+  let status: OTSpanStatus?
+}
+
+/// `Span.Event` per the OTLP proto, used for redirect hops.
+struct OTSpanEvent: Codable, Sendable {
+  let timeUnixNano: UInt64
+  let name: String
+  let attributes: [OTAttribute]
+}
+
+/// `Status` per the OTLP proto. Only attached when the span represents a failure; a successful
+/// client span stays UNSET by omitting the status entirely, per the semantic conventions.
+struct OTSpanStatus: Codable, Sendable {
+  let code: Int
+  let message: String?
+}
+
+struct OTScopeSpans: Codable, Sendable {
+  let scope: OTScope
+  let spans: [OTSpan]
+}
+
+struct OTResourceSpans: Codable, Sendable {
+  let resource: OTMetadata
+  let scopeSpans: [OTScopeSpans]
+  let schemaUrl: String
+}
+
 // MARK: -- Event extensions for Open Telemetry
 
 /// OpenTelemetry Semantic Conventions schema URL referenced by the resource on
@@ -263,6 +305,87 @@ extension Event.Log {
       droppedAttributesCount: totalDrops > 0 ? totalDrops : nil
     )
   }
+}
+
+/// Maximum span events the ingestion endpoint keeps per span; anything past it is counted as
+/// dropped server-side, so the SDK truncates locally and reports the loss itself instead of
+/// shipping payload that is guaranteed to be discarded.
+private let maxSpanEventCount = 32
+
+/// Converts a persisted unix-epoch millisecond timestamp to nanoseconds, saturating instead of
+/// trapping: a corrupt row or a device clock set far into the future must never crash the host
+/// app from inside the telemetry library.
+private func spanNanoseconds(fromMilliseconds milliseconds: Int64) -> UInt64 {
+  let maxRepresentableMs = Int64(UInt64.max / 1_000_000)
+  return UInt64(min(max(0, milliseconds), maxRepresentableMs)) * 1_000_000
+}
+
+extension SpanRow {
+  /// Maps one persisted span row onto the OTLP wire shape. The mapping is producer-agnostic:
+  /// attributes and events were shaped by whichever producer recorded the row (per its own
+  /// semantic conventions), and this conversion only handles the generic concerns: timestamps,
+  /// the session attribute, the event cap, and the JSON-to-`AnyValue` typing.
+  func toOTSpan() -> OTSpan {
+    // Millisecond precision matches the backend's DateTime64(3) storage. A clock adjustment
+    // mid-span can invert the two wall-clock timestamps, and the server rejects a span whose
+    // end precedes its start, so the end clamps to the start.
+    let startNs = spanNanoseconds(fromMilliseconds: startTimestampMs)
+    let endNs = max(startNs, spanNanoseconds(fromMilliseconds: endTimestampMs))
+
+    var otAttributes: [OTAttribute] = [
+      OTAttribute(key: "session.id", rawValue: sessionId)
+    ]
+    if let attributesDict = decodeJSONObject(attributes) {
+      otAttributes.append(contentsOf: otAttributesFromUserDict(attributesDict).attributes)
+    }
+
+    // The ingestion endpoint keeps at most `maxSpanEventCount` events per span and counts the
+    // rest as dropped; truncating locally reports the same loss without shipping payload that
+    // is guaranteed to be discarded.
+    let allEvents = decodeJSONArray(events) ?? []
+    let otEvents = allEvents.prefix(maxSpanEventCount).compactMap { event -> OTSpanEvent? in
+      guard let name = event["name"] as? String else {
+        return nil
+      }
+      let eventAttributes = (event["attributes"] as? [String: Any]).map {
+        otAttributesFromUserDict($0).attributes
+      }
+      // Producers may record a per-event timestamp; without one the event anchors to the span
+      // start, which keeps it inside the span window.
+      let timeNs = (event["timeMs"] as? Int64).map(spanNanoseconds(fromMilliseconds:)) ?? startNs
+      return OTSpanEvent(timeUnixNano: timeNs, name: name, attributes: eventAttributes ?? [])
+    }
+
+    return OTSpan(
+      traceId: traceId,
+      spanId: spanId,
+      parentSpanId: parentSpanId,
+      name: name,
+      kind: kind,
+      startTimeUnixNano: startNs,
+      endTimeUnixNano: endNs,
+      attributes: otAttributes,
+      events: otEvents,
+      droppedEventsCount: max(0, allEvents.count - maxSpanEventCount),
+      status: statusCode.map { OTSpanStatus(code: $0, message: statusMessage) }
+    )
+  }
+}
+
+/// Decodes a JSON-object column into a dictionary, or `nil` when absent or malformed.
+private func decodeJSONObject(_ json: String?) -> [String: Any]? {
+  guard let json, let data = json.data(using: .utf8) else {
+    return nil
+  }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+}
+
+/// Decodes a JSON-array column into an array of objects, or `nil` when absent or malformed.
+private func decodeJSONArray(_ json: String?) -> [[String: Any]]? {
+  guard let json, let data = json.data(using: .utf8) else {
+    return nil
+  }
+  return (try? JSONSerialization.jsonObject(with: data)) as? [[String: Any]]
 }
 
 /// Maps a caller-supplied attribute dictionary to typed `OTAttribute`s. Returns the
@@ -417,6 +540,22 @@ extension Event {
       schemaUrl: semConvSchemaUrl
     )
   }
+
+  /// Wraps already-mapped spans in this event's resource envelope. Spans are passed in rather
+  /// than derived from the event because they come from `spans` rows, which are not part of the
+  /// `Event` payload shape the metrics/logs signals share.
+  func toOTResourceSpans(_ easClientId: String, spans: [OTSpan]) -> OTResourceSpans {
+    OTResourceSpans(
+      resource: toOTMetadata(easClientId),
+      scopeSpans: [
+        OTScopeSpans(
+          scope: OTScope(name: "expo-observe", version: ObserveVersions.clientVersion),
+          spans: spans
+        )
+      ],
+      schemaUrl: semConvSchemaUrl
+    )
+  }
 }
 
 // MARK: -- Request body for Open Telemetry events
@@ -429,19 +568,24 @@ internal struct OTLogsRequestBody: Codable, Sendable {
   let resourceLogs: [OTResourceLogs]
 }
 
+internal struct OTTracesRequestBody: Codable, Sendable {
+  let resourceSpans: [OTResourceSpans]
+}
+
 // MARK: -- Response shapes for Open Telemetry endpoints
 
-/// Per OTLP/HTTP, both `/v1/metrics` and `/v1/logs` return an `ExportXServiceResponse` with an
-/// optional `partial_success` object. Our server emits it (with camelCase JSON keys — no
-/// snake_case translation) only when there were actual rejections, e.g.
+/// Per OTLP/HTTP, the `/v1/metrics`, `/v1/logs` and `/v1/traces` endpoints return an
+/// `ExportXServiceResponse` with an optional `partial_success` object. Our server emits it (with
+/// camelCase JSON keys, with no snake_case translation) only when there were actual rejections, e.g.
 /// `{ "partialSuccess": { "rejectedDataPoints": 3, "errorMessage": "..." } }`. We model the
-/// union — `rejectedDataPoints` for metrics responses, `rejectedLogRecords` for logs responses
-/// — so a single decoder works for either endpoint.
+/// union (`rejectedDataPoints` for metrics, `rejectedLogRecords` for logs, `rejectedSpans` for
+/// traces), so a single decoder works for any of the endpoints.
 ///
 /// Spec: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
 internal struct OTPartialSuccess: Codable, Equatable, Sendable {
   let rejectedDataPoints: Int64?
   let rejectedLogRecords: Int64?
+  let rejectedSpans: Int64?
   let errorMessage: String?
 
   /// Count of records the server says it rejected from this batch. The OTLP spec also allows
@@ -449,7 +593,7 @@ internal struct OTPartialSuccess: Codable, Equatable, Sendable {
   /// `errorMessage`); the dispatch classifier treats that as a successful send with a logged
   /// warning rather than a batch drop.
   var rejectedCount: Int64 {
-    (rejectedDataPoints ?? 0) + (rejectedLogRecords ?? 0)
+    (rejectedDataPoints ?? 0) + (rejectedLogRecords ?? 0) + (rejectedSpans ?? 0)
   }
 }
 

--- a/packages/expo-observe/ios/SpanDispatchLoop.swift
+++ b/packages/expo-observe/ios/SpanDispatchLoop.swift
@@ -1,0 +1,112 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoAppMetrics
+
+/// The chunk-by-chunk send loop behind span dispatch, with its collaborators injected so the
+/// outcome handling can be tested without a database, a network, or the module's globals.
+///
+/// Spans deliberately do not reuse `DispatchLoop`: that loop owns a persisted cursor and stops
+/// after a batch it cannot advance past, whereas spans have no cursor (the table is the queue)
+/// and delete a dropped chunk before continuing with the next one.
+@AppMetricsActor
+internal enum SpanDispatchLoop {
+  /// What the loop should do with a chunk it has finished with.
+  internal enum Disposition {
+    /// Delete the chunk's rows and continue with the next chunk.
+    case deleteAndContinue
+    /// Leave every remaining row in place and stop, so the next dispatch retries them.
+    case keepAndStop
+  }
+
+  /// Sends pending spans one server-sized chunk at a time, halving any chunk the server rejects
+  /// as too large.
+  ///
+  /// Rows are re-read after each delivered chunk rather than materialized up front: each row
+  /// carries attribute and event JSON, this runs on resign-active and terminate, and re-reading
+  /// also picks up spans inserted while a long drain was in flight. Mirrors the Android loop.
+  ///
+  /// - Parameters:
+  ///   - chunkSize: maximum spans per POST, and per read.
+  ///   - fetchChunk: reads up to `limit` rows with an id greater than `afterId`, in id order.
+  ///   - send: performs one request. Returning `nil` means the chunk had nothing to send (every
+  ///     session row was pruned), which still deletes the rows: they are unrecoverable.
+  ///   - deleteUpTo: deletes every row through the given id.
+  internal static func drain(
+    chunkSize: Int,
+    fetchChunk: (_ afterId: Int64, _ limit: Int) throws -> [SpanRow],
+    send: (_ chunk: [SpanRow]) async throws -> DispatchResult?,
+    deleteUpTo: (Int64?) -> Void
+  ) async {
+    var readCursor: Int64 = -1
+    var chunks: [[SpanRow]] = []
+
+    while !Task.isCancelled {
+      if chunks.isEmpty {
+        let nextChunk: [SpanRow]
+        do {
+          nextChunk = try fetchChunk(readCursor, chunkSize)
+        } catch {
+          observeLogger.warn("[EAS Observe] Failed to read pending spans: \(error.localizedDescription)")
+          return
+        }
+        guard !nextChunk.isEmpty else {
+          return
+        }
+        // A row with no id cannot advance the cursor, and re-reading from the same place would
+        // loop on it forever.
+        guard let lastId = nextChunk.last?.id, lastId > readCursor else {
+          observeLogger.warn("[EAS Observe] Pending spans carry no usable id; stopping")
+          return
+        }
+        readCursor = lastId
+        chunks.append(nextChunk)
+      }
+
+      let chunk = chunks.removeFirst()
+      let result: DispatchResult?
+      do {
+        result = try await send(chunk)
+      } catch {
+        // Only the session read throws here, so the spans are intact and a transient database
+        // error must not cost them. Kept for the next dispatch, as in `DispatchLoop` and on
+        // Android. The insert-time cap bounds how long a persistently failing chunk can pin the
+        // queue.
+        observeLogger.warn(
+          "[EAS Observe] Failed to assemble trace events: \(error.localizedDescription)"
+        )
+        return
+      }
+      guard let result else {
+        deleteUpTo(chunk.last?.id)
+        continue
+      }
+      switch disposition(for: result, chunkCount: chunk.count) {
+      case .keepAndStop:
+        return
+      case .deleteAndContinue:
+        deleteUpTo(chunk.last?.id)
+      case nil:
+        // Too large to send and still splittable, so retry the halves before anything after them.
+        chunks.insert(Array(chunk[(chunk.count / 2)...]), at: 0)
+        chunks.insert(Array(chunk[..<(chunk.count / 2)]), at: 0)
+      }
+    }
+  }
+
+  /// Maps a send outcome onto what the loop does next, or `nil` when the chunk must be halved
+  /// and retried. Pure, so every branch is assertable on its own.
+  internal static func disposition(for result: DispatchResult, chunkCount: Int) -> Disposition? {
+    switch result {
+    case .success, .partialSuccess:
+      return .deleteAndContinue
+    case .retryableFailure:
+      return .keepAndStop
+    case .nonRetryableFailure:
+      return .deleteAndContinue
+    case .payloadTooLarge:
+      // A single row cannot be split, so it is dropped: keeping it would block every span
+      // behind it on every future dispatch.
+      return chunkCount > 1 ? nil : .deleteAndContinue
+    }
+  }
+}

--- a/packages/expo-observe/ios/Tests/DispatchLoopTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchLoopTests.swift
@@ -37,7 +37,12 @@ struct DispatchLoopTests {
 
   @Test
   func `partial success advances and continues`() async {
-    let partial = OTPartialSuccess(rejectedDataPoints: 1, rejectedLogRecords: nil, errorMessage: nil)
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 1,
+      rejectedLogRecords: nil,
+      rejectedSpans: nil,
+      errorMessage: nil
+    )
     let state = State(rows: rows(1...3), results: [.partialSuccess(partial), .success], chunkSize: 2)
 
     await drain(state)

--- a/packages/expo-observe/ios/Tests/DispatchSerializerTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchSerializerTests.swift
@@ -1,0 +1,100 @@
+import ExpoAppMetrics
+import Testing
+
+@testable import ExpoObserve
+
+@Suite("DispatchSerializer")
+@AppMetricsActor
+struct DispatchSerializerTests {
+  @Test
+  func `runs the work it is given`() async {
+    let serializer = DispatchSerializer()
+    var ran = false
+    await serializer.run {
+      ran = true
+    }
+    #expect(ran)
+  }
+
+  @Test
+  func `a second caller waits instead of running concurrently`() async {
+    // The actor is reentrant at every network `await`, so two overlapping passes would read and
+    // send the same pending rows twice. Waiting (rather than skipping) is what lets a JS
+    // `dispatchEvents()` promise mean the queue was drained.
+    let serializer = DispatchSerializer()
+    let tracker = OverlapTracker()
+    async let first: Void = serializer.run {
+      await tracker.enter()
+      await Task.yield()
+      await tracker.leave()
+    }
+    async let second: Void = serializer.run {
+      await tracker.enter()
+      await Task.yield()
+      await tracker.leave()
+    }
+    _ = await (first, second)
+    #expect(await tracker.runCount == 2)
+    #expect(await tracker.maxConcurrent == 1)
+  }
+
+  @Test
+  func `a later caller runs after the one ahead finishes`() async {
+    let serializer = DispatchSerializer()
+    let tracker = OverlapTracker()
+    await serializer.run {
+      await tracker.enter()
+      await tracker.leave()
+    }
+    await serializer.run {
+      await tracker.enter()
+      await tracker.leave()
+    }
+    #expect(await tracker.runCount == 2)
+    #expect(await tracker.maxConcurrent == 1)
+  }
+
+  @Test
+  func `three overlapping callers each run exactly once, in turn`() async {
+    // The chain has to link each caller behind the pass it found. Publishing the new task before
+    // awaiting is what makes that work: awaiting first would let all three observe an idle
+    // serializer and run together.
+    let serializer = DispatchSerializer()
+    let tracker = OverlapTracker()
+    async let first: Void = serializer.run {
+      await tracker.enter()
+      await Task.yield()
+      await tracker.leave()
+    }
+    async let second: Void = serializer.run {
+      await tracker.enter()
+      await Task.yield()
+      await tracker.leave()
+    }
+    async let third: Void = serializer.run {
+      await tracker.enter()
+      await Task.yield()
+      await tracker.leave()
+    }
+    _ = await (first, second, third)
+    #expect(await tracker.runCount == 3)
+    #expect(await tracker.maxConcurrent == 1)
+  }
+}
+
+/// Records how many passes ran and whether any two overlapped.
+private actor OverlapTracker {
+  private(set) var runCount = 0
+  private(set) var maxConcurrent = 0
+  private var current = 0
+
+  func enter() {
+    runCount += 1
+    current += 1
+    maxConcurrent = max(maxConcurrent, current)
+  }
+
+  func leave() {
+    current -= 1
+  }
+}

--- a/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
@@ -47,7 +47,12 @@ struct DispatchUtilsNextCursorTests {
   /// re-sending the same rows would just trip the same rejection.
   @Test
   func `partialSuccess advances cursor to highestId`() {
-    let partial = OTPartialSuccess(rejectedDataPoints: 1, rejectedLogRecords: nil, errorMessage: "x")
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 1,
+      rejectedLogRecords: nil,
+      rejectedSpans: nil,
+      errorMessage: "x"
+    )
     let next = DispatchUtils.nextCursor(
       for: .partialSuccess(partial),
       currentCursor: 10,

--- a/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
@@ -57,7 +57,12 @@ struct DispatchUtilsNextCursorTests {
   /// re-sending the same rows would just trip the same rejection.
   @Test
   func `partialSuccess advances cursor to highestId`() {
-    let partial = OTPartialSuccess(rejectedDataPoints: 1, rejectedLogRecords: nil, errorMessage: "x")
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 1,
+      rejectedLogRecords: nil,
+      rejectedSpans: nil,
+      errorMessage: "x"
+    )
     let next = DispatchUtils.nextCursor(
       for: .partialSuccess(partial),
       currentCursor: 10,

--- a/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
@@ -40,7 +40,12 @@ struct DispatchUtilsRetryGateTests {
       dispatchAfterDate: now.addingTimeInterval(60),
       consecutiveRetryableFailures: 4
     )
-    let partial = OTPartialSuccess(rejectedDataPoints: 2, rejectedLogRecords: nil, errorMessage: nil)
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: 2,
+      rejectedLogRecords: nil,
+      rejectedSpans: nil,
+      errorMessage: nil
+    )
     let next = DispatchUtils.nextRetryGateState(
       result: .partialSuccess(partial),
       currentState: state,

--- a/packages/expo-observe/ios/Tests/OTSpanTests.swift
+++ b/packages/expo-observe/ios/Tests/OTSpanTests.swift
@@ -1,0 +1,283 @@
+import ExpoAppMetrics
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+/// Fixed span window used across these tests: 250 ms starting at a whole second, so the
+/// nanosecond expectations stay readable.
+private let startMs: Int64 = 1_782_131_895_000
+private let endMs: Int64 = 1_782_131_895_250
+
+private func makeRow(
+  sessionId: String = "0f8fad5b-d9cb-469f-a165-70867728950e",
+  traceId: String = "a3ce929d0e0e4736a3ce929d0e0e4736",
+  spanId: String = "00f067aa0ba902b7",
+  parentSpanId: String? = nil,
+  name: String = "GET",
+  kind: Int = SpanRow.clientKind,
+  startTimestampMs: Int64 = startMs,
+  endTimestampMs: Int64 = endMs,
+  statusCode: Int? = nil,
+  statusMessage: String? = nil,
+  attributes: String? = nil,
+  events: String? = nil
+) -> SpanRow {
+  return SpanRow(
+    sessionId: sessionId,
+    traceId: traceId,
+    spanId: spanId,
+    parentSpanId: parentSpanId,
+    name: name,
+    kind: kind,
+    startTimestampMs: startTimestampMs,
+    endTimestampMs: endTimestampMs,
+    statusCode: statusCode,
+    statusMessage: statusMessage,
+    attributes: attributes,
+    events: events
+  )
+}
+
+/// Looks up a span attribute by key, returning `nil` when absent.
+private func attribute(_ span: OTSpan, _ key: String) -> OTAnyValue? {
+  return span.attributes.first { $0.key == key }?.value
+}
+
+private func stringAttribute(_ span: OTSpan, _ key: String) -> String? {
+  guard case .string(let value) = attribute(span, key) else {
+    return nil
+  }
+  return value
+}
+
+private func intAttribute(_ span: OTSpan, _ key: String) -> Int64? {
+  guard case .int(let value) = attribute(span, key) else {
+    return nil
+  }
+  return value
+}
+
+@Suite("SpanRow to OTSpan mapping")
+struct SpanRowMappingTests {
+  @Test
+  func `passes the persisted identity through to the wire shape`() {
+    // Ids are generated at record time and persisted precisely so that the export layer never
+    // invents new ones — a redelivered row must stay byte-identical on the server.
+    let span = makeRow(name: "POST", kind: 5).toOTSpan()
+    #expect(span.traceId == "a3ce929d0e0e4736a3ce929d0e0e4736")
+    #expect(span.spanId == "00f067aa0ba902b7")
+    #expect(span.name == "POST")
+    #expect(span.kind == 5)
+  }
+
+  @Test
+  func `omits the parent span id for a root span`() {
+    // The server rejects a present-but-invalid parent id, so a root span must leave it absent
+    // rather than empty.
+    let span = makeRow().toOTSpan()
+    #expect(span.parentSpanId == nil)
+  }
+
+  @Test
+  func `passes a present parent span id through`() {
+    let span = makeRow(parentSpanId: "abcdef0123456789").toOTSpan()
+    #expect(span.parentSpanId == "abcdef0123456789")
+  }
+
+  @Test
+  func `converts the start and end timestamps to unix nanoseconds`() {
+    let span = makeRow().toOTSpan()
+    #expect(span.startTimeUnixNano == 1_782_131_895_000_000_000)
+    #expect(span.endTimeUnixNano == 1_782_131_895_250_000_000)
+  }
+
+  @Test
+  func `never reports an end that precedes the start`() {
+    // The server rejects a span whose end is before its start. A clock adjustment mid-span
+    // can invert the two wall-clock timestamps, so the mapping has to clamp.
+    let span = makeRow(startTimestampMs: startMs, endTimestampMs: startMs - 5_000).toOTSpan()
+    #expect(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  func `clamps a far-future timestamp instead of trapping on overflow`() {
+    // A corrupt row or a device clock set far into the future must never crash the host app
+    // from inside the telemetry library; the nanosecond conversion saturates instead.
+    let span = makeRow(startTimestampMs: Int64.max, endTimestampMs: Int64.max).toOTSpan()
+    #expect(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  func `attaches the session id as an attribute`() {
+    let sessionId = UUID().uuidString
+    let span = makeRow(sessionId: sessionId).toOTSpan()
+    #expect(stringAttribute(span, "session.id") == sessionId)
+  }
+
+  @Test
+  func `decodes the attributes blob into typed wire attributes`() {
+    let json =
+      #"{"http.request.method":"GET","http.response.status_code":200,"http.request.size":412,"retried":false,"sampling.rate":0.5}"#
+    let span = makeRow(attributes: json).toOTSpan()
+    #expect(stringAttribute(span, "http.request.method") == "GET")
+    #expect(intAttribute(span, "http.response.status_code") == 200)
+    #expect(intAttribute(span, "http.request.size") == 412)
+    if case .bool(let retried) = attribute(span, "retried") {
+      #expect(retried == false)
+    } else {
+      Issue.record("Expected a bool `retried` attribute")
+    }
+    if case .double(let rate) = attribute(span, "sampling.rate") {
+      #expect(rate == 0.5)
+    } else {
+      Issue.record("Expected a double `sampling.rate` attribute")
+    }
+  }
+
+  @Test
+  func `tolerates an absent or malformed attributes blob`() {
+    // Only the session attribute remains; a bad blob must not fail the whole span.
+    for blob in [nil, "not json", "[1,2,3]"] {
+      let span = makeRow(attributes: blob).toOTSpan()
+      #expect(span.attributes.count == 1)
+      #expect(span.attributes.first?.key == "session.id")
+    }
+  }
+
+  @Test
+  func `passes the error status and message through`() {
+    let span = makeRow(statusCode: 2, statusMessage: "offline").toOTSpan()
+    #expect(span.status?.code == 2)
+    #expect(span.status?.message == "offline")
+  }
+
+  @Test
+  func `omits the status when the row has none`() {
+    // UNSET is expressed by omitting the status object entirely, per the conventions.
+    let span = makeRow(statusCode: nil).toOTSpan()
+    #expect(span.status == nil)
+  }
+}
+
+@Suite("Span event decoding")
+struct SpanEventDecodingTests {
+  private func eventsJSON(count: Int) -> String {
+    let events = (0..<count).map { index in
+      return #"{"name":"http.redirect","attributes":{"from":"https://example.com/\#(index)","statusCode":302}}"#
+    }
+    return "[\(events.joined(separator: ","))]"
+  }
+
+  @Test
+  func `decodes events with their attributes`() throws {
+    let span = makeRow(events: eventsJSON(count: 2)).toOTSpan()
+    #expect(span.events.count == 2)
+    #expect(span.events.allSatisfy { $0.name == "http.redirect" })
+    let first = try #require(span.events.first)
+    let attributes = Dictionary(uniqueKeysWithValues: first.attributes.map { ($0.key, $0.value) })
+    if case .string(let from) = attributes["from"] {
+      #expect(from == "https://example.com/0")
+    } else {
+      Issue.record("Expected a string `from` attribute")
+    }
+    if case .int(let statusCode) = attributes["statusCode"] {
+      #expect(statusCode == 302)
+    } else {
+      Issue.record("Expected an int `statusCode` attribute")
+    }
+  }
+
+  @Test
+  func `anchors events without a timestamp to the span start`() {
+    // Producers may omit per-event timestamps; an out-of-window event is meaningless in a
+    // trace waterfall, so the fallback is the span start.
+    let span = makeRow(events: eventsJSON(count: 2)).toOTSpan()
+    for event in span.events {
+      #expect(event.timeUnixNano == span.startTimeUnixNano)
+    }
+  }
+
+  @Test
+  func `uses a per-event timestamp when the producer recorded one`() {
+    let json = #"[{"name":"checkpoint","timeMs":\#(startMs + 100)}]"#
+    let span = makeRow(events: json).toOTSpan()
+    #expect(span.events.first?.timeUnixNano == 1_782_131_895_100_000_000)
+  }
+
+  @Test
+  func `drops an event without a name`() {
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    let json = #"[{"attributes":{"orphan":true}},{"name":"kept"}]"#
+    let span = makeRow(events: json).toOTSpan()
+    #expect(span.events.map(\.name) == ["kept"])
+  }
+
+  @Test
+  func `emits no events when the row has none`() {
+    let span = makeRow().toOTSpan()
+    #expect(span.events.isEmpty)
+    #expect(span.droppedEventsCount == 0)
+  }
+
+  @Test
+  func `caps the number of emitted events at the server limit`() {
+    // The server keeps at most 32 events per span and counts the rest as dropped. Sending
+    // more just wastes payload, so the SDK truncates and reports the loss itself.
+    let span = makeRow(events: eventsJSON(count: 40)).toOTSpan()
+    #expect(span.events.count == 32)
+    #expect(span.droppedEventsCount == 8)
+  }
+}
+
+@Suite("Traces request body encoding")
+struct OTTracesRequestBodyTests {
+  private func encodeSpans(_ spans: [OTSpan]) throws -> [[String: Any]] {
+    let body = OTTracesRequestBody(resourceSpans: [
+      OTResourceSpans(
+        resource: OTMetadata(attributes: []),
+        scopeSpans: [
+          OTScopeSpans(scope: OTScope(name: "expo-observe", version: "1.0.0"), spans: spans)
+        ],
+        schemaUrl: "https://opentelemetry.io/schemas/1.27.0"
+      )
+    ])
+    let data = try JSONEncoder().encode(body)
+    let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let resourceSpans = try #require(json["resourceSpans"] as? [[String: Any]])
+    let scopeSpans = try #require(resourceSpans.first?["scopeSpans"] as? [[String: Any]])
+    return try #require(scopeSpans.first?["spans"] as? [[String: Any]])
+  }
+
+  @Test
+  func `encodes the resourceSpans envelope the endpoint expects`() throws {
+    let spans = try encodeSpans([makeRow().toOTSpan()])
+    #expect(spans.count == 1)
+    #expect(spans.first?["name"] as? String == "GET")
+    #expect(spans.first?["kind"] as? Int == 3)
+    #expect(spans.first?["traceId"] as? String == "a3ce929d0e0e4736a3ce929d0e0e4736")
+  }
+
+  @Test
+  func `omits an absent parent span id from the encoded span`() throws {
+    // The server rejects a span carrying a present-but-invalid parent id, so a root span
+    // must leave the key out entirely rather than encode null or an empty string.
+    let spans = try encodeSpans([makeRow().toOTSpan()])
+    let encodedSpan = try #require(spans.first)
+    #expect(encodedSpan.keys.contains("parentSpanId") == false)
+  }
+}
+
+@Suite("Traces partial-success decoding")
+struct OTTracesPartialSuccessTests {
+  @Test
+  func `counts rejected spans from a traces partial success`() throws {
+    // The traces endpoint reports `rejectedSpans`, a field neither the metrics nor the logs
+    // response carries. Without it the shared decoder reads a rejection as a clean success.
+    let json = #"{"partialSuccess":{"rejectedSpans":3,"errorMessage":"bad span"}}"#
+    let response = try JSONDecoder().decode(OTServiceResponse.self, from: Data(json.utf8))
+    let partial = try #require(response.partialSuccess)
+    #expect(partial.rejectedCount == 3)
+    #expect(partial.errorMessage == "bad span")
+  }
+}

--- a/packages/expo-observe/ios/Tests/OTSpanTests.swift
+++ b/packages/expo-observe/ios/Tests/OTSpanTests.swift
@@ -1,0 +1,283 @@
+import ExpoAppMetrics
+import Foundation
+import Testing
+
+@testable import ExpoObserve
+
+/// Fixed span window used across these tests: 250 ms starting at a whole second, so the
+/// nanosecond expectations stay readable.
+private let startMs: Int64 = 1_782_131_895_000
+private let endMs: Int64 = 1_782_131_895_250
+
+private func makeRow(
+  sessionId: String = "0f8fad5b-d9cb-469f-a165-70867728950e",
+  traceId: String = "a3ce929d0e0e4736a3ce929d0e0e4736",
+  spanId: String = "00f067aa0ba902b7",
+  parentSpanId: String? = nil,
+  name: String = "GET",
+  kind: Int = SpanRow.clientKind,
+  startTimestampMs: Int64 = startMs,
+  endTimestampMs: Int64 = endMs,
+  statusCode: Int? = nil,
+  statusMessage: String? = nil,
+  attributes: String? = nil,
+  events: String? = nil
+) -> SpanRow {
+  return SpanRow(
+    sessionId: sessionId,
+    traceId: traceId,
+    spanId: spanId,
+    parentSpanId: parentSpanId,
+    name: name,
+    kind: kind,
+    startTimestampMs: startTimestampMs,
+    endTimestampMs: endTimestampMs,
+    statusCode: statusCode,
+    statusMessage: statusMessage,
+    attributes: attributes,
+    events: events
+  )
+}
+
+/// Looks up a span attribute by key, returning `nil` when absent.
+private func attribute(_ span: OTSpan, _ key: String) -> OTAnyValue? {
+  return span.attributes.first { $0.key == key }?.value
+}
+
+private func stringAttribute(_ span: OTSpan, _ key: String) -> String? {
+  guard case .string(let value) = attribute(span, key) else {
+    return nil
+  }
+  return value
+}
+
+private func intAttribute(_ span: OTSpan, _ key: String) -> Int64? {
+  guard case .int(let value) = attribute(span, key) else {
+    return nil
+  }
+  return value
+}
+
+@Suite("SpanRow to OTSpan mapping")
+struct SpanRowMappingTests {
+  @Test
+  func `passes the persisted identity through to the wire shape`() {
+    // Ids are generated at record time and persisted precisely so that the export layer never
+    // invents new ones, because a redelivered row must stay byte-identical on the server.
+    let span = makeRow(name: "POST", kind: 5).toOTSpan()
+    #expect(span.traceId == "a3ce929d0e0e4736a3ce929d0e0e4736")
+    #expect(span.spanId == "00f067aa0ba902b7")
+    #expect(span.name == "POST")
+    #expect(span.kind == 5)
+  }
+
+  @Test
+  func `omits the parent span id for a root span`() {
+    // The server rejects a present-but-invalid parent id, so a root span must leave it absent
+    // rather than empty.
+    let span = makeRow().toOTSpan()
+    #expect(span.parentSpanId == nil)
+  }
+
+  @Test
+  func `passes a present parent span id through`() {
+    let span = makeRow(parentSpanId: "abcdef0123456789").toOTSpan()
+    #expect(span.parentSpanId == "abcdef0123456789")
+  }
+
+  @Test
+  func `converts the start and end timestamps to unix nanoseconds`() {
+    let span = makeRow().toOTSpan()
+    #expect(span.startTimeUnixNano == 1_782_131_895_000_000_000)
+    #expect(span.endTimeUnixNano == 1_782_131_895_250_000_000)
+  }
+
+  @Test
+  func `never reports an end that precedes the start`() {
+    // The server rejects a span whose end is before its start. A clock adjustment mid-span
+    // can invert the two wall-clock timestamps, so the mapping has to clamp.
+    let span = makeRow(startTimestampMs: startMs, endTimestampMs: startMs - 5_000).toOTSpan()
+    #expect(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  func `clamps a far-future timestamp instead of trapping on overflow`() {
+    // A corrupt row or a device clock set far into the future must never crash the host app
+    // from inside the telemetry library; the nanosecond conversion saturates instead.
+    let span = makeRow(startTimestampMs: Int64.max, endTimestampMs: Int64.max).toOTSpan()
+    #expect(span.endTimeUnixNano >= span.startTimeUnixNano)
+  }
+
+  @Test
+  func `attaches the session id as an attribute`() {
+    let sessionId = UUID().uuidString
+    let span = makeRow(sessionId: sessionId).toOTSpan()
+    #expect(stringAttribute(span, "session.id") == sessionId)
+  }
+
+  @Test
+  func `decodes the attributes blob into typed wire attributes`() {
+    let json =
+      #"{"http.request.method":"GET","http.response.status_code":200,"http.request.size":412,"retried":false,"sampling.rate":0.5}"#
+    let span = makeRow(attributes: json).toOTSpan()
+    #expect(stringAttribute(span, "http.request.method") == "GET")
+    #expect(intAttribute(span, "http.response.status_code") == 200)
+    #expect(intAttribute(span, "http.request.size") == 412)
+    if case .bool(let retried) = attribute(span, "retried") {
+      #expect(retried == false)
+    } else {
+      Issue.record("Expected a bool `retried` attribute")
+    }
+    if case .double(let rate) = attribute(span, "sampling.rate") {
+      #expect(rate == 0.5)
+    } else {
+      Issue.record("Expected a double `sampling.rate` attribute")
+    }
+  }
+
+  @Test
+  func `tolerates an absent or malformed attributes blob`() {
+    // Only the session attribute remains; a bad blob must not fail the whole span.
+    for blob in [nil, "not json", "[1,2,3]"] {
+      let span = makeRow(attributes: blob).toOTSpan()
+      #expect(span.attributes.count == 1)
+      #expect(span.attributes.first?.key == "session.id")
+    }
+  }
+
+  @Test
+  func `passes the error status and message through`() {
+    let span = makeRow(statusCode: 2, statusMessage: "offline").toOTSpan()
+    #expect(span.status?.code == 2)
+    #expect(span.status?.message == "offline")
+  }
+
+  @Test
+  func `omits the status when the row has none`() {
+    // UNSET is expressed by omitting the status object entirely, per the conventions.
+    let span = makeRow(statusCode: nil).toOTSpan()
+    #expect(span.status == nil)
+  }
+}
+
+@Suite("Span event decoding")
+struct SpanEventDecodingTests {
+  private func eventsJSON(count: Int) -> String {
+    let events = (0..<count).map { index in
+      return #"{"name":"http.redirect","attributes":{"from":"https://example.com/\#(index)","statusCode":302}}"#
+    }
+    return "[\(events.joined(separator: ","))]"
+  }
+
+  @Test
+  func `decodes events with their attributes`() throws {
+    let span = makeRow(events: eventsJSON(count: 2)).toOTSpan()
+    #expect(span.events.count == 2)
+    #expect(span.events.allSatisfy { $0.name == "http.redirect" })
+    let first = try #require(span.events.first)
+    let attributes = Dictionary(uniqueKeysWithValues: first.attributes.map { ($0.key, $0.value) })
+    if case .string(let from) = attributes["from"] {
+      #expect(from == "https://example.com/0")
+    } else {
+      Issue.record("Expected a string `from` attribute")
+    }
+    if case .int(let statusCode) = attributes["statusCode"] {
+      #expect(statusCode == 302)
+    } else {
+      Issue.record("Expected an int `statusCode` attribute")
+    }
+  }
+
+  @Test
+  func `anchors events without a timestamp to the span start`() {
+    // Producers may omit per-event timestamps; an out-of-window event is meaningless in a
+    // trace waterfall, so the fallback is the span start.
+    let span = makeRow(events: eventsJSON(count: 2)).toOTSpan()
+    for event in span.events {
+      #expect(event.timeUnixNano == span.startTimeUnixNano)
+    }
+  }
+
+  @Test
+  func `uses a per-event timestamp when the producer recorded one`() {
+    let json = #"[{"name":"checkpoint","timeMs":\#(startMs + 100)}]"#
+    let span = makeRow(events: json).toOTSpan()
+    #expect(span.events.first?.timeUnixNano == 1_782_131_895_100_000_000)
+  }
+
+  @Test
+  func `drops an event without a name`() {
+    // The server drops nameless events anyway; skipping them locally keeps the payload honest.
+    let json = #"[{"attributes":{"orphan":true}},{"name":"kept"}]"#
+    let span = makeRow(events: json).toOTSpan()
+    #expect(span.events.map(\.name) == ["kept"])
+  }
+
+  @Test
+  func `emits no events when the row has none`() {
+    let span = makeRow().toOTSpan()
+    #expect(span.events.isEmpty)
+    #expect(span.droppedEventsCount == 0)
+  }
+
+  @Test
+  func `caps the number of emitted events at the server limit`() {
+    // The server keeps at most 32 events per span and counts the rest as dropped. Sending
+    // more just wastes payload, so the SDK truncates and reports the loss itself.
+    let span = makeRow(events: eventsJSON(count: 40)).toOTSpan()
+    #expect(span.events.count == 32)
+    #expect(span.droppedEventsCount == 8)
+  }
+}
+
+@Suite("Traces request body encoding")
+struct OTTracesRequestBodyTests {
+  private func encodeSpans(_ spans: [OTSpan]) throws -> [[String: Any]] {
+    let body = OTTracesRequestBody(resourceSpans: [
+      OTResourceSpans(
+        resource: OTMetadata(attributes: []),
+        scopeSpans: [
+          OTScopeSpans(scope: OTScope(name: "expo-observe", version: "1.0.0"), spans: spans)
+        ],
+        schemaUrl: "https://opentelemetry.io/schemas/1.27.0"
+      )
+    ])
+    let data = try JSONEncoder().encode(body)
+    let json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+    let resourceSpans = try #require(json["resourceSpans"] as? [[String: Any]])
+    let scopeSpans = try #require(resourceSpans.first?["scopeSpans"] as? [[String: Any]])
+    return try #require(scopeSpans.first?["spans"] as? [[String: Any]])
+  }
+
+  @Test
+  func `encodes the resourceSpans envelope the endpoint expects`() throws {
+    let spans = try encodeSpans([makeRow().toOTSpan()])
+    #expect(spans.count == 1)
+    #expect(spans.first?["name"] as? String == "GET")
+    #expect(spans.first?["kind"] as? Int == 3)
+    #expect(spans.first?["traceId"] as? String == "a3ce929d0e0e4736a3ce929d0e0e4736")
+  }
+
+  @Test
+  func `omits an absent parent span id from the encoded span`() throws {
+    // The server rejects a span carrying a present-but-invalid parent id, so a root span
+    // must leave the key out entirely rather than encode null or an empty string.
+    let spans = try encodeSpans([makeRow().toOTSpan()])
+    let encodedSpan = try #require(spans.first)
+    #expect(encodedSpan.keys.contains("parentSpanId") == false)
+  }
+}
+
+@Suite("Traces partial-success decoding")
+struct OTTracesPartialSuccessTests {
+  @Test
+  func `counts rejected spans from a traces partial success`() throws {
+    // The traces endpoint reports `rejectedSpans`, a field neither the metrics nor the logs
+    // response carries. Without it the shared decoder reads a rejection as a clean success.
+    let json = #"{"partialSuccess":{"rejectedSpans":3,"errorMessage":"bad span"}}"#
+    let response = try JSONDecoder().decode(OTServiceResponse.self, from: Data(json.utf8))
+    let partial = try #require(response.partialSuccess)
+    #expect(partial.rejectedCount == 3)
+    #expect(partial.errorMessage == "bad span")
+  }
+}

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -22,6 +22,7 @@ struct ObservabilityClassifyResponseTests {
     let partial = OTPartialSuccess(
       rejectedDataPoints: 3,
       rejectedLogRecords: nil,
+      rejectedSpans: nil,
       errorMessage: "metric_kind_mismatch"
     )
     let result = DispatchUtils.classifyResponse(
@@ -39,6 +40,7 @@ struct ObservabilityClassifyResponseTests {
     let partial = OTPartialSuccess(
       rejectedDataPoints: nil,
       rejectedLogRecords: 1,
+      rejectedSpans: nil,
       errorMessage: "log_too_large"
     )
     let result = DispatchUtils.classifyResponse(
@@ -56,6 +58,7 @@ struct ObservabilityClassifyResponseTests {
     let partial = OTPartialSuccess(
       rejectedDataPoints: 0,
       rejectedLogRecords: 0,
+      rejectedSpans: nil,
       errorMessage: "deprecation_warning"
     )
     let result = DispatchUtils.classifyResponse(

--- a/packages/expo-observe/ios/Tests/SpanDispatchLoopTests.swift
+++ b/packages/expo-observe/ios/Tests/SpanDispatchLoopTests.swift
@@ -1,0 +1,201 @@
+import ExpoAppMetrics
+import Testing
+
+@testable import ExpoObserve
+
+@AppMetricsActor
+@Suite("SpanDispatchLoop")
+struct SpanDispatchLoopTests {
+  /// Records what the loop sent and deleted so each outcome can be asserted end to end.
+  private final class Recorder {
+    var sentIds: [[Int64?]] = []
+    var deletedIds: [Int64?] = []
+    var fetchCursors: [Int64] = []
+    var results: [DispatchResult?]
+    var sendError: Error?
+    var fetchError: Error?
+
+    init(results: [DispatchResult?]) {
+      self.results = results
+    }
+  }
+
+  private enum TestError: Error {
+    case failed
+  }
+
+  @Test
+  func `an empty table sends nothing and deletes nothing`() async {
+    let recorder = Recorder(results: [])
+    await drain(rows: [], recorder: recorder)
+    #expect(recorder.sentIds.isEmpty)
+    #expect(recorder.deletedIds.isEmpty)
+  }
+
+  @Test
+  func `a successful chunk is deleted up to its highest id`() async {
+    let recorder = Recorder(results: [.success])
+    await drain(rows: rows(1...3), recorder: recorder)
+    #expect(recorder.sentIds == [[1, 2, 3]])
+    #expect(recorder.deletedIds == [3])
+  }
+
+  @Test
+  func `a backlog goes out as sequential chunks`() async {
+    let recorder = Recorder(results: [.success, .success, .success])
+    await drain(rows: rows(1...5), recorder: recorder, chunkSize: 2)
+    #expect(recorder.sentIds == [[1, 2], [3, 4], [5]])
+    #expect(recorder.deletedIds == [2, 4, 5])
+  }
+
+  @Test
+  func `a retryable failure keeps every remaining row and stops`() async {
+    // The table is the queue, so leaving the rows is the only way the next dispatch finds them.
+    let recorder = Recorder(results: [.success, .retryableFailure(retryAfter: nil)])
+    await drain(rows: rows(1...6), recorder: recorder, chunkSize: 2)
+    #expect(recorder.sentIds == [[1, 2], [3, 4]])
+    #expect(recorder.deletedIds == [2])
+  }
+
+  @Test
+  func `a non-retryable failure drops its chunk and continues`() async {
+    // Unlike metrics and logs, spans keep going: the next chunk may well be fine, and there is
+    // no cursor whose ordering would be violated.
+    let recorder = Recorder(results: [.nonRetryableFailure(reason: "bad"), .success])
+    await drain(rows: rows(1...4), recorder: recorder, chunkSize: 2)
+    #expect(recorder.sentIds == [[1, 2], [3, 4]])
+    #expect(recorder.deletedIds == [2, 4])
+  }
+
+  @Test
+  func `partial success deletes the chunk including the rejected rows`() async {
+    // A rejection is permanent (a malformed id, a session id that is not a UUID), so resending
+    // the same bytes would fail identically.
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: nil,
+      rejectedLogRecords: nil,
+      rejectedSpans: 2,
+      errorMessage: "2 invalid spans"
+    )
+    let recorder = Recorder(results: [.partialSuccess(partial)])
+    await drain(rows: rows(1...3), recorder: recorder)
+    #expect(recorder.deletedIds == [3])
+  }
+
+  @Test
+  func `an oversized chunk is halved and both halves are sent`() async {
+    let recorder = Recorder(results: [.payloadTooLarge, .success, .success])
+    await drain(rows: rows(1...4), recorder: recorder)
+    #expect(recorder.sentIds == [[1, 2, 3, 4], [1, 2], [3, 4]])
+    #expect(recorder.deletedIds == [2, 4])
+  }
+
+  @Test
+  func `halving repeats until a single span is left, which is dropped`() async {
+    // 4 -> 2 -> 1. The last row cannot be split, so it is dropped rather than blocking the
+    // three rows behind it forever.
+    let recorder = Recorder(results: Array(repeating: .payloadTooLarge, count: 8))
+    await drain(rows: rows(1...4), recorder: recorder)
+    #expect(recorder.sentIds.map(\.count) == [4, 2, 1, 1, 2, 1, 1])
+    #expect(recorder.deletedIds == [1, 2, 3, 4])
+  }
+
+  @Test
+  func `a retryable failure after halving keeps the whole original chunk`() async {
+    let recorder = Recorder(results: [.payloadTooLarge, .retryableFailure(retryAfter: nil)])
+    await drain(rows: rows(1...4), recorder: recorder)
+    #expect(recorder.sentIds == [[1, 2, 3, 4], [1, 2]])
+    #expect(recorder.deletedIds.isEmpty)
+  }
+
+  @Test
+  func `a chunk with nothing to send is still deleted`() async {
+    // Every session row was pruned, so the spans carry no resource metadata and can never be
+    // sent. They are deleted instead of being read again on every dispatch.
+    let recorder = Recorder(results: [nil, .success])
+    await drain(rows: rows(1...4), recorder: recorder, chunkSize: 2)
+    #expect(recorder.sentIds == [[1, 2], [3, 4]])
+    #expect(recorder.deletedIds == [2, 4])
+  }
+
+  @Test
+  func `reads one chunk at a time rather than the whole backlog`() async {
+    // Each row carries attribute and event JSON, and this runs on resign-active, so the resident
+    // set must stay at one chunk. Re-reading also picks up spans inserted during a long drain.
+    let recorder = Recorder(results: [.success, .success, .success])
+    await drain(rows: rows(1...5), recorder: recorder, chunkSize: 2)
+    #expect(recorder.sentIds == [[1, 2], [3, 4], [5]])
+    // Cursor advances past each delivered chunk, and one final read returns empty to stop.
+    #expect(recorder.fetchCursors == [-1, 2, 4, 5])
+  }
+
+  @Test
+  func `a fetch that throws stops without sending`() async {
+    let recorder = Recorder(results: [.success])
+    recorder.fetchError = TestError.failed
+    await drain(rows: rows(1...3), recorder: recorder)
+    #expect(recorder.sentIds.isEmpty)
+    #expect(recorder.deletedIds.isEmpty)
+  }
+
+  @Test
+  func `a send that throws keeps its chunk and stops`() async {
+    // Only the session read throws here, so the spans themselves are fine and a transient
+    // database error must not cost them. Matches `DispatchLoop` and Android, where a throwing
+    // session read leaves the rows for the next dispatch.
+    let recorder = Recorder(results: [.success])
+    recorder.sendError = TestError.failed
+    await drain(rows: rows(1...3), recorder: recorder, chunkSize: 2)
+    #expect(recorder.deletedIds.isEmpty)
+  }
+
+  @Test
+  func `every outcome maps to a disposition`() {
+    let partial = OTPartialSuccess(
+      rejectedDataPoints: nil,
+      rejectedLogRecords: nil,
+      rejectedSpans: 1,
+      errorMessage: nil
+    )
+    #expect(SpanDispatchLoop.disposition(for: .success, chunkCount: 2) == .deleteAndContinue)
+    #expect(SpanDispatchLoop.disposition(for: .partialSuccess(partial), chunkCount: 2) == .deleteAndContinue)
+    #expect(SpanDispatchLoop.disposition(for: .nonRetryableFailure(reason: "x"), chunkCount: 2) == .deleteAndContinue)
+    #expect(SpanDispatchLoop.disposition(for: .retryableFailure(retryAfter: nil), chunkCount: 2) == .keepAndStop)
+    #expect(SpanDispatchLoop.disposition(for: .payloadTooLarge, chunkCount: 2) == nil)
+    #expect(SpanDispatchLoop.disposition(for: .payloadTooLarge, chunkCount: 1) == .deleteAndContinue)
+  }
+
+  private func drain(rows: [SpanRow], recorder: Recorder, chunkSize: Int = 512) async {
+    await SpanDispatchLoop.drain(
+      chunkSize: chunkSize,
+      fetchChunk: { afterId, limit in
+        recorder.fetchCursors.append(afterId)
+        if let error = recorder.fetchError {
+          throw error
+        }
+        return Array(rows.filter { ($0.id ?? .max) > afterId }.prefix(limit))
+      },
+      send: { chunk in
+        recorder.sentIds.append(chunk.map(\.id))
+        if let error = recorder.sendError {
+          throw error
+        }
+        return recorder.results.isEmpty ? .success : recorder.results.removeFirst()
+      },
+      deleteUpTo: { recorder.deletedIds.append($0) }
+    )
+  }
+
+  private func rows(_ ids: ClosedRange<Int64>) -> [SpanRow] {
+    return ids.map { id in
+      return SpanRow(
+        id: id,
+        sessionId: "s",
+        name: "GET",
+        kind: SpanRow.clientKind,
+        startTimestampMs: 1_782_131_895_000,
+        endTimestampMs: 1_782_131_895_250
+      )
+    }
+  }
+}

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -167,7 +167,8 @@ export declare class ObserveModule extends NativeModule<ObserveModuleEvents> {
    * this method to flush events manually, for example, during testing or to ensure events
    * are sent before a specific point.
    *
-   * @returns A promise that resolves when the pending events have been dispatched.
+   * @returns A promise that resolves once the events have been dispatched. A call made while
+   * another dispatch is running waits for it to finish first.
    *
    * @example
    * ```ts


### PR DESCRIPTION
# Why

Second half of the traces feature: expo/expo#48861 records network requests as generic span rows; this PR ships them to the `/v1/traces` ingestion endpoint (expo/universe#29874) on iOS and Android.

Closes ENG-25894.

# How

Spans dispatch alongside metrics and logs with their own retry gate (and mutex on Android). The mapping onto the OTLP wire shape is producer-agnostic: rows already carry their identifiers, attributes, and events, so the exporter only handles timestamps, value typing, and the per-session resource envelope, and future span producers need no changes here.

Unlike metrics and logs there's no persisted cursor or pending-ids store: nothing reads span rows back, so a dispatched (or deliberately dropped) batch is deleted outright and the table itself is the queue. Batches are chunked at the server's 512-span limit, `rejectedSpans` counts in partial-success handling, and on iOS an in-flight guard keeps overlapping dispatch calls from re-sending a backlog.

# Test Plan

New unit suites on both platforms cover the row-to-wire mapping (typed attribute decoding, malformed-blob tolerance, per-event timestamps, event caps, overflow-safe timestamps), the request envelope, and `rejectedSpans` decoding. `et native-unit-tests` passes for expo-observe on iOS (Swift Testing) and Android (Robolectric).
