### PR TITLE
[ios][background-task] Read the real Background App Refresh status in getStatusAsync

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### 🎉 New features
 
+- [iOS] Added `BackgroundTaskStatus.Denied`, returned when the user has turned Background App Refresh off for the app or for the whole system. It is distinct from `Restricted`, which the user cannot lift. ([#PR](https://github.com/expo/expo/pull/PR) by [@arnautresserras](https://github.com/arnautresserras))
+
 ### 🐛 Bug fixes
+
+- [iOS] Fixed `getStatusAsync` reporting `Available` on every physical device regardless of the system Background App Refresh setting. It now reads `UIApplication.backgroundRefreshStatus` instead of only checking whether the app is running on a simulator. ([#PR](https://github.com/expo/expo/pull/PR) by [@arnautresserras](https://github.com/arnautresserras))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/ios/BackgroundTaskModule.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskModule.swift
@@ -1,5 +1,6 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 import ExpoModulesCore
+import UIKit
 
 private let onTasksExpired = "onTasksExpired"
 public let onTasksExpiredNotification = Notification.Name(onTasksExpired)
@@ -65,10 +66,18 @@ public class BackgroundTaskModule: Module {
       }
     }
 
-    AsyncFunction("getStatusAsync") {
-      return BackgroundTaskScheduler.supportsBackgroundTasks()
-        ? BackgroundTaskStatus.available : .restricted
+    // Runs on the main queue because `UIApplication.shared` must only be touched there,
+    // while `AsyncFunction` runs off the main queue by default.
+    AsyncFunction("getStatusAsync") { () -> BackgroundTaskStatus in
+      // BGTaskScheduler never runs work on a simulator, so the system setting is
+      // meaningless there and we keep reporting `restricted`.
+      if !BackgroundTaskScheduler.supportsBackgroundTasks() {
+        return .restricted
+      }
+
+      return BackgroundTaskStatus(refreshStatus: UIApplication.shared.backgroundRefreshStatus)
     }
+    .runOnQueue(.main)
   }
 
   @objc func handleTasksExpiredNotification(_ notification: Notification) {

--- a/packages/expo-background-task/ios/BackgroundTaskRecords.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskRecords.swift
@@ -1,9 +1,32 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 import ExpoModulesCore
+import UIKit
 
 enum BackgroundTaskStatus: Int, Enumerable {
   case restricted = 1
   case available = 2
+  case denied = 3
+}
+
+extension BackgroundTaskStatus {
+  /**
+   Maps the system Background App Refresh setting onto the status reported to JavaScript.
+
+   An unknown future case is reported as `available`: a status we cannot interpret must not make
+   apps tell their users that background refresh is switched off when it may well be on.
+   */
+  init(refreshStatus: UIBackgroundRefreshStatus) {
+    switch refreshStatus {
+    case .available:
+      self = .available
+    case .denied:
+      self = .denied
+    case .restricted:
+      self = .restricted
+    @unknown default:
+      self = .available
+    }
+  }
 }
 
 enum BackgroundTaskResult: Int, Enumerable {

--- a/packages/expo-background-task/ios/Tests/BackgroundTaskStatusTests.swift
+++ b/packages/expo-background-task/ios/Tests/BackgroundTaskStatusTests.swift
@@ -1,0 +1,25 @@
+import UIKit
+import XCTest
+
+@testable import ExpoBackgroundTask
+
+final class BackgroundTaskStatusTests: XCTestCase {
+  func testMapsAvailableRefreshStatus() {
+    XCTAssertEqual(BackgroundTaskStatus(refreshStatus: .available), .available)
+  }
+
+  func testMapsDeniedRefreshStatus() {
+    XCTAssertEqual(BackgroundTaskStatus(refreshStatus: .denied), .denied)
+  }
+
+  func testMapsRestrictedRefreshStatus() {
+    XCTAssertEqual(BackgroundTaskStatus(refreshStatus: .restricted), .restricted)
+  }
+
+  func testMapsUnknownRefreshStatusToAvailable() {
+    guard let unknown = UIBackgroundRefreshStatus(rawValue: 99) else {
+      return
+    }
+    XCTAssertEqual(BackgroundTaskStatus(refreshStatus: unknown), .available)
+  }
+}

--- a/packages/expo-background-task/src/BackgroundTask.ts
+++ b/packages/expo-background-task/src/BackgroundTask.ts
@@ -5,8 +5,8 @@ import type { BackgroundTaskOptions } from './BackgroundTask.types';
 import { BackgroundTaskStatus } from './BackgroundTask.types';
 import ExpoBackgroundTaskModule from './ExpoBackgroundTaskModule';
 
-// Flag to warn about running on Apple simulator
-let warnAboutRunningOniOSSimulator = false;
+// Flag to warn only once about a restricted environment (an Apple simulator, or a device policy)
+let warnedAboutRestrictedStatus = false;
 
 let warnedAboutExpoGo = false;
 
@@ -27,10 +27,18 @@ function _validate(taskName: unknown) {
 
 // @needsAudit
 /**
- * Returns the status for the Background Task API. On web, it always returns `BackgroundTaskStatus.Restricted`,
- * while on native platforms it returns `BackgroundTaskStatus.Available`.
+ * Returns the status for the Background Task API.
  *
- * @returns A BackgroundTaskStatus enum value or `null` if not available.
+ * On iOS this reflects the system **Background App Refresh** setting: `BackgroundTaskStatus.Available`
+ * when it is on, `BackgroundTaskStatus.Denied` when the user has turned it off for this app or for
+ * the whole system, and `BackgroundTaskStatus.Restricted` when a device policy forbids background
+ * activity or the app is running on a simulator. On Android it always returns
+ * `BackgroundTaskStatus.Available`, and on web `BackgroundTaskStatus.Restricted`.
+ *
+ * Because there is more than one way for background tasks to be unavailable, test for
+ * `BackgroundTaskStatus.Available` rather than comparing against a single unavailable value.
+ *
+ * @returns A BackgroundTaskStatus enum value.
  */
 export const getStatusAsync = async (): Promise<BackgroundTaskStatus> => {
   if (!ExpoBackgroundTaskModule.getStatusAsync) {
@@ -84,14 +92,18 @@ export async function registerTaskAsync(
     );
   }
 
+  // Only `Restricted` skips registration, because nothing the user does can lift it. `Denied`
+  // deliberately falls through and registers the task: the user can turn Background App Refresh
+  // back on at any moment, and a task that was never registered would not start running when
+  // they do.
   if ((await ExpoBackgroundTaskModule.getStatusAsync()) === BackgroundTaskStatus.Restricted) {
-    if (!warnAboutRunningOniOSSimulator) {
+    if (!warnedAboutRestrictedStatus) {
       const message =
         Platform.OS === 'ios'
-          ? `Background tasks are not supported on iOS simulators. Skipped registering task: ${taskName}.`
+          ? `Background tasks are restricted on this device — they are unsupported on iOS simulators, and a device policy such as parental controls or MDM can forbid them. Skipped registering task: ${taskName}.`
           : `Background tasks are not available in the current environment. Skipped registering task: ${taskName}.`;
       console.warn(message);
-      warnAboutRunningOniOSSimulator = true;
+      warnedAboutRestrictedStatus = true;
     }
     return;
   }

--- a/packages/expo-background-task/src/BackgroundTask.types.ts
+++ b/packages/expo-background-task/src/BackgroundTask.types.ts
@@ -4,13 +4,21 @@
  */
 export enum BackgroundTaskStatus {
   /**
-   * Background tasks are unavailable.
+   * Background tasks are unavailable to the app and the user cannot turn them on — on iOS this
+   * means a device policy such as parental controls or MDM forbids background activity, or the
+   * app is running on a simulator.
    */
   Restricted = 1,
   /**
    * Background tasks are available for the app.
    */
   Available = 2,
+  /**
+   * The user has turned **Background App Refresh** off, either for this app specifically or for
+   * the whole system. Unlike `Restricted`, this can be undone by the user in the system settings.
+   * @platform ios
+   */
+  Denied = 3,
 }
 
 // @needsAudit


### PR DESCRIPTION
# Why

Fixes #48786.

On iOS, `BackgroundTask.getStatusAsync()` never consulted the OS Background App Refresh setting. It
was derived purely from `BackgroundTaskScheduler.supportsBackgroundTasks()`, a bare
`#if targetEnvironment(simulator)`, so it returned `Restricted` on the Simulator and `Available` on
**every** physical device — no matter what the user had set in **Settings → General → Background App
Refresh**. That makes it unusable for its most obvious purpose: telling the user that background work
will not run because they switched it off.

The predecessor package `expo-background-fetch`, still on `main`, reads
`UIApplication.shared.backgroundRefreshStatus` correctly including all three cases
([`BackgroundFetchModule.swift#L39-L54`](https://github.com/expo/expo/blob/main/packages/expo-background-fetch/ios/BackgroundFetchModule.swift#L39-L54)),
which suggests the check was dropped unintentionally in the move to the `BGTaskScheduler`
implementation rather than removed on purpose.

# How

- `getStatusAsync` now reads `UIApplication.shared.backgroundRefreshStatus`. The Simulator
  short-circuit is kept ahead of it — `BGTaskScheduler` never runs work there, so the system setting
  is meaningless and `Restricted` stays the right answer.
- Added `BackgroundTaskStatus.Denied` (`3`) on both the Swift and TypeScript sides.
  `UIBackgroundRefreshStatus` has three cases and `BackgroundTaskStatus` had two, so without this
  `.denied` — the user switching the toggle off, by far the common case — could only be reported as
  `Restricted`, which Apple documents as meaning parental controls / MDM. Consumers could not tell
  "send the user to Settings" from "policy forbids it, do not bother asking".
- `registerTaskAsync` still skips registration only on `Restricted`. `Denied` deliberately falls
  through and registers, because the user can turn Background App Refresh back on at any moment and
  a task that was never registered would not start running when they do. This keeps today's
  on-device behaviour unchanged for every user who has the setting off.
- The `Restricted` warning text in `registerTaskAsync` said "not supported on iOS simulators", which
  is now reachable on a real device under a device policy, so it mentions both.
- An unknown future `UIBackgroundRefreshStatus` case maps to `available`. Note this differs from
  `expo-background-fetch`, which maps it to `.denied`: a status we cannot interpret should not make
  apps tell users background refresh is switched off when it may well be on. Happy to flip it to
  match the sibling package if you would rather have consistency there.

The third item from the issue — surfacing
`UIApplication.backgroundRefreshStatusDidChangeNotification` so consumers stop polling on every
`AppState` resume — is deliberately **not** in this PR. It is a new public API surface with its own
naming and listener-shape questions, and it would make this change harder to review. Happy to open
it as a follow-up if you want it.

# Test Plan

- New `ios/Tests/BackgroundTaskStatusTests.swift` covers the `UIBackgroundRefreshStatus` →
  `BackgroundTaskStatus` mapping for all three cases plus the unknown-case fallback.
- `et check-packages expo-background-task` passes.
- Device-verified behaviour: this is the same logic I implemented and verified on a physical iPhone
  (iOS 18) in a standalone module,
  [`expo-background-refresh-status`](https://www.npmjs.com/package/expo-background-refresh-status),
  before filing #48786 — `available` at baseline, `denied` with the per-app switch off, `denied`
  with the global switch off, and back to `available` on re-enable.
- `.restricted` is not reachable without a supervised device, so it ships covered only by the unit
  test above. That is the reason `registerTaskAsync` keys off `Restricted` alone and consumers are
  documented to test for `Available` rather than for a specific unavailable value.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

The API reference under `docs/` is generated from the JSDoc in `src/`, so this PR touches no `docs/`
files — tell me if you would rather I run `et generate-docs-api-data -p expo-background-task` and
include the regenerated data here.

# Note for reviewers

One behavioural consequence worth stating explicitly: apps that today detect "background refresh is
unavailable" with `status === BackgroundTaskStatus.Restricted` will not see the newly reported
`Denied`. The JSDoc now tells consumers to test for `Available` instead. If you would prefer this
land as a breaking change note, or prefer to keep the enum two-valued and map `.denied` onto
`Restricted` (at the cost of `registerTaskAsync` then skipping registration for those users), I am
glad to rework it.
