### PR TITLE
[expo-task-manager][Android] Fix persisted job scheduling

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent crashes when scheduling persisted TaskManager jobs without the required `RECEIVE_BOOT_COMPLETED` permission. ([#48979](https://github.com/expo/expo/pull/48979) by [@LizunovSergey](https://github.com/LizunovSergey))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent crashes when scheduling persisted TaskManager jobs without the required `RECEIVE_BOOT_COMPLETED` permission. ([#48979](https://github.com/expo/expo/pull/48979) by [@LizunovSergey](https://github.com/LizunovSergey))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/expo-task-manager/android/src/main/AndroidManifest.xml
+++ b/packages/expo-task-manager/android/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
     <application>
         <receiver
             android:name="expo.modules.taskManager.TaskBroadcastReceiver"

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskManagerUtils.java
@@ -143,7 +143,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
         JobInfo mergedJobInfo = createJobInfoByAddingData(newestJob, data);
         jobScheduler.cancel(newestJob.getId());
         jobScheduler.schedule(mergedJobInfo);
-      } catch (IllegalStateException e) {
+      } catch (IllegalArgumentException | IllegalStateException e) {
         Log.e(this.getClass().getName(), "Unable to merge job: " + e.getMessage());
       }
       return;
@@ -153,7 +153,7 @@ public class TaskManagerUtils implements TaskManagerUtilsInterface {
     try {
       JobInfo jobInfo = createJobInfo(context, task, newJobId, data);
       jobScheduler.schedule(jobInfo);
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException | IllegalStateException e) {
       Log.e(this.getClass().getName(), "Unable to schedule job: " + e.getMessage());
     }
   }


### PR DESCRIPTION
## Summary

- Declare `RECEIVE_BOOT_COMPLETED` for TaskManager persisted jobs.
- Handle scheduler failures instead of crashing the host app.

Fixes #48935.

## Test plan

- `:expo-task-manager:testDebugUnitTest`
- `:expo-task-manager:processDebugManifest` (verified the merged manifest contains `RECEIVE_BOOT_COMPLETED`)
- `git diff --check`
- `xmllint --noout packages/expo-task-manager/android/src/main/AndroidManifest.xml`