### PR TITLE
[ios][expo-go] Deduplicate recently opened entries for published updates

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeViewModel.swift
@@ -147,9 +147,14 @@ class HomeViewModel: ObservableObject {
   func addToRecentlyOpened(url: String, name: String, iconUrl: String? = nil) {
     let normalizedUrl = normalizeUrl(url)
 
-    if let existingIndex = recentlyOpenedApps.firstIndex(where: {
+    // Update permalinks are unique per published update, so entries for the same app are
+    // matched by name instead of URL to avoid one row per update.
+    let isDuplicate: (RecentlyOpenedApp) -> Bool = {
       normalizeUrl($0.url) == normalizedUrl
-    }) {
+        || (isUpdatePermalink($0.url) && isUpdatePermalink(url) && $0.name == name)
+    }
+
+    if let existingIndex = recentlyOpenedApps.firstIndex(where: isDuplicate) {
       let existingApp = recentlyOpenedApps[existingIndex]
 
       if existingApp.name == name && iconUrl != nil && existingApp.iconUrl == nil {
@@ -160,7 +165,7 @@ class HomeViewModel: ObservableObject {
         return
       }
 
-      recentlyOpenedApps.remove(at: existingIndex)
+      recentlyOpenedApps.removeAll(where: isDuplicate)
     }
 
     let newApp = RecentlyOpenedApp(

--- a/apps/expo-go/ios/Client/SwiftUI/Utils/UrlUtils.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/Utils/UrlUtils.swift
@@ -23,6 +23,13 @@ func normalizeUrl(_ url: String) -> String {
   return components.joined()
 }
 
+func isUpdatePermalink(_ url: String) -> Bool {
+  guard let components = URLComponents(string: url) else {
+    return false
+  }
+  return components.host == "u.expo.dev" && components.path.hasPrefix("/update/")
+}
+
 func sanitizeUrlString(_ urlString: String) -> String? {
   var sanitizedUrl = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
 


### PR DESCRIPTION
# Why
Every published update has a unique manifest link, so opening successive updates of the same project filled Recently Opened with duplicate rows that all showed the same name.

# How
Entries are also treated as duplicates when both URLs are update links and the display name matches.

# Test Plan
Publish two updates to the same branch and open each. Recently Opened shows a single row.
