### PR TITLE
[cli] Auto-sync agent skills on expo start

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add `npx expo skills` command to link agent skills from npm packages into `.claude/skills` and `.agents/skills`. ([#48592](https://github.com/expo/expo/pull/48592) by [@kudo](https://github.com/kudo))
 - Sync agent skills automatically on `npx expo install` for the agents selected with `npx expo skills`, opt out per run with `--no-agent-skills`. ([#48972](https://github.com/expo/expo/pull/48972) by [@kudo](https://github.com/kudo))
+- Sync agent skills in the background on `npx expo start` for the agents selected with `npx expo skills`. ([#48973](https://github.com/expo/expo/pull/48973) by [@kudo](https://github.com/kudo))
 - Add `pageHeaders` to exported routes manifests ([#47429](https://github.com/expo/expo/pull/47429) by [@hassankhan](https://github.com/hassankhan))
 - Apply `pageHeaders` when serving static exports with `expo serve` ([#47781](https://github.com/expo/expo/pull/47781) by [@hassankhan](https://github.com/hassankhan))
 - Create `pageHeaders` rules from loader-declared `Cache-Control` headers for SSG ([#47774](https://github.com/expo/expo/pull/47774) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -217,11 +217,11 @@ describeSkipWin('auto sync on `npx expo start`', () => {
     // Cache the agent selection like a previous `expo skills` run would
     await fs.promises.mkdir(path.join(projectRoot, '.expo'), { recursive: true });
     await fs.promises.writeFile(
-      path.join(projectRoot, '.expo/agent-links.json'),
+      path.join(projectRoot, '.expo/agent-skill-links.json'),
       JSON.stringify({ agents: ['claude-code'] })
     );
 
-    linkPath = path.join(projectRoot, '.claude', 'skills', 'npm-test-skills-alpha');
+    linkPath = path.join(projectRoot, '.claude', 'skills', 'alpha');
   });
 
   it('links skills in the background', async () => {

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -216,8 +216,15 @@ describeSkipWin('auto sync on `npx expo start`', () => {
 
     const pkgPath = path.join(projectRoot, 'package.json');
     const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf8'));
-    pkg.expo = { skills: { autoSync: true, agents: ['claude-code'] } };
+    pkg.expo = { skills: { autoSync: true } };
     await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
+
+    // Cache the agent selection like a previous `expo skills` run would
+    await fs.promises.mkdir(path.join(projectRoot, '.expo'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(projectRoot, '.expo/skills.json'),
+      JSON.stringify({ agents: ['claude-code'] })
+    );
 
     linkPath = path.join(projectRoot, '.claude', 'skills', 'npm-test-skills-alpha');
   });

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -214,15 +214,10 @@ describeSkipWin('auto sync on `npx expo start`', () => {
     });
     await addSkillDependencyAsync(projectRoot, 'test-skills', ['alpha']);
 
-    const pkgPath = path.join(projectRoot, 'package.json');
-    const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf8'));
-    pkg.expo = { skills: { autoSync: true } };
-    await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
-
     // Cache the agent selection like a previous `expo skills` run would
     await fs.promises.mkdir(path.join(projectRoot, '.expo'), { recursive: true });
     await fs.promises.writeFile(
-      path.join(projectRoot, '.expo/skills.json'),
+      path.join(projectRoot, '.expo/agents.json'),
       JSON.stringify({ agents: ['claude-code'] })
     );
 

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -217,7 +217,7 @@ describeSkipWin('auto sync on `npx expo start`', () => {
     // Cache the agent selection like a previous `expo skills` run would
     await fs.promises.mkdir(path.join(projectRoot, '.expo'), { recursive: true });
     await fs.promises.writeFile(
-      path.join(projectRoot, '.expo/agents.json'),
+      path.join(projectRoot, '.expo/agent-links.json'),
       JSON.stringify({ agents: ['claude-code'] })
     );
 

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -2,8 +2,9 @@
 import fs from 'fs';
 import path from 'path';
 
-import { executeExpoAsync } from '../utils/expo';
+import { createExpoStart, executeExpoAsync } from '../utils/expo';
 import {
+  bin,
   projectRoot,
   getLoadedModulesAsync,
   setupTestProjectWithOptionsAsync,
@@ -198,3 +199,61 @@ describe('skills actions', () => {
     );
   });
 });
+
+// Due to change in `expo` package the tests suit will fail on Windows, as npm pack fails to execute `expo` prepare on Windows.
+const describeSkipWin = process.platform === 'win32' ? describe.skip : describe;
+
+describeSkipWin('auto sync on `npx expo start`', () => {
+  let projectRoot: string;
+  let linkPath: string;
+
+  beforeAll(async () => {
+    projectRoot = await setupTestProjectWithOptionsAsync('skills-autosync-start', 'with-blank', {
+      reuseExisting: false,
+      linkExpoPackages: ['expo', 'babel-preset-expo'],
+    });
+    await addSkillDependencyAsync(projectRoot, 'test-skills', ['alpha']);
+
+    const pkgPath = path.join(projectRoot, 'package.json');
+    const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf8'));
+    pkg.expo = { skills: { autoSync: true, agents: ['claude-code'] } };
+    await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
+
+    linkPath = path.join(projectRoot, '.claude', 'skills', 'npm-test-skills-alpha');
+  });
+
+  it('links skills in the background', async () => {
+    const expo = createExpoStart({ cwd: projectRoot });
+    await expo.startAsync();
+    try {
+      await waitForAsync(() => fs.existsSync(linkPath), 30000);
+      expect(fs.existsSync(linkPath)).toBe(true);
+    } finally {
+      await expo.stopAsync();
+    }
+  });
+
+  it('skips linking with --no-agent-skills', async () => {
+    await executeExpoAsync(projectRoot, ['skills', 'clean']);
+
+    const expo = createExpoStart({
+      cwd: projectRoot,
+      command: (port) => [bin, 'start', `--port=${port}`, '--no-agent-skills'],
+    });
+    await expo.startAsync();
+    try {
+      // The sync starts before the dev server is ready, give it time to finish if it wrongly runs.
+      await waitForAsync(() => fs.existsSync(linkPath), 5000);
+      expect(fs.existsSync(linkPath)).toBe(false);
+    } finally {
+      await expo.stopAsync();
+    }
+  });
+});
+
+async function waitForAsync(check: () => boolean, timeoutMs: number): Promise<void> {
+  const endTime = Date.now() + timeoutMs;
+  while (!check() && Date.now() < endTime) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+}

--- a/packages/@expo/cli/e2e/__tests__/skills-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/skills-test.ts
@@ -200,10 +200,7 @@ describe('skills actions', () => {
   });
 });
 
-// Due to change in `expo` package the tests suit will fail on Windows, as npm pack fails to execute `expo` prepare on Windows.
-const describeSkipWin = process.platform === 'win32' ? describe.skip : describe;
-
-describeSkipWin('auto sync on `npx expo start`', () => {
+describe('auto sync on `npx expo start`', () => {
   let projectRoot: string;
   let linkPath: string;
 

--- a/packages/@expo/cli/e2e/__tests__/start-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/start-test.ts
@@ -67,6 +67,7 @@ it('runs `npx expo start --help`', async () => {
         --localhost                     Same as --host localhost
         
         --offline                       Skip network requests and use anonymous manifest signatures
+        --no-agent-skills               Skip linking agent skills from installed packages
         --https                         Start the dev server with https protocol. Deprecated in favor of --tunnel
         --scheme <scheme>               Custom URI protocol to use when launching an app
         -p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). Default: 8081

--- a/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
+++ b/packages/@expo/cli/src/start/__tests__/resolveOptions-test.ts
@@ -183,6 +183,14 @@ describe(resolveOptionsAsync, () => {
     jest.mocked(hasDirectDevClientDependency).mockReturnValueOnce(true);
     expect((await resolveOptionsAsync('/noop', { '--go': true })).devClient).toBe(false);
   });
+  it(`defaults agentSkills to true`, async () => {
+    expect((await resolveOptionsAsync('/noop', {})).agentSkills).toBe(true);
+  });
+  it(`--no-agent-skills sets agentSkills to false`, async () => {
+    expect((await resolveOptionsAsync('/noop', { '--no-agent-skills': true })).agentSkills).toBe(
+      false
+    );
+  });
 });
 
 describe(resolveHostType, () => {

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -28,6 +28,7 @@ export const expoStart: Command = async (argv) => {
       '--localhost': Boolean,
       '--offline': Boolean,
       '--go': Boolean,
+      '--no-agent-skills': Boolean,
       // Aliases
       '-h': '--help',
       '-c': '--clear',
@@ -71,6 +72,7 @@ export const expoStart: Command = async (argv) => {
         `--localhost                     Same as --host localhost`,
         ``,
         `--offline                       Skip network requests and use anonymous manifest signatures`,
+        `--no-agent-skills               Skip linking agent skills from installed packages`,
         chalk`--https                         Start the dev server with https protocol. {bold Deprecated in favor of --tunnel}`,
         `--scheme <scheme>               Custom URI protocol to use when launching an app`,
         chalk`-p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). {dim Default: 8081}`,

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -23,6 +23,8 @@ export type Options = {
   devClient: boolean;
   scheme: string | null;
   host: 'localhost' | 'lan' | 'tunnel';
+  /** Should link agent skills on start, set to false with --no-agent-skills */
+  agentSkills: boolean;
 };
 
 export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
@@ -79,6 +81,7 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
 
     scheme,
     host,
+    agentSkills: !args['--no-agent-skills'],
   };
 }
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -84,6 +84,14 @@ export async function startAsync(
 
   const { exp, pkg } = profile(getConfig)(projectRoot);
 
+  if (options.agentSkills !== false) {
+    const { autoSyncSkillsAsync } =
+      require('../skills/skillsAsync') as typeof import('../skills/skillsAsync');
+    autoSyncSkillsAsync(projectRoot).catch(() => {
+      // noop -- autoSyncSkillsAsync handles its own errors.
+    });
+  }
+
   // Start dependency version check in the background as early as possible (non-blocking).
   // The result will be displayed in the TUI once it resolves.
   let dependencyCheckRef: DependencyCheckRef | undefined;

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -26,7 +26,7 @@ import { openPlatformsAsync } from './server/openPlatforms';
 import type { PlatformBundlers } from './server/platformBundlers';
 import { getPlatformBundlers } from './server/platformBundlers';
 
-// Wait for startup to settle before the background agent-skills sync.
+// How long to wait after startup before syncing skills in the background.
 const SKILLS_SYNC_IDLE_DELAY_MS = 3000;
 
 /** Exported for testing. `startAsync` is the entry point. */
@@ -176,14 +176,15 @@ export async function startAsync(
     }`
   );
 
-  // Sync agent skills after startup settles, so the scan never competes with the first bundle.
+  // Sync skills a few seconds after the app starts, so the scan doesn't slow the first bundle.
   if (options.agentSkills !== false) {
     const timer = setTimeout(() => {
       const { autoSyncSkillsAsync } =
         require('../skills/skillsAsync') as typeof import('../skills/skillsAsync');
       autoSyncSkillsAsync(projectRoot).catch(() => {});
     }, SKILLS_SYNC_IDLE_DELAY_MS) as unknown as NodeJS.Timeout;
-    // unref so a pending sync never blocks exit; the RN global setTimeout type lacks it.
+    // Don't let a slow sync hold the CLI open.
+    // RN's setTimeout type is missing unref, so we cast above to reach it.
     timer.unref();
   }
 }

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -26,6 +26,9 @@ import { openPlatformsAsync } from './server/openPlatforms';
 import type { PlatformBundlers } from './server/platformBundlers';
 import { getPlatformBundlers } from './server/platformBundlers';
 
+// Wait for startup to settle before the background agent-skills sync.
+const SKILLS_SYNC_IDLE_DELAY_MS = 3000;
+
 /** Exported for testing. `startAsync` is the entry point. */
 export async function _getMultiBundlerStartOptions(
   projectRoot: string,
@@ -83,14 +86,6 @@ export async function startAsync(
   }
 
   const { exp, pkg } = profile(getConfig)(projectRoot);
-
-  if (options.agentSkills !== false) {
-    const { autoSyncSkillsAsync } =
-      require('../skills/skillsAsync') as typeof import('../skills/skillsAsync');
-    autoSyncSkillsAsync(projectRoot).catch(() => {
-      // noop -- autoSyncSkillsAsync handles its own errors.
-    });
-  }
 
   // Start dependency version check in the background as early as possible (non-blocking).
   // The result will be displayed in the TUI once it resolves.
@@ -180,4 +175,19 @@ export async function startAsync(
       isInteractive() ? chalk.dim(` Press Ctrl+C to exit.`) : ''
     }`
   );
+
+  // Sync agent skills last, once startup has settled, so the dependency scan never competes
+  // with the first bundle. Deferred to an idle tick; runs in the background and never throws.
+  if (options.agentSkills !== false) {
+    // setTimeout uses the global React Native definitions, which lack Node's `unref`.
+    const timer = setTimeout(() => {
+      const { autoSyncSkillsAsync } =
+        require('../skills/skillsAsync') as typeof import('../skills/skillsAsync');
+      autoSyncSkillsAsync(projectRoot).catch(() => {
+        // noop -- autoSyncSkillsAsync handles its own errors.
+      });
+    }, SKILLS_SYNC_IDLE_DELAY_MS) as unknown as NodeJS.Timeout;
+    // Never let a pending sync hold the process open during shutdown.
+    timer.unref();
+  }
 }

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -176,18 +176,14 @@ export async function startAsync(
     }`
   );
 
-  // Sync agent skills last, once startup has settled, so the dependency scan never competes
-  // with the first bundle. Deferred to an idle tick; runs in the background and never throws.
+  // Sync agent skills after startup settles, so the scan never competes with the first bundle.
   if (options.agentSkills !== false) {
-    // setTimeout uses the global React Native definitions, which lack Node's `unref`.
     const timer = setTimeout(() => {
       const { autoSyncSkillsAsync } =
         require('../skills/skillsAsync') as typeof import('../skills/skillsAsync');
-      autoSyncSkillsAsync(projectRoot).catch(() => {
-        // noop -- autoSyncSkillsAsync handles its own errors.
-      });
+      autoSyncSkillsAsync(projectRoot).catch(() => {});
     }, SKILLS_SYNC_IDLE_DELAY_MS) as unknown as NodeJS.Timeout;
-    // Never let a pending sync hold the process open during shutdown.
+    // unref so a pending sync never blocks exit; the RN global setTimeout type lacks it.
     timer.unref();
   }
 }


### PR DESCRIPTION
# Why

similar to #48972 but for `npx expo start` to sync all skills
close ENG-25661

# How

- after `npx expo start` about 3000ms (about to idle !?), start to run agent skills sync 
- offers `--no-agent-skills` to opt-out the behavior

# Test Plan

- added e2e tests

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)