### PR TITLE
[expo-ui] feat: add dismissOnBackPress to universal BottomSheet on Android

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Added the `listRowSeparatorTint` modifier, so a list row separator can be recolored and not only shown or hidden. ([#48804](https://github.com/expo/expo/issues/48804) by [@marco242424](https://github.com/marco242424)) ([#48810](https://github.com/expo/expo/pull/48810) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Added the `geometryGroup` modifier, so a view's subviews can resolve their geometry against it instead of an animating ancestor. Without it, a `Button` inside a container with an `animation` modifier can draw its label away from its own background while the animation runs. ([#48838](https://github.com/expo/expo/pull/48838) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Add a Jetpack Compose `Image` component. ([#48521](https://github.com/expo/expo/pull/48521) by [@jakex7](https://github.com/jakex7))
+- [android] Add `dismissOnBackPress` prop to the universal `BottomSheet` component, forwarding it to `ModalBottomSheet` via `properties.shouldDismissOnBackPress`. When false, the back press does not dismiss the sheet (and the press still does not reach BackHandler). Part of #48867.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Added the `listRowSeparatorTint` modifier, so a list row separator can be recolored and not only shown or hidden. ([#48804](https://github.com/expo/expo/issues/48804) by [@marco242424](https://github.com/marco242424)) ([#48810](https://github.com/expo/expo/pull/48810) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Added the `geometryGroup` modifier, so a view's subviews can resolve their geometry against it instead of an animating ancestor. Without it, a `Button` inside a container with an `animation` modifier can draw its label away from its own background while the animation runs. ([#48838](https://github.com/expo/expo/pull/48838) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Add a Jetpack Compose `Image` component. ([#48521](https://github.com/expo/expo/pull/48521) by [@jakex7](https://github.com/jakex7))
-- [android] Add `dismissOnBackPress` prop to the universal `BottomSheet` component, forwarding it to `ModalBottomSheet` via `properties.shouldDismissOnBackPress`. When false, the back press does not dismiss the sheet (and the press still does not reach BackHandler). Part of #48867.
+- [android] Add `shouldDismissOnBackPress` prop to the universal `BottomSheet` component, forwarding it to `ModalBottomSheet` via `properties.shouldDismissOnBackPress`. When false, the back press does not dismiss the sheet (and the press still does not reach BackHandler). ([#48987](https://github.com/expo/expo/pull/48987) by [@webdevsamran](https://github.com/webdevsamran))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/src/universal/BottomSheet/index.android.tsx
+++ b/packages/expo-ui/src/universal/BottomSheet/index.android.tsx
@@ -38,6 +38,7 @@ export function BottomSheet({
   snapPoints,
   testID,
   modifiers,
+  dismissOnBackPress = true,
 }: BottomSheetProps) {
   const sheetRef = useRef<ModalBottomSheetRef>(null);
   const [mount, setMount] = useState(isPresented);
@@ -71,6 +72,7 @@ export function BottomSheet({
         onDismissRequest={onDismiss}
         showDragHandle={showDragIndicator}
         skipPartiallyExpanded={shouldSkipPartiallyExpanded(snapPoints)}
+        properties={{ shouldDismissOnBackPress: dismissOnBackPress }}
         modifiers={modifiers}>
         {/* When the drag handle is hidden, add top padding so content doesn't crop against the top edge of the sheet. */}
         <Column modifiers={contentModifiers}>{children}</Column>

--- a/packages/expo-ui/src/universal/BottomSheet/index.android.tsx
+++ b/packages/expo-ui/src/universal/BottomSheet/index.android.tsx
@@ -38,7 +38,7 @@ export function BottomSheet({
   snapPoints,
   testID,
   modifiers,
-  dismissOnBackPress = true,
+  shouldDismissOnBackPress = true,
 }: BottomSheetProps) {
   const sheetRef = useRef<ModalBottomSheetRef>(null);
   const [mount, setMount] = useState(isPresented);
@@ -72,7 +72,7 @@ export function BottomSheet({
         onDismissRequest={onDismiss}
         showDragHandle={showDragIndicator}
         skipPartiallyExpanded={shouldSkipPartiallyExpanded(snapPoints)}
-        properties={{ shouldDismissOnBackPress: dismissOnBackPress }}
+        properties={{ shouldDismissOnBackPress }}
         modifiers={modifiers}>
         {/* When the drag handle is hidden, add top padding so content doesn't crop against the top edge of the sheet. */}
         <Column modifiers={contentModifiers}>{children}</Column>

--- a/packages/expo-ui/src/universal/BottomSheet/types.ts
+++ b/packages/expo-ui/src/universal/BottomSheet/types.ts
@@ -62,7 +62,7 @@ export interface BottomSheetProps {
    * @default true
    * @platform android
    */
-  dismissOnBackPress?: boolean;
+  shouldDismissOnBackPress?: boolean;
 
   /**
    * Platform-specific modifier escape hatch. Pass an array of modifier configs

--- a/packages/expo-ui/src/universal/BottomSheet/types.ts
+++ b/packages/expo-ui/src/universal/BottomSheet/types.ts
@@ -56,6 +56,15 @@ export interface BottomSheetProps {
   testID?: string;
 
   /**
+   * Whether pressing the Android hardware back button (or back gesture) dismisses the bottom sheet.
+   * When `false`, the back press does not dismiss the sheet (note: the press still does not reach
+   * React Native's `BackHandler`).
+   * @default true
+   * @platform android
+   */
+  dismissOnBackPress?: boolean;
+
+  /**
    * Platform-specific modifier escape hatch. Pass an array of modifier configs
    * from `@expo/ui/swift-ui/modifiers` or `@expo/ui/jetpack-compose/modifiers`.
    */


### PR DESCRIPTION
## Summary

Adds dismissOnBackPress prop to the universal BottomSheet component on Android.

## Problem

On Android, the universal BottomSheet wraps Jetpack Compose's ModalBottomSheet. Because Compose places the modal sheet into its own window, the hardware back button / back gesture is intercepted and handled directly by Compose to dismiss the sheet.

By default, the sheet dismisses itself on back press. Developers may want to disable this automatic dismissal.

## Solution

Jetpack Compose's ModalBottomSheet supports opting out of this behavior via ModalBottomSheetProperties(shouldDismissOnBackPress = false).

This PR:
1. Adds dismissOnBackPress?: boolean (default 	rue) to BottomSheetProps in packages/expo-ui/src/universal/BottomSheet/types.ts.
2. Forwards properties={{ shouldDismissOnBackPress: dismissOnBackPress }} to ModalBottomSheet in packages/expo-ui/src/universal/BottomSheet/index.android.tsx.

When dismissOnBackPress={false} is set, pressing back will not dismiss the sheet natively. Note: as identified in testing, the press still does not reach React Native BackHandler listeners because the modal dialog window does not dispatch events to the Activity. This fulfills part of the requirement to control back press behavior natively.

## Backward Compatibility

dismissOnBackPress defaults to 	rue, maintaining exact backwards compatibility with existing behavior.

Part of #48867
