### PR TITLE
[cli][android] Time out unresponsive adb client commands

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
+- Fail with an actionable error instead of hanging forever when the adb server is unresponsive. ([#48744](https://github.com/expo/expo/issues/48744) by [@MatheusMartinho](https://github.com/MatheusMartinho))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
+++ b/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
@@ -1,4 +1,4 @@
-import spawnAsync from '@expo/spawn-async';
+import spawnAsync, { SpawnResult } from '@expo/spawn-async';
 import { execFileSync } from 'child_process';
 
 import { Log } from '../../../log';
@@ -9,6 +9,14 @@ import { event } from '../events';
 import { assertSdkRoot } from './AndroidSdk';
 
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
+
+/**
+ * Time in milliseconds to wait for an adb client command before assuming the adb server is
+ * unresponsive. Healthy invocations take milliseconds; a wedged server (commonly left behind by a
+ * device that disconnects mid-transfer) never answers at all, which would otherwise hang the CLI
+ * with no output.
+ */
+const ADB_COMMAND_TIMEOUT = 15000;
 
 // This is a tricky class since it controls a system state (side-effects).
 // A more ideal solution would be to implement ADB in JS.
@@ -45,7 +53,7 @@ export class ADBServer {
       }
     });
     const adb = this.getAdbExecutablePath();
-    const result = await this.resolveAdbPromise(spawnAsync(adb, ['start-server']));
+    const result = await this.resolveAdbPromise(this.spawnWithTimeoutAsync(adb, ['start-server']));
     const lines = result.stderr.trim().split(/\r?\n/);
     const isStarted = lines.includes('* daemon started successfully');
     this.isRunning = isStarted;
@@ -77,7 +85,7 @@ export class ADBServer {
     await this.startAsync();
 
     event('adb_server_run', { command: [adb, ...args].join(' ') });
-    const result = await this.resolveAdbPromise(spawnAsync(adb, args));
+    const result = await this.resolveAdbPromise(this.spawnWithTimeoutAsync(adb, args));
     return result.output.join('\n');
   }
 
@@ -96,6 +104,35 @@ export class ADBServer {
     );
     event('adb_file_output', { output: results });
     return results;
+  }
+
+  /**
+   * Spawn an adb client command, rejecting if the adb server does not answer within
+   * {@link ADB_COMMAND_TIMEOUT}. The client is killed on timeout so the CLI surfaces an actionable
+   * error instead of hanging with no output.
+   */
+  private async spawnWithTimeoutAsync(adb: string, args: string[]): Promise<SpawnResult> {
+    const promise = spawnAsync(adb, args);
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            promise.child.kill();
+            reject(
+              new CommandError(
+                'ADB_TIMEOUT',
+                `adb did not respond within ${ADB_COMMAND_TIMEOUT / 1000}s while running "${args.join(' ')}". The adb server may be unresponsive, which can happen when a device disconnects mid-transfer. Try running "adb kill-server" and then re-running this command.`
+              )
+            );
+          }, ADB_COMMAND_TIMEOUT);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /** Formats error info. */

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
@@ -80,6 +80,49 @@ describe('resolveAdbPromise', () => {
   });
 });
 
+describe('adb command timeout', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  /** A spawn that never settles, like an adb client talking to a wedged server. */
+  function mockHangingSpawn() {
+    const kill = jest.fn();
+    const promise: any = new Promise(() => {});
+    promise.child = { kill };
+    jest.mocked(spawnAsync).mockReturnValueOnce(promise);
+    return { kill };
+  }
+
+  it(`fails with an actionable error when adb never responds`, async () => {
+    const { kill } = mockHangingSpawn();
+    const server = new ADBServer();
+    server.startAsync = jest.fn();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+
+    // Capture the rejection up front so advancing the timers cannot surface it as an unhandled
+    // rejection before the assertion runs.
+    const error = server.runAsync(['devices', '-l']).catch((error) => error);
+    await jest.advanceTimersByTimeAsync(15000);
+
+    await expect(error).resolves.toThrow(
+      'adb did not respond within 15s while running "devices -l". The adb server may be unresponsive, which can happen when a device disconnects mid-transfer. Try running "adb kill-server" and then re-running this command.'
+    );
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it(`does not time out a command that responds`, async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
+      output: ['did thing'],
+      stderr: 'did thing',
+    } as any);
+    const server = new ADBServer();
+    server.startAsync = jest.fn();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+
+    await expect(server.runAsync(['foo'])).resolves.toBe('did thing');
+  });
+});
+
 describe('startAsync', () => {
   it(`starts the ADB server`, async () => {
     jest.mocked(spawnAsync).mockResolvedValueOnce({


### PR DESCRIPTION
# Why

Fixes #48744.

`expo run:android` resolves a device before doing anything else, and every adb call on that path is awaited without a timeout: `resolveDeviceAsync` → `AndroidDeviceManager.resolveAsync()` → `getAttachedDevicesAsync()` → `ADBServer.runAsync(['devices', '-l'])`, which first awaits `startAsync()` (`adb start-server`).

When the resident adb server is wedged — commonly after a USB device drops off mid-transfer, which is a recurring report on Windows — the adb client connects to the dead server's socket and blocks forever. The CLI then hangs with no output at all: no spinner, no message, no error, and no Gradle process ever starts, so the user has no signal about what it is waiting on. #30401 is the same symptom, closed with only a manual workaround.

# How

`ADBServer` now runs adb client commands through a small `spawnWithTimeoutAsync` helper that races the spawn against a 15s timer (healthy invocations take milliseconds), kills the client on timeout, and rejects with a `CommandError` that states what failed, the likely cause, and the recovery step:

```
adb did not respond within 15s while running "devices -l". The adb server may be unresponsive, which can happen when a device disconnects mid-transfer. Try running "adb kill-server" and then re-running this command.
```

I used a `Promise.race` because `@expo/spawn-async` takes no timeout option, following the existing timeout pattern in `emulator.ts` in the same directory. Only the two `spawnAsync` call sites are affected (`start-server` and the general `runAsync` path); `getFileOutputAsync` uses `execFileSync` and is left alone.

# Test Plan

Added two tests to `ADBServer-test.ts`, red/green verified:

- a spawn that never settles (the wedged-server case) rejects with the message above and kills the client — this test times out against `main` without the fix, reproducing the reported hang
- a command that responds is unaffected

```
$ jest src/start/platforms/android/__tests__/
Test Suites: 12 passed, 12 total
Tests:       95 passed, 95 total
```

`tsc --noEmit` reports no new errors for the changed files.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
