### PR TITLE
[router] Fix platform-specific route parsing and loader keys

### DIFF
--- a/apps/router-e2e/__e2e__/server-loader/app/(group)/platform/[...slug].tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/(group)/platform/[...slug].tsx
@@ -1,0 +1,5 @@
+import { Text } from 'react-native';
+
+export default function PlatformCatchAllFallbackRoute() {
+  return <Text>Platform catch-all fallback</Text>;
+}

--- a/apps/router-e2e/__e2e__/server-loader/app/(group)/platform/[...slug].web.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/(group)/platform/[...slug].web.tsx
@@ -1,0 +1,42 @@
+import { useLoaderData, useLocalSearchParams, usePathname } from 'expo-router';
+import { Suspense } from 'react';
+
+import { Loading } from '../../../components/Loading';
+import { SiteLinks, SiteLink } from '../../../components/SiteLink';
+import { Table, TableRow } from '../../../components/Table';
+
+export async function generateStaticParams(): Promise<Record<string, string>[]> {
+  return [{ slug: 'alpha/beta' }];
+}
+
+export async function loader() {
+  return Promise.resolve({ data: 'platform-catch-all' });
+}
+
+export default function PlatformCatchAllRoute() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <PlatformCatchAllScreen />
+    </Suspense>
+  );
+}
+
+function PlatformCatchAllScreen() {
+  const pathname = usePathname();
+  const localParams = useLocalSearchParams();
+  const data = useLoaderData<typeof loader>();
+
+  return (
+    <>
+      <Table>
+        <TableRow label="Pathname" value={pathname} testID="pathname-result" />
+        <TableRow label="Local Params" value={localParams} testID="localparams-result" />
+        <TableRow label="Loader Data" value={data} testID="loader-result" />
+      </Table>
+
+      <SiteLinks>
+        <SiteLink href="/">Go to Index</SiteLink>
+      </SiteLinks>
+    </>
+  );
+}

--- a/apps/router-e2e/__e2e__/server-loader/app/index.tsx
+++ b/apps/router-e2e/__e2e__/server-loader/app/index.tsx
@@ -49,6 +49,7 @@ const IndexScreen = () => {
         <SiteLink href="/posts/static-post-2">Go to static Post 2</SiteLink>
         <SiteLink href="/error">Go to Error</SiteLink>
         <SiteLink href="/(group)">Go to Grouped Index</SiteLink>
+        <SiteLink href="/platform/alpha/beta">Go to Platform Catch-all</SiteLink>
         <SiteLink href="/static-helper">Go to Static Helper</SiteLink>
         <SiteLink href="/server-helper">Go to Server Helper</SiteLink>
       </SiteLinks>

--- a/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
+++ b/apps/router-e2e/__e2e__/server-loader/workerd/config.capnp
@@ -22,6 +22,7 @@ const server :Workerd.Worker = (
     (name = "_expo/loaders/request.js", commonJsModule = embed "_expo/loaders/request.js"),
     (name = "_expo/loaders/response.js", commonJsModule = embed "_expo/loaders/response.js"),
     (name = "_expo/loaders/(group)/index.js", commonJsModule = embed "_expo/loaders/(group)/index.js"),
+    (name = "_expo/loaders/(group)/platform/[...slug].js", commonJsModule = embed "_expo/loaders/(group)/platform/[...slug].js"),
     (name = "_expo/loaders/static-helper.js", commonJsModule = embed "_expo/loaders/static-helper.js"),
     (name = "_expo/loaders/server-helper.js", commonJsModule = embed "_expo/loaders/server-helper.js"),
   ],

--- a/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/server-loader.test.ts
@@ -56,6 +56,7 @@ describe.each(
     expect(files).not.toContain('posts/[postId].html');
     expect(files).not.toContain('posts/static-post-1.html');
     expect(files).not.toContain('posts/static-post-2.html');
+    expect(files).not.toContain('platform/alpha/beta.html');
 
     // Loader bundles should exist
     expect(files).toContain('_expo/loaders/index.js');
@@ -69,6 +70,7 @@ describe.each(
     expect(files).toContain('_expo/loaders/nullish/[value].js');
     expect(files).toContain('_expo/loaders/posts/[postId].js');
     expect(files).toContain('_expo/loaders/(group)/index.js');
+    expect(files).toContain('_expo/loaders/(group)/platform/[...slug].js');
     expect(files).toContain('_expo/loaders/static-helper.js');
     expect(files).toContain('_expo/loaders/server-helper.js');
   });
@@ -126,6 +128,17 @@ describe.each(
 
       const data = await getData(response);
       expect(data).toEqual({ data: 'grouped-index' });
+    }
+  );
+
+  it.each(getPageAndLoaderData('/(group)/platform/alpha/beta'))(
+    'can access platform-specific catch-all data for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+
+      const data = await getData(response);
+      expect(data).toEqual({ data: 'platform-catch-all' });
     }
   );
 

--- a/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-loader.test.ts
@@ -57,6 +57,7 @@ describe.each(
     expect(files).toContain('posts/[postId].html');
     expect(files).toContain('posts/static-post-1.html');
     expect(files).toContain('posts/static-post-2.html');
+    expect(files).toContain('platform/alpha/beta.html');
     expect(files).toContain('static-helper.html');
     expect(files).toContain('server-helper.html');
 
@@ -75,6 +76,7 @@ describe.each(
     expect(files).toContain('_expo/loaders/posts/static-post-1');
     expect(files).toContain('_expo/loaders/posts/static-post-2');
     expect(files).toContain('_expo/loaders/(group)/index');
+    expect(files).toContain('_expo/loaders/(group)/platform/alpha/beta');
     expect(files).toContain('_expo/loaders/static-helper');
   });
 
@@ -113,6 +115,17 @@ describe.each(
 
       const data = await getData(response);
       expect(data).toEqual({ data: 'grouped-index' });
+    }
+  );
+
+  it.each(getPageAndLoaderData('/(group)/platform/alpha/beta'))(
+    'can access platform-specific catch-all data for $url ($name)',
+    async ({ getData, url }) => {
+      const response = await server.fetchAsync(url);
+      expect(response.status).toBe(200);
+
+      const data = await getData(response);
+      expect(data).toEqual({ data: 'platform-catch-all' });
     }
   );
 
@@ -263,6 +276,8 @@ describe.each(
         // Header-less loader routes: the SSG default, applied to each page and loader file.
         { namedRegex: '^/(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/\\(group\\)(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/\\(group\\)/platform/\\[\\.\\.\\.slug\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/\\(group\\)/platform/alpha/beta(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/env(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/error(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/meta(?:/)?$', headers: SSG_DEFAULT },
@@ -270,12 +285,22 @@ describe.each(
         { namedRegex: '^/nullish/\\[value\\](?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/nullish/null(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/nullish/undefined(?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/platform/\\[\\.\\.\\.slug\\](?:/)?$', headers: SSG_DEFAULT },
+        { namedRegex: '^/platform/alpha/beta(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/posts/\\[postId\\](?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/posts/static\\-post\\-1(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/posts/static\\-post\\-2(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/request(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/static\\-helper(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/\\(group\\)/index(?:/)?$', headers: SSG_DEFAULT },
+        {
+          namedRegex: '^/_expo/loaders/\\(group\\)/platform/\\[\\.\\.\\.slug\\](?:/)?$',
+          headers: SSG_DEFAULT,
+        },
+        {
+          namedRegex: '^/_expo/loaders/\\(group\\)/platform/alpha/beta(?:/)?$',
+          headers: SSG_DEFAULT,
+        },
         { namedRegex: '^/_expo/loaders/env(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/error(?:/)?$', headers: SSG_DEFAULT },
         { namedRegex: '^/_expo/loaders/index(?:/)?$', headers: SSG_DEFAULT },

--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -60,6 +60,46 @@ for (const outputMode of outputModes) {
       expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
     });
 
+    test('loads grouped loader data on client-side navigation', async ({ page }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/')) {
+          loaderRequests.push(request.url());
+        }
+      });
+
+      await page.goto(expoStart.url.href);
+      await page.getByText('Go to Grouped Index').click();
+      await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+        JSON.stringify({ data: 'grouped-index' }, null, 2)
+      );
+      expect(loaderRequests).toContainEqual(
+        expect.stringContaining('/_expo/loaders/(group)/index')
+      );
+    });
+
+    test('loads a platform-specific catch-all loader on client-side navigation', async ({
+      page,
+    }) => {
+      const loaderRequests: string[] = [];
+      page.on('request', (request) => {
+        if (request.url().includes('/_expo/loaders/')) {
+          loaderRequests.push(request.url());
+        }
+      });
+
+      await page.goto(expoStart.url.href);
+      await page.getByText('Go to Platform Catch-all').click();
+      await expect(page).toHaveURL(/\/platform\/alpha\/beta$/);
+      await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+        JSON.stringify({ data: 'platform-catch-all' }, null, 2)
+      );
+      expect(loaderRequests).toContainEqual(
+        expect.stringContaining('/_expo/loaders/(group)/platform/alpha/beta')
+      );
+      expect(loaderRequests).not.toContainEqual(expect.stringContaining('[...slug].web'));
+    });
+
     test('defaults headerless loaders to no-store without replacing declared headers', async ({
       request,
     }) => {

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -63,6 +63,26 @@ test.describe('server loaders in production', () => {
     expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
+  test('loads a platform-specific catch-all loader on client-side navigation', async ({ page }) => {
+    const loaderRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/_expo/loaders/')) {
+        loaderRequests.push(request.url());
+      }
+    });
+
+    await page.goto(expoServe.url.href);
+    await page.getByText('Go to Platform Catch-all').click();
+    await expect(page).toHaveURL(/\/platform\/alpha\/beta$/);
+    await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+      JSON.stringify({ data: 'platform-catch-all' }, null, 2)
+    );
+    expect(loaderRequests).toContainEqual(
+      expect.stringContaining('/_expo/loaders/(group)/platform/alpha/beta')
+    );
+    expect(loaderRequests).not.toContainEqual(expect.stringContaining('[...slug].web'));
+  });
+
   test('refetches headerless loader data on every fresh mount', async ({ page }) => {
     const loaderRequests: string[] = [];
     page.on('request', (request) => {

--- a/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
@@ -60,6 +60,42 @@ test.describe('static loaders in production', () => {
     expect(JSON.parse(loaderDataContent!)).toEqual({ params: { postId: 'static-post-1' } });
   });
 
+  test('loads grouped loader data on client-side navigation', async ({ page }) => {
+    const loaderRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/_expo/loaders/')) {
+        loaderRequests.push(request.url());
+      }
+    });
+
+    await page.goto(expoServe.url.href);
+    await page.getByText('Go to Grouped Index').click();
+    await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+      JSON.stringify({ data: 'grouped-index' }, null, 2)
+    );
+    expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/(group)/index'));
+  });
+
+  test('loads a platform-specific catch-all loader on client-side navigation', async ({ page }) => {
+    const loaderRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/_expo/loaders/')) {
+        loaderRequests.push(request.url());
+      }
+    });
+
+    await page.goto(expoServe.url.href);
+    await page.getByText('Go to Platform Catch-all').click();
+    await expect(page).toHaveURL(/\/platform\/alpha\/beta$/);
+    await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+      JSON.stringify({ data: 'platform-catch-all' }, null, 2)
+    );
+    expect(loaderRequests).toContainEqual(
+      expect.stringContaining('/_expo/loaders/(group)/platform/alpha/beta')
+    );
+    expect(loaderRequests).not.toContainEqual(expect.stringContaining('[...slug].web'));
+  });
+
   test('revalidates headerless loader data on every fresh mount', async ({ page }) => {
     const loaderRequests: string[] = [];
     page.on('request', (request) => {

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Fix `replace` navigation in tabs leaving the replaced route in history. ([#48256](https://github.com/expo/expo/pull/48256) by [@Ubax](https://github.com/Ubax))
 - Prevent `useLoaderData()` from re-rendering readers of unrelated loader paths ([#48523](https://github.com/expo/expo/pull/48523) by [@hassankhan](https://github.com/hassankhan))
 - Fix package export for `expo-router/unstable-split-view` ([#49001](https://github.com/expo/expo/pull/49001) by [@hassankhan](https://github.com/hassankhan))
+- Fix platform-specific route parsing and loader keys ([#49035](https://github.com/expo/expo/pull/49035) by [@hassankhan](https://github.com/hassankhan))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
+++ b/packages/expo-router/src/__tests__/getRoutes.test.ios.ts
@@ -183,6 +183,25 @@ describe('getRoutes', () => {
     );
   });
 
+  // NOTE(@hassankhan): Should we throw an error for invalid platforms for
+  // `_layout` like we do for `+not-found`?
+  it(`does not treat an unsupported dotted suffix as a layout qualifier`, () => {
+    const routes = getRoutes(
+      inMemoryContext({
+        './_layout.custom.tsx': () => null,
+      }),
+      { internal_stripLoadRoute: true, skipGenerated: true }
+    );
+
+    expect(routes?.children).toContainEqual(
+      expect.objectContaining({
+        contextKey: './_layout.custom.tsx',
+        route: '_layout.custom',
+        type: 'route',
+      })
+    );
+  });
+
   it(`should name routes relative to the closest _layout`, () => {
     expect(
       getRoutes(
@@ -341,6 +360,16 @@ describe('+html', () => {
 });
 
 describe('+not-found', () => {
+  it(`rejects an unsupported dotted suffix`, () => {
+    expect(() =>
+      getRoutes(
+        inMemoryContext({
+          './+not-found.custom.tsx': () => null,
+        })
+      )
+    ).toThrowError("Route nodes cannot start with the '+' character");
+  });
+
   it(`should not append a +not-found if there already is a top level +not+found`, () => {
     expect(
       getRoutes(

--- a/packages/expo-router/src/__tests__/matchers.test.ios.ts
+++ b/packages/expo-router/src/__tests__/matchers.test.ios.ts
@@ -1,4 +1,5 @@
 import {
+  getContextKey,
   matchDynamicName,
   getNameFromFilePath,
   matchGroupName,
@@ -6,7 +7,42 @@ import {
   stripInvisibleSegmentsFromPath,
   matchArrayGroupName,
   matchLastGroupName,
+  getPlatformFromFilePath,
+  VALID_PLATFORMS,
 } from '../matchers';
+
+describe(getPlatformFromFilePath, () => {
+  it.each([...VALID_PLATFORMS])('returns the supported .%s extension', (platform) => {
+    expect(getPlatformFromFilePath(`./folder/page.${platform}.tsx`)).toBe(platform);
+  });
+
+  it('ignores unsupported and non-trailing extensions', () => {
+    expect(getPlatformFromFilePath('./page.custom.tsx')).toBeUndefined();
+    expect(getPlatformFromFilePath('./page.web.archive.tsx')).toBeUndefined();
+    expect(getPlatformFromFilePath('./web.tsx')).toBeUndefined();
+  });
+});
+
+describe(getContextKey, () => {
+  it.each([
+    ['./page.web.tsx', '/page'],
+    ['./page.ios.tsx', '/page'],
+    ['./page.android.tsx', '/page'],
+    ['./page.native.tsx', '/page'],
+    ['./(website)/blog/[...slug].web.tsx', '/(website)/blog/[...slug]'],
+    ['./(website)/_layout.web.tsx', '/(website)'],
+  ])('strips the platform extension from %s', (filePath, contextKey) => {
+    expect(getContextKey(filePath)).toBe(contextKey);
+  });
+
+  it.each([
+    ['./page.custom.tsx', '/page.custom'],
+    ['./page.web.archive.tsx', '/page.web.archive'],
+    ['./releases/version.2.tsx', '/releases/version.2'],
+  ])('preserves unsupported dotted route names in %s', (filePath, contextKey) => {
+    expect(getContextKey(filePath)).toBe(contextKey);
+  });
+});
 
 describe(stripGroupSegmentsFromPath, () => {
   it(`strips group segments, preserving initial slash`, () => {

--- a/packages/expo-router/src/__tests__/platform-routes.test.web.ts
+++ b/packages/expo-router/src/__tests__/platform-routes.test.web.ts
@@ -72,6 +72,33 @@ it(`should only load web routes`, () => {
   });
 });
 
+it.each([
+  ['web', 'web', './(website)/blog/[...slug].web.tsx'],
+  ['iOS', 'ios', './(website)/blog/[...slug].ios.tsx'],
+  ['Android', 'android', './(website)/blog/[...slug].android.tsx'],
+  ['a platform-neutral build', undefined, './(website)/blog/[...slug].tsx'],
+])('resolves a platform-specific deep dynamic route on %s', (_, platform, contextKey) => {
+  const routes = getRoutes(
+    inMemoryContext({
+      './(website)/blog/[...slug].tsx': () => null,
+      './(website)/blog/[...slug].android.tsx': () => null,
+      './(website)/blog/[...slug].ios.tsx': () => null,
+      './(website)/blog/[...slug].native.tsx': () => null,
+      './(website)/blog/[...slug].web.tsx': () => null,
+    }),
+    { internal_stripLoadRoute: true, platform, skipGenerated: true }
+  );
+
+  expect(routes?.children).toEqual([
+    expect.objectContaining({
+      contextKey,
+      dynamic: [{ deep: true, name: 'slug' }],
+      route: '(website)/blog/[...slug]',
+      type: 'route',
+    }),
+  ]);
+});
+
 it(`should skip platform routes when no platform has been provided`, () => {
   expect(
     getRoutes(

--- a/packages/expo-router/src/getRoutesCore.ts
+++ b/packages/expo-router/src/getRoutesCore.ts
@@ -9,6 +9,7 @@ import {
   matchDynamicName,
   matchGroupName,
   matchLastGroupName,
+  getPlatformFromFilePath,
   removeFileSystemDots,
   removeFileSystemExtensions,
   removeSupportedExtensions,
@@ -83,8 +84,6 @@ export type PageHeadersConfig = {
   source: string;
   headers: Record<string, string | string[]>;
 };
-
-const validPlatforms = new Set(['android', 'ios', 'native', 'web']);
 
 /**
  * Given a Metro context module, return an array of nested routes.
@@ -729,14 +728,17 @@ function getFileMeta(
   rewrites: Record<string, RewriteConfig>
 ) {
   // Remove the leading `./`
+  // NOTE(@hassankhan): Why not use `getNameFromFilePath()` here?
   const key = removeSupportedExtensions(removeFileSystemDots(originalKey));
   let route = key;
 
   const parts = removeFileSystemDots(originalKey).split('/');
   const filename = parts[parts.length - 1]!;
-  const filenameParts = removeSupportedExtensions(filename).split('.');
-  const filenameWithoutExtensions = filenameParts[0]!;
-  const platformExtension = filenameParts[1];
+  const filenameWithoutFileExtension = removeSupportedExtensions(filename);
+  const platformExtension = getPlatformFromFilePath(filename);
+  const filenameWithoutExtensions = platformExtension
+    ? filenameWithoutFileExtension.slice(0, -(platformExtension.length + 1))
+    : filenameWithoutFileExtension;
 
   const isLayout = filenameWithoutExtensions === '_layout';
   const isApi = originalKey.match(/\+api\.(\w+\.)?[jt]sx?$/);
@@ -754,7 +756,7 @@ function getFileMeta(
   }
   let specificity = 0;
 
-  const hasPlatformExtension = validPlatforms.has(platformExtension!);
+  const hasPlatformExtension = platformExtension != null;
   const usePlatformRoutes = options.platformRoutes ?? true;
 
   if (hasPlatformExtension) {
@@ -783,7 +785,7 @@ function getFileMeta(
       );
     }
 
-    route = route.replace(new RegExp(`.${platformExtension}$`), '');
+    route = route.slice(0, -(platformExtension.length + 1));
   }
 
   return {

--- a/packages/expo-router/src/loaders/__tests__/utils.test.web.ts
+++ b/packages/expo-router/src/loaders/__tests__/utils.test.web.ts
@@ -44,6 +44,12 @@ describe(fetchLoader, () => {
     expect(fetchedUrl()).toBe('/_expo/loaders/about');
   });
 
+  it('preserves route groups and query parameters in loader URLs', async () => {
+    await fetchLoader('/(website)/blog/index?preview=true');
+
+    expect(fetchedUrl()).toBe('/_expo/loaders/(website)/blog/index?preview=true');
+  });
+
   it('appends a cache-busting revision to loader URLs after a dev invalidation', async () => {
     bumpDevLoaderRevision();
 

--- a/packages/expo-router/src/matchers.tsx
+++ b/packages/expo-router/src/matchers.tsx
@@ -6,6 +6,9 @@ interface DynamicNameMatch {
   deep: boolean;
 }
 
+// NOTE(@hassankhan): Should we retrieve these from a more central location?
+export const VALID_PLATFORMS = new Set(['android', 'ios', 'native', 'web']);
+
 /** Match `[page]` -> `page` */
 export function matchDynamicName(name: string): DynamicNameMatch | undefined {
   const paramName = name.match(dynamicNameRe)?.[1];
@@ -42,10 +45,27 @@ export function getNameFromFilePath(name: string): string {
   return removeSupportedExtensions(removeFileSystemDots(name));
 }
 
+export function getPlatformFromFilePath(filePath: string): string | undefined {
+  const filename = getNameFromFilePath(filePath).split('/').pop()!;
+  const extensionIndex = filename.lastIndexOf('.');
+
+  if (extensionIndex < 0) {
+    return undefined;
+  }
+
+  const platform = filename.slice(extensionIndex + 1);
+  return VALID_PLATFORMS.has(platform) ? platform : undefined;
+}
+
 export function getContextKey(name: string): string {
   // The root path is `` (empty string) so always prepend `/` to ensure
   // there is some value.
-  const normal = '/' + getNameFromFilePath(name);
+  const contextKey = getNameFromFilePath(name);
+  const platform = getPlatformFromFilePath(name);
+  const contextKeyWithoutPlatform = platform
+    ? contextKey.slice(0, -(platform.length + 1))
+    : contextKey;
+  const normal = '/' + contextKeyWithoutPlatform;
   if (!normal.endsWith('_layout')) {
     return normal;
   }


### PR DESCRIPTION
# Why

This PR addresses issues found by Musclog [here](https://musclog.app/blog/2026/08/this-blog-was-built-using-expo). 

Platform-specific catch-all routes such as `[...slug].web.tsx` were parsed incorrectly because we split on `.` in `getRoutesCore()`;  the dots in `...slug` were mistakenly split on, preventing Expo Router from recognizing `.web` as the platform suffix. 

Platform suffixes are also preserved by `getContextKey()`, this prevented platform-specific layouts' such as `_layout.web.tsx` from being normalized consistently.

# How

- Added a new `getPlatformFromFilePath()` which recognises one of the following platforms: `android`, `ios`, `native` and `web`.
- Refactored `getRoutesCore()` to use `getPlatformFromFilePath()`.
- Refactored `getContextKey()` to remove the platform as found by `getPlatformFromFilePath()`. This now means that `layout.tsx` and `layout.web.tsx` both become `""` after being passed to `getContextKey()`.

# Test Plan

- CI

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
