### PR TITLE
[expo-video][android] Guard setAutoEnterEnabled against NoSuchMethodError on non-conformant firmwares

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Guard `PictureInPictureParams.Builder.setAutoEnterEnabled` against `NoSuchMethodError` on stock OEM firmwares that report API 31+ without shipping the method, which crashed the app from `VideoView.onLayout` even when Picture in Picture was disabled. ([#48957](https://github.com/expo/expo/pull/48957) by [@onlyshyun](https://github.com/onlyshyun))
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureUtils.kt
@@ -87,7 +87,17 @@ internal fun applyPiPParams(activity: Activity, autoEnterPiP: Boolean, aspectRat
       paramsBuilder.setAspectRatio(it)
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-      paramsBuilder.setAutoEnterEnabled(autoEnterPiP)
+      // Some stock OEM firmwares report SDK_INT >= 31 and FEATURE_PICTURE_IN_PICTURE while shipping a
+      // framework.jar that does not contain PictureInPictureParams.Builder.setAutoEnterEnabled, so the
+      // API level check above is not a sufficient capability signal. NoSuchMethodError is an Error, not
+      // an Exception, so it is not covered by runWithPiPMisconfigurationSoftHandling below. Auto-enter
+      // PiP is the only functionality lost by skipping the call, which beats an unrecoverable crash in
+      // View.onLayout.
+      try {
+        paramsBuilder.setAutoEnterEnabled(autoEnterPiP)
+      } catch (e: NoSuchMethodError) {
+        Log.w("ExpoVideo", "PictureInPictureParams.Builder.setAutoEnterEnabled is missing on this device, skipping auto-enter PiP setup", e)
+      }
     }
     runWithPiPMisconfigurationSoftHandling {
       activity.setPictureInPictureParams(paramsBuilder.build())


### PR DESCRIPTION
# Why

`PictureInPictureUtils.applyPiPParams` guards the `setAutoEnterEnabled` call with `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S`, which is correct per the platform docs. We have production crashes from **two different OEMs** whose **stock, unmodified** firmwares report `SDK_INT >= 31` **and** `PackageManager.FEATURE_PICTURE_IN_PICTURE`, yet whose `framework.jar` does not contain `PictureInPictureParams$Builder.setAutoEnterEnabled(Z)`:

| Device                        | Android | `SDK_INT` | ROM state  |
| ----------------------------- | ------- | --------- | ---------- |
| Samsung SM-A325F (Galaxy A32) | 13      | 33        | unmodified |
| motorola one 5G UW ace        | 12      | 31        | unmodified |

Because the API level check and the PiP system-feature check **both pass**, there is no capability signal left for the library to branch on. The only way to survive this is to attempt the call and catch the failure.

**To be clear about where the fault lies: the root cause is the OEM firmware, not `expo-video`.** `setAutoEnterEnabled` is a standard public API since API 31, and shipping a build that reports `SDK_INT` 31/33 without it is a compatibility violation on the vendor's side. Trusting `SDK_INT` as a capability signal is the documented approach, so the current code isn't wrong.

The problem is that **`expo-video` is the only layer that can do anything about it.** These are budget devices that will not receive a firmware update, and app developers have no way out either:

- The `NoSuchMethodError` propagates out of `VideoView.onLayout`, so it fires on **every layout pass** that mounts a `VideoView` — it cannot be caught or recovered from in app code.
- It is not opt-in. `findAndSetupPipCandidate` calls `applyPiPParams` inside the `if (!newAutoEnter)` branch too, so apps that never enable PiP (`allowsPictureInPicture={false}` or the default) are affected identically.

In our app the affected screen is the first screen after launch, so those users cannot get into the app at all — relaunching just crashes again. We see **3 distinct installations / 24 crash events / 19 sessions** over 90 days; the roughly one-event-per-session ratio is the signature of launch → crash → relaunch → crash again.

<details>
<summary>Stack trace</summary>

```
java.lang.NoSuchMethodError: No virtual method setAutoEnterEnabled(Z)Landroid/app/PictureInPictureParams$Builder;
in class Landroid/app/PictureInPictureParams$Builder; or its super classes
(declaration of 'android.app.PictureInPictureParams$Builder' appears in /system/framework/framework.jar)

  at expo.modules.video.utils.PictureInPictureUtilsKt.applyPiPParams (PictureInPictureUtils.kt:90)
  at expo.modules.video.utils.PictureInPictureUtilsKt.applyPiPParams$default (PictureInPictureUtils.kt:79)
  at expo.modules.video.managers.PictureInPictureManager.findAndSetupPipCandidate (PictureInPictureManager.kt:78)
  at expo.modules.video.managers.PictureInPictureManager.onPiPParamsChanged (PictureInPictureManager.kt:111)
  at expo.modules.video.VideoView.pipParams_delegate$lambda$2 (VideoView.kt:96)
  at expo.modules.video.delegates.IgnoreSameSet.setValue (IgnoreSameSet.kt:22)
  at expo.modules.video.VideoView.setPipParams (VideoView.kt:94)
  at expo.modules.video.VideoView.onLayout (VideoView.kt:338)
  at android.view.View.layout (View.java:22972)
  at android.view.ViewGroup.layout (ViewGroup.java:6389)
  at com.facebook.react.fabric.mounting.SurfaceMountingManager.updateLayout (SurfaceMountingManager.java:983)
  ...
```

Samsung build fingerprint from the native crash dump, showing a stock release build:

```
FINGERPRINT: samsung/a32ser/a32:13/TP1A.220624.014/A325FXXSCDXL2:user/release-keys
TAGS: release-keys
SDK: 33
VERSION.RELEASE: 13
```

</details>

Note that one of the two devices is on **Android 12 / API 31 itself** — the release that introduced `setAutoEnterEnabled`. That suggests some OEM firmwares from that period shipped without the method fully present, and that this is not specific to one vendor or SKU. Affected devices can't be enumerated ahead of time, so a device allowlist/denylist isn't a viable mitigation.

# How

Treat the setter as best-effort. Auto-enter PiP is the only functionality lost when it is unavailable, so degrading gracefully is strictly better than an unrecoverable crash.

Two things worth noting about how this fits the existing code:

1. **This isn't a new pattern — it's a consistency fix.** Every other PiP framework call in this file already goes through `runWithPiPMisconfigurationSoftHandling`, which soft-handles `IllegalStateException` from a misconfigured manifest for exactly the same reason (the library can't verify device/manifest state up front). `setAutoEnterEnabled` was the one call sitting _outside_ that protection:

   ```kotlin
   if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     paramsBuilder.setAutoEnterEnabled(autoEnterPiP)   // <- not wrapped
   }
   runWithPiPMisconfigurationSoftHandling {
     activity.setPictureInPictureParams(paramsBuilder.build())   // <- wrapped
   }
   ```

2. **Simply moving the call inside that block would not fix it.** `NoSuchMethodError` is an `Error` (a `LinkageError`), not an `Exception`, so it isn't caught by `catch (e: IllegalStateException)`. It has to be caught explicitly — done inline here, but I'm happy to widen the helper instead if you'd prefer that shape.

# Test Plan

I don't have access to either affected device, so I could not verify the fix on failing hardware — the data above comes from production crash reporting. I want to be upfront about that rather than imply a test I didn't run.

What I can say about verifiability:

- **This is not a flaky or low-probability bug.** `NoSuchMethodError` is a static linkage failure — the method is either present in `framework.jar` or it isn't, with no timing or race component — and the call site is reached from `View.onLayout`, so it fires on every layout pass. On an affected firmware build it reproduces **100% of the time**. (Strictly the unit is the firmware build, not the model — the fingerprint above is `A325FXXSCDXL2`, so a different build for the same model may well contain the method.)
- **The change is a provable no-op on conformant devices.** `setAutoEnterEnabled` either resolves (behaviour identical to before) or it doesn't (currently a fatal crash). There is no third state, so there is no behavioural risk to devices that work today.
- The failure path can be simulated on any device by temporarily replacing the call with `throw NoSuchMethodError()`: before the change the app crash-loops on any screen containing a `VideoView`; after it, the video renders and only auto-enter PiP is skipped.

We are already shipping the equivalent change as a `yarn patch` in our own app, compiled from source (see below), and it builds and passes our release pipeline — so the change is at least known to compile and not to regress conformant devices in a real app.

Downstream context: we currently ship this exact change as a `yarn patch`. On Expo SDK 55 that alone isn't enough, because `expo-video` is linked as a precompiled AAR, so patching the Kotlin source in `node_modules` has no effect. We also had to add:

```json
"expo": { "autolinking": { "android": { "buildFromSource": ["expo-video"] } } }
```

which forces `expo-video` to compile from source and measurably increases Android build times on every build, including CI. An upstream fix lets us drop both workarounds.

Affected versions: the relevant code block is byte-identical in `55.0.11` (where we observed the crashes), `55.0.18`, `55.0.19` (`sdk-55`), `57.0.2` (`latest`) and current `main`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
