### PR TITLE
[cli] Fix flaky offline install e2e by scaffolding the fixture online

### DIFF
--- a/packages/@expo/cli/e2e/__tests__/install-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-test.ts
@@ -65,40 +65,26 @@ it('installs a local package tarball without network access', async () => {
     HTTPS_PROXY: 'http://127.0.0.1:9',
     NO_PROXY: '',
   };
-  const originalEnv = Object.fromEntries(
-    Object.keys(offlineEnv).map((key) => [key, process.env[key]])
-  );
-  Object.assign(process.env, offlineEnv);
 
-  try {
-    const projectRoot = await setupTestProjectWithOptionsAsync(
-      'local-package-install',
-      'with-blank',
-      {
-        reuseExisting: false,
-      }
-    );
-    const tarball = await createPackageTarball(
-      projectRoot,
-      'packages/@expo/cli/e2e/fixtures/install-smoke-package'
-    );
-
-    await expect(
-      executeExpoAsync(projectRoot, ['install', tarball.packageReference, '--', '--offline'], {
-        env: offlineEnv,
-      })
-    ).resolves.toMatchObject({ exitCode: 0 });
-
-    const pkg: any = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
-    expect(pkg.dependencies?.[tarball.name]).toEqual(expect.any(String));
-    expect(require.resolve(tarball.name, { paths: [projectRoot] })).toEqual(expect.any(String));
-  } finally {
-    for (const [key, value] of Object.entries(originalEnv)) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
+  const projectRoot = await setupTestProjectWithOptionsAsync(
+    'local-package-install',
+    'with-blank',
+    {
+      reuseExisting: false,
     }
-  }
+  );
+  const tarball = await createPackageTarball(
+    projectRoot,
+    'packages/@expo/cli/e2e/fixtures/install-smoke-package'
+  );
+
+  await expect(
+    executeExpoAsync(projectRoot, ['install', tarball.packageReference, '--', '--offline'], {
+      env: offlineEnv,
+    })
+  ).resolves.toMatchObject({ exitCode: 0 });
+
+  const pkg: any = await JsonFile.readAsync(path.resolve(projectRoot, 'package.json'));
+  expect(pkg.dependencies?.[tarball.name]).toEqual(expect.any(String));
+  expect(require.resolve(tarball.name, { paths: [projectRoot] })).toEqual(expect.any(String));
 });


### PR DESCRIPTION
# Why

fix flaky expo ci test: https://github.com/expo/expo/actions/runs/32028680446/job/95383525455

# How

when creating the fixture project, we should not be offline. move offline setup after fixture creation and before `npx expo install`

# Test Plan

ci passed

# Checklist

- [n/a] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - no user faced changes
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)