### PR TITLE
feat(expo-doctor): Add Hermes v1 check targeting memory regression and add upgrade recommendation

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Internal] Prevent `ncc` from removing dynamic requires where we need them ([#48887](https://github.com/expo/expo/pull/48887) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 1.20.1 - 2026-07-15

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Warn projects using Expo SDKs affected by the Hermes v1 memory regression ([#48887](https://github.com/expo/expo/pull/48887) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
+++ b/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
@@ -21,18 +21,18 @@ function getInstalledExpoVersion(projectRoot: string): string | null {
   return typeof version === 'string' && semver.valid(version) ? version : null;
 }
 
-function isHermesV1Enabled(exp: DoctorCheckParams['exp']): boolean {
+function isHermesV1Enabled(exp: DoctorCheckParams['exp'], defaultValue: boolean = false): boolean {
   const plugin = exp.plugins?.find(
     (plugin): plugin is [string, Record<string, any>] =>
       Array.isArray(plugin) && plugin[0] === 'expo-build-properties'
   );
   const props = plugin?.[1];
   if (!props) {
-    return false;
+    return defaultValue;
   }
 
-  const androidValue = props.android?.useHermesV1 ?? props.useHermesV1 ?? false;
-  const iosValue = props.ios?.useHermesV1 ?? props.useHermesV1 ?? false;
+  const androidValue = props.android?.useHermesV1 ?? props.useHermesV1 ?? defaultValue;
+  const iosValue = props.ios?.useHermesV1 ?? props.useHermesV1 ?? defaultValue;
   return androidValue === true || iosValue === true;
 }
 
@@ -65,11 +65,12 @@ export class HermesV1VersionCheck implements DoctorCheck {
     const expoVersion = getInstalledExpoVersion(projectRoot);
     const hermesVersion = getHermesVersion(projectRoot);
     const isSdk55 = semver.satisfies(exp.sdkVersion!, '>=55.0.0 <56.0.0');
-    const usesHermesV1 = isSdk55 ? isHermesV1Enabled(exp) : true;
+    const usesHermesV1 = isHermesV1Enabled(exp, !isSdk55);
     const expoVersionMajor = expoVersion ? semver.major(expoVersion) : null;
     const isExpoVersionAffected =
+      usesHermesV1 &&
       !!expoVersion &&
-      ((expoVersionMajor === 55 && usesHermesV1) ||
+      (expoVersionMajor === 55 ||
         expoVersionMajor === 56 ||
         (expoVersionMajor === 57 && semver.lt(expoVersion, FIXED_EXPO_VERSION)));
     const isHermesVersionAffected =

--- a/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
+++ b/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
@@ -2,6 +2,7 @@ import JsonFile from '@expo/json-file';
 import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
+import { loadBabelConfigPlugins } from '../utils/babelConfigLoader';
 import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 const FIXED_EXPO_VERSION = '57.0.9';
@@ -31,6 +32,26 @@ function isHermesV1Enabled(exp: DoctorCheckParams['exp']): boolean {
   return androidValue === true || iosValue === true;
 }
 
+function isWorkletsBundleModeEnabled(projectRoot: string): boolean {
+  const plugins = loadBabelConfigPlugins(projectRoot);
+  return !!plugins?.some((plugin) => {
+    const request = plugin.file?.request;
+    const resolved = plugin.file?.resolved;
+    const isWorkletsPlugin =
+      request === 'react-native-worklets/plugin' ||
+      (typeof resolved === 'string' &&
+        /react-native-worklets[\\/]plugin(?:[\\/]|$)/.test(resolved));
+    const options = plugin.options;
+    return (
+      isWorkletsPlugin &&
+      typeof options === 'object' &&
+      options !== null &&
+      'bundleMode' in options &&
+      options.bundleMode === true
+    );
+  });
+}
+
 export class HermesV1VersionCheck implements DoctorCheck {
   description = 'Check for Expo SDK versions affected by Hermes V1 regressions';
 
@@ -51,14 +72,21 @@ export class HermesV1VersionCheck implements DoctorCheck {
       return { isSuccessful: true, issues: [], advice: [] };
     }
 
+    const advice = [
+      'Upgrade to Expo SDK 57 and expo@57.0.9 or later by running `npx expo install expo@^57.0.9 --fix`. See https://expo.dev/changelog/sdk-57#known-regressions for the latest details.',
+    ];
+    if (isWorkletsBundleModeEnabled(projectRoot)) {
+      advice.push(
+        'Worklets Bundle Mode is enabled in your Babel config. It is unsupported and experimental, may not work as expected in many cases, and is not recommended for production use until it is officially supported. If you enabled it only as a workaround for this memory regression, review and remove the Bundle Mode Babel and Metro configuration after upgrading.'
+      );
+    }
+
     return {
       isSuccessful: false,
       issues: [
         `This project uses Hermes V1 with expo@${expoVersion}, which is affected by a known memory regression.`,
       ],
-      advice: [
-        'Upgrade to Expo SDK 57 and expo@57.0.9 or later by running `npx expo install expo@^57.0.9 --fix`. See https://expo.dev/changelog/sdk-57#known-regressions for the latest details.',
-      ],
+      advice,
     };
   }
 }

--- a/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
+++ b/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
@@ -66,11 +66,12 @@ export class HermesV1VersionCheck implements DoctorCheck {
     const hermesVersion = getHermesVersion(projectRoot);
     const isSdk55 = semver.satisfies(exp.sdkVersion!, '>=55.0.0 <56.0.0');
     const usesHermesV1 = isSdk55 ? isHermesV1Enabled(exp) : true;
+    const expoVersionMajor = expoVersion ? semver.major(expoVersion) : null;
     const isExpoVersionAffected =
       !!expoVersion &&
-      (isSdk55
-        ? usesHermesV1 && semver.lt(expoVersion, '56.0.0')
-        : semver.satisfies(expoVersion, `>=56.0.0 <${FIXED_EXPO_VERSION}`));
+      ((expoVersionMajor === 55 && usesHermesV1) ||
+        expoVersionMajor === 56 ||
+        (expoVersionMajor === 57 && semver.lt(expoVersion, FIXED_EXPO_VERSION)));
     const isHermesVersionAffected =
       usesHermesV1 &&
       !!hermesVersion &&

--- a/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
+++ b/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
@@ -3,9 +3,13 @@ import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 import { loadBabelConfigPlugins } from '../utils/babelConfigLoader';
+import { getHermesVersion } from '../utils/hermesVersion';
 import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 
 const FIXED_EXPO_VERSION = '57.0.9';
+const AFFECTED_HERMES_VERSION_PREFIX = '250829098.';
+const LAST_AFFECTED_HERMES_VERSION = '250829098.0.15';
+const FIRST_FIXED_HERMES_VERSION = '250829098.0.16';
 
 function getInstalledExpoVersion(projectRoot: string): string | null {
   const packageJsonPath = resolveFrom.silent(projectRoot, 'expo/package.json');
@@ -59,22 +63,45 @@ export class HermesV1VersionCheck implements DoctorCheck {
 
   async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const expoVersion = getInstalledExpoVersion(projectRoot);
-    if (!expoVersion || semver.gte(expoVersion, FIXED_EXPO_VERSION)) {
+    const hermesVersion = getHermesVersion(projectRoot);
+    const isSdk55 = semver.satisfies(exp.sdkVersion!, '>=55.0.0 <56.0.0');
+    const usesHermesV1 = isSdk55 ? isHermesV1Enabled(exp) : true;
+    const isExpoVersionAffected =
+      !!expoVersion &&
+      (isSdk55
+        ? usesHermesV1 && semver.lt(expoVersion, '56.0.0')
+        : semver.satisfies(expoVersion, `>=56.0.0 <${FIXED_EXPO_VERSION}`));
+    const isHermesVersionAffected =
+      usesHermesV1 &&
+      !!hermesVersion &&
+      hermesVersion.version.startsWith(AFFECTED_HERMES_VERSION_PREFIX) &&
+      semver.lte(hermesVersion.version, LAST_AFFECTED_HERMES_VERSION);
+
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    if (isExpoVersionAffected) {
+      issues.push(
+        `This project uses Hermes V1 with expo@${expoVersion}, which is affected by a known memory regression.`
+      );
+      advice.push(
+        'Upgrade to Expo SDK 57 and expo@57.0.9 or later by running `npx expo install expo@^57.0.9 --fix`. See https://expo.dev/changelog/sdk-57#known-regressions for the latest details.'
+      );
+    }
+
+    if (isHermesVersionAffected) {
+      issues.push(
+        `Detected Hermes V1 ${hermesVersion.version} from ${hermesVersion.source === 'react-native' ? 'React Native' : 'hermes-compiler'}. Hermes V1 ${LAST_AFFECTED_HERMES_VERSION} and earlier are affected by this regression; ${FIRST_FIXED_HERMES_VERSION} is the first version that contains the fix.`
+      );
+      advice.push(
+        'Upgrade to React Native 0.86.2 or later, which includes the fixed Hermes version. For Expo projects, install Expo SDK 57 with expo@57.0.9 or later and run `npx expo install --fix` to align React Native and other dependencies.'
+      );
+    }
+
+    if (issues.length === 0) {
       return { isSuccessful: true, issues: [], advice: [] };
     }
 
-    const isSdk55 = semver.satisfies(expoVersion, '>=55.0.0 <56.0.0');
-    const isAffected = isSdk55
-      ? isHermesV1Enabled(exp)
-      : semver.satisfies(expoVersion, '>=56.0.0 <57.0.9');
-
-    if (!isAffected) {
-      return { isSuccessful: true, issues: [], advice: [] };
-    }
-
-    const advice = [
-      'Upgrade to Expo SDK 57 and expo@57.0.9 or later by running `npx expo install expo@^57.0.9 --fix`. See https://expo.dev/changelog/sdk-57#known-regressions for the latest details.',
-    ];
     if (isWorkletsBundleModeEnabled(projectRoot)) {
       advice.push(
         'Worklets Bundle Mode is enabled in your Babel config. It is unsupported and experimental, may not work as expected in many cases, and is not recommended for production use until it is officially supported. If you enabled it only as a workaround for this memory regression, review and remove the Bundle Mode Babel and Metro configuration after upgrading.'
@@ -83,9 +110,7 @@ export class HermesV1VersionCheck implements DoctorCheck {
 
     return {
       isSuccessful: false,
-      issues: [
-        `This project uses Hermes V1 with expo@${expoVersion}, which is affected by a known memory regression.`,
-      ],
+      issues,
       advice,
     };
   }

--- a/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
+++ b/packages/expo-doctor/src/checks/HermesV1VersionCheck.ts
@@ -1,0 +1,64 @@
+import JsonFile from '@expo/json-file';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+const FIXED_EXPO_VERSION = '57.0.9';
+
+function getInstalledExpoVersion(projectRoot: string): string | null {
+  const packageJsonPath = resolveFrom.silent(projectRoot, 'expo/package.json');
+  if (!packageJsonPath) {
+    return null;
+  }
+
+  const { version } = JsonFile.read(packageJsonPath, { json5: true });
+  return typeof version === 'string' && semver.valid(version) ? version : null;
+}
+
+function isHermesV1Enabled(exp: DoctorCheckParams['exp']): boolean {
+  const plugin = exp.plugins?.find(
+    (plugin): plugin is [string, Record<string, any>] =>
+      Array.isArray(plugin) && plugin[0] === 'expo-build-properties'
+  );
+  const props = plugin?.[1];
+  if (!props) {
+    return false;
+  }
+
+  const androidValue = props.android?.useHermesV1 ?? props.useHermesV1 ?? false;
+  const iosValue = props.ios?.useHermesV1 ?? props.useHermesV1 ?? false;
+  return androidValue === true || iosValue === true;
+}
+
+export class HermesV1VersionCheck implements DoctorCheck {
+  description = 'Check for Expo SDK versions affected by Hermes V1 regressions';
+
+  sdkVersionRange = '>=55.0.0 <58.0.0';
+
+  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const expoVersion = getInstalledExpoVersion(projectRoot);
+    if (!expoVersion || semver.gte(expoVersion, FIXED_EXPO_VERSION)) {
+      return { isSuccessful: true, issues: [], advice: [] };
+    }
+
+    const isSdk55 = semver.satisfies(expoVersion, '>=55.0.0 <56.0.0');
+    const isAffected = isSdk55
+      ? isHermesV1Enabled(exp)
+      : semver.satisfies(expoVersion, '>=56.0.0 <57.0.9');
+
+    if (!isAffected) {
+      return { isSuccessful: true, issues: [], advice: [] };
+    }
+
+    return {
+      isSuccessful: false,
+      issues: [
+        `This project uses Hermes V1 with expo@${expoVersion}, which is affected by a known memory regression.`,
+      ],
+      advice: [
+        'Upgrade to Expo SDK 57 and expo@57.0.9 or later by running `npx expo install expo@^57.0.9 --fix`. See https://expo.dev/changelog/sdk-57#known-regressions for the latest details.',
+      ],
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
@@ -1,0 +1,134 @@
+import { vol } from 'memfs';
+
+import { HermesV1VersionCheck } from '../HermesV1VersionCheck';
+
+jest.mock('fs');
+jest.mock('resolve-from');
+
+const projectRoot = '/tmp/project';
+const baseParams = {
+  pkg: { name: 'name', version: '1.0.0' },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+function installExpo(version: string) {
+  vol.fromJSON({
+    [`${projectRoot}/node_modules/expo/package.json`]: JSON.stringify({
+      version,
+    }),
+  });
+}
+
+describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('warns for SDK 55 when Hermes V1 is enabled at the top level', async () => {
+    installExpo('55.0.28');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: {
+        name: 'name',
+        slug: 'slug',
+        sdkVersion: '55.0.0',
+        plugins: [['expo-build-properties', { useHermesV1: true }]],
+      },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues[0]).toContain('expo@55.0.28');
+    expect(result.advice[0]).toContain('expo@^57.0.9');
+  });
+
+  it('warns for SDK 55 when Hermes V1 is enabled for one platform', async () => {
+    installExpo('55.0.28');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: {
+        name: 'name',
+        slug: 'slug',
+        sdkVersion: '55.0.0',
+        plugins: [
+          ['expo-build-properties', { useHermesV1: true, android: { useHermesV1: false } }],
+        ],
+      },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+  });
+
+  it('passes for SDK 55 when Hermes V1 is not enabled', async () => {
+    installExpo('55.0.28');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '55.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('passes for SDK 55 when Hermes V1 is disabled on both platforms', async () => {
+    installExpo('55.0.28');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: {
+        name: 'name',
+        slug: 'slug',
+        sdkVersion: '55.0.0',
+        plugins: [
+          [
+            'expo-build-properties',
+            {
+              useHermesV1: true,
+              android: { useHermesV1: false },
+              ios: { useHermesV1: false },
+            },
+          ],
+        ],
+      },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it.each(['56.0.0', '56.0.18', '57.0.0', '57.0.8'])(
+    'warns for affected expo@%s installs',
+    async (version) => {
+      installExpo(version);
+      const result = await new HermesV1VersionCheck().runAsync({
+        ...baseParams,
+        exp: {
+          name: 'name',
+          slug: 'slug',
+          sdkVersion: `${version.split('.')[0]}.0.0`,
+        },
+      });
+
+      expect(result.isSuccessful).toBe(false);
+      expect(result.issues[0]).toContain(`expo@${version}`);
+    }
+  );
+
+  it.each(['57.0.9', '57.0.10'])('passes for fixed expo@%s installs', async (version) => {
+    installExpo(version);
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('passes when the installed Expo version cannot be resolved', async () => {
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+});

--- a/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
@@ -101,6 +101,32 @@ describe('runAsync', () => {
     expect(result.isSuccessful).toBe(true);
   });
 
+  it('does not treat an installed Expo 54 package as affected when config reports SDK 55', async () => {
+    installExpo('54.0.0');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: {
+        name: 'name',
+        slug: 'slug',
+        sdkVersion: '55.0.0',
+        plugins: [['expo-build-properties', { useHermesV1: true }]],
+      },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('warns for an SDK 56 prerelease', async () => {
+    installExpo('56.0.0-beta.3');
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '56.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues[0]).toContain('expo@56.0.0-beta.3');
+  });
+
   it.each(['56.0.0', '56.0.18', '57.0.0', '57.0.8'])(
     'warns for affected expo@%s installs',
     async (version) => {

--- a/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
@@ -1,11 +1,13 @@
 import { vol } from 'memfs';
 
 import { loadBabelConfigPlugins } from '../../utils/babelConfigLoader';
+import { getHermesVersion } from '../../utils/hermesVersion';
 import { HermesV1VersionCheck } from '../HermesV1VersionCheck';
 
 jest.mock('fs');
 jest.mock('resolve-from');
 jest.mock('../../utils/babelConfigLoader');
+jest.mock('../../utils/hermesVersion');
 
 const projectRoot = '/tmp/project';
 const baseParams = {
@@ -28,6 +30,7 @@ describe('runAsync', () => {
   afterEach(() => {
     vol.reset();
     jest.mocked(loadBabelConfigPlugins).mockReturnValue(null);
+    jest.mocked(getHermesVersion).mockReturnValue(null);
   });
 
   it('warns for SDK 55 when Hermes V1 is enabled at the top level', async () => {
@@ -160,6 +163,87 @@ describe('runAsync', () => {
 
     expect(result.isSuccessful).toBe(false);
     expect(result.advice).toHaveLength(1);
+  });
+
+  it.each(['250829098.0.14', '250829098.0.15'])(
+    'adds a secondary issue for affected Hermes %s from React Native',
+    async (version) => {
+      installExpo('57.0.8');
+      jest.mocked(getHermesVersion).mockReturnValue({
+        source: 'react-native',
+        version,
+      });
+      const result = await new HermesV1VersionCheck().runAsync({
+        ...baseParams,
+        exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+      });
+
+      expect(result.issues).toHaveLength(2);
+      expect(result.issues[1]).toContain(`Detected Hermes V1 ${version} from React Native`);
+      expect(result.issues[1]).toContain('250829098.0.16 is the first version');
+      expect(result.advice).toHaveLength(2);
+    }
+  );
+
+  it('does not add a secondary issue for a fixed Hermes version', async () => {
+    installExpo('57.0.8');
+    jest.mocked(getHermesVersion).mockReturnValue({
+      source: 'react-native',
+      version: '250829098.0.16',
+    });
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+    });
+
+    expect(result.issues).toHaveLength(1);
+  });
+
+  it('does not compare Hermes versions outside the affected version prefix', async () => {
+    installExpo('57.0.9');
+    jest.mocked(getHermesVersion).mockReturnValue({
+      source: 'react-native',
+      version: '0.17.0',
+    });
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('warns for an affected Hermes version independently of a fixed Expo version', async () => {
+    installExpo('57.0.9');
+    jest.mocked(getHermesVersion).mockReturnValue({
+      source: 'react-native',
+      version: '250829098.0.15',
+    });
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '57.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('Detected Hermes V1 250829098.0.15');
+    expect(result.advice[0]).toContain('React Native 0.86.2 or later');
+  });
+
+  it('warns for an affected Hermes version when the Expo version cannot be resolved', async () => {
+    jest.mocked(getHermesVersion).mockReturnValue({
+      source: 'hermes-compiler',
+      version: '250829098.0.14',
+    });
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '56.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('from hermes-compiler');
   });
 
   it('passes when the installed Expo version cannot be resolved', async () => {

--- a/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
@@ -145,6 +145,29 @@ describe('runAsync', () => {
     }
   );
 
+  it.each(['56.0.18', '57.0.8'])(
+    'passes for affected expo@%s when Hermes V1 is explicitly disabled',
+    async (version) => {
+      installExpo(version);
+      jest.mocked(getHermesVersion).mockReturnValue({
+        source: 'react-native',
+        version: '250829098.0.15',
+      });
+      const result = await new HermesV1VersionCheck().runAsync({
+        ...baseParams,
+        exp: {
+          name: 'name',
+          slug: 'slug',
+          sdkVersion: `${version.split('.')[0]}.0.0`,
+          plugins: [['expo-build-properties', { useHermesV1: false }]],
+        },
+      });
+
+      expect(result.isSuccessful).toBe(true);
+      expect(result.issues).toEqual([]);
+    }
+  );
+
   it.each(['57.0.9', '57.0.10'])('passes for fixed expo@%s installs', async (version) => {
     installExpo(version);
     const result = await new HermesV1VersionCheck().runAsync({

--- a/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/HermesV1VersionCheck.test.ts
@@ -1,9 +1,11 @@
 import { vol } from 'memfs';
 
+import { loadBabelConfigPlugins } from '../../utils/babelConfigLoader';
 import { HermesV1VersionCheck } from '../HermesV1VersionCheck';
 
 jest.mock('fs');
 jest.mock('resolve-from');
+jest.mock('../../utils/babelConfigLoader');
 
 const projectRoot = '/tmp/project';
 const baseParams = {
@@ -25,6 +27,7 @@ function installExpo(version: string) {
 describe('runAsync', () => {
   afterEach(() => {
     vol.reset();
+    jest.mocked(loadBabelConfigPlugins).mockReturnValue(null);
   });
 
   it('warns for SDK 55 when Hermes V1 is enabled at the top level', async () => {
@@ -121,6 +124,42 @@ describe('runAsync', () => {
     });
 
     expect(result.isSuccessful).toBe(true);
+  });
+
+  it('adds advice when Worklets Bundle Mode is enabled in Babel config', async () => {
+    installExpo('56.0.18');
+    jest.mocked(loadBabelConfigPlugins).mockReturnValue([
+      {
+        file: { request: 'react-native-worklets/plugin' },
+        options: { bundleMode: true },
+      },
+    ]);
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '56.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.advice).toHaveLength(2);
+    expect(result.advice[1]).toContain('Worklets Bundle Mode is enabled');
+    expect(result.advice[1]).toContain('not recommended for production use');
+  });
+
+  it('does not add Bundle Mode advice when it is disabled', async () => {
+    installExpo('56.0.18');
+    jest.mocked(loadBabelConfigPlugins).mockReturnValue([
+      {
+        file: { request: 'react-native-worklets/plugin' },
+        options: { bundleMode: false },
+      },
+    ]);
+    const result = await new HermesV1VersionCheck().runAsync({
+      ...baseParams,
+      exp: { name: 'name', slug: 'slug', sdkVersion: '56.0.0' },
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.advice).toHaveLength(1);
   });
 
   it('passes when the installed Expo version cannot be resolved', async () => {

--- a/packages/expo-doctor/src/utils/__tests__/babelConfigLoader.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/babelConfigLoader.test.ts
@@ -1,0 +1,82 @@
+import resolveFrom from 'resolve-from';
+
+import { loadBabelConfigPlugins } from '../babelConfigLoader';
+
+jest.mock('resolve-from', () => ({
+  __esModule: true,
+  default: { silent: jest.fn() },
+}));
+
+const projectRoot = '/tmp/project';
+const mockLoadPartialConfigSync = jest.fn();
+
+jest.mock('/tmp/babel-core.js', () => ({ loadPartialConfigSync: mockLoadPartialConfigSync }), {
+  virtual: true,
+});
+
+describe(loadBabelConfigPlugins, () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('resolves Babel through the project Expo and Expo Metro config packages', () => {
+    jest.mocked(resolveFrom.silent).mockImplementation((fromDirectory, request) => {
+      if (fromDirectory === projectRoot && request === 'expo/package.json') {
+        return '/tmp/project/node_modules/expo/package.json';
+      }
+      if (
+        fromDirectory === '/tmp/project/node_modules/expo' &&
+        request === '@expo/metro-config/package.json'
+      ) {
+        return '/tmp/project/node_modules/expo/node_modules/@expo/metro-config/package.json';
+      }
+      if (
+        fromDirectory === '/tmp/project/node_modules/expo/node_modules/@expo/metro-config' &&
+        request === '@babel/core'
+      ) {
+        return '/tmp/babel-core.js';
+      }
+      return undefined;
+    });
+    const plugins = [
+      {
+        file: { request: 'react-native-worklets/plugin' },
+        options: { bundleMode: true },
+      },
+    ];
+    mockLoadPartialConfigSync.mockReturnValue({ options: { plugins } });
+
+    expect(loadBabelConfigPlugins(projectRoot)).toEqual(plugins);
+    expect(mockLoadPartialConfigSync).toHaveBeenCalledWith({
+      cwd: projectRoot,
+      filename: '/tmp/project/index.js',
+      root: projectRoot,
+    });
+  });
+
+  it('fails safely when a nested package cannot be resolved', () => {
+    jest.mocked(resolveFrom.silent).mockReturnValue(undefined);
+
+    expect(loadBabelConfigPlugins(projectRoot)).toBeNull();
+  });
+
+  it('fails safely when Babel cannot load the project config', () => {
+    jest.mocked(resolveFrom.silent).mockImplementation((_fromDirectory, request) => {
+      if (request === 'expo/package.json') {
+        return '/tmp/project/node_modules/expo/package.json';
+      }
+      if (request === '@expo/metro-config/package.json') {
+        return '/tmp/project/node_modules/@expo/metro-config/package.json';
+      }
+      if (request === '@babel/core') {
+        return '/tmp/babel-core.js';
+      }
+      return undefined;
+    });
+    mockLoadPartialConfigSync.mockImplementation(() => {
+      throw new Error('Invalid Babel config');
+    });
+
+    expect(loadBabelConfigPlugins(projectRoot)).toBeNull();
+  });
+});

--- a/packages/expo-doctor/src/utils/__tests__/hermesVersion.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/hermesVersion.test.ts
@@ -1,0 +1,78 @@
+import { vol } from 'memfs';
+
+import { getHermesVersion } from '../hermesVersion';
+
+jest.mock('fs');
+jest.mock('resolve-from');
+
+const projectRoot = '/tmp/project';
+
+describe(getHermesVersion, () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  it('reads the Hermes V1 version from React Native version.properties', () => {
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-native/package.json`]: JSON.stringify({
+        version: '0.86.0',
+      }),
+      [`${projectRoot}/node_modules/react-native/sdks/hermes-engine/version.properties`]:
+        'HERMES_VERSION_NAME=0.17.0\nHERMES_V1_VERSION_NAME=250829098.0.14\n',
+    });
+
+    expect(getHermesVersion(projectRoot)).toEqual({
+      source: 'react-native',
+      version: '250829098.0.14',
+    });
+  });
+
+  it('uses HERMES_VERSION_NAME when there is no separate Hermes V1 property', () => {
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-native/package.json`]: JSON.stringify({
+        version: '0.87.0',
+      }),
+      [`${projectRoot}/node_modules/react-native/sdks/hermes-engine/version.properties`]:
+        'HERMES_VERSION_NAME=250829098.0.15\n',
+    });
+
+    expect(getHermesVersion(projectRoot)).toEqual({
+      source: 'react-native',
+      version: '250829098.0.15',
+    });
+  });
+
+  it('falls back to the installed hermes-compiler version', () => {
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-native/package.json`]: JSON.stringify({
+        version: '0.83.0',
+      }),
+      [`${projectRoot}/node_modules/react-native/node_modules/hermes-compiler/package.json`]:
+        JSON.stringify({
+          version: '250829098.0.4',
+        }),
+    });
+
+    expect(getHermesVersion(projectRoot)).toEqual({
+      source: 'hermes-compiler',
+      version: '250829098.0.4',
+    });
+  });
+
+  it('does not resolve hermes-compiler from the project root', () => {
+    vol.fromJSON({
+      [`${projectRoot}/node_modules/react-native/package.json`]: JSON.stringify({
+        version: '0.83.0',
+      }),
+      [`${projectRoot}/node_modules/hermes-compiler/package.json`]: JSON.stringify({
+        version: '250829098.0.4',
+      }),
+    });
+
+    expect(getHermesVersion(projectRoot)).toBeNull();
+  });
+
+  it('fails safely when neither version can be resolved', () => {
+    expect(getHermesVersion(projectRoot)).toBeNull();
+  });
+});

--- a/packages/expo-doctor/src/utils/autolinkingResolutions.ts
+++ b/packages/expo-doctor/src/utils/autolinkingResolutions.ts
@@ -1,6 +1,7 @@
 import type { DependencyResolution } from 'expo-modules-autolinking/exports';
 import resolveFrom from 'resolve-from';
 
+import { dynamicRequire } from './dynamicRequire';
 import type { VersionedNativeModuleNamesCache } from './versionedNativeModules';
 import { getVersionedNativeModuleNamesAsync } from './versionedNativeModules';
 
@@ -17,7 +18,7 @@ export function importAutolinkingExportsFromProject(
     );
   }
   try {
-    const mod = require(autolinkingExportsResolved);
+    const mod = dynamicRequire(autolinkingExportsResolved);
     if (
       typeof mod.makeCachedDependenciesLinker !== 'function' ||
       typeof mod.scanDependencyResolutionsForPlatform !== 'function'

--- a/packages/expo-doctor/src/utils/babelConfigLoader.ts
+++ b/packages/expo-doctor/src/utils/babelConfigLoader.ts
@@ -1,0 +1,61 @@
+import path from 'path';
+import resolveFrom from 'resolve-from';
+
+export interface BabelPluginConfig {
+  file?: {
+    request?: string;
+    resolved?: string;
+  };
+  options?: unknown;
+}
+
+interface BabelPartialConfig {
+  options: {
+    plugins?: readonly BabelPluginConfig[];
+  };
+}
+
+interface BabelCore {
+  loadPartialConfigSync(options: {
+    cwd: string;
+    filename: string;
+    root: string;
+  }): BabelPartialConfig | null;
+}
+
+export function loadBabelConfigPlugins(projectRoot: string): readonly BabelPluginConfig[] | null {
+  try {
+    const expoPackageJsonPath = resolveFrom.silent(projectRoot, 'expo/package.json');
+    if (!expoPackageJsonPath) {
+      return null;
+    }
+
+    // Resolve the Babel version used by the project's Expo Metro config. This mirrors the nested
+    // project-relative resolution in metroConfigLoader and works with non-hoisted installations.
+    const metroConfigPackageJsonPath = resolveFrom.silent(
+      path.dirname(expoPackageJsonPath),
+      '@expo/metro-config/package.json'
+    );
+    if (!metroConfigPackageJsonPath) {
+      return null;
+    }
+
+    const babelCorePath = resolveFrom.silent(
+      path.dirname(metroConfigPackageJsonPath),
+      '@babel/core'
+    );
+    if (!babelCorePath) {
+      return null;
+    }
+
+    const babelCore = require(babelCorePath) as BabelCore;
+    const partialConfig = babelCore.loadPartialConfigSync({
+      cwd: projectRoot,
+      filename: path.join(projectRoot, 'index.js'),
+      root: projectRoot,
+    });
+    return partialConfig?.options.plugins ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -10,6 +10,7 @@ import { ExpoConfigCommonIssueCheck } from '../checks/ExpoConfigCommonIssueCheck
 import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
 import { ExpoRouterReactNavigationCheck } from '../checks/ExpoRouterReactNavigationCheck';
 import { GlobalPackageInstalledLocallyCheck } from '../checks/GlobalPackageInstalledLocallyCheck';
+import { HermesV1VersionCheck } from '../checks/HermesV1VersionCheck';
 import { IllegalPackageCheck } from '../checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from '../checks/InstalledDependencyVersionCheck';
 import { LockfileCheck } from '../checks/LockfileCheck';
@@ -63,6 +64,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     new SupportPackageVersionCheck(),
     new NativeToolingVersionCheck(),
     new DependencyVersionOverrideCheck(),
+    new HermesV1VersionCheck(),
 
     // Compatibility Checks
     new StoreCompatibilityCheck(),

--- a/packages/expo-doctor/src/utils/dynamicRequire.ts
+++ b/packages/expo-doctor/src/utils/dynamicRequire.ts
@@ -1,0 +1,4 @@
+// Keep runtime project dependency loading opaque to ncc so it isn't replaced with an empty
+// webpack context in the bundled CLI.
+// eslint-disable-next-line no-eval -- ncc rewrites dynamic require and createRequire calls
+export const dynamicRequire: NodeRequire = eval('require');

--- a/packages/expo-doctor/src/utils/hermesVersion.ts
+++ b/packages/expo-doctor/src/utils/hermesVersion.ts
@@ -1,0 +1,62 @@
+import JsonFile from '@expo/json-file';
+import fs from 'fs';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+export interface HermesVersionInfo {
+  source: 'hermes-compiler' | 'react-native';
+  version: string;
+}
+
+function getReactNativeHermesVersion(reactNativePackageJsonPath: string): HermesVersionInfo | null {
+  const versionPropertiesPath = path.join(
+    path.dirname(reactNativePackageJsonPath),
+    'sdks/hermes-engine/version.properties'
+  );
+  const contents = fs.readFileSync(versionPropertiesPath, 'utf8');
+  const version =
+    contents.match(/^HERMES_V1_VERSION_NAME=(.+)$/m)?.[1]?.trim() ??
+    contents.match(/^HERMES_VERSION_NAME=(.+)$/m)?.[1]?.trim();
+
+  return version && semver.valid(version) ? { source: 'react-native', version } : null;
+}
+
+function getHermesCompilerVersion(reactNativePackageJsonPath: string): HermesVersionInfo | null {
+  const packageJsonPath = resolveFrom.silent(
+    path.dirname(reactNativePackageJsonPath),
+    'hermes-compiler/package.json'
+  );
+  if (!packageJsonPath) {
+    return null;
+  }
+
+  const { version } = JsonFile.read(packageJsonPath, { json5: true });
+  return typeof version === 'string' && semver.valid(version)
+    ? { source: 'hermes-compiler', version }
+    : null;
+}
+
+export function getHermesVersion(projectRoot: string): HermesVersionInfo | null {
+  try {
+    const reactNativePackageJsonPath = resolveFrom.silent(projectRoot, 'react-native/package.json');
+    if (!reactNativePackageJsonPath) {
+      return null;
+    }
+
+    try {
+      return (
+        getReactNativeHermesVersion(reactNativePackageJsonPath) ??
+        getHermesCompilerVersion(reactNativePackageJsonPath)
+      );
+    } catch {
+      try {
+        return getHermesCompilerVersion(reactNativePackageJsonPath);
+      } catch {
+        return null;
+      }
+    }
+  } catch {
+    return null;
+  }
+}

--- a/packages/expo-doctor/src/utils/metroConfigLoader.ts
+++ b/packages/expo-doctor/src/utils/metroConfigLoader.ts
@@ -2,6 +2,8 @@ import type { InputConfigT } from '@expo/metro/metro-config';
 import path from 'path';
 import resolveFrom from 'resolve-from';
 
+import { dynamicRequire } from './dynamicRequire';
+
 const notFoundError = (basePackage: string): Error =>
   new MetroConfigPackageMissingError(
     `Missing package "${basePackage}" in the project. ` +
@@ -20,10 +22,10 @@ function importMetroConfigFromProject(
   try {
     // NOTE(@kitten): We need to use the version of metro-config that Expo uses
     // Luckily, we can import `@expo/metro` via `expo` to get to the same version
-    const expoMetro = require.resolve('@expo/metro/metro-config', {
+    const expoMetro = dynamicRequire.resolve('@expo/metro/metro-config', {
       paths: [path.dirname(expoResolved)],
     });
-    return require(expoMetro);
+    return dynamicRequire(expoMetro);
   } catch {
     // NOTE(@kitten): Older versions of expo will not have `@expo/metro`. Let's try to
     // require `metro-config` directly
@@ -31,7 +33,7 @@ function importMetroConfigFromProject(
     if (!metroConfig) {
       throw notFoundError('react-native');
     }
-    return require(metroConfig);
+    return dynamicRequire(metroConfig);
   }
 }
 
@@ -45,7 +47,7 @@ function loadExpoMetroConfig(projectDir: string): typeof import('expo/metro-conf
   if (!expoMetroConfigResolved) {
     throw notFoundError('expo');
   }
-  _expoMetroConfig = require(expoMetroConfigResolved);
+  _expoMetroConfig = dynamicRequire(expoMetroConfigResolved);
   return _expoMetroConfig!;
 }
 


### PR DESCRIPTION
# Why

Related to #46519

We have a few Hermes v1 versions where newer ones resolve the memory regression, reported in the issue above. However, these weren't backported into React Native versions that are shipped by SDK 55 and 56. Hence, we'll have to detect exact versions (including on 57) and issue upgrade recommendations more forcefully to avoid confusion.

> [!WARNING]
> We have to issue additional notices on the issue above, and pin those. We should also check if there are any issues related to this that are duplicates and we haven't closed/caught yet as such.

# How

- Add SDK version upgrade recommendations as needed for Hermes v1 memory regression
- Add Babel config check for Worklets mode (only on affected versions, to avoid users leaving it on)
- Add `hermes-engine` and `hermes-compiler` checks to catch edge cases

# Test Plan

- Unit tests added

**Note for internal review:** See referenced PR on changelog blog post updates

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
