### PR TITLE
[ios][app-metrics] Retry the OTA AppInfo patch after updates startup

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
+- [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-app-metrics/ios/AppMetricsModule.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsModule.swift
@@ -167,6 +167,14 @@ public final class AppMetricsModule: Module, UpdatesStateChangeListener {
   }
 
   public func updatesStateDidChange(_ event: [String: Any]) {
+    // `OnCreate` can run before `EnabledAppController.start()` assigns its startup procedure, in
+    // which case the launched update reads as nil and `AppInfo` keeps the embedded build's
+    // attribution for the rest of the session. Retry here: by the time any state change arrives
+    // the launched update is known, and the patch no-ops once an id has been recorded.
+    AppMetricsActor.isolated {
+      AppMetrics.mainSession.updatesMonitor.patchAppInfoIfNeeded()
+    }
+
     if UpdatesStateEvent.fromDict(event)?.type ?? .restart == .downloadCompleteWithUpdate,
       let metric = AppMetrics.mainSession.updatesMonitor.downloadTimeMetric(subscription)
     {

--- a/packages/expo-app-metrics/ios/Storage/AppInfo.swift
+++ b/packages/expo-app-metrics/ios/Storage/AppInfo.swift
@@ -57,8 +57,6 @@ public struct AppInfo: Codable, Equatable, Sendable {
   public nonisolated(unsafe) static var current: AppInfo = {
     let bundle = Bundle.main
     let infoPlist = bundle.infoDictionary ?? [:]
-    let updatesInfo = UpdatesMonitoring.getUpdatesMetricsInfo()
-
     return AppInfo(
       appId: bundle.bundleIdentifier,
       appName: (infoPlist["CFBundleDisplayName"] ?? infoPlist["CFBundleName"]) as? String,


### PR DESCRIPTION
# Why

`UpdatesMonitoring.patchAppInfoIfNeeded()` is called from exactly one place — `AppMetricsModule`'s `OnCreate`. If the module registry is created before `EnabledAppController.start()` has assigned its startup procedure, `getUpdatesMetricsInfo()` reads no launched update and returns nils. Nothing ever re-reads it: `updatesStateDidChange` only handles `downloadCompleteWithUpdate` for the download-time metric, and there is no other caller.

The result is that the session — and every metric and log on it — keeps the embedded build's attribution instead of the OTA update's. `MetricsDatabase` already anticipates this case ("...or `getUpdatesMetricsInfo()` initially returned nil") and `updateAppUpdatesInfoForActiveSessions` exists to repair it, but on iOS nothing invokes that path a second time.

This is reachable today via the `guard let updatesController = UpdatesControllerRegistry.sharedInstance.controller else { return ...nil }` early return, independent of #48898.

# What this changes

1. Retry `patchAppInfoIfNeeded()` from `updatesStateDidChange`. It is already idempotent — it returns early once `AppInfo.current.updatesInfo?.updateId` is set — so this only does work on the launch where the first read lost the race.
2. Drop a duplicate `getUpdatesMetricsInfo()` call in `AppInfo.current`. The result was bound to an unused local (`let updatesInfo = ...`) and then the initializer called it again. Removing the dead binding also halves the number of updates-controller reads during launch.

# The part I want to flag, because it's the weak point

**Retrying on state change is best-effort, not a guarantee.** It fixes the case where a state change arrives after startup completes — which I'd expect to be the common one, since check/download events follow startup — but I could not verify from outside the repo whether `expo-app-metrics` is always subscribed before the relevant events fire. If the module subscribes after the last state change of a given launch, the attribution is still lost.

My first draft hooked specifically on `.endStartup`, which reads better, but I couldn't establish that `.endStartup` reliably arrives *after* `OnCreate` subscribes — if updates startup wins that race, the hook never fires. Retrying on any event is strictly more robust for the same cost, so I went with it, but I'm aware that's a workaround for not knowing the ordering rather than a fix that follows from it.

If there's a deterministic post-startup hook you'd rather key off — or if you'd prefer `expo-updates` expose one — I'd much rather do that, and I'm happy to rework this or drop it in favour of an issue. I didn't want to quietly present a race-dependent fix as a settled one.

# Testing

Honest accounting: **I have not run the `expo-app-metrics` iOS test suite against this branch**, and unlike the two related PRs I have **no downstream production evidence for this one** — we have not shipped this change, and I have not measured how often iOS sessions actually lose OTA attribution. This PR comes from reading the call graph, not from an observed regression.

The dead-binding removal in `AppInfo.swift` is mechanical and safe. The retry is behavior-affecting and deserves the scrutiny.

# Related

- #48898 — `[ios][updates]` the nil-unwrap and listener-dictionary races on the `expo-updates` side. Fixing that turns the crash into a silent nil, which is what makes this attribution gap worth closing.
- #48896 — `[android][app-metrics]` unrelated Android FK crash.
