### PR TITLE
[docs] Exempt the Japanese pages from the sentence case heading rule

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -34,3 +34,9 @@ BasedOnStyles =
 [**/README.md]
 expo-docs.Prerequisites = NO
 expo-docs.KeyboardShortcuts = NO
+
+# Sentence case is an English orthography rule. Japanese headings lead with the
+# object, so they routinely open with a lowercase identifier or an acronym, and
+# the check can only ever fire on those. See expo/expo#48816.
+[**/pages/ja/**]
+expo-docs.HeadingCase = NO

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -35,8 +35,5 @@ BasedOnStyles =
 expo-docs.Prerequisites = NO
 expo-docs.KeyboardShortcuts = NO
 
-# Sentence case is an English orthography rule. Japanese headings lead with the
-# object, so they routinely open with a lowercase identifier or an acronym, and
-# the check can only ever fire on those. See expo/expo#48816.
 [**/pages/ja/**]
 expo-docs.HeadingCase = NO


### PR DESCRIPTION
# Why

Follow-up to #48816, where we agreed to handle this in a separate PR.

Sentence case is an English orthography rule. Japanese has no letter case, so `HeadingCase` can only ever fire on a Japanese heading that happens to open with an ASCII identifier — and Japanese headings are verb-final, so they routinely open with the object: a file name, a job type, a CLI flag, an acronym.

In #48816 that produced ten headings where applying the rule renamed real files — `### Hello.yml ファイルを追加する` above instructions to create a file named **hello.yml** — and the resolution was six new exception patterns.

The pattern repeats on every batch of translated pages, and the exceptions it needs are wide enough to reach the English docs. Translating the Development process guides needs another twelve: `app config`, `assetlinks.json`, `babel-plugin`, `config plugin`, `direnv`, `gradle`, `jest`, `monorepo`, `peerDependencies`, `react-native-config`, `source-map-explorer`, `DOM`, and `ref`. That last one has to be `.*\brefs?\b.*` to cover `## ref を渡す`, which exempts every English heading containing "ref" or "refs" as a side effect. So each new translated page quietly buys down the check for pages the rule was written for.

# How

Scope the rule out of `pages/ja/**` in `.vale.ini`, the same way `README.md` already opts out of `Prerequisites` and `KeyboardShortcuts`.

```ini
[**/pages/ja/**]
expo-docs.HeadingCase = NO
```

`HeadingCase.yml` is untouched — the six patterns added in #48816 stay where they are rather than being cleaned up here, so this PR is six lines and reversible on its own.

The other 24 styles still apply to the translations.

# Test Plan

- `pnpm lint-prose` — clean, 1592 files.
- Confirmed the exemption is scoped to this one rule, not to the directory. Added a merge conflict marker to `pages/ja/tutorial/screenshot.mdx` and `expo-docs.MergeConflictMarkers` still fired; added `## console ログを削除する` to a Japanese page and `HeadingCase` stayed quiet.
- Confirmed English pages are unaffected: this PR changes no style file, and the run above covers the full `pages` tree.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
