### PR TITLE
[cli] Pin agent-cli-detector to 0.1.6

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -79,7 +79,7 @@
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0",
     "accepts": "^1.3.8",
-    "agent-cli-detector": "^0.1.2",
+    "agent-cli-detector": "0.1.6",
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1875,8 +1875,8 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8
       agent-cli-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: 0.1.6
+        version: 0.1.6
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -9971,6 +9971,11 @@ packages:
 
   agent-cli-detector@0.1.2:
     resolution: {integrity: sha512-qdZ/9JFORtTKJNhT/IczMeEfEUbUU0K5umYeiIQHX+AjHs+Y9SXVzSgaYlpZeyNMrvuh2HpZiOTpvS57iPfBkQ==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+
+  agent-cli-detector@0.1.6:
+    resolution: {integrity: sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==}
     engines: {node: '>=18.18'}
     hasBin: true
 
@@ -18784,6 +18789,8 @@ snapshots:
   agent-base@7.1.4: {}
 
   agent-cli-detector@0.1.2: {}
+
+  agent-cli-detector@0.1.6: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:


### PR DESCRIPTION
updates agent-cli-detector to 0.1.6 to detect opencode and muse code in telemetry context