### PR TITLE
[expo-codemod] Fix react-navigation codemod skipping migratable imports in mixed files

### DIFF
--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ahmdshrif](https://github.com/ahmdshrif))
+- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#48941](https://github.com/expo/expo/pull/48941) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ahmdshrif](https://github.com/ahmdshrif))
+
 ### 💡 Others
 
 ## 57.0.0 - 2026-06-25

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -393,16 +393,20 @@ describe('unsupported packages (no direct equivalent)', () => {
     );
   });
 
-  test('throws even when other react-navigation imports would otherwise be rewritten', () => {
+  test('reports the unsupported package but still migrates the supported import in the same file', () => {
     const input = [
       `import { useNavigation } from '@react-navigation/native';`,
       `import { createDrawerNavigator } from '@react-navigation/drawer';`,
     ].join('\n');
-    run(input);
+    const output = run(input);
+    // The unsupported package is reported for manual migration...
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy.mock.calls[0]).toHaveLength(1);
     const message = errorSpy.mock.calls[0]![0] as string;
     expect(message).toContain('import from "@react-navigation/drawer" cannot be migrated');
+    // ...but the supported import is still migrated (rather than silently skipped).
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`import { createDrawerNavigator } from '@react-navigation/drawer'`);
   });
 });
 
@@ -567,5 +571,37 @@ describe('merging type and value imports', () => {
     expect(output).toBe(
       `import { useRouter, type NavigationProp } from "expo-router/react-navigation";`
     );
+  });
+});
+
+describe('mixed files: migratable imports are rewritten even alongside unsupported ones', () => {
+  test('rewrites named import when the file also imports from @react-navigation/native-stack', () => {
+    const input = [
+      `import { NavigationContainer } from '@react-navigation/native';`,
+      `import { createNativeStackNavigator } from '@react-navigation/native-stack';`,
+    ].join('\n');
+    const output = run(input);
+    // The migratable named import is rewritten...
+    expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
+    // ...the unsupported package is reported for manual migration...
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain('@react-navigation/native-stack');
+    // ...and left untouched for the user to migrate by hand.
+    expect(output).toContain(
+      `import { createNativeStackNavigator } from '@react-navigation/native-stack'`
+    );
+  });
+
+  test('rewrites a clean named import while leaving a default-style import in the same file', () => {
+    const input = [
+      `import { NavigationContainer } from '@react-navigation/native';`,
+      `import Stack from '@react-navigation/stack';`,
+    ].join('\n');
+    const output = run(input);
+    // Clean named import migrated...
+    expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
+    // ...default-style import reported and left untouched.
+    expect(errorSpy).toHaveBeenCalled();
+    expect(output).toContain(`import Stack from '@react-navigation/stack'`);
   });
 });

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -585,7 +585,7 @@ describe('mixed files: migratable imports are rewritten even alongside unsupport
     expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
     // ...the unsupported package is reported for manual migration...
     expect(errorSpy).toHaveBeenCalled();
-    expect(errorSpy.mock.calls[0][0]).toContain('@react-navigation/native-stack');
+    expect(errorSpy.mock.calls[0]![0]).toContain('@react-navigation/native-stack');
     // ...and left untouched for the user to migrate by hand.
     expect(output).toContain(
       `import { createNativeStackNavigator } from '@react-navigation/native-stack'`

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -201,13 +201,27 @@ const transform: Transform = (fileInfo, api) => {
     printErrorBlock('Unsupported import style — manual change needed', errors);
   }
 
-  if (unsupportedPackageErrors.length || errors.length) {
-    return undefined;
-  }
-
+  // We intentionally do not bail out of the entire file when there are
+  // unsupported packages (e.g. native-stack/drawer) or unsupported import
+  // styles. Those are reported above for the user to migrate manually, but any
+  // clean named imports in the same file must still be rewritten. Otherwise they
+  // are left pointing at `@react-navigation/*`, which silently loads a second
+  // copy of react-navigation and crashes at navigator registration.
+  let didRewrite = false;
   for (const path of mappablePaths) {
+    const specifiers = (path.node.specifiers ?? []) as ImportSpecifierWithKind[];
+    // Skip imports we cannot safely rewrite (default/namespace style). These are
+    // reported above and left untouched for the user to migrate manually.
+    if (specifiers.some((spec) => UNSUPPORTED_SPECIFIERS[spec.type] != null)) {
+      continue;
+    }
     const sourceModule = path.node.source.value as string;
     path.node.source.value = IMPORT_MAP[sourceModule];
+    didRewrite = true;
+  }
+
+  if (!didRewrite) {
+    return undefined;
   }
 
   const groups = groupPathsBySource(root.find(j.ImportDeclaration).paths());

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -204,9 +204,15 @@ const transform: Transform = (fileInfo, api) => {
   // We intentionally do not bail out of the entire file when there are
   // unsupported packages (e.g. native-stack/drawer) or unsupported import
   // styles. Those are reported above for the user to migrate manually, but any
-  // clean named imports in the same file must still be rewritten. Otherwise they
-  // are left pointing at `@react-navigation/*`, which silently loads a second
-  // copy of react-navigation and crashes at navigator registration.
+  // clean named imports in the same file must still be rewritten — otherwise
+  // they are silently left on `@react-navigation/*` with nothing reported about
+  // them, which is the failure mode this codemod exists to prevent.
+  //
+  // A file that still holds a reported import is not usable until that manual
+  // migration happens either way: Metro rejects any `@react-navigation/*`
+  // import from app code once expo-router is installed (see
+  // `withMetroMultiPlatform.ts`). Migrating what we can shrinks the manual step
+  // instead of hiding it.
   let didRewrite = false;
   for (const path of mappablePaths) {
     const specifiers = (path.node.specifiers ?? []) as ImportSpecifierWithKind[];


### PR DESCRIPTION
# Why

Fixes #46481. Split out of #46679 as requested by @Ubax — this PR contains only the bug fix; the named re-export / `jest.mock` reporting work is in a separate PR.

The `sdk-56-expo-router-react-navigation-replace` codemod is supposed to rewrite every `@react-navigation/{native,bottom-tabs,material-top-tabs,stack,...}` import to its `expo-router/*` equivalent. On real codebases it silently leaves a large share of imports unmigrated.

Root cause: the transform **bails out of the entire file** as soon as it sees *any* unsupported import:

```ts
if (unsupportedPackageErrors.length || errors.length) {
  return undefined; // skips the whole file
}
```

Unsupported imports include `@react-navigation/native-stack` and `@react-navigation/drawer` (which the vast majority of apps use) and default/namespace imports. So any file that also imports `native-stack` has its perfectly migratable `@react-navigation/native` named imports left untouched — with no error pointing at them. The result compiles and bundles, but loads a second copy of `@react-navigation`, crashing at navigator registration:

> Couldn't register the navigator. … This can also happen if there are multiple copies of '@react-navigation' packages installed.

# How

Don't abort the whole file. Migrate the clean named imports, and only skip the *specific* imports that can't be rewritten (default/namespace style). Unsupported packages (`native-stack`/`drawer`) and unsupported styles are still reported for manual migration and left untouched — exactly as before — but they no longer suppress the migration of unrelated, migratable imports in the same file.

A `didRewrite` flag preserves the previous "no changes" return for files where nothing could be rewritten.

The change is localized to the transform's rewrite step; the warning/reporting behavior is unchanged.

# Test Plan

`et test expo-codemod` (run locally via an isolated jscodeshift + jest harness): **51 passed**.

- All existing tests still pass — the previous behavior was only exercised with *single-import* files, which still short-circuit to "no changes" (now via "nothing was rewritten") and still print their warnings.
- Updated the one mixed-file test (`native` + `drawer`) to assert the new, correct behavior: the supported import is migrated **and** the unsupported package is reported.
- Added tests for the previously-broken mixed cases:
  - migratable named import alongside `@react-navigation/native-stack` → named import migrated, `native-stack` reported + left untouched
  - clean named import alongside a default-style import → named import migrated, default-style import reported + left untouched

# Checklist

- [x] I added a [changelog entry](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md).
- [x] Tested the changes.
