### PR TITLE
[observe][android] Dispatch pending metrics and logs in chunks

### DIFF
--- a/apps/observe-tester/app/(tabs)/examples/_layout.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/_layout.tsx
@@ -15,6 +15,7 @@ export default function ExamplesLayout() {
       <Stack.Screen name="nested-stack" options={{ headerShown: false }} />
       <Stack.Screen name="preloaded" options={{ headerShown: false }} />
       <Stack.Screen name="modals" options={{ headerShown: false }} />
+      <Stack.Screen name="event-flood" options={{ title: 'Event flood' }} />
     </Stack>
   );
 }

--- a/apps/observe-tester/app/(tabs)/examples/event-flood.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/event-flood.tsx
@@ -8,7 +8,7 @@ import { useTheme } from '@/utils/theme';
 
 export default function EventFlood() {
   const theme = useTheme();
-  const [lastRun, setLastRun] = useState<{ count: number; elapsedMs: number } | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
 
   function logFlood(count: number) {
     const startedAt = performance.now();
@@ -35,11 +35,19 @@ export default function EventFlood() {
       });
     }
 
-    setLastRun({ count, elapsedMs: Math.round(performance.now() - startedAt) });
+    setStatus(
+      `Logged ${count.toLocaleString()} events in ${Math.round(performance.now() - startedAt).toLocaleString()} ms`
+    );
   }
 
   async function clearStoredEntries() {
-    await AppMetrics.clearStoredEntries();
+    try {
+      await AppMetrics.clearStoredEntries();
+      setStatus('Cleared stored entries');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setStatus(`Failed to clear stored entries: ${message}`);
+    }
   }
 
   return (
@@ -53,11 +61,7 @@ export default function EventFlood() {
       <Button title="Log 1,000 events" onPress={() => logFlood(1_000)} />
       <Button title="Log 5,000 events" onPress={() => logFlood(5_000)} />
       <Button title="Clear stored entries" onPress={clearStoredEntries} theme="secondary" />
-      {lastRun ? (
-        <Text style={[styles.status, { color: theme.text.default }]}>
-          Logged {lastRun.count.toLocaleString()} events in {lastRun.elapsedMs.toLocaleString()} ms
-        </Text>
-      ) : null}
+      {status ? <Text style={[styles.status, { color: theme.text.default }]}>{status}</Text> : null}
     </ScrollView>
   );
 }

--- a/apps/observe-tester/app/(tabs)/examples/event-flood.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/event-flood.tsx
@@ -1,0 +1,81 @@
+import AppMetrics from 'expo-app-metrics';
+import { Observe } from 'expo-observe';
+import { useState } from 'react';
+import { Platform, ScrollView, StyleSheet, Text } from 'react-native';
+
+import { Button } from '@/components/Button';
+import { useTheme } from '@/utils/theme';
+
+export default function EventFlood() {
+  const theme = useTheme();
+  const [lastRun, setLastRun] = useState<{ count: number; elapsedMs: number } | null>(null);
+
+  function logFlood(count: number) {
+    const startedAt = performance.now();
+
+    for (let index = 0; index < count; index++) {
+      Observe.logEvent('stress.driver_event', {
+        severity: 'info',
+        body: 'Driver telemetry update received',
+        attributes: {
+          driverId: 'driver_48291',
+          vehicleId: 'vehicle_731',
+          tripId: 'trip_2026_08_14_1842',
+          mode: 'delivery',
+          isOnline: true,
+          speedKph: 42.7,
+          location: {
+            latitude: 37.7751,
+            longitude: -122.4193,
+            accuracyMeters: 8.4,
+          },
+          route: ['warehouse', 'pickup', 'dropoff'],
+          index,
+        },
+      });
+    }
+
+    setLastRun({ count, elapsedMs: Math.round(performance.now() - startedAt) });
+  }
+
+  async function clearStoredEntries() {
+    await AppMetrics.clearStoredEntries();
+  }
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: theme.background.screen }]}
+      contentContainerStyle={styles.content}>
+      <Text style={[styles.description, { color: theme.text.secondary }]}>
+        Log a burst of driver telemetry events synchronously to reproduce high-volume integrations.
+      </Text>
+      <Button title="Log 100 events" onPress={() => logFlood(100)} />
+      <Button title="Log 1,000 events" onPress={() => logFlood(1_000)} />
+      <Button title="Log 5,000 events" onPress={() => logFlood(5_000)} />
+      <Button title="Clear stored entries" onPress={clearStoredEntries} theme="secondary" />
+      {lastRun ? (
+        <Text style={[styles.status, { color: theme.text.default }]}>
+          Logged {lastRun.count.toLocaleString()} events in {lastRun.elapsedMs.toLocaleString()} ms
+        </Text>
+      ) : null}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: Platform.select({ ios: 30, android: 150 }),
+  },
+  description: {
+    fontSize: 14,
+    marginBottom: 20,
+  },
+  status: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/observe-tester/app/(tabs)/examples/index.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/index.tsx
@@ -33,6 +33,11 @@ export default function ExamplesIndex() {
         description="modal / formSheet / pageSheet presentations"
         onPress={() => router.push('/examples/modals')}
       />
+      <Button
+        title="Event flood"
+        description="Generate high-volume log events"
+        onPress={() => router.push('/examples/event-flood')}
+      />
     </ScrollView>
   );
 }

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work.
+- [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work. ([#49012](https://github.com/expo/expo/pull/49012) by [@Ubax](https://github.com/Ubax))
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))
 
 ## 57.0.9 — 2026-07-29

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks.
+- [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work.
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))
 
 ## 57.0.9 — 2026-07-29

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks.
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))
 
 ## 57.0.9 — 2026-07-29

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/Constants.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/Constants.kt
@@ -3,4 +3,5 @@ package expo.modules.observe
 internal const val OBSERVE_TAG = "EasObserve"
 internal const val OBSERVE_DEFAULT_BASE_URL = "https://o.expo.dev/"
 
+internal const val DISPATCH_CHUNK_SIZE = 200
 internal const val SQLITE_MAX_BIND_VARIABLES = 900

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -119,7 +119,8 @@ class ObservabilityBackgroundWorker(
         .getInstance(context)
         .enqueueUniqueWork(
           WORK_NAME,
-          ExistingWorkPolicy.REPLACE,
+          // Keep an in-flight dispatch; cancelling it can duplicate a request the server received.
+          ExistingWorkPolicy.KEEP,
           periodicWork
         )
     }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -189,9 +189,6 @@ class BaseObservabilityManager(
         val result = eventDispatcher.dispatch(events)
         metricsRetryGate = nextGate(metricsRetryGate, result)
         val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
-        if (DispatchUtils.shouldRemovePending(result)) {
-          pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-        }
         when (result) {
           is DispatchResult.PartialSuccess ->
             Log.w(
@@ -207,7 +204,12 @@ class BaseObservabilityManager(
             )
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
-        if (result is DispatchResult.RetryableFailure) {
+        if (!DispatchUtils.shouldRemovePending(result)) {
+          break
+        }
+        pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
+        if (result is DispatchResult.NonRetryableFailure) {
           break
         }
       }
@@ -260,9 +262,6 @@ class BaseObservabilityManager(
         val result = eventDispatcher.dispatchLogs(events)
         logsRetryGate = nextGate(logsRetryGate, result)
         val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
-        if (DispatchUtils.shouldRemovePending(result)) {
-          pendingLogsManager.removePendingLogs(dispatchedLogIds)
-        }
         when (result) {
           is DispatchResult.PartialSuccess ->
             Log.w(
@@ -278,11 +277,15 @@ class BaseObservabilityManager(
             )
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
-        if (result is DispatchResult.RetryableFailure) {
+        if (!DispatchUtils.shouldRemovePending(result)) {
+          break
+        }
+        pendingLogsManager.removePendingLogs(dispatchedLogIds)
+        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
+        if (result is DispatchResult.NonRetryableFailure) {
           break
         }
       }
-
     }
   }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -8,6 +8,8 @@ import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.interfaces.constants.ConstantsInterface
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -163,7 +165,7 @@ class BaseObservabilityManager(
       return
     }
 
-    while (true) {
+    while (currentCoroutineContext().isActive) {
       val pendingIds = pendingMetricsManager.getPendingMetricIds(dispatchChunkSize)
       if (pendingIds.isEmpty()) {
         break
@@ -234,7 +236,7 @@ class BaseObservabilityManager(
       return
     }
 
-    while (true) {
+    while (currentCoroutineContext().isActive) {
       val pendingIds = pendingLogsManager.getPendingLogIds(dispatchChunkSize)
       if (pendingIds.isEmpty()) {
         break

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -81,7 +81,8 @@ class BaseObservabilityManager(
   private val deterministicUniformValueProvider: () -> Double = {
     EASClientID.deterministicUniformValue(EASClientID(context).uuid)
   },
-  private val currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() }
+  private val currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() },
+  private val dispatchChunkSize: Int = DISPATCH_CHUNK_SIZE
 ) {
   private val eventDispatcher = EventDispatcher(
     context = context,
@@ -149,8 +150,7 @@ class BaseObservabilityManager(
   )
 
   suspend fun dispatchUnsentMetrics(): Unit = metricsDispatchMutex.withLock {
-    val pendingIds = pendingMetricsManager.getAllPendingMetricIds()
-    if (pendingIds.isEmpty()) {
+    if (!pendingMetricsManager.hasPendingMetrics()) {
       return
     }
 
@@ -159,50 +159,58 @@ class BaseObservabilityManager(
     }
 
     if (!shouldDispatch()) {
-      pendingMetricsManager.removePendingMetrics(pendingIds)
+      pendingMetricsManager.removeAllPendingMetrics()
       return
     }
 
-    val sessionsWithPendingMetrics = sessionManager.getSessionsWithMetrics(pendingIds)
+    while (true) {
+      val pendingIds = pendingMetricsManager.getPendingMetricIds(dispatchChunkSize)
+      if (pendingIds.isEmpty()) {
+        break
+      }
 
-    // Clean up orphaned pending IDs (metrics deleted from MetricsDatabase but still in pending table)
-    val resolvedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }.toSet()
-    val orphanedIds = pendingIds.filter { it !in resolvedMetricIds }
-    if (orphanedIds.isNotEmpty()) {
-      pendingMetricsManager.removePendingMetrics(orphanedIds)
-    }
+      val sessionsWithPendingMetrics = sessionManager.getSessionsWithMetrics(pendingIds)
 
-    if (sessionsWithPendingMetrics.isEmpty()) {
-      return
-    }
+      // Clean up orphaned pending IDs (metrics deleted from MetricsDatabase but still in pending table)
+      val resolvedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }.toSet()
+      val orphanedIds = pendingIds.filter { it !in resolvedMetricIds }
+      if (orphanedIds.isNotEmpty()) {
+        pendingMetricsManager.removePendingMetrics(orphanedIds)
+      }
 
-    val events = sessionsWithPendingMetrics.map { sessionWithMetrics ->
-      Event(
-        metadata = Metadata.fromSessionMetadata(sessionWithMetrics.session),
-        metrics = sessionWithMetrics.metrics.map { EASMetric.fromMetric(it) }
-      )
-    }
+      if (sessionsWithPendingMetrics.isNotEmpty()) {
+        val events = sessionsWithPendingMetrics.map { sessionWithMetrics ->
+          Event(
+            metadata = Metadata.fromSessionMetadata(sessionWithMetrics.session),
+            metrics = sessionWithMetrics.metrics.map { EASMetric.fromMetric(it) }
+          )
+        }
 
-    val result = eventDispatcher.dispatch(events)
-    metricsRetryGate = nextGate(metricsRetryGate, result)
-    val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
-    if (DispatchUtils.shouldRemovePending(result)) {
-      pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-    }
-    when (result) {
-      is DispatchResult.PartialSuccess ->
-        Log.w(
-          OBSERVE_TAG,
-          "Partial success on batch of ${dispatchedMetricIds.size} metric event(s): " +
-            "server rejected ${result.partial.rejectedCount} " +
-            "(${result.partial.errorMessage ?: "no error message"})"
-        )
-      is DispatchResult.NonRetryableFailure ->
-        Log.w(
-          OBSERVE_TAG,
-          "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
-        )
-      is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        val result = eventDispatcher.dispatch(events)
+        metricsRetryGate = nextGate(metricsRetryGate, result)
+        val dispatchedMetricIds = sessionsWithPendingMetrics.flatMap { it.metrics }.map { it.metricId }
+        if (DispatchUtils.shouldRemovePending(result)) {
+          pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+        }
+        when (result) {
+          is DispatchResult.PartialSuccess ->
+            Log.w(
+              OBSERVE_TAG,
+              "Partial success on batch of ${dispatchedMetricIds.size} metric event(s): " +
+                "server rejected ${result.partial.rejectedCount} " +
+                "(${result.partial.errorMessage ?: "no error message"})"
+            )
+          is DispatchResult.NonRetryableFailure ->
+            Log.w(
+              OBSERVE_TAG,
+              "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
+            )
+          is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.RetryableFailure) {
+          break
+        }
+      }
     }
   }
 
@@ -211,8 +219,7 @@ class BaseObservabilityManager(
    * a logs failure doesn't affect the metrics pending table and vice versa.
    */
   suspend fun dispatchUnsentLogs(): Unit = logsDispatchMutex.withLock {
-    val pendingIds = pendingLogsManager.getAllPendingLogIds()
-    if (pendingIds.isEmpty()) {
+    if (!pendingLogsManager.hasPendingLogs()) {
       return
     }
 
@@ -221,52 +228,61 @@ class BaseObservabilityManager(
     }
 
     if (!shouldDispatch()) {
-      pendingLogsManager.removePendingLogs(pendingIds)
+      pendingLogsManager.removeAllPendingLogs()
       return
     }
 
-    val sessionsWithPendingLogs = sessionManager.getSessionsWithLogs(pendingIds)
+    while (true) {
+      val pendingIds = pendingLogsManager.getPendingLogIds(dispatchChunkSize)
+      if (pendingIds.isEmpty()) {
+        break
+      }
 
-    // Clean up orphaned pending IDs (logs deleted from the `logs` table but
-    // still tracked in `pending_logs`).
-    val resolvedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }.toSet()
-    val orphanedIds = pendingIds.filter { it !in resolvedLogIds }
-    if (orphanedIds.isNotEmpty()) {
-      pendingLogsManager.removePendingLogs(orphanedIds)
-    }
+      val sessionsWithPendingLogs = sessionManager.getSessionsWithLogs(pendingIds)
 
-    if (sessionsWithPendingLogs.isEmpty()) {
-      return
-    }
+      // Clean up orphaned pending IDs (logs deleted from the `logs` table but
+      // still tracked in `pending_logs`).
+      val resolvedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }.toSet()
+      val orphanedIds = pendingIds.filter { it !in resolvedLogIds }
+      if (orphanedIds.isNotEmpty()) {
+        pendingLogsManager.removePendingLogs(orphanedIds)
+      }
 
-    val events = sessionsWithPendingLogs.map { sessionWithLogs ->
-      Event(
-        metadata = Metadata.fromSessionMetadata(sessionWithLogs.session),
-        metrics = emptyList(),
-        logs = sessionWithLogs.logs.map { LogEvent.fromLogRecord(it) }
-      )
-    }
+      if (sessionsWithPendingLogs.isNotEmpty()) {
+        val events = sessionsWithPendingLogs.map { sessionWithLogs ->
+          Event(
+            metadata = Metadata.fromSessionMetadata(sessionWithLogs.session),
+            metrics = emptyList(),
+            logs = sessionWithLogs.logs.map { LogEvent.fromLogRecord(it) }
+          )
+        }
 
-    val result = eventDispatcher.dispatchLogs(events)
-    logsRetryGate = nextGate(logsRetryGate, result)
-    val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
-    if (DispatchUtils.shouldRemovePending(result)) {
-      pendingLogsManager.removePendingLogs(dispatchedLogIds)
-    }
-    when (result) {
-      is DispatchResult.PartialSuccess ->
-        Log.w(
-          OBSERVE_TAG,
-          "Partial success on batch of ${dispatchedLogIds.size} log event(s): " +
-            "server rejected ${result.partial.rejectedCount} " +
-            "(${result.partial.errorMessage ?: "no error message"})"
-        )
-      is DispatchResult.NonRetryableFailure ->
-        Log.w(
-          OBSERVE_TAG,
-          "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
-        )
-      is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        val result = eventDispatcher.dispatchLogs(events)
+        logsRetryGate = nextGate(logsRetryGate, result)
+        val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
+        if (DispatchUtils.shouldRemovePending(result)) {
+          pendingLogsManager.removePendingLogs(dispatchedLogIds)
+        }
+        when (result) {
+          is DispatchResult.PartialSuccess ->
+            Log.w(
+              OBSERVE_TAG,
+              "Partial success on batch of ${dispatchedLogIds.size} log event(s): " +
+                "server rejected ${result.partial.rejectedCount} " +
+                "(${result.partial.errorMessage ?: "no error message"})"
+            )
+          is DispatchResult.NonRetryableFailure ->
+            Log.w(
+              OBSERVE_TAG,
+              "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
+            )
+          is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.RetryableFailure) {
+          break
+        }
+      }
+
     }
   }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
@@ -30,8 +30,14 @@ interface PendingMetricDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
   suspend fun insertAll(metrics: List<PendingMetric>)
 
-  @Query("SELECT metricId FROM pending_metrics")
-  suspend fun getAllMetricIds(): List<String>
+  @Query("SELECT metricId FROM pending_metrics ORDER BY addedAt ASC LIMIT :limit")
+  suspend fun getMetricIds(limit: Int): List<String>
+
+  @Query("SELECT EXISTS(SELECT 1 FROM pending_metrics)")
+  suspend fun hasMetricIds(): Boolean
+
+  @Query("DELETE FROM pending_metrics")
+  suspend fun deleteAll()
 
   @Query("DELETE FROM pending_metrics WHERE metricId IN (:metricIds)")
   suspend fun deleteByIds(metricIds: List<String>)
@@ -45,8 +51,14 @@ interface PendingLogDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
   suspend fun insertAll(logs: List<PendingLog>)
 
-  @Query("SELECT logId FROM pending_logs")
-  suspend fun getAllLogIds(): List<String>
+  @Query("SELECT logId FROM pending_logs ORDER BY addedAt ASC LIMIT :limit")
+  suspend fun getLogIds(limit: Int): List<String>
+
+  @Query("SELECT EXISTS(SELECT 1 FROM pending_logs)")
+  suspend fun hasLogIds(): Boolean
+
+  @Query("DELETE FROM pending_logs")
+  suspend fun deleteAll()
 
   @Query("DELETE FROM pending_logs WHERE logId IN (:logIds)")
   suspend fun deleteByIds(logIds: List<String>)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
@@ -11,6 +11,8 @@ import androidx.room.Query
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
+// TODO: Draining large backlogs from both pending tables reruns `ORDER BY addedAt`
+// for every chunk. Consider `Index("addedAt")` and a version bump if this matters in practice.
 @Entity(tableName = "pending_metrics")
 data class PendingMetric(
   @PrimaryKey val metricId: String,

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingLogsManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingLogsManager.kt
@@ -17,7 +17,11 @@ class PendingLogsManager(
     database.pendingLogDao().insertAll(pendingLogs)
   }
 
-  suspend fun getAllPendingLogIds(): List<String> = database.pendingLogDao().getAllLogIds()
+  suspend fun getPendingLogIds(limit: Int): List<String> = database.pendingLogDao().getLogIds(limit)
+
+  suspend fun hasPendingLogs(): Boolean = database.pendingLogDao().hasLogIds()
+
+  suspend fun removeAllPendingLogs() = database.pendingLogDao().deleteAll()
 
   suspend fun removePendingLogs(logIds: List<String>) {
     database.withTransaction {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingMetricsManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingMetricsManager.kt
@@ -17,7 +17,11 @@ class PendingMetricsManager(
     database.pendingMetricDao().insertAll(pendingMetrics)
   }
 
-  suspend fun getAllPendingMetricIds(): List<String> = database.pendingMetricDao().getAllMetricIds()
+  suspend fun getPendingMetricIds(limit: Int): List<String> = database.pendingMetricDao().getMetricIds(limit)
+
+  suspend fun hasPendingMetrics(): Boolean = database.pendingMetricDao().hasMetricIds()
+
+  suspend fun removeAllPendingMetrics() = database.pendingMetricDao().deleteAll()
 
   suspend fun removePendingMetrics(metricIds: List<String>) {
     database.withTransaction {

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -10,6 +10,9 @@ import expo.modules.appmetrics.storage.SessionWithLogs
 import expo.modules.appmetrics.storage.SessionWithMetrics
 import expo.modules.appmetrics.utils.TimeUtils
 import io.mockk.*
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -746,10 +749,10 @@ class BaseObservabilityManagerTest {
   @Test
   fun `dispatchUnsentMetrics dispatches a backlog in successive chunks`() =
     runTest {
+      val pendingIds = mutableListOf("metric-1", "metric-2", "metric-3")
       val requestedChunks = mutableListOf<List<String>>()
       val removedIds = mutableListOf<String>()
-      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
-        listOf(listOf("metric-1", "metric-2"), listOf("metric-3"), emptyList())
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers { pendingIds.take(2) }
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
         val ids = firstArg<List<String>>()
         requestedChunks.add(ids)
@@ -759,7 +762,9 @@ class BaseObservabilityManagerTest {
       }
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
+        val ids = firstArg<List<String>>()
+        removedIds.addAll(ids)
+        pendingIds.removeAll(ids.toSet())
       }
 
       createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
@@ -771,6 +776,30 @@ class BaseObservabilityManagerTest {
       assertEquals(listOf("metric-1", "metric-2", "metric-3"), removedIds)
       coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
       coVerify(exactly = 3) { mockPendingMetricsManager.getPendingMetricIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics stops reading chunks after cancellation`() =
+    runTest {
+      val pendingIds = mutableListOf("metric-1", "metric-2", "metric-3")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers { pendingIds.take(2) }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } coAnswers {
+        pendingIds.removeAll(firstArg<List<String>>().toSet())
+        currentCoroutineContext().cancel()
+      }
+
+      launch {
+        createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+      }.join()
+
+      assertEquals(listOf("metric-3"), pendingIds)
+      coVerify(exactly = 1) { mockPendingMetricsManager.getPendingMetricIds(2) }
     }
 
   @Test
@@ -830,38 +859,39 @@ class BaseObservabilityManagerTest {
   @Test
   fun `dispatchUnsentMetrics removes an orphaned chunk and continues`() =
     runTest {
+      val pendingIds = mutableListOf("orphan-1", "metric-1", "metric-2")
       val removedChunks = mutableListOf<List<String>>()
-      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
-        listOf(listOf("orphan-1", "orphan-2"), listOf("metric-1"), emptyList())
-      coEvery { mockSessionManager.getSessionsWithMetrics(listOf("orphan-1", "orphan-2")) } returns emptyList()
-      coEvery { mockSessionManager.getSessionsWithMetrics(listOf("metric-1")) } returns listOf(
-        createSessionWithMetrics(
-          "session-1",
-          "production",
-          listOf(createMetric("metric-1", metricId = "metric-1"))
-        )
-      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers { pendingIds.take(2) }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>()
+          .filter { it.startsWith("metric-") }
+          .map { id ->
+            createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+          }
+      }
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedChunks.add(firstArg<List<String>>())
+        val ids = firstArg<List<String>>()
+        removedChunks.add(ids)
+        pendingIds.removeAll(ids.toSet())
       }
 
       createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
 
       assertEquals(
-        listOf(listOf("orphan-1", "orphan-2"), listOf("metric-1")),
+        listOf(listOf("orphan-1"), listOf("metric-1"), listOf("metric-2")),
         removedChunks
       )
-      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
     }
 
   @Test
   fun `dispatchUnsentLogs dispatches a backlog in successive chunks`() =
     runTest {
+      val pendingIds = mutableListOf("log-1", "log-2", "log-3")
       val requestedChunks = mutableListOf<List<String>>()
       val removedIds = mutableListOf<String>()
-      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
-        listOf(listOf("log-1", "log-2"), listOf("log-3"), emptyList())
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers { pendingIds.take(2) }
       coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
         val ids = firstArg<List<String>>()
         requestedChunks.add(ids)
@@ -871,7 +901,9 @@ class BaseObservabilityManagerTest {
       }
       coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
       coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
+        val ids = firstArg<List<String>>()
+        removedIds.addAll(ids)
+        pendingIds.removeAll(ids.toSet())
       }
 
       createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
@@ -880,6 +912,30 @@ class BaseObservabilityManagerTest {
       assertEquals(listOf("log-1", "log-2", "log-3"), removedIds)
       coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
       coVerify(exactly = 3) { mockPendingLogsManager.getPendingLogIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs stops reading chunks after cancellation`() =
+    runTest {
+      val pendingIds = mutableListOf("log-1", "log-2", "log-3")
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers { pendingIds.take(2) }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } coAnswers {
+        pendingIds.removeAll(firstArg<List<String>>().toSet())
+        currentCoroutineContext().cancel()
+      }
+
+      launch {
+        createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+      }.join()
+
+      assertEquals(listOf("log-3"), pendingIds)
+      coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(2) }
     }
 
   @Test
@@ -939,26 +995,27 @@ class BaseObservabilityManagerTest {
   @Test
   fun `dispatchUnsentLogs removes an orphaned chunk and continues`() =
     runTest {
+      val pendingIds = mutableListOf("orphan-1", "log-1", "log-2")
       val removedChunks = mutableListOf<List<String>>()
-      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
-        listOf(listOf("orphan-1", "orphan-2"), listOf("log-1"), emptyList())
-      coEvery { mockSessionManager.getSessionsWithLogs(listOf("orphan-1", "orphan-2")) } returns emptyList()
-      coEvery { mockSessionManager.getSessionsWithLogs(listOf("log-1")) } returns listOf(
-        createSessionWithLogs(
-          "session-1",
-          "production",
-          listOf(createLog("log-1", logId = "log-1"))
-        )
-      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers { pendingIds.take(2) }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>()
+          .filter { it.startsWith("log-") }
+          .map { id ->
+            createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+          }
+      }
       coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
       coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
-        removedChunks.add(firstArg<List<String>>())
+        val ids = firstArg<List<String>>()
+        removedChunks.add(ids)
+        pendingIds.removeAll(ids.toSet())
       }
 
       createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
 
-      assertEquals(listOf(listOf("orphan-1", "orphan-2"), listOf("log-1")), removedChunks)
-      coVerify(exactly = 1) { mockEventDispatcher.dispatchLogs(any()) }
+      assertEquals(listOf(listOf("orphan-1"), listOf("log-1"), listOf("log-2")), removedChunks)
+      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
     }
 
   // endregion

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -40,6 +40,8 @@ class BaseObservabilityManagerTest {
     mockEventDispatcher = mockk(relaxed = true)
     mockPendingMetricsManager = mockk(relaxed = true)
     mockPendingLogsManager = mockk(relaxed = true)
+    coEvery { mockPendingMetricsManager.hasPendingMetrics() } returns true
+    coEvery { mockPendingLogsManager.hasPendingLogs() } returns true
 
     // Default to enabled so existing tests aren't short-circuited
     mockkObject(ObservePreferences)
@@ -59,12 +61,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = false)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
-
-      val removedIds = mutableListOf<String>()
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
-      }
 
       val manager = createManager()
 
@@ -77,10 +73,8 @@ class BaseObservabilityManagerTest {
       // Assert - sessions are never fetched
       coVerify(exactly = 0) { mockSessionManager.getSessionsWithMetrics(any()) }
 
-      // Assert - all pending metric IDs are removed
-      assertEquals(2, removedIds.size)
-      assertTrue("id1 should be removed", removedIds.contains("id1"))
-      assertTrue("id2 should be removed", removedIds.contains("id2"))
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
+      coVerify(exactly = 0) { mockPendingMetricsManager.getPendingMetricIds(any()) }
     }
 
   @Test
@@ -95,7 +89,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(devMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("dev-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -133,7 +127,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(devMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("dev-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -171,7 +165,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(prodMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("prod-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -206,7 +200,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(devMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("dev-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -230,23 +224,16 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — explicit opt-out behaves like the default on debug builds.
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchInDebug = false)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
-
-      val removedIds = mutableListOf<String>()
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
-      }
 
       val manager = createManager(isDebugBuild = true)
 
       // Act
       manager.dispatchUnsentMetrics()
 
-      // Assert — short-circuit: no session lookup, no dispatch, single removePendingMetrics call.
+      // Assert — short-circuit: no session lookup, no dispatch, and the pending table is cleared.
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
       coVerify(exactly = 0) { mockSessionManager.getSessionsWithMetrics(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1", "id2")) }
-      assertEquals(2, removedIds.size)
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -261,7 +248,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(prodMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("prod-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -282,9 +269,6 @@ class BaseObservabilityManagerTest {
         dispatchingEnabled = false,
         dispatchInDebug = true
       )
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(isDebugBuild = true)
 
       // Act
@@ -292,7 +276,7 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   // endregion
@@ -306,9 +290,6 @@ class BaseObservabilityManagerTest {
       every { ObservePreferences.getBundleDefaults(any()) } returns
         PersistedBundleDefaults(environment = "development", isJsDev = true)
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchInDebug = false)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(isDebugBuild = false)
 
       // Act
@@ -316,7 +297,7 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -333,7 +314,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(devMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("dev-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("dev-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(devSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
@@ -361,7 +342,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(prodMetric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("prod-metric-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("prod-metric-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(prodSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
@@ -381,9 +362,6 @@ class BaseObservabilityManagerTest {
       // Arrange — cold start before JS has run. isJsDev defaults to false.
       every { ObservePreferences.getBundleDefaults(any()) } returns null
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchInDebug = false)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(isDebugBuild = true)
 
       // Act
@@ -391,7 +369,7 @@ class BaseObservabilityManagerTest {
 
       // Assert — isDebugBuild alone gates dispatch.
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   // endregion
@@ -409,7 +387,7 @@ class BaseObservabilityManagerTest {
         environment = "production",
         metrics = listOf(metric)
       )
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -434,7 +412,7 @@ class BaseObservabilityManagerTest {
         environment = "production",
         metrics = listOf(metric)
       )
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -452,12 +430,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — sampleRate = 0.5, device value = 0.8 → out-of-sample
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(sampleRate = 0.5)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
-
-      val removedIds = mutableListOf<String>()
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
-      }
 
       val manager = createManager(deterministicUniformValue = 0.8)
 
@@ -467,7 +439,7 @@ class BaseObservabilityManagerTest {
       // Assert — no dispatch, pending is cleared
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
       coVerify(exactly = 0) { mockSessionManager.getSessionsWithMetrics(any()) }
-      assertEquals(listOf("id1", "id2"), removedIds)
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -475,12 +447,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — sampleRate = 0.5, device value = 0.5 → out-of-sample (comparison is strict <).
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(sampleRate = 0.5)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
-
-      val removedIds = mutableListOf<String>()
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
-        removedIds.addAll(firstArg<List<String>>())
-      }
 
       val manager = createManager(deterministicUniformValue = 0.5)
 
@@ -490,7 +456,7 @@ class BaseObservabilityManagerTest {
       // Assert — no dispatch, pending is cleared
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
       coVerify(exactly = 0) { mockSessionManager.getSessionsWithMetrics(any()) }
-      assertEquals(listOf("id1", "id2"), removedIds)
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -498,9 +464,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — any deterministic value is >= 0, so sampleRate=0 → out.
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(sampleRate = 0.0)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(deterministicUniformValue = 0.0)
 
       // Act
@@ -508,7 +471,7 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -522,7 +485,7 @@ class BaseObservabilityManagerTest {
         environment = "production",
         metrics = listOf(metric)
       )
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -546,7 +509,7 @@ class BaseObservabilityManagerTest {
         environment = "production",
         metrics = listOf(metric)
       )
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -564,9 +527,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — -0.5 → clamped to 0.0 → out-of-sample.
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(sampleRate = -0.5)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(deterministicUniformValue = 0.0)
 
       // Act
@@ -574,7 +534,7 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   @Test
@@ -582,9 +542,6 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange — dispatchingEnabled=false wins over sampleRate=1.0.
       every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = false, sampleRate = 1.0)
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
-      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs
-
       val manager = createManager(deterministicUniformValue = 0.0)
 
       // Act
@@ -592,7 +549,7 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
-      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("id1")) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.removeAllPendingMetrics() }
     }
 
   // endregion
@@ -603,7 +560,7 @@ class BaseObservabilityManagerTest {
   fun `dispatchUnsentMetrics does nothing when no pending metrics exist`() =
     runTest {
       // Arrange
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns emptyList()
+      coEvery { mockPendingMetricsManager.hasPendingMetrics() } returns false
 
       val manager = createManager()
 
@@ -613,6 +570,7 @@ class BaseObservabilityManagerTest {
       // Assert
       coVerify(exactly = 0) { mockEventDispatcher.dispatch(any()) }
       coVerify(exactly = 0) { mockPendingMetricsManager.removePendingMetrics(any()) }
+      coVerify(exactly = 0) { mockPendingMetricsManager.getPendingMetricIds(any()) }
       coVerify(exactly = 0) { mockSessionManager.getSessionsWithMetrics(any()) }
     }
 
@@ -621,7 +579,7 @@ class BaseObservabilityManagerTest {
     runTest {
       // Arrange
       val pendingIds = listOf("metric-1", "metric-2")
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns pendingIds
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(pendingIds, emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(pendingIds) } returns emptyList()
 
       val manager = createManager()
@@ -630,7 +588,7 @@ class BaseObservabilityManagerTest {
       manager.dispatchUnsentMetrics()
 
       // Assert
-      coVerify(exactly = 1) { mockPendingMetricsManager.getAllPendingMetricIds() }
+      coVerify(exactly = 2) { mockPendingMetricsManager.getPendingMetricIds(any()) }
       coVerify(exactly = 1) { mockSessionManager.getSessionsWithMetrics(pendingIds) }
     }
 
@@ -645,7 +603,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric1)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "orphaned-id")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1", "orphaned-id"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -669,7 +627,7 @@ class BaseObservabilityManagerTest {
   fun `dispatchUnsentMetrics cleans up all orphaned pending IDs when no sessions match`() =
     runTest {
       // Arrange - all pending IDs are orphaned
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("orphan-1", "orphan-2")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("orphan-1", "orphan-2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns emptyList()
 
       val removedIds = mutableListOf<String>()
@@ -707,7 +665,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric3)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2", "id3")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1", "id2", "id3"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session1, session2)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -741,7 +699,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric1, metric2)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1", "id2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.NonRetryableFailure("HTTP 400")
 
@@ -772,7 +730,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric1, metric2)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1", "id2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.RetryableFailure()
 
@@ -783,6 +741,225 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 0) { mockPendingMetricsManager.removePendingMetrics(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics dispatches a backlog in successive chunks`() =
+    runTest {
+      val requestedChunks = mutableListOf<List<String>>()
+      val removedIds = mutableListOf<String>()
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        val ids = firstArg<List<String>>()
+        requestedChunks.add(ids)
+        ids.map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedIds.addAll(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+
+      assertEquals(
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3")),
+        requestedChunks
+      )
+      assertEquals(listOf("metric-1", "metric-2", "metric-3"), removedIds)
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+      coVerify(exactly = 3) { mockPendingMetricsManager.getPendingMetricIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics stops after a retryable chunk and sets the gate`() =
+    runTest {
+      val session = createSessionWithMetrics(
+        "session-1",
+        "production",
+        listOf(
+          createMetric("metric-1", metricId = "metric-1"),
+          createMetric("metric-2", metricId = "metric-2")
+        )
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returns listOf("metric-1", "metric-2")
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
+      coEvery { mockEventDispatcher.dispatch(any()) } returns
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
+
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+      manager.dispatchUnsentMetrics()
+      manager.dispatchUnsentMetrics()
+
+      coVerify(exactly = 1) { mockPendingMetricsManager.getPendingMetricIds(2) }
+      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
+      coVerify(exactly = 0) { mockPendingMetricsManager.removePendingMetrics(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics drops a non-retryable chunk and continues`() =
+    runTest {
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.NonRetryableFailure("HTTP 400"),
+        DispatchResult.Success
+      )
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+
+      assertEquals(
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3")),
+        removedChunks
+      )
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics removes an orphaned chunk and continues`() =
+    runTest {
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
+        listOf(listOf("orphan-1", "orphan-2"), listOf("metric-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(listOf("orphan-1", "orphan-2")) } returns emptyList()
+      coEvery { mockSessionManager.getSessionsWithMetrics(listOf("metric-1")) } returns listOf(
+        createSessionWithMetrics(
+          "session-1",
+          "production",
+          listOf(createMetric("metric-1", metricId = "metric-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+
+      assertEquals(
+        listOf(listOf("orphan-1", "orphan-2"), listOf("metric-1")),
+        removedChunks
+      )
+      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs dispatches a backlog in successive chunks`() =
+    runTest {
+      val requestedChunks = mutableListOf<List<String>>()
+      val removedIds = mutableListOf<String>()
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
+        listOf(listOf("log-1", "log-2"), listOf("log-3"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        val ids = firstArg<List<String>>()
+        requestedChunks.add(ids)
+        ids.map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
+        removedIds.addAll(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+
+      assertEquals(listOf(listOf("log-1", "log-2"), listOf("log-3")), requestedChunks)
+      assertEquals(listOf("log-1", "log-2", "log-3"), removedIds)
+      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
+      coVerify(exactly = 3) { mockPendingLogsManager.getPendingLogIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs stops after a retryable chunk and sets the gate`() =
+    runTest {
+      val session = createSessionWithLogs(
+        "session-1",
+        "production",
+        listOf(
+          createLog("log-1", logId = "log-1"),
+          createLog("log-2", logId = "log-2")
+        )
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returns listOf("log-1", "log-2")
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(session)
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns
+        DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
+
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+      manager.dispatchUnsentLogs()
+      manager.dispatchUnsentLogs()
+
+      coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(2) }
+      coVerify(exactly = 1) { mockEventDispatcher.dispatchLogs(any()) }
+      coVerify(exactly = 0) { mockPendingLogsManager.removePendingLogs(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs drops a non-retryable chunk and continues`() =
+    runTest {
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
+        listOf(listOf("log-1", "log-2"), listOf("log-3"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.NonRetryableFailure("HTTP 400"),
+        DispatchResult.Success
+      )
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+
+      assertEquals(listOf(listOf("log-1", "log-2"), listOf("log-3")), removedChunks)
+      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs removes an orphaned chunk and continues`() =
+    runTest {
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
+        listOf(listOf("orphan-1", "orphan-2"), listOf("log-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(listOf("orphan-1", "orphan-2")) } returns emptyList()
+      coEvery { mockSessionManager.getSessionsWithLogs(listOf("log-1")) } returns listOf(
+        createSessionWithLogs(
+          "session-1",
+          "production",
+          listOf(createLog("log-1", logId = "log-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+
+      assertEquals(listOf(listOf("orphan-1", "orphan-2"), listOf("log-1")), removedChunks)
+      coVerify(exactly = 1) { mockEventDispatcher.dispatchLogs(any()) }
     }
 
   // endregion
@@ -961,7 +1138,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric1, metric2)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("m1", "m2")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("m1", "m2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -1005,7 +1182,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric2)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("metric-id-1", "metric-id-2")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("metric-id-1", "metric-id-2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session1, session2)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -1054,7 +1231,7 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returns
         DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
@@ -1089,12 +1266,12 @@ class BaseObservabilityManagerTest {
         logs = listOf(logRecord)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns
         DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
 
-      coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
+      coEvery { mockPendingLogsManager.getPendingLogIds(any()) } returnsMany listOf(listOf("log-1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
       coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.Success
 
@@ -1125,12 +1302,12 @@ class BaseObservabilityManagerTest {
         logs = listOf(logRecord)
       )
 
-      coEvery { mockPendingLogsManager.getAllPendingLogIds() } returns listOf("log-1")
+      coEvery { mockPendingLogsManager.getPendingLogIds(any()) } returnsMany listOf(listOf("log-1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(logSession)
       coEvery { mockEventDispatcher.dispatchLogs(any()) } returns
         DispatchResult.RetryableFailure(retryAfterMs = 60_000L)
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany listOf(listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(metricSession)
       coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.Success
 
@@ -1155,7 +1332,8 @@ class BaseObservabilityManagerTest {
         metrics = listOf(metric)
       )
 
-      coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(any()) } returnsMany
+        listOf(listOf("id1"), listOf("id1"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(session)
       coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
         DispatchResult.RetryableFailure(retryAfterMs = 60_000L),
@@ -1179,7 +1357,8 @@ class BaseObservabilityManagerTest {
   private fun createManager(
     isDebugBuild: Boolean = false,
     deterministicUniformValue: Double = 0.0,
-    currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() }
+    currentTimeMs: () -> Long = { TimeUtils.getWallClockMillis() },
+    dispatchChunkSize: Int = DISPATCH_CHUNK_SIZE
   ): BaseObservabilityManager {
     val manager = BaseObservabilityManager(
       context = mockContext,
@@ -1190,7 +1369,8 @@ class BaseObservabilityManagerTest {
       baseUrl = testBaseUrl,
       isDebugBuild = isDebugBuild,
       deterministicUniformValueProvider = { deterministicUniformValue },
-      currentTimeMs = currentTimeMs
+      currentTimeMs = currentTimeMs,
+      dispatchChunkSize = dispatchChunkSize
     )
     // Replace the internal EventDispatcher with our mock
     val field = BaseObservabilityManager::class.java.getDeclaredField("eventDispatcher")

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -802,7 +802,7 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
-  fun `dispatchUnsentMetrics drops a non-retryable chunk and continues`() =
+  fun `dispatchUnsentMetrics drops a non-retryable chunk and stops`() =
     runTest {
       val removedChunks = mutableListOf<List<String>>()
       coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
@@ -822,11 +822,9 @@ class BaseObservabilityManagerTest {
 
       createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
 
-      assertEquals(
-        listOf(listOf("metric-1", "metric-2"), listOf("metric-3")),
-        removedChunks
-      )
-      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+      assertEquals(listOf(listOf("metric-1", "metric-2")), removedChunks)
+      coVerify(exactly = 1) { mockEventDispatcher.dispatch(any()) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.getPendingMetricIds(2) }
     }
 
   @Test
@@ -913,7 +911,7 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
-  fun `dispatchUnsentLogs drops a non-retryable chunk and continues`() =
+  fun `dispatchUnsentLogs drops a non-retryable chunk and stops`() =
     runTest {
       val removedChunks = mutableListOf<List<String>>()
       coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
@@ -933,8 +931,9 @@ class BaseObservabilityManagerTest {
 
       createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
 
-      assertEquals(listOf(listOf("log-1", "log-2"), listOf("log-3")), removedChunks)
-      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
+      assertEquals(listOf(listOf("log-1", "log-2")), removedChunks)
+      coVerify(exactly = 1) { mockEventDispatcher.dispatchLogs(any()) }
+      coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(2) }
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/storage/PendingLogsManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/storage/PendingLogsManagerTest.kt
@@ -1,0 +1,156 @@
+package expo.modules.observe.storage
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class PendingLogsManagerTest {
+  private lateinit var database: ObserveDatabase
+  private lateinit var manager: PendingLogsManager
+
+  @Before
+  fun setUp() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, ObserveDatabase::class.java)
+      .allowMainThreadQueries()
+      .build()
+    manager = PendingLogsManager(context, database)
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  @Test
+  fun `addPendingLogs inserts logs correctly`() =
+    runTest {
+      val logIds = listOf("log-1", "log-2", "log-3")
+
+      manager.addPendingLogs(logIds)
+
+      val result = manager.getPendingLogIds(Int.MAX_VALUE)
+      assertEquals(3, result.size)
+      assertTrue(result.containsAll(logIds))
+    }
+
+  @Test
+  fun `getPendingLogIds returns all inserted IDs from multiple add calls`() =
+    runTest {
+      manager.addPendingLogs(listOf("log-1", "log-2"))
+      manager.addPendingLogs(listOf("log-3"))
+
+      val result = manager.getPendingLogIds(Int.MAX_VALUE)
+
+      assertEquals(3, result.size)
+      assertTrue(result.containsAll(listOf("log-1", "log-2", "log-3")))
+    }
+
+  @Test
+  fun `getPendingLogIds returns the oldest IDs up to the limit`() =
+    runTest {
+      database.pendingLogDao().insertAll(
+        listOf(
+          PendingLog("log-3", "2025-01-03T00:00:00.000Z"),
+          PendingLog("log-1", "2025-01-01T00:00:00.000Z"),
+          PendingLog("log-4", "2025-01-04T00:00:00.000Z"),
+          PendingLog("log-2", "2025-01-02T00:00:00.000Z")
+        )
+      )
+
+      val result = manager.getPendingLogIds(2)
+
+      assertEquals(listOf("log-1", "log-2"), result)
+    }
+
+  @Test
+  fun `hasPendingLogs reflects whether logs are pending`() =
+    runTest {
+      assertFalse(manager.hasPendingLogs())
+
+      manager.addPendingLogs(listOf("log-1"))
+
+      assertTrue(manager.hasPendingLogs())
+    }
+
+  @Test
+  fun `removePendingLogs deletes specified IDs only`() =
+    runTest {
+      manager.addPendingLogs(listOf("log-1", "log-2", "log-3"))
+
+      manager.removePendingLogs(listOf("log-1", "log-3"))
+
+      assertEquals(listOf("log-2"), manager.getPendingLogIds(Int.MAX_VALUE))
+    }
+
+  @Test
+  fun `cleanupOldPendingLogs removes old entries`() =
+    runTest {
+      database.pendingLogDao().insertAll(
+        listOf(PendingLog(logId = "old-log", addedAt = "2020-01-01T00:00:00.000Z"))
+      )
+      manager.addPendingLogs(listOf("recent-log"))
+
+      manager.cleanupOldPendingLogs()
+
+      assertEquals(listOf("recent-log"), manager.getPendingLogIds(Int.MAX_VALUE))
+    }
+
+  @Test
+  fun `addPendingLogs with duplicate IDs ignores duplicates`() =
+    runTest {
+      manager.addPendingLogs(listOf("log-1", "log-2"))
+
+      manager.addPendingLogs(listOf("log-2", "log-3"))
+
+      val result = manager.getPendingLogIds(Int.MAX_VALUE)
+      assertEquals(3, result.size)
+      assertTrue(result.containsAll(listOf("log-1", "log-2", "log-3")))
+    }
+
+  @Test
+  fun `removePendingLogs with empty list is a no-op`() =
+    runTest {
+      manager.addPendingLogs(listOf("log-1", "log-2"))
+
+      manager.removePendingLogs(emptyList())
+
+      assertEquals(2, manager.getPendingLogIds(Int.MAX_VALUE).size)
+    }
+
+  @Test
+  fun `removeAllPendingLogs deletes all pending logs`() =
+    runTest {
+      manager.addPendingLogs(listOf("log-1", "log-2"))
+
+      manager.removeAllPendingLogs()
+
+      assertFalse(manager.hasPendingLogs())
+    }
+
+  @Test
+  fun `removePendingLogs handles more than 900 items`() =
+    runTest {
+      val allIds = (1..1100).map { "log-$it" }
+      allIds.chunked(500).forEach { chunk ->
+        manager.addPendingLogs(chunk)
+      }
+      assertEquals(1100, manager.getPendingLogIds(Int.MAX_VALUE).size)
+
+      manager.removePendingLogs(allIds)
+
+      val remaining = manager.getPendingLogIds(Int.MAX_VALUE)
+      assertTrue("Expected empty but got ${remaining.size} items", remaining.isEmpty())
+    }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/storage/PendingMetricsManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/storage/PendingMetricsManagerTest.kt
@@ -43,24 +43,41 @@ class PendingMetricsManagerTest {
       manager.addPendingMetrics(metricIds)
 
       // Assert
-      val result = manager.getAllPendingMetricIds()
+      val result = manager.getPendingMetricIds(Int.MAX_VALUE)
       assertEquals(3, result.size)
       assertTrue(result.containsAll(metricIds))
     }
 
   @Test
-  fun `getAllPendingMetricIds returns all inserted IDs from multiple add calls`() =
+  fun `getPendingMetricIds returns all inserted IDs from multiple add calls`() =
     runTest {
       // Arrange
       manager.addPendingMetrics(listOf("metric-1", "metric-2"))
       manager.addPendingMetrics(listOf("metric-3"))
 
       // Act
-      val result = manager.getAllPendingMetricIds()
+      val result = manager.getPendingMetricIds(Int.MAX_VALUE)
 
       // Assert
       assertEquals(3, result.size)
       assertTrue(result.containsAll(listOf("metric-1", "metric-2", "metric-3")))
+    }
+
+  @Test
+  fun `getPendingMetricIds returns the oldest IDs up to the limit`() =
+    runTest {
+      database.pendingMetricDao().insertAll(
+        listOf(
+          PendingMetric("metric-3", "2025-01-03T00:00:00.000Z"),
+          PendingMetric("metric-1", "2025-01-01T00:00:00.000Z"),
+          PendingMetric("metric-4", "2025-01-04T00:00:00.000Z"),
+          PendingMetric("metric-2", "2025-01-02T00:00:00.000Z")
+        )
+      )
+
+      val result = manager.getPendingMetricIds(2)
+
+      assertEquals(listOf("metric-1", "metric-2"), result)
     }
 
   @Test
@@ -73,7 +90,7 @@ class PendingMetricsManagerTest {
       manager.removePendingMetrics(listOf("metric-1", "metric-3"))
 
       // Assert
-      val remaining = manager.getAllPendingMetricIds()
+      val remaining = manager.getPendingMetricIds(Int.MAX_VALUE)
       assertEquals(1, remaining.size)
       assertEquals("metric-2", remaining[0])
     }
@@ -89,13 +106,13 @@ class PendingMetricsManagerTest {
       manager.addPendingMetrics(listOf("recent-metric"))
 
       // Verify both exist
-      assertEquals(2, manager.getAllPendingMetricIds().size)
+      assertEquals(2, manager.getPendingMetricIds(Int.MAX_VALUE).size)
 
       // Act
       manager.cleanupOldPendingMetrics()
 
       // Assert - only recent metric survives
-      val remaining = manager.getAllPendingMetricIds()
+      val remaining = manager.getPendingMetricIds(Int.MAX_VALUE)
       assertEquals(1, remaining.size)
       assertEquals("recent-metric", remaining[0])
     }
@@ -110,7 +127,7 @@ class PendingMetricsManagerTest {
       manager.addPendingMetrics(listOf("metric-2", "metric-3"))
 
       // Assert - no duplicates
-      val result = manager.getAllPendingMetricIds()
+      val result = manager.getPendingMetricIds(Int.MAX_VALUE)
       assertEquals(3, result.size)
       assertTrue(result.containsAll(listOf("metric-1", "metric-2", "metric-3")))
     }
@@ -125,7 +142,17 @@ class PendingMetricsManagerTest {
       manager.removePendingMetrics(emptyList())
 
       // Assert - nothing removed
-      assertEquals(2, manager.getAllPendingMetricIds().size)
+      assertEquals(2, manager.getPendingMetricIds(Int.MAX_VALUE).size)
+    }
+
+  @Test
+  fun `removeAllPendingMetrics deletes all pending metrics`() =
+    runTest {
+      manager.addPendingMetrics(listOf("metric-1", "metric-2"))
+
+      manager.removeAllPendingMetrics()
+
+      assertFalse(manager.hasPendingMetrics())
     }
 
   @Test
@@ -136,13 +163,13 @@ class PendingMetricsManagerTest {
       allIds.chunked(500).forEach { chunk ->
         manager.addPendingMetrics(chunk)
       }
-      assertEquals(1100, manager.getAllPendingMetricIds().size)
+      assertEquals(1100, manager.getPendingMetricIds(Int.MAX_VALUE).size)
 
       // Act - remove all 1100 at once
       manager.removePendingMetrics(allIds)
 
       // Assert - all removed
-      val remaining = manager.getAllPendingMetricIds()
+      val remaining = manager.getPendingMetricIds(Int.MAX_VALUE)
       assertTrue("Expected empty but got ${remaining.size} items", remaining.isEmpty())
     }
 }


### PR DESCRIPTION
# Why

If a lot of metrics/events have accumulated, the request sending all of them may be rejected by the server. Additionally loading all of them may cause OOM exception.

# How

1. Change the access layer to pending metrics/events db - instead of a single `getAll`, add `has`, `get` (with limit), and `removeAll`
2. Chunk metrics/events when sending and continue until all metrics are dispatched
3. Change the conflict resolution of the background worker to `KEEP` - instead of aborting in flight request and the dispatch loop, it will keep the existing worker. Previously we used `REPLACE` to ensure that the newest data is sent and then removed from pending metrics. Now since chunking always loads the oldest not dispatched metrics, we can keep the existing worker and let it fetch data.
4. Add observe-tester screen for adding large quantities of events

# Test Plan

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
