### PR TITLE
[app-metrics][android] Fetch only requested metrics from db

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- [Android] Load only requested metric and log rows when preparing observability payloads.
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Add a `caught` source to the private `reportError` for errors reported from user code. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [Android] Load only requested metric and log rows when preparing observability payloads.
+- [Android] Load only requested metric and log rows when preparing observability payloads. ([#49011](https://github.com/expo/expo/pull/49011) by [@Ubax](https://github.com/Ubax))
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))
 - Add a `caught` source to the private `reportError` for errors reported from user code. ([#47871](https://github.com/expo/expo/pull/47871) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -219,6 +219,9 @@ interface MetricDao {
   @Delete
   suspend fun delete(metrics: List<Metric>)
 
+  @Query("SELECT * FROM metrics WHERE metricId IN (:metricIds)")
+  suspend fun getByIds(metricIds: List<String>): List<Metric>
+
   @Query("SELECT * FROM metrics WHERE sessionId = :sessionId ORDER BY timestamp ASC")
   suspend fun getMetricsForSession(sessionId: String): List<Metric>
 }
@@ -230,6 +233,9 @@ interface LogDao {
 
   @Delete
   suspend fun delete(logs: List<LogRecord>)
+
+  @Query("SELECT * FROM logs WHERE logId IN (:logIds)")
+  suspend fun getByIds(logIds: List<String>): List<LogRecord>
 
   @Query("DELETE FROM logs WHERE timestamp < :cutoffTimestamp")
   suspend fun deleteLogsOlderThan(cutoffTimestamp: String)
@@ -268,6 +274,9 @@ interface SessionDao {
 
   @Query("SELECT * FROM sessions WHERE id = :id")
   suspend fun getById(id: String): Session?
+
+  @Query("SELECT * FROM sessions WHERE id IN (:ids)")
+  suspend fun getByIds(ids: List<String>): List<Session>
 
   // The most recent session other than `:currentSessionId` (null matches all
   // rows, so it returns the latest of any).
@@ -316,12 +325,4 @@ interface SessionDao {
   @Transaction
   @Query("SELECT * FROM sessions WHERE id = :id")
   suspend fun getSessionWithMetricsBySessionId(id: String): SessionWithMetrics?
-
-  @Transaction
-  @Query("SELECT DISTINCT s.* FROM sessions s INNER JOIN metrics m ON s.id = m.sessionId WHERE m.metricId IN (:metricIds)")
-  suspend fun getSessionsWithMetricsByMetricIds(metricIds: List<String>): List<SessionWithMetrics>
-
-  @Transaction
-  @Query("SELECT DISTINCT s.* FROM sessions s INNER JOIN logs l ON s.id = l.sessionId WHERE l.logId IN (:logIds)")
-  suspend fun getSessionsWithLogsByLogIds(logIds: List<String>): List<SessionWithLogs>
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -125,6 +125,7 @@ data class SessionWithMetrics(
     entityColumn = "sessionId"
   )
   val metrics: List<Metric>,
+  /** Only populated by relation-backed `SessionDao` queries. */
   @Relation(
     parentColumn = "id",
     entityColumn = "sessionId"
@@ -160,11 +161,7 @@ data class LogRecord(
 )
 
 data class SessionWithLogs(
-  @Embedded val session: Session,
-  @Relation(
-    parentColumn = "id",
-    entityColumn = "sessionId"
-  )
+  val session: Session,
   val logs: List<LogRecord>
 )
 
@@ -219,7 +216,7 @@ interface MetricDao {
   @Delete
   suspend fun delete(metrics: List<Metric>)
 
-  @Query("SELECT * FROM metrics WHERE metricId IN (:metricIds)")
+  @Query("SELECT * FROM metrics WHERE metricId IN (:metricIds) ORDER BY timestamp ASC")
   suspend fun getByIds(metricIds: List<String>): List<Metric>
 
   @Query("SELECT * FROM metrics WHERE sessionId = :sessionId ORDER BY timestamp ASC")
@@ -234,7 +231,7 @@ interface LogDao {
   @Delete
   suspend fun delete(logs: List<LogRecord>)
 
-  @Query("SELECT * FROM logs WHERE logId IN (:logIds)")
+  @Query("SELECT * FROM logs WHERE logId IN (:logIds) ORDER BY timestamp ASC")
   suspend fun getByIds(logIds: List<String>): List<LogRecord>
 
   @Query("DELETE FROM logs WHERE timestamp < :cutoffTimestamp")

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -160,11 +160,7 @@ data class LogRecord(
 )
 
 data class SessionWithLogs(
-  @Embedded val session: Session,
-  @Relation(
-    parentColumn = "id",
-    entityColumn = "sessionId"
-  )
+  val session: Session,
   val logs: List<LogRecord>
 )
 
@@ -219,7 +215,7 @@ interface MetricDao {
   @Delete
   suspend fun delete(metrics: List<Metric>)
 
-  @Query("SELECT * FROM metrics WHERE metricId IN (:metricIds)")
+  @Query("SELECT * FROM metrics WHERE metricId IN (:metricIds) ORDER BY timestamp ASC")
   suspend fun getByIds(metricIds: List<String>): List<Metric>
 
   @Query("SELECT * FROM metrics WHERE sessionId = :sessionId ORDER BY timestamp ASC")
@@ -234,7 +230,7 @@ interface LogDao {
   @Delete
   suspend fun delete(logs: List<LogRecord>)
 
-  @Query("SELECT * FROM logs WHERE logId IN (:logIds)")
+  @Query("SELECT * FROM logs WHERE logId IN (:logIds) ORDER BY timestamp ASC")
   suspend fun getByIds(logIds: List<String>): List<LogRecord>
 
   @Query("DELETE FROM logs WHERE timestamp < :cutoffTimestamp")

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -224,8 +224,10 @@ class SessionManager(
 
   suspend fun getSessionsWithMetrics(metricIds: List<String>): List<SessionWithMetrics> {
     val metricsBySessionId = metricIds
+      .distinct()
       .chunked(SQLITE_MAX_BIND_VARIABLES)
       .flatMap { database.metricDao().getByIds(it) }
+      .sortedBy { it.timestamp }
       .groupBy { it.sessionId }
     val sessionsById = getSessionsByIds(metricsBySessionId.keys).associateBy { it.id }
 
@@ -238,8 +240,10 @@ class SessionManager(
 
   suspend fun getSessionsWithLogs(logIds: List<String>): List<SessionWithLogs> {
     val logsBySessionId = logIds
+      .distinct()
       .chunked(SQLITE_MAX_BIND_VARIABLES)
       .flatMap { database.logDao().getByIds(it) }
+      .sortedBy { it.timestamp }
       .groupBy { it.sessionId }
     val sessionsById = getSessionsByIds(logsBySessionId.keys).associateBy { it.id }
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -223,52 +223,35 @@ class SessionManager(
   }
 
   suspend fun getSessionsWithMetrics(metricIds: List<String>): List<SessionWithMetrics> {
-    val metricIdSet = metricIds.toSet()
-    if (metricIds.size <= SQLITE_MAX_BIND_VARIABLES) {
-      return database.sessionDao().getSessionsWithMetricsByMetricIds(metricIds).map { sessionWithMetrics ->
-        sessionWithMetrics.copy(metrics = sessionWithMetrics.metrics.filter { it.metricId in metricIdSet })
-      }
-    }
+    val metricsBySessionId = metricIds
+      .chunked(SQLITE_MAX_BIND_VARIABLES)
+      .flatMap { database.metricDao().getByIds(it) }
+      .groupBy { it.sessionId }
+    val sessionsById = getSessionsByIds(metricsBySessionId.keys).associateBy { it.id }
 
-    val allResults = metricIds.chunked(SQLITE_MAX_BIND_VARIABLES).flatMap { chunk ->
-      database.sessionDao().getSessionsWithMetricsByMetricIds(chunk)
-    }
-    return allResults
-      .groupBy { it.session.id }
-      .map { (_, sessions) ->
-        SessionWithMetrics(
-          session = sessions.first().session,
-          metrics = sessions
-            .flatMap { it.metrics }
-            .distinctBy { it.metricId }
-            .filter { it.metricId in metricIdSet }
-        )
+    return metricsBySessionId.mapNotNull { (sessionId, metrics) ->
+      sessionsById[sessionId]?.let { session ->
+        SessionWithMetrics(session = session, metrics = metrics)
       }
+    }
   }
 
   suspend fun getSessionsWithLogs(logIds: List<String>): List<SessionWithLogs> {
-    val logIdSet = logIds.toSet()
-    if (logIds.size <= SQLITE_MAX_BIND_VARIABLES) {
-      return database.sessionDao().getSessionsWithLogsByLogIds(logIds).map { sessionWithLogs ->
-        sessionWithLogs.copy(logs = sessionWithLogs.logs.filter { it.logId in logIdSet })
-      }
-    }
+    val logsBySessionId = logIds
+      .chunked(SQLITE_MAX_BIND_VARIABLES)
+      .flatMap { database.logDao().getByIds(it) }
+      .groupBy { it.sessionId }
+    val sessionsById = getSessionsByIds(logsBySessionId.keys).associateBy { it.id }
 
-    val allResults = logIds.chunked(SQLITE_MAX_BIND_VARIABLES).flatMap { chunk ->
-      database.sessionDao().getSessionsWithLogsByLogIds(chunk)
-    }
-    return allResults
-      .groupBy { it.session.id }
-      .map { (_, sessions) ->
-        SessionWithLogs(
-          session = sessions.first().session,
-          logs = sessions
-            .flatMap { it.logs }
-            .distinctBy { it.logId }
-            .filter { it.logId in logIdSet }
-        )
+    return logsBySessionId.mapNotNull { (sessionId, logs) ->
+      sessionsById[sessionId]?.let { session ->
+        SessionWithLogs(session = session, logs = logs)
       }
+    }
   }
+
+  private suspend fun getSessionsByIds(sessionIds: Collection<String>): List<Session> =
+    sessionIds.chunked(SQLITE_MAX_BIND_VARIABLES).flatMap { database.sessionDao().getByIds(it) }
 
   /**
    * Decodes a JSON-encoded `params` / `attributes` column, folds the current

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -434,30 +434,7 @@ class SessionManagerTest {
     }
 
   @Test
-  fun `getSessionsWithMetrics deduplicates sessions spanning multiple chunks`() =
-    runTest {
-      // Arrange - one session with metrics that will land in different chunks
-      val sessionId = "session-1"
-      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
-
-      // Insert 1100 metrics into the same session
-      val allMetricIds = (1..1100).map { "metric-$it" }
-      allMetricIds.chunked(500).forEach { chunk ->
-        val metrics = chunk.map { createMetric(it, sessionId) }
-        database.metricDao().insertAll(metrics)
-      }
-
-      // Act - query all 1100 metric IDs
-      val result = sessionManager.getSessionsWithMetrics(allMetricIds)
-
-      // Assert - session should appear exactly once with all 1100 metrics
-      assertEquals(1, result.size)
-      assertEquals(sessionId, result[0].session.id)
-      assertEquals(1100, result[0].metrics.size)
-    }
-
-  @Test
-  fun `getSessionsWithMetrics filters correctly across chunk boundaries`() =
+  fun `getSessionsWithMetrics returns only requested metrics across query chunks`() =
     runTest {
       // Arrange - session has 1200 metrics, but we only request 1100 of them
       val sessionId = "session-1"
@@ -484,7 +461,7 @@ class SessionManagerTest {
     }
 
   @Test
-  fun `getSessionsWithMetrics merges multiple sessions across chunks`() =
+  fun `getSessionsWithMetrics groups multiple sessions across query chunks`() =
     runTest {
       // Arrange - two sessions, each with metrics spanning chunk boundaries
       val session1Id = "session-1"
@@ -517,29 +494,58 @@ class SessionManagerTest {
     }
 
   @Test
-  fun `getSessionsWithMetrics yields empty logs from the chunked merger path`() =
+  fun `getSessionsWithMetrics does not load logs`() =
     runTest {
-      // Arrange — the chunked-merger branch in `getSessionsWithMetrics`
-      // constructs `SessionWithMetrics(...)` without passing logs and relies on
-      // the `= emptyList()` default. The session DOES have logs in storage,
-      // but the merger projects metrics-only. This test fails loudly if the
-      // default is removed or the merger ever needs to surface logs too.
       val sessionId = "session-with-logs"
       sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
-
-      val metricIds = (1..1100).map { "metric-$it" }
-      metricIds.chunked(500).forEach { chunk ->
-        database.metricDao().insertAll(chunk.map { createMetric(it, sessionId) })
-      }
-      // Also insert logs so an accidental relation-load would surface them.
+      database.metricDao().insertAll(listOf(createMetric("metric-1", sessionId)))
       database.logDao().insertAll(listOf(createLog("log-a", sessionId)))
 
-      // Act — 1100 IDs forces the chunked path
-      val result = sessionManager.getSessionsWithMetrics(metricIds)
+      val result = sessionManager.getSessionsWithMetrics(listOf("metric-1"))
 
-      // Assert
       assertEquals(1, result.size)
       assertEquals(emptyList<LogRecord>(), result[0].logs)
+    }
+
+  // endregion
+
+  // region getSessionsWithLogs Tests
+
+  @Test
+  fun `getSessionsWithLogs returns only requested logs`() =
+    runTest {
+      val sessionId = "session-1"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      database.logDao().insertAll(
+        listOf(
+          createLog("log-1", sessionId),
+          createLog("log-2", sessionId),
+          createLog("log-3", sessionId)
+        )
+      )
+
+      val result = sessionManager.getSessionsWithLogs(listOf("log-1", "log-3"))
+
+      assertEquals(1, result.size)
+      assertEquals(sessionId, result[0].session.id)
+      assertEquals(setOf("log-1", "log-3"), result[0].logs.map { it.logId }.toSet())
+    }
+
+  @Test
+  fun `getSessionsWithLogs groups requested logs spanning multiple query chunks`() =
+    runTest {
+      val sessionId = "session-1"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      val logIds = (1..1100).map { "log-$it" }
+      logIds.chunked(500).forEach { chunk ->
+        database.logDao().insertAll(chunk.map { createLog(it, sessionId) })
+      }
+
+      val result = sessionManager.getSessionsWithLogs(logIds)
+
+      assertEquals(1, result.size)
+      assertEquals(sessionId, result[0].session.id)
+      assertEquals(logIds.toSet(), result[0].logs.map { it.logId }.toSet())
     }
 
   // endregion

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import expo.modules.appmetrics.AppMetadata
 import expo.modules.appmetrics.AppUpdatesInfo
 import expo.modules.appmetrics.BuildConfig
+import expo.modules.appmetrics.SQLITE_MAX_BIND_VARIABLES
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -393,6 +394,26 @@ class SessionManagerTest {
     }
 
   @Test
+  fun `getSessionsWithMetrics returns unique metrics in chronological order`() =
+    runTest {
+      val sessionId = "session-1"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      database.metricDao().insertAll(
+        listOf(
+          createMetric("metric-z", sessionId, timestamp = "2025-01-01T00:00:02.000Z"),
+          createMetric("metric-a", sessionId, timestamp = "2025-01-01T00:00:01.000Z")
+        )
+      )
+      val metricIds = listOf("metric-z") +
+        (1 until SQLITE_MAX_BIND_VARIABLES).map { "missing-$it" } +
+        listOf("metric-a", "metric-z")
+
+      val result = sessionManager.getSessionsWithMetrics(metricIds)
+
+      assertEquals(listOf("metric-a", "metric-z"), result.single().metrics.map { it.metricId })
+    }
+
+  @Test
   fun `getSessionsWithMetrics returns empty when no metrics match`() =
     runTest {
       // Arrange
@@ -529,6 +550,26 @@ class SessionManagerTest {
       assertEquals(1, result.size)
       assertEquals(sessionId, result[0].session.id)
       assertEquals(setOf("log-1", "log-3"), result[0].logs.map { it.logId }.toSet())
+    }
+
+  @Test
+  fun `getSessionsWithLogs returns unique logs in chronological order`() =
+    runTest {
+      val sessionId = "session-1"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      database.logDao().insertAll(
+        listOf(
+          createLog("log-z", sessionId, timestamp = "2025-01-01T00:00:02.000Z"),
+          createLog("log-a", sessionId, timestamp = "2025-01-01T00:00:01.000Z")
+        )
+      )
+      val logIds = listOf("log-z") +
+        (1 until SQLITE_MAX_BIND_VARIABLES).map { "missing-$it" } +
+        listOf("log-a", "log-z")
+
+      val result = sessionManager.getSessionsWithLogs(logIds)
+
+      assertEquals(listOf("log-a", "log-z"), result.single().logs.map { it.logId })
     }
 
   @Test
@@ -766,12 +807,13 @@ class SessionManagerTest {
     sessionId: String,
     name: String = "test-metric",
     category: String = "test",
-    value: Double = 123.45
+    value: Double = 123.45,
+    timestamp: String = "2025-01-01T00:00:00.000Z"
   ): Metric =
     Metric(
       metricId = metricId,
       sessionId = sessionId,
-      timestamp = "2025-01-01T00:00:00.000Z",
+      timestamp = timestamp,
       category = category,
       name = name,
       value = value,
@@ -784,12 +826,13 @@ class SessionManagerTest {
     sessionId: String,
     name: String = "test.event",
     severity: String = "info",
-    attributes: String? = null
+    attributes: String? = null,
+    timestamp: String = "2025-01-01T00:00:00.000Z"
   ): LogRecord =
     LogRecord(
       logId = logId,
       sessionId = sessionId,
-      timestamp = "2025-01-01T00:00:00.000Z",
+      timestamp = timestamp,
       name = name,
       body = null,
       severity = severity,


### PR DESCRIPTION
# Why

At the moment when we load any metric/event from Room DB, all metrics from its session are loaded. While for short sessions this is not an issue, the longer the session lives, the more data it accumulates and the more expensive the query becomes.

In practice we only need to load the metrics we want to send, so there is no need to load all of them from given session.

# How

1. Don't relay on `Relation` to fetch the data
2. Add two separate queries - one to load metrics by id and second to load sessions 
3. Combine the metrics and sessions together in Kotlin

## Before

1. One DB query with a `join` - fetches all the metrics
2. Kotlin side filtering of only requested metrics

## After

1. Two DB queries - only necessary data is loaded
2. Kotlin side grouping into a combined object

# Test Plan

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
