### PR TITLE
[docs] Fix multiple markdown export issues

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -1251,6 +1251,26 @@ describe('API returns section', () => {
     expect(md).toContain('Returns:');
     expect(md).toMatch(/Returns: .?Promise.?/);
   });
+
+  it('preserves the casing of generic type arguments', () => {
+    const html = [
+      '<main><h3>getPermissionsAsync()</h3>',
+      '<div data-md="api-returns" class="flex flex-row items-start gap-2">',
+      '<div class="flex flex-row items-center gap-2">',
+      '<span class="text-sm">Returns:</span>',
+      '</div>',
+      '<code>',
+      '<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a>',
+      '<span class="text-quaternary">&lt;</span>',
+      '<span>PermissionResponse</span>',
+      '<span class="text-quaternary">&gt;</span>',
+      '</code>',
+      '</div></main>',
+    ].join('');
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('Promise<PermissionResponse>');
+    expect(md).not.toContain('permissionresponse');
+  });
 });
 
 describe('API parameter names', () => {

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -967,6 +967,12 @@ describe('checkPage (check-markdown-pages)', () => {
     const errors = checkPage(md);
     expect(errors.some(error => error.includes('Unbalanced code fences'))).toBe(true);
   });
+
+  it('detects doubled periods', () => {
+    expect(
+      checkPage('# Title\n\n| Parameter | Type |\n| --- | --- |\n| `. .uris` | `string[]` |\n')
+    ).toEqual(['Contains ". ." (corrupted ellipsis or doubled period)']);
+  });
 });
 
 describe('collapsible/details', () => {
@@ -1191,6 +1197,18 @@ describe('blockquote in table cells', () => {
     const md = convertHtmlToMarkdown(html);
     expect(md).not.toContain('> Allows');
     expect(md).toContain('Allows read only access to phone state');
+  });
+
+  it('preserves ... in table cells and does not emit doubled periods', () => {
+    const html = `<main><table><thead><tr><th>Name</th><th>Description</th></tr></thead>
+      <tbody><tr>
+        <td><code>...uris</code></td>
+        <td><div><p>Deprecated: use X instead.</p></div><div><p>More.</p></div></td>
+      </tr></tbody></table></main>`;
+    const md = convertHtmlToMarkdown(html);
+    expect(md).toContain('...uris');
+    expect(md).not.toContain('. .');
+    expect(md).not.toContain('instead..');
   });
 });
 

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -811,14 +811,22 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
       });
     }
     // Clean up artifacts from block flattening:
-    // - Collapse ". ." / ".." from nested unwrapping
+    // - Collapse ". ." / ".." from nested unwrapping. Skip <code>/<pre> so "..." is untouched.
+    // - Repeat until stable: a single pass leaves ". ." from triple nesting.
     // - Trim leading ". " at cell start
     // - Remove orphan "-" after periods (upstream renders a bare dash for empty descriptions)
-    const cellHtml = $cell
-      .html()!
-      .replace(/\.\s*\.\s*/g, '. ')
+    const blocks: string[] = [];
+    let cellHtml = $cell.html()!.replace(/<(code|pre)\b[^>]*>[\s\S]*?<\/\1>/gi, match => {
+      blocks.push(match);
+      return `%%MD_CODE_${blocks.length - 1}%%`;
+    });
+    while (/\.\s*\./.test(cellHtml)) {
+      cellHtml = cellHtml.replace(/\.\s*\./g, '. ');
+    }
+    cellHtml = cellHtml
       .replace(/^\s*\.\s*/, '')
-      .replace(/\.\s*-\s*$/, '.');
+      .replace(/\.\s*-\s*$/, '.')
+      .replace(/%%MD_CODE_(\d+)%%/g, (_, i) => blocks[Number(i)]);
     $cell.html(cellHtml);
   });
 
@@ -1025,6 +1033,10 @@ export function checkPage(markdown: string, pagePath?: string): string[] {
 
   if (CI_CSS_CLASS_PATTERN.test(prose)) {
     errors.push('Contains CSS class names in text');
+  }
+
+  if (markdown.includes('. .')) {
+    errors.push('Contains ". ." (corrupted ellipsis or doubled period)');
   }
 
   return errors.filter(error => !exemptions.some(ex => error.startsWith(ex)));

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -816,7 +816,7 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     // - Trim leading ". " at cell start
     // - Remove orphan "-" after periods (upstream renders a bare dash for empty descriptions)
     const blocks: string[] = [];
-    let cellHtml = $cell.html()!.replace(/<(code|pre)\b[^>]*>[\s\S]*?<\/\1>/gi, match => {
+    let cellHtml = $cell.html()!.replace(/<(code|pre)\b[^>]*>[\S\s]*?<\/\1>/gi, match => {
       blocks.push(match);
       return `%%MD_CODE_${blocks.length - 1}%%`;
     });

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -650,6 +650,11 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     }
   });
 
+  // Escape before re-injecting as HTML: cheerio would otherwise parse a generic
+  // like Promise<PermissionResponse> as a tag and lowercase the type name.
+  const escapeHtml = (value: string) =>
+    value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
   // Convert API returns sections to inline "Returns: type" text.
   main.find('[data-md="api-returns"]').each((_, el) => {
     const $el = $(el);
@@ -657,14 +662,14 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     const typeText =
       codeEl.length > 0 ? codeEl.text().trim() : $el.text().replace('Returns:', '').trim();
     if (typeText) {
-      $el.replaceWith('<p>Returns: <code>' + typeText + '</code></p>');
+      $el.replaceWith('<p>Returns: <code>' + escapeHtml(typeText) + '</code></p>');
     }
   });
 
   // Convert API parameter name spans to <code> for backtick formatting.
   main.find('[data-md="api-param-name"]').each((_, el) => {
     const $el = $(el);
-    $el.replaceWith('<code>' + $el.text() + '</code>');
+    $el.replaceWith('<code>' + escapeHtml($el.text()) + '</code>');
   });
 
   // Preserve angle brackets around unknown HTML elements in type signatures.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26010 ENG-26015

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix Markdown export corrupting `...` and doubling periods in table cells.
- Fix Markdown export lowercases generic type names in Returns lines

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->



**Fix for Markdown export corrupting `...` (https://pr-49041.expo-docs.pages.dev/versions/v56.0.0/sdk/filesystem.md)**


<img width="838" height="258" alt="CleanShot 2026-08-18 at 00 44 05@2x" src="https://github.com/user-attachments/assets/bda66ced-f997-4b79-8015-8ace632d6db3" />


**Fix for Markdown export lowercases generic type names in Returns lines (https://pr-49041.expo-docs.pages.dev/versions/v56.0.0/sdk/accelerometer.md)**

<img width="950" height="252" alt="CleanShot 2026-08-18 at 00 55 21@2x" src="https://github.com/user-attachments/assets/8ed0a386-6bf4-467b-8a6b-864b61775d70" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
