### PR TITLE
[location][ios] Nest background permission scope and accuracy under `ios` field

### DIFF
--- a/apps/test-suite/tests/Location.ts
+++ b/apps/test-suite/tests/Location.ts
@@ -1,52 +1,53 @@
-'use strict';
-
 import Constants from 'expo-constants';
 import * as Location from 'expo-location';
 import * as TaskManager from 'expo-task-manager';
 import { Platform } from 'react-native';
 
 import * as TestUtils from '../TestUtils';
+import type { JasmineInterface } from '../types';
+import { requireNotNull } from '../utils/requireNotNull';
 
 const BACKGROUND_LOCATION_TASK = 'background-location-updates';
 const GEOFENCING_TASK = 'geofencing-task';
 
 export const name = 'Location';
 
-export async function test(t) {
+export async function test(t: JasmineInterface) {
   const shouldSkipTestsRequiringPermissions =
     await TestUtils.shouldSkipTestsRequiringPermissionsAsync();
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : t.describe;
 
-  const testShapeOrUnauthorized = (testFunction) => async () => {
-    const providerStatus = await Location.getProviderStatusAsync();
-    if (providerStatus.locationServicesEnabled) {
-      const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
-        return Location.requestForegroundPermissionsAsync();
-      });
-      if (status === 'granted') {
-        const location = await testFunction();
-        testLocationShape(location);
+  const testShapeOrUnauthorized =
+    (testFunction: () => Promise<Location.LocationObject>) => async () => {
+      const providerStatus = await Location.getProviderStatusAsync();
+      if (providerStatus.locationServicesEnabled) {
+        const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
+          return Location.requestForegroundPermissionsAsync();
+        });
+        if (status === 'granted') {
+          const location = await testFunction();
+          testLocationShape(location);
+        } else {
+          let error: any;
+          try {
+            await testFunction();
+          } catch (e) {
+            error = e;
+          }
+          t.expect(error.message).toMatch(/Not authorized/);
+        }
       } else {
-        let error;
+        let error: any;
         try {
           await testFunction();
         } catch (e) {
           error = e;
         }
-        t.expect(error.message).toMatch(/Not authorized/);
+        t.expect(error.message).toMatch(/Location services are disabled/);
       }
-    } else {
-      let error;
-      try {
-        await testFunction();
-      } catch (e) {
-        error = e;
-      }
-      t.expect(error.message).toMatch(/Location services are disabled/);
-    }
-  };
+    };
 
-  function testLocationShape(location) {
+  function testLocationShape(location: Location.LocationObject) {
     t.expect(typeof location === 'object').toBe(true);
 
     const { coords, timestamp } = location;
@@ -70,7 +71,7 @@ export async function test(t) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.scope).toBe('whenInUse');
+          t.expect(permission.ios?.scope).toBe('whenInUse');
         }
       });
     });
@@ -81,7 +82,7 @@ export async function test(t) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.scope).toBe('whenInUse');
+          t.expect(permission.ios?.scope).toBe('whenInUse');
         }
       });
     });
@@ -92,7 +93,8 @@ export async function test(t) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.scope).toBe('always');
+          // Typed as a plain `PermissionResponse`, but carries `ios.scope`.
+          t.expect((permission as Location.LocationPermissionResponse).ios?.scope).toBe('always');
         }
       });
     });
@@ -103,7 +105,8 @@ export async function test(t) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.scope).toBe('always');
+          // Typed as a plain `PermissionResponse`, but carries `ios.scope`.
+          t.expect((permission as Location.LocationPermissionResponse).ios?.scope).toBe('always');
         }
       });
     });
@@ -121,7 +124,7 @@ export async function test(t) {
         'checks if location services are enabled',
         async () => {
           const result = await Location.getProviderStatusAsync();
-          t.expect(result.locationServicesEnabled).not.toBe(undefined);
+          t.expect(result.locationServicesEnabled).toBeDefined();
         },
         timeout
       );
@@ -167,7 +170,7 @@ export async function test(t) {
               const result = await Location.getProviderStatusAsync();
               t.expect(result.networkAvailable).toBe(true);
             }
-          } catch (error) {
+          } catch (error: any) {
             // User has denied the dialog.
             t.expect(error.code).toBe('E_LOCATION_SETTINGS_UNSATISFIED');
           }
@@ -278,7 +281,9 @@ export async function test(t) {
 
       t.it(
         'gets a result of the correct shape, or throws error if no permission or disabled',
-        testShapeOrUnauthorized(() => Location.getLastKnownPositionAsync()),
+        testShapeOrUnauthorized(async () =>
+          requireNotNull(await Location.getLastKnownPositionAsync())
+        ),
         timeout
       );
 
@@ -292,7 +297,7 @@ export async function test(t) {
 
           t.expect(current).not.toBeNull();
           t.expect(lastKnown).not.toBeNull();
-          t.expect(lastKnown.timestamp).toBeGreaterThanOrEqual(current.timestamp);
+          t.expect(lastKnown?.timestamp).toBeGreaterThanOrEqual(current.timestamp);
         },
         timeout
       );
@@ -354,14 +359,14 @@ export async function test(t) {
 
     describeWithPermissions('Location.watchPositionAsync()', () => {
       t.it('gets a result of the correct shape', async () => {
-        let subscriber;
-        const location = await new Promise(async (resolve) => {
+        let subscriber: Location.LocationSubscription | undefined;
+        const location = await new Promise<Location.LocationObject>(async (resolve) => {
           subscriber = await Location.watchPositionAsync({}, (location) => {
             setTimeout(() => resolve(location));
           });
         });
 
-        subscriber.remove();
+        subscriber?.remove();
         testLocationShape(location);
       });
 
@@ -381,7 +386,7 @@ export async function test(t) {
 
     if (Platform.OS !== 'web') {
       describeWithPermissions('Location.getHeadingAsync()', () => {
-        const testCompass = (options) => async () => {
+        const testCompass = () => async () => {
           // Disable Compass Test if in simulator
           if (Constants.isDevice) {
             const { status } = await TestUtils.acceptPermissionsAndRunCommandAsync(() => {
@@ -396,7 +401,7 @@ export async function test(t) {
               let error;
               try {
                 await Location.getHeadingAsync();
-              } catch (e) {
+              } catch (e: any) {
                 error = e;
               }
               t.expect(error.message).toMatch(/Not authorized/);
@@ -453,11 +458,11 @@ export async function test(t) {
             });
             t.expect(Array.isArray(result)).toBe(true);
             t.expect(typeof result[0]).toBe('object');
-            const fields = ['city', 'street', 'region', 'country', 'postalCode', 'name'];
+            // Reads the first address; the module returns `null` for unresolved fields.
+            const fields = ['city', 'street', 'region', 'country', 'postalCode', 'name'] as const;
             fields.forEach((field) => {
-              t.expect(
-                typeof result[field] === 'string' || typeof result[field] === 'undefined'
-              ).toBe(true);
+              const value = result[0][field];
+              t.expect(typeof value === 'string' || value == null).toBe(true);
             });
           },
           timeout
@@ -467,7 +472,10 @@ export async function test(t) {
           let error;
           try {
             await Location.reverseGeocodeAsync({
+              // Deliberately not numbers — the spec asserts the module rejects them.
+              // @ts-expect-error
               latitude: '60',
+              // @ts-expect-error
               longitude: '24',
             });
           } catch (e) {
@@ -478,8 +486,11 @@ export async function test(t) {
       });
 
       describeWithPermissions('Location - background location updates', () => {
-        async function expectTaskAccuracyToBe(accuracy) {
-          const locationTask = await TaskManager.getTaskOptionsAsync(BACKGROUND_LOCATION_TASK);
+        async function expectTaskAccuracyToBe(accuracy: Location.LocationAccuracy) {
+          const locationTask =
+            await TaskManager.getTaskOptionsAsync<Location.LocationTaskOptions>(
+              BACKGROUND_LOCATION_TASK
+            );
 
           t.expect(locationTask).toBeDefined();
           t.expect(locationTask.accuracy).toBe(accuracy);
@@ -536,8 +547,10 @@ export async function test(t) {
           },
         ];
 
-        async function expectTaskRegionsToBeLike(regions) {
-          const geofencingTask = await TaskManager.getTaskOptionsAsync(GEOFENCING_TASK);
+        async function expectTaskRegionsToBeLike(regions: Location.LocationRegion[]) {
+          const geofencingTask = await TaskManager.getTaskOptionsAsync<{
+            regions: Location.LocationRegion[];
+          }>(GEOFENCING_TASK);
 
           t.expect(geofencingTask).toBeDefined();
           t.expect(geofencingTask.regions).toBeDefined();
@@ -593,6 +606,7 @@ export async function test(t) {
           await (async () => {
             let error;
             try {
+              // @ts-expect-error
               await Location.startGeofencingAsync(GEOFENCING_TASK, [{ longitude: 'not a number' }]);
             } catch (e) {
               error = e;
@@ -606,5 +620,5 @@ export async function test(t) {
 }
 
 // Define empty tasks, otherwise tasks might automatically unregister themselves if no task is defined.
-TaskManager.defineTask(BACKGROUND_LOCATION_TASK, () => {});
-TaskManager.defineTask(GEOFENCING_TASK, () => {});
+TaskManager.defineTask(BACKGROUND_LOCATION_TASK, async () => {});
+TaskManager.defineTask(GEOFENCING_TASK, async () => {});

--- a/apps/test-suite/tests/Location.ts
+++ b/apps/test-suite/tests/Location.ts
@@ -9,6 +9,7 @@ import { requireNotNull } from '../utils/requireNotNull';
 
 const BACKGROUND_LOCATION_TASK = 'background-location-updates';
 const GEOFENCING_TASK = 'geofencing-task';
+const GEOCODING_TIMEOUT = 10000; // Allow time for network requests.
 
 export const name = 'Location';
 
@@ -63,6 +64,28 @@ export async function test(t: JasmineInterface) {
     t.expect(typeof timestamp === 'number').toBe(true);
   }
 
+  /**
+   * Awaits a geocoding call, marking the spec pending when the device has no
+   * Geocoder — Android images without Google APIs ship none and reject with
+   * `ERR_NO_GEOCODE`. Any other rejection still fails the spec.
+   *
+   * This has to be decided per call rather than up front: the Android module checks
+   * the foreground permission before it checks for a Geocoder, so before the
+   * permission specs above have run, a missing Geocoder is indistinguishable from a
+   * missing permission.
+   */
+  async function geocodingOrPending<T>(call: () => Promise<T>): Promise<T> {
+    try {
+      return await call();
+    } catch (error: any) {
+      if (error?.code === 'ERR_NO_GEOCODE') {
+        // `pending` throws to abort the spec, so nothing below it runs.
+        t.pending('the device has no Geocoder');
+      }
+      throw error;
+    }
+  }
+
   t.describe('Location', () => {
     // On Android, foreground permission needs to be asked before the background permissions
     describeWithPermissions('Location.requestForegroundPermissionsAsync()', () => {
@@ -71,7 +94,9 @@ export async function test(t: JasmineInterface) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.ios?.scope).toBe('whenInUse');
+          // `always` also grants foreground access, and the two scopes cannot both
+          // be held: once the background specs below grant `always`, this reports it.
+          t.expect(['whenInUse', 'always']).toContain(permission.ios?.scope);
         }
       });
     });
@@ -82,7 +107,9 @@ export async function test(t: JasmineInterface) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          t.expect(permission.ios?.scope).toBe('whenInUse');
+          // `always` also grants foreground access, and the two scopes cannot both
+          // be held: once the background specs below grant `always`, this reports it.
+          t.expect(['whenInUse', 'always']).toContain(permission.ios?.scope);
         }
       });
     });
@@ -93,8 +120,7 @@ export async function test(t: JasmineInterface) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          // Typed as a plain `PermissionResponse`, but carries `ios.scope`.
-          t.expect((permission as Location.LocationPermissionResponse).ios?.scope).toBe('always');
+          t.expect(permission.ios?.scope).toBe('always');
         }
       });
     });
@@ -105,8 +131,7 @@ export async function test(t: JasmineInterface) {
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
         if (Platform.OS === 'ios') {
-          // Typed as a plain `PermissionResponse`, but carries `ios.scope`.
-          t.expect((permission as Location.LocationPermissionResponse).ios?.scope).toBe('always');
+          t.expect(permission.ios?.scope).toBe('always');
         }
       });
     });
@@ -172,7 +197,7 @@ export async function test(t: JasmineInterface) {
             }
           } catch (error: any) {
             // User has denied the dialog.
-            t.expect(error.code).toBe('E_LOCATION_SETTINGS_UNSATISFIED');
+            t.expect(error.code).toBe('ERR_LOCATION_SETTINGS_UNSATISFIED');
           }
         },
         20000
@@ -419,12 +444,12 @@ export async function test(t: JasmineInterface) {
       });
 
       t.describe('Location.geocodeAsync()', () => {
-        const timeout = 2000;
-
         t.it(
           'geocodes a place of the right shape',
           async () => {
-            const result = await Location.geocodeAsync('900 State St, Salem, OR');
+            const result = await geocodingOrPending(() =>
+              Location.geocodeAsync('900 State St, Salem, OR')
+            );
             t.expect(Array.isArray(result)).toBe(true);
             t.expect(typeof result[0]).toBe('object');
             const { latitude, longitude, accuracy, altitude } = result[0];
@@ -433,29 +458,29 @@ export async function test(t: JasmineInterface) {
             t.expect(typeof accuracy).toBe('number');
             t.expect(typeof altitude).toBe('number');
           },
-          timeout
+          GEOCODING_TIMEOUT
         );
 
         t.it(
           'returns an empty array when the address is not found',
           async () => {
-            const result = await Location.geocodeAsync(':(');
+            const result = await geocodingOrPending(() => Location.geocodeAsync(':('));
             t.expect(result).toEqual([]);
           },
-          timeout
+          GEOCODING_TIMEOUT
         );
       });
 
       t.describe('Location.reverseGeocodeAsync()', () => {
-        const timeout = 2000;
-
         t.it(
           'gives a right shape address of a point location',
           async () => {
-            const result = await Location.reverseGeocodeAsync({
-              latitude: 60.166595,
-              longitude: 24.944865,
-            });
+            const result = await geocodingOrPending(() =>
+              Location.reverseGeocodeAsync({
+                latitude: 60.166595,
+                longitude: 24.944865,
+              })
+            );
             t.expect(Array.isArray(result)).toBe(true);
             t.expect(typeof result[0]).toBe('object');
             // Reads the first address; the module returns `null` for unresolved fields.
@@ -465,7 +490,7 @@ export async function test(t: JasmineInterface) {
               t.expect(typeof value === 'string' || value == null).toBe(true);
             });
           },
-          timeout
+          GEOCODING_TIMEOUT
         );
 
         t.it("throws for a location where `latitude` and `longitude` aren't numbers", async () => {
@@ -606,7 +631,7 @@ export async function test(t: JasmineInterface) {
           await (async () => {
             let error;
             try {
-              // @ts-expect-error
+              // @ts-expect-error string is not a number
               await Location.startGeofencingAsync(GEOFENCING_TASK, [{ longitude: 'not a number' }]);
             } catch (e) {
               error = e;

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add `scope` and `accuracy` under `ios` to the responses from `getBackgroundPermissionsAsync` and `requestBackgroundPermissionsAsync`, matching the `LocationPermissionResponse` type.
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))
 - [Android] Fix leaking watches ([#48294](https://github.com/expo/expo/pull/48294) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Add `scope` and `accuracy` under `ios` to the responses from `getBackgroundPermissionsAsync` and `requestBackgroundPermissionsAsync`, matching the `LocationPermissionResponse` type.
+- [iOS] Add `scope` and `accuracy` under `ios` to the responses from `getBackgroundPermissionsAsync` and `requestBackgroundPermissionsAsync`, matching the `LocationPermissionResponse` type. ([#48926](https://github.com/expo/expo/pull/48926) by [@vonovak](https://github.com/vonovak))
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))
 - [Android] Fix leaking watches ([#48294](https://github.com/expo/expo/pull/48294) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
+++ b/packages/expo-location/ios/Requesters/EXBackgroundLocationPermissionRequester.m
@@ -151,7 +151,19 @@ static SEL alwaysAuthorizationSelector;
     }
   }
   
-  return @{ @"status": @(status), @"scope": @(systemStatus == kCLAuthorizationStatusAuthorizedWhenInUse ? "whenInUse" : systemStatus == kCLAuthorizationStatusAuthorizedAlways ? "always" : "none"), @"accuracy": [self accuracyAuthorizationString] };
+  NSString *scope = @(systemStatus == kCLAuthorizationStatusAuthorizedWhenInUse ? "whenInUse" : systemStatus == kCLAuthorizationStatusAuthorizedAlways ? "always" : "none");
+  NSString *accuracy = [self accuracyAuthorizationString];
+
+  return @{ @"status": @(status),
+            @"ios": @{
+              @"scope": scope,
+              @"accuracy": accuracy
+            },
+            // Keep these long-standing fields during the migration to the platform-specific response shape.
+            // TODO: Remove the top-level `scope` and `accuracy` fields after SDK 59.
+            @"scope": scope,
+            @"accuracy": accuracy
+         };
 }
 
 @end

--- a/packages/expo-location/src/Location.ts
+++ b/packages/expo-location/src/Location.ts
@@ -297,9 +297,9 @@ export const useForegroundPermissions = createPermissionHook({
 // @needsAudit
 /**
  * Checks user's permissions for accessing location while the app is in the background.
- * @return A promise that fulfills with an object of type [`PermissionResponse`](#permissionresponse).
+ * @return A promise that fulfills with an object of type [`LocationPermissionResponse`](#locationpermissionresponse).
  */
-export async function getBackgroundPermissionsAsync(): Promise<PermissionResponse> {
+export async function getBackgroundPermissionsAsync(): Promise<LocationPermissionResponse> {
   return await ExpoLocation.getBackgroundPermissionsAsync();
 }
 
@@ -311,9 +311,9 @@ export async function getBackgroundPermissionsAsync(): Promise<PermissionRespons
  * For example, you can use `Modal` component from `react-native` to do that.
  * > __Note__: Foreground permissions should be granted before asking for the background permissions
  * (your app can't obtain background permission without foreground permission).
- * @return A promise that fulfills with an object of type [`PermissionResponse`](#permissionresponse).
+ * @return A promise that fulfills with an object of type [`LocationPermissionResponse`](#locationpermissionresponse).
  */
-export async function requestBackgroundPermissionsAsync(): Promise<PermissionResponse> {
+export async function requestBackgroundPermissionsAsync(): Promise<LocationPermissionResponse> {
   return await ExpoLocation.requestBackgroundPermissionsAsync();
 }
 


### PR DESCRIPTION
## Why

#48009 moved `scope` and `accuracy` under `ios` for the foreground permission response and dropped the stale top-level keys. The background requester also needs this treatment.

found by migrating tests from JS to TS

# How

- migrate tests to TS
- fix the permission response shape

# Test Plan

- bare expo

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
