### PR TITLE
[ios][expo-go] Keep list content during pull-to-refresh and ignore cancelled requests

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Errors.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Errors.swift
@@ -27,6 +27,15 @@ enum APIError: LocalizedError {
     }
   }
 
+  // Cancellation happens whenever SwiftUI tears down a refreshable or task modifier; it is
+  // never worth surfacing to the user.
+  var isCancellation: Bool {
+    if case .networkError(let error) = self {
+      return error is CancellationError || (error as? URLError)?.code == .cancelled
+    }
+    return false
+  }
+
   var isAuthenticationError: Bool {
     if case .httpError(let statusCode, _) = self, statusCode == 401 {
       return true

--- a/apps/expo-go/ios/Client/SwiftUI/Views/BranchDetailsView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/BranchDetailsView.swift
@@ -171,6 +171,9 @@ class BranchDetailsViewModel: ObservableObject {
       branch = response.data.app.byId.updateBranchByName
       hasLoadedRemote = true
     } catch {
+      if (error as? APIError)?.isCancellation == true {
+        return
+      }
       self.error = error
     }
   }

--- a/apps/expo-go/ios/Client/SwiftUI/Views/ProjectsListView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/ProjectsListView.swift
@@ -93,7 +93,6 @@ class ProjectsListViewModel: ObservableObject {
 
   func refresh() async {
     currentOffset = 0
-    projects = []
     await fetchProjects()
   }
 
@@ -129,6 +128,9 @@ class ProjectsListViewModel: ObservableObject {
 
       hasMore = projects.count < totalCount
     } catch {
+      if (error as? APIError)?.isCancellation == true {
+        return
+      }
       self.error = error
       self.showingError = true
     }

--- a/apps/expo-go/ios/Client/SwiftUI/Views/SnacksListView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Views/SnacksListView.swift
@@ -92,7 +92,6 @@ class SnacksListViewModel: ObservableObject {
 
   func refresh() async {
     currentOffset = 0
-    snacks = []
     await fetchSnacks()
   }
 
@@ -126,6 +125,9 @@ class SnacksListViewModel: ObservableObject {
 
       hasMore = newSnacks.count >= pageSize
     } catch {
+      if (error as? APIError)?.isCancellation == true {
+        return
+      }
       self.error = error
       self.showingError = true
     }


### PR DESCRIPTION
# Why
Pull-to-refresh on the Projects and Snacks screens showed an immediate "Network error: cancelled" alert. Clearing the list before fetching swapped the rows, which cancelled the refreshable task and surfaced the cancellation as an error.

# How
Refresh keeps the current rows until fresh data replaces them

# Test Plan
Pull to refresh on Projects and Snacks. Works as expected
