### PR TITLE
[expo-web-browser][Android] Fix custom tabs toolbar colors

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `toolbarColor` and `secondaryToolbarColor` when opening Custom Tabs. ([#48980](https://github.com/expo/expo/pull/48980) by [@LizunovSergey](https://github.com/LizunovSergey))
+
 ### 💡 Others
 
 ## 57.0.2 - 2026-07-22

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
@@ -104,20 +104,14 @@ class WebBrowserModule : Module() {
   private fun createCustomTabsIntent(options: OpenBrowserOptions): CustomTabsIntent {
     val builder = CustomTabsIntent.Builder()
 
-    val color = options.toolbarColor
-    if (color != null) {
-      val params = CustomTabColorSchemeParams.Builder()
-        .setSecondaryToolbarColor(color)
+    if (options.toolbarColor != null || options.secondaryToolbarColor != null) {
+      val colorSchemeParams = CustomTabColorSchemeParams.Builder()
+        .apply {
+          options.toolbarColor?.let { setToolbarColor(it) }
+          options.secondaryToolbarColor?.let { setSecondaryToolbarColor(it) }
+        }
         .build()
-      builder.setDefaultColorSchemeParams(params)
-    }
-
-    val secondaryColor = options.secondaryToolbarColor
-    if (secondaryColor != null) {
-      val params = CustomTabColorSchemeParams.Builder()
-        .setSecondaryToolbarColor(secondaryColor)
-        .build()
-      builder.setDefaultColorSchemeParams(params)
+      builder.setDefaultColorSchemeParams(colorSchemeParams)
     }
 
     builder.setShowTitle(options.showTitle)

--- a/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
+++ b/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
@@ -141,6 +141,33 @@ internal class WebBrowserModuleTest {
   }
 
   @Test
+  fun `test toolbar colors are passed to custom tabs`() = withWebBrowserMock {
+    // given
+    val toolbarColor = 0xFF361030.toInt()
+    val secondaryToolbarColor = 0xFF103630.toInt()
+    val intentSlot = slot<CustomTabsIntent>()
+    val mock = mockkCustomTabsActivitiesHelper(defaultCanResolveIntent = true, startIntentSlot = intentSlot)
+    initialize(moduleSpy, customTabsActivitiesHelper = mock)
+
+    // when
+    module.openBrowserAsync(
+      "http://expo.io",
+      OpenBrowserOptions(
+        toolbarColor = toolbarColor,
+        secondaryToolbarColor = secondaryToolbarColor
+      )
+    )
+
+    // then
+    val intent = intentSlot.captured.intent
+    assertEquals(toolbarColor, intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, 0))
+    assertEquals(
+      secondaryToolbarColor,
+      intent.getIntExtra(CustomTabsIntent.EXTRA_SECONDARY_TOOLBAR_COLOR, 0)
+    )
+  }
+
+  @Test
   fun testActivitiesAndServicesReturnedForValidKeys() = withWebBrowserMock {
     // given
     val services = arrayListOf("service1", "service2")


### PR DESCRIPTION
## Summary

- Pass `toolbarColor` to the Custom Tabs toolbar field.
- Build one color-scheme parameter object so `toolbarColor` and `secondaryToolbarColor` are preserved together.
- Add a regression test for both intent extras.

Fixes #48900.

## Test plan

- `:expo-web-browser:testDebugUnitTest` (11 tests passed)
- `:expo-web-browser:spotlessCheck`
- `git diff --check`