### PR TITLE
[ios][screen-orientation] Resolve nested RNS orientation owners

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed per-screen orientation lookup through deeply nested view-controller containers.
+- [iOS] Fixed per-screen orientation lookup through deeply nested view-controller containers. ([#48912](https://github.com/expo/expo/pull/48912) by [@IkeStudios](https://github.com/IkeStudios))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed per-screen orientation lookup through deeply nested view-controller containers.
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -100,20 +100,74 @@ class ScreenOrientationViewController: UIViewController {
   }
 
   /// Finds the VC whose subtree has a react-native-screens screen with orientation set.
-  /// Checks self first (the common case), then each child VC. The child-level search handles
-  /// cases where an intermediate VC (e.g. DevLauncherViewController from expo-dev-client)
-  /// sits between this root VC and the RNSNavigationController, blocking the single-level
-  /// traversal that RNScreens' shouldAskScreensForScreenOrientation performs.
+  /// Checks self first (the common case), then walks the containment hierarchy. This handles
+  /// wrappers such as DevLauncherViewController without depending on their exact nesting depth.
   private func vcWithRNScreenOrientation() -> UIViewController? {
     guard let screenWindowTraitsClass = NSClassFromString("RNSScreenWindowTraits") else {
       return nil
     }
-    if screenWindowTraitsClass.shouldAskScreensForScreenOrientation?(in: self) ?? false {
+
+    func shouldAskScreensForOrientation(in viewController: UIViewController) -> Bool {
+      return screenWindowTraitsClass
+        .shouldAskScreensForScreenOrientation?(in: viewController) ?? false
+    }
+
+    func activeChildren(of viewController: UIViewController) -> [UIViewController] {
+      if let navigationController = viewController as? UINavigationController {
+        var children: [UIViewController] = []
+        if let topViewController = navigationController.topViewController {
+          children.append(topViewController)
+        }
+        if let visibleViewController = navigationController.visibleViewController,
+           !children.contains(where: { $0 === visibleViewController }) {
+          // The caller searches in reverse, so a presented modal is checked before the route
+          // underneath it while the route remains eligible to own the orientation.
+          children.append(visibleViewController)
+        }
+        return children
+      }
+      if let tabBarController = viewController as? UITabBarController {
+        return tabBarController.selectedViewController.map { [$0] } ?? []
+      }
+      if let pageViewController = viewController as? UIPageViewController {
+        return pageViewController.viewControllers ?? []
+      }
+      if let splitViewController = viewController as? UISplitViewController {
+        return splitViewController.viewControllers.filter { $0.viewIfLoaded?.window != nil }
+      }
+      if viewController.children.count == 1 {
+        return viewController.children
+      }
+      // Unknown wrappers do not expose an active-child API. Only follow children whose views
+      // are currently attached, so retained off-screen controllers cannot supply the mask.
+      return viewController.children.filter { $0.viewIfLoaded?.window != nil }
+    }
+
+    func findOrientationOwner(in viewController: UIViewController) -> UIViewController? {
+      // Prefer the active descendant over a broad container. The RNScreens predicate inspects
+      // a container's last child, which is not necessarily active for every UIKit container.
+      let children = activeChildren(of: viewController)
+      for child in children.reversed() {
+        if let owner = findOrientationOwner(in: child) {
+          return owner
+        }
+      }
+      // Only query the parent when the last child that RNScreens will inspect is active.
+      // Otherwise its predicate can select a retained, off-screen navigation branch.
+      if let inspectedChild = viewController.children.last,
+         children.contains(where: { $0 === inspectedChild }),
+         shouldAskScreensForOrientation(in: viewController) {
+        return viewController
+      }
+      return nil
+    }
+
+    if shouldAskScreensForOrientation(in: self) {
       return self
     }
-    for child in children {
-      if screenWindowTraitsClass.shouldAskScreensForScreenOrientation?(in: child) ?? false {
-        return child
+    for child in activeChildren(of: self).reversed() {
+      if let owner = findOrientationOwner(in: child) {
+        return owner
       }
     }
     return nil

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -63,11 +63,7 @@ class ScreenOrientationViewController: UIViewController {
     if let vc = vcWithRNScreenOrientation() {
       // react-native-screens has per-screen orientation set. Defer to that VC's
       // supportedInterfaceOrientations so RNScreens' swizzled implementation can
-      // resolve the active screen's orientation mask. When the matching VC is
-      // self, call super to avoid recursing into this override.
-      if vc === self {
-        return super.supportedInterfaceOrientations
-      }
+      // resolve the active screen's orientation mask.
       return vc.supportedInterfaceOrientations
     }
 
@@ -114,17 +110,7 @@ class ScreenOrientationViewController: UIViewController {
 
     func activeChildren(of viewController: UIViewController) -> [UIViewController] {
       if let navigationController = viewController as? UINavigationController {
-        var children: [UIViewController] = []
-        if let topViewController = navigationController.topViewController {
-          children.append(topViewController)
-        }
-        if let visibleViewController = navigationController.visibleViewController,
-           !children.contains(where: { $0 === visibleViewController }) {
-          // The caller searches in reverse, so a presented modal is checked before the route
-          // underneath it while the route remains eligible to own the orientation.
-          children.append(visibleViewController)
-        }
-        return children
+        return navigationController.topViewController.map { [$0] } ?? []
       }
       if let tabBarController = viewController as? UITabBarController {
         return tabBarController.selectedViewController.map { [$0] } ?? []
@@ -133,10 +119,20 @@ class ScreenOrientationViewController: UIViewController {
         return pageViewController.viewControllers ?? []
       }
       if let splitViewController = viewController as? UISplitViewController {
-        return splitViewController.viewControllers.filter { $0.viewIfLoaded?.window != nil }
+        let splitChildren = splitViewController.viewControllers
+        if splitViewController.viewIfLoaded?.window == nil, splitChildren.count == 1 {
+          return splitChildren
+        }
+        return splitChildren.filter { $0.viewIfLoaded?.window != nil }
       }
-      if viewController.children.count == 1 {
-        return viewController.children
+      if let onlyChild = viewController.children.first, viewController.children.count == 1 {
+        // Before attachment, a single-child wrapper has no ambiguous branch to choose. Once the
+        // wrapper is on-screen, require its child to be attached so a retained stale child cannot
+        // supply the orientation during replacement or teardown.
+        if viewController.viewIfLoaded?.window == nil || onlyChild.viewIfLoaded?.window != nil {
+          return [onlyChild]
+        }
+        return []
       }
       // Unknown wrappers do not expose an active-child API. Only follow children whose views
       // are currently attached, so retained off-screen controllers cannot supply the mask.
@@ -144,28 +140,30 @@ class ScreenOrientationViewController: UIViewController {
     }
 
     func findOrientationOwner(in viewController: UIViewController) -> UIViewController? {
-      // Prefer the active descendant over a broad container. The RNScreens predicate inspects
-      // a container's last child, which is not necessarily active for every UIKit container.
       let children = activeChildren(of: viewController)
+      // Only trust the predicate when the last child that RNScreens inspects is active.
+      // Return that RNS container directly: generic parents do not necessarily forward
+      // supportedInterfaceOrientations to every RNS container type.
+      if let inspectedChild = viewController.children.last,
+         children.contains(where: { $0 === inspectedChild }),
+         shouldAskScreensForOrientation(in: viewController) {
+        return inspectedChild
+      }
       for child in children.reversed() {
         if let owner = findOrientationOwner(in: child) {
           return owner
         }
       }
-      // Only query the parent when the last child that RNScreens will inspect is active.
-      // Otherwise its predicate can select a retained, off-screen navigation branch.
-      if let inspectedChild = viewController.children.last,
-         children.contains(where: { $0 === inspectedChild }),
-         shouldAskScreensForOrientation(in: viewController) {
-        return viewController
-      }
       return nil
     }
 
-    if shouldAskScreensForOrientation(in: self) {
-      return self
+    let rootChildren = activeChildren(of: self)
+    if let inspectedChild = self.children.last,
+       rootChildren.contains(where: { $0 === inspectedChild }),
+       shouldAskScreensForOrientation(in: self) {
+      return inspectedChild
     }
-    for child in activeChildren(of: self).reversed() {
+    for child in rootChildren.reversed() {
       if let owner = findOrientationOwner(in: child) {
         return owner
       }


### PR DESCRIPTION
## Why

`ScreenOrientationViewController` currently asks react-native-screens about itself and then one level of child view controllers. That fixed the known `expo-dev-client` hierarchy in #44181, but orientation falls back to the Expo registry whenever another UIKit container is inserted between that child and the active RNS navigation controller.

The lookup should not depend on a fixed containment depth. At the same time, recursively scanning every retained child is unsafe: tab, page, navigation, and custom containers can keep inactive controllers whose screen orientation must not override the visible route.

## Reproduction

A standalone neutral reproduction and config plugin are available here:

https://github.com/IkeStudios/expo-screen-orientation-nested-repro

| Before — stock one-level lookup | After — this PR's lookup |
| --- | --- |
| ![Stock behavior: landscape route remains portrait](https://raw.githubusercontent.com/IkeStudios/expo-screen-orientation-nested-repro/main/recordings/before-transition.gif) | ![Patched behavior: route rotates to landscape and restores portrait](https://raw.githubusercontent.com/IkeStudios/expo-screen-orientation-nested-repro/main/recordings/after.gif) |
| [Full-resolution MP4](https://github.com/IkeStudios/expo-screen-orientation-nested-repro/blob/main/recordings/before.mp4) | [Full-resolution MP4](https://github.com/IkeStudios/expo-screen-orientation-nested-repro/blob/main/recordings/after.mp4) |

Inline previews play at 2x speed.

The fixture inserts two transparent UIKit containment wrappers around the React controller. With stock `expo-screen-orientation@55.0.18`, tapping the landscape route changes the rendered route but leaves the interface at `420 x 912` portrait. Applying this PR's lookup change rotates the same route to `912 x 420` landscape-right and restores `420 x 912` when returning.

[Expo's hosted verification](https://github.com/expo/expo/pull/48912#issuecomment-5289627666) independently reproduced the same failure on SDK 57 and also found a non-synthetic case in `expo-router/unstable-native-tabs`: stock remained `402 x 874` while the earlier PR revision rotated the declared routes to `874 x 402`. That hosted run tested revision `05dbb2ac`; the current revision retains the verified containment walk while narrowing presented-controller and inactive-child handling.

## How

- Preserve the existing self-first fast path.
- Walk the active containment hierarchy until the RNS orientation owner is found.
- Use each standard UIKit container's active-child API (`top`, `selected`, or current pages) without following presented non-children.
- Follow only attached children for unknown multi-child wrappers, while still allowing a single wrapper child before view attachment.
- Trust `RNSScreenWindowTraits` only when the child it inspects is one of the container's resolved active children, then ask that confirmed RNS container directly.
- Let react-native-screens perform its own modal-aware orientation resolution from the active contained route.

This retains the runtime/optional integration with react-native-screens and does not import it as a dependency.

## Test plan

Automated/static:

- `xcrun swiftc -parse packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift`
- `git diff --check`

Simulator reproduction through the linked fixture:

1. Launch the portrait route (`420 x 912`).
2. Tap **Open landscape route**.
3. Stock lookup: route renders but remains `420 x 912`.
4. PR lookup: route rotates to `912 x 420` landscape-right.
5. Tap **Return to portrait** and verify `420 x 912` is restored.

The traversal was also reviewed against retained inactive tabs, page/split containers, detached replacement children, and navigation controllers with presented modals so the recursive lookup stays within containment without trading the depth bug for an inactive-controller bug.

## Changelog

- [iOS] Fixed per-screen orientation lookup through deeply nested view-controller containers.





