### PR TITLE
[ui][ios] Forward modifiers to the native view in Overlay, Alert, ConfirmationDialog and Popover

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [iOS] Fix `community/bottom-sheet` close callbacks firing before the sheet finished dismissing. ([#48389](https://github.com/expo/expo/issues/48389) by [@nicklamont](https://github.com/nicklamont)) ([#48436](https://github.com/expo/expo/pull/48436) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed viewport size measurement reading the main screen instead of the scene the view is in. ([#48170](https://github.com/expo/expo/pull/48170) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed `Overlay`, `Alert`, `ConfirmationDialog` and `Popover` silently ignoring the `modifiers` prop, which never reached the native view. (by [@Den1Marshall](https://github.com/Den1Marshall))
+- [iOS] Fixed `Overlay`, `Alert`, `ConfirmationDialog` and `Popover` silently ignoring the `modifiers` prop, which never reached the native view. ([#48949](https://github.com/expo/expo/pull/48949) by [@Den1Marshall](https://github.com/Den1Marshall))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Fix `community/bottom-sheet` close callbacks firing before the sheet finished dismissing. ([#48389](https://github.com/expo/expo/issues/48389) by [@nicklamont](https://github.com/nicklamont)) ([#48436](https://github.com/expo/expo/pull/48436) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the `community/datetime-picker` field collapsing to zero width — invisible and untappable — when its parent doesn't stretch it (e.g. `alignItems: 'center'`). ([#47033](https://github.com/expo/expo/pull/47033) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed viewport size measurement reading the main screen instead of the scene the view is in. ([#48170](https://github.com/expo/expo/pull/48170) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed `Overlay`, `Alert`, `ConfirmationDialog` and `Popover` silently ignoring the `modifiers` prop, which never reached the native view. (by [@Den1Marshall](https://github.com/Den1Marshall))
 
 ### 💡 Others
 

--- a/packages/expo-ui/src/swift-ui/Alert/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Alert/index.tsx
@@ -73,6 +73,7 @@ function Alert(props: AlertProps) {
   return (
     <AlertNativeView
       {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      modifiers={modifiers}
       {...restProps}
       onIsPresentedChange={handleIsPresentedChange}>
       {children}

--- a/packages/expo-ui/src/swift-ui/ConfirmationDialog/index.tsx
+++ b/packages/expo-ui/src/swift-ui/ConfirmationDialog/index.tsx
@@ -76,6 +76,7 @@ function ConfirmationDialog(props: ConfirmationDialogProps) {
   return (
     <ConfirmationDialogNativeView
       {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      modifiers={modifiers}
       {...restProps}
       onIsPresentedChange={handleIsPresentedChange}>
       {children}

--- a/packages/expo-ui/src/swift-ui/Overlay/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Overlay/index.tsx
@@ -30,6 +30,7 @@ export function Overlay(props: OverlayProps) {
   return (
     <OverlayNativeView
       {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      modifiers={modifiers}
       {...restProps}>
       {children}
     </OverlayNativeView>

--- a/packages/expo-ui/src/swift-ui/Popover/index.tsx
+++ b/packages/expo-ui/src/swift-ui/Popover/index.tsx
@@ -56,6 +56,7 @@ export function Popover(props: PopoverViewProps) {
   return (
     <PopoverNativeView
       {...(modifiers ? createViewModifierEventListener(modifiers) : undefined)}
+      modifiers={modifiers}
       {...restProps}
       isPresented={isPresented}
       onIsPresentedChange={handleIsPresentedChange}>


### PR DESCRIPTION
# Why

Follow-up to #48904, where @brentvatne spotted that `Background` declared a
`modifiers` prop but never forwarded it. The same bug is in `main` for four more
components: `Overlay`, `Alert`, `ConfirmationDialog` and `Popover`. Every
modifier passed to them is silently ignored.

# How

All four destructured `modifiers` out of the props and used it only as the
source of event listeners – `createViewModifierEventListener` returns just
`{ onGlobalEvent }`, so the array itself never reached the native view. They now
pass it on, the same way `Shapes`, `Button` and `List` already do.

The native side needed no changes: their props inherit the `modifiers` field
from `UIBaseViewProps`, and `ExpoUIView` wraps each view in `UIBaseView`, which
calls `applyModifiers`.

# Test Plan

Verified in bare-expo on the iOS simulator: temporarily added
`modifiers={[opacity(0.4)]}` to the `Overlay` in the native-component-list
screen (not part of this PR) and confirmed the whole composition — the card and
the NEW badge – renders translucent. Before the fix the modifier had no effect.

`et check-packages @expo/ui` passes.

| Before | After |
| --- | --- |
| <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-15 at 01 58 02" src="https://github.com/user-attachments/assets/60adc458-64eb-4b8f-b5be-2ef7669c8dce" /> | <img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-15 at 01 57 53" src="https://github.com/user-attachments/assets/8687cbe0-3fae-4e7b-b491-4ff461f70d46" /> |



# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build
- [x] Conforms with the Documentation Writing Style Guide
