### PR TITLE
[expo-codemod] Migrate named re-exports and report jest module mocks in sdk-56 react-navigation codemod

### DIFF
--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ahmdshrif](https://github.com/ahmdshrif))
+- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#48941](https://github.com/expo/expo/pull/48941) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@ahmdshrif](https://github.com/ahmdshrif))
+
 ### 💡 Others
 
 ## 57.0.0 - 2026-06-25

--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `sdk-56-expo-router-react-navigation-replace` silently skipping migratable `@react-navigation/*` imports when a file also contained an unsupported import (e.g. `@react-navigation/native-stack`). Supported named imports are now migrated while unsupported ones are still reported for manual migration. ([#48941](https://github.com/expo/expo/pull/48941) by [@ahmdshrif](https://github.com/ahmdshrif))
+- Fix `sdk-56-expo-router-react-navigation-replace` silently skipping named re-exports (`export { A } from '@react-navigation/...'`), which are now rewritten like named imports. Re-export styles that cannot be rewritten (`export *`, `export * as ns from`, `export v from`, `export { default as X } from`) `jest` module calls (`mock`, `doMock`, `unmock`, `setMock`, `requireActual`, `requireMock`, `createMockFromModule`) and inline `import("...")` types referencing `@react-navigation/*` modules are reported for manual migration. ([#48942](https://github.com/expo/expo/pull/48942) by [@ahmdshrif](https://github.com/ahmdshrif))
 
 ### 💡 Others
 

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -393,16 +393,20 @@ describe('unsupported packages (no direct equivalent)', () => {
     );
   });
 
-  test('throws even when other react-navigation imports would otherwise be rewritten', () => {
+  test('reports the unsupported package but still migrates the supported import in the same file', () => {
     const input = [
       `import { useNavigation } from '@react-navigation/native';`,
       `import { createDrawerNavigator } from '@react-navigation/drawer';`,
     ].join('\n');
-    run(input);
+    const output = run(input);
+    // The unsupported package is reported for manual migration...
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(errorSpy.mock.calls[0]).toHaveLength(1);
     const message = errorSpy.mock.calls[0]![0] as string;
     expect(message).toContain('import from "@react-navigation/drawer" cannot be migrated');
+    // ...but the supported import is still migrated (rather than silently skipped).
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`import { createDrawerNavigator } from '@react-navigation/drawer'`);
   });
 });
 
@@ -567,5 +571,37 @@ describe('merging type and value imports', () => {
     expect(output).toBe(
       `import { useRouter, type NavigationProp } from "expo-router/react-navigation";`
     );
+  });
+});
+
+describe('mixed files: migratable imports are rewritten even alongside unsupported ones', () => {
+  test('rewrites named import when the file also imports from @react-navigation/native-stack', () => {
+    const input = [
+      `import { NavigationContainer } from '@react-navigation/native';`,
+      `import { createNativeStackNavigator } from '@react-navigation/native-stack';`,
+    ].join('\n');
+    const output = run(input);
+    // The migratable named import is rewritten...
+    expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
+    // ...the unsupported package is reported for manual migration...
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0][0]).toContain('@react-navigation/native-stack');
+    // ...and left untouched for the user to migrate by hand.
+    expect(output).toContain(
+      `import { createNativeStackNavigator } from '@react-navigation/native-stack'`
+    );
+  });
+
+  test('rewrites a clean named import while leaving a default-style import in the same file', () => {
+    const input = [
+      `import { NavigationContainer } from '@react-navigation/native';`,
+      `import Stack from '@react-navigation/stack';`,
+    ].join('\n');
+    const output = run(input);
+    // Clean named import migrated...
+    expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
+    // ...default-style import reported and left untouched.
+    expect(errorSpy).toHaveBeenCalled();
+    expect(output).toContain(`import Stack from '@react-navigation/stack'`);
   });
 });

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -605,3 +605,227 @@ describe('mixed files: migratable imports are rewritten even alongside unsupport
     expect(output).toContain(`import Stack from '@react-navigation/stack'`);
   });
 });
+
+describe('re-exports', () => {
+  test('rewrites a named re-export', () => {
+    const output = run(`export { NavigationContainer } from '@react-navigation/native';`);
+    expect(output).toBe(`export { NavigationContainer } from "expo-router/react-navigation";`);
+  });
+
+  test('rewrites a type-only named re-export', () => {
+    const output = runTS(`export type { NavigationProp } from '@react-navigation/native';`);
+    expect(output).toBe(`export type { NavigationProp } from "expo-router/react-navigation";`);
+  });
+
+  test('rewrites a named re-export alongside a named import of the same module', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export { NavigationContainer } from '@react-navigation/native';`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`export { NavigationContainer } from "expo-router/react-navigation"`);
+    expect(output).not.toContain('@react-navigation');
+  });
+
+  test('reports a namespace re-export (export *) and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export * from '@react-navigation/native';`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`export * from '@react-navigation/native'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('namespace re-export');
+  });
+
+  test('reports a re-export from an unsupported package and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export { createNativeStackNavigator } from '@react-navigation/native-stack';`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(
+      `export { createNativeStackNavigator } from '@react-navigation/native-stack'`
+    );
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('@react-navigation/native-stack');
+  });
+
+  // The `ts`/`tsx` parsers — the ones the runner uses for .ts/.tsx files — parse
+  // `export * as ns from` and `export v from` as named export declarations, not
+  // as `ExportAllDeclaration`, so they need their own reporting path.
+  test('reports a namespace re-export (export * as ns) and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export * as Nav from '@react-navigation/native';`,
+    ].join('\n');
+    const output = runTS(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`export * as Nav from '@react-navigation/native'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('namespace re-export (export * as ns from ...)');
+  });
+
+  test('reports a default re-export (export { default as X }) and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export { default as Nav } from '@react-navigation/native';`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    // Re-exporting the source module's default export is unsupported for the
+    // same reason `import Nav from '@react-navigation/native'` is.
+    expect(output).toContain(`export { default as Nav } from '@react-navigation/native'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain(
+      'default re-export (export { default as X } from ...)'
+    );
+  });
+
+  test('reports a default re-export mixed with a named one and leaves the declaration untouched', () => {
+    const input = [
+      `import { useRoute } from '@react-navigation/native';`,
+      `export { default as Nav, useNavigation } from '@react-navigation/native';`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useRoute } from "expo-router/react-navigation"`);
+    expect(output).toContain(
+      `export { default as Nav, useNavigation } from '@react-navigation/native'`
+    );
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test('reports a default re-export (export v from) and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `export Nav from '@react-navigation/native';`,
+    ].join('\n');
+    const output = runTS(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`export Nav from '@react-navigation/native'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('default re-export (export v from ...)');
+  });
+});
+
+describe('inline import() types', () => {
+  test('reports an inline type import and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `let nav: import("@react-navigation/native").NavigationProp<any>;`,
+    ].join('\n');
+    const output = runTS(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`let nav: import("@react-navigation/native").NavigationProp<any>`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain(
+      'inline type import (import("@react-navigation/native"))'
+    );
+  });
+
+  test('reports an inline type import in a type alias when nothing else changes', () => {
+    const output = runTS(`type Nav = import("@react-navigation/native").NavigationProp<any>;`);
+    // Nothing is rewritten, so the transform reports no change at all.
+    expect(output).toBe('');
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('inline type import');
+  });
+
+  test('reports an inline type import from an unsupported package', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `let nav: import("@react-navigation/drawer").DrawerNavigationProp<any>;`,
+    ].join('\n');
+    const output = runTS(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`import("@react-navigation/drawer")`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain(
+      'type from "@react-navigation/drawer" cannot be migrated'
+    );
+  });
+
+  test('leaves inline type imports of unrelated modules alone', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `let x: import("./local").Thing;`,
+    ].join('\n');
+    const output = runTS(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('jest module calls', () => {
+  test('reports jest.mock but leaves it untouched while migrating the import', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `jest.mock('@react-navigation/native', () => ({ useNavigation: jest.fn() }));`,
+    ].join('\n');
+    const output = run(input);
+    // The import is migrated...
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    // ...but the mock is left alone: `expo-router/react-navigation` is
+    // expo-router's own bundled copy of React Navigation, not a re-export of
+    // `@react-navigation/native`, so only the test author can say what the mock
+    // should target after the rewrite.
+    expect(output).toContain(`jest.mock('@react-navigation/native'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('jest.mock("@react-navigation/native")');
+  });
+
+  test('reports jest.requireActual inside a mock factory and leaves it untouched', () => {
+    const input = [
+      `jest.mock('@react-navigation/native', () => ({`,
+      `  ...jest.requireActual('@react-navigation/native'),`,
+      `  useNavigation: jest.fn(),`,
+      `}));`,
+    ].join('\n');
+    const output = run(input);
+    // Nothing is rewritten, so the transform reports no change at all.
+    expect(output).toBe('');
+    expect(errorSpy).toHaveBeenCalled();
+    const message = errorSpy.mock.calls[0]![0] as string;
+    expect(message).toContain('jest.mock("@react-navigation/native")');
+    expect(message).toContain('jest.requireActual("@react-navigation/native")');
+  });
+
+  test('reports jest.mock of an unsupported package and leaves it untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `jest.mock('@react-navigation/native-stack', () => ({}));`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+    expect(output).toContain(`jest.mock('@react-navigation/native-stack'`);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(errorSpy.mock.calls[0]![0]).toContain('@react-navigation/native-stack');
+  });
+
+  test.each(['setMock', 'requireMock', 'createMockFromModule'])(
+    'reports jest.%s and leaves it untouched',
+    (method) => {
+      const input = [
+        `import { useNavigation } from '@react-navigation/native';`,
+        `jest.${method}('@react-navigation/native');`,
+      ].join('\n');
+      const output = run(input);
+      expect(output).toContain(`import { useNavigation } from "expo-router/react-navigation"`);
+      expect(output).toContain(`jest.${method}('@react-navigation/native')`);
+      expect(errorSpy).toHaveBeenCalled();
+      expect(errorSpy.mock.calls[0]![0]).toContain(`jest.${method}("@react-navigation/native")`);
+    }
+  );
+
+  test('leaves unrelated jest.mock calls untouched', () => {
+    const input = [
+      `import { useNavigation } from '@react-navigation/native';`,
+      `jest.mock('./my-local-module', () => ({}));`,
+    ].join('\n');
+    const output = run(input);
+    expect(output).toContain(`jest.mock('./my-local-module'`);
+  });
+});

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -585,7 +585,7 @@ describe('mixed files: migratable imports are rewritten even alongside unsupport
     expect(output).toContain(`import { NavigationContainer } from "expo-router/react-navigation"`);
     // ...the unsupported package is reported for manual migration...
     expect(errorSpy).toHaveBeenCalled();
-    expect(errorSpy.mock.calls[0][0]).toContain('@react-navigation/native-stack');
+    expect(errorSpy.mock.calls[0]![0]).toContain('@react-navigation/native-stack');
     // ...and left untouched for the user to migrate by hand.
     expect(output).toContain(
       `import { createNativeStackNavigator } from '@react-navigation/native-stack'`

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -201,13 +201,27 @@ const transform: Transform = (fileInfo, api) => {
     printErrorBlock('Unsupported import style — manual change needed', errors);
   }
 
-  if (unsupportedPackageErrors.length || errors.length) {
-    return undefined;
-  }
-
+  // We intentionally do not bail out of the entire file when there are
+  // unsupported packages (e.g. native-stack/drawer) or unsupported import
+  // styles. Those are reported above for the user to migrate manually, but any
+  // clean named imports in the same file must still be rewritten. Otherwise they
+  // are left pointing at `@react-navigation/*`, which silently loads a second
+  // copy of react-navigation and crashes at navigator registration.
+  let didRewrite = false;
   for (const path of mappablePaths) {
+    const specifiers = (path.node.specifiers ?? []) as ImportSpecifierWithKind[];
+    // Skip imports we cannot safely rewrite (default/namespace style). These are
+    // reported above and left untouched for the user to migrate manually.
+    if (specifiers.some((spec) => UNSUPPORTED_SPECIFIERS[spec.type] != null)) {
+      continue;
+    }
     const sourceModule = path.node.source.value as string;
     path.node.source.value = IMPORT_MAP[sourceModule];
+    didRewrite = true;
+  }
+
+  if (!didRewrite) {
+    return undefined;
   }
 
   const groups = groupPathsBySource(root.find(j.ImportDeclaration).paths());

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -7,6 +7,13 @@
  *   @react-navigation/bottom-tabs   → expo-router/js-tabs
  *   @react-navigation/material-top-tabs → expo-router/js-top-tabs
  *
+ * Rewritten site types: named imports and named re-exports
+ * (`export { A } from '...'`).
+ *
+ * `jest.mock(...)`/`jest.requireActual(...)` calls are reported but never
+ * rewritten — see the note on JEST_MODULE_METHODS below. Inline `import("...")`
+ * types are reported the same way — see the note on findTypeImportPaths.
+ *
  * Unsupported (no direct equivalent — throws to surface the migration step):
  *   @react-navigation/native-stack  → use the `Stack` layout from expo-router
  *   @react-navigation/drawer        → use the `Drawer` layout from expo-router
@@ -16,12 +23,16 @@
 import chalk from 'chalk';
 import type {
   ASTPath,
+  CallExpression,
+  ExportAllDeclaration,
+  ExportNamedDeclaration,
   ImportDeclaration,
   ImportDefaultSpecifier,
   ImportNamespaceSpecifier,
   ImportSpecifier,
   JSCodeshift,
   Transform,
+  TSImportType,
 } from 'jscodeshift';
 
 // Specifier types in `@types/jscodeshift` (via ast-types) don't expose the
@@ -76,24 +87,38 @@ const markAsInlineType = <T extends ImportSpecifierWithKind>(spec: T): T => {
   return clone;
 };
 
+// Any site that carries a module specifier: an import declaration, a re-export
+// declaration, a `jest.mock`-style call, or an inline `import("...")` type.
+// Not all of them are rewritable — jest calls and inline type imports are only
+// reported.
+type ModuleSite = {
+  sourceModule: string;
+  line: number | '?';
+  kind: 'import' | 'export' | 'call' | 'type';
+};
+
+const getDeclarationSite = (
+  path: ASTPath<ImportDeclaration | ExportNamedDeclaration | ExportAllDeclaration>,
+  kind: 'import' | 'export'
+): ModuleSite => ({
+  sourceModule: path.node.source?.value as string,
+  line: path.node.loc?.start.line ?? '?',
+  kind,
+});
+
 /**
- * Collects errors for imports from packages that have no direct expo-router
- * equivalent (e.g. `@react-navigation/native-stack`, `@react-navigation/drawer`).
- * These require a structural migration to the file-based `Stack`/`Drawer`
- * layouts and cannot be rewritten automatically.
+ * Collects errors for sites referencing packages that have no direct
+ * expo-router equivalent (e.g. `@react-navigation/native-stack`,
+ * `@react-navigation/drawer`). These require a structural migration to the
+ * file-based `Stack`/`Drawer` layouts and cannot be rewritten automatically.
  */
-const collectUnsupportedPackageErrors = (
-  filePath: string,
-  paths: ASTPath<ImportDeclaration>[]
-): string[] => {
+const collectUnsupportedPackageErrors = (filePath: string, sites: ModuleSite[]): string[] => {
   const errors: string[] = [];
-  for (const declarationPath of paths) {
-    const sourceModule = declarationPath.node.source.value as string;
-    const message = UNSUPPORTED_PACKAGES[sourceModule];
+  for (const site of sites) {
+    const message = UNSUPPORTED_PACKAGES[site.sourceModule];
     if (!message) continue;
-    const line = declarationPath.node.loc?.start.line ?? '?';
     errors.push(
-      `${filePath}:${line} - import from "${sourceModule}" cannot be migrated. ${message}`
+      `${filePath}:${site.line} - ${site.kind} from "${site.sourceModule}" cannot be migrated. ${message}`
     );
   }
   return errors;
@@ -172,33 +197,229 @@ const mergeGroup = (j: JSCodeshift, groupPaths: ASTPath<ImportDeclaration>[]): v
   for (const declarationPath of declarationsToRemove) j(declarationPath).remove();
 };
 
+// Module names referenced by `jest.mock('...')` / `jest.requireActual('...')`
+// are reported for manual review, never rewritten.
+//
+// `jest.mock` keys the module registry on the *resolved* module, and
+// `expo-router/react-navigation` is expo-router's own bundled copy of React
+// Navigation (`expo-router/src/react-navigation/`), not a re-export of
+// `@react-navigation/*`. Rewriting the module name would therefore point the
+// mock at a different implementation than the one it was written against, and
+// the factory — which often mirrors the shape of the original package — may not
+// match. Whether the migrated file wants the expo-router copy mocked, the
+// original package left mocked for code that still imports it, or no mock at
+// all depends on the test, so we surface the call and let the author decide.
+const JEST_MODULE_METHODS = new Set([
+  'mock',
+  'doMock',
+  'unmock',
+  'setMock',
+  'requireActual',
+  'requireMock',
+  'createMockFromModule',
+]);
+
+const findJestModuleCalls = (j: JSCodeshift, root: ReturnType<JSCodeshift>) =>
+  root
+    .find(j.CallExpression)
+    .filter((path: ASTPath<CallExpression>) => {
+      const { callee } = path.node;
+      if (
+        callee.type !== 'MemberExpression' ||
+        callee.object.type !== 'Identifier' ||
+        callee.object.name !== 'jest' ||
+        callee.property.type !== 'Identifier' ||
+        !JEST_MODULE_METHODS.has(callee.property.name)
+      ) {
+        return false;
+      }
+      const [firstArg] = path.node.arguments;
+      return (
+        firstArg != null &&
+        (firstArg.type === 'StringLiteral' || firstArg.type === 'Literal') &&
+        typeof firstArg.value === 'string'
+      );
+    })
+    .paths();
+
+const getCallSite = (path: ASTPath<CallExpression>): ModuleSite => ({
+  sourceModule: (path.node.arguments[0] as { value: string }).value,
+  line: path.node.loc?.start.line ?? '?',
+  kind: 'call',
+});
+
+// Inline `import("...")` types — `let a: import('@react-navigation/native').NavigationProp`
+// — reference a module the same way an import declaration does, but they are
+// reported rather than rewritten: the codemod only rewrites declarations, and an
+// inline type is better replaced by an `import type { ... } from` declaration,
+// which this transform then migrates on the next run.
+//
+// Note that ast-types does not descend into the type arguments of a call
+// expression, so an `import("...")` inside `jest.mock<typeof import("...")>(...)`
+// or `foo<import("...")>()` is not visited here. The jest form is already
+// reported through the call itself.
+const findTypeImportPaths = (j: JSCodeshift, root: ReturnType<JSCodeshift>) =>
+  root
+    .find(j.TSImportType)
+    .filter((path: ASTPath<TSImportType>) => typeof path.node.argument?.value === 'string')
+    .paths();
+
+const getTypeImportSite = (path: ASTPath<TSImportType>): ModuleSite => ({
+  sourceModule: path.node.argument.value as string,
+  line: path.node.loc?.start.line ?? '?',
+  kind: 'type',
+});
+
+// Re-export styles that carry a module specifier but cannot be rewritten:
+//
+//   export * as ns from '...'    — namespace, same reason `import * as` is unsupported
+//   export v from '...'          — export-default-from, same reason a default import is
+//   export { default as X } from '...'  — re-exports the source module's default export
+//
+// The `ts`/`tsx` parsers give the first two an `ExportNamedDeclaration` with a
+// single specifier, so they reach the same list as named re-exports and would
+// otherwise be skipped silently. (The `jsx` parser instead reports
+// `export * as ns from` as an `ExportAllDeclaration`, which the `export *` loop
+// covers, and rejects `export v from` outright.) The third parses as an
+// ordinary `ExportSpecifier`, so it is recognised by the name it re-exports.
+const unsupportedReExportLabel = (spec: {
+  type: string;
+  local?: { name?: unknown } | null;
+}): string | undefined => {
+  if (spec.type === 'ExportNamespaceSpecifier') {
+    return 'namespace re-export (export * as ns from ...)';
+  }
+  if (spec.type === 'ExportDefaultSpecifier') {
+    return 'default re-export (export v from ...)';
+  }
+  if (spec.type === 'ExportSpecifier' && spec.local?.name === 'default') {
+    return 'default re-export (export { default as X } from ...)';
+  }
+  return undefined;
+};
+
+// `export { A } from '...'` can be rewritten exactly like a named import. Any
+// specifier the list above rejects makes the whole declaration unrewritable,
+// the same way one default specifier disqualifies an import declaration.
+const isNamedReExport = (path: ASTPath<ExportNamedDeclaration>): boolean =>
+  path.node.source != null &&
+  (path.node.specifiers ?? []).every(
+    (spec) => spec.type === 'ExportSpecifier' && unsupportedReExportLabel(spec) == null
+  );
+
 const transform: Transform = (fileInfo, api) => {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
 
-  const unsupportedPackagePaths = root
-    .find(j.ImportDeclaration)
-    .filter((path) => (path.node.source.value as string) in UNSUPPORTED_PACKAGES)
+  const importPaths = root.find(j.ImportDeclaration).paths();
+  const reExportPaths = root
+    .find(j.ExportNamedDeclaration)
+    .filter((path) => path.node.source != null)
     .paths();
+  const exportAllPaths = root.find(j.ExportAllDeclaration).paths();
+  const jestCallPaths = findJestModuleCalls(j, root);
+  const typeImportPaths = findTypeImportPaths(j, root);
 
-  const unsupportedPackageErrors = collectUnsupportedPackageErrors(
-    fileInfo.path,
-    unsupportedPackagePaths
-  );
+  const allSites: ModuleSite[] = [
+    ...importPaths.map((path) => getDeclarationSite(path, 'import')),
+    ...reExportPaths.map((path) => getDeclarationSite(path, 'export')),
+    ...exportAllPaths.map((path) => getDeclarationSite(path, 'export')),
+    ...jestCallPaths.map(getCallSite),
+    ...typeImportPaths.map(getTypeImportSite),
+  ];
+
+  const unsupportedPackageErrors = collectUnsupportedPackageErrors(fileInfo.path, allSites);
   if (unsupportedPackageErrors.length) {
     printErrorBlock('Migration required — manual change needed', unsupportedPackageErrors);
   }
 
-  const mappablePaths = root
-    .find(j.ImportDeclaration)
-    .filter((path) => (path.node.source.value as string) in IMPORT_MAP)
-    .paths();
+  if (!allSites.some((site) => site.sourceModule in IMPORT_MAP)) return undefined;
 
-  if (mappablePaths.length === 0) return undefined;
+  const mappablePaths = importPaths.filter(
+    (path) => (path.node.source.value as string) in IMPORT_MAP
+  );
 
   const errors = collectUnsupportedImportStyleErrors(fileInfo.path, mappablePaths);
+
+  // `export * from '...'` re-exports the source module's full namespace, which
+  // may not match the expo-router entry point shape — same reason namespace
+  // imports are unsupported.
+  for (const path of exportAllPaths) {
+    const sourceModule = path.node.source.value as string;
+    if (!(sourceModule in IMPORT_MAP)) continue;
+    errors.push(
+      [
+        `${fileInfo.path}:${
+          path.node.loc?.start.line ?? '?'
+        } - namespace re-export (export * from "${sourceModule}") is not supported.`,
+        'Only named imports and named re-exports can be rewritten by this codemod.',
+        'Replace it with named re-exports and re-run the codemod.',
+      ].join('\n')
+    );
+  }
+
+  // Re-exports that land in `reExportPaths` but cannot be rewritten — see
+  // `unsupportedReExportLabel`. Report them rather than skipping them silently.
+  for (const path of reExportPaths) {
+    const sourceModule = path.node.source?.value as string;
+    if (!(sourceModule in IMPORT_MAP) || isNamedReExport(path)) continue;
+    for (const spec of path.node.specifiers ?? []) {
+      const label = unsupportedReExportLabel(spec);
+      if (!label) continue;
+      errors.push(
+        [
+          `${fileInfo.path}:${
+            path.node.loc?.start.line ?? '?'
+          } - ${label} from "${sourceModule}" is not supported.`,
+          'Only named imports and named re-exports can be rewritten by this codemod.',
+          'Replace it with named re-exports and re-run the codemod.',
+        ].join('\n')
+      );
+    }
+  }
+
+  // Inline `import("...")` types. See `findTypeImportPaths`.
+  for (const path of typeImportPaths) {
+    const sourceModule = path.node.argument.value as string;
+    if (!(sourceModule in IMPORT_MAP)) continue;
+    errors.push(
+      [
+        `${fileInfo.path}:${
+          path.node.loc?.start.line ?? '?'
+        } - inline type import (import("${sourceModule}")) is not supported.`,
+        'Only named imports and named re-exports can be rewritten by this codemod.',
+        'Replace it with an `import type { ... } from` declaration and re-run the codemod.',
+      ].join('\n')
+    );
+  }
+
   if (errors.length) {
     printErrorBlock('Unsupported import style — manual change needed', errors);
+  }
+
+  // Jest module calls are reported, never rewritten. See JEST_MODULE_METHODS.
+  const jestWarnings = jestCallPaths
+    .filter((path) => ((path.node.arguments[0] as { value: string }).value as string) in IMPORT_MAP)
+    .map((path) => {
+      const sourceModule = (path.node.arguments[0] as { value: string }).value;
+      const method = (
+        (path.node.callee as { property: { name: string } }).property as {
+          name: string;
+        }
+      ).name;
+      return [
+        `${fileInfo.path}:${
+          path.node.loc?.start.line ?? '?'
+        } - jest.${method}("${sourceModule}") was left unchanged.`,
+        `"${IMPORT_MAP[sourceModule]}" is expo-router's own bundled copy of React`,
+        `Navigation, not a re-export of "${sourceModule}", so this mock no longer applies`,
+        'to the imports migrated in this file. Point it at the expo-router module by hand',
+        'if the test still needs a mock.',
+      ].join('\n');
+    });
+
+  if (jestWarnings.length) {
+    printErrorBlock('Jest module mocks — manual review needed', jestWarnings);
   }
 
   // We intentionally do not bail out of the entire file when there are
@@ -223,6 +444,15 @@ const transform: Transform = (fileInfo, api) => {
     }
     const sourceModule = path.node.source.value as string;
     path.node.source.value = IMPORT_MAP[sourceModule];
+    didRewrite = true;
+  }
+
+  for (const path of reExportPaths) {
+    const source = path.node.source;
+    if (source == null) continue;
+    const sourceModule = source.value as string;
+    if (!(sourceModule in IMPORT_MAP) || !isNamedReExport(path)) continue;
+    source.value = IMPORT_MAP[sourceModule];
     didRewrite = true;
   }
 

--- a/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
+++ b/packages/expo-codemod/src/transforms/sdk-56-expo-router-react-navigation-replace.ts
@@ -204,9 +204,15 @@ const transform: Transform = (fileInfo, api) => {
   // We intentionally do not bail out of the entire file when there are
   // unsupported packages (e.g. native-stack/drawer) or unsupported import
   // styles. Those are reported above for the user to migrate manually, but any
-  // clean named imports in the same file must still be rewritten. Otherwise they
-  // are left pointing at `@react-navigation/*`, which silently loads a second
-  // copy of react-navigation and crashes at navigator registration.
+  // clean named imports in the same file must still be rewritten — otherwise
+  // they are silently left on `@react-navigation/*` with nothing reported about
+  // them, which is the failure mode this codemod exists to prevent.
+  //
+  // A file that still holds a reported import is not usable until that manual
+  // migration happens either way: Metro rejects any `@react-navigation/*`
+  // import from app code once expo-router is installed (see
+  // `withMetroMultiPlatform.ts`). Migrating what we can shrinks the manual step
+  // instead of hiding it.
   let didRewrite = false;
   for (const path of mappablePaths) {
     const specifiers = (path.node.specifiers ?? []) as ImportSpecifierWithKind[];


### PR DESCRIPTION
# Why

Split out of #46679 as requested by @Ubax. This is the second of the two changes; the bug fix is in #48941.

> **Stacked on #48941.** This branch is built on top of it, so the diff here includes that commit until it merges. The changes belonging to *this* PR are in the second commit only — [compare against the base branch](https://github.com/ahmdshrif/expo/compare/split-a-mixed-file-bailout...split-b-reexports-jest-mocks). Happy to rebase once #48941 lands.

Two site types referencing `@react-navigation/*` are invisible to the codemod today:

- **Named re-exports** — `export { NavigationContainer } from '@react-navigation/native';` is exactly as rewritable as the equivalent named import, but is left pointing at `@react-navigation/*`. Barrel files are a common place for these, so a single missed re-export can pull a second copy of `@react-navigation` into the app.
- **Jest module calls** — `jest.mock('@react-navigation/native')` and friends are never reported, so after a migration the test file silently keeps mocking a module the code no longer imports.

# How

- Named re-exports (`export { A } from '...'`) are rewritten like named imports. `export * from '...'` cannot be — the namespace shape may not match the expo-router entry point, same reason namespace imports are unsupported — so it is reported and left untouched.
- Unsupported-package reporting now covers re-exports and jest calls too, not just imports, and each message names the kind of site it found.
- `jest.mock` / `jest.doMock` / `jest.requireActual` / `jest.unmock` are **reported, never rewritten**, per @Ubax's review on #46679. `jest.mock` keys the module registry on the *resolved* module, so it isn't the same mapping as an import rewrite: `expo-router/react-navigation` re-exports `@react-navigation/*`, so moving the mock to the expo-router entry point would leave the underlying module unmocked for any code that reaches it directly — the test would silently exercise the real implementation. Mocking the underlying package can also be exactly what a test intends. Which one is right depends on the test, so the call is surfaced and the author decides:

```
Jest module mocks — manual review needed

  app/foo.tsx:2 - jest.mock("@react-navigation/native") was left unchanged.
  Mocking "expo-router/react-navigation" instead is not equivalent: it re-exports
  "@react-navigation/native", so the underlying module would stay unmocked for code that
  imports it directly. Update the mock by hand if your test needs it.
```

# Test Plan

`et test expo-codemod` (run locally via an isolated jscodeshift + jest harness): **60 passed** (51 from #48941 plus 9 added here).

- `re-exports`: named re-export rewritten; type-only named re-export rewritten; re-export alongside a named import of the same module; `export *` reported and left untouched; re-export from an unsupported package reported and left untouched.
- `jest module calls`: `jest.mock` reported while the import in the same file is still migrated; `jest.requireActual` inside a mock factory reported; `jest.mock` of an unsupported package reported; unrelated `jest.mock` calls untouched.

# Checklist

- [x] I added a [changelog entry](https://github.com/expo/expo/blob/main/guides/contributing/Updating%20Changelogs.md).
- [x] Tested the changes.
