### PR TITLE
[video][iOS] Deactivate the audio session after playback stops

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Deactivate the audio session after video playback stops so interrupted background audio can resume. ([#49030](https://github.com/expo/expo/pull/49030) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -14,6 +14,9 @@ class VideoManager {
   private var mediaServicesResetObserver: NSObjectProtocol?
   private var videoViews = NSHashTable<VideoView>.weakObjects()
   private let videoPlayers = SynchronizedHashTable<VideoPlayer>(weakObjects: true)
+  private var pendingAudioSessionDeactivation: DispatchWorkItem?
+  private var pictureInPictureVideoViews = Set<ObjectIdentifier>()
+  private var audioSessionIsActive = false
 
   var hasRegisteredPlayers: Bool {
     return !videoPlayers.allObjects.isEmpty
@@ -44,6 +47,7 @@ class VideoManager {
 
   func unregister(videoPlayer: VideoPlayer) {
     videoPlayers.remove(videoPlayer)
+    setAppropriateAudioSessionOrWarn()
   }
 
   func register(videoView: VideoView) {
@@ -52,6 +56,22 @@ class VideoManager {
 
   func unregister(videoView: VideoView) {
     videoViews.remove(videoView)
+    setPictureInPictureActive(videoView, active: false)
+  }
+
+  func setPictureInPictureActive(_ videoView: VideoView, active: Bool) {
+    let identifier = ObjectIdentifier(videoView)
+    Self.managerQueue.async { [weak self] in
+      guard let self else {
+        return
+      }
+      if active {
+        self.pictureInPictureVideoViews.insert(identifier)
+      } else {
+        self.pictureInPictureVideoViews.remove(identifier)
+      }
+      self.setAudioSession()
+    }
   }
 
   func onAppForegrounded() {
@@ -106,6 +126,9 @@ class VideoManager {
   }
 
   private func setAudioSession() {
+    pendingAudioSessionDeactivation?.cancel()
+    pendingAudioSessionDeactivation = nil
+
     let audioSession = AVAudioSession.sharedInstance()
     let audioMixingMode = findAudioMixingMode()
     var audioSessionCategoryOptions: AVAudioSession.CategoryOptions = audioSession.categoryOptions
@@ -149,10 +172,49 @@ class VideoManager {
     if isOutputtingAudio || doNotMixOverride {
       do {
         try audioSession.setActive(true)
+        audioSessionIsActive = true
       } catch {
         log.warn("[expo-video] Failed to activate the audio session. This might cause issues with audio playback. \(error.localizedDescription)")
       }
+    } else if audioSessionIsActive && !isAudioSessionInUse {
+      scheduleAudioSessionDeactivation()
     }
+  }
+
+  private var isAudioSessionInUse: Bool {
+    // Muting only silences AVPlayer's output; its audio pipeline remains active. Wait until every
+    // player is actually paused to avoid AVAudioSession.ErrorCode.isBusy during deactivation.
+    let hasActivePlayer = videoPlayers.allObjects.contains { player in
+      player.ref.timeControlStatus != .paused
+    }
+    let hasNowPlayingPlayer = videoPlayers.allObjects.contains { player in
+      player.showNowPlayingNotification
+    }
+    return hasActivePlayer || hasNowPlayingPlayer || !pictureInPictureVideoViews.isEmpty
+  }
+
+  private func scheduleAudioSessionDeactivation() {
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self else {
+        return
+      }
+      self.pendingAudioSessionDeactivation = nil
+      guard self.audioSessionIsActive, !self.isAudioSessionInUse else {
+        return
+      }
+
+      do {
+        defer {
+          self.audioSessionIsActive = false
+        }
+        try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+      } catch {
+        log.warn("[expo-video] Failed to deactivate the audio session. Background audio may not resume. \(error.localizedDescription)")
+      }
+    }
+    pendingAudioSessionDeactivation = workItem
+    // Coalesce transient player state changes and give AVPlayer time to stop its audio pipeline.
+    Self.managerQueue.asyncAfter(deadline: .now() + .milliseconds(100), execute: workItem)
   }
 
   private func findAudioMixingMode() -> AudioMixingMode? {

--- a/packages/expo-video/ios/VideoManager.swift
+++ b/packages/expo-video/ios/VideoManager.swift
@@ -204,10 +204,8 @@ class VideoManager {
       }
 
       do {
-        defer {
-          self.audioSessionIsActive = false
-        }
         try AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+        self.audioSessionIsActive = false
       } catch {
         log.warn("[expo-video] Failed to deactivate the audio session. Background audio may not resume. \(error.localizedDescription)")
       }

--- a/packages/expo-video/ios/VideoView.swift
+++ b/packages/expo-video/ios/VideoView.swift
@@ -158,10 +158,12 @@ public final class VideoView: ExpoView, AVPlayerViewControllerDelegate {
   #endif
 
   public func playerViewControllerDidStartPictureInPicture(_ playerViewController: AVPlayerViewController) {
+    VideoManager.shared.setPictureInPictureActive(self, active: true)
     onPictureInPictureStart()
   }
 
   public func playerViewControllerDidStopPictureInPicture(_ playerViewController: AVPlayerViewController) {
+    VideoManager.shared.setPictureInPictureActive(self, active: false)
     onPictureInPictureStop()
   }
 


### PR DESCRIPTION
# Why

When an `expo-video` player interrupts background audio on iOS, the shared `AVAudioSession` remains active after video playback stops. Because the session is never deactivated with `.notifyOthersOnDeactivation`, interrupted music and podcast apps are not told that they may resume.

This is the iOS follow-up to #48546, split out as requested in that review.

# How

Extend the existing automatic audio-session management in `VideoManager`:

- Track whether `expo-video` activated the audio session.
- Once no video player is playing or waiting to play, schedule session deactivation with `.notifyOthersOnDeactivation`.
- Delay deactivation by 100 ms, coalesce rapid state changes, and re-check the current player state before deactivating.
- Keep the session active while a player participates in Now Playing or while a video view is in Picture in Picture.
- Re-evaluate the session after the last player is released.
- Only mark the session inactive after a successful deactivation so a transient failure can be retried.

A muted player that continues playback intentionally keeps the session active. Muting an `AVPlayer` silences its output but leaves its audio pipeline running, so deactivating at that point can fail with `AVAudioSession.ErrorCode.isBusy`.

# Test Plan

Automated/static checks:

- `et check-packages expo-video`
- Swift parser check for the modified files

Manual device validation still recommended during review:

- Start Spotify or Apple Music, then start an unmuted video using `audioMixingMode: "auto"`; background audio should pause.
- Pause, finish, or release the last video player; background audio should resume.
- Buffering or seeking must not briefly resume background audio.
- Active PiP and Now Playing playback must remain unaffected.
- Muting a still-playing video must not attempt to deactivate the session.

# Checklist

- [x] The change uses the existing automatic audio-session management.
- [x] No new public API is introduced.
- [x] Package build, typecheck, lint, and formatting checks pass.
- [ ] Physical-device scenarios above have been revalidated with this automatic implementation.
