### PR TITLE
[observe][android] Retry the dispatch on 413

### DIFF
--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [Android] Retry a dispatch that gets HTTP 413
+- [Android] Retry a dispatch that gets HTTP 413 ([#49016](https://github.com/expo/expo/pull/49016) by [@Ubax](https://github.com/Ubax))
 - [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work. ([#49012](https://github.com/expo/expo/pull/49012) by [@Ubax](https://github.com/Ubax))
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))
 

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- [Android] Retry a dispatch that gets HTTP 413
 - [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work. ([#49012](https://github.com/expo/expo/pull/49012) by [@Ubax](https://github.com/Ubax))
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -220,7 +220,8 @@ object DispatchUtils {
    *   server-side) doesn't introduce a new pause.
    * - `NonRetryableFailure` also resets the counter. A permanent drop isn't a sign that the
    *   server is unhealthy and shouldn't pause subsequent rounds.
-   * - `PayloadTooLarge` leaves both fields untouched because chunk-size retries are immediate.
+   * - `PayloadTooLarge` also resets the counter because a reachable server returned a definitive
+   *   response, and leaves the gate alone because chunk-size retries are immediate.
    * - `RetryableFailure` increments the counter and sets the gate to `now + delay`, where
    *   `delay` is the server-supplied `retryAfterMs` if present, otherwise `backoff(nextCount)`.
    *
@@ -235,9 +236,9 @@ object DispatchUtils {
   ): RetryGateState = when (result) {
     is DispatchResult.Success,
     is DispatchResult.PartialSuccess,
-    is DispatchResult.NonRetryableFailure ->
+    is DispatchResult.NonRetryableFailure,
+    is DispatchResult.PayloadTooLarge ->
       currentState.copy(consecutiveRetryableFailures = 0)
-    is DispatchResult.PayloadTooLarge -> currentState
     is DispatchResult.RetryableFailure -> {
       val nextCount = currentState.consecutiveRetryableFailures + 1
       val delay = result.retryAfterMs ?: backoff(nextCount)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -11,7 +11,7 @@ import kotlin.math.pow
 import kotlin.random.Random
 
 /**
- * Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
+ * Outcome of a single dispatch attempt to the OTLP endpoint. Five cases, modeled after the
  * OTLP retry guidance (see https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
  *
  * - `Success` — server accepted the batch without rejections.
@@ -22,6 +22,7 @@ import kotlin.random.Random
  *   it as a drop.
  * - `RetryableFailure` — transient failure (429/502/503/504 or transport error); retry
  *   the same batch after `retryAfterMs` or a client-computed backoff.
+ * - `PayloadTooLarge` — HTTP 413; retry immediately with fewer records.
  * - `NonRetryableFailure` — permanent failure (4xx/5xx outside the retryable set, encoding
  *   error); drop the batch so it can't wedge the queue.
  *
@@ -33,6 +34,7 @@ sealed class DispatchResult {
   object Success : DispatchResult()
   data class PartialSuccess(val partial: OTPartialSuccess) : DispatchResult()
   data class RetryableFailure(val retryAfterMs: Long? = null) : DispatchResult()
+  object PayloadTooLarge : DispatchResult()
   data class NonRetryableFailure(val reason: String) : DispatchResult()
 }
 
@@ -43,7 +45,7 @@ sealed class DispatchResult {
  */
 object DispatchUtils {
   /**
-   * Pure classifier that maps an HTTP response into one of three retry outcomes. Extracted
+   * Pure classifier that maps an HTTP response into a dispatch outcome. Extracted
    * from the dispatch call site so the OTLP-spec rules can be unit-tested without a real
    * network call.
    *
@@ -57,8 +59,6 @@ object DispatchUtils {
     responseBody: String?,
     bodyExcerpt: () -> String = { "" }
   ): DispatchResult {
-    val retryAfter = parseRetryAfter(retryAfterHeader)
-
     if (statusCode in 200..299) {
       // The OTLP spec allows `partial_success` to carry a warning-only payload —
       // `rejectedCount == 0` with a non-empty `errorMessage`. Treat that as a successful send
@@ -78,7 +78,8 @@ object DispatchUtils {
     }
 
     return when (statusCode) {
-      429, 502, 503, 504 -> DispatchResult.RetryableFailure(retryAfter)
+      413 -> DispatchResult.PayloadTooLarge
+      429, 502, 503, 504 -> DispatchResult.RetryableFailure(parseRetryAfter(retryAfterHeader))
       else -> {
         val excerpt = bodyExcerpt()
         val suffix = if (excerpt.isEmpty()) "" else ": $excerpt"
@@ -97,13 +98,14 @@ object DispatchUtils {
    *   permanently, so retrying would produce the same answer; removing them drops the batch
    *   so it can't wedge subsequent rounds. This is the acceptance-criterion behavior: a
    *   400/403 must not be re-sent on the next cycle.
-   * - `RetryableFailure` keeps them so the next dispatch round picks the same rows up again.
+   * - `RetryableFailure` and `PayloadTooLarge` keep them so they can be retried.
    */
   fun shouldRemovePending(result: DispatchResult): Boolean = when (result) {
     is DispatchResult.Success,
     is DispatchResult.PartialSuccess,
     is DispatchResult.NonRetryableFailure -> true
-    is DispatchResult.RetryableFailure -> false
+    is DispatchResult.RetryableFailure,
+    is DispatchResult.PayloadTooLarge -> false
   }
 
   /**
@@ -218,6 +220,7 @@ object DispatchUtils {
    *   server-side) doesn't introduce a new pause.
    * - `NonRetryableFailure` also resets the counter. A permanent drop isn't a sign that the
    *   server is unhealthy and shouldn't pause subsequent rounds.
+   * - `PayloadTooLarge` leaves both fields untouched because chunk-size retries are immediate.
    * - `RetryableFailure` increments the counter and sets the gate to `now + delay`, where
    *   `delay` is the server-supplied `retryAfterMs` if present, otherwise `backoff(nextCount)`.
    *
@@ -234,6 +237,7 @@ object DispatchUtils {
     is DispatchResult.PartialSuccess,
     is DispatchResult.NonRetryableFailure ->
       currentState.copy(consecutiveRetryableFailures = 0)
+    is DispatchResult.PayloadTooLarge -> currentState
     is DispatchResult.RetryableFailure -> {
       val nextCount = currentState.consecutiveRetryableFailures + 1
       val delay = result.retryAfterMs ?: backoff(nextCount)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/DispatchUtils.kt
@@ -98,14 +98,16 @@ object DispatchUtils {
    *   permanently, so retrying would produce the same answer; removing them drops the batch
    *   so it can't wedge subsequent rounds. This is the acceptance-criterion behavior: a
    *   400/403 must not be re-sent on the next cycle.
-   * - `RetryableFailure` and `PayloadTooLarge` keep them so they can be retried.
+   * - `PayloadTooLarge` removes the pending ID because multi-record batches are retried with
+   *   smaller chunks before this check, so reaching it means a single record exceeded the limit.
+   * - `RetryableFailure` keeps them so they can be retried.
    */
   fun shouldRemovePending(result: DispatchResult): Boolean = when (result) {
     is DispatchResult.Success,
     is DispatchResult.PartialSuccess,
-    is DispatchResult.NonRetryableFailure -> true
-    is DispatchResult.RetryableFailure,
-    is DispatchResult.PayloadTooLarge -> false
+    is DispatchResult.NonRetryableFailure,
+    is DispatchResult.PayloadTooLarge -> true
+    is DispatchResult.RetryableFailure -> false
   }
 
   /**

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -132,6 +132,8 @@ class EventDispatcher(
         )
       is DispatchResult.RetryableFailure ->
         Log.w(OBSERVE_TAG, "Server responded with ${response.code} (retryable) and data: $responseBody")
+      is DispatchResult.PayloadTooLarge ->
+        Log.w(OBSERVE_TAG, "Server responded with ${response.code} (payload too large) and data: $responseBody")
       is DispatchResult.NonRetryableFailure ->
         Log.w(
           OBSERVE_TAG,

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -168,7 +168,9 @@ class BaseObservabilityManager(
     var chunkSize = dispatchChunkSize
     while (currentCoroutineContext().isActive) {
       val pendingIds = pendingMetricsManager.getPendingMetricIds(chunkSize)
-      // Use the default for the next batch unless a 413 below overrides it.
+      // Use the default for the next batch unless a 413 below overrides it. Re-discovering
+      // the limit each batch is fine: the server accepts payloads over 1 MB, so the default
+      // chunk stays far below the limit and a 413 is exceptional.
       chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
@@ -211,8 +213,11 @@ class BaseObservabilityManager(
             if (dispatchedMetricIds.size > 1) {
               chunkSize = dispatchedMetricIds.size / 2
             } else {
+              // A single record can't realistically exceed the server's payload limit, so drop
+              // it as a last-resort safety valve and stop this dispatch round.
               Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
               pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+              break
             }
           }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
@@ -250,7 +255,9 @@ class BaseObservabilityManager(
     var chunkSize = dispatchChunkSize
     while (currentCoroutineContext().isActive) {
       val pendingIds = pendingLogsManager.getPendingLogIds(chunkSize)
-      // Use the default for the next batch unless a 413 below overrides it.
+      // Use the default for the next batch unless a 413 below overrides it. Re-discovering
+      // the limit each batch is fine: the server accepts payloads over 1 MB, so the default
+      // chunk stays far below the limit and a 413 is exceptional.
       chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
@@ -295,8 +302,11 @@ class BaseObservabilityManager(
             if (dispatchedLogIds.size > 1) {
               chunkSize = dispatchedLogIds.size / 2
             } else {
+              // A single record can't realistically exceed the server's payload limit, so drop
+              // it as a last-resort safety valve and stop this dispatch round.
               Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
               pendingLogsManager.removePendingLogs(dispatchedLogIds)
+              break
             }
           }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -209,25 +209,23 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
             )
-          is DispatchResult.PayloadTooLarge -> {
-            if (dispatchedMetricIds.size > 1) {
-              chunkSize = dispatchedMetricIds.size / 2
-            } else {
-              // A single record can't realistically exceed the server's payload limit, so drop
-              // it as a last-resort safety valve and stop this dispatch round.
+          is DispatchResult.PayloadTooLarge ->
+            if (dispatchedMetricIds.size == 1) {
               Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
-              pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-              break
             }
-          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.PayloadTooLarge && dispatchedMetricIds.size > 1) {
+          chunkSize = dispatchedMetricIds.size / 2
+          // Keep the pending metrics, but retry immediately with a smaller chunk.
+          continue
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
           break
         }
         pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
-        if (result is DispatchResult.NonRetryableFailure) {
+        // A systematic rejection or an oversized record: leave the rest for the next run.
+        if (result is DispatchResult.NonRetryableFailure || result is DispatchResult.PayloadTooLarge) {
           break
         }
       }
@@ -298,25 +296,23 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
             )
-          is DispatchResult.PayloadTooLarge -> {
-            if (dispatchedLogIds.size > 1) {
-              chunkSize = dispatchedLogIds.size / 2
-            } else {
-              // A single record can't realistically exceed the server's payload limit, so drop
-              // it as a last-resort safety valve and stop this dispatch round.
+          is DispatchResult.PayloadTooLarge ->
+            if (dispatchedLogIds.size == 1) {
               Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
-              pendingLogsManager.removePendingLogs(dispatchedLogIds)
-              break
             }
-          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.PayloadTooLarge && dispatchedLogIds.size > 1) {
+          chunkSize = dispatchedLogIds.size / 2
+          // Keep the pending logs, but retry immediately with a smaller chunk.
+          continue
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
           break
         }
         pendingLogsManager.removePendingLogs(dispatchedLogIds)
-        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
-        if (result is DispatchResult.NonRetryableFailure) {
+        // A systematic rejection or an oversized record: leave the rest for the next run.
+        if (result is DispatchResult.NonRetryableFailure || result is DispatchResult.PayloadTooLarge) {
           break
         }
       }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -165,8 +165,11 @@ class BaseObservabilityManager(
       return
     }
 
+    var chunkSize = dispatchChunkSize
     while (currentCoroutineContext().isActive) {
-      val pendingIds = pendingMetricsManager.getPendingMetricIds(dispatchChunkSize)
+      val pendingIds = pendingMetricsManager.getPendingMetricIds(chunkSize)
+      // Use the default for the next batch unless a 413 below overrides it.
+      chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
       }
@@ -204,6 +207,14 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
             )
+          is DispatchResult.PayloadTooLarge -> {
+            if (dispatchedMetricIds.size > 1) {
+              chunkSize = dispatchedMetricIds.size / 2
+            } else {
+              Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
+              pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+            }
+          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
@@ -236,8 +247,11 @@ class BaseObservabilityManager(
       return
     }
 
+    var chunkSize = dispatchChunkSize
     while (currentCoroutineContext().isActive) {
-      val pendingIds = pendingLogsManager.getPendingLogIds(dispatchChunkSize)
+      val pendingIds = pendingLogsManager.getPendingLogIds(chunkSize)
+      // Use the default for the next batch unless a 413 below overrides it.
+      chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
       }
@@ -277,6 +291,14 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
             )
+          is DispatchResult.PayloadTooLarge -> {
+            if (dispatchedLogIds.size > 1) {
+              chunkSize = dispatchedLogIds.size / 2
+            } else {
+              Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
+              pendingLogsManager.removePendingLogs(dispatchedLogIds)
+            }
+          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
         if (!DispatchUtils.shouldRemovePending(result)) {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -166,7 +166,9 @@ class BaseObservabilityManager(
     var chunkSize = dispatchChunkSize
     while (true) {
       val pendingIds = pendingMetricsManager.getPendingMetricIds(chunkSize)
-      // Use the default for the next batch unless a 413 below overrides it.
+      // Use the default for the next batch unless a 413 below overrides it. Re-discovering
+      // the limit each batch is fine: the server accepts payloads over 1 MB, so the default
+      // chunk stays far below the limit and a 413 is exceptional.
       chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
@@ -209,8 +211,11 @@ class BaseObservabilityManager(
             if (dispatchedMetricIds.size > 1) {
               chunkSize = dispatchedMetricIds.size / 2
             } else {
+              // A single record can't realistically exceed the server's payload limit, so drop
+              // it as a last-resort safety valve and stop this dispatch round.
               Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
               pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+              break
             }
           }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
@@ -248,7 +253,9 @@ class BaseObservabilityManager(
     var chunkSize = dispatchChunkSize
     while (true) {
       val pendingIds = pendingLogsManager.getPendingLogIds(chunkSize)
-      // Use the default for the next batch unless a 413 below overrides it.
+      // Use the default for the next batch unless a 413 below overrides it. Re-discovering
+      // the limit each batch is fine: the server accepts payloads over 1 MB, so the default
+      // chunk stays far below the limit and a 413 is exceptional.
       chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
@@ -293,8 +300,11 @@ class BaseObservabilityManager(
             if (dispatchedLogIds.size > 1) {
               chunkSize = dispatchedLogIds.size / 2
             } else {
+              // A single record can't realistically exceed the server's payload limit, so drop
+              // it as a last-resort safety valve and stop this dispatch round.
               Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
               pendingLogsManager.removePendingLogs(dispatchedLogIds)
+              break
             }
           }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -163,8 +163,11 @@ class BaseObservabilityManager(
       return
     }
 
+    var chunkSize = dispatchChunkSize
     while (true) {
-      val pendingIds = pendingMetricsManager.getPendingMetricIds(dispatchChunkSize)
+      val pendingIds = pendingMetricsManager.getPendingMetricIds(chunkSize)
+      // Use the default for the next batch unless a 413 below overrides it.
+      chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
       }
@@ -202,6 +205,14 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
             )
+          is DispatchResult.PayloadTooLarge -> {
+            if (dispatchedMetricIds.size > 1) {
+              chunkSize = dispatchedMetricIds.size / 2
+            } else {
+              Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
+              pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
+            }
+          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
@@ -234,8 +245,11 @@ class BaseObservabilityManager(
       return
     }
 
+    var chunkSize = dispatchChunkSize
     while (true) {
-      val pendingIds = pendingLogsManager.getPendingLogIds(dispatchChunkSize)
+      val pendingIds = pendingLogsManager.getPendingLogIds(chunkSize)
+      // Use the default for the next batch unless a 413 below overrides it.
+      chunkSize = dispatchChunkSize
       if (pendingIds.isEmpty()) {
         break
       }
@@ -275,6 +289,14 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
             )
+          is DispatchResult.PayloadTooLarge -> {
+            if (dispatchedLogIds.size > 1) {
+              chunkSize = dispatchedLogIds.size / 2
+            } else {
+              Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
+              pendingLogsManager.removePendingLogs(dispatchedLogIds)
+            }
+          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
         }
         if (!DispatchUtils.shouldRemovePending(result)) {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -207,25 +207,23 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedMetricIds.size} metric event(s): ${result.reason}"
             )
-          is DispatchResult.PayloadTooLarge -> {
-            if (dispatchedMetricIds.size > 1) {
-              chunkSize = dispatchedMetricIds.size / 2
-            } else {
-              // A single record can't realistically exceed the server's payload limit, so drop
-              // it as a last-resort safety valve and stop this dispatch round.
+          is DispatchResult.PayloadTooLarge ->
+            if (dispatchedMetricIds.size == 1) {
               Log.w(OBSERVE_TAG, "Dropping metric event that exceeds the server's payload limit")
-              pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-              break
             }
-          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.PayloadTooLarge && dispatchedMetricIds.size > 1) {
+          chunkSize = dispatchedMetricIds.size / 2
+          // Keep the pending metrics, but retry immediately with a smaller chunk.
+          continue
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
           break
         }
         pendingMetricsManager.removePendingMetrics(dispatchedMetricIds)
-        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
-        if (result is DispatchResult.NonRetryableFailure) {
+        // A systematic rejection or an oversized record: leave the rest for the next run.
+        if (result is DispatchResult.NonRetryableFailure || result is DispatchResult.PayloadTooLarge) {
           break
         }
       }
@@ -296,25 +294,23 @@ class BaseObservabilityManager(
               OBSERVE_TAG,
               "Dropping batch of ${dispatchedLogIds.size} log event(s): ${result.reason}"
             )
-          is DispatchResult.PayloadTooLarge -> {
-            if (dispatchedLogIds.size > 1) {
-              chunkSize = dispatchedLogIds.size / 2
-            } else {
-              // A single record can't realistically exceed the server's payload limit, so drop
-              // it as a last-resort safety valve and stop this dispatch round.
+          is DispatchResult.PayloadTooLarge ->
+            if (dispatchedLogIds.size == 1) {
               Log.w(OBSERVE_TAG, "Dropping log event that exceeds the server's payload limit")
-              pendingLogsManager.removePendingLogs(dispatchedLogIds)
-              break
             }
-          }
           is DispatchResult.Success, is DispatchResult.RetryableFailure -> Unit
+        }
+        if (result is DispatchResult.PayloadTooLarge && dispatchedLogIds.size > 1) {
+          chunkSize = dispatchedLogIds.size / 2
+          // Keep the pending logs, but retry immediately with a smaller chunk.
+          continue
         }
         if (!DispatchUtils.shouldRemovePending(result)) {
           break
         }
         pendingLogsManager.removePendingLogs(dispatchedLogIds)
-        // A non-retryable rejection is likely systematic, so leave the rest for the next dispatch run.
-        if (result is DispatchResult.NonRetryableFailure) {
+        // A systematic rejection or an oversized record: leave the rest for the next run.
+        if (result is DispatchResult.NonRetryableFailure || result is DispatchResult.PayloadTooLarge) {
           break
         }
       }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -895,7 +895,7 @@ class BaseObservabilityManagerTest {
       createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
 
       coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
-      coVerify(exactly = 2) { mockPendingMetricsManager.getPendingMetricIds(4) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.getPendingMetricIds(4) }
     }
 
   @Test
@@ -922,7 +922,7 @@ class BaseObservabilityManagerTest {
 
       createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
 
-      assertEquals(listOf(2, 1, 2), requestedLimits)
+      assertEquals(listOf(2, 1), requestedLimits)
       coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
     }
 
@@ -930,7 +930,7 @@ class BaseObservabilityManagerTest {
   fun `dispatchUnsentMetrics does not set the retry gate after 413`() =
     runTest {
       coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
-        listOf(listOf("metric-1"), emptyList(), listOf("metric-2"), emptyList())
+        listOf(listOf("metric-1"), listOf("metric-2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
         firstArg<List<String>>().map { id ->
           createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
@@ -1144,7 +1144,93 @@ class BaseObservabilityManagerTest {
       createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
 
       coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
-      coVerify(exactly = 2) { mockPendingLogsManager.getPendingLogIds(4) }
+      coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(4) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves the dispatched count after removing orphans`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("log-1", "log-2", "orphan-1", "orphan-2"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("log-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().filter { it.startsWith("log-") }.map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      assertEquals(listOf(4, 1, 4), requestedLimits)
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves to one then drops the oversized log`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(listOf("log-1", "log-2"), emptyList())
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers {
+        requestedLimits.add(2)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("log-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+
+      assertEquals(listOf(2, 1), requestedLimits)
+      coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs does not set the retry gate after 413`() =
+    runTest {
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
+        listOf(listOf("log-1"), listOf("log-2"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+
+      manager.dispatchUnsentLogs()
+      manager.dispatchUnsentLogs()
+
+      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -803,6 +803,155 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
+  fun `dispatchUnsentMetrics halves the chunk after 413 then resets to the default size`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("metric-1", "metric-2", "metric-3", "metric-4"),
+          listOf("metric-3", "metric-4"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers {
+        requestedLimits.add(2)
+        listOf("metric-1", "metric-2")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success,
+        DispatchResult.Success
+      )
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      assertEquals(listOf(4, 2, 4, 4), requestedLimits)
+      assertEquals(
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3", "metric-4")),
+        removedChunks
+      )
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics halves the dispatched count after removing orphans`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("metric-1", "metric-2", "orphan-1", "orphan-2"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("metric-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().filter { it.startsWith("metric-") }.map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      assertEquals(listOf(4, 1, 4), requestedLimits)
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics drops a single metric that still gets 413`() =
+    runTest {
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } returnsMany
+        listOf(listOf("metric-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(
+        createSessionWithMetrics(
+          "session-1",
+          "production",
+          listOf(createMetric("metric-1", metricId = "metric-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
+      coVerify(exactly = 2) { mockPendingMetricsManager.getPendingMetricIds(4) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics halves to one then drops the oversized metric`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(listOf("metric-1", "metric-2"), emptyList())
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers {
+        requestedLimits.add(2)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("metric-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+
+      assertEquals(listOf(2, 1, 2), requestedLimits)
+      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics does not set the retry gate after 413`() =
+    runTest {
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
+        listOf(listOf("metric-1"), emptyList(), listOf("metric-2"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+
+      manager.dispatchUnsentMetrics()
+      manager.dispatchUnsentMetrics()
+
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  @Test
   fun `dispatchUnsentMetrics stops after a retryable chunk and sets the gate`() =
     runTest {
       val session = createSessionWithMetrics(
@@ -936,6 +1085,66 @@ class BaseObservabilityManagerTest {
 
       assertEquals(listOf("log-3"), pendingIds)
       coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves the chunk after 413 then resets to the default size`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("log-1", "log-2", "log-3", "log-4"),
+          listOf("log-3", "log-4"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers {
+        requestedLimits.add(2)
+        listOf("log-1", "log-2")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success,
+        DispatchResult.Success
+      )
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      assertEquals(listOf(4, 2, 4, 4), requestedLimits)
+      assertEquals(listOf(listOf("log-1", "log-2"), listOf("log-3", "log-4")), removedChunks)
+    }
+
+  @Test
+  fun `dispatchUnsentLogs drops a single log that still gets 413`() =
+    runTest {
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } returnsMany
+        listOf(listOf("log-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(
+        createSessionWithLogs(
+          "session-1",
+          "production",
+          listOf(createLog("log-1", logId = "log-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
+      coVerify(exactly = 2) { mockPendingLogsManager.getPendingLogIds(4) }
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -866,7 +866,7 @@ class BaseObservabilityManagerTest {
       createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
 
       coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
-      coVerify(exactly = 2) { mockPendingMetricsManager.getPendingMetricIds(4) }
+      coVerify(exactly = 1) { mockPendingMetricsManager.getPendingMetricIds(4) }
     }
 
   @Test
@@ -893,7 +893,7 @@ class BaseObservabilityManagerTest {
 
       createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
 
-      assertEquals(listOf(2, 1, 2), requestedLimits)
+      assertEquals(listOf(2, 1), requestedLimits)
       coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
     }
 
@@ -901,7 +901,7 @@ class BaseObservabilityManagerTest {
   fun `dispatchUnsentMetrics does not set the retry gate after 413`() =
     runTest {
       coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
-        listOf(listOf("metric-1"), emptyList(), listOf("metric-2"), emptyList())
+        listOf(listOf("metric-1"), listOf("metric-2"), emptyList())
       coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
         firstArg<List<String>>().map { id ->
           createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
@@ -1088,7 +1088,93 @@ class BaseObservabilityManagerTest {
       createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
 
       coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
-      coVerify(exactly = 2) { mockPendingLogsManager.getPendingLogIds(4) }
+      coVerify(exactly = 1) { mockPendingLogsManager.getPendingLogIds(4) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves the dispatched count after removing orphans`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("log-1", "log-2", "orphan-1", "orphan-2"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("log-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().filter { it.startsWith("log-") }.map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      assertEquals(listOf(4, 1, 4), requestedLimits)
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves to one then drops the oversized log`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(listOf("log-1", "log-2"), emptyList())
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers {
+        requestedLimits.add(2)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("log-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentLogs()
+
+      assertEquals(listOf(2, 1), requestedLimits)
+      coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs does not set the retry gate after 413`() =
+    runTest {
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } returnsMany
+        listOf(listOf("log-1"), listOf("log-2"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+
+      manager.dispatchUnsentLogs()
+      manager.dispatchUnsentLogs()
+
+      coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -774,6 +774,155 @@ class BaseObservabilityManagerTest {
     }
 
   @Test
+  fun `dispatchUnsentMetrics halves the chunk after 413 then resets to the default size`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("metric-1", "metric-2", "metric-3", "metric-4"),
+          listOf("metric-3", "metric-4"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers {
+        requestedLimits.add(2)
+        listOf("metric-1", "metric-2")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success,
+        DispatchResult.Success
+      )
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      assertEquals(listOf(4, 2, 4, 4), requestedLimits)
+      assertEquals(
+        listOf(listOf("metric-1", "metric-2"), listOf("metric-3", "metric-4")),
+        removedChunks
+      )
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics halves the dispatched count after removing orphans`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("metric-1", "metric-2", "orphan-1", "orphan-2"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("metric-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().filter { it.startsWith("metric-") }.map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      assertEquals(listOf(4, 1, 4), requestedLimits)
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics drops a single metric that still gets 413`() =
+    runTest {
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(4) } returnsMany
+        listOf(listOf("metric-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } returns listOf(
+        createSessionWithMetrics(
+          "session-1",
+          "production",
+          listOf(createMetric("metric-1", metricId = "metric-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentMetrics()
+
+      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
+      coVerify(exactly = 2) { mockPendingMetricsManager.getPendingMetricIds(4) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics halves to one then drops the oversized metric`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(listOf("metric-1", "metric-2"), emptyList())
+      )
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } answers {
+        requestedLimits.add(2)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(1) } answers {
+        requestedLimits.add(1)
+        listOf("metric-1")
+      }
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 2).dispatchUnsentMetrics()
+
+      assertEquals(listOf(2, 1, 2), requestedLimits)
+      coVerify(exactly = 1) { mockPendingMetricsManager.removePendingMetrics(listOf("metric-1")) }
+    }
+
+  @Test
+  fun `dispatchUnsentMetrics does not set the retry gate after 413`() =
+    runTest {
+      coEvery { mockPendingMetricsManager.getPendingMetricIds(2) } returnsMany
+        listOf(listOf("metric-1"), emptyList(), listOf("metric-2"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithMetrics(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithMetrics("session-$id", "production", listOf(createMetric(id, metricId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatch(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success
+      )
+      val manager = createManager(
+        currentTimeMs = { 1_700_000_000_000L },
+        dispatchChunkSize = 2
+      )
+
+      manager.dispatchUnsentMetrics()
+      manager.dispatchUnsentMetrics()
+
+      coVerify(exactly = 2) { mockEventDispatcher.dispatch(any()) }
+    }
+
+  @Test
   fun `dispatchUnsentMetrics stops after a retryable chunk and sets the gate`() =
     runTest {
       val session = createSessionWithMetrics(
@@ -880,6 +1029,66 @@ class BaseObservabilityManagerTest {
       assertEquals(listOf("log-1", "log-2", "log-3"), removedIds)
       coVerify(exactly = 2) { mockEventDispatcher.dispatchLogs(any()) }
       coVerify(exactly = 3) { mockPendingLogsManager.getPendingLogIds(2) }
+    }
+
+  @Test
+  fun `dispatchUnsentLogs halves the chunk after 413 then resets to the default size`() =
+    runTest {
+      val requestedLimits = mutableListOf<Int>()
+      val defaultChunks = ArrayDeque(
+        listOf(
+          listOf("log-1", "log-2", "log-3", "log-4"),
+          listOf("log-3", "log-4"),
+          emptyList()
+        )
+      )
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } answers {
+        requestedLimits.add(4)
+        defaultChunks.removeFirst()
+      }
+      coEvery { mockPendingLogsManager.getPendingLogIds(2) } answers {
+        requestedLimits.add(2)
+        listOf("log-1", "log-2")
+      }
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } answers {
+        firstArg<List<String>>().map { id ->
+          createSessionWithLogs("session-$id", "production", listOf(createLog(id, logId = id)))
+        }
+      }
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returnsMany listOf(
+        DispatchResult.PayloadTooLarge,
+        DispatchResult.Success,
+        DispatchResult.Success
+      )
+      val removedChunks = mutableListOf<List<String>>()
+      coEvery { mockPendingLogsManager.removePendingLogs(any()) } answers {
+        removedChunks.add(firstArg<List<String>>())
+      }
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      assertEquals(listOf(4, 2, 4, 4), requestedLimits)
+      assertEquals(listOf(listOf("log-1", "log-2"), listOf("log-3", "log-4")), removedChunks)
+    }
+
+  @Test
+  fun `dispatchUnsentLogs drops a single log that still gets 413`() =
+    runTest {
+      coEvery { mockPendingLogsManager.getPendingLogIds(4) } returnsMany
+        listOf(listOf("log-1"), emptyList())
+      coEvery { mockSessionManager.getSessionsWithLogs(any()) } returns listOf(
+        createSessionWithLogs(
+          "session-1",
+          "production",
+          listOf(createLog("log-1", logId = "log-1"))
+        )
+      )
+      coEvery { mockEventDispatcher.dispatchLogs(any()) } returns DispatchResult.PayloadTooLarge
+
+      createManager(dispatchChunkSize = 4).dispatchUnsentLogs()
+
+      coVerify(exactly = 1) { mockPendingLogsManager.removePendingLogs(listOf("log-1")) }
+      coVerify(exactly = 2) { mockPendingLogsManager.getPendingLogIds(4) }
     }
 
   @Test

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
@@ -74,8 +74,11 @@ class DispatchUtilsRetryGateTest {
     assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
   }
 
+  // `PayloadTooLarge` is a definitive answer from a reachable server, so the counter resets
+  // like it does for `NonRetryableFailure`; the gate stays where it is because chunk-size
+  // retries are immediate.
   @Test
-  fun `PayloadTooLarge leaves the retry gate unchanged`() {
+  fun `PayloadTooLarge resets the counter and leaves the gate alone`() {
     val state = DispatchUtils.RetryGateState(
       dispatchAfterMs = now + 60_000L,
       consecutiveRetryableFailures = 2
@@ -87,7 +90,8 @@ class DispatchUtilsRetryGateTest {
       backoff = stubbedBackoff
     )
 
-    assertEquals(state, next)
+    assertEquals(0, next.consecutiveRetryableFailures)
+    assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
   }
 
   // First retryable failure (from `.initial`): counter goes to 1, gate is `now + backoff(1)`.

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsRetryGateTest.kt
@@ -74,6 +74,22 @@ class DispatchUtilsRetryGateTest {
     assertEquals(state.dispatchAfterMs, next.dispatchAfterMs)
   }
 
+  @Test
+  fun `PayloadTooLarge leaves the retry gate unchanged`() {
+    val state = DispatchUtils.RetryGateState(
+      dispatchAfterMs = now + 60_000L,
+      consecutiveRetryableFailures = 2
+    )
+    val next = DispatchUtils.nextRetryGateState(
+      result = DispatchResult.PayloadTooLarge,
+      currentState = state,
+      now = now,
+      backoff = stubbedBackoff
+    )
+
+    assertEquals(state, next)
+  }
+
   // First retryable failure (from `.initial`): counter goes to 1, gate is `now + backoff(1)`.
   // `retryAfterMs` is `null`, so we fall through to `computeBackoffDelay` (the stubbed value
   // of 10 here).

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -162,6 +162,19 @@ class DispatchUtilsClassifyResponseTest {
     }
   }
 
+  @Test
+  fun `413 returns PayloadTooLarge with or without Retry-After`() {
+    for (retryAfter in listOf(null, "120")) {
+      val result = DispatchUtils.classifyResponse(
+        statusCode = 413,
+        retryAfterHeader = retryAfter,
+        responseBody = null
+      )
+
+      assertEquals(DispatchResult.PayloadTooLarge, result)
+    }
+  }
+
   // MARK: -- Non-retryable 4xx / other 5xx
 
   @Test
@@ -258,6 +271,11 @@ class DispatchUtilsShouldRemovePendingTest {
   fun `Retryable keeps pending IDs`() {
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure()))
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure(retryAfterMs = 30_000L)))
+  }
+
+  @Test
+  fun `PayloadTooLarge keeps pending IDs`() {
+    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.PayloadTooLarge))
   }
 
   // `PartialSuccess` removes pending IDs like `Success` does: the bytes landed on the

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/DispatchUtilsTest.kt
@@ -265,17 +265,19 @@ class DispatchUtilsShouldRemovePendingTest {
     assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.Success))
   }
 
+  // Multi-record payloads are retried in smaller chunks before this check, so a 413 here
+  // represents a single oversized record that must not wedge the queue.
+  @Test
+  fun `PayloadTooLarge removes pending IDs`() {
+    assertTrue(DispatchUtils.shouldRemovePending(DispatchResult.PayloadTooLarge))
+  }
+
   // `Retryable` is the "leave them alone" case — the next dispatch round picks the same
   // rows up again. This is what keeps an in-flight outage from losing telemetry.
   @Test
   fun `Retryable keeps pending IDs`() {
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure()))
     assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.RetryableFailure(retryAfterMs = 30_000L)))
-  }
-
-  @Test
-  fun `PayloadTooLarge keeps pending IDs`() {
-    assertTrue(!DispatchUtils.shouldRemovePending(DispatchResult.PayloadTooLarge))
   }
 
   // `PartialSuccess` removes pending IDs like `Success` does: the bytes landed on the

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/EventDispatcherTest.kt
@@ -140,6 +140,21 @@ class EventDispatcherTest {
     }
 
   @Test
+  fun `dispatch returns PayloadTooLarge on 413 response`() =
+    runTest {
+      mockServer.enqueue(
+        MockResponse()
+          .setResponseCode(413)
+          .setBody("""{"error": "Payload Too Large"}""")
+      )
+
+      val result = eventDispatcher.dispatch(listOf(createTestEvent()))
+
+      assertEquals(DispatchResult.PayloadTooLarge, result)
+      assertEquals(1, mockServer.requestCount)
+    }
+
+  @Test
   fun `dispatch returns NonRetryable on 500 server error`() =
     runTest {
       // 500 is NOT in OTLP's retryable list — only 429/502/503/504 are. 500 means an


### PR DESCRIPTION
# Why

At the moment we treat response with status `413` as non-retryable. Now with chunking, we can reduce the size of the chunk and retry.

# How

1. Add new result type `PayloadTooLarge`
2. When it is detected reduce the number of metrics/events sent to the server by half and retry

# Test Plan

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>