### PR TITLE
[iOS][expo-widgets] Add contentDate to LiveActivity.update

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [iOS] Expose ActivityKit's `contentDate` on `LiveActivity.update()` to prevent older local updates from replacing newer local or push updates.
+- [iOS] Expose ActivityKit's `contentDate` on `LiveActivity.update()` to prevent older local updates from replacing newer local or push updates. ([#49017](https://github.com/expo/expo/pull/49017) by [@LouisRaverdy](https://github.com/LouisRaverdy))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))
 - Add an initial layout registry for widgets. ([#46501](https://github.com/expo/expo/pull/46501) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] Expose ActivityKit's `contentDate` on `LiveActivity.update()` to prevent older local updates from replacing newer local or push updates.
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))
 - Add an initial layout registry for widgets. ([#46501](https://github.com/expo/expo/pull/46501) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/ios/LiveActivity.swift
+++ b/packages/expo-widgets/ios/LiveActivity.swift
@@ -12,15 +12,22 @@ final class LiveActivity: SharedObject {
     super.init()
   }
 
-  func update(props: String?, staleDate: Date?) async throws {
+  func update(props: String?, staleDate: Date?, contentDate: Date?) async throws {
     guard #available(iOS 16.2, *) else { throw LiveActivitiesNotSupportedException() }
 
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
       throw LiveActivityNotFoundException(id)
     }
 
-    let newState = LiveActivityAttributes.ContentState(name: name, props: props)
-    await activity.update(ActivityContent(state: newState, staleDate: staleDate))
+    let content = ActivityContent(
+      state: LiveActivityAttributes.ContentState(name: name, props: props),
+      staleDate: staleDate
+    )
+    guard let contentDate, #available(iOS 17.2, *) else {
+      return await activity.update(content)
+    }
+
+    await activity.update(content, timestamp: contentDate)
   }
 
   func end(dismissalPolicy: LiveActivityDismissalPolicy?, afterDate: Date?, props: String?, contentDate: Date?) async throws {

--- a/packages/expo-widgets/ios/WidgetsModule.swift
+++ b/packages/expo-widgets/ios/WidgetsModule.swift
@@ -100,8 +100,8 @@ public final class WidgetsModule: Module {
     }
 
     Class("LiveActivity", LiveActivity.self) {
-      AsyncFunction("update") { (instance: LiveActivity, props: String?, staleDate: Date?) in
-        try await instance.update(props: props, staleDate: staleDate)
+      AsyncFunction("update") { (instance: LiveActivity, props: String?, staleDate: Date?, contentDate: Date?) in
+        try await instance.update(props: props, staleDate: staleDate, contentDate: contentDate)
       }
 
       AsyncFunction("end") { (instance: LiveActivity, dismissalPolicy: LiveActivityDismissalPolicy?, afterDate: Date?, props: String?, contentDate: Date?) in

--- a/packages/expo-widgets/src/ExpoWidgets.ts
+++ b/packages/expo-widgets/src/ExpoWidgets.ts
@@ -27,7 +27,7 @@ class WidgetStub {
 }
 
 class LiveActivityStub {
-  async update(_props?: string): Promise<void> {}
+  async update(_props?: string, _staleDate?: number, _contentDate?: number): Promise<void> {}
   async end(
     _dismissalPolicy?: string,
     _afterDate?: number,

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -107,9 +107,15 @@ export class LiveActivity<T extends object = object> {
    * Updates the Live Activity's content. The UI reflects the new properties immediately.
    * @param props The updated content properties.
    * @param staleDate When set, the system may de-emphasize the activity after this date if content has not been refreshed.
+   * @param contentDate The time the data in the update was generated. On iOS 17.2 and later, the
+   *   system ignores this update if it is older than a previous update or push payload.
    */
-  update(props: T, staleDate?: Date): Promise<void> {
-    return this.nativeLiveActivity.update(JSON.stringify(props), staleDate?.getTime());
+  update(props: T, staleDate?: Date, contentDate?: Date): Promise<void> {
+    return this.nativeLiveActivity.update(
+      JSON.stringify(props),
+      staleDate?.getTime(),
+      contentDate?.getTime()
+    );
   }
 
   /**

--- a/packages/expo-widgets/src/Widgets.types.ts
+++ b/packages/expo-widgets/src/Widgets.types.ts
@@ -316,7 +316,7 @@ export declare class NativeLiveActivityFactory extends SharedObject {
 }
 
 export declare class NativeLiveActivity extends SharedObject<LiveActivityEvents> {
-  update(props?: string, staleDate?: number): Promise<void>;
+  update(props?: string, staleDate?: number, contentDate?: number): Promise<void>;
   end(
     dismissalPolicy?: string,
     afterDate?: number,


### PR DESCRIPTION
# Why

ActivityKit 17.2 added a timestamped `update` API. The timestamp represents when the data was generated, and the system ignores the update when a newer local update or push payload has already been applied.

`expo-widgets` already exposes this behavior as `contentDate` when ending a Live Activity, but `LiveActivity.update()` only exposes `staleDate`. Apps that combine local updates with ActivityKit push notifications therefore cannot prevent a delayed local update from replacing newer push content.

We already use this implementation through a local `expo-widgets` patch. Upstreaming it removes the need to maintain that patch and makes ActivityKit's ordering behavior available to other apps that combine local and push updates.

# How

- Add an optional third `contentDate` argument to `LiveActivity.update(props, staleDate?, contentDate?)`, preserving the existing API.
- Forward the JavaScript timestamp through the native module as a `Date`.
- Use ActivityKit's timestamped update API on iOS 17.2 and later when `contentDate` is provided.
- Keep the existing update path when `contentDate` is omitted or the device runs an earlier iOS version.

# Test Plan

From `packages/expo-widgets`:

```sh
pnpm run format --check
pnpm run lint
pnpm run typecheck
pnpm run build
pnpm run test --runInBand
```

All checks pass. Jest reports 3 passing suites and 13 passing tests.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
