### PR TITLE
[ui][Android] Preserve vector drawable fill types

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Preserve vector drawable `fillType` values when loading images so even-odd paths render correctly.
 - [universal] Fix `Cannot use shared object that was already released` when a worklet callback prop closes over an unstable value. ([#48819](https://github.com/expo/expo/pull/48819) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [universal] Add an explicit type annotation to `BottomSheetTextInput` so its type doesn't depend on referencing React Native's internal `TextInputType`. ([#48218](https://github.com/expo/expo/pull/48218) by [@zoontek](https://github.com/zoontek))
 - [iOS] Fix `community/bottom-sheet` close callbacks firing before the sheet finished dismissing. ([#48389](https://github.com/expo/expo/issues/48389) by [@nicklamont](https://github.com/nicklamont)) ([#48436](https://github.com/expo/expo/pull/48436) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/graphics/ImageLoader.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/graphics/ImageLoader.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.util.Log
 import android.util.LruCache
 import android.util.Xml
+import androidx.compose.ui.graphics.PathFillType
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.PathParser
@@ -317,6 +318,7 @@ class ImageLoader(
     try {
       var pathData = ""
       var fillColor: androidx.compose.ui.graphics.Color? = null
+      var pathFillType = PathFillType.NonZero
 
       for (i in 0 until parser.attributeCount) {
         when (parser.getAttributeName(i)) {
@@ -324,7 +326,13 @@ class ImageLoader(
           "fillColor" -> {
             fillColor = parseColor(parser.getAttributeValue(i))
           }
-          // Note: stroke properties, fillType, opacity not yet supported
+          "fillType" -> {
+            pathFillType = when (parser.getAttributeValue(i)) {
+              "evenOdd", "1" -> PathFillType.EvenOdd
+              else -> PathFillType.NonZero
+            }
+          }
+          // Note: stroke properties and opacity are not yet supported
         }
       }
 
@@ -332,7 +340,8 @@ class ImageLoader(
         val nodes = PathParser().parsePathString(pathData).toNodes()
         builder.addPath(
           pathData = nodes,
-          fill = fillColor?.let { SolidColor(it) }
+          fill = fillColor?.let { SolidColor(it) },
+          pathFillType = pathFillType
         )
       }
     } catch (e: Exception) {

--- a/packages/expo-ui/android/src/test/java/expo/modules/ui/graphics/ImageLoaderTest.kt
+++ b/packages/expo-ui/android/src/test/java/expo/modules/ui/graphics/ImageLoaderTest.kt
@@ -2,6 +2,8 @@ package expo.modules.ui.graphics
 
 import android.content.Context
 import android.util.Xml
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.vector.VectorPath
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
@@ -143,6 +145,36 @@ class ImageLoaderTest {
     val imageVector = loader.parseXmlToImageVector(xml.toByteArray())
 
     assertThat(imageVector).isNotNull()
+  }
+
+  @Test
+  fun `should preserve vector path fill types`() {
+    val xml = """
+      <vector xmlns:android="http://schemas.android.com/apk/res/android"
+          android:width="24dp"
+          android:height="24dp"
+          android:viewportWidth="24"
+          android:viewportHeight="24">
+        <path
+            android:fillColor="#000000"
+            android:fillType="evenOdd"
+            android:pathData="M0,0L24,0L24,24L0,24ZM6,6L6,18L18,18L18,6Z"/>
+        <path
+            android:fillColor="#000000"
+            android:fillType="1"
+            android:pathData="M0,0L24,0L24,24L0,24ZM6,6L6,18L18,18L18,6Z"/>
+        <path
+            android:fillColor="#000000"
+            android:pathData="M0,0L24,24"/>
+      </vector>
+    """.trimIndent()
+
+    val imageVector = loader.parseXmlToImageVector(xml.toByteArray())
+
+    assertThat(imageVector).isNotNull()
+    assertThat((imageVector!!.root[0] as VectorPath).pathFillType).isEqualTo(PathFillType.EvenOdd)
+    assertThat((imageVector.root[1] as VectorPath).pathFillType).isEqualTo(PathFillType.EvenOdd)
+    assertThat((imageVector.root[2] as VectorPath).pathFillType).isEqualTo(PathFillType.NonZero)
   }
 
   // ========== URI Loading Tests ==========


### PR DESCRIPTION
## Why

`@expo/ui` converts Android VectorDrawable XML into Compose `ImageVector` instances. `ImageLoader` currently drops `android:fillType`, so paths authored with the even-odd fill rule render using Compose's default non-zero rule instead.

This affects any Android icon or image path that relies on `android:fillType="evenOdd"`; it is not specific to a particular component or icon.

## How

Parse the VectorDrawable `fillType` attribute and pass the corresponding `PathFillType` to `ImageVector.Builder.addPath`.

The parser accepts both the textual `evenOdd` value used by source XML and the compiled enum value `1` returned by Android's `XmlResourceParser`. Paths without the attribute continue to use `PathFillType.NonZero`.

## Test Plan

- `pnpm et check-packages @expo/ui`
- `cd apps/bare-expo/android && ./gradlew :expo-ui:spotlessCheck`
- `cd apps/bare-expo/android && ./gradlew :expo-ui:testDebugUnitTest --tests expo.modules.ui.graphics.ImageLoaderTest`
- Added regression coverage for textual `evenOdd`, compiled value `1`, and the default non-zero fill rule. All 25 `ImageLoaderTest` tests pass.

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
