### PR TITLE
feat(env): Add internal config mode helper

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,7 +38,7 @@
 
 ### 💡 Others
 
-- [Internal] Use `@expo/env` to read `EXPO_CONFIG_MODE` and keep older EAS Build versions in production mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
+- [Internal] Use `@expo/env` to read the EAS config mode and keep older EAS Build versions in production mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add sandbox detection to telemetry context ([#47928](https://github.com/expo/expo/pull/47928) by [@davidmokos](https://github.com/davidmokos))
 - [Internal] Remove the unreachable port fallbacks and increase consistency in port selection logic ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Add experimental `tvos` and `macos` autolinking gated by `expriments.outOfTreePlatforms` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### 💡 Others
 
+- [Internal] Use `@expo/env` to read `EXPO_CONFIG_MODE` and keep older EAS Build versions in production mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add sandbox detection to telemetry context ([#47928](https://github.com/expo/expo/pull/47928) by [@davidmokos](https://github.com/davidmokos))
 - [Internal] Remove the unreachable port fallbacks and increase consistency in port selection logic ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))
 - Add experimental `tvos` and `macos` autolinking gated by `expriments.outOfTreePlatforms` ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/config/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/config/__tests__/index-test.ts
@@ -45,7 +45,7 @@ describe('config mode', () => {
     );
   });
 
-  it('uses the production mode from EXPO_CONFIG_MODE', async () => {
+  it('uses the production mode from __EXPO_CONFIG_MODE', async () => {
     getConfigEnvMode.mockReturnValue('production');
 
     await expoConfig([]);

--- a/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/index-test.ts
@@ -46,7 +46,7 @@ it('loads development env files before prebuild', async () => {
   );
 });
 
-it('uses the production mode from EXPO_CONFIG_MODE', async () => {
+it('uses the production mode from __EXPO_CONFIG_MODE', async () => {
   getConfigEnvMode.mockReturnValue('production');
 
   await expoPrebuild([]);

--- a/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
@@ -10,7 +10,7 @@ describe('Node environment', () => {
     process.env = { ...originalEnv };
     delete process.env.__EXPO_ENV_LOADED;
     delete process.env.EAS_BUILD;
-    delete process.env.EXPO_CONFIG_MODE;
+    delete process.env.__EXPO_CONFIG_MODE;
     delete process.env.EXPO_PUBLIC_VALUE;
     vol.reset();
   });
@@ -19,26 +19,28 @@ describe('Node environment', () => {
     process.env = originalEnv;
   });
 
-  it('reads and removes EXPO_CONFIG_MODE', () => {
-    process.env.EXPO_CONFIG_MODE = 'production';
+  it('reads and removes __EXPO_CONFIG_MODE', () => {
+    process.env.__EXPO_CONFIG_MODE = 'production';
 
     expect(getConfigEnvMode()).toBe('production');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('uses development when EXPO_CONFIG_MODE is not set', () => {
+  it('uses development when __EXPO_CONFIG_MODE is empty', () => {
+    process.env.__EXPO_CONFIG_MODE = '';
+
     expect(getConfigEnvMode()).toBe('development');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('uses production in EAS Build when EXPO_CONFIG_MODE is not set', () => {
+  it('uses production in EAS Build when __EXPO_CONFIG_MODE is not set', () => {
     process.env.EAS_BUILD = 'true';
 
     expect(getConfigEnvMode()).toBe('production');
   });
 
-  it('rejects an invalid EXPO_CONFIG_MODE value', () => {
-    process.env.EXPO_CONFIG_MODE = 'staging';
+  it('rejects an invalid __EXPO_CONFIG_MODE value', () => {
+    process.env.__EXPO_CONFIG_MODE = 'staging';
 
     try {
       getConfigEnvMode();
@@ -47,10 +49,10 @@ describe('Node environment', () => {
       expect(error).toBeInstanceOf(CommandError);
       expect(error).toMatchObject({
         code: 'BAD_ARGS',
-        message: 'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".',
+        message: 'Invalid __EXPO_CONFIG_MODE value: "staging". Use "development" or "production".',
       });
     }
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
   it('uses production mode when loading and reloading env files', () => {
@@ -62,6 +64,7 @@ describe('Node environment', () => {
       '/app'
     );
     (process.env as Record<string, string | undefined>).NODE_ENV = 'staging';
+
     const mode = 'production';
     loadEnvFiles('/app', { mode, silent: true });
 

--- a/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/nodeEnv-test.ts
@@ -9,6 +9,7 @@ describe('Node environment', () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env.__EXPO_ENV_LOADED;
+    delete process.env.EAS_BUILD;
     delete process.env.EXPO_CONFIG_MODE;
     delete process.env.EXPO_PUBLIC_VALUE;
     vol.reset();
@@ -25,11 +26,15 @@ describe('Node environment', () => {
     expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('uses development when EXPO_CONFIG_MODE is empty', () => {
-    process.env.EXPO_CONFIG_MODE = '';
-
+  it('uses development when EXPO_CONFIG_MODE is not set', () => {
     expect(getConfigEnvMode()).toBe('development');
     expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('uses production in EAS Build when EXPO_CONFIG_MODE is not set', () => {
+    process.env.EAS_BUILD = 'true';
+
+    expect(getConfigEnvMode()).toBe('production');
   });
 
   it('rejects an invalid EXPO_CONFIG_MODE value', () => {
@@ -51,33 +56,25 @@ describe('Node environment', () => {
   it('uses production mode when loading and reloading env files', () => {
     vol.fromJSON(
       {
-        '.env.production': ['EXPO_CONFIG_MODE=development', 'EXPO_PUBLIC_VALUE=production-v1'].join(
-          '\n'
-        ),
+        '.env.production': 'EXPO_PUBLIC_VALUE=production-v1',
         '.env.development': 'EXPO_PUBLIC_VALUE=development',
       },
       '/app'
     );
     (process.env as Record<string, string | undefined>).NODE_ENV = 'staging';
-
     const mode = 'production';
     loadEnvFiles('/app', { mode, silent: true });
 
     expect(process.env.NODE_ENV).toBe('production');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
     expect(process.env.EXPO_PUBLIC_VALUE).toBe('production-v1');
     expect(getEnvFiles('/app', mode)).toContain('/app/.env.production');
     expect(getEnvFiles('/app', mode)).not.toContain('/app/.env.development');
 
     process.env.NODE_ENV = 'development';
-    vol.writeFileSync(
-      '/app/.env.production',
-      ['EXPO_CONFIG_MODE=development', 'EXPO_PUBLIC_VALUE=production-v2'].join('\n')
-    );
+    vol.writeFileSync('/app/.env.production', 'EXPO_PUBLIC_VALUE=production-v2');
     reloadEnvFiles('/app', mode);
 
     expect(process.env.NODE_ENV).toBe('production');
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
     expect(process.env.EXPO_PUBLIC_VALUE).toBe('production-v2');
   });
 });

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -245,11 +245,6 @@ class Env {
     return getOriginalEnvValue('__EXPO_EAGER_BUNDLE_OPTIONS') || '';
   }
 
-  /** @internal Mode passed to `expo config` or `expo prebuild` by another tool. */
-  get EXPO_CONFIG_MODE(): string | undefined {
-    return getOriginalEnvValue('EXPO_CONFIG_MODE') || undefined;
-  }
-
   /** Disable server deployment during production builds (during `expo export:embed`). This is useful for testing API routes and server components against a local server. */
   get EXPO_NO_DEPLOY(): boolean {
     return boolish('EXPO_NO_DEPLOY', false);

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -52,12 +52,12 @@ export function setNodeEnv(mode: EnvironmentMode) {
 
 export function getConfigEnvMode(): EnvironmentMode {
   try {
-    // Older EAS Build versions do not pass EXPO_CONFIG_MODE.
+    // Older EAS Build versions do not pass __EXPO_CONFIG_MODE.
     return env.consumeConfigEnvMode() ?? (cliEnv.EAS_BUILD ? 'production' : 'development');
   } catch (error) {
     throw new CommandError(
       'BAD_ARGS',
-      error instanceof Error ? error.message : 'Invalid EXPO_CONFIG_MODE value.'
+      error instanceof Error ? error.message : 'Invalid __EXPO_CONFIG_MODE value.'
     );
   }
 }

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -51,19 +51,15 @@ export function setNodeEnv(mode: EnvironmentMode) {
 }
 
 export function getConfigEnvMode(): EnvironmentMode {
-  const mode = cliEnv.EXPO_CONFIG_MODE;
-  delete process.env.EXPO_CONFIG_MODE;
-
-  if (!mode) {
-    return 'development';
-  }
-  if (mode !== 'development' && mode !== 'production') {
+  try {
+    // Older EAS Build versions do not pass EXPO_CONFIG_MODE.
+    return env.consumeConfigEnvMode() ?? (cliEnv.EAS_BUILD ? 'production' : 'development');
+  } catch (error) {
     throw new CommandError(
       'BAD_ARGS',
-      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
+      error instanceof Error ? error.message : 'Invalid EXPO_CONFIG_MODE value.'
     );
   }
-  return mode;
 }
 
 interface LoadEnvFilesOptions {
@@ -116,40 +112,36 @@ export function getEnvFiles(projectRoot: string, mode: EnvironmentMode) {
 export function reloadEnvFiles(projectRoot: string, mode: EnvironmentMode) {
   setNodeEnv(mode);
 
-  try {
-    const isEnabled = env.isEnabled();
-    if (isEnabled) {
-      const params = {
-        force: true,
-        silent: true,
-        mode,
-        systemEnv: process.env,
-      };
+  const isEnabled = env.isEnabled();
+  if (isEnabled) {
+    const params = {
+      force: true,
+      silent: true,
+      mode,
+      systemEnv: process.env,
+    };
 
-      // We use a global tracker to allow overwrites of env vars we set ourselves
-      const envInfo = env.parseProjectEnv(projectRoot, params);
-      const envOutput: EnvOutput = {};
-      for (const key in envInfo.env) {
-        const value = envInfo.env[key];
-        if (process.env[key] !== value) {
-          if (
-            typeof process.env[key] === 'undefined' ||
-            ((!prevEnvKeys || prevEnvKeys.has(key)) && process.env[key] !== value)
-          ) {
-            (prevEnvKeys ||= new Set()).add(key);
-            process.env[key] = envInfo.env[key];
-            envOutput[key] = value ?? undefined;
-          }
+    // We use a global tracker to allow overwrites of env vars we set ourselves
+    const envInfo = env.parseProjectEnv(projectRoot, params);
+    const envOutput: EnvOutput = {};
+    for (const key in envInfo.env) {
+      const value = envInfo.env[key];
+      if (process.env[key] !== value) {
+        if (
+          typeof process.env[key] === 'undefined' ||
+          ((!prevEnvKeys || prevEnvKeys.has(key)) && process.env[key] !== value)
+        ) {
+          (prevEnvKeys ||= new Set()).add(key);
+          process.env[key] = envInfo.env[key];
+          envOutput[key] = value ?? undefined;
         }
       }
-
-      event('load', {
-        mode: params.mode,
-        files: relativeFiles(envInfo.files),
-        keys: Object.keys(envOutput),
-      });
     }
-  } finally {
-    delete process.env.EXPO_CONFIG_MODE;
+
+    event('load', {
+      mode: params.mode,
+      files: relativeFiles(envInfo.files),
+      keys: Object.keys(envOutput),
+    });
   }
 }

--- a/packages/@expo/cli/src/utils/nodeEnv.ts
+++ b/packages/@expo/cli/src/utils/nodeEnv.ts
@@ -85,12 +85,7 @@ export function loadEnvFiles(projectRoot: string, options: LoadEnvFilesOptions) 
     systemEnv: process.env,
   };
 
-  let envInfo: ReturnType<typeof env.loadProjectEnv>;
-  try {
-    envInfo = env.loadProjectEnv(projectRoot, params);
-  } finally {
-    delete process.env.EXPO_CONFIG_MODE;
-  }
+  const envInfo = env.loadProjectEnv(projectRoot, params);
   const envOutput: EnvOutput = {};
   if (envInfo.result === 'loaded') {
     prevEnvKeys = new Set();

--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Set `NODE_ENV` when `loadProjectEnv` receives a development or production mode. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Remove `EXPO_CONFIG_MODE` after loading env files with a mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -7,11 +7,12 @@
 ### 🎉 New features
 
 - Add `setNodeEnv` for Expo commands and tools. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Add `consumeConfigEnvMode` for Expo commands and tools. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 🐛 Bug fixes
 
 - Set `NODE_ENV` when `loadProjectEnv` receives a development or production mode. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
-- Remove `EXPO_CONFIG_MODE` after loading env files with a mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Prevent env files from setting `EXPO_CONFIG_MODE`. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -7,14 +7,14 @@
 ### 🎉 New features
 
 - Add `setNodeEnv` for Expo commands and tools. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
-- Add `consumeConfigEnvMode` for Expo commands and tools. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 🐛 Bug fixes
 
 - Set `NODE_ENV` when `loadProjectEnv` receives a development or production mode. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
-- Prevent env files from setting `EXPO_CONFIG_MODE`. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
+
+- Pass the config mode through an internal variable and remove inherited dotenv values from Expo subprocesses. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ## 2.4.2 - 2026-07-15
 

--- a/packages/@expo/env/src/__tests__/index.test.ts
+++ b/packages/@expo/env/src/__tests__/index.test.ts
@@ -63,20 +63,20 @@ describe(setNodeEnv, () => {
 });
 
 describe(consumeConfigEnvMode, () => {
-  it('reads and removes EXPO_CONFIG_MODE', () => {
-    const systemEnv = { EXPO_CONFIG_MODE: 'production' };
+  it('reads and removes __EXPO_CONFIG_MODE', () => {
+    const systemEnv = { __EXPO_CONFIG_MODE: 'production' };
 
     expect(consumeConfigEnvMode({ systemEnv })).toBe('production');
-    expect(systemEnv.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(systemEnv.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 
-  it('removes an invalid EXPO_CONFIG_MODE value', () => {
-    process.env.EXPO_CONFIG_MODE = 'staging';
+  it('removes an invalid __EXPO_CONFIG_MODE value', () => {
+    process.env.__EXPO_CONFIG_MODE = 'staging';
 
     expect(() => consumeConfigEnvMode()).toThrow(
-      'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
+      'Invalid __EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
     );
-    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
+    expect(process.env.__EXPO_CONFIG_MODE).toBeUndefined();
   });
 });
 
@@ -517,6 +517,28 @@ describe(getOriginalEnv, () => {
     expect(getOriginalEnv()[LOADED_ENV_NAME]).toBeUndefined();
   });
 
+  it('removes dotenv values inherited from a parent process', () => {
+    const inheritedEnv = {
+      FOO: 'from-parent-dotenv',
+      PRE_EXISTING: 'original',
+      [LOADED_ENV_NAME]: JSON.stringify(['FOO']),
+    };
+
+    expect(getOriginalEnv(inheritedEnv)).toEqual({ PRE_EXISTING: 'original' });
+  });
+
+  it('removes inherited dotenv values after a forced local load', () => {
+    const inheritedEnv = {
+      FOO: 'from-parent-dotenv',
+      [LOADED_ENV_NAME]: JSON.stringify(['FOO']),
+    };
+    vol.fromJSON({ '.env': 'BAR=from-current-dotenv' }, '/');
+
+    loadProjectEnv('/', { force: true, systemEnv: inheritedEnv });
+
+    expect(getOriginalEnv(inheritedEnv)).toEqual({});
+  });
+
   it('preserves the pre-load value when loadProjectEnv skipped the assignment', () => {
     process.env.FOO = 'shell-provided';
     vol.fromJSON({ '.env': 'FOO=from-env' }, '/');
@@ -612,6 +634,18 @@ describe(getOriginalEnvValue, () => {
     expect(process.env.FOO).toBe('bar');
 
     expect(getOriginalEnvValue('FOO')).toBeUndefined();
+  });
+
+  it('returns undefined for a dotenv value inherited from a parent process', () => {
+    const inheritedEnv = {
+      FOO: 'from-parent-dotenv',
+      PRE_EXISTING: 'original',
+      [LOADED_ENV_NAME]: JSON.stringify(['FOO']),
+    };
+
+    expect(getOriginalEnvValue('FOO', inheritedEnv)).toBeUndefined();
+    expect(getOriginalEnvValue('PRE_EXISTING', inheritedEnv)).toBe('original');
+    expect(getOriginalEnvValue(LOADED_ENV_NAME, inheritedEnv)).toBeUndefined();
   });
 
   it('falls through to systemEnv for keys @expo/env never touched', () => {
@@ -779,10 +813,10 @@ describe('isLocalEnvKey policy', () => {
     expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/EXPO_UNSAFE_DOTENV_KEYS/);
   });
 
-  it('blocks EXPO_CONFIG_MODE in env files', () => {
-    vol.fromJSON({ '.env': 'EXPO_CONFIG_MODE=production' }, '/');
+  it('blocks __EXPO_CONFIG_MODE in env files', () => {
+    vol.fromJSON({ '.env': '__EXPO_CONFIG_MODE=production' }, '/');
 
-    expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/EXPO_CONFIG_MODE/);
+    expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/__EXPO_CONFIG_MODE/);
   });
 
   it('combines both violation classes into a single thrown error', () => {

--- a/packages/@expo/env/src/__tests__/index.test.ts
+++ b/packages/@expo/env/src/__tests__/index.test.ts
@@ -5,6 +5,7 @@ import { stripVTControlCharacters } from 'node:util';
 
 import type { loadEnvFiles } from '../';
 import {
+  consumeConfigEnvMode,
   getEnvFiles,
   getOriginalEnv,
   getOriginalEnvValue,
@@ -58,6 +59,24 @@ describe(setNodeEnv, () => {
       EXAMPLE: 'value',
     });
     expect(process.env.NODE_ENV).toBe('development');
+  });
+});
+
+describe(consumeConfigEnvMode, () => {
+  it('reads and removes EXPO_CONFIG_MODE', () => {
+    const systemEnv = { EXPO_CONFIG_MODE: 'production' };
+
+    expect(consumeConfigEnvMode({ systemEnv })).toBe('production');
+    expect(systemEnv.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('removes an invalid EXPO_CONFIG_MODE value', () => {
+    process.env.EXPO_CONFIG_MODE = 'staging';
+
+    expect(() => consumeConfigEnvMode()).toThrow(
+      'Invalid EXPO_CONFIG_MODE value: "staging". Use "development" or "production".'
+    );
+    expect(process.env.EXPO_CONFIG_MODE).toBeUndefined();
   });
 });
 
@@ -341,24 +360,6 @@ describe(loadProjectEnv, () => {
       loaded: ['FOO'],
     });
     expect(process.env.NODE_ENV).toBe('production');
-  });
-
-  it('removes EXPO_CONFIG_MODE after loading with a mode', () => {
-    const systemEnv: NodeJS.ProcessEnv = { EXPO_CONFIG_MODE: 'production' };
-    vol.fromJSON({ '.env.production': 'EXPO_CONFIG_MODE=development' }, '/');
-
-    loadProjectEnv('/', { mode: 'production', systemEnv });
-
-    expect(systemEnv.NODE_ENV).toBe('production');
-    expect(systemEnv.EXPO_CONFIG_MODE).toBeUndefined();
-  });
-
-  it('keeps EXPO_CONFIG_MODE when no mode is given', () => {
-    process.env.EXPO_CONFIG_MODE = 'production';
-
-    loadProjectEnv('/');
-
-    expect(process.env.EXPO_CONFIG_MODE).toBe('production');
   });
 
   it('parses .env file with mutating system environment variables', () => {
@@ -776,6 +777,12 @@ describe('isLocalEnvKey policy', () => {
 
     expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/NODE_OPTIONS/);
     expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/EXPO_UNSAFE_DOTENV_KEYS/);
+  });
+
+  it('blocks EXPO_CONFIG_MODE in env files', () => {
+    vol.fromJSON({ '.env': 'EXPO_CONFIG_MODE=production' }, '/');
+
+    expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/EXPO_CONFIG_MODE/);
   });
 
   it('combines both violation classes into a single thrown error', () => {

--- a/packages/@expo/env/src/__tests__/index.test.ts
+++ b/packages/@expo/env/src/__tests__/index.test.ts
@@ -343,6 +343,24 @@ describe(loadProjectEnv, () => {
     expect(process.env.NODE_ENV).toBe('production');
   });
 
+  it('removes EXPO_CONFIG_MODE after loading with a mode', () => {
+    const systemEnv: NodeJS.ProcessEnv = { EXPO_CONFIG_MODE: 'production' };
+    vol.fromJSON({ '.env.production': 'EXPO_CONFIG_MODE=development' }, '/');
+
+    loadProjectEnv('/', { mode: 'production', systemEnv });
+
+    expect(systemEnv.NODE_ENV).toBe('production');
+    expect(systemEnv.EXPO_CONFIG_MODE).toBeUndefined();
+  });
+
+  it('keeps EXPO_CONFIG_MODE when no mode is given', () => {
+    process.env.EXPO_CONFIG_MODE = 'production';
+
+    loadProjectEnv('/');
+
+    expect(process.env.EXPO_CONFIG_MODE).toBe('production');
+  });
+
   it('parses .env file with mutating system environment variables', () => {
     delete process.env.FOO;
     vol.fromJSON({ '.env': 'FOO=bar' }, '/');

--- a/packages/@expo/env/src/constants.ts
+++ b/packages/@expo/env/src/constants.ts
@@ -25,6 +25,7 @@ export function isIgnoredEnvKey(name: string) {
   switch (name) {
     // NOTE: Expo internal env vars
     case '__EXPO_ENV_LOADED':
+    case 'EXPO_CONFIG_MODE':
     case 'EXPO_NO_DOTENV':
     case 'EXPO_UNSAFE_DOTENV_KEYS':
       return true;

--- a/packages/@expo/env/src/constants.ts
+++ b/packages/@expo/env/src/constants.ts
@@ -25,7 +25,7 @@ export function isIgnoredEnvKey(name: string) {
   switch (name) {
     // NOTE: Expo internal env vars
     case '__EXPO_ENV_LOADED':
-    case 'EXPO_CONFIG_MODE':
+    case '__EXPO_CONFIG_MODE':
     case 'EXPO_NO_DOTENV':
     case 'EXPO_UNSAFE_DOTENV_KEYS':
       return true;

--- a/packages/@expo/env/src/index.ts
+++ b/packages/@expo/env/src/index.ts
@@ -56,6 +56,24 @@ export function setNodeEnv(
   return systemEnv;
 }
 
+/** Read and remove the mode passed by a parent Expo tool. */
+export function consumeConfigEnvMode({ systemEnv = process.env }: { systemEnv?: EnvOutput } = {}):
+  | EnvMode
+  | undefined {
+  const mode = systemEnv.EXPO_CONFIG_MODE;
+  delete systemEnv.EXPO_CONFIG_MODE;
+
+  if (!mode) {
+    return undefined;
+  }
+  if (mode !== 'development' && mode !== 'production') {
+    throw new Error(
+      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
+    );
+  }
+  return mode;
+}
+
 /**
  * Get a list of all `.env*` files based on the `NODE_ENV` mode.
  * This returns a list of files, in order of highest priority to lowest priority.
@@ -287,8 +305,7 @@ export function parseProjectEnv(
 /**
  * Parse all environment variables using the detected list of `.env*` files from a project.
  * This won't override existing environment variables defined in the system environment.
- * A development or production mode also sets `NODE_ENV` before loading and removes
- * `EXPO_CONFIG_MODE` after loading.
+ * A development or production mode also sets `NODE_ENV` before loading.
  * Once the mutations are done, this will also set a property `__EXPO_ENV=true` on the system env to avoid multiple mutations.
  * This check can be disabled through `{ force: true }`.
  */
@@ -296,24 +313,14 @@ export function loadProjectEnv(
   projectRoot: string,
   options?: Parameters<typeof getEnvFiles>[0] & Parameters<typeof loadEnvFiles>[1]
 ) {
-  const mode = options?.mode;
-  const systemEnv = options?.systemEnv ?? process.env;
-  const hasExpoMode = mode === 'development' || mode === 'production';
-
-  if (hasExpoMode) {
-    setNodeEnv(mode, { systemEnv });
+  if (options?.mode === 'development' || options?.mode === 'production') {
+    setNodeEnv(options.mode, { systemEnv: options.systemEnv });
   }
 
-  try {
-    return loadEnvFiles(
-      getEnvFiles(options).map((envFile) => path.join(projectRoot, envFile)),
-      options
-    );
-  } finally {
-    if (hasExpoMode) {
-      delete systemEnv.EXPO_CONFIG_MODE;
-    }
-  }
+  return loadEnvFiles(
+    getEnvFiles(options).map((envFile) => path.join(projectRoot, envFile)),
+    options
+  );
 }
 
 /**

--- a/packages/@expo/env/src/index.ts
+++ b/packages/@expo/env/src/index.ts
@@ -39,6 +39,21 @@ export const KNOWN_MODES = ['development', 'test', 'production'];
 /** The environment variable name to use when marking the environment as loaded */
 export const LOADED_ENV_NAME = '__EXPO_ENV_LOADED';
 
+function getLoadedEnvKeys(loadedEnvMarker: string | undefined): string[] {
+  if (!loadedEnvMarker) {
+    return [];
+  }
+
+  try {
+    const loadedKeys = JSON.parse(loadedEnvMarker);
+    return Array.isArray(loadedKeys)
+      ? loadedKeys.filter((key): key is string => typeof key === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+}
+
 /** Modes used by Expo commands and tools. */
 export type EnvMode = 'development' | 'production';
 
@@ -56,19 +71,19 @@ export function setNodeEnv(
   return systemEnv;
 }
 
-/** Read and remove the mode passed by a parent Expo tool. */
+/** @internal Read and remove the config mode passed by a parent Expo tool. */
 export function consumeConfigEnvMode({ systemEnv = process.env }: { systemEnv?: EnvOutput } = {}):
   | EnvMode
   | undefined {
-  const mode = systemEnv.EXPO_CONFIG_MODE;
-  delete systemEnv.EXPO_CONFIG_MODE;
+  const mode = systemEnv.__EXPO_CONFIG_MODE;
+  delete systemEnv.__EXPO_CONFIG_MODE;
 
   if (!mode) {
     return undefined;
   }
   if (mode !== 'development' && mode !== 'production') {
     throw new Error(
-      `Invalid EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
+      `Invalid __EXPO_CONFIG_MODE value: "${mode}". Use "development" or "production".`
     );
   }
   return mode;
@@ -331,8 +346,9 @@ export function loadProjectEnv(
  * `.env*` files were loaded — for example, when resolving SDK tooling paths
  * that should not be influenced by project-controlled `.env` values.
  *
- * Allocates lazily: nothing is held until this function is called, and each
- * call returns a new object so callers may mutate it freely.
+ * An inherited `__EXPO_ENV_LOADED` marker identifies dotenv values loaded by a parent process.
+ *
+ * Each call returns a new object so callers may mutate it freely.
  *
  * @param systemEnv The env to revert against; defaults to `process.env`.
  */
@@ -348,14 +364,26 @@ export function getOriginalEnv(systemEnv: EnvOutput = process.env): EnvOutput {
       }
     }
   }
+
+  // A new process cannot access its parent's in-memory backup, so use the inherited marker to
+  // remove the parent's dotenv values.
+  for (const key of getLoadedEnvKeys(result[LOADED_ENV_NAME])) {
+    if (!isUnsafeAllowedEnvKey(key)) {
+      delete result[key];
+    }
+  }
+  delete result[LOADED_ENV_NAME];
+
   return result;
 }
 
 /**
  * Get the pre-load value of a single environment variable as recorded by
  * `@expo/env`. Falls through to the value in `systemEnv` for keys that
- * `@expo/env` never touched. O(1) and allocation-free, intended for read-sites
- * that resolve filesystem paths or executables from a single env var.
+ * `@expo/env` never touched. Intended for read-sites that resolve filesystem
+ * paths or executables from a single env var.
+ *
+ * An inherited `__EXPO_ENV_LOADED` marker identifies dotenv values loaded by a parent process.
  *
  * Honors `EXPO_UNSAFE_DOTENV_KEYS`: keys the caller has explicitly opted into
  * via the escape hatch return their currently loaded value, not the original.
@@ -368,6 +396,16 @@ export function getOriginalEnvValue(
   systemEnv: EnvOutput = process.env
 ): string | undefined {
   const backup = originalEnvBackup.get(systemEnv);
+  const marker = backup?.has(LOADED_ENV_NAME)
+    ? backup.get(LOADED_ENV_NAME)
+    : systemEnv[LOADED_ENV_NAME];
+
+  if (
+    key === LOADED_ENV_NAME ||
+    (!isUnsafeAllowedEnvKey(key) && getLoadedEnvKeys(marker).includes(key))
+  ) {
+    return undefined;
+  }
   if (backup && backup.has(key)) {
     return backup.get(key);
   }

--- a/packages/@expo/env/src/index.ts
+++ b/packages/@expo/env/src/index.ts
@@ -287,7 +287,8 @@ export function parseProjectEnv(
 /**
  * Parse all environment variables using the detected list of `.env*` files from a project.
  * This won't override existing environment variables defined in the system environment.
- * A development or production mode also sets `NODE_ENV` before loading.
+ * A development or production mode also sets `NODE_ENV` before loading and removes
+ * `EXPO_CONFIG_MODE` after loading.
  * Once the mutations are done, this will also set a property `__EXPO_ENV=true` on the system env to avoid multiple mutations.
  * This check can be disabled through `{ force: true }`.
  */
@@ -295,14 +296,24 @@ export function loadProjectEnv(
   projectRoot: string,
   options?: Parameters<typeof getEnvFiles>[0] & Parameters<typeof loadEnvFiles>[1]
 ) {
-  if (options?.mode === 'development' || options?.mode === 'production') {
-    setNodeEnv(options.mode, { systemEnv: options.systemEnv });
+  const mode = options?.mode;
+  const systemEnv = options?.systemEnv ?? process.env;
+  const hasExpoMode = mode === 'development' || mode === 'production';
+
+  if (hasExpoMode) {
+    setNodeEnv(mode, { systemEnv });
   }
 
-  return loadEnvFiles(
-    getEnvFiles(options).map((envFile) => path.join(projectRoot, envFile)),
-    options
-  );
+  try {
+    return loadEnvFiles(
+      getEnvFiles(options).map((envFile) => path.join(projectRoot, envFile)),
+      options
+    );
+  } finally {
+    if (hasExpoMode) {
+      delete systemEnv.EXPO_CONFIG_MODE;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
# Why

The EAS changes in [#4180](https://github.com/expo/eas-cli/pull/4180) tell Expo to use development or production mode when loading app config, so we needed a temporary internal environment variable that Expo reads and removes before app config loads.

# How

I added `__EXPO_CONFIG_MODE` as an internal handoff that `@expo/env` reads and removes before Expo loads the dotenv files and app config. I blocked `.env` files from setting the handoff and updated `getOriginalEnv()` and `getOriginalEnvValue()` to exclude dotenv values inherited from a parent process. We still use `EAS_BUILD` as the production fallback for older EAS versions.

# Test Plan

Tests and package checks pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)