### PR TITLE
[docs] Skip the latest-version link when the page is unversioned only

### DIFF
--- a/docs/common/routes.test.ts
+++ b/docs/common/routes.test.ts
@@ -1,6 +1,6 @@
 import type { NavigationRoute } from '~/types/common';
 
-import { getBreadcrumbTrail, isReferencePath } from './routes';
+import { getBreadcrumbTrail, getLatestVersionPath, isReferencePath } from './routes';
 
 describe(isReferencePath, () => {
   it('returns true for unversioned pathname', () => {
@@ -17,6 +17,68 @@ describe(isReferencePath, () => {
 
   it('returns false for non-versioned pathname', () => {
     expect(isReferencePath('/build-reference/how-tos/')).toBe(false);
+  });
+});
+
+describe(getLatestVersionPath, () => {
+  const latestRoutes: NavigationRoute[] = [
+    {
+      type: 'section',
+      name: 'Expo SDK',
+      href: '',
+      children: [
+        { type: 'page', name: 'Notifications', href: '/versions/latest/sdk/notifications' },
+        {
+          type: 'group',
+          name: 'Expo UI',
+          href: '',
+          children: [
+            {
+              type: 'page',
+              name: 'Jetpack Compose',
+              href: '/versions/latest/sdk/ui/jetpack-compose',
+              isIndex: true,
+            },
+            { type: 'page', name: 'Box', href: '/versions/latest/sdk/ui/jetpack-compose/box' },
+          ],
+        },
+      ],
+    },
+  ];
+
+  it('maps the pathname to latest when that page exists', () => {
+    expect(getLatestVersionPath(latestRoutes, '/versions/unversioned/sdk/notifications')).toBe(
+      '/versions/latest/sdk/notifications'
+    );
+  });
+
+  it('returns undefined when the page is missing from latest', () => {
+    expect(
+      getLatestVersionPath(latestRoutes, '/versions/unversioned/sdk/ui/jetpack-compose/image')
+    ).toBeUndefined();
+  });
+
+  it('does not match a section index for a missing child page', () => {
+    expect(
+      getLatestVersionPath(latestRoutes, '/versions/unversioned/sdk/ui/jetpack-compose/image/')
+    ).toBeUndefined();
+  });
+
+  it('ignores a trailing slash on the pathname', () => {
+    expect(
+      getLatestVersionPath(latestRoutes, '/versions/unversioned/sdk/ui/jetpack-compose/box/')
+    ).toBe('/versions/latest/sdk/ui/jetpack-compose/box');
+  });
+
+  it('skips null entries in route arrays', () => {
+    const routes = [
+      null,
+      { type: 'page', name: 'Box', href: '/versions/latest/sdk/ui/jetpack-compose/box' },
+    ] as unknown as NavigationRoute[];
+
+    expect(getLatestVersionPath(routes, '/versions/unversioned/sdk/ui/jetpack-compose/box')).toBe(
+      '/versions/latest/sdk/ui/jetpack-compose/box'
+    );
   });
 });
 

--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -102,6 +102,33 @@ export const getCanonicalUrl = (path: string) => {
   }
 };
 
+function collectPageHrefs(routes: NavigationRoute[], acc: Set<string>) {
+  for (const route of routes) {
+    if (!route) {
+      continue;
+    }
+    if (route.type === 'page' && route.href) {
+      acc.add(route.href);
+    }
+    if (route.children) {
+      collectPageHrefs(route.children, acc);
+    }
+  }
+}
+
+/**
+ * Resolve the path shown in the banner on unversioned pages. Returns undefined when the page has no
+ * counterpart in `latest`, which is the case for pages added after an SDK cut.
+ */
+export function getLatestVersionPath(routes: NavigationRoute[], pathname: string) {
+  const path = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  const latestPath = Utilities.replaceVersionInUrl(path, 'latest');
+  const pages = new Set<string>();
+  collectPageHrefs(routes, pages);
+
+  return pages.has(latestPath) ? latestPath : undefined;
+}
+
 export const getMarkdownPath = (asPath: string) => {
   const path = asPath.split('?')[0].split('#')[0];
   if (path === '' || path === '/') {

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -83,6 +83,10 @@ export default function DocumentationPage({
     version !== 'unversioned' && !RoutesUtils.isInternalPath(pathname)
       ? RoutesUtils.getCanonicalUrl(pathname)
       : undefined;
+  const latestVersionPath =
+    version === 'unversioned'
+      ? RoutesUtils.getLatestVersionPath(RoutesUtils.getRoutes(pathname, 'latest'), pathname)
+      : undefined;
   const techArticleSchema =
     title && canonicalUrl
       ? buildTechArticleSchema({ title, description, modificationDate, url: canonicalUrl })
@@ -380,9 +384,14 @@ export default function DocumentationPage({
           </p>
           {version && version === 'unversioned' && (
             <InlineHelp type="default" size="sm" className="mb-5! inline-flex! w-full">
-              This is documentation for the next SDK version. For up-to-date documentation, see the{' '}
-              <A href={pathname.replace('unversioned', 'latest')}>latest version</A> (
-              {versionToText(LATEST_VERSION)}).
+              This is documentation for the next SDK version.
+              {latestVersionPath && (
+                <>
+                  {' '}
+                  For up-to-date documentation, see the{' '}
+                  <A href={latestVersionPath}>latest version</A> ({versionToText(LATEST_VERSION)}).
+                </>
+              )}
             </InlineHelp>
           )}
           {title && (


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-25994 https://github.com/expo/expo/issues/49002

# How

<!--
How did you build this feature or fix this bug and why?
-->

The unversioned page banner now hides its "latest version" link when that page doesn't exist in the latest SDK.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2468" height="844" alt="CleanShot 2026-08-17 at 11 33 55@2x" src="https://github.com/user-attachments/assets/0b629df8-d484-4049-8b74-ae9d8cefc47d" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
