### PR TITLE
fix(metro-config): Fix noxcturnal plugin bugs

### DIFF
--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -93,7 +93,7 @@
     "hermes-parser": "^0.36.0",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "^1.30.1",
-    "noxcturnal": "0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc",
+    "noxcturnal": "^0.1.0",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.23",
     "resolve-from": "^5.0.0"

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
@@ -1208,6 +1208,70 @@ it('captures a lexical binding that shadows a same-named Program binding', async
   expect(result.result.code).toMatch(/\(\) => \[_?value\]/);
 });
 
+it('composes a nested server action hoist without overlapping its declaration replacement', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/app/index.tsx',
+    projectRoot: '/app',
+    source: `export default function Screen() {
+      const prefix = 'hello';
+      const action = renderNativeViews;
+      return <View action={action} />;
+      async function renderNativeViews(name: string) {
+        "use server";
+        return <Text>{prefix + name}</Text>;
+      }
+    }`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).not.toContain('"use server"');
+  expect(result.result.code).toMatch(/var \[prefix\] = .+\.value/);
+  expect(result.result.code).toMatch(
+    /var renderNativeViews = _?\$\$INLINE_ACTION\.bind\(null, _?wrapBoundArgs/
+  );
+  expect(result.result.code.indexOf('var renderNativeViews')).toBeLessThan(
+    result.result.code.indexOf('const action = renderNativeViews')
+  );
+});
+
+it('hoists a nested server action declaration without captures', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/app/index.tsx',
+    projectRoot: '/app',
+    source: `export default function Screen() {
+      "use strict";
+      const action = submit;
+      return action;
+      async function submit(value: string) {
+        "use server";
+        return value;
+      }
+    }`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/var submit = _?\$\$INLINE_ACTION;/);
+  expect(result.result.code).not.toContain('.bind(null');
+  expect(result.result.code.indexOf('"use strict"')).toBeLessThan(
+    result.result.code.indexOf('var submit')
+  );
+  expect(result.result.code.indexOf('var submit')).toBeLessThan(
+    result.result.code.indexOf('const action = submit')
+  );
+});
+
 it("matches Babel's module-level React Server action registrations", async () => {
   const candidate = '/app/actions/server.ts';
   const source = `"use server";

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
@@ -4,7 +4,9 @@ import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import {
+  defineNativePlugin,
   defineNativePipeline,
+  defineVisitor,
   NativeTransformError,
   TransformSyntaxError,
   transform as transformWithNoxcturnal,
@@ -20,6 +22,7 @@ import {
   transformNodeModuleWithNoxcturnal,
   transformNodeModuleWithNoxcturnalSync,
 } from '../../noxcturnal/noxcturnal-transformer';
+import { createExpoRouterServerExportsPlugin } from '../../noxcturnal/plugins/expo-router-server-exports';
 
 function options(overrides: Partial<JsTransformOptions> = {}): JsTransformOptions {
   return {
@@ -433,6 +436,92 @@ it('removes loader and metadata exports from a native client route', async () =>
     performConstantFolding: true,
   });
 });
+
+it.each([
+  ['sibling source', '/app/src/route.js', 'app'],
+  ['dot-dot-prefixed sibling', '/app/app-other/route.js', 'app'],
+  ['relative parent escape', '/app/route.js', 'app/nested'],
+  ['absolute custom root', '/app/custom/route.js', '/app/other'],
+] as const)(
+  'keeps Router server exports outside the configured root for %s',
+  (_name, candidate, routerRoot) => {
+    const source = `export default function Route() {}
+    export async function loader() { return null; }
+    export const generateMetadata = () => ({}), keep = 1;`;
+    const input = {
+      filename: candidate,
+      projectRoot: '/app',
+      source,
+      options: options({
+        customTransformOptions: { engine: 'hermes', routerRoot, isLoaderBundle: 'true' },
+      }),
+      isDefaultExpoTransformer: true,
+    };
+    const result = transformWithNoxcturnal(
+      source,
+      candidate,
+      defineNativePipeline({
+        phases: [
+          {
+            name: 'router-server-exports',
+            plugins: [
+              createExpoRouterServerExportsPlugin({ defineNativePlugin, defineVisitor } as any),
+            ],
+          },
+        ],
+      }),
+      { pluginData: { input } }
+    );
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.code).toBe(source);
+    expect(result.metadata.loaderReference).toBeUndefined();
+    expect(result.metadata.performConstantFolding).toBeUndefined();
+  }
+);
+
+it.each([
+  ['relative custom root', '/app/routes/route.js', 'routes'],
+  ['decoded absolute custom root', '/app/custom root/route.js', '/app/custom%20root'],
+] as const)(
+  'applies Router server exports inside the configured root for %s',
+  (_name, candidate, routerRoot) => {
+    const source = `export default function Route() {}
+    export async function loader() { return null; }
+    export function helper() {}`;
+    const input = {
+      filename: candidate,
+      projectRoot: '/app',
+      source,
+      options: options({
+        customTransformOptions: { engine: 'hermes', routerRoot, isLoaderBundle: 'true' },
+      }),
+      isDefaultExpoTransformer: true,
+    };
+    const result = transformWithNoxcturnal(
+      source,
+      candidate,
+      defineNativePipeline({
+        phases: [
+          {
+            name: 'router-server-exports',
+            plugins: [
+              createExpoRouterServerExportsPlugin({ defineNativePlugin, defineVisitor } as any),
+            ],
+          },
+        ],
+      }),
+      { pluginData: { input } }
+    );
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.code).toContain('loader');
+    expect(result.code).not.toMatch(/\bRoute\b|\bhelper\b/);
+    expect(result.metadata.loaderReference).toBe(candidate);
+  }
+);
 
 it.each(['/app/app/..admin.tsx', '/app/app/..internal/route.ts'])(
   'treats the dot-dot-prefixed descendant %s as a native client route',

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/language-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/language-plugins.test.ts
@@ -1306,6 +1306,11 @@ it.each([
     'module.exports = async (...rest) => rest.length',
     /\(\.\.\.rest\)\s*=>\s*\(async\s*\(\)\s*=>\s*\{\s*return rest\.length;/,
   ],
+  [
+    'rest parameter with block body',
+    'module.exports = async (...rest) => { return rest.length; }',
+    /\(\.\.\.rest\)\s*=>\s*\(async\s*\(\)\s*=>\s*\{\s*return rest\.length;/,
+  ],
 ])('applies the maintained async-arrow workaround for %s', async (_name, source, expected) => {
   const result = await transformNodeModuleWithNoxcturnal({
     filename,
@@ -1357,6 +1362,24 @@ it('preserves runtime behavior across maintained async-arrow rewrites', async ()
   const module = { exports: undefined as unknown };
   Function('module', 'exports', result.result.code)(module, module.exports);
   await expect((module.exports as () => Promise<unknown>)()).resolves.toEqual([1, 7, 'a:b', 1]);
+});
+
+it('preserves source mappings for a composite rest-parameter async-arrow rewrite', async () => {
+  const source = `module.exports = async (...rest) => rest.length;`;
+  const result = await transformNodeModuleWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source,
+    options: options(),
+    isDefaultExpoTransformer: true,
+  });
+  if (result.status === 'fallback') throw new Error(result.reason);
+  const original = originalPositionFor(
+    new TraceMap({ version: 3, sources: [filename], ...result.result.map } as any),
+    generatedPositionOf(result.result.code, 'rest.length')
+  );
+
+  expect(original).toMatchObject({ line: 1, column: source.indexOf('rest.length') });
 });
 
 it.each([

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
@@ -2206,6 +2206,15 @@ it.each([
 
 it.each([
   ['class', `export default class DOMException {}; DOMException.code = 1;`],
+  [
+    'lowered class',
+    `export default class DOMException extends Error {
+    #name;
+    constructor(message) { super(message); this.#name = 'Error'; }
+    get name() { return this.#name; }
+  }
+  DOMException.code = 1;`,
+  ],
   ['function', `export default function createValue() {}; createValue.code = 1;`],
 ])('preserves a named default %s declaration binding', async (_name, source) => {
   const result = await transformFileFullyWithNoxcturnal({

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-modules.test.ts
@@ -929,6 +929,38 @@ it('compacts the complete Metro output without falling back to Babel', async () 
   expect(result.dependencies.map(({ name }) => name)).toEqual(['one']);
 });
 
+it('avoids compact Metro pseudo-global collisions with module bindings', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename,
+    projectRoot: '/app',
+    source: `import value from "one";
+      let g = 1, r = 2, i = 3, a = 4, m = 5, e = 6, d = 7;
+      export default [value, g, r, i, a, m, e, d];`,
+    options: options({ dev: false, minify: true }),
+    isDefaultExpoTransformer: true,
+    config: { ...fullConfig(), unstable_compactOutput: true },
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.code).toMatch(/__d\(function\(_g,_r,_i,_a,_m,_e,_dependencyMap\)\{/);
+  let factory: Function | undefined;
+  new Function('__d', result.result.code)((value: Function) => {
+    factory = value;
+  });
+  const moduleExports: { default?: unknown } = {};
+  factory?.(
+    globalThis,
+    () => 'required',
+    () => 'imported',
+    () => ({ default: 'imported' }),
+    { exports: moduleExports },
+    moduleExports,
+    [0]
+  );
+  expect(moduleExports.default).toEqual(['required', 1, 2, 3, 4, 5, 6, 7]);
+});
+
 it('completes production constant folding and DCE in native code', async () => {
   const result = await transformFileFullyWithNoxcturnal({
     filename,

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/react-server-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/react-server-plugins.test.ts
@@ -567,6 +567,52 @@ it.each(['use client', 'use dom'])(
   }
 );
 
+it('excludes type-only and export-all declarations from client proxy exports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/client.ts',
+    projectRoot: '/app',
+    source: `'use client';
+      export interface Props { value: string }
+      export type Value = string;
+      export type { External } from './types';
+      const mixed = 2;
+      export { type Value as MixedType, mixed };
+      export * from './other';
+      export const value = 1;`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.metadata.proxyExports).toEqual(['mixed', 'value']);
+  expect(result.result.code).not.toContain('registerClientReference(proxy, "*"');
+});
+
+it('excludes Flow type declarations from client proxy exports', async () => {
+  const result = await transformFileFullyWithNoxcturnal({
+    filename: '/app/src/client.js',
+    projectRoot: '/app',
+    source: `// @flow
+      'use client';
+      export interface Props { value: string }
+      export type Value = string;
+      export const value = 1;`,
+    options: options({
+      customTransformOptions: { engine: 'hermes', environment: 'react-server' },
+    }),
+    isDefaultExpoTransformer: true,
+    config: fullConfig(),
+  });
+
+  expect(result.status).toBe('complete');
+  if (result.status !== 'complete') return;
+  expect(result.result.metadata.proxyExports).toEqual(['value']);
+});
+
 it("keeps conflicting React Server directives on Babel's diagnostic path", async () => {
   const result = await transformFileFullyWithNoxcturnal({
     filename: '/app/src/conflict.js',

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
@@ -83,11 +83,18 @@ export function sortedUniqueCaptureNames(captures: readonly NodeView[]): string[
   return [...new Set(captures.map((capture) => String(capture.name)))].sort();
 }
 
+export interface MetroPseudoGlobals {
+  global: string;
+  module: string;
+  exports: string;
+}
+
 export interface MetroTransformPluginData extends ExpoTransformPluginData {
   input: NoxcturnalMetroTransformInput;
   shared: MetroDependencyShared;
   collectOnly: boolean;
   normalizePseudoGlobals: boolean;
+  pseudoGlobals: MetroPseudoGlobals;
 }
 
 export function expoPluginInput(context: { pluginData: unknown }): NoxcturnalTransformInput {
@@ -140,6 +147,11 @@ function createMetroTransformPluginData(
       input.config.unstable_disableModuleWrapping !== true &&
       input.source.length <= (input.config.optimizationSizeLimit ?? Number.POSITIVE_INFINITY) &&
       !sourceFacts.hasPseudoGlobals,
+    pseudoGlobals: {
+      global: 'g',
+      module: 'm',
+      exports: 'e',
+    },
   };
 }
 

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-router-server-exports.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/expo-router-server-exports.ts
@@ -3,12 +3,14 @@ import path from 'path';
 
 import {
   expoPluginInput,
+  isPathInsideRoot,
   type Noxcturnal,
   type NoxcturnalTransformInput,
 } from '../noxcturnal-transformer';
 
 interface ExpoRouterExportState {
   input: NoxcturnalTransformInput;
+  enabled: boolean;
   isLoaderBundle: boolean;
   isServer: boolean;
   loaderReference?: string;
@@ -26,8 +28,14 @@ export function createExpoRouterServerExportsPlugin(
     },
     createState: (context) => {
       const input = expoPluginInput(context);
+      const routerRootOption = input.options.customTransformOptions?.routerRoot;
+      const routerRoot = typeof routerRootOption === 'string' ? decodeURI(routerRootOption) : 'app';
+      const absoluteRouterRoot = path.isAbsolute(routerRoot)
+        ? routerRoot
+        : path.join(input.projectRoot, routerRoot);
       return {
         input,
+        enabled: isPathInsideRoot(absoluteRouterRoot, input.filename),
         isLoaderBundle: String(input.options.customTransformOptions?.isLoaderBundle) === 'true',
         isServer: input.options.customTransformOptions?.environment === 'node',
         performConstantFolding: false,
@@ -35,6 +43,7 @@ export function createExpoRouterServerExportsPlugin(
     },
     visitors: [
       nox.defineVisitor('ExportDefaultDeclaration', {}, (exportPath, state) => {
+        if (!state.enabled) return;
         if (!state.isLoaderBundle) return;
         exportPath.remove();
         state.performConstantFolding = true;
@@ -63,6 +72,7 @@ export function createExpoRouterServerExportsPlugin(
           },
         },
         (exportPath, state) => {
+          if (!state.enabled) return;
           if (
             exportPath.node.source ||
             (exportPath.node.exportKind && exportPath.node.exportKind !== 'value') ||
@@ -130,6 +140,7 @@ export function createExpoRouterServerExportsPlugin(
       ),
     ],
     post(context, state) {
+      if (!state.enabled) return;
       if (state.loaderReference) {
         context.metadata.set('loaderReference', state.loaderReference);
       }

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-async-arrow-non-simple-params.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/fix-hermes-v1-async-arrow-non-simple-params.ts
@@ -42,10 +42,6 @@ export function createFixHermesV1AsyncArrowNonSimpleParamsPlugin(
           const body = arrow.getChild('body');
           if (!body) arrow.unsupported('missing-async-arrow-body');
           const bodySource = body!.getSource();
-          const blockBody = arrow.node.expression
-            ? arrow.context.code.template`{ return ${bodySource}; }`
-            : bodySource;
-
           // Hermes rejects every rest-parameter async arrow. Keep its original
           // parameter binding in a synchronous closure and invoke a zero-argument
           // async arrow inside it, matching Expo's maintained Babel transform.
@@ -56,8 +52,18 @@ export function createFixHermesV1AsyncArrowNonSimpleParamsPlugin(
                 parameter.node.type === 'BindingRestElement'
             )
           ) {
-            arrow.context.editor.remove(arrow.getSource().start, arrow.getSource().start + 5);
-            body!.replaceWith(arrow.context.code.template`(async () => ${blockBody})()`);
+            const arrowSource = arrow.getSource();
+            arrow.replaceWith({
+              kind: 'composite',
+              parts: [
+                arrow.context.sourceSlice(arrowSource.start + 5, bodySource.start),
+                '(async () => ',
+                ...(arrow.node.expression
+                  ? (['{ return ', bodySource, '; }'] as const)
+                  : ([bodySource] as const)),
+                ')()',
+              ],
+            });
             return;
           }
 

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-dependency.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-dependency.ts
@@ -297,9 +297,15 @@ export function createMetroDependencyPlugin(
           enter(program, state: MetroDependencyState) {
             const { input, normalizePseudoGlobals } = metroPluginData(program.context);
             if (normalizePseudoGlobals) {
-              state.requireName = 'r';
-              state.importDefaultName = 'i';
-              state.importAllName = 'a';
+              state.requireName = program.scope.hasBinding('r')
+                ? program.scope.generateUid('r')
+                : 'r';
+              state.importDefaultName = program.scope.hasBinding('i')
+                ? program.scope.generateUid('i')
+                : 'i';
+              state.importAllName = program.scope.hasBinding('a')
+                ? program.scope.generateUid('a')
+                : 'a';
             } else if (input.config.unstable_disableModuleWrapping !== true) {
               state.requireName =
                 input.config.unstable_renameRequire === false
@@ -819,13 +825,14 @@ export function createMetroDependencyPlugin(
       context.metadata.set('metroImportDefaultName', state.importDefaultName);
       context.metadata.set('metroImportAllName', state.importAllName);
       if (!collectOnly && input.config.unstable_disableModuleWrapping !== true) {
+        const pseudoGlobals = metroPluginData(context).pseudoGlobals;
         const parameters = [
-          normalizePseudoGlobals ? 'g' : 'global',
+          normalizePseudoGlobals ? pseudoGlobals.global : 'global',
           state.requireName,
           state.importDefaultName,
           state.importAllName,
-          normalizePseudoGlobals ? 'm' : 'module',
-          normalizePseudoGlobals ? 'e' : 'exports',
+          normalizePseudoGlobals ? pseudoGlobals.module : 'module',
+          normalizePseudoGlobals ? pseudoGlobals.exports : 'exports',
           state.dependencyMapName,
         ];
         context.editor.prepend(

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-esm-globals.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-esm-globals.ts
@@ -1,17 +1,40 @@
 import type { DefinedNativePlugin } from 'noxcturnal';
 
-import { metroPluginData, type Noxcturnal } from '../noxcturnal-transformer';
+import {
+  metroPluginData,
+  type MetroPseudoGlobals,
+  type Noxcturnal,
+} from '../noxcturnal-transformer';
 
-export function createMetroEsmGlobalsPlugin(nox: Noxcturnal): DefinedNativePlugin {
-  return nox.defineNativePlugin({
+interface MetroEsmGlobalsState {
+  names: MetroPseudoGlobals;
+}
+
+function pseudoGlobalName(
+  scope: { hasBinding(name: string): boolean; generateUid(name: string): string },
+  preferred: string
+): string {
+  return scope.hasBinding(preferred) ? scope.generateUid(preferred) : preferred;
+}
+
+export function createMetroEsmGlobalsPlugin(
+  nox: Noxcturnal
+): DefinedNativePlugin<MetroEsmGlobalsState> {
+  return nox.defineNativePlugin<MetroEsmGlobalsState>({
     name: 'metro-native-esm-pseudo-global-renames',
+    createState: () => ({ names: { global: 'g', module: 'm', exports: 'e' } }),
     visitors: [
-      nox.defineVisitor('Program', { scope: true }, (program) => {
+      nox.defineVisitor('Program', { scope: true }, (program, state) => {
         for (const name of ['global', 'require', 'module', 'exports']) {
           if (program.scope.hasBinding(name)) {
             program.scope.rename(name, program.scope.generateUid(name));
           }
         }
+        if (!metroPluginData(program.context).normalizePseudoGlobals) return;
+        state.names.global = pseudoGlobalName(program.scope, 'g');
+        state.names.module = pseudoGlobalName(program.scope, 'm');
+        state.names.exports = pseudoGlobalName(program.scope, 'e');
+        metroPluginData(program.context).pseudoGlobals = state.names;
       }),
       nox.defineVisitor(
         'Identifier',
@@ -19,16 +42,14 @@ export function createMetroEsmGlobalsPlugin(nox: Noxcturnal): DefinedNativePlugi
           fields: ['name', 'global'],
           where: { name: { oneOf: ['global', 'module', 'exports'] } },
         },
-        (identifier) => {
+        (identifier, state) => {
           if (
             identifier.node.global !== true ||
             !metroPluginData(identifier.context).normalizePseudoGlobals
           ) {
             return;
           }
-          const replacement = { global: 'g', module: 'm', exports: 'e' }[
-            String(identifier.node.name)
-          ];
+          const replacement = state.names[String(identifier.node.name) as keyof typeof state.names];
           if (replacement) identifier.replaceWith(replacement);
         }
       ),

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-live-bindings.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/metro-live-bindings.ts
@@ -21,8 +21,10 @@ export function createMetroLiveBindingsPlugin(
     return scope.generateUid(name);
   };
   const property = (object: string, name: string) => `${object}.${name}`;
-  const exportsName = (context: { pluginData: unknown }) =>
-    metroPluginData(context).normalizePseudoGlobals ? 'e' : 'exports';
+  const exportsName = (context: { pluginData: unknown }) => {
+    const { normalizePseudoGlobals, pseudoGlobals } = metroPluginData(context);
+    return normalizePseudoGlobals ? pseudoGlobals.exports : 'exports';
+  };
   const liveExport = (name: string, expression: string, target = 'exports') =>
     `Object.defineProperty(${target}, ${JSON.stringify(name)}, { enumerable: true, get: function () { return ${expression}; } });`;
   const exportValue = (name: string, expression: string, target = 'exports') =>

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-client-proxy.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-client-proxy.ts
@@ -76,19 +76,10 @@ export function createReactServerClientProxyPlugin(
         }
       ),
       nox.defineVisitor(
-        'ExportAllDeclaration',
-        { ancestry: { mode: 'programParent' } },
-        (exportPath, state) => {
-          if (state.enabled && exportPath.parentPath?.node.type === 'Program') {
-            state.exports.add('*');
-          }
-        }
-      ),
-      nox.defineVisitor(
         'ExportNamedDeclaration',
         {
+          fields: ['exportKind'],
           ancestry: { mode: 'programParent' },
-          scope: true,
           children: {
             declaration: {
               route: 'Declaration',
@@ -104,13 +95,22 @@ export function createReactServerClientProxyPlugin(
             },
             specifiers: {
               route: 'ExportSpecifier',
-              fields: ['exported'],
+              fields: ['exported', 'exportKind'],
             },
           } as any,
         },
         (exportPath, state) => {
           if (!state.enabled || exportPath.parentPath?.node.type !== 'Program') return;
+          if (exportPath.node.exportKind === 'type') return;
           const declaration = exportPath.getChild('declaration') as any;
+          if (
+            declaration?.node.type === 'TSInterfaceDeclaration' ||
+            declaration?.node.type === 'TSTypeAliasDeclaration' ||
+            declaration?.node.type === 'TypeAlias' ||
+            declaration?.node.type === 'InterfaceDeclaration'
+          ) {
+            return;
+          }
           if (typeof declaration?.node.name === 'string') {
             state.exports.add(declaration.node.name);
           } else if (declaration?.node.type === 'VariableDeclaration') {
@@ -122,6 +122,7 @@ export function createReactServerClientProxyPlugin(
             }
           }
           for (const specifier of exportPath.getChildList('specifiers')) {
+            if (specifier.node.exportKind === 'type') continue;
             state.exports.add(String(specifier.node.exported));
           }
         }

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-module-actions.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/plugins/react-server-module-actions.ts
@@ -19,7 +19,12 @@ interface ReactServerActionsState {
   registerBinding: string;
   wrapperBinding: string;
   usesCapturedArgs: boolean;
+  hoists: Code[];
   actions: { localName?: string; exportedName: string }[];
+}
+
+function emitHoist(state: ReactServerActionsState, code: Code): void {
+  state.hoists.push(code);
 }
 
 export function createReactServerModuleActionsPlugin(
@@ -41,6 +46,7 @@ export function createReactServerModuleActionsPlugin(
         registerBinding: '',
         wrapperBinding: '',
         usesCapturedArgs: false,
+        hoists: [],
         actions: [],
       };
     },
@@ -116,12 +122,10 @@ export function createReactServerModuleActionsPlugin(
           const closureInit = closureParameter
             ? `var [${capturedNames.join(', ')}] = ${closureParameter}.value;`
             : '';
-          arrow
-            .getProgramParent()!
-            .unshiftContainer(
-              'body',
-              `export var ${actionId} = ${state.registerBinding}(async (${extractedParameters}) => {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
-            );
+          emitHoist(
+            state,
+            `export var ${actionId} = ${state.registerBinding}(async (${extractedParameters}) => {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+          );
           arrow.replaceWith(
             closureParameter
               ? `${actionId}.bind(null, ${state.wrapperBinding}(() => [${capturedNames.join(', ')}]))`
@@ -181,12 +185,10 @@ export function createReactServerModuleActionsPlugin(
           const closureInit = closureParameter
             ? `var [${capturedNames.join(', ')}] = ${closureParameter}.value;`
             : '';
-          fn.scope
-            .getProgramParent()
-            .path!.unshiftContainer(
-              'body',
-              `export var ${actionId} = ${state.registerBinding}(async function${name}(${extractedParameters}) {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
-            );
+          emitHoist(
+            state,
+            `export var ${actionId} = ${state.registerBinding}(async function${name}(${extractedParameters}) {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+          );
           fn.replaceWith(
             closureParameter
               ? `${actionId}.bind(null, ${state.wrapperBinding}(() => [${capturedNames.join(', ')}]))`
@@ -202,7 +204,10 @@ export function createReactServerModuleActionsPlugin(
         {
           fields: ['async', 'generator', 'name', 'bodyEnd'],
           scope: true,
-          ancestry: { mode: 2 },
+          ancestry: {
+            mode: 2,
+            routes: { Function: { fields: ['bodyStart'] } },
+          },
           children: {
             body: {
               route: 'FunctionBody',
@@ -226,29 +231,53 @@ export function createReactServerModuleActionsPlugin(
           if (fn.node.async !== true || fn.node.generator === true) {
             fn.unsupported('server-action-non-async-inline');
           }
+          if (typeof fn.node.name !== 'string') {
+            fn.unsupported('server-action-nested-function-declaration');
+          }
+          const declarationName = String(fn.node.name);
           const topLevel =
             fn.parentPath?.node.type === 'Program' ||
             (fn.parentPath?.node.type === 'ExportNamedDeclaration' &&
               fn.parentPath.parentPath?.node.type === 'Program');
-          if (!topLevel || typeof fn.node.name !== 'string') {
-            fn.unsupported('server-action-nested-function-declaration');
-          }
+          const captures = topLevel
+            ? []
+            : (fn.context.query({
+                captures: [{ functionId: fn.node.id, programBindings: false }],
+              }).captures[fn.node.id] ?? []);
+          const capturedNames = sortedUniqueCaptureNames(captures);
           const actionId = fn.scope.getProgramParent().generateUid('$$INLINE_ACTION');
           const parameters = fn
             .getChildList('params')
             .map((parameter) => parameter.sourceText())
             .join(', ');
           const bodySource = fn.context.source.slice(directive.node.end, Number(fn.node.bodyEnd));
-          fn.scope
-            .getProgramParent()
-            .path!.unshiftContainer(
-              'body',
-              `export var ${actionId} = ${state.registerBinding}(async function ${fn.node.name}(${parameters}) {${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
-            );
-          fn.replaceWith(`var ${fn.node.name} = ${actionId};`);
+          const closureParameter =
+            capturedNames.length === 0 ? '' : fn.scope.generateUid('$$CLOSURE');
+          const extractedParameters = [...(closureParameter ? [closureParameter] : []), parameters]
+            .filter(Boolean)
+            .join(', ');
+          const closureInit = closureParameter
+            ? `var [${capturedNames.join(', ')}] = ${closureParameter}.value;`
+            : '';
+          emitHoist(
+            state,
+            `export var ${actionId} = ${state.registerBinding}(async function ${declarationName}(${extractedParameters}) {${closureInit}${bodySource}}, ${JSON.stringify(state.moduleId)}, ${JSON.stringify(actionId)});`
+          );
+          const replacement = `var ${declarationName} = ${
+            closureParameter
+              ? `${actionId}.bind(null, ${state.wrapperBinding}(() => [${capturedNames.join(', ')}]))`
+              : actionId
+          };`;
+          if (topLevel) {
+            fn.replaceWith(replacement);
+          } else {
+            fn.remove();
+            fn.scope.parent!.push(replacement);
+          }
+          if (closureParameter) state.usesCapturedArgs = true;
           state.boundary.handledDirectives.add(directive.id);
           state.actions.push({
-            localName: fn.node.name,
+            localName: declarationName,
             exportedName: actionId,
           });
         }
@@ -419,7 +448,7 @@ export { ${name} as default };`);
           state.usesCapturedArgs
             ? `var ${state.wrapperBinding} = (thunk) => { let cache; return { get value() { return cache || (cache = thunk()); } }; };\n`
             : ''
-        }`
+        }${state.hoists.length > 0 ? `${state.hoists.join('\n')}\n` : ''}`
       );
       context.metadata.set('reactServerActions', payload);
       context.metadata.set('reactServerReference', pathToFileURL(state.input.filename).href);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2652,8 +2652,8 @@ importers:
         specifier: ^1.30.1
         version: 1.32.0
       noxcturnal:
-        specifier: 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-        version: 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+        specifier: ^0.1.0
+        version: 0.1.0
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -8115,54 +8115,54 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@noxcturnal/noxcturnal-darwin-arm64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-jxiuwa80/CjzlMcWsXyvMiP17M0/F00v+fl3pbF5oPB5kc8oyB3B9cC9jdq1zEpkwl//EgceNMOybD49nhYbyA==}
+  '@noxcturnal/noxcturnal-darwin-arm64@0.1.0':
+    resolution: {integrity: sha512-ne7o6o2S0MVvifcqqg5pOA7oHAJ9jFl9jztvC2qV6Tn2PrYEcCgy3hy2o43U2ibRb50rhxPmk5BxTdWLQTN+2Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@noxcturnal/noxcturnal-darwin-x64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-lPEt5SnKC+A0sKpMTQ0VdDKk7tXSqteewasAiJJuuNvcdt7OWz+wYjy2Q5IVhpWNhSYKKiTLoBQhynX0bI9xzA==}
+  '@noxcturnal/noxcturnal-darwin-x64@0.1.0':
+    resolution: {integrity: sha512-/C83y+fUIh3j6bvM5ImHv+ZsfulFxBHdxqtSC+BTm+3i9Lhob4LKoE2vvxu1JOoNz+EUJsMnHXiGK3M5gWtg2A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-sP7c5EDnCSRw5McqZVfmEd+zbULbZby0Bm/OwGUp0oTYMjYFHzn7DVrRCKDFk69JpKphV78THF9GpIM7zAMMcg==}
+  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.0':
+    resolution: {integrity: sha512-eLFf4xeKDri/KFWj9aycsKeYSj3e5xLwAxU97BATICtOYc8TVy0hJVhpRSKI/ct+TshHK+RBLnlEK9SNqjA5Fw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-WgxQaZWZ2xAJB3vri3T7H+2lggLlmesjQ2b+JugRmWHmeDRgnm8+bO9pTTkdUYiwgJjtxgRbZsAdg96jXOyMXA==}
+  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.0':
+    resolution: {integrity: sha512-3EBJ+OuhPJ8+wN/XEvvHj7KeXRizNPvqE/Cqc/aMU1APpvfVq8zc6DSNrkd/p3tMws9MMLADek2xt8NXl0MxCg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-dEraHw0g9OHoqsROD6XZhZkr1bUA0nbwMXdovwo3xbtkAYc/ZuRofoz8+eM6g3wULphe0LauI8wDe8qPRGi7gA==}
+  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.0':
+    resolution: {integrity: sha512-Y/UkWoHT3DF//ctVETW2cnZzvILVXrabXEe8KbdA0Uz53AyAslHe/uHrDvcI42Fw9XFIuV26pvrn55T2IKhpaQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-CqYPb/cSb3P+DxP7nuZ/MhH5Ta16QhR0+YqMpyeeRj1hkeDEF+xNtodvZJb9t1xw7JzWk/rfTg3DuzUzWsVE3g==}
+  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.0':
+    resolution: {integrity: sha512-MZSkPghxh6k9zxsljYIZfQH0Q6YtOAmP2tZC1DMfWYGR2dNR9lyCxzJqYkiRpyND+y4CnjgPwuwZvKYHfcR6Sw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-3VNTWxkFMu8+s4vWdFjWQIdcwEIo9/EJKcDPSNulKM5zOrMe35H883ht5KqUhAXnPaQ7/KGwdzd4l/bxxl45UA==}
+  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.0':
+    resolution: {integrity: sha512-Wc+Zq26fux3byuCiKJVdW+NQYFdkTlsB7lhfr+w6fb6Xd4XVLAOOwzdocuvvKYLT0vA44StDgBbKDCQGSRGNDQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
-    resolution: {integrity: sha512-lZhOmUPSdekQ6lnzOAQeC7O1aKpr2vco2RKUz+aDAUmRXZgzpirdK1jri1cpgWemb278Za5FXXZq+O0v0aYVTQ==}
+  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.0':
+    resolution: {integrity: sha512-1Lat4+4WaiYLMm2dbnwEthj0Kx0i2ycwwcJ1JEjDXXXf6I113tSSSmCDmo4C/PAvXBGTQLWw3/8scoY2QA3G5w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -13035,8 +13035,8 @@ packages:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
 
-  noxcturnal@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc:
-    resolution: {integrity: sha512-kR6JyVKbh4wVjll329UI+jA2OBoTeCX65I0wejTFX+KAP1poW6XR5+r+TcO6PbbyASTWNThc4UFqTM2dv1ee2A==}
+  noxcturnal@0.1.0:
+    resolution: {integrity: sha512-BkFZhSdTpH0L5z+nvWYj1IyhcCTYobg6HVQm6u7iW41zum43axs7I14tcXwy3a1ugDYRbSoXpzZ8+XqON7R1Uw==}
     engines: {node: '>=18'}
 
   npm-bundled@2.0.1:
@@ -17034,28 +17034,28 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@noxcturnal/noxcturnal-darwin-arm64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-darwin-arm64@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-darwin-x64@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-darwin-x64@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-linux-arm64-gnu@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-linux-arm64-musl@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-linux-x64-gnu@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-linux-x64-musl@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-win32-arm64-msvc@0.1.0':
     optional: true
 
-  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc':
+  '@noxcturnal/noxcturnal-win32-x64-msvc@0.1.0':
     optional: true
 
   '@octokit/auth-token@3.0.4': {}
@@ -22440,19 +22440,19 @@ snapshots:
 
   normalize-url@6.1.0: {}
 
-  noxcturnal@0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc:
+  noxcturnal@0.1.0:
     dependencies:
       '@babel/code-frame': 7.29.7
       '@oxc-project/types': 0.141.0
     optionalDependencies:
-      '@noxcturnal/noxcturnal-darwin-arm64': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-darwin-x64': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-linux-arm64-gnu': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-linux-arm64-musl': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-linux-x64-gnu': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-linux-x64-musl': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-win32-arm64-msvc': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
-      '@noxcturnal/noxcturnal-win32-x64-msvc': 0.1.1-canary-5e28645fa13a4dee3b1814eac789f79b8e7259bc
+      '@noxcturnal/noxcturnal-darwin-arm64': 0.1.0
+      '@noxcturnal/noxcturnal-darwin-x64': 0.1.0
+      '@noxcturnal/noxcturnal-linux-arm64-gnu': 0.1.0
+      '@noxcturnal/noxcturnal-linux-arm64-musl': 0.1.0
+      '@noxcturnal/noxcturnal-linux-x64-gnu': 0.1.0
+      '@noxcturnal/noxcturnal-linux-x64-musl': 0.1.0
+      '@noxcturnal/noxcturnal-win32-arm64-msvc': 0.1.0
+      '@noxcturnal/noxcturnal-win32-x64-msvc': 0.1.0
 
   npm-bundled@2.0.1:
     dependencies:


### PR DESCRIPTION
# Why

Follow-up to #48443 with fixes. No changelog entry added since these are follow-on changes to an experimental + unreleased feature.

These were raised autonomously by an LLM while writing a Babel adapter for noxcturnal. The fixes are unrelated to this experiment/spike.

# How

- Prevent `expo-router-server-exports` (i.e. loaders) from applying outside the server root (conditions didn't match Babel plugins)
- Prevent overlapping edits for the async rest-arrow fixing the Hermes v1 quirk (can cause ordering bugs on editing body + args)
- Exclude type exports from RSC client-proxy (they're not values, obviously)
- Fix RSC server action hoisting edge cases (when we hoist a server function, we can't let its function declaration clash with a surrounding declaration/var)
- Fix pseudo global collisions on renaming module wrapper args (we rename the wrapper args, like `require` to `r` when `optimize` is enabled in production, but weren't checking whether these names have conflicting declarations in the module already)
- Update noxcturnal to fix default export + class declaration lowering (See: https://github.com/expo/noxcturnal/pull/1)

Each fix is one commit, so looking at commits separately is easier for reviewing this PR.

# Test Plan

- Tests were added, one each (at least) per fix above
  - Note: The global collisions tests span a few test files
- Ran `native-component-list` manually to verify

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
