### PR TITLE
[metro-file-map] Watch through the long path root on Windows

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent a Node crash on Windows when a watched path contains an 8.3 short name, by watching through the long form of the root ([#48978](https://github.com/expo/expo/pull/48978) by [@brentvatne](https://github.com/brentvatne))
+
 ### 💡 Others
 
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-file-map/src/watchers/FallbackWatcher.ts
+++ b/packages/@expo/metro-file-map/src/watchers/FallbackWatcher.ts
@@ -43,6 +43,7 @@ export default class FallbackWatcher extends AbstractWatcher {
     [directory: string]: { [file: string]: true };
   } = Object.create(null);
   readonly #watched: { [key: string]: FSWatcher } = Object.create(null);
+  #longPathRoot: string | null = null;
 
   async startWatching(): Promise<void> {
     this.#watchdir(this.root);
@@ -159,13 +160,43 @@ export default class FallbackWatcher extends AbstractWatcher {
   };
 
   /**
+   * The path to give `fs.watch` for a directory.
+   *
+   * On Windows, a watch on a path with an 8.3 short-name component, such as
+   * `C:\Users\RUNNER~1`, crashes Node on libuv 1.52.x (bundled since
+   * Node 24.4): when the watch reports an event, libuv resolves the long form
+   * of the changed path and aborts on the prefix mismatch with the short
+   * watch path. See https://github.com/libuv/libuv/issues/5010.
+   *
+   * Expand the root to its long form once, and give `fs.watch` every
+   * directory through the expanded prefix. All bookkeeping and all reported
+   * events keep the original paths.
+   */
+  #watchablePath(dir: string): string {
+    if (platform !== 'win32') {
+      return dir;
+    }
+    if (this.#longPathRoot == null) {
+      try {
+        // Unlike `fs.realpathSync`, the native variant expands short names.
+        this.#longPathRoot = fs.realpathSync.native(this.root);
+      } catch {
+        this.#longPathRoot = this.root;
+      }
+    }
+    return this.#longPathRoot === this.root
+      ? dir
+      : this.#longPathRoot + dir.slice(this.root.length);
+  }
+
+  /**
    * Watch a directory.
    */
   #watchdir: (dir: string) => boolean = (dir: string) => {
     if (this.#watched[dir]) {
       return false;
     }
-    const watcher = fs.watch(dir, { persistent: true }, (event, filename) =>
+    const watcher = fs.watch(this.#watchablePath(dir), { persistent: true }, (event, filename) =>
       this.#normalizeChange(dir, event, filename as string)
     );
     this.#watched[dir] = watcher;

--- a/packages/@expo/metro-file-map/src/watchers/__tests__/FallbackWatcherWin32Paths.test.ts
+++ b/packages/@expo/metro-file-map/src/watchers/__tests__/FallbackWatcherWin32Paths.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import EventEmitter from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import type { WatcherBackendChangeEvent } from '../../types';
+import FallbackWatcher from '../FallbackWatcher';
+
+// `FallbackWatcher` expands the watch root on win32 only, and it reads the
+// platform when the module loads, so mock it before the import runs.
+jest.mock('os', () => {
+  const actual = jest.requireActual('os');
+  return { ...actual, platform: () => 'win32' };
+});
+
+// This suite drives the real filesystem, so it opts out of the memfs mock
+// that `jest.setup.ts` installs.
+jest.unmock('fs');
+jest.unmock('fs/promises');
+
+const WAIT_TIMEOUT_MS = 5000;
+const POLL_INTERVAL_MS = 10;
+
+async function waitFor(predicate: () => boolean, description: string): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > WAIT_TIMEOUT_MS) {
+      throw new Error(`Timed out after ${WAIT_TIMEOUT_MS}ms while waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+/**
+ * Stands in for an `FSWatcher`, so the test can capture the path that
+ * `fs.watch` receives and deliver events by hand.
+ */
+class StubWatcher extends EventEmitter {
+  close(): void {
+    this.emit('close');
+  }
+}
+
+describe('FallbackWatcher watch paths on win32', () => {
+  let root: string;
+  let watcher: FallbackWatcher | null = null;
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    root = fs.mkdtempSync(
+      path.join(fs.realpathSync.native(os.tmpdir()), 'expo-fallback-longpath-')
+    );
+    fs.mkdirSync(path.join(root, 'node_modules'));
+    fs.mkdirSync(path.join(root, 'node_modules', 'pkg'));
+    fs.writeFileSync(path.join(root, 'node_modules', 'pkg', 'index.js'), 'module.exports = 1;\n');
+  });
+
+  afterEach(async () => {
+    await watcher?.stopWatching();
+    watcher = null;
+    jest.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+    jest.useFakeTimers();
+  });
+
+  test('watches through the expanded root and reports the original paths', async () => {
+    // Model a root whose long form differs, as when the configured root
+    // contains an 8.3 short name such as `C:\Users\RUNNER~1`.
+    const longRoot = path.join(path.dirname(root), 'long-form-' + path.basename(root));
+    jest
+      .spyOn(fs.realpathSync, 'native')
+      .mockImplementation(((target: any) => longRoot) as typeof fs.realpathSync.native);
+
+    const watchedPaths: string[] = [];
+    const listeners = new Map<string, (event: string, filename: string) => void>();
+    jest.spyOn(fs, 'watch').mockImplementation(((target: any, _options: any, listener: any) => {
+      watchedPaths.push(target);
+      listeners.set(target, listener);
+      return new StubWatcher() as unknown as fs.FSWatcher;
+    }) as typeof fs.watch);
+
+    const events: WatcherBackendChangeEvent[] = [];
+    watcher = new FallbackWatcher(root, { dot: true, globs: [], ignored: null });
+    watcher.onFileEvent((event) => {
+      events.push(event);
+    });
+    await watcher.startWatching();
+
+    // Every watch goes to the expanded prefix, never to the original root.
+    expect(watchedPaths).toEqual(
+      expect.arrayContaining([
+        longRoot,
+        path.join(longRoot, 'node_modules'),
+        path.join(longRoot, 'node_modules', 'pkg'),
+      ])
+    );
+    expect(watchedPaths.some((watched) => watched.startsWith(root))).toBe(false);
+
+    // An event delivered by the watch still reports the original paths.
+    const pkgListener = listeners.get(path.join(longRoot, 'node_modules', 'pkg'));
+    expect(pkgListener).toBeDefined();
+    pkgListener!('change', 'index.js');
+
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.event === 'touch' &&
+            event.relativePath === path.join('node_modules', 'pkg', 'index.js')
+        ),
+      'a touch event for node_modules/pkg/index.js'
+    );
+    const touchEvent = events.find(
+      (event) => event.relativePath === path.join('node_modules', 'pkg', 'index.js')
+    );
+    expect(touchEvent!.root).toBe(root);
+  });
+
+  test('watches the original paths when the root has no distinct long form', async () => {
+    jest
+      .spyOn(fs.realpathSync, 'native')
+      .mockImplementation(((target: any) => root) as typeof fs.realpathSync.native);
+
+    const watchedPaths: string[] = [];
+    jest.spyOn(fs, 'watch').mockImplementation(((target: any) => {
+      watchedPaths.push(target);
+      return new StubWatcher() as unknown as fs.FSWatcher;
+    }) as typeof fs.watch);
+
+    watcher = new FallbackWatcher(root, { dot: true, globs: [], ignored: null });
+    await watcher.startWatching();
+
+    expect(watchedPaths).toEqual(expect.arrayContaining([root, path.join(root, 'node_modules')]));
+  });
+});


### PR DESCRIPTION
# Why

`fs.watch` on a path that contains an 8.3 short-name component, such as `C:\Users\RUNNER~1\...`, crashes the whole Node process on libuv 1.52.x, which Node bundles since 24.4:

```
Assertion failed: !_wcsnicmp(filename, dir, dirlen), file src\win\fs-event.c, line 72
```

When a watched directory reports an event, libuv resolves the changed path to its long form and asserts that the result is prefixed by the watch path. A short-name watch path fails that check, and the assert aborts the process ([libuv#5010](https://github.com/libuv/libuv/issues/5010)). The upstream fix ([libuv#5152](https://github.com/libuv/libuv/pull/5152), merged 2026-06-10) has not shipped in a Node release yet.

`FallbackWatcher` is the default watcher on Windows, so an Expo dev server on Node ≥ 24.4 hard-crashes when the project path contains a short-name component. Short paths are common through `%TEMP%` and tooling that resolves user profile paths. A bare `fs.watch(dir)` plus one file write under such a path reproduces the crash with no Expo code involved (verified on `windows-latest` CI runners, Node 24.18.1/24.19.0; Node ≤ 24.3 and 22/20 are unaffected). This was found while adding Windows coverage for #48954.

# How

`FallbackWatcher` now expands its root to the canonical long form once, with `fs.realpathSync.native` — the JavaScript `fs.realpathSync` resolves symlinks but keeps short names, while the native variant expands them. Every `fs.watch` call then goes through the expanded prefix. All bookkeeping, registry keys, and reported events keep the original paths, so nothing changes for consumers. The expansion is win32-only; on other platforms the method returns the path unchanged.

# Test Plan

New tests in `FallbackWatcherWin32Paths.test.ts`, red before the fix and green after:

- `watches through the expanded root and reports the original paths` — mocks the platform to win32 and models a root with a distinct long form; asserts every `fs.watch` call uses the expanded prefix and a delivered event still reports the original root and relative path.
- `watches the original paths when the root has no distinct long form` — asserts the common case stays unchanged.

Verification on macOS: new tests pass, `pnpm test` (18 suites, 701 tests), `pnpm run format`, `pnpm run lint`, and `pnpm run typecheck` all clean. Verification on Windows (`windows-latest`, Node 24.19.0 / libuv 1.52.1, the affected combination): the full package suite passed, 18 suites and 701 tests, including both new tests — run linked in the comments.

Note for reviewers: this lands after #48954; the only expected overlap is adjacent context in `#watchdir` and the changelog.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

