### PR TITLE
[android][app-metrics] Stop a metrics/logs foreign-key violation from crashing the host app

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
+- [android] Stop a `SQLiteConstraintException` on the `metrics.sessionId`/`logs.sessionId` foreign key from crashing the host app: writes that reach `SessionManager` without going through `SessionSharedObject` can race the session-row INSERT, so the batch is now dropped and logged instead of propagating off a background coroutine. ([#48896](https://github.com/expo/expo/pull/48896) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -9,6 +9,7 @@ import expo.modules.appmetrics.TAG
 import expo.modules.appmetrics.GlobalAttributes
 import expo.modules.appmetrics.utils.JsonAny
 import expo.modules.appmetrics.utils.TimeUtils
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -102,7 +103,18 @@ class SessionManager(
         params = mergeGlobalAttributesIntoJsonString(metric.params)
       )
     }
-    database.metricDao().insertAll(metricsWithSession)
+    // `metrics.sessionId` carries a foreign key to `sessions.id`. Callers that reach
+    // `SessionManager` without going through `SessionSharedObject` can supply an id whose row is
+    // not persisted yet — or never will be — and the resulting SQLiteConstraintException is thrown
+    // on a background coroutine, which is fatal. Telemetry is not worth the host app.
+    try {
+      database.metricDao().insertAll(metricsWithSession)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Log.e(TAG, "Dropped ${metricsWithSession.size} metric(s) for session $sessionId", e)
+      return
+    }
     val metricIds = metricsWithSession.map { it.metricId }
     metricsInsertListeners.forEach { listener ->
       try {
@@ -202,7 +214,15 @@ class SessionManager(
         attributes = mergeGlobalAttributesIntoJsonString(log.attributes)
       )
     }
-    database.logDao().insertAll(logsWithSession)
+    // Same foreign key on `logs.sessionId`, same rule: never fatal.
+    try {
+      database.logDao().insertAll(logsWithSession)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Log.e(TAG, "Dropped ${logsWithSession.size} log(s) for session $sessionId", e)
+      return
+    }
     val logIds = logsWithSession.map { it.logId }
     logsInsertListeners.forEach { listener ->
       try {


### PR DESCRIPTION
# Why

`metrics.sessionId` and `logs.sessionId` carry a foreign key to `sessions.id` (`SQLiteDatabase` runs with `PRAGMA foreign_keys = ON`). `SessionSharedObject.addMetrics`/`addLogs` await the session-row INSERT before writing, so they are safe. Two paths reach `SessionManager` directly and do not:

- `AppMetricsModule.addCustomMetricToSession` — `sessionManager.addMetrics(listOf(metric.toMetric()), sessionId = metric.sessionId)` with an id supplied by JS.
- `MemoryMetricsManager.takeMemorySnapshot` — `sessionManager.addMetrics(metrics, sessionId = sessionId)`, reached from the `takeMemoryUsageSnapshotAsync` async function.

When the id's row is not persisted yet, `insertAll` throws `SQLiteConstraintException: FOREIGN KEY constraint failed` on a background coroutine, and that is fatal to the host app. This is the same class of ordering bug that `SessionSharedObject` was introduced to fix (the `ENG-21739` guarantee referenced in `SessionSharedObjectTest`); these two callers just sit outside it.

# What this changes

Wrap both `insertAll` calls: drop the batch and log it rather than propagating. `CancellationException` is rethrown first so coroutine cancellation still works.

This is deliberately the defensive half of the fix, not the ordering half. An `awaitSessionPersisted()` would close the two callers above, but neither is guaranteed to be writing to the *main* session — both take a `sessionId` argument that originates in JS, so a stale or already-cleared id can't be fixed by waiting. A dropped metric is the correct outcome there, and a crash never is. If you'd prefer the ordering change too I'm happy to add it, but it needs a decision from you about what those two entry points are contractually allowed to receive, which I don't want to guess at.

# Impact we measured

Downstream in a production React Native app (Expo SDK 56, `expo-observe` 56.0.26 / `expo-app-metrics` 56.0.23): **~1.5k crash events across ~1.26k users in 14 days**, our top Android crash by user count at the time. We have been shipping the equivalent change as a `patch-package` patch since early August and it eliminated the issue for us.

# Testing

Honest accounting: **I have not run the `expo-app-metrics` Android test suite against this branch.** I don't have the monorepo's Android toolchain set up locally, and I didn't want to claim a green run I didn't produce. What I have is the downstream evidence above — the same change, built from source into a production app, and the crash going to zero.

The change is confined to two `try`/`catch` blocks around existing calls and adds no new behavior on the success path, so I'd expect existing tests to be unaffected — but please treat that as an expectation, not a verified claim, and let me know if you'd like me to add a regression test for the drop-on-constraint path.
