### PR TITLE
[router] Use routing queue for deep links and browser history operations

### DIFF
--- a/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/_layout.tsx
+++ b/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function ExploreLayout() {
+  return <Stack />;
+}

--- a/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/details.tsx
+++ b/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/details.tsx
@@ -1,0 +1,18 @@
+import { Link, usePathname } from 'expo-router';
+import { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+
+export default function DetailsScreen() {
+  const pathname = usePathname();
+  const [count, setCount] = useState(0);
+  return (
+    <View>
+      <Text testID="details-content">{pathname}</Text>
+      <Text testID="details-count">{count}</Text>
+      <Button testID="increment-details" title="Increment" onPress={() => setCount(count + 1)} />
+      <Link href="/(tabs)/explore/final" testID="go-final">
+        Go Final
+      </Link>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/final.tsx
+++ b/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/final.tsx
@@ -1,0 +1,6 @@
+import { usePathname } from 'expo-router';
+import { Text } from 'react-native';
+
+export default function FinalScreen() {
+  return <Text testID="final-content">{usePathname()}</Text>;
+}

--- a/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/index.tsx
+++ b/apps/router-e2e/__e2e__/navigator-browser-history/app/(tabs)/explore/index.tsx
@@ -1,11 +1,14 @@
 import { Link, usePathname } from 'expo-router';
 import { View, Text } from 'react-native';
 
-export default function TabTwoScreen() {
+export default function ExploreScreen() {
   const pathname = usePathname();
   return (
     <View>
       <Text testID="explore-content">{pathname}</Text>
+      <Link href="/(tabs)/explore/details" testID="go-details">
+        Go Details
+      </Link>
       <Link href="/(tabs)" testID="go-home">
         Go Home
       </Link>

--- a/packages/@expo/cli/e2e/playwright/dev/navigator-browser-history.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/navigator-browser-history.test.ts
@@ -3,6 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
+import { pageCollectErrors } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -39,7 +40,7 @@ test.describe(inputDir, () => {
   // Test expo router history by navigating through <Link>,
   // then using the browser back/forward actions
   test('navigator browser history', async ({ page }) => {
-    page.on('console', (msg) => console.log(msg.text()));
+    const pageErrors = pageCollectErrors(page);
 
     await page.goto(`${expoStart.url}`);
 
@@ -60,5 +61,64 @@ test.describe(inputDir, () => {
     await page.goForward();
 
     await expect(page.locator('[data-testid="explore-content"]')).toHaveText('/explore');
+
+    expect(pageErrors.all).toEqual([]);
+  });
+
+  test('rapid history traverses nested state', async ({ page }) => {
+    const pageErrors = pageCollectErrors(page);
+
+    await page.goto(`${expoStart.url}`);
+    await expect(page.locator('[data-testid="home-content"]')).toHaveText('/');
+
+    await page.locator('[data-testid="go-explore"]').click();
+    await expect(page.locator('[data-testid="explore-content"]')).toHaveText('/explore');
+    await page.locator('[data-testid="go-details"]').click();
+    await expect(page.locator('[data-testid="details-content"]')).toHaveText('/explore/details');
+    await page.locator('[data-testid="go-final"]').click();
+    await expect(page.locator('[data-testid="final-content"]')).toHaveText('/explore/final');
+
+    await page.evaluate(() => {
+      // Wait for the first traversal before starting the second; browsers may collapse synchronous calls.
+      addEventListener('popstate', () => history.back(), { once: true });
+      history.back();
+    });
+    await expect(page).toHaveURL(/\/explore$/);
+    await expect(page.locator('[data-testid="explore-content"]')).toHaveText('/explore');
+
+    await page.evaluate(() => {
+      // Chain the second traversal from `popstate` while the router is still processing the first.
+      addEventListener('popstate', () => history.forward(), { once: true });
+      history.forward();
+    });
+    await expect(page.locator('[data-testid="final-content"]')).toHaveText('/explore/final');
+
+    await page.reload();
+    await expect(page.locator('[data-testid="final-content"]')).toHaveText('/explore/final');
+    await page.goBack();
+    await expect(page.locator('[data-testid="details-content"]')).toHaveText('/explore/details');
+    await page.goForward();
+    await expect(page.locator('[data-testid="final-content"]')).toHaveText('/explore/final');
+
+    expect(pageErrors.all).toEqual([]);
+  });
+
+  test('restores a nested tab stack without remounting', async ({ page }) => {
+    const pageErrors = pageCollectErrors(page);
+
+    await page.goto(`${expoStart.url}`);
+    await page.locator('[data-testid="go-explore"]').click();
+    await page.locator('[data-testid="go-details"]').click();
+    await page.locator('[data-testid="increment-details"]').click();
+    await expect(page.locator('[data-testid="details-count"]')).toHaveText('1');
+
+    await page.locator('[data-testid="go-final"]').click();
+    await expect(page.locator('[data-testid="final-content"]')).toHaveText('/explore/final');
+    await page.goBack();
+    await expect(page).toHaveURL(/\/explore\/details$/);
+    await expect(page.locator('[data-testid="details-content"]')).toHaveText('/explore/details');
+    await expect(page.locator('[data-testid="details-count"]')).toHaveText('1');
+
+    expect(pageErrors.all).toEqual([]);
   });
 });

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### 🐛 Bug fixes
 
+- Route deep links and browser history through the navigation queue while preserving saved navigation state.
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### 🐛 Bug fixes
 
+- Route deep links and browser history through the navigation queue while preserving saved navigation state.
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.ios.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.ios.tsx
@@ -1,13 +1,58 @@
 import { expect, jest, test } from '@jest/globals';
 import { render, type RenderAPI } from '@testing-library/react-native';
 
+import { routingQueue } from '../../global-state/routingQueue';
 import { createNavigationContainerRef, type ParamListBase } from '../../react-navigation/core';
 import { useLinking } from '../useLinking';
 
-let errorSpy: jest.SpiedFunction<typeof console.error>;
+let errorSpy: jest.SpiedFunction<typeof console.error> | undefined;
+
+beforeEach(() => {
+  routingQueue.queue = [];
+});
 
 afterEach(() => {
-  errorSpy.mockRestore();
+  errorSpy?.mockRestore();
+});
+
+test('queues an incoming deep link using its extracted app path', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+  ref.current = {
+    getRootState: () => ({ routeNames: ['home'] }),
+  } as typeof ref.current;
+  let listener: ((url: string) => void) | undefined;
+  const getStateFromPath = jest.fn(() => ({ routes: [{ name: 'home' }] }));
+
+  function Sample() {
+    useLinking(
+      ref,
+      {
+        prefixes: ['example://'],
+        getStateFromPath,
+        subscribe: (nextListener) => {
+          listener = nextListener;
+          return () => {};
+        },
+      },
+      () => {}
+    );
+    return null;
+  }
+
+  render(<Sample />);
+  listener?.('example://home?from=link');
+
+  expect(getStateFromPath).toHaveBeenCalledWith('home?from=link', undefined);
+  expect(routingQueue.queue).toEqual([
+    {
+      type: 'NAVIGATE_TO_HREF',
+      payload: {
+        href: '/home?from=link',
+        originalHref: 'example://home?from=link',
+        options: { event: 'NAVIGATE' },
+      },
+    },
+  ]);
 });
 
 test('throws if multiple instances of useLinking are used', () => {

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
@@ -1,23 +1,28 @@
 import { act, render, waitFor } from '@testing-library/react-native';
 
 import { RouterRegistryProvider } from '../../global-state/routerRegistry';
+import { routingQueue } from '../../global-state/routingQueue';
 import { Screen } from '../../react-navigation/core/Screen';
 import { createNavigationContainerRef } from '../../react-navigation/core/createNavigationContainerRef';
 import { useNavigationBuilder } from '../../react-navigation/core/useNavigationBuilder';
 import { CommonActions, StackRouter } from '../../react-navigation/routers';
 import { NavigationContainer } from '../NavigationContainer';
 import { createMemoryHistory } from '../createMemoryHistory';
+import { useLinking } from '../useLinking';
 
 jest.mock('../createMemoryHistory');
 
 let mockNavigationRef: ReturnType<typeof createNavigationContainerRef>;
-
 jest.mock('../../global-state/storeContext', () => ({
   useExpoRouterStore: () => ({
     get state() {
-      return mockNavigationRef.current?.getRootState();
+      return mockNavigationRef?.current?.getRootState();
     },
   }),
+}));
+jest.mock('../../global-state/utils', () => ({
+  ...jest.requireActual<typeof import('../../global-state/utils')>('../../global-state/utils'),
+  getRootStackRouteNames: () => ['home'],
 }));
 
 const history = {
@@ -36,10 +41,92 @@ function EmptyScreen() {
 }
 
 beforeEach(() => {
+  routingQueue.queue = [];
   jest.mocked(createMemoryHistory).mockReturnValue(history);
   Object.defineProperty(globalThis, 'location', {
     configurable: true,
     value: { hash: '' },
+  });
+});
+
+const webTest = typeof window === 'undefined' ? test.skip : test;
+
+webTest('queues forward history and restores saved, parsed, and initial state', () => {
+  let historyListener: (() => void) | undefined;
+  let historyIndex = 3;
+  jest.mocked(createMemoryHistory).mockReturnValueOnce({
+    ...history,
+    get index() {
+      return historyIndex;
+    },
+    listen: (listener: () => void) => {
+      historyListener = listener;
+      return () => {};
+    },
+  });
+  const savedState = {
+    stale: false,
+    type: 'stack',
+    key: 'saved-stack',
+    index: 0,
+    routeNames: ['home'],
+    routes: [{ key: 'saved-home', name: 'home' }],
+  };
+  const parsedState = { routes: [{ name: 'home' }] };
+  const navigation = {
+    addListener: jest.fn(() => () => {}),
+    getRootState: jest.fn(() => ({ key: 'root' })),
+  };
+  const ref = { current: navigation } as any;
+  const getStateFromPath = jest.fn(() => parsedState);
+
+  function Sample() {
+    useLinking(ref, { prefixes: [], getStateFromPath }, jest.fn());
+    return null;
+  }
+
+  render(<Sample />);
+
+  historyIndex = 4;
+  history.get.mockReturnValueOnce(undefined);
+  Object.assign(globalThis.location, { pathname: '/forward', search: '', hash: '' });
+  act(() => historyListener?.());
+  expect(routingQueue.queue[0]).toMatchObject({
+    type: 'NAVIGATE_TO_HREF',
+    payload: { href: '/forward', options: { event: 'NAVIGATE' } },
+    metadata: { history: { id: 0, path: '/forward' } },
+  });
+
+  historyIndex = 3;
+  history.get.mockReturnValueOnce({ path: '/saved', state: savedState });
+  Object.assign(globalThis.location, { pathname: '/saved', search: '', hash: '' });
+  act(() => historyListener?.());
+  expect(routingQueue.queue[1]).toMatchObject({
+    type: 'ACTION',
+    payload: { action: { type: 'RESET', payload: savedState, target: 'saved-stack' } },
+    metadata: { history: { id: 1, path: '/saved' } },
+  });
+
+  historyIndex = 2;
+  history.get.mockReturnValueOnce({ path: '/other' });
+  Object.assign(globalThis.location, { pathname: '/parsed', search: '', hash: '' });
+  act(() => historyListener?.());
+  expect(routingQueue.queue[2]).toMatchObject({
+    type: 'ACTION',
+    payload: { action: { type: 'RESET', payload: parsedState, target: 'root' } },
+    metadata: { history: { id: 2, path: '/parsed' } },
+  });
+
+  const initialState = { routes: [{ key: 'initial', name: 'home' }] };
+  getStateFromPath.mockReturnValueOnce(undefined as never);
+  historyIndex = 1;
+  history.get.mockReturnValueOnce(undefined).mockReturnValueOnce({ state: initialState });
+  Object.assign(globalThis.location, { pathname: '/invalid', search: '', hash: '' });
+  act(() => historyListener?.());
+  expect(routingQueue.queue[3]).toMatchObject({
+    type: 'ACTION',
+    payload: { action: { type: 'RESET', payload: initialState, target: 'root' } },
+    metadata: { history: { id: 3, path: '/invalid' } },
   });
 });
 

--- a/packages/expo-router/src/fork/useBrowserHistorySync.ts
+++ b/packages/expo-router/src/fork/useBrowserHistorySync.ts
@@ -1,0 +1,307 @@
+import isEqual from 'fast-deep-equal';
+import { type RefObject, useEffect, useRef, useState } from 'react';
+
+import { routingQueue, type RoutingIntent } from '../global-state/routingQueue';
+import { useExpoRouterStore } from '../global-state/storeContext';
+import { getRootStackRouteNames } from '../global-state/utils';
+import {
+  type LinkingOptions,
+  findFocusedRoute,
+  type NavigationContainerRef,
+  type NavigationState,
+  type ParamListBase,
+  type PartialState,
+} from '../react-navigation/native';
+import { getHistoryLength } from '../utils/stack';
+import { createMemoryHistory } from './createMemoryHistory';
+import { appendBaseUrl } from './getPathFromState';
+
+type GetStateFromPath = NonNullable<LinkingOptions<ParamListBase>['getStateFromPath']>;
+type GetPathFromState = NonNullable<LinkingOptions<ParamListBase>['getPathFromState']>;
+type ResetState = NavigationState | PartialState<NavigationState>;
+
+/**
+ * Find the matching navigation state that changed between 2 navigation states
+ * e.g.: a -> b -> c -> d and a -> b -> c -> e -> f, if history in b changed, b is the matching state
+ */
+const findMatchingState = <T extends NavigationState>(
+  a: T | undefined,
+  b: T | undefined
+): [T | undefined, T | undefined] => {
+  if (a === undefined || b === undefined || a.key !== b.key) {
+    return [undefined, undefined];
+  }
+
+  // Tab and drawer will have `history` property, but stack will have history in `routes`
+  const aHistoryLength = getHistoryLength(a);
+  const bHistoryLength = getHistoryLength(b);
+
+  const aRoute = a.routes[a.index]!;
+  const bRoute = b.routes[b.index]!;
+
+  const aChildState = aRoute.state as T | undefined;
+  const bChildState = bRoute.state as T | undefined;
+
+  // Stop here if this is the state object that changed:
+  // - history length is different
+  // - focused routes are different
+  // - one of them doesn't have child state
+  // - child state keys are different
+  if (
+    aHistoryLength !== bHistoryLength ||
+    aRoute.key !== bRoute.key ||
+    aChildState === undefined ||
+    bChildState === undefined ||
+    aChildState.key !== bChildState.key
+  ) {
+    return [a, b];
+  }
+
+  return findMatchingState(aChildState, bChildState);
+};
+
+/** Run async function in series as it's called. */
+const series = (cb: () => Promise<void>) => {
+  let queue = Promise.resolve();
+  return () => {
+    queue = queue.then(cb);
+  };
+};
+
+export function useBrowserHistorySync({
+  ref,
+  enabled,
+  config,
+  getStateFromPath,
+  getPathFromState,
+  onUnhandledLinking,
+}: {
+  ref: RefObject<NavigationContainerRef<ParamListBase> | null>;
+  enabled: boolean;
+  config: LinkingOptions<ParamListBase>['config'];
+  getStateFromPath: GetStateFromPath;
+  getPathFromState: GetPathFromState;
+  onUnhandledLinking: (path: string | undefined) => void;
+}) {
+  const store = useExpoRouterStore();
+  const [history] = useState(createMemoryHistory);
+  const configRef = useRef(config);
+  const getStateFromPathRef = useRef(getStateFromPath);
+  const getPathFromStateRef = useRef(getPathFromState);
+  const previousIndexRef = useRef<number | undefined>(undefined);
+  const previousStateRef = useRef<NavigationState | undefined>(undefined);
+  const nextHistoryOperationIdRef = useRef(0);
+  const pendingHistoryOperationsRef = useRef<{ id: number; path: string }[]>([]);
+
+  useEffect(() => {
+    configRef.current = config;
+    getStateFromPathRef.current = getStateFromPath;
+    getPathFromStateRef.current = getPathFromState;
+  });
+
+  useEffect(() => {
+    previousIndexRef.current = history.index;
+
+    const unsubscribe = history.listen(() => {
+      const navigation = ref.current;
+
+      if (!navigation || !enabled) {
+        return;
+      }
+
+      const { location } = window;
+      const path = location.pathname + location.search + location.hash;
+      const index = history.index;
+      const previousIndex = previousIndexRef.current ?? 0;
+
+      previousIndexRef.current = index;
+      const operation = { id: nextHistoryOperationIdRef.current++, path };
+      const queueHistoryIntent = (intent: RoutingIntent) => {
+        intent.metadata = { history: operation };
+        intent.onDispatch = (metadata) => {
+          if (metadata?.history) {
+            pendingHistoryOperationsRef.current.push(metadata.history);
+          }
+        };
+        routingQueue.add(intent);
+      };
+      const reset = (state: ResetState) => ({
+        type: 'RESET',
+        payload: state,
+        target: ('key' in state ? state.key : undefined) ?? navigation.getRootState()?.key,
+      });
+
+      // Saved state is authoritative: parsing its URL again would lose route keys and nested history.
+      const record = history.get(index);
+      if (record?.path === path && record?.state) {
+        queueHistoryIntent({
+          type: 'ACTION',
+          payload: { action: reset(record.state) },
+        });
+        return;
+      }
+
+      const state = getStateFromPathRef.current(path, configRef.current);
+      if (state) {
+        onUnhandledLinking(path);
+        // Expo Router's root navigator contains only the internal slot route.
+        const routeNames = getRootStackRouteNames();
+        if (state.routes.some((route) => !routeNames.includes(route.name))) {
+          return;
+        }
+
+        if (
+          index > previousIndex ||
+          /*
+           * Hash links emit popstate without changing the memory-history index. Treat a hash added
+           * to the current record as forward navigation instead of restoring the current state.
+           */
+          (index === previousIndex && (!record || `${record?.path}${location.hash}` === path))
+        ) {
+          queueHistoryIntent({
+            type: 'NAVIGATE_TO_HREF',
+            payload: { href: path, options: { event: 'NAVIGATE' } },
+          });
+        } else {
+          queueHistoryIntent({
+            type: 'ACTION',
+            payload: { action: reset(state) },
+          });
+        }
+      } else {
+        const initialState = history.get(0)?.state;
+        if (initialState) {
+          queueHistoryIntent({
+            type: 'ACTION',
+            payload: { action: reset(initialState) },
+          });
+        } else {
+          pendingHistoryOperationsRef.current = [];
+        }
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      pendingHistoryOperationsRef.current = [];
+    };
+  }, [enabled, history, onUnhandledLinking, ref]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const getPathForRoute = (
+      route: ReturnType<typeof findFocusedRoute>,
+      state: NavigationState
+    ): string => {
+      let path;
+
+      // Preserve the original URL for wildcard routes while the route and params still match.
+      if (route?.path) {
+        const stateForPath = getStateFromPathRef.current(route.path, configRef.current);
+
+        if (stateForPath) {
+          const focusedRoute = findFocusedRoute(stateForPath);
+
+          if (
+            focusedRoute &&
+            focusedRoute.name === route.name &&
+            isEqual({ ...focusedRoute.params }, { ...route.params })
+          ) {
+            path = appendBaseUrl(route.path);
+          }
+        }
+      }
+
+      return path ?? getPathFromStateRef.current(state, configRef.current);
+    };
+
+    if (ref.current) {
+      const rootState = ref.current.getRootState();
+      const state = store.state as NavigationState;
+
+      if (state) {
+        const path = getPathForRoute(findFocusedRoute(state), state);
+        previousStateRef.current ??= rootState;
+        history.replace({ path, state });
+      }
+    }
+
+    const onStateChange = async () => {
+      const navigation = ref.current;
+
+      if (!navigation || !enabled) {
+        return;
+      }
+
+      const previousState = previousStateRef.current;
+      const rootState = navigation.getRootState();
+      const state = store.state as NavigationState;
+
+      if (!state) {
+        return;
+      }
+
+      const path = getPathForRoute(findFocusedRoute(state), state);
+      let pendingOperation: { id: number; path: string } | undefined;
+
+      // React may batch multiple queued actions into one state event, so use the latest matching operation.
+      const pendingOperationIndex = pendingHistoryOperationsRef.current.findLastIndex(
+        (operation) => operation.path === path
+      );
+      if (pendingOperationIndex !== -1) {
+        pendingOperation = pendingHistoryOperationsRef.current[pendingOperationIndex];
+        pendingHistoryOperationsRef.current.splice(0, pendingOperationIndex + 1);
+      }
+      if (!pendingOperation) {
+        // Do not let a failed, redirected, or otherwise unmatched operation affect later navigation.
+        pendingHistoryOperationsRef.current.shift();
+      }
+
+      previousStateRef.current = rootState;
+      const [previousFocusedState, focusedState] = findMatchingState(previousState, state);
+
+      if (
+        previousFocusedState &&
+        focusedState &&
+        // A matching popstate already changed the browser URL, so don't write another entry.
+        !pendingOperation
+      ) {
+        const historyDelta =
+          getHistoryLength(focusedState) - getHistoryLength(previousFocusedState);
+
+        if (historyDelta > 0) {
+          history.push({ path, state });
+        } else if (historyDelta < 0) {
+          const nextIndex = history.backIndex({ path });
+          const currentIndex = history.index;
+
+          try {
+            if (
+              nextIndex !== -1 &&
+              nextIndex < currentIndex &&
+              history.get(nextIndex - currentIndex)
+            ) {
+              await history.go(nextIndex - currentIndex);
+            } else {
+              await history.go(historyDelta);
+            }
+
+            history.replace({ path, state });
+          } catch {
+            // The navigation was interrupted.
+          }
+        } else {
+          history.replace({ path, state });
+        }
+      } else {
+        history.replace({ path, state });
+      }
+    };
+
+    // Serialize writes because `history.go` is asynchronous and can be interrupted by another write.
+    return ref.current?.addListener('state', series(onStateChange));
+  }, [enabled, history, ref]);
+}

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -2,9 +2,9 @@ import * as ExpoLinking from 'expo-linking';
 import { type RefObject, useEffect, useCallback, useRef } from 'react';
 import { Linking, Platform } from 'react-native';
 
+import { routingQueue } from '../global-state/routingQueue';
 import {
   type LinkingOptions,
-  getActionFromState as getActionFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
   type ParamListBase,
@@ -47,7 +47,6 @@ export function useLinking(
       };
     },
     getStateFromPath = getStateFromPathDefault,
-    getActionFromState = getActionFromStateDefault,
   }: Options,
   onUnhandledLinking: (lastUnhandledLining: string | undefined) => void
 ) {
@@ -98,7 +97,6 @@ export function useLinking(
   const configRef = useRef(config);
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
-  const getActionFromStateRef = useRef(getActionFromState);
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -107,7 +105,6 @@ export function useLinking(
     configRef.current = config;
     getInitialURLRef.current = getInitialURL;
     getStateFromPathRef.current = getStateFromPath;
-    getActionFromStateRef.current = getActionFromState;
   });
 
   const getStateFromURL = useCallback(
@@ -169,33 +166,25 @@ export function useLinking(
       }
 
       const navigation = ref.current;
-      const state = navigation ? getStateFromURL(url) : undefined;
+      const path = extractExpoPathFromURL(prefixes, url);
+      const state = navigation && path !== undefined ? getStateFromURL(url) : undefined;
 
       if (navigation && state) {
         // If the link were handled, it gets cleared in NavigationContainer
-        onUnhandledLinking(extractExpoPathFromURL(prefixes, url));
+        onUnhandledLinking(path);
         const rootState = navigation.getRootState();
         if (state.routes.some((r) => !rootState?.routeNames.includes(r.name))) {
           return;
         }
 
-        const action = getActionFromStateRef.current(state, configRef.current);
-
-        if (action !== undefined) {
-          try {
-            navigation.dispatch(action);
-          } catch (e) {
-            // Ignore any errors from deep linking.
-            // This could happen in case of malformed links, navigation object not being initialized etc.
-            console.warn(
-              `An error occurred when trying to handle the link '${url}': ${
-                typeof e === 'object' && e != null && 'message' in e ? e.message : e
-              }`
-            );
-          }
-        } else {
-          navigation.resetRoot(state);
-        }
+        routingQueue.add({
+          type: 'NAVIGATE_TO_HREF',
+          payload: {
+            href: path.startsWith('/') ? path : `/${path}`,
+            originalHref: url,
+            options: { event: 'NAVIGATE' },
+          },
+        });
       }
     };
 

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -2,9 +2,9 @@ import * as ExpoLinking from 'expo-linking';
 import { type RefObject, useEffect, useCallback, useRef } from 'react';
 import { Linking, Platform } from 'react-native';
 
+import { routingQueue } from '../global-state/routingQueue';
 import {
   type LinkingOptions,
-  getActionFromState as getActionFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
   type ParamListBase,
@@ -51,7 +51,6 @@ export function useLinking(
       };
     });
   const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
-  const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
 
   useEffect(() => {
@@ -99,7 +98,6 @@ export function useLinking(
   const configRef = useRef(config);
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
-  const getActionFromStateRef = useRef(getActionFromState);
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -108,7 +106,6 @@ export function useLinking(
     configRef.current = config;
     getInitialURLRef.current = getInitialURL;
     getStateFromPathRef.current = getStateFromPath;
-    getActionFromStateRef.current = getActionFromState;
   });
 
   const getStateFromURL = useCallback(
@@ -170,33 +167,25 @@ export function useLinking(
       }
 
       const navigation = ref.current;
-      const state = navigation ? getStateFromURL(url) : undefined;
+      const path = extractExpoPathFromURL(prefixes, url);
+      const state = navigation && path !== undefined ? getStateFromURL(url) : undefined;
 
       if (navigation && state) {
         // If the link were handled, it gets cleared in NavigationContainer
-        onUnhandledLinking(extractExpoPathFromURL(prefixes, url));
+        onUnhandledLinking(path);
         const rootState = navigation.getRootState();
         if (state.routes.some((r) => !rootState?.routeNames.includes(r.name))) {
           return;
         }
 
-        const action = getActionFromStateRef.current(state, configRef.current);
-
-        if (action !== undefined) {
-          try {
-            navigation.dispatch(action);
-          } catch (e) {
-            // Ignore any errors from deep linking.
-            // This could happen in case of malformed links, navigation object not being initialized etc.
-            console.warn(
-              `An error occurred when trying to handle the link '${url}': ${
-                typeof e === 'object' && e != null && 'message' in e ? e.message : e
-              }`
-            );
-          }
-        } else {
-          navigation.resetRoot(state);
-        }
+        routingQueue.add({
+          type: 'NAVIGATE_TO_HREF',
+          payload: {
+            href: path.startsWith('/') ? path : `/${path}`,
+            originalHref: url,
+            options: { event: 'NAVIGATE' },
+          },
+        });
       }
     };
 

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -1,76 +1,17 @@
-import isEqual from 'fast-deep-equal';
-import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'react';
+import { type RefObject, useEffect, useCallback, useRef, use } from 'react';
 
 import { ServerContext } from '../global-state/serverLocationContext';
-import { useExpoRouterStore } from '../global-state/storeContext';
-import { getRootStackRouteNames } from '../global-state/utils';
 import {
   type LinkingOptions,
-  findFocusedRoute,
-  getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
-  type NavigationState,
   type ParamListBase,
   useNavigationIndependentTree,
 } from '../react-navigation/native';
-import { getHistoryLength } from '../utils/stack';
-import { createMemoryHistory } from './createMemoryHistory';
-import { appendBaseUrl } from './getPathFromState';
+import { useBrowserHistorySync } from './useBrowserHistorySync';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
-
-/**
- * Find the matching navigation state that changed between 2 navigation states
- * e.g.: a -> b -> c -> d and a -> b -> c -> e -> f, if history in b changed, b is the matching state
- */
-const findMatchingState = <T extends NavigationState>(
-  a: T | undefined,
-  b: T | undefined
-): [T | undefined, T | undefined] => {
-  if (a === undefined || b === undefined || a.key !== b.key) {
-    return [undefined, undefined];
-  }
-
-  // Tab and drawer will have `history` property, but stack will have history in `routes`
-  const aHistoryLength = getHistoryLength(a);
-  const bHistoryLength = getHistoryLength(b);
-
-  const aRoute = a.routes[a.index]!;
-  const bRoute = b.routes[b.index]!;
-
-  const aChildState = aRoute.state as T | undefined;
-  const bChildState = bRoute.state as T | undefined;
-
-  // Stop here if this is the state object that changed:
-  // - history length is different
-  // - focused routes are different
-  // - one of them doesn't have child state
-  // - child state keys are different
-  if (
-    aHistoryLength !== bHistoryLength ||
-    aRoute.key !== bRoute.key ||
-    aChildState === undefined ||
-    bChildState === undefined ||
-    aChildState.key !== bChildState.key
-  ) {
-    return [a, b];
-  }
-
-  return findMatchingState(aChildState, bChildState);
-};
-
-/**
- * Run async function in series as it's called.
- */
-export const series = (cb: () => Promise<void>) => {
-  let queue = Promise.resolve();
-  const callback = () => {
-    queue = queue.then(cb);
-  };
-  return callback;
-};
 
 const linkingHandlers: symbol[] = [];
 
@@ -83,13 +24,10 @@ export function useLinking(
     config,
     getStateFromPath = getStateFromPathDefault,
     getPathFromState = getPathFromStateDefault,
-    getActionFromState = getActionFromStateDefault,
   }: Options,
   onUnhandledLinking: (lastUnhandledLining: string | undefined) => void
 ) {
   const independent = useNavigationIndependentTree();
-
-  const store = useExpoRouterStore();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
@@ -127,43 +65,18 @@ export function useLinking(
     };
   }, [enabled, independent]);
 
-  const [history] = useState(createMemoryHistory);
-
   // We store these options in ref to avoid re-creating getInitialState and re-subscribing listeners
   // This lets user avoid wrapping the items in `React.useCallback` or `React.useMemo`
   // Not re-creating `getInitialState` is important coz it makes it easier for the user to use in an effect
   const enabledRef = useRef(enabled);
   const configRef = useRef(config);
   const getStateFromPathRef = useRef(getStateFromPath);
-  const getPathFromStateRef = useRef(getPathFromState);
-  const getActionFromStateRef = useRef(getActionFromState);
 
   useEffect(() => {
     enabledRef.current = enabled;
     configRef.current = config;
     getStateFromPathRef.current = getStateFromPath;
-    getPathFromStateRef.current = getPathFromState;
-    getActionFromStateRef.current = getActionFromState;
   });
-
-  const validateRoutesNotExistInRootState = useCallback(
-    (state: ResultState) => {
-      // START FORK
-      // Instead of using the rootState, we use INTERNAL_SLOT_NAME, which is the only route in the root navigator in Expo Router
-      // const navigation = ref.current;
-      // const rootState = navigation?.getRootState();
-      const routeNames = getRootStackRouteNames();
-      // END FORK
-
-      // Make sure that the routes in the state exist in the root navigator
-      // Otherwise there's an error in the linking configuration
-      // START FORK
-      // return state?.routes.some((r) => !rootState?.routeNames?.includes(r.name));
-      return state?.routes.some((r) => !routeNames.includes(r.name));
-      // END FORK
-    },
-    [ref]
-  );
 
   const server = use(ServerContext);
 
@@ -199,281 +112,14 @@ export function useLinking(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const previousIndexRef = useRef<number | undefined>(undefined);
-  const previousStateRef = useRef<NavigationState | undefined>(undefined);
-  const pendingPopStatePathRef = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    previousIndexRef.current = history.index;
-
-    return history.listen(() => {
-      const navigation = ref.current;
-
-      if (!navigation || !enabled) {
-        return;
-      }
-
-      const { location } = window;
-
-      const path = location.pathname + location.search + location.hash;
-      const index = history.index;
-
-      const previousIndex = previousIndexRef.current ?? 0;
-
-      previousIndexRef.current = index;
-      pendingPopStatePathRef.current = path;
-
-      // When browser back/forward is clicked, we first need to check if state object for this index exists
-      // If it does we'll reset to that state object
-      // Otherwise, we'll handle it like a regular deep link
-      const record = history.get(index);
-
-      if (record?.path === path && record?.state) {
-        navigation.resetRoot(record.state);
-        return;
-      }
-
-      const state = getStateFromPathRef.current(path, configRef.current);
-
-      // We should only dispatch an action when going forward
-      // Otherwise the action will likely add items to history, which would mess things up
-      if (state) {
-        // If the link were handled, it gets cleared in NavigationContainer
-        onUnhandledLinking(path);
-        // Make sure that the routes in the state exist in the root navigator
-        // Otherwise there's an error in the linking configuration
-        if (validateRoutesNotExistInRootState(state)) {
-          return;
-        }
-
-        if (
-          index > previousIndex ||
-          /* START FORK
-           *
-           * This is a workaround for React Navigation's handling of hashes (it doesn't handle them)
-           * When you click on <a href="#hash">, the browser will first fire a popstate event
-           * and this callback will be called.
-           *
-           * From React Navigation's perspective, it's treating the new hash change like a back/forward
-           * button press, so it thinks it should reset the state. When we should
-           * be to be pushing the new state
-           *
-           * Our fix is to check if the index is the same as the previous index
-           * and if the incoming path is the same as the old path but with the hash added,
-           * then treat it as a push instead of a reset
-           *
-           * This also works for subsequent hash changes, as internally RN
-           * doesn't store the hash in the history state.
-           *
-           * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#when_popstate_is_sent
-           */
-          (index === previousIndex && (!record || `${record?.path}${location.hash}` === path))
-          // END FORK
-        ) {
-          const action = getActionFromStateRef.current(state, configRef.current);
-
-          if (action !== undefined) {
-            try {
-              navigation.dispatch(action);
-            } catch (e) {
-              // Ignore any errors from deep linking.
-              // This could happen in case of malformed links, navigation object not being initialized etc.
-              console.warn(
-                `An error occurred when trying to handle the link '${path}': ${
-                  typeof e === 'object' && e != null && 'message' in e ? e.message : e
-                }`
-              );
-            }
-          } else {
-            navigation.resetRoot(state);
-          }
-        } else {
-          navigation.resetRoot(state);
-        }
-      } else {
-        // if current path didn't return any state, we should revert to initial state
-        navigation.resetRoot(state);
-      }
-    });
-  }, [enabled, history, onUnhandledLinking, ref, validateRoutesNotExistInRootState]);
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const getPathForRoute = (
-      route: ReturnType<typeof findFocusedRoute>,
-      state: NavigationState
-    ): string => {
-      let path;
-
-      // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
-      // This makes sure that we preserve the original URL for wildcard routes
-      if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(route.path, configRef.current);
-
-        if (stateForPath) {
-          const focusedRoute = findFocusedRoute(stateForPath);
-
-          if (
-            focusedRoute &&
-            focusedRoute.name === route.name &&
-            isEqual({ ...focusedRoute.params }, { ...route.params })
-          ) {
-            // START FORK - Ensure paths coming from events (e.g refresh) have the base URL
-            // path = route.path;
-            path = appendBaseUrl(route.path);
-            // END FORK
-          }
-        }
-      }
-
-      if (path == null) {
-        path = getPathFromStateRef.current(state, configRef.current);
-      }
-
-      // START FORK - ExpoRouter manually handles hashes. This code is intentionally removed
-      // const previousRoute = previousStateRef.current
-      //   ? findFocusedRoute(previousStateRef.current)
-      //   : undefined;
-
-      // Preserve the hash if the route didn't change
-      // if (
-      //   previousRoute &&
-      //   route &&
-      //   'key' in previousRoute &&
-      //   'key' in route &&
-      //   previousRoute.key === route.key
-      // ) {
-      //   path = path + location.hash;
-      // }
-      // END FORK
-
-      return path;
-    };
-
-    if (ref.current) {
-      // We need to record the current metadata on the first render if they aren't set
-      // This will allow the initial state to be in the history entry
-
-      // START FORK
-      // Instead of using the rootState (which might be stale) we should use the focused state
-      // const state = ref.current.getRootState();
-      const rootState = ref.current.getRootState();
-      const state = store.state as NavigationState;
-
-      // END FORK
-
-      if (state) {
-        const route = findFocusedRoute(state);
-        const path = getPathForRoute(route, state);
-
-        if (previousStateRef.current === undefined) {
-          // START FORK
-          // previousStateRef.current = state;
-          previousStateRef.current = rootState;
-          // END FORK
-        }
-
-        history.replace({ path, state });
-      }
-    }
-
-    const onStateChange = async () => {
-      const navigation = ref.current;
-
-      if (!navigation || !enabled) {
-        return;
-      }
-
-      const previousState = previousStateRef.current;
-      // START FORK
-      // Instead of using the rootState (which might be stale) we should use the focused state
-      // const state = navigation.getRootState();
-      const rootState = navigation.getRootState();
-      const state = store.state as NavigationState;
-
-      // END FORK
-
-      // root state may not available, for example when root navigators switch inside the container
-      if (!state) {
-        return;
-      }
-
-      const pendingPath = pendingPopStatePathRef.current;
-      const route = findFocusedRoute(state);
-      const path = getPathForRoute(route, state);
-
-      // START FORK
-      // previousStateRef.current = state;
-      previousStateRef.current = rootState;
-      // END FORK
-      pendingPopStatePathRef.current = undefined;
-
-      // To detect the kind of state change, we need to:
-      // - Find the common focused navigation state in previous and current state
-      // - If only the route keys changed, compare history/routes.length to check if we go back/forward/replace
-      // - If no common focused navigation state found, it's a replace
-      const [previousFocusedState, focusedState] = findMatchingState(previousState, state);
-
-      if (
-        previousFocusedState &&
-        focusedState &&
-        // We should only handle push/pop if path changed from what was in last `popstate`
-        // Otherwise it's likely a change triggered by `popstate`
-        path !== pendingPath
-      ) {
-        const historyDelta =
-          getHistoryLength(focusedState) - getHistoryLength(previousFocusedState);
-
-        if (historyDelta > 0) {
-          // If history length is increased, we should pushState
-          // Note that path might not actually change here, for example, drawer open should pushState
-          history.push({ path, state });
-        } else if (historyDelta < 0) {
-          // If history length is decreased, i.e. entries were removed, we want to go back
-
-          const nextIndex = history.backIndex({ path });
-          const currentIndex = history.index;
-
-          try {
-            if (
-              nextIndex !== -1 &&
-              nextIndex < currentIndex &&
-              // We should only go back if the entry exists and it's less than current index
-              history.get(nextIndex - currentIndex)
-            ) {
-              // An existing entry for this path exists and it's less than current index, go back to that
-              await history.go(nextIndex - currentIndex);
-            } else {
-              // We couldn't find an existing entry to go back to, so we'll go back by the delta
-              // This won't be correct if multiple routes were pushed in one go before
-              // Usually this shouldn't happen and this is a fallback for that
-              await history.go(historyDelta);
-            }
-
-            // Store the updated state as well as fix the path if incorrect
-            history.replace({ path, state });
-          } catch {
-            // The navigation was interrupted
-          }
-        } else {
-          // If history length is unchanged, we want to replaceState
-          history.replace({ path, state });
-        }
-      } else {
-        // If no common navigation state was found, assume it's a replace
-        // This would happen if the user did a reset/conditionally changed navigators
-        history.replace({ path, state });
-      }
-    };
-
-    // We debounce onStateChange coz we don't want multiple state changes to be handled at one time
-    // This could happen since `history.go(n)` is asynchronous
-    // If `pushState` or `replaceState` were called before `history.go(n)` completes, it'll mess stuff up
-    return ref.current?.addListener('state', series(onStateChange));
-  }, [enabled, history, ref]);
+  useBrowserHistorySync({
+    ref,
+    enabled,
+    config,
+    getStateFromPath,
+    getPathFromState,
+    onUnhandledLinking,
+  });
 
   return {
     getInitialState,

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -1,76 +1,17 @@
-import isEqual from 'fast-deep-equal';
-import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'react';
+import { type RefObject, useEffect, useCallback, useRef, use } from 'react';
 
 import { ServerContext } from '../global-state/serverLocationContext';
-import { useExpoRouterStore } from '../global-state/storeContext';
-import { getRootStackRouteNames } from '../global-state/utils';
 import {
   type LinkingOptions,
-  findFocusedRoute,
-  getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
   getStateFromPath as getStateFromPathDefault,
   type NavigationContainerRef,
-  type NavigationState,
   type ParamListBase,
   useNavigationIndependentTree,
 } from '../react-navigation/native';
-import { getHistoryLength } from '../utils/stack';
-import { createMemoryHistory } from './createMemoryHistory';
-import { appendBaseUrl } from './getPathFromState';
+import { useBrowserHistorySync } from './useBrowserHistorySync';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
-
-/**
- * Find the matching navigation state that changed between 2 navigation states
- * e.g.: a -> b -> c -> d and a -> b -> c -> e -> f, if history in b changed, b is the matching state
- */
-const findMatchingState = <T extends NavigationState>(
-  a: T | undefined,
-  b: T | undefined
-): [T | undefined, T | undefined] => {
-  if (a === undefined || b === undefined || a.key !== b.key) {
-    return [undefined, undefined];
-  }
-
-  // Tab and drawer will have `history` property, but stack will have history in `routes`
-  const aHistoryLength = getHistoryLength(a);
-  const bHistoryLength = getHistoryLength(b);
-
-  const aRoute = a.routes[a.index]!;
-  const bRoute = b.routes[b.index]!;
-
-  const aChildState = aRoute.state as T | undefined;
-  const bChildState = bRoute.state as T | undefined;
-
-  // Stop here if this is the state object that changed:
-  // - history length is different
-  // - focused routes are different
-  // - one of them doesn't have child state
-  // - child state keys are different
-  if (
-    aHistoryLength !== bHistoryLength ||
-    aRoute.key !== bRoute.key ||
-    aChildState === undefined ||
-    bChildState === undefined ||
-    aChildState.key !== bChildState.key
-  ) {
-    return [a, b];
-  }
-
-  return findMatchingState(aChildState, bChildState);
-};
-
-/**
- * Run async function in series as it's called.
- */
-export const series = (cb: () => Promise<void>) => {
-  let queue = Promise.resolve();
-  const callback = () => {
-    queue = queue.then(cb);
-  };
-  return callback;
-};
 
 const linkingHandlers: symbol[] = [];
 
@@ -85,10 +26,7 @@ export function useLinking(
   const config = options?.config;
   const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
-  const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
-
-  const store = useExpoRouterStore();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
@@ -126,43 +64,18 @@ export function useLinking(
     };
   }, [enabled, independent]);
 
-  const [history] = useState(createMemoryHistory);
-
   // We store these options in ref to avoid re-creating getInitialState and re-subscribing listeners
   // This lets user avoid wrapping the items in `React.useCallback` or `React.useMemo`
   // Not re-creating `getInitialState` is important coz it makes it easier for the user to use in an effect
   const enabledRef = useRef(enabled);
   const configRef = useRef(config);
   const getStateFromPathRef = useRef(getStateFromPath);
-  const getPathFromStateRef = useRef(getPathFromState);
-  const getActionFromStateRef = useRef(getActionFromState);
 
   useEffect(() => {
     enabledRef.current = enabled;
     configRef.current = config;
     getStateFromPathRef.current = getStateFromPath;
-    getPathFromStateRef.current = getPathFromState;
-    getActionFromStateRef.current = getActionFromState;
   });
-
-  const validateRoutesNotExistInRootState = useCallback(
-    (state: ResultState) => {
-      // START FORK
-      // Instead of using the rootState, we use INTERNAL_SLOT_NAME, which is the only route in the root navigator in Expo Router
-      // const navigation = ref.current;
-      // const rootState = navigation?.getRootState();
-      const routeNames = getRootStackRouteNames();
-      // END FORK
-
-      // Make sure that the routes in the state exist in the root navigator
-      // Otherwise there's an error in the linking configuration
-      // START FORK
-      // return state?.routes.some((r) => !rootState?.routeNames?.includes(r.name));
-      return state?.routes.some((r) => !routeNames.includes(r.name));
-      // END FORK
-    },
-    [ref]
-  );
 
   const server = use(ServerContext);
 
@@ -198,281 +111,14 @@ export function useLinking(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const previousIndexRef = useRef<number | undefined>(undefined);
-  const previousStateRef = useRef<NavigationState | undefined>(undefined);
-  const pendingPopStatePathRef = useRef<string | undefined>(undefined);
-
-  useEffect(() => {
-    previousIndexRef.current = history.index;
-
-    return history.listen(() => {
-      const navigation = ref.current;
-
-      if (!navigation || !enabled) {
-        return;
-      }
-
-      const { location } = window;
-
-      const path = location.pathname + location.search + location.hash;
-      const index = history.index;
-
-      const previousIndex = previousIndexRef.current ?? 0;
-
-      previousIndexRef.current = index;
-      pendingPopStatePathRef.current = path;
-
-      // When browser back/forward is clicked, we first need to check if state object for this index exists
-      // If it does we'll reset to that state object
-      // Otherwise, we'll handle it like a regular deep link
-      const record = history.get(index);
-
-      if (record?.path === path && record?.state) {
-        navigation.resetRoot(record.state);
-        return;
-      }
-
-      const state = getStateFromPathRef.current(path, configRef.current);
-
-      // We should only dispatch an action when going forward
-      // Otherwise the action will likely add items to history, which would mess things up
-      if (state) {
-        // If the link were handled, it gets cleared in NavigationContainer
-        onUnhandledLinking(path);
-        // Make sure that the routes in the state exist in the root navigator
-        // Otherwise there's an error in the linking configuration
-        if (validateRoutesNotExistInRootState(state)) {
-          return;
-        }
-
-        if (
-          index > previousIndex ||
-          /* START FORK
-           *
-           * This is a workaround for React Navigation's handling of hashes (it doesn't handle them)
-           * When you click on <a href="#hash">, the browser will first fire a popstate event
-           * and this callback will be called.
-           *
-           * From React Navigation's perspective, it's treating the new hash change like a back/forward
-           * button press, so it thinks it should reset the state. When we should
-           * be to be pushing the new state
-           *
-           * Our fix is to check if the index is the same as the previous index
-           * and if the incoming path is the same as the old path but with the hash added,
-           * then treat it as a push instead of a reset
-           *
-           * This also works for subsequent hash changes, as internally RN
-           * doesn't store the hash in the history state.
-           *
-           * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#when_popstate_is_sent
-           */
-          (index === previousIndex && (!record || `${record?.path}${location.hash}` === path))
-          // END FORK
-        ) {
-          const action = getActionFromStateRef.current(state, configRef.current);
-
-          if (action !== undefined) {
-            try {
-              navigation.dispatch(action);
-            } catch (e) {
-              // Ignore any errors from deep linking.
-              // This could happen in case of malformed links, navigation object not being initialized etc.
-              console.warn(
-                `An error occurred when trying to handle the link '${path}': ${
-                  typeof e === 'object' && e != null && 'message' in e ? e.message : e
-                }`
-              );
-            }
-          } else {
-            navigation.resetRoot(state);
-          }
-        } else {
-          navigation.resetRoot(state);
-        }
-      } else {
-        // if current path didn't return any state, we should revert to initial state
-        navigation.resetRoot(state);
-      }
-    });
-  }, [enabled, history, onUnhandledLinking, ref, validateRoutesNotExistInRootState]);
-
-  useEffect(() => {
-    if (!enabled) {
-      return;
-    }
-
-    const getPathForRoute = (
-      route: ReturnType<typeof findFocusedRoute>,
-      state: NavigationState
-    ): string => {
-      let path;
-
-      // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
-      // This makes sure that we preserve the original URL for wildcard routes
-      if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(route.path, configRef.current);
-
-        if (stateForPath) {
-          const focusedRoute = findFocusedRoute(stateForPath);
-
-          if (
-            focusedRoute &&
-            focusedRoute.name === route.name &&
-            isEqual({ ...focusedRoute.params }, { ...route.params })
-          ) {
-            // START FORK - Ensure paths coming from events (e.g refresh) have the base URL
-            // path = route.path;
-            path = appendBaseUrl(route.path);
-            // END FORK
-          }
-        }
-      }
-
-      if (path == null) {
-        path = getPathFromStateRef.current(state, configRef.current);
-      }
-
-      // START FORK - ExpoRouter manually handles hashes. This code is intentionally removed
-      // const previousRoute = previousStateRef.current
-      //   ? findFocusedRoute(previousStateRef.current)
-      //   : undefined;
-
-      // Preserve the hash if the route didn't change
-      // if (
-      //   previousRoute &&
-      //   route &&
-      //   'key' in previousRoute &&
-      //   'key' in route &&
-      //   previousRoute.key === route.key
-      // ) {
-      //   path = path + location.hash;
-      // }
-      // END FORK
-
-      return path;
-    };
-
-    if (ref.current) {
-      // We need to record the current metadata on the first render if they aren't set
-      // This will allow the initial state to be in the history entry
-
-      // START FORK
-      // Instead of using the rootState (which might be stale) we should use the focused state
-      // const state = ref.current.getRootState();
-      const rootState = ref.current.getRootState();
-      const state = store.state as NavigationState;
-
-      // END FORK
-
-      if (state) {
-        const route = findFocusedRoute(state);
-        const path = getPathForRoute(route, state);
-
-        if (previousStateRef.current === undefined) {
-          // START FORK
-          // previousStateRef.current = state;
-          previousStateRef.current = rootState;
-          // END FORK
-        }
-
-        history.replace({ path, state });
-      }
-    }
-
-    const onStateChange = async () => {
-      const navigation = ref.current;
-
-      if (!navigation || !enabled) {
-        return;
-      }
-
-      const previousState = previousStateRef.current;
-      // START FORK
-      // Instead of using the rootState (which might be stale) we should use the focused state
-      // const state = navigation.getRootState();
-      const rootState = navigation.getRootState();
-      const state = store.state as NavigationState;
-
-      // END FORK
-
-      // root state may not available, for example when root navigators switch inside the container
-      if (!state) {
-        return;
-      }
-
-      const pendingPath = pendingPopStatePathRef.current;
-      const route = findFocusedRoute(state);
-      const path = getPathForRoute(route, state);
-
-      // START FORK
-      // previousStateRef.current = state;
-      previousStateRef.current = rootState;
-      // END FORK
-      pendingPopStatePathRef.current = undefined;
-
-      // To detect the kind of state change, we need to:
-      // - Find the common focused navigation state in previous and current state
-      // - If only the route keys changed, compare history/routes.length to check if we go back/forward/replace
-      // - If no common focused navigation state found, it's a replace
-      const [previousFocusedState, focusedState] = findMatchingState(previousState, state);
-
-      if (
-        previousFocusedState &&
-        focusedState &&
-        // We should only handle push/pop if path changed from what was in last `popstate`
-        // Otherwise it's likely a change triggered by `popstate`
-        path !== pendingPath
-      ) {
-        const historyDelta =
-          getHistoryLength(focusedState) - getHistoryLength(previousFocusedState);
-
-        if (historyDelta > 0) {
-          // If history length is increased, we should pushState
-          // Note that path might not actually change here, for example, drawer open should pushState
-          history.push({ path, state });
-        } else if (historyDelta < 0) {
-          // If history length is decreased, i.e. entries were removed, we want to go back
-
-          const nextIndex = history.backIndex({ path });
-          const currentIndex = history.index;
-
-          try {
-            if (
-              nextIndex !== -1 &&
-              nextIndex < currentIndex &&
-              // We should only go back if the entry exists and it's less than current index
-              history.get(nextIndex - currentIndex)
-            ) {
-              // An existing entry for this path exists and it's less than current index, go back to that
-              await history.go(nextIndex - currentIndex);
-            } else {
-              // We couldn't find an existing entry to go back to, so we'll go back by the delta
-              // This won't be correct if multiple routes were pushed in one go before
-              // Usually this shouldn't happen and this is a fallback for that
-              await history.go(historyDelta);
-            }
-
-            // Store the updated state as well as fix the path if incorrect
-            history.replace({ path, state });
-          } catch {
-            // The navigation was interrupted
-          }
-        } else {
-          // If history length is unchanged, we want to replaceState
-          history.replace({ path, state });
-        }
-      } else {
-        // If no common navigation state was found, assume it's a replace
-        // This would happen if the user did a reset/conditionally changed navigators
-        history.replace({ path, state });
-      }
-    };
-
-    // We debounce onStateChange coz we don't want multiple state changes to be handled at one time
-    // This could happen since `history.go(n)` is asynchronous
-    // If `pushState` or `replaceState` were called before `history.go(n)` completes, it'll mess stuff up
-    return ref.current?.addListener('state', series(onStateChange));
-  }, [enabled, history, ref]);
+  useBrowserHistorySync({
+    ref,
+    enabled,
+    config,
+    getStateFromPath,
+    getPathFromState,
+    onUnhandledLinking,
+  });
 
   return {
     getInitialState,

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -156,6 +156,47 @@ describe('routingQueue', () => {
     expect(dispatch.mock.calls).toEqual([[navigateAction], [{ type: 'GO_BACK' }]]);
   });
 
+  it('run() reports the queued action when handling fails', () => {
+    const ref = makeRef();
+    mockGetNavigateAction.mockImplementationOnce(() => {
+      throw new Error('malformed');
+    });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    routingQueue.add({
+      type: 'NAVIGATE_TO_HREF',
+      payload: {
+        href: '/home',
+        originalHref: 'example://home',
+        options: { event: 'NAVIGATE' },
+      },
+    });
+
+    routingQueue.run(ref);
+
+    expect(warn).toHaveBeenCalledWith(
+      'An error occurred when trying to handle navigation action ' +
+        '{"type":"NAVIGATE_TO_HREF","payload":{"href":"/home","originalHref":"example://home","options":{"event":"NAVIGATE"}}}: malformed'
+    );
+    warn.mockRestore();
+  });
+
+  it('run() invokes onDispatch immediately before dispatching', () => {
+    const calls: string[] = [];
+    const ref = makeRef({ dispatch: jest.fn(() => calls.push('dispatch')) });
+    const action = { type: 'RESET', payload: undefined };
+
+    routingQueue.add({
+      type: 'ACTION',
+      payload: { action },
+      onDispatch: () => calls.push('onDispatch'),
+    });
+
+    routingQueue.run(ref);
+
+    expect(calls).toEqual(['onDispatch', 'dispatch']);
+  });
+
   it('run() warns when a path is invalid', () => {
     const ref = makeRef();
     mockGetNavigateAction.mockReturnValueOnce({

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -160,6 +160,47 @@ describe('routingQueue', () => {
     expect(dispatch.mock.calls).toEqual([[navigateAction], [{ type: 'GO_BACK' }]]);
   });
 
+  it('run() reports the queued action when handling fails', () => {
+    const ref = makeRef();
+    mockGetNavigateAction.mockImplementationOnce(() => {
+      throw new Error('malformed');
+    });
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    routingQueue.add({
+      type: 'NAVIGATE_TO_HREF',
+      payload: {
+        href: '/home',
+        originalHref: 'example://home',
+        options: { event: 'NAVIGATE' },
+      },
+    });
+
+    routingQueue.run(ref);
+
+    expect(warn).toHaveBeenCalledWith(
+      'An error occurred when trying to handle navigation action ' +
+        '{"type":"NAVIGATE_TO_HREF","payload":{"href":"/home","originalHref":"example://home","options":{"event":"NAVIGATE"}}}: malformed'
+    );
+    warn.mockRestore();
+  });
+
+  it('run() invokes onDispatch immediately before dispatching', () => {
+    const calls: string[] = [];
+    const ref = makeRef({ dispatch: jest.fn(() => calls.push('dispatch')) });
+    const action = { type: 'RESET', payload: undefined };
+
+    routingQueue.add({
+      type: 'ACTION',
+      payload: { action },
+      onDispatch: () => calls.push('onDispatch'),
+    });
+
+    routingQueue.run(ref);
+
+    expect(calls).toEqual(['onDispatch', 'dispatch']);
+  });
+
   it('run() warns when a path is invalid', () => {
     const ref = makeRef();
     mockGetNavigateAction.mockReturnValueOnce({

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -14,12 +14,27 @@ interface NavigateToHrefIntent {
   payload: {
     options: LinkToOptions;
     href: string;
+    originalHref?: string;
+  };
+  metadata?: RoutingIntentMetadata;
+  onDispatch?: (metadata: RoutingIntentMetadata | undefined) => void;
+}
+
+interface RoutingIntentMetadata {
+  history?: {
+    id: number;
+    path: string;
   };
 }
 
 export type RoutingIntent =
   | NavigateToHrefIntent
-  | { type: 'ACTION'; payload: { action: NavigationAction } };
+  | {
+      type: 'ACTION';
+      payload: { action: NavigationAction };
+      metadata?: RoutingIntentMetadata;
+      onDispatch?: (metadata: RoutingIntentMetadata | undefined) => void;
+    };
 
 export const routingQueue = {
   queue: [] as RoutingIntent[],
@@ -74,9 +89,8 @@ export const routingQueue = {
             !!options.__internal__PreviewKey
           );
           if (resolution.status === 'invalid') {
-            console.warn(
-              `Could not generate a valid navigation state for the given path: ${resolution.href}`
-            );
+            const href = intent.payload.originalHref ?? resolution.href;
+            console.warn(`Could not generate a valid navigation state for the given path: ${href}`);
             continue;
           }
           dispatchAction = resolution.action;
@@ -95,12 +109,13 @@ export const routingQueue = {
           stateTargets.add(target);
         }
 
+        intent.onDispatch?.(intent.metadata);
         ref.current.dispatch(dispatchAction);
       } catch (error) {
+        const message =
+          typeof error === 'object' && error != null && 'message' in error ? error.message : error;
         console.warn(
-          `An error occurred when trying to handle a navigation action: ${
-            typeof error === 'object' && error != null && 'message' in error ? error.message : error
-          }`
+          `An error occurred when trying to handle navigation action ${JSON.stringify(intent)}: ${message}`
         );
       }
     }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
