### PR TITLE
[app-metrics][observe] Add a `networkTraces` option to configure, gating network trace recording at capture time

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 💡 Others
 
+- Add an internal `setNetworkSpansConfig` to gate and filter network span recording at capture time. ([#48891](https://github.com/expo/expo/pull/48891) by [@tsapeta](https://github.com/tsapeta))
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Add a `caught` source to the private `reportError` for errors reported from user code. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -16,6 +16,7 @@ import expo.modules.appmetrics.networkrequests.NetworkRequestFilter
 import expo.modules.appmetrics.networkrequests.NetworkRequestMonitor
 import expo.modules.appmetrics.networkrequests.NetworkRequestObserver
 import expo.modules.appmetrics.networkrequests.NetworkRequestPersistence
+import expo.modules.appmetrics.networkrequests.NetworkSpansConfiguration
 import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.logevents.sanitizeLogEventAttributes
 import expo.modules.appmetrics.logevents.validateDisplayName
@@ -69,8 +70,9 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   lateinit var mainSession: SessionSharedObject
 
   /**
-   * The span producer installed on the monitor in `OnCreate`, kept so `OnDestroy` can
-   * uninstall it when the module is torn down (a JS reload).
+   * The span producer installed on the monitor in `OnCreate`, kept so `setNetworkSpansConfig`
+   * can apply a new recording policy to the live instance and `OnDestroy` can uninstall it
+   * when the module is torn down (a JS reload).
    */
   private var networkRequestPersistence: NetworkRequestPersistence? = null
 
@@ -136,6 +138,19 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         GlobalAttributes.set(attributes)
       }
 
+      Function("setNetworkSpansConfig") { config: NetworkSpansConfigParam ->
+        val configuration = NetworkSpansConfiguration(
+          enabled = config.enabled,
+          hosts = config.filter?.hosts,
+          methods = config.filter?.methods
+        )
+        // Persist first so the setting survives the process; the live producer picks it up for
+        // every request recorded after the volatile write. Applies forward only — rows
+        // persisted earlier in the launch still dispatch.
+        AppMetricsPreferences.setNetworkSpansConfiguration(context, configuration)
+        networkRequestPersistence?.setConfiguration(configuration)
+      }
+
       OnCreate {
         sessionManager = SessionManager(context)
 
@@ -172,6 +187,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
             sessionId = mainSession.sessionId
           )
           networkRequestPersistence = persistence
+          // The policy is read from preferences only after the reference above is visible:
+          // a `setNetworkSpansConfig` call landing before this line has already persisted its
+          // value and is picked up here; one landing after it hits the live setter instead.
+          // Reading before the assignment would let a concurrent configure fall between the
+          // read and the assignment and leave a stale policy until the next launch.
+          persistence.setConfiguration(AppMetricsPreferences.getNetworkSpansConfiguration(context))
           NetworkRequestMonitor.shared.installPersistence(persistence)
         }
 
@@ -390,4 +411,14 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
 data class MetricAttributes(
   @Field val routeName: String? = null,
   @Field val params: Map<String, Any>? = null
+) : Record
+
+/**
+ * Payload of `setNetworkSpansConfig`: the normalized `traces.network` setting pushed down by
+ * `Observe.configure`.
+ */
+@OptimizedRecord
+data class NetworkSpansConfigParam(
+  @Field val enabled: Boolean = true,
+  @Field val filter: NetworkRequestFilter? = null
 ) : Record

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsPreferences.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsPreferences.kt
@@ -2,10 +2,12 @@ package expo.modules.appmetrics
 
 import android.content.Context
 import androidx.core.content.edit
+import expo.modules.appmetrics.networkrequests.NetworkSpansConfiguration
 
 private const val PREFS_NAME = "dev.expo.app-metrics"
 private const val KEY_ENVIRONMENT = "environment"
 private const val KEY_LAST_PROCESSED_EXIT_MILLIS = "lastProcessedExitMillis"
+private const val KEY_NETWORK_SPANS_CONFIGURATION = "networkSpansConfiguration"
 
 object AppMetricsPreferences {
   /**
@@ -40,5 +42,25 @@ object AppMetricsPreferences {
 
   fun getDefaultEnvironment(): String? {
     return if (BuildConfig.DEBUG) "development" else null
+  }
+
+  /**
+   * Last-applied network spans recording policy, or the default when JS never configured one.
+   * Persisted so requests observed before the JS bundle configures the SDK — early startup, or
+   * the next launch — follow the last-known setting.
+   */
+  fun getNetworkSpansConfiguration(context: Context): NetworkSpansConfiguration {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    val json = prefs.getString(KEY_NETWORK_SPANS_CONFIGURATION, null)
+      ?: return NetworkSpansConfiguration()
+    return NetworkSpansConfiguration.fromJson(json)
+  }
+
+  fun setNetworkSpansConfiguration(
+    context: Context,
+    configuration: NetworkSpansConfiguration
+  ) {
+    val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    prefs.edit(commit = true) { putString(KEY_NETWORK_SPANS_CONFIGURATION, configuration.toJson()) }
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
@@ -29,6 +29,7 @@ private const val TAG = "ExpoAppMetrics"
 class NetworkRequestPersistence(
   private val database: MetricsDatabase,
   private val scope: CoroutineScope,
+  initialConfiguration: NetworkSpansConfiguration = NetworkSpansConfiguration(),
   /**
    * A plain value, not a provider: the id is constant for a persistence instance (it is
    * constructed after the main session exists), and resolving it eagerly means the monitor's
@@ -38,11 +39,30 @@ class NetworkRequestPersistence(
   private val sessionId: String
 ) {
   /**
+   * Capture-time recording policy. Volatile because the monitor calls in from OkHttp dispatcher
+   * threads while JS reconfigures from the modules queue. Checked before each insert so a change
+   * takes effect for future requests immediately; rows persisted earlier are untouched.
+   */
+  @Volatile
+  private var configuration: NetworkSpansConfiguration = initialConfiguration
+
+  /**
+   * Applies a new recording policy to subsequent requests. Called when JS reconfigures
+   * `traces.network`; the caller persists the value separately.
+   */
+  fun setConfiguration(configuration: NetworkSpansConfiguration) {
+    this.configuration = configuration
+  }
+
+  /**
    * Persists one completed request as a span. The insert runs on `scope` so the monitor's
    * record path (OkHttp dispatcher threads) never blocks on the database; failures are logged
    * and swallowed — persistence must never break the monitor's fan-out.
    */
   fun persist(request: NetworkRequest) {
+    if (!configuration.allows(request.url, request.method)) {
+      return
+    }
     val span = request.toSpan(sessionId) ?: return
     scope.launch {
       try {
@@ -66,6 +86,9 @@ class NetworkRequestPersistence(
     }
     scope.launch {
       for (request in requests) {
+        if (!configuration.allows(request.url, request.method)) {
+          continue
+        }
         val span = request.toSpan(sessionId) ?: continue
         try {
           database.spanDao().insertCapped(span)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkSpansConfiguration.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkSpansConfiguration.kt
@@ -1,0 +1,80 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.appmetrics.networkrequests
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Capture-time recording policy for network request spans: whether completed requests are
+ * written to the `spans` table at all, plus an optional host/method allowlist. Consulted by
+ * `NetworkRequestPersistence` before each insert — a request rejected here never reaches disk,
+ * unlike the dispatch-side gates (`dispatchingEnabled`, sampling) which only suppress the
+ * upload of rows that were already persisted.
+ *
+ * Persisted in `AppMetricsPreferences` so requests observed before JS configuration runs
+ * (early startup, or the next launch) follow the last-applied setting. Mirrors the iOS
+ * `NetworkSpansConfiguration`.
+ */
+data class NetworkSpansConfiguration(
+  val enabled: Boolean = true,
+  /**
+   * Allowed hosts, compared for exact, case-insensitive equality. `null` allows every host;
+   * an empty list allows none.
+   */
+  val hosts: List<String>? = null,
+  /** Allowed HTTP methods, compared case-insensitively. `null` allows every method. */
+  val methods: List<String>? = null
+) {
+  /**
+   * Whether a request with the given URL and method should be recorded. Mirrors the
+   * `NetworkRequestFilter.matches` semantics used by the JS-facing observer.
+   */
+  fun allows(url: String, method: String): Boolean {
+    if (!enabled) {
+      return false
+    }
+    hosts?.let { allowedHosts ->
+      val host = url.toHttpUrlOrNull()?.host
+      val allowed = allowedHosts.any { it.equals(host, ignoreCase = true) }
+      if (!allowed) {
+        return false
+      }
+    }
+    methods?.let { allowedMethods ->
+      val allowed = allowedMethods.any { it.equals(method, ignoreCase = true) }
+      if (!allowed) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /** JSON form for the preferences store. */
+  fun toJson(): String {
+    val json = JSONObject()
+    json.put("enabled", enabled)
+    hosts?.let { json.put("hosts", JSONArray(it)) }
+    methods?.let { json.put("methods", JSONArray(it)) }
+    return json.toString()
+  }
+
+  companion object {
+    /** Parses the preferences-store form; a malformed blob falls back to the default policy. */
+    fun fromJson(json: String): NetworkSpansConfiguration {
+      return runCatching {
+        val obj = JSONObject(json)
+        NetworkSpansConfiguration(
+          enabled = obj.optBoolean("enabled", true),
+          hosts = obj.optJSONArray("hosts")?.let { array ->
+            List(array.length()) { index -> array.getString(index) }
+          },
+          methods = obj.optJSONArray("methods")?.let { array ->
+            List(array.length()) { index -> array.getString(index) }
+          }
+        )
+      }.getOrDefault(NetworkSpansConfiguration())
+    }
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
@@ -25,6 +25,20 @@ class AppMetricsPreferencesTest {
   }
 
   @Test
+  fun `network spans configuration round-trips and defaults to enabled`() {
+    assertEquals(
+      expo.modules.appmetrics.networkrequests.NetworkSpansConfiguration(),
+      AppMetricsPreferences.getNetworkSpansConfiguration(context)
+    )
+    val configured = expo.modules.appmetrics.networkrequests.NetworkSpansConfiguration(
+      enabled = true,
+      hosts = listOf("api.example.com")
+    )
+    AppMetricsPreferences.setNetworkSpansConfiguration(context, configured)
+    assertEquals(configured, AppMetricsPreferences.getNetworkSpansConfiguration(context))
+  }
+
+  @Test
   fun `getEnvironment returns default environment when nothing saved`() {
     val expected = if (BuildConfig.DEBUG) "development" else null
     assertEquals(expected, AppMetricsPreferences.getEnvironment(context))

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
@@ -326,6 +326,55 @@ class NetworkRequestPersistenceTest {
   }
 
   @Test
+  fun `drops every request while recording is disabled`() = runTest(testDispatcher) {
+    insertSession("s")
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      initialConfiguration = NetworkSpansConfiguration(enabled = false),
+      sessionId = "s"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertTrue(database.spanDao().getAll().isEmpty())
+  }
+
+  @Test
+  fun `records only requests matching the configured filter`() = runTest(testDispatcher) {
+    insertSession("s")
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      initialConfiguration = NetworkSpansConfiguration(enabled = true, hosts = listOf("API.myapp.com")),
+      sessionId = "s"
+    )
+    persistence.persist(makeRequest(url = "https://api.example.com/skip"))
+    persistence.persist(makeRequest(url = "https://api.myapp.com/keep"))
+    testScheduler.advanceUntilIdle()
+    val rows = database.spanDao().getAll()
+    assertEquals(1, rows.size)
+    val recordedUrl = JSONObject(checkNotNull(rows.single().attributes)).getString("url.full")
+    assertEquals("https://api.myapp.com/keep", recordedUrl)
+  }
+
+  @Test
+  fun `applies a configuration change to subsequent requests only`() = runTest(testDispatcher) {
+    // "Applies forward": rows persisted before the change stay in the table and still dispatch.
+    insertSession("s")
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    persistence.setConfiguration(NetworkSpansConfiguration(enabled = false))
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertEquals(1, database.spanDao().getAll().size)
+  }
+
+  @Test
   fun `persists a completed request as a span attributed to the provided session`() = runTest(testDispatcher) {
     insertSession("main-session")
     val persistence = NetworkRequestPersistence(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkSpansConfigurationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkSpansConfigurationTest.kt
@@ -1,0 +1,80 @@
+package expo.modules.appmetrics.networkrequests
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class NetworkSpansConfigurationTest {
+  @Test
+  fun `allows every request by default`() {
+    val config = NetworkSpansConfiguration()
+    assertTrue(config.allows("https://api.example.com/items", "GET"))
+    assertTrue(config.allows("https://other.dev/x", "DELETE"))
+  }
+
+  @Test
+  fun `blocks every request while disabled, even ones matching the filter`() {
+    val config = NetworkSpansConfiguration(enabled = false, hosts = listOf("api.example.com"))
+    assertFalse(config.allows("https://api.example.com/items", "GET"))
+  }
+
+  @Test
+  fun `matches hosts for exact case-insensitive equality`() {
+    val config = NetworkSpansConfiguration(hosts = listOf("API.Example.com"))
+    assertTrue(config.allows("https://api.example.com/items", "GET"))
+    assertFalse(config.allows("https://sub.api.example.com/items", "GET"))
+    assertFalse(config.allows("https://other.dev/x", "GET"))
+  }
+
+  @Test
+  fun `an empty host list blocks every request`() {
+    // `null` means unconstrained; an empty list is an allowlist with no entries.
+    val config = NetworkSpansConfiguration(hosts = emptyList())
+    assertFalse(config.allows("https://api.example.com/items", "GET"))
+  }
+
+  @Test
+  fun `matches methods case-insensitively`() {
+    val config = NetworkSpansConfiguration(methods = listOf("get", "Post"))
+    assertTrue(config.allows("https://api.example.com/items", "GET"))
+    assertTrue(config.allows("https://api.example.com/items", "POST"))
+    assertFalse(config.allows("https://api.example.com/items", "DELETE"))
+  }
+
+  @Test
+  fun `a request whose URL has no parseable host never matches a host list`() {
+    // A host allowlist means "only these hosts"; an unparseable URL can't prove membership.
+    val config = NetworkSpansConfiguration(hosts = listOf("api.example.com"))
+    assertFalse(config.allows("not a url", "GET"))
+  }
+
+  @Test
+  fun `round-trips through the preferences encoding`() {
+    val full = NetworkSpansConfiguration(
+      enabled = false,
+      hosts = listOf("api.example.com", "cdn.example.com"),
+      methods = listOf("GET")
+    )
+    assertEquals(full, NetworkSpansConfiguration.fromJson(full.toJson()))
+    val minimal = NetworkSpansConfiguration()
+    val restored = NetworkSpansConfiguration.fromJson(minimal.toJson())
+    assertEquals(minimal, restored)
+    assertNull(restored.hosts)
+    assertNull(restored.methods)
+  }
+
+  @Test
+  fun `falls back to the default policy for a malformed blob`() {
+    // A corrupt preferences entry must never disable recording or crash module creation.
+    for (blob in listOf("", "not json", "[1,2]", """{"hosts":"nope"}""")) {
+      assertEquals(NetworkSpansConfiguration(), NetworkSpansConfiguration.fromJson(blob))
+    }
+  }
+}

--- a/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
@@ -14,7 +14,12 @@ public class AppMetricsAppDelegateSubscriber: ExpoAppDelegateSubscriber {
       // From here on every completed request is written to the database, attributed to the main
       // session. The session's row INSERT was enqueued on the actor when `mainSession` was first
       // touched above, so it lands before any request row that references it.
-      NetworkRequestMonitor.shared.persistence = NetworkRequestPersistence(database: AppMetrics.database) {
+      // The persisted recording policy applies from the first observed request; JS can replace
+      // it later via `setNetworkSpansConfig`, affecting subsequent requests only.
+      NetworkRequestMonitor.shared.persistence = NetworkRequestPersistence(
+        database: AppMetrics.database,
+        configuration: AppMetricsUserDefaults.networkSpansConfiguration ?? NetworkSpansConfiguration()
+      ) {
         return AppMetrics.mainSession.id
       }
     }

--- a/packages/expo-app-metrics/ios/AppMetricsModule.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsModule.swift
@@ -64,6 +64,25 @@ public final class AppMetricsModule: Module, UpdatesStateChangeListener {
       GlobalAttributes.set(attributes)
     }
 
+    Function("setNetworkSpansConfig") { (config: NetworkSpansConfigParam) in
+      let configuration = NetworkSpansConfiguration(
+        enabled: config.enabled,
+        hosts: config.filter?.hosts,
+        methods: config.filter?.methods
+      )
+      // Persist first so the setting survives the process; the live producer picks it up for
+      // every request recorded after this hop to the actor. Applies forward only — rows
+      // persisted earlier in the launch still dispatch.
+      AppMetricsUserDefaults.networkSpansConfiguration = configuration
+      Task { @AppMetricsActor in
+        // Re-read instead of capturing `configuration`: two rapid `configure()` calls create
+        // two unordered actor hops, while the persisted value is written in call order —
+        // reading it here makes the last write win regardless of task interleaving.
+        let latest = AppMetricsUserDefaults.networkSpansConfiguration ?? NetworkSpansConfiguration()
+        NetworkRequestMonitor.shared.persistence?.setConfiguration(latest)
+      }
+    }
+
     AsyncFunction("getAppStartupTimesAsync") {
       return await AppMetrics.mainSession.appStartupMonitor.metrics
     }
@@ -185,6 +204,16 @@ private func storedSession(id: String) throws -> StoredSession? {
     return nil
   }
   return StoredSession(from: row)
+}
+
+/// Payload of `setNetworkSpansConfig`: the normalized `traces.network` setting pushed down by
+/// `Observe.configure`.
+internal struct NetworkSpansConfigParam: Record {
+  @Field
+  var enabled: Bool = true
+
+  @Field
+  var filter: NetworkRequestFilter?
 }
 
 struct MetricAttributes: Record {

--- a/packages/expo-app-metrics/ios/AppMetricsUserDefaults.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsUserDefaults.swift
@@ -8,6 +8,7 @@ public final class AppMetricsUserDefaults: UserDefaults {
   private enum Keys: String {
     case lastAppLaunchState
     case environment
+    case networkSpansConfiguration
   }
 
   private init() {
@@ -39,6 +40,18 @@ public final class AppMetricsUserDefaults: UserDefaults {
     }
     set {
       defaults.set(codable: newValue, forKey: Keys.lastAppLaunchState.rawValue)
+    }
+  }
+
+  /// Last-applied network spans recording policy, or `nil` when JS never configured one (the
+  /// default policy applies). Persisted so requests observed before the JS bundle configures
+  /// the SDK — early startup, or the next launch — follow the last-known setting.
+  static var networkSpansConfiguration: NetworkSpansConfiguration? {
+    get {
+      return defaults.codable(forKey: Keys.networkSpansConfiguration.rawValue, as: NetworkSpansConfiguration.self)
+    }
+    set {
+      defaults.set(codable: newValue, forKey: Keys.networkSpansConfiguration.rawValue)
     }
   }
 }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
@@ -16,17 +16,35 @@ final class NetworkRequestPersistence: Sendable {
   private let database: MetricsDatabase?
   private let sessionId: @Sendable () -> String
 
+  /// Capture-time recording policy. Checked before each insert so disabling (or filtering)
+  /// takes effect for future requests immediately; rows persisted earlier are untouched.
+  private var configuration: NetworkSpansConfiguration
+
   /// `database` is optional so a failed database open degrades to dropped rows instead of
   /// blocking monitor start. `sessionId` is a closure so constructing the persistence doesn't
   /// force the session machinery into existence before the app delegate finished wiring it.
-  init(database: MetricsDatabase?, sessionId: @escaping @Sendable () -> String) {
+  init(
+    database: MetricsDatabase?,
+    configuration: NetworkSpansConfiguration = NetworkSpansConfiguration(),
+    sessionId: @escaping @Sendable () -> String
+  ) {
     self.database = database
+    self.configuration = configuration
     self.sessionId = sessionId
+  }
+
+  /// Applies a new recording policy to subsequent requests. Called when JS reconfigures
+  /// `traces.network`; the caller persists the value separately.
+  func setConfiguration(_ configuration: NetworkSpansConfiguration) {
+    self.configuration = configuration
   }
 
   /// Persists one completed request as a span. Failures are logged and swallowed — persistence
   /// must never break the monitor's fan-out to its delegates.
   func persist(_ request: NetworkRequest) {
+    guard configuration.allows(url: request.url, method: request.method) else {
+      return
+    }
     guard let database, let row = SpanRow.from(request: request, sessionId: sessionId()) else {
       return
     }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkSpansConfiguration.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkSpansConfiguration.swift
@@ -1,0 +1,49 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Capture-time recording policy for network request spans: whether completed requests are
+/// written to the `spans` table at all, plus an optional host/method allowlist. Consulted by
+/// `NetworkRequestPersistence` before each insert — a request rejected here never reaches disk,
+/// unlike the dispatch-side gates (`dispatchingEnabled`, sampling) which only suppress the
+/// upload of rows that were already persisted.
+///
+/// Persisted in `AppMetricsUserDefaults` so requests observed before JS configuration runs
+/// (early startup, or the next launch) follow the last-applied setting.
+internal struct NetworkSpansConfiguration: Codable, Sendable {
+  var enabled: Bool = true
+
+  /// Allowed hosts, compared for exact, case-insensitive equality. `nil` allows every host;
+  /// an empty array allows none.
+  var hosts: [String]?
+
+  /// Allowed HTTP methods, compared case-insensitively. `nil` allows every method.
+  var methods: [String]?
+
+  /// Whether a request with the given URL and method should be recorded. Mirrors the
+  /// `NetworkRequestFilter.matches` semantics used by the JS-facing observer.
+  func allows(url: URL, method: String) -> Bool {
+    if !enabled {
+      return false
+    }
+    if let hosts {
+      let host = url.host?.lowercased()
+      let allowed = hosts.contains { allowedHost in
+        return allowedHost.lowercased() == host
+      }
+      if !allowed {
+        return false
+      }
+    }
+    if let methods {
+      let requestMethod = method.uppercased()
+      let allowed = methods.contains { allowedMethod in
+        return allowedMethod.uppercased() == requestMethod
+      }
+      if !allowed {
+        return false
+      }
+    }
+    return true
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
@@ -325,6 +325,55 @@ struct NetworkRequestPersistenceTests {
   }
 
   @Test
+  func `drops every request while recording is disabled`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "s", into: database)
+      let persistence = NetworkRequestPersistence(
+        database: database,
+        configuration: NetworkSpansConfiguration(enabled: false)
+      ) {
+        return "s"
+      }
+      persistence.persist(makeRequest())
+      #expect(try database.getSpans(afterId: -1).isEmpty)
+    }
+  }
+
+  @Test
+  func `records only requests matching the configured filter`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "s", into: database)
+      let persistence = NetworkRequestPersistence(
+        database: database,
+        configuration: NetworkSpansConfiguration(enabled: true, hosts: ["API.myapp.com"], methods: nil)
+      ) {
+        return "s"
+      }
+      persistence.persist(makeRequest(url: "https://api.example.com/skip"))
+      persistence.persist(makeRequest(url: "https://api.myapp.com/keep"))
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.count == 1)
+      let attributes = try attributesDict(#require(rows.first))
+      #expect(attributes["url.full"] as? String == "https://api.myapp.com/keep")
+    }
+  }
+
+  @Test
+  func `applies a configuration change to subsequent requests only`() throws {
+    // "Applies forward": rows persisted before the change stay in the table and still dispatch.
+    try withTemporaryDatabase { database in
+      try insertSession(id: "s", into: database)
+      let persistence = NetworkRequestPersistence(database: database) {
+        return "s"
+      }
+      persistence.persist(makeRequest())
+      persistence.setConfiguration(NetworkSpansConfiguration(enabled: false))
+      persistence.persist(makeRequest())
+      #expect(try database.getSpans(afterId: -1).count == 1)
+    }
+  }
+
+  @Test
   func `persists a completed request as a span attributed to the provided session`() throws {
     try withTemporaryDatabase { database in
       try insertSession(id: "main-session", into: database)

--- a/packages/expo-app-metrics/ios/Tests/NetworkSpansConfigurationTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkSpansConfigurationTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("NetworkSpansConfiguration")
+struct NetworkSpansConfigurationTests {
+  private let url = URL(string: "https://api.example.com/v1/items")!
+
+  @Test
+  func `allows every request by default`() {
+    let config = NetworkSpansConfiguration()
+    #expect(config.allows(url: url, method: "GET"))
+    #expect(config.allows(url: URL(string: "https://other.dev/x")!, method: "DELETE"))
+  }
+
+  @Test
+  func `blocks every request while disabled, even ones matching the filter`() {
+    let config = NetworkSpansConfiguration(enabled: false, hosts: ["api.example.com"], methods: nil)
+    #expect(!config.allows(url: url, method: "GET"))
+  }
+
+  @Test
+  func `matches hosts for exact case-insensitive equality`() {
+    let config = NetworkSpansConfiguration(enabled: true, hosts: ["API.Example.com"], methods: nil)
+    #expect(config.allows(url: url, method: "GET"))
+    #expect(!config.allows(url: URL(string: "https://sub.api.example.com/x")!, method: "GET"))
+    #expect(!config.allows(url: URL(string: "https://other.dev/x")!, method: "GET"))
+  }
+
+  @Test
+  func `an empty host list blocks every request`() {
+    // `nil` means unconstrained; an empty array is an allowlist with no entries.
+    let config = NetworkSpansConfiguration(enabled: true, hosts: [], methods: nil)
+    #expect(!config.allows(url: url, method: "GET"))
+  }
+
+  @Test
+  func `matches methods case-insensitively`() {
+    let config = NetworkSpansConfiguration(enabled: true, hosts: nil, methods: ["get", "Post"])
+    #expect(config.allows(url: url, method: "GET"))
+    #expect(config.allows(url: url, method: "POST"))
+    #expect(!config.allows(url: url, method: "DELETE"))
+  }
+
+  @Test
+  func `a request whose URL has no host never matches a host list`() {
+    // A host allowlist means "only these hosts"; a hostless URL can't prove membership.
+    let config = NetworkSpansConfiguration(enabled: true, hosts: ["api.example.com"], methods: nil)
+    #expect(!config.allows(url: URL(string: "file:///tmp/payload.json")!, method: "GET"))
+  }
+
+  @Test
+  func `round-trips through its persisted encoding`() throws {
+    let full = NetworkSpansConfiguration(
+      enabled: false,
+      hosts: ["api.example.com", "cdn.example.com"],
+      methods: ["GET"]
+    )
+    let decodedFull = try JSONDecoder().decode(
+      NetworkSpansConfiguration.self,
+      from: JSONEncoder().encode(full)
+    )
+    #expect(decodedFull.enabled == false)
+    #expect(decodedFull.hosts == ["api.example.com", "cdn.example.com"])
+    #expect(decodedFull.methods == ["GET"])
+    let minimal = NetworkSpansConfiguration()
+    let decodedMinimal = try JSONDecoder().decode(
+      NetworkSpansConfiguration.self,
+      from: JSONEncoder().encode(minimal)
+    )
+    #expect(decodedMinimal.enabled)
+    #expect(decodedMinimal.hosts == nil)
+    #expect(decodedMinimal.methods == nil)
+  }
+}

--- a/packages/expo-app-metrics/src/module.web.ts
+++ b/packages/expo-app-metrics/src/module.web.ts
@@ -54,6 +54,7 @@ class ExpoAppMetricsModule extends NativeModule implements ExpoAppMetricsModuleT
   async markInteractive(attributes?: MetricAttributes) {}
   logEvent(name: string, options?: LogEventOptions) {}
   setGlobalAttributes(attributes?: Record<string, LogAttributeValue> | null) {}
+  setNetworkSpansConfig() {}
   async clearStoredEntries() {}
   async getInactiveSessions() {
     return [];

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -494,6 +494,23 @@ export type DebugSession = {
   crashReport?: CrashReport | null;
 };
 
+/**
+ * Controls whether completed network requests are recorded as trace spans, with an optional
+ * capture filter. Consumed by `Observe.configure({ traces: { network } })`; the value persists
+ * across launches so early-startup requests follow the last-applied setting.
+ * @hidden
+ */
+export type NetworkSpansConfig = {
+  /**
+   * Whether completed network requests are written to the local `spans` table.
+   */
+  enabled: boolean;
+  /**
+   * Only requests matching the filter are recorded. An omitted filter records every request.
+   */
+  filter?: NetworkRequestFilter | null;
+};
+
 export interface ExpoAppMetricsModuleType {
   markFirstRender(): void;
   markInteractive(attributes?: MetricAttributes): void;
@@ -508,6 +525,12 @@ export interface ExpoAppMetricsModuleType {
    * @param options Optional body, attributes, and severity overrides.
    */
   logEvent(name: string, options?: LogEventOptions): void;
+  /**
+   * Applies and persists the network spans recording setting. Affects future captures only;
+   * spans already written keep dispatching.
+   * @hidden
+   */
+  setNetworkSpansConfig(config: NetworkSpansConfig): void;
   /**
    * Sets attributes merged into every subsequent metric and log event.
    * Per-record keys win on collision. Pass `null`, `undefined`, or an empty

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add `reportError` to report caught, non-fatal errors from your own `try`/`catch` blocks. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))
 - Add an `errorHandlingEnabled` option to `configure` to opt out of recording unhandled JavaScript errors. ([#48506](https://github.com/expo/expo/pull/48506) by [@tsapeta](https://github.com/tsapeta))
 - Export network requests as OTLP traces. ([#48883](https://github.com/expo/expo/pull/48883) by [@tsapeta](https://github.com/tsapeta))
+- Add a `traces` option to `configure` to control whether network requests are recorded as trace spans, with an optional capture filter. ([#48891](https://github.com/expo/expo/pull/48891) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-observe/src/__tests__/module.test.native.ts
+++ b/packages/expo-observe/src/__tests__/module.test.native.ts
@@ -19,6 +19,7 @@ const mockAppMetrics = {
   markInteractive: jest.fn(),
   setGlobalAttributes: jest.fn(),
   reportError: jest.fn(),
+  setNetworkSpansConfig: jest.fn(),
 };
 
 const mockSetErrorHandlerEnabled = jest.fn();
@@ -153,6 +154,32 @@ describe('module Proxy', () => {
     expect(initRouterIntegration).toHaveBeenCalledTimes(1);
     expect(initRouterIntegration).toHaveBeenCalledWith(true);
     expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('enables network spans by default when configure omits traces', () => {
+    // `configure` is a full replacement: an absent `traces` resets to the default (on, no filter).
+    const Observe = loadModule();
+    Observe.configure({ environment: 'test' });
+    expect(mockAppMetrics.setNetworkSpansConfig).toHaveBeenCalledTimes(1);
+    expect(mockAppMetrics.setNetworkSpansConfig).toHaveBeenCalledWith({ enabled: true });
+  });
+
+  it.each([true, false])('maps traces.network: %s to the native config', (enabled) => {
+    const Observe = loadModule();
+    Observe.configure({ environment: 'test', traces: { network: enabled } });
+    expect(mockAppMetrics.setNetworkSpansConfig).toHaveBeenCalledWith({ enabled });
+  });
+
+  it('passes a capture filter down with the enabled flag', () => {
+    const Observe = loadModule();
+    Observe.configure({
+      environment: 'test',
+      traces: { network: { filter: { hosts: ['api.myapp.com'], methods: ['GET'] } } },
+    });
+    expect(mockAppMetrics.setNetworkSpansConfig).toHaveBeenCalledWith({
+      enabled: true,
+      filter: { hosts: ['api.myapp.com'], methods: ['GET'] },
+    });
   });
 
   it('leaves unhandled-error reporting enabled when errorHandlingEnabled is unset', () => {

--- a/packages/expo-observe/src/index.ts
+++ b/packages/expo-observe/src/index.ts
@@ -41,5 +41,7 @@ export type {
   ObserveModule,
   ObserveModuleEvents,
   ObserveNavigationIntegrationConfig,
+  ObserveTracesConfig,
+  ObserveTracesNetworkConfig,
 } from './types';
 export { useObserve } from './useObserve';

--- a/packages/expo-observe/src/module.ts
+++ b/packages/expo-observe/src/module.ts
@@ -8,6 +8,19 @@ import { isReactNavigationInstalled } from './integrations/react-navigation/reac
 import { reportCaughtError } from './reportCaughtError';
 import type { ObserveConfig, ObserveIntegrationsConfig, ObserveModule } from './types';
 
+/**
+ * Normalizes the `traces.network` sugar (`true` / `false` / `{ filter }`) into the config shape
+ * the native producer persists. `configure` is a full replacement, so an absent `traces` resets
+ * to the default: enabled, no filter.
+ */
+function networkSpansConfigFromTraces(traces: ObserveConfig['traces']) {
+  const network = traces?.network ?? true;
+  if (typeof network === 'boolean') {
+    return { enabled: network };
+  }
+  return network.filter != null ? { enabled: true, filter: network.filter } : { enabled: true };
+}
+
 const native = requireNativeModule<ObserveModule>('ExpoObserve');
 
 const Observe: ObserveModule = new Proxy(native, {
@@ -17,6 +30,11 @@ const Observe: ObserveModule = new Proxy(native, {
         // The handler is already installed at this point (it installs on import), so this only
         // toggles whether it records anything.
         setErrorHandlerEnabled(config.errorHandlingEnabled ?? true);
+
+        // Recording is gated in expo-app-metrics (the producer side), so the setting travels
+        // there rather than into the native `configure` payload. Applies to future captures
+        // only; spans persisted earlier in the launch still dispatch.
+        AppMetrics.setNetworkSpansConfig(networkSpansConfigFromTraces(config.traces));
 
         const routerEnabled = !!config.integrations?.['expo-router'];
         const reactNavigationEnabled = !!config.integrations?.['react-navigation'];

--- a/packages/expo-observe/src/types.ts
+++ b/packages/expo-observe/src/types.ts
@@ -1,5 +1,10 @@
 import type { NativeModule } from 'expo';
-import type { LogAttributeValue, LogEventOptions, MetricAttributes } from 'expo-app-metrics';
+import type {
+  LogAttributeValue,
+  LogEventOptions,
+  MetricAttributes,
+  NetworkRequestFilter,
+} from 'expo-app-metrics';
 
 /**
  * Value types accepted as attribute values in `setGlobalAttributes` and the
@@ -81,6 +86,38 @@ export type ObserveConfig = {
    * [integrate your own package](/eas/observe/integrations/third-party/).
    */
   integrations?: ObserveIntegrationsConfig;
+  /**
+   * Controls which trace spans are recorded on the device.
+   */
+  traces?: ObserveTracesConfig;
+};
+
+export type ObserveTracesNetworkConfig = {
+  /**
+   * Only network requests matching the filter are recorded as spans. Requests that don't match
+   * are never written to the local database. An omitted field matches every request; an empty
+   * array matches none.
+   */
+  filter?: NetworkRequestFilter | null;
+};
+
+export type ObserveTracesConfig = {
+  /**
+   * Whether observed network requests are recorded as trace spans and exported to EAS Observe.
+   *
+   * The setting controls recording, not just export: when disabled (or when a request doesn't
+   * match the configured filter), the request is never written to the local database. Spans
+   * recorded before `configure` ran - including requests from early startup - are unaffected
+   * and still dispatch.
+   *
+   * The value persists across launches, so requests observed before `configure` runs on the
+   * next launch follow the last-applied setting.
+   *
+   * Pass an object to record only requests matching a filter.
+   *
+   * @default true
+   */
+  network?: boolean | ObserveTracesNetworkConfig;
 };
 
 export type ObserveNavigationIntegrationConfig = {


### PR DESCRIPTION
# Why

Network spans record full URLs, and until now the SDK offered no way to turn recording off or narrow it. The review of expo/expo#48861 flagged that dispatch-side gates aren't enough: rows shouldn't reach disk at all when the app opts out.

Closes ENG-26033.

# How

`Observe.configure` gains a `networkTraces` option: a boolean or `{ filter }` object. Gating and filtering happen at capture time in the producer, so a request that doesn't match is never written to the database. The setting persists (UserDefaults / SharedPreferences), so early-startup requests on the next launch follow the last-applied value. It applies forward only: rows persisted before the change keep dispatching, as decided during the design review.

The policy lives in expo-app-metrics next to the producer. `configure` normalizes the sugar and pushes it down via an internal `setNetworkTracesConfig` module function that persists the value and updates the live producer. Matching delegates to `NetworkRequestFilter`, the same type the JS-facing observer uses, so the capture gate can't drift from it. Both platforms resolve the persisted policy before the producer exists (into its constructor), and apply later changes on the queue that owns the producer, so a `configure` racing startup can't be dropped.

```ts
import { Observe } from 'expo-observe';

// Turn network span recording off entirely.
Observe.configure({ networkTraces: false });

// Or record only the hosts and methods you care about.
Observe.configure({
  networkTraces: { filter: { hosts: ['api.myapp.com'], methods: ['GET', 'POST'] } },
});
```

The option sits flat on the config root, next to `dispatchingEnabled` and `errorHandlingEnabled`, rather than under a `traces` namespace: it is the only span-recording switch today, and the surrounding config uses compound names instead of nesting. The producer-side type is `NetworkTracesConfiguration` so the name matches from the public option down to the persisted key.

# Test Plan

New native suites on both platforms cover the matching matrix (case-insensitivity, empty-allowlist, hostless URLs), the persisted encoding round-trip, malformed-blob fallback, and persistence-level gating (disabled drops, filter drops, live reconfigure applies forward). Jest covers the `configure` normalization, including the default when `networkTraces` is omitted.

- `et native-unit-tests -p ios --packages expo-observe,expo-app-metrics`: 477 passed, 0 failed
- `et native-unit-tests -p android`: both packages BUILD SUCCESSFUL
- Jest: 68 suites / 576 tests passed
- `tsc` clean for both packages

