### PR TITLE
[eslint-plugin-expo] Add no-sensitive-public-env-var rule

### DIFF
--- a/packages/eslint-plugin-expo/README.md
+++ b/packages/eslint-plugin-expo/README.md
@@ -32,6 +32,7 @@ Then configure the rules you want to use under the rules section.
 {
   "rules": {
     "expo/no-env-var-destructuring": "error",
+    "expo/no-sensitive-public-env-var": "error",
     "expo/no-dynamic-env-var": "error",
     "expo/use-dom-exports": "error",
     "expo/prefer-box-shadow": "warn"
@@ -45,5 +46,6 @@ Then configure the rules you want to use under the rules section.
 | :----------------------------------------------------------------- | :-------------------------------------------------------------------------------------- |
 | [no-dynamic-env-var](docs/rules/no-dynamic-env-var.md)             | Prevents process.env from being accessed dynamically                                    |
 | [no-env-var-destructuring](docs/rules/no-env-var-destructuring.md) | Disallow destructuring of environment variables                                         |
+| [no-sensitive-public-env-var](docs/rules/no-sensitive-public-env-var.md) | Prevents credentials from being stored in EXPO_PUBLIC_ environment variables |
 | [use-dom-exports](docs/rules/use-dom-exports.md)                   | Enforce using DOM exports from react-native-web                                         |
 | [prefer-box-shadow](docs/rules/prefer-box-shadow.md)               | Suggest using box-shadow instead of shadowColor/shadowOffset/shadowOpacity/shadowRadius |

--- a/packages/eslint-plugin-expo/docs/rules/no-sensitive-public-env-var.md
+++ b/packages/eslint-plugin-expo/docs/rules/no-sensitive-public-env-var.md
@@ -1,0 +1,61 @@
+# Prevents credentials from being stored in EXPO_PUBLIC_ environment variables (`expo/no-sensitive-public-env-var`)
+
+Environment variables prefixed with `EXPO_PUBLIC_` are inlined into the JavaScript bundle at build time. Anyone with the app can read them, as the [environment variables guide](https://docs.expo.dev/guides/environment-variables/#security-considerations) says:
+
+> Never store sensitive secrets in environment variables that are prefixed with `EXPO_PUBLIC_`. When an end-user runs your app, they have access to all of the code and embedded environment variables in your app.
+
+Nothing enforces this today. The failure is quiet: the value inlines, the app works, and the credential ships inside the bundle.
+
+## Rule Details
+
+This rule reports `process.env.EXPO_PUBLIC_*` where the variable name suggests a credential rather than configuration.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const key = process.env.EXPO_PUBLIC_API_KEY;
+const secret = process.env.EXPO_PUBLIC_STRIPE_SECRET_KEY;
+const password = process.env.EXPO_PUBLIC_DB_PASSWORD;
+
+fetch(url, {
+  headers: { Authorization: process.env.EXPO_PUBLIC_AUTH_TOKEN },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const url = process.env.EXPO_PUBLIC_API_URL;
+const enabled = process.env.EXPO_PUBLIC_ENABLE_BETA;
+
+// Not prefixed with EXPO_PUBLIC_, so it is not inlined into the bundle
+const secret = process.env.STRIPE_SECRET_KEY;
+```
+
+The name is split on `_` and each segment is checked, so `EXPO_PUBLIC_MONKEY` and `EXPO_PUBLIC_AUTHORITY` are not reported.
+
+## Options
+
+```json
+{
+  "expo/no-sensitive-public-env-var": [
+    "error",
+    {
+      "allow": ["EXPO_PUBLIC_MAPS_KEY"],
+      "additionalPatterns": ["TENANT_ID$"]
+    }
+  ]
+}
+```
+
+- `allow` — variable names to exempt. Some keys really are meant to be public, for example a browser-restricted Google Maps key.
+- `additionalPatterns` — extra regular expressions to treat as sensitive, for project specific naming.
+
+## When Not To Use It
+
+If you're not using Expo, or if you have decided every `EXPO_PUBLIC_` value in your project is safe to ship and would rather not annotate exceptions.
+
+## Further Reading
+
+- [Environment variables in Expo, security considerations](https://docs.expo.dev/guides/environment-variables/#security-considerations)
+- [Storing sensitive info, React Native](https://reactnative.dev/docs/security#storing-sensitive-info)

--- a/packages/eslint-plugin-expo/src/__tests__/no-sensitive-public-env-var.test.ts
+++ b/packages/eslint-plugin-expo/src/__tests__/no-sensitive-public-env-var.test.ts
@@ -1,0 +1,67 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+
+import { noSensitivePublicEnvVar } from '../rules/no-sensitive-public-env-var';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('noSensitivePublicEnvVar', noSensitivePublicEnvVar, {
+  valid: [
+    // Configuration, not credentials.
+    { code: 'const url = process.env.EXPO_PUBLIC_API_URL;' },
+    { code: 'const flag = process.env.EXPO_PUBLIC_ENABLE_BETA;' },
+    { code: 'const name = process.env.EXPO_PUBLIC_APP_NAME;' },
+    // Not public, so not inlined.
+    { code: 'const secret = process.env.STRIPE_SECRET_KEY;' },
+    { code: 'const token = process.env.AUTH_TOKEN;' },
+    // A word merely containing a sensitive substring is not a match.
+    { code: 'const monkey = process.env.EXPO_PUBLIC_MONKEY;' },
+    { code: 'const authority = process.env.EXPO_PUBLIC_AUTHORITY;' },
+    // Dynamic access is covered by no-dynamic-env-var, not this rule.
+    { code: 'const value = process.env["EXPO_PUBLIC_API_KEY"];' },
+    // Explicitly allowed.
+    {
+      code: 'const key = process.env.EXPO_PUBLIC_MAPS_KEY;',
+      options: [{ allow: ['EXPO_PUBLIC_MAPS_KEY'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'const key = process.env.EXPO_PUBLIC_API_KEY;',
+      errors: [
+        {
+          messageId: 'sensitivePublicEnvVar',
+          data: { name: 'EXPO_PUBLIC_API_KEY' },
+        },
+      ],
+    },
+    {
+      code: 'const secret = process.env.EXPO_PUBLIC_STRIPE_SECRET_KEY;',
+      errors: [{ messageId: 'sensitivePublicEnvVar' }],
+    },
+    {
+      code: 'fetch(url, { headers: { Authorization: process.env.EXPO_PUBLIC_AUTH_TOKEN } });',
+      errors: [{ messageId: 'sensitivePublicEnvVar' }],
+    },
+    {
+      code: 'const pw = process.env.EXPO_PUBLIC_DB_PASSWORD;',
+      errors: [{ messageId: 'sensitivePublicEnvVar' }],
+    },
+    {
+      code: 'const pk = process.env.EXPO_PUBLIC_PRIVATE_KEY;',
+      errors: [{ messageId: 'sensitivePublicEnvVar' }],
+    },
+    {
+      code: 'const id = process.env.EXPO_PUBLIC_TENANT_ID;',
+      options: [{ additionalPatterns: ['TENANT_ID$'] }],
+      errors: [{ messageId: 'sensitivePublicEnvVar' }],
+    },
+  ],
+});

--- a/packages/eslint-plugin-expo/src/rules/index.ts
+++ b/packages/eslint-plugin-expo/src/rules/index.ts
@@ -1,11 +1,13 @@
 import { noDynamicEnvVar } from './no-dynamic-env-var';
 import { noEnvVarDestructuring } from './no-env-var-destructuring';
+import { noSensitivePublicEnvVar } from './no-sensitive-public-env-var';
 import { preferBoxShadow } from './prefer-box-shadow';
 import { useDomExports } from './use-dom-exports';
 
 export const rules = {
   'no-dynamic-env-var': noDynamicEnvVar,
   'no-env-var-destructuring': noEnvVarDestructuring,
+  'no-sensitive-public-env-var': noSensitivePublicEnvVar,
   'prefer-box-shadow': preferBoxShadow,
   'use-dom-exports': useDomExports,
 };

--- a/packages/eslint-plugin-expo/src/rules/no-sensitive-public-env-var.ts
+++ b/packages/eslint-plugin-expo/src/rules/no-sensitive-public-env-var.ts
@@ -1,0 +1,124 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) =>
+    `https://github.com/expo/expo/blob/main/packages/eslint-plugin-expo/docs/rules/${name}.md`
+);
+
+const PUBLIC_PREFIX = 'EXPO_PUBLIC_';
+
+/**
+ * Name segments that suggest a credential rather than configuration. Matched
+ * against `_` separated segments so `EXPO_PUBLIC_MONKEY` does not trip on
+ * "key".
+ */
+const SENSITIVE_SEGMENTS = [
+  'key',
+  'keys',
+  'secret',
+  'secrets',
+  'token',
+  'password',
+  'passwd',
+  'pwd',
+  'credential',
+  'credentials',
+  'private',
+  'auth',
+  'apikey',
+  'accesskey',
+  'signature',
+];
+
+type Options = [
+  {
+    additionalPatterns?: string[];
+    allow?: string[];
+  },
+];
+
+type MessageIds = 'sensitivePublicEnvVar';
+
+function segmentsOf(name: string): string[] {
+  return name.slice(PUBLIC_PREFIX.length).toLowerCase().split('_').filter(Boolean);
+}
+
+export const noSensitivePublicEnvVar = createRule<Options, MessageIds>({
+  name: 'no-sensitive-public-env-var',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Prevents credentials from being stored in EXPO_PUBLIC_ environment variables, which are inlined into the app bundle',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          additionalPatterns: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+          allow: {
+            type: 'array',
+            items: { type: 'string' },
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      sensitivePublicEnvVar:
+        '{{name}} is inlined into the app bundle in plain text and is readable by anyone who has the app. Do not store secrets in EXPO_PUBLIC_ variables. Read it on a server, or if this value is genuinely public, add it to the allow option.',
+    },
+  },
+  defaultOptions: [{}],
+  create(context, [options]) {
+    const allow = new Set(options?.allow ?? []);
+    const additional = (options?.additionalPatterns ?? []).map((p) => new RegExp(p, 'i'));
+
+    function isSensitive(name: string): boolean {
+      if (allow.has(name)) {
+        return false;
+      }
+      if (additional.some((re) => re.test(name))) {
+        return true;
+      }
+      return segmentsOf(name).some((segment) => SENSITIVE_SEGMENTS.includes(segment));
+    }
+
+    return {
+      MemberExpression(node: TSESTree.MemberExpression) {
+        // process.env.EXPO_PUBLIC_X
+        if (node.computed || node.property.type !== 'Identifier') {
+          return;
+        }
+
+        const object = node.object;
+        if (
+          object.type !== 'MemberExpression' ||
+          object.computed ||
+          object.object.type !== 'Identifier' ||
+          object.object.name !== 'process' ||
+          object.property.type !== 'Identifier' ||
+          object.property.name !== 'env'
+        ) {
+          return;
+        }
+
+        const name = node.property.name;
+        if (!name.startsWith(PUBLIC_PREFIX)) {
+          return;
+        }
+
+        if (isSensitive(name)) {
+          context.report({
+            node,
+            messageId: 'sensitivePublicEnvVar',
+            data: { name },
+          });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
# Why

The environment variables guide says twice not to put secrets in `EXPO_PUBLIC_` variables:

> Never store sensitive secrets in environment variables that are prefixed with `EXPO_PUBLIC_`. When an end-user runs your app, they have access to all of the code and embedded environment variables in your app.

Nothing enforces it. The value inlines, the app builds, the app runs, and the key ships inside the bundle. There is no error anywhere to catch it.

This plugin already has two rules from that same guide, `no-dynamic-env-var` and `no-env-var-destructuring`. This is a third one.

I opened #48959 to ask first and it was closed automatically, which I gather is the policy for feature requests here. So I have sent the implementation instead. Happy to close it if you would rather not have the rule.

# How

Reports `process.env.EXPO_PUBLIC_*` when the name looks like a credential.

```js
// reported
const key = process.env.EXPO_PUBLIC_API_KEY;

// not reported
const url = process.env.EXPO_PUBLIC_API_URL;
const secret = process.env.STRIPE_SECRET_KEY;
```

The name is split on underscores and each part is checked against a list (key, secret, token, password, credential, private, auth). Checking parts rather than substrings is what keeps `EXPO_PUBLIC_MONKEY` and `EXPO_PUBLIC_AUTHORITY` quiet.

Two options for what the heuristic cannot know: `allow` for names that really are public, such as a referrer restricted Maps key, and `additionalPatterns` for project specific naming.

Computed access is left alone since `no-dynamic-env-var` already covers it.

Five files, following CONTRIBUTING.md: the rule, its test, its doc, the entry in `src/rules/index.ts`, and the README table and config example.

# Test Plan

9 valid and 6 invalid cases, using the same `@typescript-eslint/rule-tester` setup as the other rules here. The valid ones cover what I thought most likely to break: `EXPO_PUBLIC_MONKEY` and `EXPO_PUBLIC_AUTHORITY`, a non public variable, computed access, and an allowed name.

I could not run this package's jest suite because `expo-module-scripts` and `eslint-config-universe` are `workspace:*` and I was on a sparse checkout. I ran all 13 cases through ESLint 9 directly instead and they pass. If CI finds something that missed, I will fix it.

# Note on the docs

The same guide has this example a few paragraphs above the warning:

```bash .env
EXPO_PUBLIC_API_KEY=abc123
```

which is the thing it warns about, and which this rule would report. Separate diff, happy to send it if useful.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (lint rule only)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

Changelog entry to follow, since the format wants the PR number.
