### PR TITLE
[ios][expo-go] Improve the local network permission flow

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -39,6 +39,7 @@ struct HomeRootView: View {
     self.viewModel = viewModel
     let shouldSkip = DevelopmentServerService.isSimulator
       || UserDefaults.standard.bool(forKey: DevelopmentServerService.networkPermissionGrantedKey)
+      || !UserDefaults.standard.bool(forKey: "ExpoGoOnboardingFinished")
     _hasCompletedPermissionFlow = State(initialValue: shouldSkip)
   }
 

--- a/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeTabView.swift
@@ -24,6 +24,8 @@ struct HomeTabView: View {
 
           UpgradeWarningView()
 
+          NetworkPermissionBanner(serverService: viewModel.serverService)
+
           DevServersSection()
 
           if !viewModel.recentlyOpenedApps.isEmpty {

--- a/apps/expo-go/ios/Client/SwiftUI/Services/DevelopmentServerService.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Services/DevelopmentServerService.swift
@@ -26,6 +26,8 @@ class DevelopmentServerService: ObservableObject {
   private var sessionSecret: String?
   private var remoteRefreshTask: Task<Void, Never>?
   private var browser: NWBrowser?
+  private var probeListener: NWListener?
+  private let probeServiceName = "expo-go-permission-probe"
   private var pingTask: Task<Void, Never>?
   private var isFetchingRemote = false
 
@@ -59,7 +61,20 @@ class DevelopmentServerService: ObservableObject {
     permissionStatus = .granted
   }
 
+  func markNetworkPermissionDenied() {
+    UserDefaults.standard.set(false, forKey: Self.networkPermissionGrantedKey)
+    permissionStatus = .denied
+  }
+
   func checkLocalNetworkAccess() async -> Bool {
+    let granted = await probeLocalNetworkAccess()
+    if granted {
+      markNetworkPermissionGranted()
+    }
+    return granted
+  }
+
+  private func probeLocalNetworkAccess() async -> Bool {
     let serviceType = bonjourType
     let queue = DispatchQueue(label: "expo.go.permissioncheck")
 
@@ -326,11 +341,11 @@ class DevelopmentServerService: ObservableObject {
         switch state {
         case .waiting(let error):
           if case .dns(let dnsError) = error, dnsError == kDNSServiceErr_PolicyDenied {
-            self.permissionStatus = .denied
+            self.markNetworkPermissionDenied()
           }
         case .failed(let error):
           if case .dns(let dnsError) = error, dnsError == kDNSServiceErr_PolicyDenied {
-            self.permissionStatus = .denied
+            self.markNetworkPermissionDenied()
           }
         default:
           break
@@ -342,28 +357,48 @@ class DevelopmentServerService: ObservableObject {
       guard let self else { return }
       Task { @MainActor [weak self, results] in
         guard let self else { return }
+        // Results only flow once the permission is truly granted, so this is the reliable signal.
         self.markNetworkPermissionGranted()
+        self.probeListener?.cancel()
+        self.probeListener = nil
         self.pingTask?.cancel()
         self.pingTask = Task {
           defer { self.pingTask = nil }
-          await self.pingDiscoveryResults(results.map { result in
-            DiscoveryResult(
-              name: NetworkUtilities.getNWBrowserResultName(result),
-              endpoint: result.endpoint
-            )
+          await self.pingDiscoveryResults(results.compactMap { result in
+            let name = NetworkUtilities.getNWBrowserResultName(result)
+            if name?.hasPrefix(self.probeServiceName) == true {
+              return nil
+            }
+            return DiscoveryResult(name: name, endpoint: result.endpoint)
           })
         }
       }
     }
 
+    startProbeListener()
     browser?.start(queue: DispatchQueue(label: "expo.go.bonjour.discovery"))
+  }
+
+  // Advertise our own service so a granted permission always produces at least one browse
+  // result, even when no dev servers are running.
+  private func startProbeListener() {
+    guard let listener = try? NWListener(using: .tcp, on: .any) else {
+      return
+    }
+    listener.service = NWListener.Service(name: probeServiceName, type: bonjourType)
+    listener.stateUpdateHandler = { _ in }
+    listener.newConnectionHandler = { $0.cancel() }
+    listener.start(queue: DispatchQueue(label: "expo.go.bonjour.probe"))
+    probeListener = listener
   }
 
   private func stopBonjourBrowser() {
     pingTask?.cancel()
     browser?.cancel()
+    probeListener?.cancel()
     pingTask = nil
     browser = nil
+    probeListener = nil
   }
 
   private func pingDiscoveryResults(_ results: [DiscoveryResult]) async {

--- a/apps/expo-go/ios/Client/SwiftUI/Views/NetworkPermissionBanner.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/NetworkPermissionBanner.swift
@@ -1,0 +1,52 @@
+//  Copyright © 2025 650 Industries. All rights reserved.
+
+import SwiftUI
+
+struct NetworkPermissionBanner: View {
+  @ObservedObject var serverService: DevelopmentServerService
+  @State private var showingPermissionFlow = false
+
+  var body: some View {
+    Group {
+      // `showingPermissionFlow` keeps the banner alive while its sheet is up: the grant is detected the
+      // moment the system prompt appears, and hiding the banner then would tear the sheet down with it.
+      if showingPermissionFlow
+         || (!DevelopmentServerService.isSimulator
+             && !serverService.hasGrantedNetworkPermission
+             && serverService.permissionStatus != .granted) {
+        Button {
+          showingPermissionFlow = true
+        } label: {
+          HStack {
+            Image(systemName: "wifi.exclamationmark")
+              .font(.title2)
+              .foregroundColor(.orange)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Local Network Access Needed")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundColor(.primary)
+              Text("Projects running on your computer can't be discovered. Tap to enable access.")
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.leading)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+              .foregroundColor(.secondary)
+          }
+          .padding()
+        }
+        .buttonStyle(PlainButtonStyle())
+        .background(Color.expoSecondarySystemBackground)
+        .cornerRadius(18)
+      }
+    }
+    .sheet(isPresented: $showingPermissionFlow) {
+      LocalNetworkPermissionView(serverService: serverService) {
+        serverService.startDiscovery()
+        showingPermissionFlow = false
+      }
+    }
+  }
+}

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXKernelLinkingManager.m
@@ -33,6 +33,9 @@ EX_REGISTER_SINGLETON_MODULE(KernelLinkingManager);
     DDLogInfo(@"Tried to route invalid url: %@", urlString);
     return;
   }
+  // An external link means the user already has a project to open, so never gate them behind onboarding.
+  [[NSUserDefaults standardUserDefaults] setBool:YES forKey:@"ExpoGoOnboardingFinished"];
+
   EXKernelAppRegistry *appRegistry = [EXKernel sharedInstance].appRegistry;
   EXKernelAppRecord *destinationApp = nil;
   NSURL *urlToRoute = [[self class] uriTransformedForLinking:url isUniversalLink:isUniversalLink];


### PR DESCRIPTION
# Why
The local network grant was only persisted when a dev server was discovered, so users who allowed the permission with no server running were re-prompted on every launch. 

# How
Discovery now advertises its own Bonjour service, so a granted permission always produces a browse result, and the grant is persisted only when results arrive. The startup prompt is skipped until onboarding has finished, arriving from an deep link marks onboarding as done, and a banner on the home tab offers the permission flow whenever access is missing.

# Test Plan
Clean install, complete onboarding, confirm the permission screen appears on the next launch. Allow with no dev server running, relaunch, and confirm no re-prompt. Deny, relaunch, and confirm the screen returns. Open a project from a QR code on a fresh install and confirm onboarding is skipped. With permission missing, tap the home banner and complete the flow.
