### PR TITLE
[CI][ios] Fix the microphone permissions test not compiling

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### 💡 Others
 
 - [Android] Removed outdated ExoPlayer changelog references and aligned Android media dependencies with AndroidX Media3 (`1.9.1`). ([#45368](https://github.com/expo/expo/pull/45368) by [@saisreelasyaappali](https://github.com/saisreelasyaappali))
+- [iOS] Fix the microphone permissions test not compiling. ([#49027](https://github.com/expo/expo/pull/49027) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 
 ## 57.0.3 - 2026-07-22
 

--- a/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
@@ -11,7 +11,7 @@ struct AudioRecordingRequesterTests {
   func `reports denied when the usage description is missing`() {
     let permissions = AudioRecordingRequester.permissions(systemStatus: .granted, usageDescription: nil)
 
-    #expect(permissions["status"] as? Int == EXPermissionStatusDenied.rawValue)
+    #expect(permissions["status"] as? UInt32 == EXPermissionStatusDenied.rawValue)
   }
 
   @Test(arguments: [
@@ -28,7 +28,7 @@ struct AudioRecordingRequesterTests {
       usageDescription: "Allow $(PRODUCT_NAME) to access your microphone"
     )
 
-    #expect(permissions["status"] as? Int == expected.rawValue)
+    #expect(permissions["status"] as? UInt32 == expected.rawValue)
   }
 }
 #endif


### PR DESCRIPTION
# Why

`iOS Unit Tests` has been red on `main` since #48840 merged. The whole `xcodebuild` invocation fails to compile, so every scheduled package is reported as failed, not just `expo-audio`.

```
error: value of optional type 'Int?' must be unwrapped to a value of type 'Int'
    #expect(permissions["status"] as? Int == EXPermissionStatusDenied.rawValue)
```

`EXPermissionStatus` is a plain C enum, not `NS_ENUM`:

```objc
// packages/expo-modules-core/ios/Interfaces/Permissions/EXPermissionsInterface.h
typedef enum EXPermissionStatus { ... } EXPermissionStatus;
```

Swift imports a plain C enum as a `RawRepresentable` struct whose `RawValue` is `UInt32`, so `EXPermissionStatusDenied.rawValue` is `UInt32` while `permissions["status"] as? Int` is `Int?`. The comparison never typechecks. The diagnostic blames the optional, but the real mismatch is `Int` vs `UInt32`.

# How

Cast to `UInt32` instead of `Int`.

`Int(EXPermissionStatusDenied.rawValue)` would also compile, but the test would then always fail: the dictionary stores a real `UInt32`, and `as? Int` on it returns `nil`.

# Test Plan

iOS Unit tests CI should pass
