### PR TITLE
[video] Add album metadata support to Now Playing controls

### DIFF
--- a/apps/native-component-list/src/screens/Video/videoSources.ts
+++ b/apps/native-component-list/src/screens/Video/videoSources.ts
@@ -41,6 +41,7 @@ const bigBuckBunnySource: VideoSource = {
   metadata: {
     title: 'Big Buck Bunny',
     artist: 'The Open Movie Project',
+    album: 'Blender Open Movies',
     artwork: 'https://expo-test-media.com/big_buck_bunny/artwork.jpg',
   },
 };
@@ -51,6 +52,7 @@ const elephantsDreamSource: VideoSource = {
   metadata: {
     title: 'Elephants Dream',
     artist: 'Blender Foundation',
+    album: 'Blender Open Movies',
     artwork: 'https://expo-test-media.com/elephants_dream/artwork.jpg',
   },
 };

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [Android][iOS] Added album metadata support for Now Playing notifications.
+- [Android][iOS] Added album metadata support for Now Playing notifications. ([#48897](https://github.com/expo/expo/pull/48897) by [@deggertsen](https://github.com/deggertsen))
 - [Android] Added the `controllerAutoShow` prop to `VideoView` to control whether the native controls auto-show on play. ([#46665](https://github.com/expo/expo/pull/46665) by [@stevesouth](https://github.com/stevesouth))
 - [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection. ([#46992](https://github.com/expo/expo/pull/46992) by [@vargajacint](https://github.com/vargajacint))
 - [Android] Added the `videoChangeFrameRateStrategy` player builder option to control whether ExoPlayer may change the display refresh rate to match the video frame rate. On adaptive refresh rate displays (Pixel 9/10) the default matching can cap the entire app UI at 30Hz while a 30 fps video is visible. ([#47873](https://github.com/expo/expo/pull/47873) by [@invivek26](https://github.com/invivek26))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [Android][iOS] Added album metadata support for Now Playing notifications.
 - [Android] Added the `controllerAutoShow` prop to `VideoView` to control whether the native controls auto-show on play. ([#46665](https://github.com/expo/expo/pull/46665) by [@stevesouth](https://github.com/stevesouth))
 - [Android][iOS] Add `maxResolution` player option to cap adaptive video track selection. ([#46992](https://github.com/expo/expo/pull/46992) by [@vargajacint](https://github.com/vargajacint))
 - [Android] Added the `videoChangeFrameRateStrategy` player builder option to control whether ExoPlayer may change the display refresh rate to match the video frame rate. On adaptive refresh rate displays (Pixel 9/10) the default matching can cap the entire app UI at 30Hz while a 30 fps video is visible. ([#47873](https://github.com/expo/expo/pull/47873) by [@invivek26](https://github.com/invivek26))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoMetadata.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoMetadata.kt
@@ -10,5 +10,6 @@ import expo.modules.kotlin.types.OptimizedRecord
 class VideoMetadata(
   @Field var title: String? = null,
   @Field var artist: String? = null,
+  @Field var album: String? = null,
   @Field var artwork: Uri? = null
 ) : Record, Serializable

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -40,7 +40,6 @@ class VideoSource(
       "DRMHeadersValues:${this.drm?.headers?.values?.joinToString { it }}}" +
       "NotificationDataTitle:${this.metadata?.title}" +
       "NotificationDataSecondaryText:${this.metadata?.artist}" +
-      "NotificationDataAlbum:${this.metadata?.album}" +
       "NotificationDataArtwork:${this.metadata?.artwork?.path}" +
       "ContentType:${this.contentType.value}"
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -40,6 +40,7 @@ class VideoSource(
       "DRMHeadersValues:${this.drm?.headers?.values?.joinToString { it }}}" +
       "NotificationDataTitle:${this.metadata?.title}" +
       "NotificationDataSecondaryText:${this.metadata?.artist}" +
+      "NotificationDataAlbum:${this.metadata?.album}" +
       "NotificationDataArtwork:${this.metadata?.artwork?.path}" +
       "ContentType:${this.contentType.value}"
   }
@@ -68,6 +69,7 @@ class VideoSource(
           metadata?.let { data ->
             setTitle(data.title)
             setArtist(data.artist)
+            setAlbumTitle(data.album)
             data.artwork?.let {
               setArtworkUri(it)
             }

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -106,15 +106,15 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
       // Metadata fetched with the video
       let assetMetadata = try? await loadMetadata(for: currentItem)
 
-      let title = assetMetadata?.first(where: {
+      let assetTitle = assetMetadata?.first(where: {
         $0.commonKey == .commonKeyTitle
       })
 
-      let artist = assetMetadata?.first(where: {
+      let assetArtist = assetMetadata?.first(where: {
         $0.commonKey == .commonKeyArtist
       })
 
-      let album = assetMetadata?.first(where: {
+      let assetAlbum = assetMetadata?.first(where: {
         $0.commonKey == .commonKeyAlbumName
       })
 
@@ -124,9 +124,18 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
 
       var nowPlayingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
 
-      nowPlayingInfo[MPMediaItemPropertyTitle] = userMetadata?.title ?? title
-      nowPlayingInfo[MPMediaItemPropertyArtist] = userMetadata?.artist ?? artist
-      nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = userMetadata?.album ?? album
+      nowPlayingInfo[MPMediaItemPropertyTitle] = await resolveNowPlayingMetadataValue(
+        userValue: userMetadata?.title,
+        assetValue: assetTitle
+      )
+      nowPlayingInfo[MPMediaItemPropertyArtist] = await resolveNowPlayingMetadataValue(
+        userValue: userMetadata?.artist,
+        assetValue: assetArtist
+      )
+      nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = await resolveNowPlayingMetadataValue(
+        userValue: userMetadata?.album,
+        assetValue: assetAlbum
+      )
       nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
       nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
       nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = currentItem.duration.isIndefinite

--- a/packages/expo-video/ios/NowPlayingManager.swift
+++ b/packages/expo-video/ios/NowPlayingManager.swift
@@ -114,6 +114,10 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
         $0.commonKey == .commonKeyArtist
       })
 
+      let album = assetMetadata?.first(where: {
+        $0.commonKey == .commonKeyAlbumName
+      })
+
       let artwork = assetMetadata?.first(where: {
         $0.commonKey == .commonKeyArtwork
       })
@@ -122,6 +126,7 @@ class NowPlayingManager: VideoPlayerObserverDelegate {
 
       nowPlayingInfo[MPMediaItemPropertyTitle] = userMetadata?.title ?? title
       nowPlayingInfo[MPMediaItemPropertyArtist] = userMetadata?.artist ?? artist
+      nowPlayingInfo[MPMediaItemPropertyAlbumTitle] = userMetadata?.album ?? album
       nowPlayingInfo[MPMediaItemPropertyPlaybackDuration] = currentItem.duration.seconds
       nowPlayingInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = currentItem.currentTime().seconds
       nowPlayingInfo[MPNowPlayingInfoPropertyIsLiveStream] = currentItem.duration.isIndefinite

--- a/packages/expo-video/ios/NowPlayingMetadata.swift
+++ b/packages/expo-video/ios/NowPlayingMetadata.swift
@@ -1,0 +1,10 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import AVFoundation
+
+func resolveNowPlayingMetadataValue(userValue: String?, assetValue: AVMetadataItem?) async -> String? {
+  if let userValue {
+    return userValue
+  }
+  return try? await assetValue?.load(.stringValue)
+}

--- a/packages/expo-video/ios/Records/VideoMetadata.swift
+++ b/packages/expo-video/ios/Records/VideoMetadata.swift
@@ -11,6 +11,9 @@ internal struct VideoMetadata: Record {
   var artist: String? = nil
 
   @Field
+  var album: String? = nil
+
+  @Field
   var artwork: URL? = nil
 }
 // swiftlint:enable redundant_optional_initialization

--- a/packages/expo-video/ios/Tests/NowPlayingManagerTests.swift
+++ b/packages/expo-video/ios/Tests/NowPlayingManagerTests.swift
@@ -1,0 +1,33 @@
+import AVFoundation
+import Testing
+
+@testable import ExpoVideo
+
+@Suite("NowPlayingManager")
+struct NowPlayingManagerTests {
+  @Test
+  func `user metadata takes precedence over asset metadata`() async {
+    let assetMetadata = AVMutableMetadataItem()
+    assetMetadata.value = "Asset album" as NSString
+
+    let value = await resolveNowPlayingMetadataValue(
+      userValue: "User album",
+      assetValue: assetMetadata
+    )
+
+    #expect(value == "User album")
+  }
+
+  @Test
+  func `asset metadata is converted to a string`() async {
+    let assetMetadata = AVMutableMetadataItem()
+    assetMetadata.value = "Asset album" as NSString
+
+    let value = await resolveNowPlayingMetadataValue(
+      userValue: nil,
+      assetValue: assetMetadata
+    )
+
+    #expect(value == "Asset album")
+  }
+}

--- a/packages/expo-video/src/VideoPlayer.types.ts
+++ b/packages/expo-video/src/VideoPlayer.types.ts
@@ -447,6 +447,12 @@ export type VideoMetadata = {
    */
   artist?: string;
   /**
+   * The album title of the video.
+   * @platform android
+   * @platform ios
+   */
+  album?: string;
+  /**
    * The uri of the video artwork.
    * @platform android
    * @platform ios


### PR DESCRIPTION
# Why

`expo-video` lets apps provide a title, artist, and artwork for system Now Playing controls, but it does not expose the album field supported by both Android Media3 and iOS MediaPlayer. Apps that use album-like grouping metadata (for example, a series or collection name) currently have to patch `expo-video` to show it in system media controls.

This adds an optional `album` field to `VideoMetadata` on Android and iOS.

# How

- Added `album` to the TypeScript and native `VideoMetadata` records.
- Forwarded it to Media3's `setAlbumTitle` on Android and `MPMediaItemPropertyAlbumTitle` on iOS.
- On iOS, resolved embedded title, artist, and album metadata to strings before adding them to the Now Playing dictionary, while preserving explicit user metadata as the priority.
- Added focused iOS native tests for user-metadata precedence and embedded-metadata conversion.
- Added album values to the Native Component List's Now Playing video sources for manual verification.

# Test Plan

- Ran `et check-packages expo-video native-component-list` for the package API and demo changes (build, typecheck, dependency checks, tests, lint, and formatting): all checks passed.
- Type-checked the new iOS metadata resolver and Swift Testing suite with Xcode 26.6, and ran focused runtime assertions for explicit metadata precedence and embedded `AVMetadataItem` string conversion.
- Built an equivalent downstream patch in a real Expo app with Android `:app:assembleDebug` and an iOS simulator `xcodebuild`.
- Manual review path: open Native Component List > Video > Now Playing, play either source, then inspect the system Now Playing controls on Android or a physical iOS device. The album should display as `Blender Open Movies`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
