### PR TITLE
[router] Add RoutingIntent to router-queue, to unify action dispatching

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 ### 💡 Others
 
+- Rename the routing queue's `ROUTER_LINK` item to `NAVIGATE_TO_HREF` and wrap raw navigation actions in a generic `ACTION` intent. `linkTo('..')` now defers a queued `GO_BACK` instead of calling `navigationRef.goBack()` synchronously, and `goBack()` no longer throws when the navigation container is not ready. ([#TODO](https://github.com/expo/expo/pull/TODO) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))
 - Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -65,6 +65,7 @@
 ### 💡 Others
 
 - Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
+- Rename the routing queue's `ROUTER_LINK` item to `NAVIGATE_TO_HREF` and wrap raw navigation actions in a generic `ACTION` intent. `linkTo('..')` now defers a queued `GO_BACK` instead of calling `navigationRef.goBack()` synchronously, and `goBack()` no longer throws when the navigation container is not ready. ([#48886](https://github.com/expo/expo/pull/48886) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))
 - Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
@@ -181,11 +181,11 @@ describe('canDismiss', () => {
 });
 
 describe('linkTo', () => {
-  it('enqueues ROUTER_LINK action with href and options for normal paths', () => {
+  it('enqueues NAVIGATE_TO_HREF intent with href and options for normal paths', () => {
     linkTo('/home', { event: 'NAVIGATE' });
 
     expect(mockAdd).toHaveBeenCalledWith({
-      type: 'ROUTER_LINK',
+      type: 'NAVIGATE_TO_HREF',
       payload: {
         href: '/home',
         options: { event: 'NAVIGATE' },
@@ -207,38 +207,24 @@ describe('linkTo', () => {
   });
 
   // https://linear.app/expo/issue/ENG-20200/investigate-why-navigationrefgoback-is-called-when-href-is-or
-  it('calls navigationRef.goBack() for .. href', () => {
+  it('queues GO_BACK for .. href', () => {
     linkTo('..');
 
-    expect(store.navigationRef.current!.goBack).toHaveBeenCalled();
-    expect(mockAdd).not.toHaveBeenCalled();
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'GO_BACK' } },
+    });
+    expect(store.navigationRef.current!.goBack).not.toHaveBeenCalled();
   });
 
-  // https://linear.app/expo/issue/ENG-20200/investigate-why-navigationrefgoback-is-called-when-href-is-or
-  it('calls navigationRef.goBack() for ../ href', () => {
+  it('queues GO_BACK for ../ href', () => {
     linkTo('../');
 
-    expect(store.navigationRef.current!.goBack).toHaveBeenCalled();
-  });
-
-  it('throws when navigationRef is null for .. href', () => {
-    const originalCurrent = store.navigationRef.current;
-    (store.navigationRef as any).current = null;
-
-    expect(() => linkTo('..')).toThrow(
-      "Couldn't find a navigation object. Is your component inside NavigationContainer?"
-    );
-
-    (store.navigationRef as any).current = originalCurrent;
-  });
-
-  it('throws when store.linking is falsy for .. href', () => {
-    const originalLinking = (store as any).linking;
-    Object.defineProperty(store, 'linking', { value: null, configurable: true });
-
-    expect(() => linkTo('..')).toThrow('Attempted to link to route when no routes are present');
-
-    Object.defineProperty(store, 'linking', { value: originalLinking, configurable: true });
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'GO_BACK' } },
+    });
+    expect(store.navigationRef.current!.goBack).not.toHaveBeenCalled();
   });
 
   it('resolves object hrefs via resolveHref', () => {
@@ -246,7 +232,7 @@ describe('linkTo', () => {
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           href: '/profile',
         }),
@@ -256,12 +242,12 @@ describe('linkTo', () => {
 });
 
 describe('router action functions', () => {
-  it('navigate enqueues ROUTER_LINK action with NAVIGATE event', () => {
+  it('navigate enqueues NAVIGATE_TO_HREF intent with NAVIGATE event', () => {
     navigate('/path');
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           options: expect.objectContaining({ event: 'NAVIGATE' }),
         }),
@@ -269,12 +255,12 @@ describe('router action functions', () => {
     );
   });
 
-  it('push enqueues ROUTER_LINK action with PUSH event', () => {
+  it('push enqueues NAVIGATE_TO_HREF intent with PUSH event', () => {
     push('/path');
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           options: expect.objectContaining({ event: 'PUSH' }),
         }),
@@ -282,12 +268,12 @@ describe('router action functions', () => {
     );
   });
 
-  it('replace enqueues ROUTER_LINK action with REPLACE event', () => {
+  it('replace enqueues NAVIGATE_TO_HREF intent with REPLACE event', () => {
     replace('/path');
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           options: expect.objectContaining({ event: 'REPLACE' }),
         }),
@@ -295,12 +281,12 @@ describe('router action functions', () => {
     );
   });
 
-  it('prefetch enqueues ROUTER_LINK action with PRELOAD event', () => {
+  it('prefetch enqueues NAVIGATE_TO_HREF intent with PRELOAD event', () => {
     prefetch('/path');
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           options: expect.objectContaining({ event: 'PRELOAD' }),
         }),
@@ -308,12 +294,12 @@ describe('router action functions', () => {
     );
   });
 
-  it('dismissTo enqueues ROUTER_LINK action with POP_TO event', () => {
+  it('dismissTo enqueues NAVIGATE_TO_HREF intent with POP_TO event', () => {
     dismissTo('/path');
 
     expect(mockAdd).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: 'ROUTER_LINK',
+        type: 'NAVIGATE_TO_HREF',
         payload: expect.objectContaining({
           options: expect.objectContaining({ event: 'POP_TO' }),
         }),
@@ -321,29 +307,41 @@ describe('router action functions', () => {
     );
   });
 
-  it('dismiss(2) enqueues POP action with count 2', () => {
+  it('dismiss(2) enqueues a POP action with count 2', () => {
     dismiss(2);
 
-    expect(mockAdd).toHaveBeenCalledWith({ type: 'POP', payload: { count: 2 } });
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'POP', payload: { count: 2 } } },
+    });
   });
 
   it('dismiss() defaults count to 1', () => {
     dismiss();
 
-    expect(mockAdd).toHaveBeenCalledWith({ type: 'POP', payload: { count: 1 } });
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'POP', payload: { count: 1 } } },
+    });
   });
 
-  it('dismissAll enqueues POP_TO_TOP', () => {
+  it('dismissAll enqueues a POP_TO_TOP action', () => {
     dismissAll();
 
-    expect(mockAdd).toHaveBeenCalledWith({ type: 'POP_TO_TOP' });
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'POP_TO_TOP' } },
+    });
   });
 
-  it('goBack calls store.assertIsReady and enqueues GO_BACK', () => {
+  it('goBack enqueues GO_BACK without requiring the container to be ready', () => {
     goBack();
 
-    expect(store.assertIsReady).toHaveBeenCalled();
-    expect(mockAdd).toHaveBeenCalledWith({ type: 'GO_BACK' });
+    expect(store.assertIsReady).not.toHaveBeenCalled();
+    expect(mockAdd).toHaveBeenCalledWith({
+      type: 'ACTION',
+      payload: { action: { type: 'GO_BACK' } },
+    });
   });
 
   it('reload throws not implemented', () => {

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -45,14 +45,17 @@ beforeEach(() => {
 });
 
 describe('routingQueue', () => {
-  it('add() pushes action to queue and notifies subscribers', () => {
+  it('add() pushes intent to queue and notifies subscribers', () => {
     const callback = jest.fn();
     routingQueue.subscribe(callback);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     expect(routingQueue.queue).toHaveLength(1);
-    expect(routingQueue.queue[0]).toEqual({ type: 'GO_BACK' });
+    expect(routingQueue.queue[0]).toEqual({
+      type: 'ACTION',
+      payload: { action: { type: 'GO_BACK' } },
+    });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -60,49 +63,54 @@ describe('routingQueue', () => {
     const callback = jest.fn();
     const unsubscribe = routingQueue.subscribe(callback);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
     expect(callback).toHaveBeenCalledTimes(1);
     callback.mockClear();
 
     unsubscribe();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
     expect(callback).not.toHaveBeenCalled();
   });
 
   it('snapshot() returns the current queue array', () => {
-    routingQueue.add({ type: 'GO_BACK' });
-    routingQueue.add({ type: 'POP_TO_TOP' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 
     const snapshot = routingQueue.snapshot();
 
     expect(snapshot).toHaveLength(2);
-    expect(snapshot[0]).toEqual({ type: 'GO_BACK' });
-    expect(snapshot[1]).toEqual({ type: 'POP_TO_TOP' });
+    expect(snapshot[0]).toEqual({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    expect(snapshot[1]).toEqual({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
   });
 
   it('run() drains the queue', () => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
-    routingQueue.add({ type: 'POP_TO_TOP' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 
     routingQueue.run(ref);
 
     expect(routingQueue.queue).toHaveLength(0);
   });
 
-  it('run() dispatches plain actions via ref.current.dispatch()', () => {
+  it.each([
+    { type: 'GO_BACK' },
+    { type: 'POP', payload: { count: 2 } },
+    { type: 'POP_TO_TOP' },
+    { type: 'CUSTOM_ACTION', payload: { value: 1 } },
+  ])('run() dispatches ACTION intent payload %j unchanged', (action) => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action } });
 
     routingQueue.run(ref);
 
-    expect(ref.current!.dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
+    expect(ref.current!.dispatch).toHaveBeenCalledWith(action);
   });
 
-  it('run() converts ROUTER_LINK actions via getNavigateAction then dispatches', () => {
+  it('run() converts NAVIGATE_TO_HREF intents via getNavigateAction then dispatches', () => {
     const ref = makeRef();
     const navigateAction = {
       type: 'NAVIGATE',
@@ -112,7 +120,7 @@ describe('routingQueue', () => {
     mockGetNavigateAction.mockReturnValueOnce(navigateAction);
 
     routingQueue.add({
-      type: 'ROUTER_LINK',
+      type: 'NAVIGATE_TO_HREF',
       payload: { href: '/home', options: { event: 'NAVIGATE' } },
     });
 
@@ -129,12 +137,26 @@ describe('routingQueue', () => {
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });
 
+  it('run() dispatches mixed NAVIGATE_TO_HREF and ACTION intents in queue order', () => {
+    const ref = makeRef();
+    const navigateAction = { type: 'NAVIGATE', payload: { name: 'a' } };
+    mockGetNavigateAction.mockReturnValueOnce(navigateAction);
+
+    routingQueue.add({ type: 'NAVIGATE_TO_HREF', payload: { href: '/a', options: {} } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+
+    routingQueue.run(ref);
+
+    const dispatch = ref.current!.dispatch as jest.Mock;
+    expect(dispatch.mock.calls).toEqual([[navigateAction], [{ type: 'GO_BACK' }]]);
+  });
+
   it('run() does not dispatch when getNavigateAction returns undefined', () => {
     const ref = makeRef();
     mockGetNavigateAction.mockReturnValueOnce(undefined);
 
     routingQueue.add({
-      type: 'ROUTER_LINK',
+      type: 'NAVIGATE_TO_HREF',
       payload: { href: '/redirect', options: { event: 'NAVIGATE' } },
     });
 
@@ -146,7 +168,7 @@ describe('routingQueue', () => {
   it('run() does nothing when ref.current is null', () => {
     const ref = { current: null };
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     routingQueue.run(ref as any);
 
@@ -157,7 +179,7 @@ describe('routingQueue', () => {
   it('run() resets queue identity so new actions during run go to a fresh array', () => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     const oldQueue = routingQueue.queue;
 
@@ -177,7 +199,7 @@ describe('routingQueue', () => {
     routingQueue.subscribe(callback2);
     routingQueue.subscribe(callback3);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     expect(callback1).toHaveBeenCalledTimes(1);
     expect(callback2).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -45,14 +45,17 @@ beforeEach(() => {
 });
 
 describe('routingQueue', () => {
-  it('add() pushes action to queue and notifies subscribers', () => {
+  it('add() pushes intent to queue and notifies subscribers', () => {
     const callback = jest.fn();
     routingQueue.subscribe(callback);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     expect(routingQueue.queue).toHaveLength(1);
-    expect(routingQueue.queue[0]).toEqual({ type: 'GO_BACK' });
+    expect(routingQueue.queue[0]).toEqual({
+      type: 'ACTION',
+      payload: { action: { type: 'GO_BACK' } },
+    });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
@@ -60,49 +63,54 @@ describe('routingQueue', () => {
     const callback = jest.fn();
     const unsubscribe = routingQueue.subscribe(callback);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
     expect(callback).toHaveBeenCalledTimes(1);
     callback.mockClear();
 
     unsubscribe();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
     expect(callback).not.toHaveBeenCalled();
   });
 
   it('snapshot() returns the current queue array', () => {
-    routingQueue.add({ type: 'GO_BACK' });
-    routingQueue.add({ type: 'POP_TO_TOP' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 
     const snapshot = routingQueue.snapshot();
 
     expect(snapshot).toHaveLength(2);
-    expect(snapshot[0]).toEqual({ type: 'GO_BACK' });
-    expect(snapshot[1]).toEqual({ type: 'POP_TO_TOP' });
+    expect(snapshot[0]).toEqual({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    expect(snapshot[1]).toEqual({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
   });
 
   it('run() drains the queue', () => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
-    routingQueue.add({ type: 'POP_TO_TOP' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 
     routingQueue.run(ref);
 
     expect(routingQueue.queue).toHaveLength(0);
   });
 
-  it('run() dispatches plain actions via ref.current.dispatch()', () => {
+  it.each([
+    { type: 'GO_BACK' },
+    { type: 'POP', payload: { count: 2 } },
+    { type: 'POP_TO_TOP' },
+    { type: 'CUSTOM_ACTION', payload: { value: 1 } },
+  ])('run() dispatches ACTION intent payload %j unchanged', (action) => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action } });
 
     routingQueue.run(ref);
 
-    expect(ref.current!.dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
+    expect(ref.current!.dispatch).toHaveBeenCalledWith(action);
   });
 
-  it('run() converts ROUTER_LINK actions via getNavigateAction then dispatches', () => {
+  it('run() converts NAVIGATE_TO_HREF intents via getNavigateAction then dispatches', () => {
     const ref = makeRef();
     const navigateAction = {
       type: 'NAVIGATE',
@@ -112,7 +120,7 @@ describe('routingQueue', () => {
     mockGetNavigateAction.mockReturnValueOnce(navigateAction);
 
     routingQueue.add({
-      type: 'ROUTER_LINK',
+      type: 'NAVIGATE_TO_HREF',
       payload: { href: '/home', options: { event: 'NAVIGATE' } },
     });
 
@@ -129,12 +137,30 @@ describe('routingQueue', () => {
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });
 
+  it('run() dispatches mixed NAVIGATE_TO_HREF and ACTION intents in queue order', () => {
+    const ref = makeRef();
+    const navigateAction = {
+      type: 'NAVIGATE',
+      payload: { name: 'a', params: {}, singular: false },
+      target: 'root',
+    };
+    mockGetNavigateAction.mockReturnValueOnce(navigateAction);
+
+    routingQueue.add({ type: 'NAVIGATE_TO_HREF', payload: { href: '/a', options: {} } });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+
+    routingQueue.run(ref);
+
+    const dispatch = ref.current!.dispatch as jest.Mock;
+    expect(dispatch.mock.calls).toEqual([[navigateAction], [{ type: 'GO_BACK' }]]);
+  });
+
   it('run() does not dispatch when getNavigateAction returns undefined', () => {
     const ref = makeRef();
     mockGetNavigateAction.mockReturnValueOnce(undefined);
 
     routingQueue.add({
-      type: 'ROUTER_LINK',
+      type: 'NAVIGATE_TO_HREF',
       payload: { href: '/redirect', options: { event: 'NAVIGATE' } },
     });
 
@@ -146,7 +172,7 @@ describe('routingQueue', () => {
   it('run() does nothing when ref.current is null', () => {
     const ref = { current: null };
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     routingQueue.run(ref as any);
 
@@ -157,7 +183,7 @@ describe('routingQueue', () => {
   it('run() resets queue identity so new actions during run go to a fresh array', () => {
     const ref = makeRef();
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     const oldQueue = routingQueue.queue;
 
@@ -177,7 +203,7 @@ describe('routingQueue', () => {
     routingQueue.subscribe(callback2);
     routingQueue.subscribe(callback3);
 
-    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 
     expect(callback1).toHaveBeenCalledTimes(1);
     expect(callback2).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/global-state/router.ts
+++ b/packages/expo-router/src/global-state/router.ts
@@ -39,7 +39,10 @@ export function dismiss(count: number = 1) {
     return;
   }
 
-  routingQueue.add({ type: 'POP', payload: { count } });
+  routingQueue.add({
+    type: 'ACTION',
+    payload: { action: { type: 'POP', payload: { count } } },
+  });
 }
 
 export function dismissTo(href: Href, options?: NavigationOptions) {
@@ -54,15 +57,15 @@ export function dismissAll() {
   if (emitDomDismissAll()) {
     return;
   }
-  routingQueue.add({ type: 'POP_TO_TOP' });
+  routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 }
 
+// `GO_BACK` follows focused back handling; `POP` (used by `dismiss`) explicitly removes stack routes.
 export function goBack() {
   if (emitDomGoBack()) {
     return;
   }
-  store.assertIsReady();
-  routingQueue.add({ type: 'GO_BACK' });
+  routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
 }
 
 export function canGoBack(): boolean {
@@ -133,25 +136,11 @@ export function linkTo(originalHref: Href | string, options: LinkToOptions = {})
   }
 
   if (href === '..' || href === '../') {
-    store.assertIsReady();
-    const navigationRef = store.navigationRef.current;
-
-    if (navigationRef == null) {
-      throw new Error(
-        "Couldn't find a navigation object. Is your component inside NavigationContainer?"
-      );
-    }
-
-    if (!store.linking) {
-      throw new Error('Attempted to link to route when no routes are present');
-    }
-
-    navigationRef.goBack();
-    return;
+    return goBack();
   }
 
   const linkAction = {
-    type: 'ROUTER_LINK' as const,
+    type: 'NAVIGATE_TO_HREF' as const,
     payload: {
       href,
       options,

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -8,16 +8,20 @@ import type {
 import { getNavigateAction } from './getNavigationAction';
 import type { LinkToOptions } from './types';
 
-export interface LinkAction {
-  type: 'ROUTER_LINK';
+interface NavigateToHrefIntent {
+  type: 'NAVIGATE_TO_HREF';
   payload: {
     options: LinkToOptions;
     href: string;
   };
 }
 
+export type RoutingIntent =
+  | NavigateToHrefIntent
+  | { type: 'ACTION'; payload: { action: NavigationAction } };
+
 export const routingQueue = {
-  queue: [] as (NavigationAction | LinkAction)[],
+  queue: [] as RoutingIntent[],
   subscribers: new Set<() => void>(),
   subscribe(callback: () => void) {
     routingQueue.subscribers.add(callback);
@@ -28,8 +32,8 @@ export const routingQueue = {
   snapshot() {
     return routingQueue.queue;
   },
-  add(action: NavigationAction | LinkAction) {
-    routingQueue.queue.push(action);
+  add(intent: RoutingIntent) {
+    routingQueue.queue.push(intent);
     for (const callback of routingQueue.subscribers) {
       callback();
     }
@@ -38,16 +42,16 @@ export const routingQueue = {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
-    let action: NavigationAction | LinkAction | undefined;
-    while ((action = events.shift())) {
+    let intent: RoutingIntent | undefined;
+    while ((intent = events.shift())) {
       // TODO: Consider warning when ref.current is null — actions are silently dropped
       if (ref.current) {
-        if (action.type === 'ROUTER_LINK') {
+        if (intent.type === 'NAVIGATE_TO_HREF') {
           const {
             payload: { href, options },
-          } = action as LinkAction;
+          } = intent;
 
-          action = getNavigateAction(
+          const action = getNavigateAction(
             href,
             options,
             options.event,
@@ -60,7 +64,7 @@ export const routingQueue = {
             ref.current.dispatch(action);
           }
         } else {
-          ref.current.dispatch(action);
+          ref.current.dispatch(intent.payload.action);
         }
       }
     }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
