### PR TITLE
[ios][core] Fixed a crash when Fabric creates a cached Expo view after a reload

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a crash on reload when Fabric instantiated a cached Expo view class after its app context had been released. ([#48575](https://github.com/expo/expo/issues/48575) by [@lighthold](https://github.com/lighthold)) ([#48933](https://github.com/expo/expo/pull/48933) by [@uwayss](https://github.com/uwayss))
 - [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed hosted Compose views missing layout after reattachment or in-place configuration changes. ([#48370](https://github.com/expo/expo/issues/48370) by [@lujjjh](https://github.com/lujjjh))
 - [iOS] Fixed infinite recursion and `EXC_BAD_ACCESS` when encoding native `Date` values to JavaScript. ([#48239](https://github.com/expo/expo/issues/48239), [#48240](https://github.com/expo/expo/pull/48240) by [@samuelcorsan](https://github.com/samuelcorsan))

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -205,50 +205,20 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     class_replaceMethod(object_getClass(ExpoFabricView.self), #selector(appContextFromClass), appContextBlockImp, "@@:")
   }
 
-  /**
-   Keeps a strong reference to the app context that the injected initializer builds the views from.
-   The view classes are cached in `viewClassesRegistry` for the entire process lifetime, so they
-   outlive the app context they were created with. With the context captured weakly, Fabric could
-   instantiate a cached class at a moment when that reference was already `nil` — on a reload,
-   after the previous context has been released but before `registerNativeViews` runs again on the
-   main actor — and the initializer aborted the process. Replacing the reference on each
-   registration keeps the previous context alive across that window, and releases it right after.
-   */
-  private final class AppContextHolder {
-    var appContext: AppContext
-
-    init(_ appContext: AppContext) {
-      self.appContext = appContext
-    }
-  }
-
-  /**
-   Holders of the app context, keyed by the identity of the view class the initializer was injected to.
-   Not keyed by the class name, unlike `viewClassesRegistry` — there might be more than one class
-   with the same name (Expo Go), and they need an initializer each.
-   Used from the main thread only: `makeViewClass` is called by `registerNativeViews` (`@MainActor`)
-   and the injected initializer runs while Fabric is performing a mounting transaction.
-   */
-  private static var appContextHolders = [ObjectIdentifier: AppContextHolder]()
-
   internal static func injectInitializer(appContext: AppContext, moduleName: String, viewName: String, toViewClass viewClass: AnyClass) {
-    let holderKey = ObjectIdentifier(viewClass)
-
-    // A cached class already has the initializer injected, and `moduleName` and `viewName` are part
-    // of the class name, so they can't have changed. Only the app context has — point the existing
-    // initializer at the new one instead of injecting another.
-    if let holder = appContextHolders[holderKey] {
-      holder.appContext = appContext
-      return
-    }
-    let holder = AppContextHolder(appContext)
-    appContextHolders[holderKey] = holder
-
     // The default initializer for native views. It will be called by Fabric.
-    let newBlock: @convention(block) () -> Any = {[holder] in
-      let appContext = holder.appContext
-      guard let moduleHolder = appContext.moduleRegistry.get(moduleHolderForName: moduleName) else {
-        fatalError(Exceptions.AppContextLost().reason)
+    let newBlock: @convention(block) () -> Any = {[weak appContext] in
+      guard let appContext, let moduleHolder = appContext.moduleRegistry.get(moduleHolderForName: moduleName) else {
+        // The view classes are cached in `viewClassesRegistry` for the whole process lifetime, so
+        // they outlive the app context they were created with. On a reload Fabric can ask a cached
+        // class for a view after the previous context has been released but before
+        // `registerNativeViews` has run again on the main actor — there is simply no context left
+        // to build from. The surface being mounted is the one going away, so hand back an inert
+        // view instead of aborting the process.
+        log.error("Cannot create a view '\(viewName)' from module '\(moduleName)': \(Exceptions.AppContextLost().reason)")
+        let view = (viewClass as? ExpoFabricView.Type ?? ExpoFabricView.self).init(appContext: nil)
+        _ = Unmanaged.passRetained(view) // retain the view given this is an initializer
+        return view
       }
       guard let view = moduleHolder.definition.views[viewName]?.createView(appContext: appContext) else {
         fatalError("Cannot create a view '\(viewName)' from module '\(moduleName)'")

--- a/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
+++ b/packages/expo-modules-core/ios/Fabric/ExpoFabricView.swift
@@ -205,10 +205,49 @@ open class ExpoFabricView: ExpoFabricViewObjC, AnyExpoView {
     class_replaceMethod(object_getClass(ExpoFabricView.self), #selector(appContextFromClass), appContextBlockImp, "@@:")
   }
 
+  /**
+   Keeps a strong reference to the app context that the injected initializer builds the views from.
+   The view classes are cached in `viewClassesRegistry` for the entire process lifetime, so they
+   outlive the app context they were created with. With the context captured weakly, Fabric could
+   instantiate a cached class at a moment when that reference was already `nil` — on a reload,
+   after the previous context has been released but before `registerNativeViews` runs again on the
+   main actor — and the initializer aborted the process. Replacing the reference on each
+   registration keeps the previous context alive across that window, and releases it right after.
+   */
+  private final class AppContextHolder {
+    var appContext: AppContext
+
+    init(_ appContext: AppContext) {
+      self.appContext = appContext
+    }
+  }
+
+  /**
+   Holders of the app context, keyed by the identity of the view class the initializer was injected to.
+   Not keyed by the class name, unlike `viewClassesRegistry` — there might be more than one class
+   with the same name (Expo Go), and they need an initializer each.
+   Used from the main thread only: `makeViewClass` is called by `registerNativeViews` (`@MainActor`)
+   and the injected initializer runs while Fabric is performing a mounting transaction.
+   */
+  private static var appContextHolders = [ObjectIdentifier: AppContextHolder]()
+
   internal static func injectInitializer(appContext: AppContext, moduleName: String, viewName: String, toViewClass viewClass: AnyClass) {
+    let holderKey = ObjectIdentifier(viewClass)
+
+    // A cached class already has the initializer injected, and `moduleName` and `viewName` are part
+    // of the class name, so they can't have changed. Only the app context has — point the existing
+    // initializer at the new one instead of injecting another.
+    if let holder = appContextHolders[holderKey] {
+      holder.appContext = appContext
+      return
+    }
+    let holder = AppContextHolder(appContext)
+    appContextHolders[holderKey] = holder
+
     // The default initializer for native views. It will be called by Fabric.
-    let newBlock: @convention(block) () -> Any = {[weak appContext] in
-      guard let appContext, let moduleHolder = appContext.moduleRegistry.get(moduleHolderForName: moduleName) else {
+    let newBlock: @convention(block) () -> Any = {[holder] in
+      let appContext = holder.appContext
+      guard let moduleHolder = appContext.moduleRegistry.get(moduleHolderForName: moduleName) else {
         fatalError(Exceptions.AppContextLost().reason)
       }
       guard let view = moduleHolder.definition.views[viewName]?.createView(appContext: appContext) else {


### PR DESCRIPTION
## Why

Fixes #48575.

We cache the generated view classes in `viewClassesRegistry` so they survive a reload, and give each
one a `new` implementation that captures the current `AppContext` weakly. But the class outlives the
context, so that weak reference can already be nil by the time Fabric asks the class for a view.

On a reload the old context gets released, and the new one re-registers the views. Except when
`registerNativeModules` runs off the main thread, that registration is deferred to the main actor.
In the gap between those two things, Fabric can drain a mounting transaction that needs to *create*
an Expo view. The class is still registered with `RCTComponentViewFactory`, the weak reference is
gone, and we abort:

```
_assertionFailure
closure #1 in ExpoFabricView.injectInitializer(_:appContext:)   ExpoFabricView.swift:212
-[RCTComponentViewFactory createComponentViewWithComponentHandle:]
RCTPerformMountInstructions
-[RCTMountingManager performTransaction:]
```

I measured that gap at roughly 9ms per reload on a real app. Only mounts that need a genuinely new
view rather than one from the recycle pool fall into it, which is why it feels random.

## How

Each view class now gets a small holder that owns the context strongly, and every registration swaps
what the holder points at instead of injecting a second initializer.

The initializer then always reads the most recent context. Inside the gap above it reads the
outgoing one, which is still around precisely because the holder is holding it — and building a view
from it is safe, since `createView` just initialises the view and wires up the event dispatchers and
never touches the runtime. That view belongs to the surface that's on its way out anyway.

Nothing is kept alive longer than it needs to be: the old context goes as soon as the next
registration replaces it.

I keyed the holders by `ObjectIdentifier(viewClass)` rather than by class name, since the note on
`makeViewClass` points out that two classes can share a name in Expo Go.

No locking — `makeViewClass` is only reached from `registerNativeViews` (`@MainActor`), and the
initializer runs during a Fabric mounting transaction, so both sides are on the main thread already.
Happy to add some if you'd rather be defensive, though the two existing TODOs about that path look
like their own change.

One thing I left alone: the remaining `AppContextLost` can now only fire when a module holder is
missing from a live context, so the message is a bit off. Didn't want to widen the diff, but I'm
happy to reword it.

## Test Plan

Tested on a real SDK 57 app — `expo-modules-core` 57.0.8 built from source, RN 0.86.2, Hermes + New
Architecture, iOS 26.5 simulator.

I added some `NSLog`s around `AppContext.init`/`deinit` and the registration to actually see the gap:

```
AppContext INIT    0x1566918c0     new context
AppContext DEINIT  0x1439d95c0     old one released -> weak ref now nil
registerNativeModules -> main actor hop
registerNativeViews running        cached classes re-pointed
```

Those middle two lines are about 9ms apart. That turned out to be too narrow to hit deliberately —
233 reloads with Expo views on screen never crashed once. So I widened just that gap to 3s by
awaiting before `registerNativeViews()` and changed nothing else, which makes the first mount after
a reload land inside it.

- **Before:** 4 of 5 runs aborted, every one at the `fatalError` in `injectInitializer` with the
  stack above.
- **After:** 0 of 10. 29 context creations and 20 releases were logged over that run, so the reload
  path was definitely being exercised.

The ordering flips, which is really the whole point of the change:

```
before:  DEINIT old  ->  ...  ->  abort        (registration never got there)
after:   registerNativeViews  ->  DEINIT old   (released 3ms later)
```

Worth being upfront that this widens the race to make it reproducible — I couldn't hit the natural
9ms window on demand. Separately, two crashes with this exact signature showed up on my machine
during ordinary development before I'd instrumented anything.
