### PR TITLE
[audio][ios] Session-queue follow-ups: interruption race, shared-queue block, activation-error surfacing

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -26,6 +26,9 @@
 - [iOS] Activate the audio session once and keep it active instead of toggling. ([#48588](https://github.com/expo/expo/pull/48588) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `createAudioPlayer`/`useAudioPlayer` throwing "Received 5 arguments, but 4 was expected" due to the native `AudioPlayer` constructor missing the iOS-only `allowsExternalPlayback` parameter. ([#48655](https://github.com/expo/expo/pull/48655) by [@RasmusKard](https://github.com/RasmusKard))
 - [iOS] Report `denied` instead of crashing the app when `NSMicrophoneUsageDescription` is missing. ([#48840](https://github.com/expo/expo/pull/48840) by [@ahmadaccino](https://github.com/ahmadaccino))
+- [iOS] Fix interruption bookkeeping (`interruptedPlayers`/`playerVolumes`) racing the queued resume path: the snapshot is taken on the notification thread, and the collections are only written on the session queue. ([#48913](https://github.com/expo/expo/pull/48913) by [@sbs44](https://github.com/sbs44))
+- [iOS] `setIsAudioActiveAsync` settles its promise from the session queue instead of blocking the shared AsyncFunction queue via `sessionQueue.sync`. ([#48913](https://github.com/expo/expo/pull/48913) by [@sbs44](https://github.com/sbs44))
+- [iOS] Surface audio-session activation failures during `AudioPlayer.play()` through the `playbackStatusUpdate` event's existing `error` field (activation is async, so `play()` cannot throw for them). ([#48913](https://github.com/expo/expo/pull/48913) by [@sbs44](https://github.com/sbs44))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -36,8 +36,8 @@ public class AudioModule: Module {
       try setAudioMode(mode: mode)
     }
 
-    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool) in
-      try setIsAudioActive(isActive)
+    AsyncFunction("setIsAudioActiveAsync") { (isActive: Bool, promise: Promise) in
+      setIsAudioActive(isActive, promise: promise)
     }
 
     AsyncFunction("requestRecordingPermissionsAsync") { (promise: Promise) in
@@ -220,7 +220,9 @@ public class AudioModule: Module {
         }
         let rate = player.currentRate > 0 ? player.currentRate : 1.0
         player.play(at: rate)
-        self.activateSession()
+        self.activateSession { message in
+          player.updateStatus(with: ["error": message])
+        }
       }
 
       Function("setPlaybackRate") { (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
@@ -649,15 +651,18 @@ public class AudioModule: Module {
   }
 
   private func handleInterruptionBegan() {
-    interruptedPlayers.removeAll()
-    playerVolumes.removeAll()
+    // Capture which players are playing before dispatching work to the `sessionQueue`.
+    // If a player is auto-paused while the `sessionQueue` is busy, a later check would
+    // miss it and it would never resume.
+    var interrupted = Set<String>()
+    var volumes = [String: Float]()
 
     registry.allPlayables.forEach { playable in
       if playable.isPlaying {
-        interruptedPlayers.insert(playable.id)
+        interrupted.insert(playable.id)
         switch interruptionMode {
         case .duckOthers:
-          playerVolumes[playable.id] = playable.volume
+          volumes[playable.id] = playable.volume
           playable.volume *= 0.5
         case .doNotMix, .doNotMixPersistent, .mixWithOthers:
           playable.pause()
@@ -673,12 +678,19 @@ public class AudioModule: Module {
     }
 #endif
 
-    recordSessionActive(false)
+    sessionQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+      self.interruptedPlayers = interrupted
+      self.playerVolumes = volumes
+      self.sessionIsActive = false
+    }
   }
 
   private func handleInterruptionEnded(with options: AVAudioSession.InterruptionOptions) {
     sessionQueue.async { [weak self] in
-      guard let self, self.audioEnabled.withLock({ $0 }), self.applySessionActive(true) else {
+      guard let self, self.audioEnabled.withLock({ $0 }), self.applySessionActive(true) == nil else {
         return
       }
       if options.contains(.shouldResume) {
@@ -812,19 +824,20 @@ public class AudioModule: Module {
     return URL(fileURLWithPath: path)
   }
 
-  private func setIsAudioActive(_ isActive: Bool) throws {
+  private func setIsAudioActive(_ isActive: Bool, promise: Promise) {
     audioEnabled.withLock { $0 = isActive }
     if !isActive {
       pauseAllPlayers()
     }
 
-    do {
-      try sessionQueue.sync {
-        try AVAudioSession.sharedInstance().setActive(isActive, options: activationOptions(isActive: isActive))
+    sessionQueue.async {
+      do {
+        try AVAudioSession.sharedInstance().setActive(isActive, options: self.activationOptions(isActive: isActive))
         self.sessionIsActive = isActive
+        promise.resolve()
+      } catch {
+        promise.reject(AudioStateException(error.localizedDescription))
       }
-    } catch {
-      throw AudioStateException(error.localizedDescription)
     }
   }
 
@@ -906,12 +919,14 @@ public class AudioModule: Module {
     return true
   }
 
-  private func activateSession() {
+  private func activateSession(onError: ((String) -> Void)? = nil) {
     sessionQueue.async { [weak self] in
       guard let self, self.audioEnabled.withLock({ $0 }), !self.sessionIsActive else {
         return
       }
-      self.applySessionActive(true)
+      if let error = self.applySessionActive(true) {
+        onError?("Audio session activation failed: \(error.localizedDescription)")
+      }
     }
   }
 
@@ -933,14 +948,14 @@ public class AudioModule: Module {
   }
 
   @discardableResult
-  private func applySessionActive(_ isActive: Bool) -> Bool {
+  private func applySessionActive(_ isActive: Bool) -> Error? {
     do {
       try AVAudioSession.sharedInstance().setActive(isActive, options: activationOptions(isActive: isActive))
       sessionIsActive = isActive
-      return true
+      return nil
     } catch {
       log.warn("[expo-audio] Failed to \(isActive ? "activate" : "deactivate") the audio session: \(error.localizedDescription)")
-      return false
+      return error
     }
   }
 


### PR DESCRIPTION
# Why

Three follow-ups to #48588 (which fixed #48531... thanks for the quick turnaround). Also flagged in a comment there.

The main one: resumeInterruptedPlayers moved onto sessionQueue, but handleInterruptionBegan still mutates interruptedPlayers/playerVolumes on the notification thread. Two threads over the same Swift collections, and the stall scenario #48588 exists for is exactly what widens the window... back-to-back interruptions will eventually crash.

Also: setIsAudioActive does sessionQueue.sync from the AsyncFunction queue, which is one serial queue shared by every function that doesn't set runOnQueue (the vast majority, across all Expo modules), so a stalled setActive blocks those app-wide. And activation failures during play() only reach os_log now that play() can't throw for them... playback continues on an inactive session and JS has no way to know.

# How

- handleInterruptionBegan snapshots isPlaying and pauses/ducks on the notification thread, same timing as before #48588, then dispatches only the writes to the two collections (and the sessionIsActive flag) onto sessionQueue. That's all the race fix needs, since the resume path reads them there.

- setIsAudioActiveAsync becomes promise-based and settles from sessionQueue. Throwing contract preserved as a rejection, JS API unchanged. One nuance: the promise now settles with null where it settled undefined (the TS type is Promise<void>, so only a literal === undefined comparison would notice).

- applySessionActive returns the error, activateSession takes an onError callback, and AudioPlayer's play() reports the failure through the playbackStatusUpdate event's existing `error` field. Playlists are left alone: AudioPlaylistStatus has no `error` field to report through (they also emit playlistStatusUpdate, not playbackStatusUpdate)... happy to add a typed field there if you want it covered too.

# Test Plan

Swift + changelog only, no JS or committed build/ changes... lint and native tests run in CI. For the race: with the repro from #48531 (https://github.com/sbs44/expo-audio-test) plus its simulated-stall patch, trigger two interruptions in quick succession during back-to-back playback.

Before, the queued resume iterates the collections while the second interruption's handler clears them; after, both run on sessionQueue. For the error surfacing: hold the session from another app under .doNotMix and watch playbackStatusUpdate.error.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)