### PR TITLE
[ios][widgets] Fix Live Activity `colorScheme` always reporting `light`

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [iOS][plugin] Only add the `aps-environment` entitlement when `enablePushNotifications` is enabled, and keep a pre-existing value. ([#47645](https://github.com/expo/expo/pull/47645) by [@kadikraman](https://github.com/kadikraman))
 - [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
 - Fix blank widget when JSX children mix a `.map()` array with sibling elements. ([#47888](https://github.com/expo/expo/pull/47888) by [@jakex7](https://github.com/jakex7))
+- [iOS] Fix Live Activity `colorScheme` and `isLuminanceReduced` always reporting default values by reading the environment from a view rather than the widget. ([#49050](https://github.com/expo/expo/pull/49050) by [@liaugust](https://github.com/liaugust))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetLiveActivity.swift
@@ -20,53 +20,41 @@ struct LiveActivityAttributes: ActivityAttributes {
 
 @available(iOS 16.1, *)
 public struct WidgetLiveActivity: Widget {
-  @Environment(\.self) var env
-  
   let widgetContext: AppContext = AppContext()
 
   public init() {}
 
   public var body: some WidgetConfiguration {
     ActivityConfiguration(for: LiveActivityAttributes.self) { context in
-      let nodes = getLiveActivityNodes(
-        forName: context.state.name,
-        props: context.state.props,
-        environment: getLiveActivityEnvironment(for: env, in: context)
-      )
       // Only apply widgetURL when the activity has one: a hierarchy with more than one
       // widgetURL modifier is undefined behavior, and layouts can set their own through
       // the widgetURL modifier from @expo/ui.
-      let banner = LiveActivityBannerView(context: context, nodes: nodes)
+      let banner = LiveActivityBannerView(context: context)
       if let url = context.attributes.url.flatMap(URL.init(string:)) {
         banner.widgetURL(url)
       } else {
         banner
       }
     } dynamicIsland: { context in
-      let nodes = getLiveActivityNodes(
-        forName: context.state.name,
-        props: context.state.props,
-        environment: getLiveActivityEnvironment(for: env, in: context)
-      )
       let island = DynamicIsland {
         DynamicIslandExpandedRegion(.center) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedCenter")
+          LiveActivitySectionView(context: context, sectionName: "expandedCenter")
         }
         DynamicIslandExpandedRegion(.leading) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedLeading")
+          LiveActivitySectionView(context: context, sectionName: "expandedLeading")
         }
         DynamicIslandExpandedRegion(.trailing) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedTrailing")
+          LiveActivitySectionView(context: context, sectionName: "expandedTrailing")
         }
         DynamicIslandExpandedRegion(.bottom) {
-          LiveActivitySectionView(context: context, nodes: nodes, sectionName: "expandedBottom")
+          LiveActivitySectionView(context: context, sectionName: "expandedBottom")
         }
       } compactLeading: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactLeading")
+        LiveActivitySectionView(context: context, sectionName: "compactLeading")
       } compactTrailing: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "compactTrailing")
+        LiveActivitySectionView(context: context, sectionName: "compactTrailing")
       } minimal: {
-        LiveActivitySectionView(context: context, nodes: nodes, sectionName: "minimal")
+        LiveActivitySectionView(context: context, sectionName: "minimal")
       }
       if let url = context.attributes.url.flatMap(URL.init(string:)) {
         return island.widgetURL(url)
@@ -79,11 +67,18 @@ public struct WidgetLiveActivity: Widget {
 
 @available(iOS 16.1, *)
 private struct LiveActivitySectionView: View {
+  // Read here rather than on the Widget: @Environment only resolves once it is installed in a
+  // view hierarchy, and returns default values everywhere else.
+  @Environment(\.self) private var env
   let context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
   let sectionName: String
 
   var body: some View {
+    let nodes = getLiveActivityNodes(
+      forName: context.state.name,
+      props: context.state.props,
+      environment: getLiveActivityEnvironment(for: env, in: context)
+    )
     if let node = nodes[sectionName] as? [String: Any] {
       WidgetsDynamicView(name: context.activityID, kind: .liveActivity, node: node)
     } else {
@@ -94,10 +89,15 @@ private struct LiveActivitySectionView: View {
 
 @available(iOS 16.1, *)
 private struct LiveActivityBannerView: View {
+  @Environment(\.self) private var env
   var context: ActivityViewContext<LiveActivityAttributes>
-  let nodes: [String: Any]
 
   var body: some View {
+    let nodes = getLiveActivityNodes(
+      forName: context.state.name,
+      props: context.state.props,
+      environment: getLiveActivityEnvironment(for: env, in: context)
+    )
     if #available(iOS 18.0, *) {
       LiveActivityBanner(context: context, nodes: nodes)
     } else if let node = nodes["banner"] as? [String: Any] {


### PR DESCRIPTION
# Why

`LiveActivityEnvironment.colorScheme` is always `"light"`, so a Live Activity layout can never adapt to the appearance it is actually rendered in. Anything written as

```tsx
const isDark = environment.colorScheme === 'dark';
```

is dead code — `isDark` is `false` on every render, including on the Lock Screen, which iOS renders in a dark context.

`isLuminanceReduced` is affected the same way and always reports its default `false`, so the always-on-display dimming path is unreachable too.

## Root cause

`WidgetLiveActivity` declares the environment on the `Widget`:

```swift
public struct WidgetLiveActivity: Widget {
  @Environment(\.self) var env

  var environment: [String: Any] {
    return getLiveActivityEnvironment(environment: env)
  }
```

and reads it inside the `ActivityConfiguration` closures to build the nodes.

`@Environment` only resolves once the property wrapper is installed in a view hierarchy. A `Widget` is not a `View`, and the configuration closures are not view bodies, so SwiftUI returns a default-constructed `EnvironmentValues` — whose `colorScheme` is `.light` — and never updates it.

SwiftUI says so at runtime, once per render:

```
[SwiftUI] Accessing Environment<EnvironmentValues>'s value outside of being installed
on a View. This will always read the default value and will not update.
```

# How

Move the environment read, and with it the layout evaluation, from the `Widget` into the two views that render the nodes — `LiveActivityBannerView` and `LiveActivitySectionView`. Both are real `View`s, so `@Environment` resolves against the hierarchy each view is actually installed in.

`WidgetLiveActivity` no longer holds any environment state, and the configuration closures just construct the views.

# Test Plan

Verified on an iPhone 16 Pro simulator (iOS 26) with a Live Activity whose layout branches on `environment.colorScheme`:

- **Before:** the banner rendered its light palette on the Lock Screen, and a probe rendering `environment.colorScheme` printed `light` with the device in dark mode. The runtime warning above appeared on every render.
- **After:** the same banner renders its dark palette on the Lock Screen, and the runtime warning no longer appears at all (`log show --predicate 'processImagePath CONTAINS "ExpoWidgets"'` → 0 matches over several minutes of rendering).

Banner, Dynamic Island compact/minimal, and expanded regions all still render.

## Note for reviewers

Each section view now evaluates the layout for the region it renders, where previously one evaluation was shared across the Dynamic Island regions. This is what makes the per-view environment correct — the regions are separate view trees and can be rendered in different contexts — but it does mean more evaluations when the expanded presentation is shown. Happy to add memoisation keyed on `(activityID, props, environment)` if you would prefer that in this PR rather than a follow-up.


# Checklist

- [x] I added a `CHANGELOG.md` entry under the package's 🐛 Bug fixes. No source rebuild was needed — the change is confined to `ios/Widgets/WidgetLiveActivity.swift`, so nothing under `src/` or `build/` is affected and the JS API is unchanged.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build. It touches only the Swift the widget extension compiles; no module plugin, podspec, entitlement or generated-project behaviour changes.
- [ ] Conforms with the Documentation Writing Style Guide — no documentation changes in this PR.
