### PR TITLE
[expo] Remove react-native-get-random-values from bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,6 @@
   "react-native": "0.86.2",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~3.1.0",
-  "react-native-get-random-values": "~1.11.0",
   "react-native-keyboard-controller": "1.21.9",
   "react-native-maps": "1.27.2",
   "react-native-pager-view": "8.0.2",


### PR DESCRIPTION
# Why

Although we list `react-native-get-random-values` in bundledNativeModules we don't actually use it anywhere anymore. In order to prevent users from getting outdated warnings like reported in https://github.com/expo/expo/pull/48643, we should just remove that entry and let users use whatever version they want

# How

Remove react-native-get-random-values from bundledNativeModules

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
