### PR TITLE
[ios][camera] Fix UI freeze when repeatedly mounting and unmounting CameraView

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available.
+- [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available. ([#49028](https://github.com/expo/expo/pull/49028) by [@barthap](https://github.com/barthap))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Fix iOS captures being saved above their native resolution due to orientation normalization rendering at the screen scale. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI on devices and simulators that report no camera, by no longer starting the capture session when no capture device is available.
+- [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available.
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Fix iOS captures being saved above their native resolution due to orientation normalization rendering at the screen scale. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI on devices and simulators that report no camera, by no longer starting the capture session when no capture device is available.
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Fix iOS captures being saved above their native resolution due to orientation normalization rendering at the screen scale. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))
 - [iOS] Fix the ZXing barcode fallback scanner returning raw AVFoundation type strings (e.g. `org.iso.PDF417`) instead of short expo `BarcodeType` values (e.g. `pdf417`) for `pdf417`, `code39`, and `codabar`, restoring the fix from [#44726](https://github.com/expo/expo/pull/44726) that was reverted by the `ExpoCameraBarcodeScanning` pod extraction in [#44766](https://github.com/expo/expo/pull/44766). ([#47613](https://github.com/expo/expo/pull/47613) by [@jensdev](https://github.com/jensdev))

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -275,12 +275,20 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
   }
 
   func stopSession() {
+    runtimeErrorTask?.cancel()
+    runtimeErrorTask = nil
+
+    // Stop before deconfiguring. Removing inputs and outputs from a session that is still
+    // running rebuilds the capture graph just to tear it down, and that rebuild waits out
+    // its own deadline when the graph never started in the first place.
+    if session.isRunning {
+      session.stopRunning()
+    }
+
     guard hasAvailableCameraDevice else {
       return
     }
 
-    runtimeErrorTask?.cancel()
-    runtimeErrorTask = nil
     session.beginConfiguration()
     for input in self.session.inputs {
       session.removeInput(input)
@@ -290,10 +298,6 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
       session.removeOutput(output)
     }
     session.commitConfiguration()
-
-    if session.isRunning {
-      session.stopRunning()
-    }
   }
 
   func addErrorNotification() {

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -109,7 +109,7 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
       return
     }
     if delegate.active {
-      if !self.session.isRunning {
+      if hasAvailableCameraDevice && !self.session.isRunning {
         self.session.startRunning()
       }
     } else {

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -324,8 +324,17 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
 
   public override func removeFromSuperview() {
     super.removeFromSuperview()
-    sessionQueue.async { [weak self] in
-      self?.sessionManager.stopSession()
+    // Capture both strongly: React Native can drop its reference to the view before this
+    // block runs, and the session has to be stopped before the preview layer detaches
+    // from it. Detaching from a still-running session is the same graph rebuild, only it
+    // happens in the layer's `dealloc` on the main thread.
+    let sessionManager: CameraSessionManager = self.sessionManager
+    let previewLayer = self.previewLayer
+    sessionQueue.async {
+      sessionManager.stopSession()
+      DispatchQueue.main.async {
+        previewLayer.session = nil
+      }
     }
     motionManager.stopAccelerometerUpdates()
     lifecycleManager?.unregisterAppLifecycleListener(self)

--- a/packages/expo-camera/ios/Tests/CameraSessionManagerTests.swift
+++ b/packages/expo-camera/ios/Tests/CameraSessionManagerTests.swift
@@ -6,7 +6,7 @@ import ExpoModulesCore
 @testable import ExpoCamera
 
 /// Mirrors `CameraView`'s arrangement: the view's backing layer is the preview layer.
-private final class PreviewHostView: UIView {
+private class PreviewHostView: UIView {
   override class var layerClass: AnyClass {
     AVCaptureVideoPreviewLayer.self
   }
@@ -60,5 +60,34 @@ struct CameraSessionManagerTests {
     manager.updateCameraIsActive()
 
     #expect(manager.session.isRunning == false)
+  }
+
+  // The guard above does not help when a capture device *is* present but the graph still
+  // cannot start, which is what https://github.com/expo/expo/issues/48780 reports. In that
+  // case teardown has to stop the session before anything detaches from it: the preview
+  // layer otherwise detaches from a running session inside `dealloc`, on the main thread.
+  // Starting a session that cannot run reproduces the same state here.
+  @Test(.enabled(if: AVCaptureDevice.default(for: .video) == nil))
+  func `stops a running session before the preview layer detaches from it`() {
+    let delegate = MockCameraViewDelegate()
+    let manager = CameraSessionManager(delegate: delegate)
+    var view: PreviewHostView? = PreviewHostView()
+    view?.previewLayer.session = manager.session
+
+    manager.session.startRunning()
+    #expect(manager.session.isRunning, "the session must be running for this to test anything")
+
+    manager.stopSession()
+    #expect(manager.session.isRunning == false)
+
+    // Releasing the view runs `AVCaptureVideoPreviewLayer.dealloc` here on the main
+    // thread. Against a stopped session that is immediate; against a running one it
+    // blocks for seconds per view.
+    let started = CFAbsoluteTimeGetCurrent()
+    view = nil
+    RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+    let blockedMs = (CFAbsoluteTimeGetCurrent() - started) * 1000
+
+    #expect(blockedMs < 1000, "main thread blocked for \(Int(blockedMs))ms while releasing the preview layer")
   }
 }

--- a/packages/expo-camera/ios/Tests/CameraSessionManagerTests.swift
+++ b/packages/expo-camera/ios/Tests/CameraSessionManagerTests.swift
@@ -1,0 +1,64 @@
+import Testing
+import UIKit
+import AVFoundation
+import ExpoModulesCore
+
+@testable import ExpoCamera
+
+/// Mirrors `CameraView`'s arrangement: the view's backing layer is the preview layer.
+private final class PreviewHostView: UIView {
+  override class var layerClass: AnyClass {
+    AVCaptureVideoPreviewLayer.self
+  }
+  var previewLayer: AVCaptureVideoPreviewLayer {
+    // swiftlint:disable:next force_cast
+    layer as! AVCaptureVideoPreviewLayer
+  }
+}
+
+/// Minimal stand-in for `CameraView` as seen by `CameraSessionManager`.
+/// Every property mirrors the real defaults in `CameraView.swift`.
+private final class MockCameraViewDelegate: NSObject, CameraSessionManagerDelegate {
+  let sessionQueue = DispatchQueue(label: "captureSessionQueue")
+  var videoQuality: VideoQuality = .video1080p
+  var mode: CameraMode = .picture
+  var pictureSize: PictureSize = .photo
+  var isMuted = false
+  var active = true
+  var presetCamera: AVCaptureDevice.Position = .back
+  var selectedLens: String?
+  var torchEnabled = false
+  var autoFocus: AVCaptureDevice.FocusMode = .continuousAutoFocus
+  var zoom: CGFloat = 0
+  let onMountError = EventDispatcher()
+  let onCameraReady = EventDispatcher()
+  var permissionsManager: EXPermissionsInterface?
+  var appContext: AppContext?
+  var barcodeScanner: BarcodeScanner?
+
+  func emitAvailableLenses() {}
+  func configurePreviewRotation() {}
+}
+
+@Suite("CameraSessionManager")
+struct CameraSessionManagerTests {
+  // Starting a session that has no capture device leaves it wedged: the capture backend
+  // never acknowledges, so every later graph rebuild waits out its own ~9s deadline. The
+  // preview layer detaches from the still-running session in `dealloc` on the main
+  // thread, which is where that wait lands. Mounting and unmounting a `CameraView` eight
+  // times froze the UI for over a minute. See https://github.com/expo/expo/issues/48780.
+  @Test(.enabled(if: AVCaptureDevice.default(for: .video) == nil))
+  func `does not start the session when no capture device is available`() {
+    let delegate = MockCameraViewDelegate()
+    let manager = CameraSessionManager(delegate: delegate)
+
+    // Binding the preview layer is what makes the capture backend engage, and is what
+    // `CameraView.setupPreview()` does on mount.
+    let view = PreviewHostView()
+    view.previewLayer.session = manager.session
+
+    manager.updateCameraIsActive()
+
+    #expect(manager.session.isRunning == false)
+  }
+}


### PR DESCRIPTION
# Why

Mounting and unmounting `CameraView` a few times freezes the iOS UI for tens of seconds. Reported in #48780 with a repro at https://github.com/nrgbistro/expo-camera-simulator-freeze-repro.

This is a regression from #44159, which replaced the compile-time `#if !targetEnvironment(simulator)` guards with a runtime device check. Two paths were left unguarded, and both end up waiting on a capture graph that cannot start.

When the graph never starts, every later rebuild of it waits out its own ~9s AVFoundation deadline. Nothing detaches the preview layer on teardown, so `AVCaptureVideoPreviewLayer` does it in `dealloc`, on the main thread, against a session still marked running. That is the stack in the report:

```
CA::Transaction::commit
NSKVODeallocate
AVCaptureVideoPreviewLayer dealloc
AVCaptureSession commitConfiguration
AVCaptureSession _buildAndRunGraph
AVRunLoopCondition _waitInMode
```

Several wedged sessions accumulate, and the waits add up into a freeze.

# How

`stopSession()` now stops the session before it removes inputs and outputs, instead of deconfiguring a live session and stopping it afterwards. The stop also moved above the device-availability guard, which previously returned early and left the session running.

`removeFromSuperview()` captures the session manager and the preview layer strongly, and detaches the layer on the main thread once the session has stopped. It captured `self` weakly before, so teardown could be skipped entirely if React Native released the view first.

`updateCameraIsActive()` checks `hasAvailableCameraDevice` before starting, which is the call site #44159 missed. `startSession()` and `stopSession()` already had that check.

# Test Plan

Added two native unit tests in `packages/expo-camera/ios/Tests/`, run with `et native-unit-tests --packages expo-camera`. Both fail on `main` and pass here. The teardown test measures how long the main thread blocks while the preview layer is released, which is the symptom users see.

Measured the freeze itself on a simulator with no capture device, over 8 mount/unmount cycles: 75.5s wall and 71.4s of main-runloop overrun before, against 4.1s and 18ms after.

One gap worth flagging: I could only reproduce with a simulator that reports no camera. The reporter's simulator does expose one, and I verified the teardown fix against the same wedged-session state instead of their exact environment. It would help if @nrgbistro could confirm against their repro.
