### PR TITLE
[expo-audio] Let the Android player handle audio focus

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Let the player handle audio focus so playback yields to other apps. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@eznix86](https://github.com/eznix86))
+- [Android] Let the player handle audio focus so playback yields to other apps. ([#48990](https://github.com/expo/expo/pull/48990) by [@eznix86](https://github.com/eznix86))
 
 - [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48151](https://github.com/expo/expo/pull/48151) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Let the player handle audio focus so playback yields to other apps. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@eznix86](https://github.com/eznix86))
+
 - [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48151](https://github.com/expo/expo/pull/48151) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -35,7 +35,7 @@ class AudioPlayer(
 ) : BaseAudioPlayer(
   player = ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
-    .setAudioAttributes(AudioAttributes.DEFAULT, false)
+    .setAudioAttributes(AudioAttributes.DEFAULT, true)
     .setHandleAudioBecomingNoisy(true)
     .setSeekForwardIncrementMs(SEEK_JUMP_INTERVAL_MS)
     .setSeekBackIncrementMs(SEEK_JUMP_INTERVAL_MS)

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
@@ -27,7 +27,7 @@ class AudioPlaylist(
 ) : BaseAudioPlayer(
   player = ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
-    .setAudioAttributes(AudioAttributes.DEFAULT, false)
+    .setAudioAttributes(AudioAttributes.DEFAULT, true)
     .setHandleAudioBecomingNoisy(true)
     .setMediaSourceFactory(DefaultMediaSourceFactory(context).setDataSourceFactory(dataSourceFactory))
     .build(),


### PR DESCRIPTION
# Why

On Android the ExoPlayer created by `expo-audio` is built with audio focus handling turned off:

```kotlin
// AudioPlayer.kt, same in AudioPlaylist.kt
.setAudioAttributes(AudioAttributes.DEFAULT, false)
```

The second argument is `handleAudioFocus`. With it set to `false` the player never joins the Android audio focus stack, so it plays over whatever else is playing and nothing can pause it.

This is easy to see from the outside. Start playback in an app that uses `expo-audio`, then start playback in any other app, and both play at once. `adb shell dumpsys audio` shows the other app holding focus and the `expo-audio` app absent from the stack while its player is `state:started`:

```
Audio Focus stack entries (last is top of stack):
  pack: com.android.chrome -- gain: GAIN -- loss: none -- uid: 10171

players:
  AudioPlaybackConfiguration ... u/pid:10235 ... state:started   <- expo-audio app
  AudioPlaybackConfiguration ... u/pid:10171 ... state:started   <- Chrome
```

Setting `interruptionMode: 'doNotMix'` in `setAudioModeAsync` does not change this. `AudioModule` requests focus separately, but the player it hands back ignores focus loss.

# What this changes

Builds both players with `handleAudioFocus = true`, so media3 requests focus when playback starts, pauses on loss, and resumes on gain. This is the behaviour media3 implements for exactly this purpose.

# Open question

`AudioModule` also manages audio focus: it calls `requestAudioFocus()` from `play()` and registers a listener that pauses every player on `AUDIOFOCUS_LOSS`. With this change there are two focus owners in one process.

In my testing that combination deadlocks. The module reads the player's own focus request as a loss and runs `allPlayables.forEach { it.pause() }` against the player that just asked to play. The app is then left holding focus with nothing playing:

```
Audio Focus stack entries (last is top of stack):
  pack: <the app> -- gain: GAIN -- loss: none

players: (no entries in state:started)
```

I worked around it downstream by setting `interruptionMode: 'mixWithOthers'`, which makes `requestAudioFocus()` return early so the module stops competing while the player keeps handling focus. That works but is clearly not the intended use of that value.

The code change is the direction I believe is right, but the module's own focus manager needs to stand down for it to be complete, and that is a design call I did not want to make on your behalf. Two things I could not resolve alone:

1. Should `requestAudioFocus()` and the pause on loss listener be removed now that the player handles focus?
2. `duckOthers` is currently implemented in that listener by halving the volume. media3 ducks automatically on `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK`, but the request type is not configurable through `handleAudioFocus`, so the distinction between `doNotMix` and `duckOthers` may need to move into the `AudioAttributes` passed to the player.

Happy to finish this in whichever direction you prefer.

# Test Plan

Tested on Android 16 and Android 17 with Expo SDK 57 and React Native 0.86, New Architecture enabled, `targetSdk 36`.

- Start playback, then start playback in another app. Before this change both play at once. After it the first player pauses.
- `adb shell dumpsys audio | sed -n '/Audio Focus stack/,/^$/p'` shows the app in the focus stack while playing, which it never did before.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
