### PR TITLE
[expo-glass-effect] Fix glass effect with low opacity animations

### DIFF
--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -255,7 +255,7 @@ export default function GlassOpacityAnimationExample() {
   const fadeOpacity = useSharedValue(0);
 
   const glassViewProps = useAnimatedProps(() => {
-    const glassEffectStyle = fadeOpacity.value > 0.01 ? 'regular' : 'none';
+    const glassEffectStyle = fadeOpacity.value > 0.02 ? 'regular' : 'none';
     return {
       glassEffectStyle,
       style: {

--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -235,7 +235,7 @@ const styles = StyleSheet.create({
 
 ### Opacity animation workaround
 
-[Apple does not recommend](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) `opacity` values below `1` on `GlassView` or its parent views, and the glass effect does not render at very low opacity. To animate opacity anyway, use Reanimated to animate a wrapper view's opacity while toggling the `glassEffectStyle` between the desired style and `'none'`.
+Apple does not recommend `opacity` values below `1` on `GlassView` or its parent views, as described in [Set the correct alpha value](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value). At very low opacity, the glass effect does not render. To animate opacity anyway, use Reanimated to animate a wrapper view's opacity while toggling the `glassEffectStyle` between the desired style and `'none'`.
 
 <SnackInline label='Glass effect opacity animation workaround' dependencies={['expo-glass-effect', 'react-native-reanimated']} platforms={['ios']}>
 

--- a/docs/pages/versions/unversioned/sdk/glass-effect.mdx
+++ b/docs/pages/versions/unversioned/sdk/glass-effect.mdx
@@ -14,10 +14,6 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 React components that render native iOS liquid glass effect using [`UIVisualEffectView`](https://developer.apple.com/documentation/uikit/uivisualeffectview). Supports customizable glass styles and tint color.
 
-## Known issues
-
-- Setting `opacity` to `0` on `GlassView` or any of its parent views causes the glass effect to not render at all. To fade in/out the glass effect, use the built-in [`animate` and `animationDuration`](#animated-glass-effect-style) props in `glassEffectStyle` instead of changing opacity. If you still want to use `opacity`, see the [opacity animation workaround](#opacity-animation-workaround) example. For more details, see [Apple's documentation](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) and [GitHub issue #41024](https://github.com/expo/expo/issues/41024).
-
 ## Installation
 
 <APIInstallSection />
@@ -239,7 +235,7 @@ const styles = StyleSheet.create({
 
 ### Opacity animation workaround
 
-Since setting `opacity` to `0` on `GlassView` or its parent views causes the glass effect to not render at all, you can use Reanimated to animate a wrapper view's opacity while toggling the `glassEffectStyle` between the desired style and `'none'`.
+[Apple does not recommend](https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value) `opacity` values below `1` on `GlassView` or its parent views, and the glass effect does not render at very low opacity. To animate opacity anyway, use Reanimated to animate a wrapper view's opacity while toggling the `glassEffectStyle` between the desired style and `'none'`.
 
 <SnackInline label='Glass effect opacity animation workaround' dependencies={['expo-glass-effect', 'react-native-reanimated']} platforms={['ios']}>
 

--- a/packages/expo-glass-effect/CHANGELOG.md
+++ b/packages/expo-glass-effect/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix the glass effect not rendering when the view fades in from low opacity ([#48994](https://github.com/expo/expo/pull/48994) by [@Nezz](https://github.com/Nezz))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-glass-effect/ios/GlassView.swift
+++ b/packages/expo-glass-effect/ios/GlassView.swift
@@ -10,6 +10,7 @@ public final class GlassView: ExpoView {
   // Glass effect does not work sometimes if view has not been laid out yet
   // https://github.com/expo/expo/issues/41024#issuecomment-3867466289
   private var isMounted = false
+  private var visibilityLink: CADisplayLink?
 
   private var glassStyle: GlassStyle?
   private var glassTintColor: UIColor?
@@ -53,13 +54,68 @@ public final class GlassView: ExpoView {
   override public func layoutSubviews() {
     super.layoutSubviews()
     if !isMounted {
-      isMounted = true
-      // Clear the stale effect before re-applying so UIKit fully tears down
-      // the old UIGlassEffect, otherwise re-assigning does not render GlassView correctly. 
-      // https://github.com/expo/expo/issues/43732
-      glassEffectView.effect = UIVisualEffect()
-      updateEffect()
+      if isEffectRenderable {
+        installEffect()
+      } else {
+        waitForVisibility()
+      }
     }
+  }
+
+  // UIKit silently skips the glass effect when the view's opacity is low,
+  // and never installs it again.
+  private var isEffectRenderable: Bool {
+    guard window != nil else {
+      return false
+    }
+    var opacity: CGFloat = 1
+    var view: UIView? = self
+    while let current = view {
+      if current.isHidden {
+        return false
+      }
+      opacity *= current.alpha
+      view = current.superview
+    }
+
+    // This number was chosen through trial and error.
+    // If adjusting it, be sure to test on various real devices.
+    return opacity > 0.02
+  }
+
+  private func installEffect() {
+    isMounted = true
+    stopWaitingForVisibility()
+    // Clear the stale effect before re-applying so UIKit fully tears down
+    // the old UIGlassEffect, otherwise re-assigning does not render GlassView correctly.
+    // https://github.com/expo/expo/issues/43732
+    glassEffectView.effect = UIVisualEffect()
+    updateEffect()
+  }
+
+  private func waitForVisibility() {
+    guard visibilityLink == nil else {
+      return
+    }
+    let link = CADisplayLink(target: WeakDisplayLinkProxy(self), selector: #selector(WeakDisplayLinkProxy.tick))
+    link.add(to: .main, forMode: .common)
+    visibilityLink = link
+  }
+
+  fileprivate func onVisibilityTick() {
+    if isEffectRenderable {
+      // UIGlassEffect must be created in layoutSubviews
+      setNeedsLayout()
+    }
+  }
+
+  private func stopWaitingForVisibility() {
+    visibilityLink?.invalidate()
+    visibilityLink = nil
+  }
+
+  deinit {
+    visibilityLink?.invalidate()
   }
 
   func updateBorderRadius() {
@@ -238,6 +294,7 @@ public final class GlassView: ExpoView {
     super.didMoveToWindow()
     if (self.window == nil) {
       isMounted = false
+      stopWaitingForVisibility()
     } else {
       // https://github.com/expo/expo/issues/43732
       // UIGlassEffect must be created during layoutSubviews
@@ -277,5 +334,18 @@ public final class GlassView: ExpoView {
 
   public override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
     childComponentView.removeFromSuperview()
+  }
+}
+
+// Use a weak proxy so CADisplayLink does not retain the view
+private final class WeakDisplayLinkProxy: NSObject {
+  private weak var view: GlassView?
+
+  init(_ view: GlassView) {
+    self.view = view
+  }
+
+  @objc func tick() {
+    view?.onVisibilityTick()
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/41024 for real. The liquid glass effect has an issue that hasn't been fixed since it was introduced to expo: when an element with liquid glass fades in, the glass effect often goes missing.

# How

Only mount the effect when the opacity of the element is high enough. The "official workaround" is basically this but without a fixed opacity:
https://docs.expo.dev/versions/latest/sdk/glass-effect/#opacity-animation-workaround

Through trial and error I found >2% opacity to work, but without knowing what's going on inside UIKit we can't know for sure what the real cutoff is.

# Test Plan

Use this minimal repro: https://github.com/Nezz/expo-repro/tree/glass-effect
Verify on the iOS Simulator and real devices. If all goes well you should see a nice grid of glass effects:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/52301344-34cf-4d8e-a82a-d69f57518cdb" />

This is what happens on the latest version of expo without this fix:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1ea1f605-1881-4272-b191-358d843f9c36" />

Use the leave screen button to verify that https://github.com/expo/expo/issues/43732 did not regress

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
