### PR TITLE
[cli] Cache the dev server manifest runtime version per session

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Resolve the signed-in username for partner provisioned actors so Expo Go can verify the account match ([#48354](https://github.com/expo/expo/pull/48354) by [@davidko604](https://github.com/davidko604))
 - Switch `ManifestMiddleware` to `expo-server`'s response helpers to avoid cancellations being surfaced as exceptions ([#48700](https://github.com/expo/expo/pull/48700) by [@kitten](https://github.com/kitten))
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
+- Cache the manifest runtime version per platform for the dev server session, instead of recomputing the `@expo/fingerprint` on every manifest request ([#48892](https://github.com/expo/expo/pull/48892) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -18,6 +18,7 @@ import type { ManifestRequestInfo } from './ManifestMiddleware';
 import { ManifestMiddleware } from './ManifestMiddleware';
 import { manifestDebugEvent } from './events';
 import { parseForwardedRequestInfo } from './resolveForwarded';
+import type { RuntimePlatform } from './resolvePlatform';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { resolveRuntimeVersionWithExpoUpdatesAsync } from './resolveRuntimeVersionWithExpoUpdatesAsync';
 import type { ServerRequest } from './server.types';
@@ -55,6 +56,13 @@ interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
 }
 
 export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
+  /**
+   * Resolved runtime versions, keyed by runtime platform and shared by every manifest request
+   * this middleware serves. One middleware instance exists per dev server, so this is a
+   * dev-server-session cache.
+   */
+  private readonly runtimeVersionCache = new Map<RuntimePlatform, Promise<string | null>>();
+
   public getParsedHeaders(req: ServerRequest): ExpoGoManifestRequestInfo {
     let platform = parsePlatformHeader(req);
 
@@ -107,6 +115,38 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     };
   }
 
+  /**
+   * Resolve the runtime version with `expo-updates`, at most once per platform per dev-server
+   * session. Resolution spawns the `expo-updates` CLI, which recomputes the entire native
+   * fingerprint under `runtimeVersion: { policy: 'fingerprint' }`. A dev client fetches the
+   * manifest before it fetches the bundle, so paying that cost on every request delays every app
+   * launch and reload, and can exceed the iOS launcher's connection timeout.
+   */
+  private resolveRuntimeVersionCachedAsync(platform: RuntimePlatform): Promise<string | null> {
+    const cached = this.runtimeVersionCache.get(platform);
+    if (cached) {
+      return cached;
+    }
+
+    // Cache the promise rather than the resolved value, so that requests arriving while a
+    // resolution is in flight join it instead of spawning another `expo-updates` process.
+    const pending = resolveRuntimeVersionWithExpoUpdatesAsync({
+      projectRoot: this.projectRoot,
+      platform,
+    });
+    this.runtimeVersionCache.set(platform, pending);
+
+    // Never remember a failure. Otherwise a transient error, such as the `expo-updates` CLI being
+    // interrupted, would keep failing for the rest of the dev server's lifetime.
+    pending.catch(() => {
+      if (this.runtimeVersionCache.get(platform) === pending) {
+        this.runtimeVersionCache.delete(platform);
+      }
+    });
+
+    return pending;
+  }
+
   private getDefaultResponseHeaders(): Headers {
     const headers = new Headers();
     // set required headers for Expo Updates manifest specification
@@ -123,10 +163,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       await this._resolveProjectSettingsAsync(requestOptions);
 
     const runtimeVersion =
-      (await resolveRuntimeVersionWithExpoUpdatesAsync({
-        projectRoot: this.projectRoot,
-        platform: requestOptions.platform,
-      })) ??
+      (await this.resolveRuntimeVersionCachedAsync(requestOptions.platform)) ??
       // if expo-updates can't determine runtime version, fall back to calculation from config-plugin.
       // this happens when expo-updates is installed but runtimeVersion hasn't yet been configured or when
       // expo-updates is not installed.

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -221,6 +221,9 @@ describe('getParsedHeaders', () => {
 describe('_getManifestResponseAsync', () => {
   beforeEach(() => {
     delete process.env.EXPO_OFFLINE;
+    // `expo-updates` returns `null` when it can't determine a runtime version, e.g. when it isn't
+    // installed. The manifest then falls back to the config-plugin calculation.
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue(null);
     jest.mocked(getUserAsync).mockImplementation(async () => ({
       __typename: 'User',
       id: 'userwat',
@@ -847,5 +850,109 @@ describe('_getManifestResponseAsync', () => {
     }
 
     expect(partsSeen.has('manifest')).toBeTruthy();
+  });
+
+  it('resolves the runtime version once per dev-server session', async () => {
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('testrtv');
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    // A dev client re-fetches the manifest on every launch and reload. Resolving the runtime
+    // version shells out to `expo-updates runtimeversion:resolve`, which recomputes the whole
+    // native fingerprint under `runtimeVersion: { policy: 'fingerprint' }`.
+    for (let i = 0; i < 3; i++) {
+      const response = await middleware._getManifestResponseAsync({
+        responseContentType: ResponseContentType.APPLICATION_JSON,
+        platform: 'android',
+        expectSignature: null,
+        hostname: 'localhost',
+      });
+      // Every response, cached or not, must carry the same resolved runtime version.
+      expect(await response.json()).toMatchObject({ runtimeVersion: 'testrtv' });
+    }
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the runtime version separately for each platform', async () => {
+    jest
+      .mocked(resolveRuntimeVersionWithExpoUpdatesAsync)
+      .mockImplementation(async ({ platform }) => `testrtv-${platform}`);
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    for (const platform of ['ios', 'android', 'ios', 'android'] as const) {
+      const response = await middleware._getManifestResponseAsync({
+        responseContentType: ResponseContentType.APPLICATION_JSON,
+        platform,
+        expectSignature: null,
+        hostname: 'localhost',
+      });
+      expect(await response.json()).toMatchObject({ runtimeVersion: `testrtv-${platform}` });
+    }
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('de-duplicates runtime version resolutions that are still in flight', async () => {
+    let resolveRuntimeVersion: (runtimeVersion: string) => void;
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveRuntimeVersion = resolve;
+      })
+    );
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    // Requests that arrive while the first resolution is still running must join it instead of
+    // spawning their own `expo-updates` process.
+    const responses = Promise.all(
+      [0, 1, 2].map(() =>
+        middleware._getManifestResponseAsync({
+          responseContentType: ResponseContentType.APPLICATION_JSON,
+          platform: 'android',
+          expectSignature: null,
+          hostname: 'localhost',
+        })
+      )
+    );
+
+    resolveRuntimeVersion!('testrtv');
+
+    for (const response of await responses) {
+      expect(await response.json()).toMatchObject({ runtimeVersion: 'testrtv' });
+    }
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a failed runtime version resolution', async () => {
+    jest
+      .mocked(resolveRuntimeVersionWithExpoUpdatesAsync)
+      .mockRejectedValueOnce(new Error('expo-updates CLI failed'))
+      .mockResolvedValue('testrtv');
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    const request = {
+      responseContentType: ResponseContentType.APPLICATION_JSON,
+      platform: 'android',
+      expectSignature: null,
+      hostname: 'localhost',
+    } as const;
+
+    await expect(middleware._getManifestResponseAsync(request)).rejects.toThrow(
+      'expo-updates CLI failed'
+    );
+
+    // A transient failure must not be remembered for the rest of the session.
+    const response = await middleware._getManifestResponseAsync(request);
+    expect(await response.json()).toMatchObject({ runtimeVersion: 'testrtv' });
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
# Why

Fixes #46415.

`ExpoGoManifestHandlerMiddleware` resolves the runtime version on **every** manifest request, and resolution is not memoized anywhere along the path:

- `ExpoGoManifestHandlerMiddleware._getManifestResponseAsync` calls `resolveRuntimeVersionWithExpoUpdatesAsync` inline, per request.
- `resolveRuntimeVersionWithExpoUpdatesAsync` shells out to `expo-updates runtimeversion:resolve` through `expoUpdatesCommandAsync`, with no cache.
- `packages/expo-updates/cli/src/resolveRuntimeVersion.ts` is a fresh Node process per invocation and has no on-disk cache, so nothing downstream absorbs the cost.

Under `runtimeVersion: { policy: 'fingerprint' }` that means a full `@expo/fingerprint` computation per manifest hit. The reporter measures ~4 s per request on a blank `create-expo-app` and ~13 s on a real project ([minimal repro](https://github.com/BadCoder1337/expo-fp-devserver-repro)). A dev client fetches the manifest *before* the bundle, so this is paid on every launch and reload, and on iOS it can exceed the launcher's connection timeout — the app then fails to connect while Android, which is more tolerant, loads fine.

Two other reporters in the thread confirm it, and one notes a second cost: the same recompute makes the dev client's built-in "your native build is stale" check too slow to rely on during local development.

This middleware is the only manifest handler — `BundlerDevServer.getManifestMiddlewareAsync` constructs it unconditionally — so both Expo Go and dev clients are affected.

# How

Memoize the resolution per runtime platform on the middleware instance. `MetroBundlerDevServer.startImplementationAsync` creates exactly one middleware instance per dev server, so the cache lifetime is the dev-server session.

Two details are deliberate:

- **The promise is cached, not the value**, so requests arriving while a resolution is still running join it rather than spawning another `expo-updates` process. A dev client's manifest fetches often arrive together.
- **A rejected resolution is evicted**, so a transient failure (for example the `expo-updates` CLI being interrupted) is not remembered for the rest of the dev server's lifetime. The eviction is guarded by an identity check so it can't drop a newer entry.

The fallback to `Updates.getRuntimeVersionAsync` when `expo-updates` returns `null` is unchanged, and `??` still short-circuits, so it only runs when the cached result is `null`.

`resolveRuntimeVersionWithExpoUpdatesAsync` has exactly one consumer, this call site, so nothing else changes behaviour. `InterstitialPageMiddleware` uses `getRuntimeVersionNullableAsync` from `@expo/config-plugins` and is untouched.

### Trade-off, and an alternative if you'd rather steer it

A session-lifetime cache means a native change made *while the dev server keeps running* (installing a native module, then rebuilding and reinstalling the dev client without restarting `expo start`) no longer bumps the served runtime version until the dev server restarts. In that window a dev client could be told its build matches when it no longer does.

I went with the session cache because it is what the issue asks for and it keeps the change contained to this middleware. The issue also suggests invalidating on watched-file changes; wiring the middleware to Metro's watcher crosses a layering boundary it currently doesn't touch, so I did not do that speculatively.

If you'd prefer a bounded staleness window instead, a TTL is a small change on top of this — the cache would store `{ promise, resolvedAt }` and re-resolve past the TTL, keeping the in-flight de-duplication and error eviction as they are. Happy to switch to that, or to a watcher-driven invalidation, if you'd rather pick the policy.

# Test Plan

Four tests added to `ExpoGoManifestHandlerMiddleware-test.ts`, where `resolveRuntimeVersionWithExpoUpdatesAsync` was already mocked:

- `resolves the runtime version once per dev-server session` — three requests, one resolution, and each response still carries the same runtime version.
- `resolves the runtime version separately for each platform` — ios and android each resolve once, so the cache key is the platform and not one global slot.
- `de-duplicates runtime version resolutions that are still in flight` — three concurrent requests fired before the first resolution settles, one resolution.
- `does not cache a failed runtime version resolution` — a rejection is not remembered and the next request retries.

```
$ yarn jest src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts

  _getManifestResponseAsync
    ✓ resolves the runtime version once per dev-server session (1 ms)
    ✓ resolves the runtime version separately for each platform (1 ms)
    ✓ de-duplicates runtime version resolutions that are still in flight
    ✓ does not cache a failed runtime version resolution (6 ms)

Tests:       21 passed, 21 total
```

Reverting only the source change, keeping the tests, turns the first three red with the expected shape (the fourth guards the fix's shape rather than the bug, and goes red if the eviction is removed):

```
  ● _getManifestResponseAsync › resolves the runtime version once per dev-server session
    expect(jest.fn()).toHaveBeenCalledTimes(expected)
    Expected number of calls: 1
    Received number of calls: 3

  ● _getManifestResponseAsync › resolves the runtime version separately for each platform
    Expected number of calls: 2
    Received number of calls: 4

  ● _getManifestResponseAsync › de-duplicates runtime version resolutions that are still in flight
    Expected number of calls: 1
    Received number of calls: 3

Tests:       3 failed, 18 passed, 21 total
```

I also ran a throwaway harness that mocks one level deeper, at the `expoUpdatesCommandAsync` subprocess boundary, so the real resolver runs. Three requests spawn the CLI once instead of three times, and the served manifests are identical apart from the intentionally per-request `id` and `createdAt`:

```
expect(jest.mocked(expoUpdatesCommandAsync).mock.calls).toEqual([
  ['/', ['runtimeversion:resolve', '--platform', 'ios']],
]);
```

Wider run: `yarn jest src/start/server` gives 753 passed, 7 failed — the 7 are pre-existing in `src/start/server/metro/__tests__/serializeHtml.test.ts` and fail identically on a clean `main` (a stale `@expo/router-server` build in the workspace). `yarn lint` and `yarn format` are clean. `yarn typecheck` reports the same 4 pre-existing errors on `main`, in `serializeHtml.ts`, `exportStaticAsync.ts`, and `MetroBundlerDevServer.ts`; none in the files touched here.

One small change to shared test setup: the suite relied on the automocked `resolveRuntimeVersionWithExpoUpdatesAsync` returning `undefined`, which its `Promise<string | null>` signature doesn't allow. The `beforeEach` now mocks `null` explicitly, matching what the real function returns when `expo-updates` can't determine a version. Behaviour of the existing tests is unchanged — they still fall through to the config-plugin calculation.

# Checklist

- [x] I added a `CHANGELOG.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
