### PR TITLE
[app-metrics][iOS][Android] Record observed network requests as trace spans

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 - Add a generic `spans` table to the metrics database for trace telemetry. ([#48861](https://github.com/expo/expo/pull/48861) by [@tsapeta](https://github.com/tsapeta))
+- Persist observed network requests in the metrics database so they can be exported as telemetry. ([#49051](https://github.com/expo/expo/pull/49051) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))
 - Add a generic `spans` table to the metrics database for trace telemetry. ([#48861](https://github.com/expo/expo/pull/48861) by [@tsapeta](https://github.com/tsapeta))
+- Persist observed network requests in the metrics database so they can be exported as telemetry. ([#49051](https://github.com/expo/expo/pull/49051) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -13,7 +13,9 @@ import expo.modules.appmetrics.crashreporting.PreferencesLastProcessedExitStore
 import expo.modules.appmetrics.crashreporting.attributeAndStoreCrashReport
 import expo.modules.appmetrics.logevents.LogEventOptions
 import expo.modules.appmetrics.networkrequests.NetworkRequestFilter
+import expo.modules.appmetrics.networkrequests.NetworkRequestMonitor
 import expo.modules.appmetrics.networkrequests.NetworkRequestObserver
+import expo.modules.appmetrics.networkrequests.NetworkRequestPersistence
 import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.logevents.sanitizeLogEventAttributes
 import expo.modules.appmetrics.logevents.validateDisplayName
@@ -22,6 +24,7 @@ import expo.modules.appmetrics.logevents.validateEventName
 import expo.modules.appmetrics.logevents.withDisplayNameAttribute
 import expo.modules.appmetrics.memory.MemoryMetricsManager
 import expo.modules.appmetrics.storage.JsDebugSession
+import expo.modules.appmetrics.storage.MetricsDatabase
 import expo.modules.appmetrics.storage.JsLogRecord
 import expo.modules.appmetrics.storage.JsMetric
 import expo.modules.appmetrics.storage.LogRecord
@@ -64,6 +67,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   lateinit var sessionManager: SessionManager
 
   lateinit var mainSession: SessionSharedObject
+
+  /**
+   * The span producer installed on the monitor in `OnCreate`, kept so `OnDestroy` can
+   * uninstall it when the module is torn down (a JS reload).
+   */
+  private var networkRequestPersistence: NetworkRequestPersistence? = null
 
   // Lazy-initialized metadata - created once when first needed
   private val metadata: AppMetadata? by lazy {
@@ -152,6 +161,20 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         // a racing write triggers (and joins) the same single start job.
         scope.launch { mainSession.awaitSessionPersisted() }
 
+        // From here on every completed request is written to the `spans` table, attributed to
+        // the main session. Awaiting the session row first keeps the FK satisfied for every
+        // span insert; installation also drains requests buffered since process start.
+        scope.launch {
+          mainSession.awaitSessionPersisted()
+          val persistence = NetworkRequestPersistence(
+            database = MetricsDatabase.getDatabase(context),
+            scope = scope,
+            sessionId = mainSession.sessionId
+          )
+          networkRequestPersistence = persistence
+          NetworkRequestMonitor.shared.installPersistence(persistence)
+        }
+
         // Sweep sessions orphaned by a previous process. The cutoff equals this
         // session's start and the comparison is strict (`<`), so this session
         // survives while older ones are swept — order vs the INSERT doesn't
@@ -215,6 +238,10 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       }
 
       OnDestroy {
+        // Stop persisting spans for this module's session. Without this, a JS reload leaves
+        // the old instance on the process-wide monitor, writing rows attributed to the
+        // torn-down session until the next OnCreate replaces it.
+        networkRequestPersistence?.let { NetworkRequestMonitor.shared.uninstallPersistence(it) }
         // `modulesQueue` is cancelled immediately after this hook returns, so
         // run the UPDATE on the calling thread to make sure the end timestamp
         // is persisted before teardown. `stop` awaits the session-start job

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -13,7 +13,9 @@ import expo.modules.appmetrics.crashreporting.PreferencesLastProcessedExitStore
 import expo.modules.appmetrics.crashreporting.attributeAndStoreCrashReport
 import expo.modules.appmetrics.logevents.LogEventOptions
 import expo.modules.appmetrics.networkrequests.NetworkRequestFilter
+import expo.modules.appmetrics.networkrequests.NetworkRequestMonitor
 import expo.modules.appmetrics.networkrequests.NetworkRequestObserver
+import expo.modules.appmetrics.networkrequests.NetworkRequestPersistence
 import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.logevents.sanitizeLogEventAttributes
 import expo.modules.appmetrics.logevents.validateDisplayName
@@ -22,6 +24,7 @@ import expo.modules.appmetrics.logevents.validateEventName
 import expo.modules.appmetrics.logevents.withDisplayNameAttribute
 import expo.modules.appmetrics.memory.MemoryMetricsManager
 import expo.modules.appmetrics.storage.JsDebugSession
+import expo.modules.appmetrics.storage.MetricsDatabase
 import expo.modules.appmetrics.storage.JsLogRecord
 import expo.modules.appmetrics.storage.JsMetric
 import expo.modules.appmetrics.storage.LogRecord
@@ -64,6 +67,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   lateinit var sessionManager: SessionManager
 
   lateinit var mainSession: SessionSharedObject
+
+  /**
+   * The span producer installed on the monitor in `OnCreate`, kept so `OnDestroy` can
+   * uninstall it when the module is torn down (a JS reload).
+   */
+  private var networkRequestPersistence: NetworkRequestPersistence? = null
 
   // Lazy-initialized metadata - created once when first needed
   private val metadata: AppMetadata? by lazy {
@@ -150,7 +159,19 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
         // Persist the session row eagerly so it's visible to readers
         // (`getMainSession`, …) as soon as possible. Idempotent:
         // a racing write triggers (and joins) the same single start job.
-        scope.launch { mainSession.awaitSessionPersisted() }
+        scope.launch {
+          mainSession.awaitSessionPersisted()
+          // From here on every completed request is written to the `spans` table, attributed to
+          // the main session. The await above keeps the FK satisfied for every span insert;
+          // installation also drains requests buffered since process start.
+          val persistence = NetworkRequestPersistence(
+            database = MetricsDatabase.getDatabase(context),
+            scope = scope,
+            sessionId = mainSession.sessionId
+          )
+          networkRequestPersistence = persistence
+          NetworkRequestMonitor.shared.installPersistence(persistence)
+        }
 
         // Sweep sessions orphaned by a previous process. The cutoff equals this
         // session's start and the comparison is strict (`<`), so this session
@@ -216,6 +237,10 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       }
 
       OnDestroy {
+        // Stop persisting spans for this module's session. Without this, a JS reload leaves
+        // the old instance on the process-wide monitor, writing rows attributed to the
+        // torn-down session until the next OnCreate replaces it.
+        networkRequestPersistence?.let { NetworkRequestMonitor.shared.uninstallPersistence(it) }
         // `modulesQueue` is cancelled immediately after this hook returns, so
         // run the UPDATE on the calling thread to make sure the end timestamp
         // is persisted before teardown. `stop` awaits the session-start job

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -49,6 +49,22 @@ data class NetworkRequest(
   val errorDescription: String?,
 
   /**
+   * Whether the request ended because the caller cancelled it (`Call.isCanceled()` at capture
+   * time). Cancellations are recorded as spans but are not errors, per the OTel conventions —
+   * RN apps abort requests routinely (`AbortController`, prefetch aborts).
+   */
+  val cancelled: Boolean = false,
+
+  /**
+   * Fully qualified class name of the completion exception (e.g. `java.net.UnknownHostException`),
+   * or `null` when the request completed without one. Unlike `errorDescription`, which is
+   * localized free text, this stays constant across locales, so telemetry can group failures by
+   * it — it feeds the low-cardinality `error.type` attribute of OpenTelemetry's semantic
+   * conventions. Mirrors the iOS `errorType` (`domain:code` there).
+   */
+  val errorType: String? = null,
+
+  /**
    * Ordered list of redirect hops that preceded the final response. Empty when the request landed
    * directly. Each entry's `fromUrl` is the URL that returned the redirect, `toUrl` is where the
    * redirect pointed, and `statusCode` is the 3xx code that caused the hop.

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequest.kt
@@ -43,25 +43,70 @@ data class NetworkRequest(
   val timings: Timings,
 
   /**
+   * How OkHttp satisfied the request, or `null` when nothing classified it (the request failed
+   * before a response). A cached response is byte-counted and timestamped like a download, so
+   * this is the only way to tell a disk read from a transfer.
+   */
+  val fetchType: FetchType? = null,
+
+  /**
    * Short human-readable error description if the request completed with an exception. Kept as a
    * string rather than carrying the throwable so the type stays serializable.
    */
   val errorDescription: String?,
 
   /**
+   * Whether the request ended because the caller canceled it (`Call.isCanceled()` at capture
+   * time). Cancellations are recorded as spans but are not errors, per the OTel conventions:
+   * RN apps abort requests routinely (`AbortController`, prefetch aborts).
+   */
+  val canceled: Boolean = false,
+
+  /**
+   * Fully qualified class name of the completion exception (e.g. `java.net.UnknownHostException`),
+   * or `null` when the request completed without one. Unlike `errorDescription`, which is
+   * localized free text, this stays constant across locales, so telemetry can group failures by
+   * it, because it feeds the low-cardinality `error.type` attribute of OpenTelemetry's semantic
+   * conventions. Mirrors the iOS `errorType` (`domain:code` there).
+   */
+  val errorType: String? = null,
+
+  /**
    * Ordered list of redirect hops that preceded the final response. Empty when the request landed
    * directly. Each entry's `fromUrl` is the URL that returned the redirect, `toUrl` is where the
-   * redirect pointed, and `statusCode` is the 3xx code that caused the hop.
+   * redirect pointed, `statusCode` is the 3xx code that caused the hop, and `respondedAtMs` is
+   * when that 3xx response arrived.
    */
   val redirects: List<Redirect>
 ) {
+  /**
+   * How a response was produced, derived from OkHttp's `cacheResponse` / `networkResponse` pair.
+   * Mirrors the iOS `NetworkRequest.FetchType`, which reports an HTTP/2 server push that OkHttp
+   * does not surface, and folds [VALIDATED] into [CACHE].
+   */
+  enum class FetchType(val attributeValue: String) {
+    /** Fetched over the network. */
+    NETWORK("network"),
+
+    /** Served from the OkHttp cache without touching the network. */
+    CACHE("cache"),
+
+    /** Revalidated with a conditional request, then served from the cache (a 304). */
+    VALIDATED("validated")
+  }
+
   data class Redirect(
     /** The URL that returned the redirect. */
     val fromUrl: String,
     /** The URL the request was redirected to. */
     val toUrl: String,
     /** The 3xx status code returned by `fromUrl` that caused this hop. */
-    val statusCode: Int
+    val statusCode: Int,
+    /**
+     * Unix-epoch milliseconds when the 3xx response headers arrived (OkHttp's
+     * `receivedResponseAtMillis`), or `null` when OkHttp did not report it.
+     */
+    val respondedAtMs: Long? = null
   )
 
   data class Timings(
@@ -98,8 +143,8 @@ data class NetworkRequest(
      * connection.
      *
      * Also what keeps cache hits out of the throughput ratio: OkHttp skips the response-body
-     * callbacks for a cached response, so this stays `null` and the request drops out. iOS needs an
-     * explicit flag for that, since `URLSession` timestamps a cache hit like any other response.
+     * callbacks for a cached response, so this stays `null` and the request drops out. See
+     * [fetchType] for how the response was produced, which both platforms report.
      */
     val measuredResponseEnd: Date?,
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -159,7 +159,8 @@ class NetworkRequestInterceptor private constructor(
       fallbackStart = startedAt,
       fallbackEnd = endDate,
       totalDuration = totalDuration,
-      error = error
+      error = error,
+      cancelled = call.isCanceled()
     )
     monitor.record(snapshot)
   }
@@ -197,7 +198,8 @@ internal fun buildSnapshot(
   fallbackStart: Date,
   fallbackEnd: Date,
   totalDuration: Double,
-  error: IOException?
+  error: IOException?,
+  cancelled: Boolean = false
 ): NetworkRequest {
   val redirects = response?.let { buildRedirectChain(it) } ?: emptyList()
 
@@ -259,6 +261,8 @@ internal fun buildSnapshot(
     // Falls back to the class name because an exception is allowed to carry no message at all, and
     // a null description would read as "this request succeeded" to `isFailed`.
     errorDescription = failure?.let { it.localizedMessage ?: it.message ?: it.javaClass.simpleName },
+    errorType = failure?.javaClass?.name,
+    cancelled = failure != null && cancelled,
     redirects = redirects
   )
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -160,7 +160,8 @@ class NetworkRequestInterceptor private constructor(
       fallbackStart = startedAt,
       fallbackEnd = endDate,
       totalDuration = totalDuration,
-      error = error
+      error = error,
+      canceled = call.isCanceled()
     )
     monitor.record(snapshot)
   }
@@ -198,7 +199,8 @@ internal fun buildSnapshot(
   fallbackStart: Date,
   fallbackEnd: Date,
   totalDuration: Double,
-  error: IOException?
+  error: IOException?,
+  canceled: Boolean = false
 ): NetworkRequest {
   val redirects = response?.let { buildRedirectChain(it) } ?: emptyList()
 
@@ -225,6 +227,20 @@ internal fun buildSnapshot(
     // which requests form the throughput ratio, so an unmeasured body would drag the denominator
     // out with no bytes to match.
     body?.let { responseHeaderBytes + it }
+  }
+
+  // OkHttp reports both halves of a conditional GET: a 304 leaves `networkResponse` set (the
+  // revalidation went out) alongside `cacheResponse` (the body came from disk). A plain cache hit
+  // has only `cacheResponse`, and a normal load only `networkResponse`. No response at all means
+  // nothing classified the fetch.
+  val fetchType = response?.let { received ->
+    val fromCache = received.cacheResponse != null
+    val fromNetwork = received.networkResponse != null
+    when {
+      fromCache && fromNetwork -> NetworkRequest.FetchType.VALIDATED
+      fromCache -> NetworkRequest.FetchType.CACHE
+      else -> NetworkRequest.FetchType.NETWORK
+    }
   }
 
   val timings = NetworkRequest.Timings(
@@ -257,9 +273,19 @@ internal fun buildSnapshot(
     requestBytesSent = requestBytesSent,
     responseBytesReceived = responseBytesReceived,
     timings = timings,
+    fetchType = fetchType,
     // Falls back to the class name because an exception is allowed to carry no message at all, and
     // a null description would read as "this request succeeded" to `isFailed`.
     errorDescription = failure?.let { it.localizedMessage ?: it.message ?: it.javaClass.simpleName },
+    errorType = failure?.javaClass?.name,
+    // A cancellation reaches this snapshot two ways: as an `IOException` when the call was cut
+    // before or during `chain.proceed`, or with no exception at all when the caller abandoned a
+    // response body it had started reading. Both are intentional aborts, so both are flagged.
+    //
+    // The status check is not about classifying errors: it stops a late cancel from masking a
+    // 4xx or 5xx the server already returned, because `canceled` suppresses both the ERROR
+    // status and `error.type` downstream.
+    canceled = canceled && (failure != null || (response?.code ?: 0) < 400),
     redirects = redirects
   )
 }
@@ -302,7 +328,9 @@ internal fun buildRedirectChain(final: Response): List<NetworkRequest.Redirect> 
       NetworkRequest.Redirect(
         fromUrl = prior.request.url.toString(),
         toUrl = next.request.url.toString(),
-        statusCode = prior.code
+        statusCode = prior.code,
+        // OkHttp reports 0 when it has no timestamp for the response.
+        respondedAtMs = prior.receivedResponseAtMillis.takeIf { it > 0 }
       )
     )
     next = prior

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
@@ -42,6 +42,65 @@ class NetworkRequestMonitor internal constructor() {
   private val delegates = mutableListOf<WeakReference<NetworkRequestObserverDelegate>>()
 
   /**
+   * Persists each recorded completion into the metrics database. Held strongly — unlike
+   * delegates, persistence is part of the pipeline, not an observer of it. `null` until the
+   * module installs it (and in tests that don't exercise persistence).
+   */
+  private var persistence: NetworkRequestPersistence? = null
+
+  /**
+   * Whether the startup backfill already ran in this process. The module reinstalls
+   * persistence on every JS reload; only the first install may drain the ring buffer, or every
+   * reload would re-write the buffered requests under a fresh session id.
+   */
+  private var hasDrainedBackfill = false
+
+  /**
+   * Installs the persistence hook and, on the first install of the process, drains the ring
+   * buffer through it. The interceptor installs at `Application.onCreate`, but persistence can
+   * only start once the module created the main session — requests observed in between sit in
+   * the buffer, so draining it here keeps startup traffic. The swap and the snapshot happen
+   * under the same lock as `record`, so a concurrent completion is either in the drained
+   * snapshot or persisted by `record`, never both.
+   */
+  fun installPersistence(persistence: NetworkRequestPersistence) {
+    val buffered = synchronized(lock) {
+      this.persistence = persistence
+      if (hasDrainedBackfill) {
+        emptyList()
+      } else {
+        recentRequests.toList()
+      }
+    }
+    if (buffered.isEmpty()) {
+      return
+    }
+    // At-least-once: the flag flips only after the batch coroutine finished writing. A JS
+    // reload cancels the module scope the batch runs on, and a flag set eagerly would turn
+    // that cancellation into silent, permanent loss of the buffered startup requests. The
+    // cost is rare duplicate rows when a reload lands exactly between the drain and the
+    // completion callback — preferred over losing the rows, since spans tolerate duplicates
+    // (distinct ids) but nothing recovers a dropped buffer.
+    persistence.persistBuffered(buffered) {
+      synchronized(lock) {
+        hasDrainedBackfill = true
+      }
+    }
+  }
+
+  /**
+   * Uninstalls `persistence` if it is still the installed instance. Called from the module's
+   * `OnDestroy` so a JS reload doesn't leave the torn-down module's instance writing rows
+   * attributed to a stale session while the next module instance spins up. The identity check
+   * keeps a late-arriving destroy from removing the replacement.
+   */
+  fun uninstallPersistence(persistence: NetworkRequestPersistence) = synchronized(lock) {
+    if (this.persistence === persistence) {
+      this.persistence = null
+    }
+  }
+
+  /**
    * Most recently observed completed requests, oldest first. Bounded by `recentCapacity`.
    * Intended for debug surfaces and the TTI summary; not for the dispatch path.
    */
@@ -77,16 +136,17 @@ class NetworkRequestMonitor internal constructor() {
     }
   }
 
-  /** Records a completed request: appends to the ring buffer and fans out. */
+  /** Records a completed request: appends to the ring buffer, persists it, and fans out. */
   fun record(request: NetworkRequest) {
-    val snapshot = synchronized(lock) {
+    val (persistence, snapshot) = synchronized(lock) {
       recentRequests.addLast(request)
       while (recentRequests.size > recentCapacity) {
         recentRequests.removeFirst()
       }
       delegates.removeAll { it.get() == null }
-      delegates.mapNotNull { it.get() }
+      persistence to delegates.mapNotNull { it.get() }
     }
+    persistence?.persist(request)
     for (delegate in snapshot) {
       if (delegate.shouldObserveRequest(request.url, request.method)) {
         delegate.onNetworkRequestCompleted(request)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
@@ -4,6 +4,7 @@ package expo.modules.appmetrics.networkrequests
 
 import java.lang.ref.WeakReference
 import java.util.Date
+import java.util.UUID
 
 /**
  * Receives notifications about HTTP requests observed by `NetworkRequestInterceptor`. Both
@@ -33,13 +34,66 @@ interface NetworkRequestObserverDelegate {
  * code). All shared state is guarded by a single intrinsic lock - the work inside is small and
  * synchronous, so contention is negligible.
  */
-class NetworkRequestMonitor internal constructor() {
+class NetworkRequestMonitor internal constructor(
   /** Maximum number of completed requests retained for debug surfaces. */
-  private val recentCapacity = 200
+  private val recentCapacity: Int = 200
+) {
 
   private val lock = Any()
   private val recentRequests = ArrayDeque<NetworkRequest>()
   private val delegates = mutableListOf<WeakReference<NetworkRequestObserverDelegate>>()
+
+  /**
+   * Persists each recorded completion into the metrics database. Held strongly, because unlike
+   * delegates, persistence is part of the pipeline, not an observer of it. `null` until the
+   * module installs it (and in tests that don't exercise persistence).
+   */
+  private var persistence: NetworkRequestPersistence? = null
+
+  // Requests already handed to a persistence instance, so a reload's reinstall does not rewrite
+  // them under a fresh session id.
+
+  private val drainedRequestIds = mutableSetOf<UUID>()
+
+  internal val drainedRequestIdCount: Int
+    get() = synchronized(lock) { drainedRequestIds.size }
+
+  /**
+   * Installs the persistence hook and drains any buffered requests through it.
+   *
+   * The interceptor starts at `Application.onCreate`, before the session exists, so requests
+   * observed in between wait in the buffer for this call.
+   */
+  fun installPersistence(persistence: NetworkRequestPersistence) {
+    val buffered = synchronized(lock) {
+      this.persistence = persistence
+      // Snapshotted under the same lock as `record`, so a concurrent completion is either here
+      // or persisted live, never both.
+      recentRequests.filter { it.id !in drainedRequestIds }
+    }
+    if (buffered.isEmpty()) {
+      return
+    }
+    persistence.persistBuffered(buffered) {
+      synchronized(lock) {
+        // Marked only on completion: a reload cancels the batch, and marking eagerly would lose
+        // those rows for good. Duplicates after a mid-drain reload are the cheaper failure.
+        buffered.forEach { drainedRequestIds.add(it.id) }
+      }
+    }
+  }
+
+  /**
+   * Uninstalls `persistence` if it is still the installed instance. Called from the module's
+   * `OnDestroy` so a JS reload doesn't leave the torn-down module's instance writing rows
+   * attributed to a stale session while the next module instance spins up. The identity check
+   * keeps a late-arriving destroy from removing the replacement.
+   */
+  fun uninstallPersistence(persistence: NetworkRequestPersistence) = synchronized(lock) {
+    if (this.persistence === persistence) {
+      this.persistence = null
+    }
+  }
 
   /**
    * Most recently observed completed requests, oldest first. Bounded by `recentCapacity`.
@@ -86,16 +140,24 @@ class NetworkRequestMonitor internal constructor() {
     }
   }
 
-  /** Records a completed request: appends to the ring buffer and fans out. */
+  /** Records a completed request: appends to the ring buffer, persists it, and fans out. */
   fun record(request: NetworkRequest) {
-    val snapshot = synchronized(lock) {
+    val (persistence, snapshot) = synchronized(lock) {
       recentRequests.addLast(request)
       while (recentRequests.size > recentCapacity) {
-        recentRequests.removeFirst()
+        // Forget the evicted request's drain state with it: the set only has to cover ids a
+        // future install could still see in the buffer.
+        drainedRequestIds.remove(recentRequests.removeFirst().id)
+      }
+      // A live persistence writes this request below, so mark it now: a later install must not
+      // drain it a second time, or every reload would duplicate whatever is still buffered.
+      if (this.persistence != null) {
+        drainedRequestIds.add(request.id)
       }
       delegates.removeAll { it.get() == null }
-      delegates.mapNotNull { it.get() }
+      persistence to delegates.mapNotNull { it.get() }
     }
+    persistence?.persist(request)
     for (delegate in snapshot) {
       if (delegate.shouldObserveRequest(request.url, request.method)) {
         delegate.onNetworkRequestCompleted(request)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
@@ -111,7 +111,10 @@ class NetworkRequestObserver private constructor(
         mapOf(
           "fromUrl" to redirect.fromUrl,
           "toUrl" to redirect.toUrl,
-          "statusCode" to redirect.statusCode
+          "statusCode" to redirect.statusCode,
+          // Same ISO 8601 UTC shape as `startedAt`, with fractional seconds: hops within one
+          // request are usually fractions of a second apart.
+          "respondedAt" to redirect.respondedAtMs?.let { TimeUtils.millisToTimestamp(it) }
         )
       }
     )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
@@ -1,0 +1,225 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.appmetrics.networkrequests
+
+import android.util.Log
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.Span
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+
+private const val TAG = "ExpoAppMetrics"
+
+/**
+ * Routes completed requests from `NetworkRequestMonitor` into the `spans` table, attributed to
+ * the main session. This is the first span producer: it converts each request into a generic
+ * `Span` following the OTel HTTP semantic conventions, so the export layer (`expo-observe`)
+ * ships spans without knowing what produced them. Unlike the in-memory ring buffer, the rows
+ * survive process death until they're dispatched, pruned with their session, or displaced past
+ * the table's row cap. Mirrors the iOS `NetworkRequestPersistence`.
+ *
+ * Installed on the monitor once the module created the main session (see `AppMetricsModule`);
+ * the monitor calls `persist` directly for every completion it records. Deliberately not a
+ * `NetworkRequestObserverDelegate`: persistence is part of the pipeline, not an observer, and
+ * the delegate contract (weak registration, `shouldObserveRequest` filtering) doesn't apply.
+ */
+class NetworkRequestPersistence(
+  private val database: MetricsDatabase,
+  private val scope: CoroutineScope,
+  /**
+   * A plain value, not a provider: the id is constant for a persistence instance (it is
+   * constructed after the main session exists), and resolving it eagerly means the monitor's
+   * record path — OkHttp dispatcher threads — never calls back into module state that a
+   * teardown could have invalidated.
+   */
+  private val sessionId: String
+) {
+  /**
+   * Persists one completed request as a span. The insert runs on `scope` so the monitor's
+   * record path (OkHttp dispatcher threads) never blocks on the database; failures are logged
+   * and swallowed — persistence must never break the monitor's fan-out.
+   */
+  fun persist(request: NetworkRequest) {
+    val span = request.toSpan(sessionId) ?: return
+    scope.launch {
+      try {
+        database.spanDao().insertCapped(span)
+      } catch (e: Exception) {
+        Log.w(TAG, "Failed to persist a network request span", e)
+      }
+    }
+  }
+
+  /**
+   * Persists the monitor's buffered startup requests. One coroutine for the whole batch: the
+   * install path runs on the module's serial queue during startup, competing with the session
+   * INSERT and crash-report processing, so converting up to 200 requests inline (JSON
+   * serialization, URL parsing) and queueing one coroutine per row there would be the most
+   * expensive way to do it. Conversion and inserts all happen inside the single launch.
+   */
+  fun persistBuffered(requests: List<NetworkRequest>, onComplete: () -> Unit = {}) {
+    if (requests.isEmpty()) {
+      return
+    }
+    scope.launch {
+      for (request in requests) {
+        val span = request.toSpan(sessionId) ?: continue
+        try {
+          database.spanDao().insertCapped(span)
+        } catch (e: Exception) {
+          Log.w(TAG, "Failed to persist a network request span", e)
+        }
+      }
+      // Deliberately not in a `finally`: a cancelled batch must not report completion, so the
+      // caller can retry the drain on the next install.
+      onComplete()
+    }
+  }
+}
+
+/**
+ * Builds a span from a completed request snapshot, per the OTel HTTP semantic conventions for a
+ * client span: the span is named after the method, a transport failure or a 4xx/5xx response
+ * makes it an ERROR, and each redirect hop becomes an `http.redirect` event.
+ *
+ * The attribute keys mirror the set the ingestion endpoint extracts into dedicated columns
+ * (`http.request.method`, `url.full`, `server.address`, ...). `url.full` is redacted here, at
+ * the instrumentation, as the conventions require: userinfo credentials and the default
+ * sensitive query values never reach disk or the wire (ingestion redacts again as defense in
+ * depth). An intentionally cancelled request keeps its span but stays UNSET with no
+ * `error.type`, per the conventions. `error.type` must stay low-cardinality: the captured
+ * exception class for a transport failure, or the bare status code when the response itself
+ * was the error; the localized `errorDescription` goes to the status message instead.
+ *
+ * Returns `null` when the snapshot carries no usable timestamps — without either endpoint of
+ * the request window there is nothing to anchor a span to.
+ */
+internal fun NetworkRequest.toSpan(sessionId: String): Span? {
+  val start = timings.fetchStart?.time
+  val end = timings.responseEnd?.time
+  val durationMs = (timings.totalDuration * 1_000).toLong()
+  val resolvedStart = start ?: end?.minus(durationMs) ?: return null
+  val resolvedEnd = end ?: start?.plus(durationMs) ?: return null
+
+  val attributes = JSONObject()
+  // Case-sensitive per the conventions: an unknown or nonstandard method becomes `_OTHER`
+  // (verbatim value preserved in `http.request.method_original`) and names the span `HTTP`,
+  // so caller-controlled verbs can't mint unbounded span names.
+  val isKnownMethod = method in KNOWN_HTTP_METHODS
+  attributes.put("http.request.method", if (isKnownMethod) method else "_OTHER")
+  if (!isKnownMethod) {
+    attributes.put("http.request.method_original", method)
+  }
+  val parsedUrl = url.toHttpUrlOrNull()
+  attributes.put("url.full", redactedUrlFull(url, parsedUrl))
+  parsedUrl?.host?.let { host ->
+    attributes.put("server.address", host)
+  }
+  // `HttpUrl.port` already resolves the scheme default when the URL carries no explicit port.
+  parsedUrl?.port?.let { port ->
+    attributes.put("server.port", port)
+  }
+  statusCode?.let { code ->
+    attributes.put("http.response.status_code", code)
+  }
+  semconvProtocolVersion(networkProtocol)?.let { version ->
+    attributes.put("network.protocol.version", version)
+  }
+  requestBytesSent?.let { bytes ->
+    attributes.put("http.request.size", bytes)
+  }
+  responseBytesReceived?.let { bytes ->
+    attributes.put("http.response.size", bytes)
+  }
+  val httpErrorStatus = (statusCode ?: 0) >= 400
+  // An intentional cancellation is not a failure: status stays UNSET and `error.type` is
+  // never set, per the conventions.
+  val resolvedErrorType = if (cancelled) {
+    null
+  } else {
+    errorType ?: statusCode?.toString().takeIf { httpErrorStatus }
+  }
+  resolvedErrorType?.let { value ->
+    attributes.put("error.type", value)
+  }
+
+  val failed = !cancelled && (errorDescription != null || errorType != null || httpErrorStatus)
+  // The conventions model redirects as resent spans (`http.request.resend_count`), not events;
+  // one span per chain is a deliberate deviation for this pipeline. The event name is
+  // `expo.`-prefixed because semconv reserves the bare `http.` namespace for itself.
+  val events = JSONArray()
+  for (redirect in redirects) {
+    val event = JSONObject()
+    event.put("name", "expo.http.redirect")
+    val eventAttributes = JSONObject()
+    eventAttributes.put("from", redirect.fromUrl)
+    eventAttributes.put("to", redirect.toUrl)
+    eventAttributes.put("statusCode", redirect.statusCode)
+    event.put("attributes", eventAttributes)
+    events.put(event)
+  }
+
+  return Span(
+    sessionId = sessionId,
+    name = if (isKnownMethod) method else "HTTP",
+    kind = Span.CLIENT_KIND,
+    startTimestampMs = resolvedStart,
+    endTimestampMs = resolvedEnd,
+    statusCode = if (failed) Span.STATUS_ERROR else null,
+    statusMessage = if (failed) errorDescription else null,
+    attributes = attributes.toString(),
+    events = if (events.length() > 0) events.toString() else null
+  )
+}
+
+/** The standard method set per RFC 9110, matched case-sensitively as the conventions require. */
+private val KNOWN_HTTP_METHODS = setOf("GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH")
+
+/**
+ * Query parameter names whose values are redacted by default, per the conventions' list for
+ * `url.full` (signed-URL secrets: S3 presigned, GCS signed, SAS-style tokens). Compared
+ * case-insensitively.
+ */
+private val SENSITIVE_QUERY_PARAMETERS = setOf("awsaccesskeyid", "signature", "sig", "x-amz-signature", "x-goog-signature")
+
+/**
+ * `url.full` with userinfo credentials replaced by `REDACTED:REDACTED` and default-sensitive
+ * query values replaced by `REDACTED`, per the conventions — redaction is the instrumentation's
+ * job, so secrets never reach the on-device database or the wire.
+ */
+private fun redactedUrlFull(url: String, parsed: okhttp3.HttpUrl?): String {
+  // An unparseable URL can't prove it carries no secrets; drop the query outright. The parsed
+  // form is passed in so `toSpan` parses each URL once — it runs on the OkHttp dispatcher
+  // thread for every completed request, and per row in the backfill batch.
+  if (parsed == null) {
+    return url.substringBefore('?')
+  }
+  val builder = parsed.newBuilder()
+  if (parsed.encodedUsername.isNotEmpty() || parsed.encodedPassword.isNotEmpty()) {
+    builder.username("REDACTED")
+    builder.password("REDACTED")
+  }
+  for (name in parsed.queryParameterNames) {
+    if (name.lowercase() in SENSITIVE_QUERY_PARAMETERS) {
+      builder.removeAllQueryParameters(name)
+      builder.addQueryParameter(name, "REDACTED")
+    }
+  }
+  return builder.build().toString()
+}
+
+/**
+ * Bare protocol version per semconv's `network.protocol.version` ("1.1", "2", "3"), mapped from
+ * the ALPN-style names OkHttp reports ("http/1.1", "h2", "h3"). Unrecognized values pass through
+ * verbatim rather than being dropped.
+ */
+private fun semconvProtocolVersion(networkProtocol: String?): String? = when {
+  networkProtocol == null -> null
+  networkProtocol == "h2" -> "2"
+  networkProtocol == "h3" -> "3"
+  networkProtocol.startsWith("http/") -> networkProtocol.removePrefix("http/")
+  else -> networkProtocol
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistence.kt
@@ -1,0 +1,252 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+package expo.modules.appmetrics.networkrequests
+
+import android.util.Log
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.Span
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.json.JSONArray
+import org.json.JSONObject
+import java.net.URLDecoder
+
+private const val TAG = "ExpoAppMetrics"
+
+/**
+ * Records completed network requests as trace spans in the `spans` table.
+ *
+ * Mirrors the iOS `NetworkRequestPersistence`.
+ */
+class NetworkRequestPersistence(
+  private val database: MetricsDatabase,
+  private val scope: CoroutineScope,
+  // A plain value rather than a provider: the id is constant for an instance, and resolving it
+  // eagerly keeps the monitor's record path off module state a teardown could have invalidated.
+  private val sessionId: String
+) {
+  /**
+   * Records one completed request as a span.
+   */
+  fun persist(request: NetworkRequest) {
+    // Converts and inserts on `scope`, so OkHttp dispatcher threads pay neither the URL parsing
+    // and JSON building nor the database write. Matches `persistBuffered`.
+    scope.launch {
+      val span = request.toSpan(sessionId) ?: return@launch
+      try {
+        database.spanDao().insert(span)
+      } catch (e: CancellationException) {
+        // A torn-down scope is routine (a JS reload), not a failure worth warning about.
+        throw e
+      } catch (e: Exception) {
+        // Swallowed: recording telemetry must never break the monitor's fan-out to its delegates.
+        Log.w(TAG, "Failed to persist a network request span", e)
+      }
+    }
+  }
+
+  /**
+   * Records the monitor's buffered startup requests as one batch.
+   *
+   * `onComplete` runs only if the batch finished, so a canceled one can be retried.
+   */
+  fun persistBuffered(requests: List<NetworkRequest>, onComplete: () -> Unit = {}) {
+    if (requests.isEmpty()) {
+      return
+    }
+    // One coroutine, converting inside it: the install path shares the module's serial queue
+    // with the session INSERT and crash-report processing, so converting up to 200 requests
+    // there would be the most expensive place to do it.
+    scope.launch {
+      for (request in requests) {
+        val span = request.toSpan(sessionId) ?: continue
+        try {
+          database.spanDao().insert(span)
+        } catch (e: CancellationException) {
+          // Must not be swallowed: `CancellationException` is an `Exception`, so a blanket catch
+          // would let the loop finish and report completion for a batch that never wrote its
+          // remaining rows, losing the buffered requests the caller means to retry.
+          throw e
+        } catch (e: Exception) {
+          Log.w(TAG, "Failed to persist a network request span", e)
+        }
+      }
+      // Deliberately not in a `finally`: a cancelled batch must not report completion, so the
+      // caller can retry the drain on the next install.
+      onComplete()
+    }
+  }
+}
+
+/**
+ * Maps a completed request onto a client span, per the OTel HTTP semantic conventions.
+ *
+ * The attribute keys are the set the ingestion endpoint extracts into dedicated columns.
+ * Returns `null` when the snapshot has no usable timestamps, leaving nothing to anchor a span to.
+ */
+internal fun NetworkRequest.toSpan(sessionId: String): Span? {
+  val start = timings.fetchStart?.time
+  val end = timings.responseEnd?.time
+  val durationMs = (timings.totalDuration * 1_000).toLong()
+  val resolvedStart = start ?: end?.minus(durationMs) ?: return null
+  val resolvedEnd = end ?: start?.plus(durationMs) ?: return null
+
+  val attributes = JSONObject()
+  // Case-sensitive per the conventions: an unknown or nonstandard method becomes `_OTHER`
+  // (verbatim value preserved in `http.request.method_original`) and names the span `HTTP`,
+  // so caller-controlled verbs can't mint unbounded span names.
+  val isKnownMethod = method in KNOWN_HTTP_METHODS
+  attributes.put("http.request.method", if (isKnownMethod) method else "_OTHER")
+  if (!isKnownMethod) {
+    attributes.put("http.request.method_original", method)
+  }
+  val parsedUrl = url.toHttpUrlOrNull()
+  attributes.put("url.full", redactedUrlFull(url, parsedUrl))
+  parsedUrl?.host?.let { host ->
+    attributes.put("server.address", host)
+  }
+  // `HttpUrl.port` already resolves the scheme default when the URL carries no explicit port.
+  parsedUrl?.port?.let { port ->
+    attributes.put("server.port", port)
+  }
+  statusCode?.let { code ->
+    attributes.put("http.response.status_code", code)
+  }
+  semconvProtocolVersion(networkProtocol)?.let { version ->
+    attributes.put("network.protocol.version", version)
+  }
+  requestBytesSent?.let { bytes ->
+    attributes.put("http.request.size", bytes)
+  }
+  responseBytesReceived?.let { bytes ->
+    attributes.put("http.response.size", bytes)
+  }
+  // Not a semconv attribute: a cached response is timestamped and byte-counted like a download,
+  // so without this a large cache hit reads as an impossible transfer rate. Omitted when nothing
+  // classified the fetch, so its absence never implies a network load.
+  fetchType?.let { type ->
+    attributes.put("expo.http.resource.fetch_type", type.attributeValue)
+  }
+  val httpErrorStatus = (statusCode ?: 0) >= 400
+  // Must stay low-cardinality, so never the localized description.
+  val resolvedErrorType = when {
+    // A cancellation is not a failure, per the conventions.
+    canceled -> null
+    // The status code wins when the server answered: iOS resolves it the same way.
+    httpErrorStatus -> statusCode?.toString()
+    else -> errorType
+  }
+  resolvedErrorType?.let { value ->
+    attributes.put("error.type", value)
+  }
+
+  val failed = !canceled && (errorDescription != null || errorType != null || httpErrorStatus)
+  // A deliberate deviation: the conventions model redirects as resent spans
+  // (`http.request.resend_count`), but this pipeline records one span per chain.
+  val events = JSONArray()
+  for (redirect in redirects) {
+    val event = JSONObject()
+    event.put("name", "expo.http.redirect")
+    // An OTLP event outside its own span has no valid place on the timeline. Without a time the
+    // exporter anchors it to the span start.
+    redirect.respondedAtMs?.takeIf { it in resolvedStart..resolvedEnd }?.let { respondedAtMs ->
+      event.put("timeMs", respondedAtMs)
+    }
+    // `expo.`-namespaced: the naming guidelines advise against application-specific names under
+    // a semconv namespace. The status code reuses the registry attribute it matches.
+    val eventAttributes = JSONObject()
+    eventAttributes.put("expo.http.redirect.from", redirect.fromUrl)
+    eventAttributes.put("expo.http.redirect.to", redirect.toUrl)
+    eventAttributes.put("http.response.status_code", redirect.statusCode)
+    event.put("attributes", eventAttributes)
+    events.put(event)
+  }
+
+  return Span(
+    sessionId = sessionId,
+    name = if (isKnownMethod) method else "HTTP",
+    kind = Span.CLIENT_KIND,
+    startTimestampMs = resolvedStart,
+    endTimestampMs = resolvedEnd,
+    statusCode = if (failed) Span.STATUS_ERROR else null,
+    statusMessage = if (failed) errorDescription else null,
+    attributes = attributes.toString(),
+    events = if (events.length() > 0) events.toString() else null
+  )
+}
+
+/**
+ * The conventions' known method set: RFC 9110's methods plus PATCH and QUERY, matched
+ * case-sensitively as the conventions require.
+ */
+private val KNOWN_HTTP_METHODS = setOf(
+  "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "QUERY"
+)
+
+/** The conventions' default-sensitive `url.full` parameters, plus the legacy S3 pair. */
+private val SENSITIVE_QUERY_PARAMETERS = setOf(
+  "awsaccesskeyid",
+  "signature",
+  "sig",
+  "x-amz-signature",
+  "x-amz-credential",
+  "x-amz-security-token",
+  "x-goog-signature"
+)
+
+/**
+ * Redacts userinfo and default-sensitive query values, so secrets never reach disk or the wire.
+ */
+private fun redactedUrlFull(url: String, parsed: okhttp3.HttpUrl?): String {
+  // An unparseable URL can't prove it carries no secrets, so drop the query outright.
+  // `parsed` is passed in so each URL is parsed once on the OkHttp dispatcher thread.
+  if (parsed == null) {
+    return url.substringBefore('?')
+  }
+  val builder = parsed.newBuilder()
+  if (parsed.encodedUsername.isNotEmpty() || parsed.encodedPassword.isNotEmpty()) {
+    builder.username("REDACTED")
+    builder.password("REDACTED")
+  }
+  // Spliced as a string because every OkHttp builder route moves the parameter to the end of
+  // the query, and `url.full` is the key URL analysis groups on.
+  parsed.encodedQuery?.let { encodedQuery ->
+    val redacted = encodedQuery
+      .split('&')
+      .joinToString("&") { pair ->
+        val separator = pair.indexOf('=')
+        // No `=` means a valueless parameter (`?sig`), which carries no secret to redact.
+        if (separator < 0) {
+          return@joinToString pair
+        }
+        val name = pair.substring(0, separator)
+        // Match the decoded name: a server reads `%73ig` as `sig`.
+        val decodedName = try {
+          URLDecoder.decode(name, "UTF-8")
+        } catch (e: IllegalArgumentException) {
+          // A malformed escape cannot be decoded; fall back to the raw name rather than drop it.
+          name
+        }
+        if (decodedName.lowercase() in SENSITIVE_QUERY_PARAMETERS) "$name=REDACTED" else pair
+      }
+    if (redacted != encodedQuery) {
+      builder.encodedQuery(redacted)
+    }
+  }
+  return builder.build().toString()
+}
+
+/**
+ * Bare protocol version per semconv's `network.protocol.version` ("1.1", "2", "3"), mapped from
+ * the ALPN-style names OkHttp reports ("http/1.1", "h2", "h3"). Unrecognized values pass through
+ * verbatim rather than being dropped.
+ */
+private fun semconvProtocolVersion(networkProtocol: String?): String? = when {
+  networkProtocol == null -> null
+  networkProtocol == "h2" -> "2"
+  networkProtocol == "h3" -> "3"
+  networkProtocol.startsWith("http/") -> networkProtocol.removePrefix("http/")
+  else -> networkProtocol
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptorTest.kt
@@ -55,6 +55,45 @@ class NetworkRequestInterceptorTest {
     assertEquals("GET", snapshot.method)
     assertNull(snapshot.errorDescription)
     assertTrue(snapshot.redirects.isEmpty())
+    // No cache is installed on the test client, so every response is a plain network load.
+    assertEquals(NetworkRequest.FetchType.NETWORK, snapshot.fetchType)
+  }
+
+  @Test
+  fun `records a cancellation that happens partway through the response body`() {
+    // The body wrapper signals on close as well as EOF, so abandoning a partially read response
+    // still records a snapshot. This pins what that snapshot looks like: OkHttp reports the
+    // cancellation through `Call.isCanceled`, not an exception on the interceptor's path, so
+    // without the `isCanceled` check a truncated transfer would read as a clean success.
+    server.enqueue(MockResponse().setResponseCode(200).setBody("0123456789"))
+
+    val call = client.newCall(Request.Builder().url(server.url("/partial")).build())
+    val response = call.execute()
+    val source = response.body!!.source()
+    source.readByte()
+    call.cancel()
+    response.close()
+
+    assertEquals(1, monitor.recent.size)
+    val snapshot = monitor.recent.first()
+    assertEquals(200, snapshot.statusCode)
+    assertTrue("a canceled call must be flagged even without an exception", snapshot.canceled)
+  }
+
+  @Test
+  fun `leaves the fetch type unknown when the request never produced a response`() {
+    // A transport failure has no response to classify, so the snapshot must not claim the
+    // response came off the network.
+    server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+
+    try {
+      client.newCall(Request.Builder().url(server.url("/boom")).build()).execute()
+    } catch (_: IOException) {
+      // Expected: the interceptor records the failure and rethrows.
+    }
+
+    assertEquals(1, monitor.recent.size)
+    assertNull(monitor.recent.first().fetchType)
   }
 
   @Test
@@ -149,8 +188,10 @@ class NetworkRequestInterceptorTest {
     server.enqueue(MockResponse().setResponseCode(301).setHeader("Location", "/c"))
     server.enqueue(MockResponse().setResponseCode(200).setBody("final"))
 
+    val before = System.currentTimeMillis()
     val response = client.newCall(Request.Builder().url(server.url("/a")).build()).execute()
     response.close()
+    val after = System.currentTimeMillis()
 
     assertEquals(1, monitor.recent.size)
     val redirects = monitor.recent.first().redirects
@@ -163,6 +204,11 @@ class NetworkRequestInterceptorTest {
     assertTrue(redirects[1].fromUrl.endsWith("/b"))
     assertTrue(redirects[1].toUrl.endsWith("/c"))
     assertEquals(301, redirects[1].statusCode)
+    // Each hop records when its 3xx response arrived, in chain order and inside the call window.
+    val firstRespondedAt = checkNotNull(redirects[0].respondedAtMs)
+    val secondRespondedAt = checkNotNull(redirects[1].respondedAtMs)
+    assertTrue(firstRespondedAt in before..after)
+    assertTrue(secondRespondedAt in firstRespondedAt..after)
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
@@ -88,7 +88,13 @@ class NetworkRequestObserverTest {
         NetworkRequest.Redirect(
           fromUrl = "https://expo.dev/a",
           toUrl = "https://expo.dev/b",
-          statusCode = 301
+          statusCode = 301,
+          respondedAtMs = 2_250_000L
+        ),
+        NetworkRequest.Redirect(
+          fromUrl = "https://expo.dev/b",
+          toUrl = "https://expo.dev/end",
+          statusCode = 302
         )
       )
     )
@@ -108,10 +114,16 @@ class NetworkRequestObserverTest {
 
     @Suppress("UNCHECKED_CAST")
     val redirects = payload["redirects"] as List<Map<String, Any?>>
-    assertEquals(1, redirects.size)
+    assertEquals(2, redirects.size)
     assertEquals("https://expo.dev/a", redirects[0]["fromUrl"])
     assertEquals("https://expo.dev/b", redirects[0]["toUrl"])
     assertEquals(301, redirects[0]["statusCode"])
+    // Hop times use the same ISO 8601 UTC format as `startedAt`, but keep milliseconds because
+    // hops within one request are usually fractions of a second apart. An unreported time is
+    // `null`.
+    assertEquals("1970-01-01T00:37:30.000Z", redirects[0]["respondedAt"])
+    assertTrue(redirects[1].containsKey("respondedAt"))
+    assertNull(redirects[1]["respondedAt"])
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
@@ -1,0 +1,470 @@
+package expo.modules.appmetrics.networkrequests
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.Session
+import expo.modules.appmetrics.storage.Span
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import java.util.Date
+import java.util.UUID
+
+private val fixedStart = Date(1_782_131_895_000)
+
+private fun makeTimings(
+  fetchStart: Date? = fixedStart,
+  responseEnd: Date? = Date(fixedStart.time + 250),
+  totalDuration: Double = 0.25
+) = NetworkRequest.Timings(
+  fetchStart = fetchStart,
+  domainLookupStart = null,
+  domainLookupEnd = null,
+  connectStart = null,
+  connectEnd = null,
+  secureConnectionStart = null,
+  secureConnectionEnd = null,
+  requestStart = null,
+  requestEnd = null,
+  responseStart = null,
+  responseEnd = responseEnd,
+  measuredResponseEnd = responseEnd,
+  totalDuration = totalDuration
+)
+
+private fun makeRequest(
+  url: String = "https://api.example.com/v1/items?page=2",
+  method: String = "GET",
+  statusCode: Int? = 200,
+  networkProtocol: String? = "h2",
+  requestBytesSent: Long? = 412,
+  responseBytesReceived: Long? = 8_192,
+  timings: NetworkRequest.Timings = makeTimings(),
+  errorDescription: String? = null,
+  errorType: String? = null,
+  cancelled: Boolean = false,
+  redirects: List<NetworkRequest.Redirect> = emptyList()
+) = NetworkRequest(
+  id = UUID.randomUUID(),
+  url = url,
+  method = method,
+  statusCode = statusCode,
+  networkProtocol = networkProtocol,
+  requestBytesSent = requestBytesSent,
+  responseBytesReceived = responseBytesReceived,
+  timings = timings,
+  errorDescription = errorDescription,
+  errorType = errorType,
+  cancelled = cancelled,
+  redirects = redirects
+)
+
+private fun makeSpan(request: NetworkRequest): Span {
+  return checkNotNull(request.toSpan(sessionId = "s"))
+}
+
+private fun attributes(span: Span): JSONObject {
+  return JSONObject(checkNotNull(span.attributes))
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class NetworkRequestToSpanMappingTest {
+  @Test
+  fun `converts a completed request into a client span with millisecond timestamps`() {
+    val span = makeSpan(makeRequest(method = "POST"))
+    assertEquals("s", span.sessionId)
+    assertEquals("POST", span.name)
+    assertEquals(Span.CLIENT_KIND, span.kind)
+    assertEquals(1_782_131_895_000, span.startTimestampMs)
+    assertEquals(1_782_131_895_250, span.endTimestampMs)
+    assertNull(span.parentSpanId)
+    assertNull(span.events)
+  }
+
+  @Test
+  fun `maps the HTTP semantic-convention attributes the server extracts to columns`() {
+    val attributes = attributes(makeSpan(makeRequest()))
+    assertEquals("GET", attributes.getString("http.request.method"))
+    assertEquals(200, attributes.getInt("http.response.status_code"))
+    assertEquals("https://api.example.com/v1/items?page=2", attributes.getString("url.full"))
+    assertEquals("api.example.com", attributes.getString("server.address"))
+    assertEquals(412L, attributes.getLong("http.request.size"))
+    assertEquals(8_192L, attributes.getLong("http.response.size"))
+  }
+
+  @Test
+  fun `normalizes the network protocol name to a semconv version`() {
+    // OkHttp reports `http/1.1`, `h2`, `h3`; semconv's `network.protocol.version` wants the
+    // bare version, and the server stores it in a LowCardinality column.
+    val expected = mapOf(
+      "http/1.1" to "1.1",
+      "http/1.0" to "1.0",
+      "h2" to "2",
+      "h3" to "3"
+    )
+    for ((reported, version) in expected) {
+      val attributes = attributes(makeSpan(makeRequest(networkProtocol = reported)))
+      assertEquals(version, attributes.getString("network.protocol.version"))
+    }
+  }
+
+  @Test
+  fun `omits attributes that were never measured`() {
+    // A request that died before headers has no status and no byte counts. Sending a
+    // placeholder would be indistinguishable from a genuine zero.
+    val request = makeRequest(
+      statusCode = null,
+      networkProtocol = null,
+      requestBytesSent = null,
+      responseBytesReceived = null
+    )
+    val attributes = attributes(makeSpan(request))
+    assertFalse(attributes.has("http.response.status_code"))
+    assertFalse(attributes.has("network.protocol.version"))
+    assertFalse(attributes.has("http.request.size"))
+    assertFalse(attributes.has("http.response.size"))
+  }
+
+  @Test
+  fun `keeps ordinary query values but redacts the default-sensitive ones`() {
+    // Redaction is the instrumentation's job per the conventions; signed-URL secrets must
+    // never reach the on-device database. Ordinary parameters stay.
+    val url = "https://api.example.com/search?q=hello&sig=secret&X-Amz-Signature=abc"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://api.example.com/search?q=hello&sig=REDACTED&X-Amz-Signature=REDACTED",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `redacts userinfo credentials from the URL`() {
+    val attributes = attributes(makeSpan(makeRequest(url = "https://user:pass@api.example.com/items")))
+    assertEquals("https://REDACTED:REDACTED@api.example.com/items", attributes.getString("url.full"))
+  }
+
+  @Test
+  fun `records the server port, defaulting from the scheme`() {
+    assertEquals(8443, attributes(makeSpan(makeRequest(url = "https://api.example.com:8443/x"))).getInt("server.port"))
+    assertEquals(443, attributes(makeSpan(makeRequest(url = "https://api.example.com/x"))).getInt("server.port"))
+    assertEquals(80, attributes(makeSpan(makeRequest(url = "http://api.example.com/x"))).getInt("server.port"))
+  }
+
+  @Test
+  fun `maps a nonstandard method to _OTHER and names the span HTTP`() {
+    // Case-sensitive per the conventions: even a lowercase standard verb is not "known", so
+    // caller-controlled method strings can't mint unbounded span names.
+    for (method in listOf("PURGE", "get")) {
+      val span = makeSpan(makeRequest(method = method))
+      val attributes = attributes(span)
+      assertEquals("HTTP", span.name)
+      assertEquals("_OTHER", attributes.getString("http.request.method"))
+      assertEquals(method, attributes.getString("http.request.method_original"))
+    }
+  }
+
+  @Test
+  fun `records a cancelled request without a status or error type`() {
+    // Intentional cancellations (AbortController, prefetch aborts) are routine in RN apps;
+    // per the conventions they keep their span but are not errors.
+    val span = makeSpan(
+      makeRequest(
+        statusCode = null,
+        errorDescription = "Canceled",
+        errorType = "java.io.IOException",
+        cancelled = true
+      )
+    )
+    assertNull(span.statusCode)
+    assertNull(span.statusMessage)
+    assertFalse(attributes(span).has("error.type"))
+  }
+
+  @Test
+  fun `leaves the status unset for a successful response`() {
+    // Semconv: a client span for a 2xx response carries no explicit status.
+    val span = makeSpan(makeRequest(statusCode = 200))
+    assertNull(span.statusCode)
+    assertNull(span.statusMessage)
+  }
+
+  @Test
+  fun `marks 4xx and 5xx responses as errors`() {
+    // Semconv makes any 4xx/5xx an error for a client span, unlike the server-span rule.
+    for (statusCode in listOf(400, 404, 429, 500, 503)) {
+      val span = makeSpan(makeRequest(statusCode = statusCode))
+      assertEquals("expected ERROR for status $statusCode", Span.STATUS_ERROR, span.statusCode)
+    }
+  }
+
+  @Test
+  fun `marks a transport failure as an error with the description as the status message`() {
+    // `errorDescription` is localized free text, so it belongs in the status message. The
+    // low-cardinality `error.type` attribute gets a separate, predictable value.
+    val span = makeSpan(
+      makeRequest(
+        statusCode = null,
+        errorDescription = "Unable to resolve host",
+        errorType = "java.net.UnknownHostException"
+      )
+    )
+    assertEquals(Span.STATUS_ERROR, span.statusCode)
+    assertEquals("Unable to resolve host", span.statusMessage)
+    assertEquals("java.net.UnknownHostException", attributes(span).getString("error.type"))
+  }
+
+  @Test
+  fun `sets the error type to the status code for an HTTP error response`() {
+    // Semconv: when a request completes with an error status and no exception, `error.type`
+    // is the status code as a string.
+    val attributes = attributes(makeSpan(makeRequest(statusCode = 503)))
+    assertEquals("503", attributes.getString("error.type"))
+  }
+
+  @Test
+  fun `omits the error type on success`() {
+    val attributes = attributes(makeSpan(makeRequest(statusCode = 204)))
+    assertFalse(attributes.has("error.type"))
+  }
+
+  @Test
+  fun `maps each redirect hop onto an event`() {
+    val request = makeRequest(
+      redirects = listOf(
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/a",
+          toUrl = "https://example.com/b",
+          statusCode = 301
+        ),
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/b",
+          toUrl = "https://example.com/c",
+          statusCode = 302
+        )
+      )
+    )
+    val events = JSONArray(checkNotNull(makeSpan(request).events))
+    assertEquals(2, events.length())
+    val first = events.getJSONObject(0)
+    assertEquals("expo.http.redirect", first.getString("name"))
+    val attributes = first.getJSONObject("attributes")
+    assertEquals("https://example.com/a", attributes.getString("from"))
+    assertEquals("https://example.com/b", attributes.getString("to"))
+    assertEquals(301, attributes.getInt("statusCode"))
+  }
+
+  @Test
+  fun `derives a missing end timestamp from the total duration`() {
+    // A snapshot recorded before the body finished can lack a response end; the row still
+    // needs a usable window for the span.
+    val timings = makeTimings(fetchStart = fixedStart, responseEnd = null, totalDuration = 1.5)
+    val span = makeSpan(makeRequest(timings = timings))
+    assertEquals(1_782_131_895_000, span.startTimestampMs)
+    assertEquals(1_782_131_896_500, span.endTimestampMs)
+  }
+
+  @Test
+  fun `returns null when the request carries no usable timestamps`() {
+    // Without either endpoint of the window there is nothing to anchor a span to.
+    val timings = makeTimings(fetchStart = null, responseEnd = null, totalDuration = 0.0)
+    assertNull(makeRequest(timings = timings).toSpan(sessionId = "s"))
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class NetworkRequestPersistenceTest {
+  // Shared by `runTest` and Room's executors: persistence inserts are fire-and-forget, and
+  // Room's suspending DAO calls hop to its executors, which live outside the test scheduler's
+  // virtual time. Pinning them to the same scheduler makes `advanceUntilIdle` actually wait
+  // for the inserts instead of racing them.
+  private val testDispatcher = StandardTestDispatcher()
+
+  private lateinit var database: MetricsDatabase
+
+  @Before
+  fun setUp() {
+    // Surface swallowed persistence warnings in the test output.
+    ShadowLog.stream = System.out
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .setQueryExecutor(testDispatcher.asExecutor())
+      .setTransactionExecutor(testDispatcher.asExecutor())
+      .build()
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun insertSession(id: String) {
+    database.sessionDao().insert(
+      Session(id = id, startTimestamp = "2026-08-13T10:00:00.000Z")
+    )
+  }
+
+  @Test
+  fun `persists a completed request as a span attributed to the provided session`() = runTest(testDispatcher) {
+    insertSession("main-session")
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "main-session"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    val rows = database.spanDao().getAll()
+    assertEquals(1, rows.size)
+    assertEquals("main-session", rows.single().sessionId)
+    assertEquals("GET", rows.single().name)
+  }
+
+  @Test
+  fun `installing on the monitor backfills buffered requests and persists new ones`() = runTest(testDispatcher) {
+    // The interceptor installs at Application.onCreate, but persistence can only start once
+    // the module created the session. Requests observed in between sit in the monitor's ring
+    // buffer, so installation drains it — startup traffic is not lost.
+    insertSession("main-session")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "main-session"
+    )
+    monitor.installPersistence(persistence)
+    monitor.record(makeRequest(method = "POST"))
+    testScheduler.advanceUntilIdle()
+    val rows = database.spanDao().getAll()
+    assertEquals(listOf("GET", "POST"), rows.map { it.name })
+  }
+
+  @Test
+  fun `reinstalling after a completed backfill does not re-drain the buffer`() = runTest(testDispatcher) {
+    // The module reinstalls on every JS reload; a second drain would duplicate the buffered
+    // startup requests under the new session id.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    testScheduler.advanceUntilIdle()
+    monitor.uninstallPersistence(first)
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    monitor.record(makeRequest(method = "POST"))
+    testScheduler.advanceUntilIdle()
+    assertEquals(listOf("GET", "POST"), database.spanDao().getAll().map { it.name })
+  }
+
+  @Test
+  fun `a backfill cancelled before completing is retried by the next install`() = runTest(testDispatcher) {
+    // A JS reload cancels the module scope the batch runs on. The drained-flag flips only on
+    // completion, so the next install drains again instead of losing the buffer for good.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val cancelledScope = CoroutineScope(testDispatcher + Job())
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = cancelledScope,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    cancelledScope.cancel()
+    testScheduler.advanceUntilIdle()
+    assertTrue(database.spanDao().getAll().isEmpty())
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    assertEquals(listOf("GET"), database.spanDao().getAll().map { it.name })
+  }
+
+  @Test
+  fun `an uninstalled persistence receives no further requests`() = runTest(testDispatcher) {
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(persistence)
+    monitor.uninstallPersistence(persistence)
+    monitor.record(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertTrue(database.spanDao().getAll().isEmpty())
+  }
+
+  @Test
+  fun `uninstalling a stale instance leaves its replacement installed`() = runTest(testDispatcher) {
+    // A late-arriving OnDestroy from the torn-down module must not remove the instance the
+    // next module installed.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    val stale = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(stale)
+    val replacement = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(replacement)
+    monitor.uninstallPersistence(stale)
+    monitor.record(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertEquals(1, database.spanDao().getAll().size)
+  }
+
+  @Test
+  fun `drops a request whose session row does not exist yet`() = runTest(testDispatcher) {
+    // The sessions FK protects referential integrity; persistence must degrade to a dropped
+    // row rather than throw into the monitor's record path.
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "never-inserted"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertTrue(database.spanDao().getAll().isEmpty())
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestPersistenceTest.kt
@@ -1,0 +1,812 @@
+package expo.modules.appmetrics.networkrequests
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.appmetrics.storage.MetricsDatabase
+import expo.modules.appmetrics.storage.Session
+import expo.modules.appmetrics.storage.Span
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.asExecutor
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowLog
+import java.util.Date
+import java.util.UUID
+
+private val fixedStart = Date(1_782_131_895_000)
+
+private fun makeTimings(
+  fetchStart: Date? = fixedStart,
+  responseEnd: Date? = Date(fixedStart.time + 250),
+  totalDuration: Double = 0.25
+) = NetworkRequest.Timings(
+  fetchStart = fetchStart,
+  domainLookupStart = null,
+  domainLookupEnd = null,
+  connectStart = null,
+  connectEnd = null,
+  secureConnectionStart = null,
+  secureConnectionEnd = null,
+  requestStart = null,
+  requestEnd = null,
+  responseStart = null,
+  responseEnd = responseEnd,
+  measuredResponseEnd = responseEnd,
+  totalDuration = totalDuration
+)
+
+private fun makeRequest(
+  url: String = "https://api.example.com/v1/items?page=2",
+  method: String = "GET",
+  statusCode: Int? = 200,
+  networkProtocol: String? = "h2",
+  requestBytesSent: Long? = 412,
+  responseBytesReceived: Long? = 8_192,
+  timings: NetworkRequest.Timings = makeTimings(),
+  errorDescription: String? = null,
+  errorType: String? = null,
+  canceled: Boolean = false,
+  fetchType: NetworkRequest.FetchType? = NetworkRequest.FetchType.NETWORK,
+  redirects: List<NetworkRequest.Redirect> = emptyList()
+) = NetworkRequest(
+  id = UUID.randomUUID(),
+  url = url,
+  method = method,
+  statusCode = statusCode,
+  networkProtocol = networkProtocol,
+  requestBytesSent = requestBytesSent,
+  responseBytesReceived = responseBytesReceived,
+  timings = timings,
+  errorDescription = errorDescription,
+  errorType = errorType,
+  canceled = canceled,
+  fetchType = fetchType,
+  redirects = redirects
+)
+
+private fun makeSpan(request: NetworkRequest): Span {
+  return checkNotNull(request.toSpan(sessionId = "s"))
+}
+
+private fun attributes(span: Span): JSONObject {
+  return JSONObject(checkNotNull(span.attributes))
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class NetworkRequestToSpanMappingTest {
+  @Test
+  fun `converts a completed request into a client span with millisecond timestamps`() {
+    val span = makeSpan(makeRequest(method = "POST"))
+    assertEquals("s", span.sessionId)
+    assertEquals("POST", span.name)
+    assertEquals(Span.CLIENT_KIND, span.kind)
+    assertEquals(1_782_131_895_000, span.startTimestampMs)
+    assertEquals(1_782_131_895_250, span.endTimestampMs)
+    assertNull(span.parentSpanId)
+    assertNull(span.events)
+  }
+
+  @Test
+  fun `maps the HTTP semantic-convention attributes the server extracts to columns`() {
+    val attributes = attributes(makeSpan(makeRequest()))
+    assertEquals("GET", attributes.getString("http.request.method"))
+    assertEquals(200, attributes.getInt("http.response.status_code"))
+    assertEquals("https://api.example.com/v1/items?page=2", attributes.getString("url.full"))
+    assertEquals("api.example.com", attributes.getString("server.address"))
+    assertEquals(412L, attributes.getLong("http.request.size"))
+    assertEquals(8_192L, attributes.getLong("http.response.size"))
+  }
+
+  @Test
+  fun `normalizes the network protocol name to a semconv version`() {
+    // OkHttp reports `http/1.1`, `h2`, `h3`; semconv's `network.protocol.version` wants the
+    // bare version, and the server stores it in a LowCardinality column.
+    val expected = mapOf(
+      "http/1.1" to "1.1",
+      "http/1.0" to "1.0",
+      "h2" to "2",
+      "h3" to "3"
+    )
+    for ((reported, version) in expected) {
+      val attributes = attributes(makeSpan(makeRequest(networkProtocol = reported)))
+      assertEquals(version, attributes.getString("network.protocol.version"))
+    }
+  }
+
+  @Test
+  fun `omits attributes that were never measured`() {
+    // A request that died before headers has no status and no byte counts. Sending a
+    // placeholder would be indistinguishable from a genuine zero.
+    val request = makeRequest(
+      statusCode = null,
+      networkProtocol = null,
+      requestBytesSent = null,
+      responseBytesReceived = null
+    )
+    val attributes = attributes(makeSpan(request))
+    assertFalse(attributes.has("http.response.status_code"))
+    assertFalse(attributes.has("network.protocol.version"))
+    assertFalse(attributes.has("http.request.size"))
+    assertFalse(attributes.has("http.response.size"))
+  }
+
+  @Test
+  fun `keeps ordinary query values but redacts the default-sensitive ones`() {
+    // Redaction is the instrumentation's job per the conventions; signed-URL secrets must
+    // never reach the on-device database. Ordinary parameters stay.
+    val url = "https://api.example.com/search?q=hello&sig=secret&X-Amz-Signature=abc"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://api.example.com/search?q=hello&sig=REDACTED&X-Amz-Signature=REDACTED",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `redacts every default-sensitive query parameter of a presigned S3 URL`() {
+    // The `url.full` convention lists five default-sensitive parameters. `X-Amz-Credential`
+    // carries the access key id and `X-Amz-Security-Token` the session token; leaking either
+    // is as bad as leaking the signature.
+    val url = "https://bucket.s3.amazonaws.com/key" +
+      "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+      "&X-Amz-Credential=AKIAEXAMPLE%2F20260907%2Fus-east-1%2Fs3%2Faws4_request" +
+      "&X-Amz-Security-Token=session-token" +
+      "&X-Amz-Signature=abc"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://bucket.s3.amazonaws.com/key" +
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+        "&X-Amz-Credential=REDACTED" +
+        "&X-Amz-Security-Token=REDACTED" +
+        "&X-Amz-Signature=REDACTED",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `redacts a sensitive parameter whose name is percent-encoded`() {
+    // A server decodes `%73ig` back to `sig`, so a presigned URL spelled that way carries a real
+    // secret. Matching the encoded name against the plain-text list would miss it.
+    val url = "https://api.example.com/search?%73ig=secret&X%2DAmz%2DSignature=abc&q=hello"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://api.example.com/search?%73ig=REDACTED&X%2DAmz%2DSignature=REDACTED&q=hello",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `keeps query parameters in the order they were sent`() {
+    // `url.full` is the key URL-level analysis groups on, so moving a redacted parameter to the
+    // end splits one endpoint into several distinct strings, and diverges from iOS for the very
+    // same request.
+    val url = "https://api.example.com/search?sig=secret&q=hello&page=2"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://api.example.com/search?sig=REDACTED&q=hello&page=2",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `redacts every occurrence of a repeated sensitive parameter`() {
+    // Both occurrences stay, each with its value replaced: collapsing them would report a URL
+    // with fewer parameters than the app actually sent.
+    val url = "https://api.example.com/search?sig=one&q=hello&sig=two"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals(
+      "https://api.example.com/search?sig=REDACTED&q=hello&sig=REDACTED",
+      attributes.getString("url.full")
+    )
+  }
+
+  @Test
+  fun `leaves a valueless sensitive parameter alone`() {
+    // `?sig` carries no secret to redact, and inventing a value for it would report a URL the
+    // app never sent. iOS skips it for the same reason.
+    val url = "https://api.example.com/search?sig&q=hello"
+    val attributes = attributes(makeSpan(makeRequest(url = url)))
+    assertEquals("https://api.example.com/search?sig&q=hello", attributes.getString("url.full"))
+  }
+
+  @Test
+  fun `redacts userinfo credentials from the URL`() {
+    val attributes = attributes(makeSpan(makeRequest(url = "https://user:pass@api.example.com/items")))
+    assertEquals("https://REDACTED:REDACTED@api.example.com/items", attributes.getString("url.full"))
+  }
+
+  @Test
+  fun `records the server port, defaulting from the scheme`() {
+    assertEquals(8443, attributes(makeSpan(makeRequest(url = "https://api.example.com:8443/x"))).getInt("server.port"))
+    assertEquals(443, attributes(makeSpan(makeRequest(url = "https://api.example.com/x"))).getInt("server.port"))
+    assertEquals(80, attributes(makeSpan(makeRequest(url = "http://api.example.com/x"))).getInt("server.port"))
+  }
+
+  @Test
+  fun `records how the response was fetched, and omits it when unknown`() {
+    // A cache hit is timestamped and byte-counted like a download, so without this attribute a
+    // 7 MB response read off disk in 100 ms looks like an impossible transfer rate. OkHttp also
+    // distinguishes a conditional-GET revalidation, which iOS folds into its cache bucket.
+    val cases = mapOf(
+      NetworkRequest.FetchType.NETWORK to "network",
+      NetworkRequest.FetchType.CACHE to "cache",
+      NetworkRequest.FetchType.VALIDATED to "validated"
+    )
+    for ((fetchType, expected) in cases) {
+      val attributes = attributes(makeSpan(makeRequest(fetchType = fetchType)))
+      assertEquals(expected, attributes.getString("expo.http.resource.fetch_type"))
+    }
+    // A transport failure never produced a response, so nothing classified the fetch.
+    val unknown = attributes(makeSpan(makeRequest(fetchType = null)))
+    assertFalse(unknown.has("expo.http.resource.fetch_type"))
+  }
+
+  @Test
+  fun `keeps the conventions' known methods verbatim`() {
+    // The known set is RFC 9110's methods plus PATCH and QUERY. Each names the span and is
+    // recorded as `http.request.method` as sent, with no `method_original`.
+    for (method in listOf("GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "QUERY")) {
+      val span = makeSpan(makeRequest(method = method))
+      val attributes = attributes(span)
+      assertEquals(method, span.name)
+      assertEquals(method, attributes.getString("http.request.method"))
+      assertFalse("unexpected method_original for $method", attributes.has("http.request.method_original"))
+    }
+  }
+
+  @Test
+  fun `maps a nonstandard method to _OTHER and names the span HTTP`() {
+    // Case-sensitive per the conventions: even a lowercase standard verb is not "known", so
+    // caller-controlled method strings can't mint unbounded span names.
+    for (method in listOf("PURGE", "get")) {
+      val span = makeSpan(makeRequest(method = method))
+      val attributes = attributes(span)
+      assertEquals("HTTP", span.name)
+      assertEquals("_OTHER", attributes.getString("http.request.method"))
+      assertEquals(method, attributes.getString("http.request.method_original"))
+    }
+  }
+
+  @Test
+  fun `records a canceled request without a status or error type`() {
+    // Intentional cancellations (AbortController, prefetch aborts) are routine in RN apps;
+    // per the conventions they keep their span but are not errors.
+    val span = makeSpan(
+      makeRequest(
+        statusCode = null,
+        errorDescription = "Canceled",
+        errorType = "java.io.IOException",
+        canceled = true
+      )
+    )
+    assertNull(span.statusCode)
+    assertNull(span.statusMessage)
+    assertFalse(attributes(span).has("error.type"))
+  }
+
+  @Test
+  fun `leaves the status unset for a successful response`() {
+    // Semconv: a client span for a 2xx response carries no explicit status.
+    val span = makeSpan(makeRequest(statusCode = 200))
+    assertNull(span.statusCode)
+    assertNull(span.statusMessage)
+  }
+
+  @Test
+  fun `marks 4xx and 5xx responses as errors`() {
+    // Semconv makes any 4xx/5xx an error for a client span, unlike the server-span rule.
+    for (statusCode in listOf(400, 404, 429, 500, 503)) {
+      val span = makeSpan(makeRequest(statusCode = statusCode))
+      assertEquals("expected ERROR for status $statusCode", Span.STATUS_ERROR, span.statusCode)
+    }
+  }
+
+  @Test
+  fun `marks a transport failure as an error with the description as the status message`() {
+    // `errorDescription` is localized free text, so it belongs in the status message. The
+    // low-cardinality `error.type` attribute gets a separate, predictable value.
+    val span = makeSpan(
+      makeRequest(
+        statusCode = null,
+        errorDescription = "Unable to resolve host",
+        errorType = "java.net.UnknownHostException"
+      )
+    )
+    assertEquals(Span.STATUS_ERROR, span.statusCode)
+    assertEquals("Unable to resolve host", span.statusMessage)
+    assertEquals("java.net.UnknownHostException", attributes(span).getString("error.type"))
+  }
+
+  @Test
+  fun `sets the error type to the status code for an HTTP error response`() {
+    // Semconv: when a request completes with an error status and no exception, `error.type`
+    // is the status code as a string.
+    val attributes = attributes(makeSpan(makeRequest(statusCode = 503)))
+    assertEquals("503", attributes.getString("error.type"))
+  }
+
+  @Test
+  fun `prefers the status code over an exception for the error type`() {
+    // When the server answered with a 5xx and the transfer then failed, the status code is the
+    // more useful low-cardinality value, and iOS resolves it the same way for the same request.
+    val attributes = attributes(
+      makeSpan(
+        makeRequest(
+          statusCode = 503,
+          errorDescription = "stream closed",
+          errorType = "java.io.IOException"
+        )
+      )
+    )
+    assertEquals("503", attributes.getString("error.type"))
+  }
+
+  @Test
+  fun `omits the error type on success`() {
+    val attributes = attributes(makeSpan(makeRequest(statusCode = 204)))
+    assertFalse(attributes.has("error.type"))
+  }
+
+  @Test
+  fun `maps each redirect hop onto an event`() {
+    val request = makeRequest(
+      redirects = listOf(
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/a",
+          toUrl = "https://example.com/b",
+          statusCode = 301,
+          respondedAtMs = 1_782_131_895_100
+        ),
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/b",
+          toUrl = "https://example.com/c",
+          statusCode = 302,
+          respondedAtMs = null
+        )
+      )
+    )
+    // Event and attribute names follow the naming guidelines: application-specific names live
+    // under the `expo.` namespace, and the hop's status reuses the registry's
+    // `http.response.status_code`.
+    val events = JSONArray(checkNotNull(makeSpan(request).events))
+    assertEquals(2, events.length())
+    val first = events.getJSONObject(0)
+    assertEquals("expo.http.redirect", first.getString("name"))
+    val attributes = first.getJSONObject("attributes")
+    assertEquals("https://example.com/a", attributes.getString("expo.http.redirect.from"))
+    assertEquals("https://example.com/b", attributes.getString("expo.http.redirect.to"))
+    assertEquals(301, attributes.getInt("http.response.status_code"))
+    assertEquals("unexpected attributes: ${attributes.keys().asSequence().sorted().toList()}", 3, attributes.length())
+    // A hop's arrival time becomes the event time; without one the exporter anchors the event
+    // to the span start, so the key is omitted rather than faked.
+    assertEquals(1_782_131_895_100L, first.getLong("timeMs"))
+    assertFalse(events.getJSONObject(1).has("timeMs"))
+  }
+
+  @Test
+  fun `keeps redirect event times inside the span window`() {
+    // A hop that the platform timed before the span's own start has no valid place on the
+    // timeline: OTLP events must sit within their span. Rather than ship an event that precedes
+    // its span, drop the time and let the exporter anchor the event to the span start.
+    val request = makeRequest(
+      redirects = listOf(
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/a",
+          toUrl = "https://example.com/b",
+          statusCode = 301,
+          respondedAtMs = fixedStart.time - 500
+        ),
+        NetworkRequest.Redirect(
+          fromUrl = "https://example.com/b",
+          toUrl = "https://example.com/c",
+          statusCode = 302,
+          respondedAtMs = fixedStart.time + 5_000
+        )
+      )
+    )
+    val events = JSONArray(checkNotNull(makeSpan(request).events))
+    assertFalse(events.getJSONObject(0).has("timeMs"))
+    assertFalse(events.getJSONObject(1).has("timeMs"))
+  }
+
+  @Test
+  fun `derives a missing end timestamp from the total duration`() {
+    // A snapshot recorded before the body finished can lack a response end; the row still
+    // needs a usable window for the span.
+    val timings = makeTimings(fetchStart = fixedStart, responseEnd = null, totalDuration = 1.5)
+    val span = makeSpan(makeRequest(timings = timings))
+    assertEquals(1_782_131_895_000, span.startTimestampMs)
+    assertEquals(1_782_131_896_500, span.endTimestampMs)
+  }
+
+  @Test
+  fun `returns null when the request carries no usable timestamps`() {
+    // Without either endpoint of the window there is nothing to anchor a span to.
+    val timings = makeTimings(fetchStart = null, responseEnd = null, totalDuration = 0.0)
+    assertNull(makeRequest(timings = timings).toSpan(sessionId = "s"))
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class NetworkRequestPersistenceTest {
+  // Shared by `runTest` and Room's executors: persistence inserts are fire-and-forget, and
+  // Room's suspending DAO calls hop to its executors, which live outside the test scheduler's
+  // virtual time. Pinning them to the same scheduler makes `advanceUntilIdle` actually wait
+  // for the inserts instead of racing them.
+  private val testDispatcher = StandardTestDispatcher()
+
+  private lateinit var database: MetricsDatabase
+
+  @Before
+  fun setUp() {
+    // Surface swallowed persistence warnings in the test output.
+    ShadowLog.stream = System.out
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    database = Room
+      .inMemoryDatabaseBuilder(context, MetricsDatabase::class.java)
+      .allowMainThreadQueries()
+      .setQueryExecutor(testDispatcher.asExecutor())
+      .setTransactionExecutor(testDispatcher.asExecutor())
+      .build()
+  }
+
+  @After
+  fun tearDown() {
+    database.close()
+  }
+
+  private suspend fun insertSession(id: String) {
+    database.sessionDao().insert(
+      Session(id = id, startTimestamp = "2026-08-13T10:00:00.000Z")
+    )
+  }
+
+  private suspend fun allSpans() = database.spanDao().getSpans(afterId = -1, limit = Int.MAX_VALUE)
+
+  @Test
+  fun `persists a completed request as a span attributed to the provided session`() = runTest(testDispatcher) {
+    insertSession("main-session")
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "main-session"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    val rows = allSpans()
+    assertEquals(1, rows.size)
+    assertEquals("main-session", rows.single().sessionId)
+    assertEquals("GET", rows.single().name)
+  }
+
+  @Test
+  fun `installing on the monitor backfills buffered requests and persists new ones`() = runTest(testDispatcher) {
+    // The interceptor installs at Application.onCreate, but persistence can only start once
+    // the module created the session. Requests observed in between sit in the monitor's ring
+    // buffer, so installation drains it and startup traffic is not lost.
+    insertSession("main-session")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "main-session"
+    )
+    monitor.installPersistence(persistence)
+    monitor.record(makeRequest(method = "POST"))
+    testScheduler.advanceUntilIdle()
+    val rows = allSpans()
+    assertEquals(listOf("GET", "POST"), rows.map { it.name })
+  }
+
+  @Test
+  fun `reinstalling after a completed backfill does not re-drain the buffer`() = runTest(testDispatcher) {
+    // The module reinstalls on every JS reload; a second drain would duplicate the buffered
+    // startup requests under the new session id.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    testScheduler.advanceUntilIdle()
+    monitor.uninstallPersistence(first)
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    monitor.record(makeRequest(method = "POST"))
+    testScheduler.advanceUntilIdle()
+    assertEquals(listOf("GET", "POST"), allSpans().map { it.name })
+  }
+
+  @Test
+  fun `a backfill canceled before completing is retried by the next install`() = runTest(testDispatcher) {
+    // A JS reload cancels the module scope the batch runs on. The drained-flag flips only on
+    // completion, so the next install drains again instead of losing the buffer for good.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    monitor.record(makeRequest(method = "GET"))
+    val canceledScope = CoroutineScope(testDispatcher + Job())
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = canceledScope,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    canceledScope.cancel()
+    testScheduler.advanceUntilIdle()
+    assertTrue(allSpans().isEmpty())
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    assertEquals(listOf("GET"), allSpans().map { it.name })
+  }
+
+  @Test
+  fun `a backfill canceled midway through does not report completion`() = runTest(testDispatcher) {
+    // Cancelling once the batch is inserting is the case a JS reload actually hits. Each
+    // remaining insert then throws `CancellationException`, and swallowing those would run the
+    // loop to the end and flip the drained flag, losing the buffered requests for good.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    repeat(3) { index ->
+      monitor.record(makeRequest(method = "GET", url = "https://api.example.com/$index"))
+    }
+    val canceledScope = CoroutineScope(testDispatcher + Job())
+    var reportedComplete = false
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = canceledScope,
+      sessionId = "s"
+    )
+    // Cancel from inside the loop's own iteration: `persistBuffered` walks this list, so
+    // cancelling as the last element is produced makes the remaining inserts throw
+    // `CancellationException` from within the loop. Swallowing those would let the loop finish
+    // and report completion for a batch that never wrote its remaining rows.
+    val buffered = monitor.recent
+    var handed = 0
+    val cancelingList = object : AbstractList<NetworkRequest>() {
+      override val size = buffered.size
+      override fun get(index: Int): NetworkRequest {
+        handed++
+        if (handed == buffered.size) {
+          canceledScope.cancel()
+        }
+        return buffered[index]
+      }
+    }
+    persistence.persistBuffered(cancelingList) { reportedComplete = true }
+    testScheduler.advanceUntilIdle()
+    assertFalse("a canceled batch must not report completion", reportedComplete)
+  }
+
+  @Test
+  fun `requests completing between uninstall and the next install are not lost`() = runTest(testDispatcher) {
+    // A production host recreation (an `expo-updates` reload) uninstalls persistence, then the
+    // next module waits for its session row before installing. Requests landing in that window
+    // reach the ring buffer but no live persistence, so without a re-drain they are never
+    // written.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    // A startup request, so the first install drains a real buffer and marks it drained.
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/startup"))
+    val first = NetworkRequestPersistence(database = database, scope = this, sessionId = "s")
+    monitor.installPersistence(first)
+    testScheduler.advanceUntilIdle()
+    monitor.uninstallPersistence(first)
+
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/in-window"))
+    testScheduler.advanceUntilIdle()
+
+    val second = NetworkRequestPersistence(database = database, scope = this, sessionId = "s")
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    val urls = allSpans().map { JSONObject(checkNotNull(it.attributes)).getString("url.full") }
+    assertTrue("the in-window request must reach the table, got $urls", urls.any { it.endsWith("/in-window") })
+  }
+
+  @Test
+  fun `a live-persisted request is not re-persisted by the next install`() = runTest(testDispatcher) {
+    // `record` writes a request through the installed persistence immediately. A later install
+    // must not drain it again from the ring buffer, or every JS reload duplicates every request
+    // still in the buffer, each copy under a fresh span id the server cannot dedupe.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    testScheduler.advanceUntilIdle()
+    // Persisted live, while a persistence is installed.
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/live"))
+    testScheduler.advanceUntilIdle()
+    monitor.uninstallPersistence(first)
+
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    val live = allSpans().count {
+      JSONObject(checkNotNull(it.attributes)).getString("url.full").endsWith("/live")
+    }
+    assertEquals("a live-persisted request must be written exactly once", 1, live)
+  }
+
+  @Test
+  fun `a drained request is not re-drained after aging out of the buffer`() = runTest(testDispatcher) {
+    // A request that both drained and then aged out of the ring buffer must not be written
+    // again by a later install.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor(recentCapacity = 2)
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/first"))
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    // Install starts the drain, then uninstall immediately: the next two requests arrive with no
+    // persistence installed, so they only reach the ring buffer and push `/first` out of it
+    // before the batch's completion callback runs.
+    monitor.installPersistence(first)
+    monitor.uninstallPersistence(first)
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/second"))
+    monitor.record(makeRequest(method = "GET", url = "https://api.example.com/third"))
+    testScheduler.advanceUntilIdle()
+
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    val firstCount = allSpans().count {
+      JSONObject(checkNotNull(it.attributes)).getString("url.full").endsWith("/first")
+    }
+    assertEquals("the evicted request must not be written twice", 1, firstCount)
+  }
+
+  @Test
+  fun `eviction prunes the drained set so it stays bounded by the buffer`() = runTest(testDispatcher) {
+    // The drained set exists only to suppress a re-drain of ids a later install could still see
+    // in the ring buffer, so eviction has to forget the evicted id. Without that the set grows
+    // for the life of the process, one UUID per request.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor(recentCapacity = 2)
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(persistence)
+    testScheduler.advanceUntilIdle()
+    for (i in 0 until 20) {
+      monitor.record(makeRequest(method = "GET", url = "https://api.example.com/$i"))
+    }
+    testScheduler.advanceUntilIdle()
+    assertEquals("the buffer must stay at its capacity", 2, monitor.recent.size)
+    assertEquals(
+      "the drained set must not outgrow the buffer it guards",
+      2,
+      monitor.drainedRequestIdCount
+    )
+  }
+
+  @Test
+  fun `overflow while persistence is installed does not re-drain the survivors`() = runTest(testDispatcher) {
+    // Every request here is written live and marked, then all but the last two are evicted. The
+    // marks that eviction drops belong to rows already on disk, so a reinstall that rescans the
+    // buffer must still find nothing to drain.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor(recentCapacity = 2)
+    val first = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(first)
+    testScheduler.advanceUntilIdle()
+    for (i in 0 until 10) {
+      monitor.record(makeRequest(method = "GET", url = "https://api.example.com/$i"))
+    }
+    testScheduler.advanceUntilIdle()
+    monitor.uninstallPersistence(first)
+
+    val second = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(second)
+    testScheduler.advanceUntilIdle()
+    val urls = allSpans().map { JSONObject(checkNotNull(it.attributes)).getString("url.full") }
+    assertEquals("every request must be written exactly once, got $urls", 10, urls.size)
+    assertEquals("no request may be written twice, got $urls", 10, urls.toSet().size)
+  }
+
+  @Test
+  fun `an uninstalled persistence receives no further requests`() = runTest(testDispatcher) {
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(persistence)
+    monitor.uninstallPersistence(persistence)
+    monitor.record(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertTrue(allSpans().isEmpty())
+  }
+
+  @Test
+  fun `uninstalling a stale instance leaves its replacement installed`() = runTest(testDispatcher) {
+    // A late-arriving OnDestroy from the torn-down module must not remove the instance the
+    // next module installed.
+    insertSession("s")
+    val monitor = NetworkRequestMonitor()
+    val stale = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(stale)
+    val replacement = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "s"
+    )
+    monitor.installPersistence(replacement)
+    monitor.uninstallPersistence(stale)
+    monitor.record(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertEquals(1, allSpans().size)
+  }
+
+  @Test
+  fun `drops a request whose session row does not exist yet`() = runTest(testDispatcher) {
+    // The sessions FK protects referential integrity; persistence must degrade to a dropped
+    // row rather than throw into the monitor's record path.
+    val persistence = NetworkRequestPersistence(
+      database = database,
+      scope = this,
+      sessionId = "never-inserted"
+    )
+    persistence.persist(makeRequest())
+    testScheduler.advanceUntilIdle()
+    assertTrue(allSpans().isEmpty())
+  }
+}

--- a/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
@@ -11,6 +11,12 @@ public class AppMetricsAppDelegateSubscriber: ExpoAppDelegateSubscriber {
     AppMetricsActor.isolated {
       NetworkPathMonitor.shared.start()
       NetworkRequestMonitor.shared.start()
+      // From here on every completed request is written to the database, attributed to the main
+      // session. The session's row INSERT was enqueued on the actor when `mainSession` was first
+      // touched above, so it lands before any request row that references it.
+      NetworkRequestMonitor.shared.persistence = NetworkRequestPersistence(database: AppMetrics.database) {
+        return AppMetrics.mainSession.id
+      }
     }
   }
 

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -50,6 +50,12 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// string rather than carrying `NSError` so the type stays `Sendable` and serializable.
   public let errorDescription: String?
 
+  /// Stable `domain:code` pair of the completion error (e.g. `NSURLErrorDomain:-1009`), or `nil`
+  /// when the task completed without one. Unlike `errorDescription`, which is localized free text,
+  /// this stays constant across locales and OS releases, so telemetry can group failures by it —
+  /// it feeds the low-cardinality `error.type` attribute of OpenTelemetry's semantic conventions.
+  public let errorType: String?
+
   /// Ordered list of redirect hops that preceded the final response. Empty when the task returned
   /// directly. Each entry describes one hop: `fromUrl` is the URL that returned the redirect,
   /// `statusCode` is the 3xx code it returned, and `toUrl` is where the redirect pointed. For a
@@ -263,6 +269,10 @@ extension NetworkRequest {
       cameFromNetwork: cameFromNetwork,
       timings: timings,
       errorDescription: error.map { ($0 as NSError).localizedDescription },
+      errorType: error.map {
+        let nsError = $0 as NSError
+        return "\(nsError.domain):\(nsError.code)"
+      },
       redirects: redirects
     )
   }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequest.swift
@@ -35,13 +35,32 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// Number of bytes received on the wire for the response (headers + body).
   public let responseBytesReceived: Int64?
 
-  /// Whether the response came off the network rather than out of a cache.
+  /// How the OS satisfied the request, or `nil` when it did not classify the fetch (an
+  /// `NSURLProtocol` subclass intercepted the task, or no transaction was reported).
   ///
-  /// `true` only for a fetch the OS identified as a network load. `URLSession` timestamps a cache
-  /// hit like any other response, so this is the only way to tell a disk read from a download, and
-  /// an unclassified fetch is treated as unusable rather than assumed. Android needs no equivalent,
-  /// since OkHttp skips the response-body callbacks for a cached response.
-  public let cameFromNetwork: Bool?
+  /// `URLSession` timestamps and byte-counts a cache hit like any other response, so this is the
+  /// only way to tell a disk read from a download: without it a large cached response looks like
+  /// an impossible transfer rate.
+  public let fetchType: FetchType?
+
+  /// How a response was produced, mapped from `URLSessionTaskTransactionMetrics.resourceFetchType`.
+  /// Mirrors the Android `NetworkRequest.FetchType`, which additionally reports a conditional-GET
+  /// revalidation that `URLSession` folds into `cache`.
+  public enum FetchType: String, Sendable {
+    /// Fetched over the network.
+    case network
+    /// Served from the local URL cache without a network load.
+    case cache
+    /// Delivered by an HTTP/2 server push.
+    case serverPush = "server_push"
+  }
+
+  /// Whether the response came off the network rather than out of a cache or a server push.
+  /// `nil` when the OS did not classify the fetch, which callers must treat as unusable rather
+  /// than assume either way.
+  public var cameFromNetwork: Bool? {
+    return fetchType.map { $0 == .network }
+  }
 
   /// Phase-by-phase timings pulled from the most recent (post-redirect) transaction.
   public let timings: Timings
@@ -50,11 +69,18 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
   /// string rather than carrying `NSError` so the type stays `Sendable` and serializable.
   public let errorDescription: String?
 
+  /// Stable `domain:code` pair of the completion error (e.g. `NSURLErrorDomain:-1009`), or `nil`
+  /// when the task completed without one. Unlike `errorDescription`, which is localized free text,
+  /// this stays constant across locales and OS releases, so telemetry can group failures by it.
+  /// It feeds the low-cardinality `error.type` attribute of OpenTelemetry's semantic conventions.
+  public let errorType: String?
+
   /// Ordered list of redirect hops that preceded the final response. Empty when the task returned
   /// directly. Each entry describes one hop: `fromUrl` is the URL that returned the redirect,
-  /// `statusCode` is the 3xx code it returned, and `toUrl` is where the redirect pointed. For a
-  /// complete chain the first entry's `fromUrl` equals the parent event's `url`, and the last
-  /// entry's `toUrl` is where the request actually landed.
+  /// `statusCode` is the 3xx code it returned, `toUrl` is where the redirect pointed, and
+  /// `respondedAt` is when that 3xx response arrived. For a complete chain the first entry's
+  /// `fromUrl` equals the parent event's `url`, and the last entry's `toUrl` is where the request
+  /// actually landed.
   public let redirects: [Redirect]
 
   public struct Redirect: Sendable, Equatable {
@@ -64,6 +90,16 @@ public struct NetworkRequest: Sendable, Equatable, Identifiable {
     public let toUrl: URL
     /// The 3xx status code returned by `fromUrl` that caused this hop.
     public let statusCode: Int
+    /// When the 3xx response arrived (the hop transaction's `responseEndDate`), or `nil` when the
+    /// OS did not report it.
+    public let respondedAt: Date?
+
+    init(fromUrl: URL, toUrl: URL, statusCode: Int, respondedAt: Date? = nil) {
+      self.fromUrl = fromUrl
+      self.toUrl = toUrl
+      self.statusCode = statusCode
+      self.respondedAt = respondedAt
+    }
   }
 
   public struct Timings: Sendable, Equatable {
@@ -167,19 +203,34 @@ extension NetworkRequest {
     let url = request.url ?? URL(string: "about:blank")!
     let method = request.httpMethod ?? "GET"
 
-    // We use the last transaction so that redirects don't drop us back to the first hop. If a
-    // future need arises to surface per-hop timing, expose `metrics.transactionMetrics` here.
+    // Per-phase fields describe the transaction that produced the final response, so they come
+    // from the last transaction: redirects must not drop us back to the first hop's connection
+    // and byte counts. `fetchStart` is the exception. It anchors the whole request, including
+    // every redirect hop the span records as an event, so it comes from the first transaction.
+    // Taking it from the last one would start the window after hops that already happened.
     let transaction = metrics?.transactionMetrics.last
+    let firstTransaction = metrics?.transactionMetrics.first
 
-    // Only a fetch the OS positively identified as a network load counts. `.unknown` is excluded
-    // too: a cache hit reports byte counts and timestamps like any other response, so an
-    // unclassified fetch that was really a disk read would otherwise divide megabytes by the
-    // milliseconds it took to read them. Costs the rate for tasks an `NSURLProtocol` subclass
-    // intercepted, which also report `.unknown`, and a missing rate beats an impossible one.
-    let cameFromNetwork = transaction.map { $0.resourceFetchType == .networkLoad }
+    // `.unknown` maps to nil rather than a guess: a cache hit reports byte counts and timestamps
+    // like any other response, so an unclassified fetch that was really a disk read would
+    // otherwise divide megabytes by the milliseconds it took to read them. Costs the throughput
+    // rate for tasks an `NSURLProtocol` subclass intercepted, which also report `.unknown`, and a
+    // missing rate beats an impossible one.
+    let fetchType: FetchType? = transaction.flatMap { transaction in
+      switch transaction.resourceFetchType {
+      case .networkLoad:
+        return .network
+      case .localCache:
+        return .cache
+      case .serverPush:
+        return .serverPush
+      default:
+        return nil
+      }
+    }
 
     let timings = NetworkRequest.Timings(
-      fetchStart: transaction?.fetchStartDate ?? fallbackStart,
+      fetchStart: firstTransaction?.fetchStartDate ?? fallbackStart,
       domainLookupStart: transaction?.domainLookupStartDate,
       domainLookupEnd: transaction?.domainLookupEndDate,
       connectStart: transaction?.connectStartDate,
@@ -247,7 +298,14 @@ extension NetworkRequest {
         else {
           continue
         }
-        result.append(Redirect(fromUrl: fromUrl, toUrl: toUrl, statusCode: response.statusCode))
+        result.append(
+          Redirect(
+            fromUrl: fromUrl,
+            toUrl: toUrl,
+            statusCode: response.statusCode,
+            respondedAt: current.responseEndDate
+          )
+        )
       }
       return result
     }()
@@ -260,9 +318,13 @@ extension NetworkRequest {
       networkProtocol: transaction?.networkProtocolName,
       requestBytesSent: requestBytesSent,
       responseBytesReceived: responseBytesReceived,
-      cameFromNetwork: cameFromNetwork,
+      fetchType: fetchType,
       timings: timings,
       errorDescription: error.map { ($0 as NSError).localizedDescription },
+      errorType: error.map {
+        let nsError = $0 as NSError
+        return "\(nsError.domain):\(nsError.code)"
+      },
       redirects: redirects
     )
   }

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestMonitor.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestMonitor.swift
@@ -46,6 +46,12 @@ public final class NetworkRequestMonitor: Sendable {
   private var delegates: [WeakDelegate] = []
   private var started = false
 
+  /// Persists each recorded completion into the metrics database. Installed at launch by
+  /// `AppMetricsAppDelegateSubscriber`; `nil` until then (and in tests that don't exercise
+  /// persistence). Held strongly — unlike delegates, persistence is part of the pipeline, not an
+  /// observer of it.
+  var persistence: NetworkRequestPersistence?
+
   /// Internal so tests can construct dedicated instances; production code uses `shared`.
   init() {}
 
@@ -99,6 +105,7 @@ public final class NetworkRequestMonitor: Sendable {
     if recentRequests.count > recentCapacity {
       recentRequests.removeFirst(recentRequests.count - recentCapacity)
     }
+    persistence?.persist(request)
     pruneDelegates()
     for entry in delegates {
       guard let delegate = entry.value else {

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestMonitor.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestMonitor.swift
@@ -46,6 +46,12 @@ public final class NetworkRequestMonitor: Sendable {
   private var delegates: [WeakDelegate] = []
   private var started = false
 
+  /// Persists each recorded completion into the metrics database. Installed at launch by
+  /// `AppMetricsAppDelegateSubscriber`; `nil` until then (and in tests that don't exercise
+  /// persistence). Held strongly because unlike delegates, persistence is part of the pipeline, not an
+  /// observer of it.
+  var persistence: NetworkRequestPersistence?
+
   /// Internal so tests can construct dedicated instances; production code uses `shared`.
   init() {}
 
@@ -99,6 +105,7 @@ public final class NetworkRequestMonitor: Sendable {
     if recentRequests.count > recentCapacity {
       recentRequests.removeFirst(recentRequests.count - recentCapacity)
     }
+    persistence?.persist(request)
     pruneDelegates()
     for entry in delegates {
       guard let delegate = entry.value else {

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestObserver.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestObserver.swift
@@ -94,11 +94,14 @@ public final class NetworkRequestObserver: SharedObject, NetworkRequestObserverD
       "startedAt": request.timings.fetchStart?.ISO8601Format(),
       "completedAt": request.timings.responseEnd?.ISO8601Format(),
       "totalDuration": request.timings.totalDuration,
-      "redirects": request.redirects.map {
+      "redirects": request.redirects.map { redirect -> [String: Any?] in
         return [
-          "fromUrl": $0.fromUrl.absoluteString,
-          "toUrl": $0.toUrl.absoluteString,
-          "statusCode": $0.statusCode,
+          "fromUrl": redirect.fromUrl.absoluteString,
+          "toUrl": redirect.toUrl.absoluteString,
+          "statusCode": redirect.statusCode,
+          // Same ISO 8601 UTC shape as `startedAt`, with fractional seconds: hops within one
+          // request are usually fractions of a second apart.
+          "respondedAt": redirect.respondedAt?.ISO8601Format(.init(includingFractionalSeconds: true)),
         ]
       },
     ]

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
@@ -1,0 +1,234 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Routes completed requests from `NetworkRequestMonitor` into the `spans` table, attributed to
+/// the main session. This is the first span producer: it converts each request into a generic
+/// `SpanRow` following the OTel HTTP semantic conventions, so the export layer (`expo-observe`)
+/// ships spans without knowing what produced them. Unlike the in-memory ring buffer, the rows
+/// survive process death until they're dispatched, pruned with their session, or displaced past
+/// the table's row cap.
+///
+/// Installed on the monitor at launch (see `AppMetricsAppDelegateSubscriber`); the monitor calls
+/// `persist` synchronously on `AppMetricsActor` for every completion it records.
+@AppMetricsActor
+final class NetworkRequestPersistence: Sendable {
+  private let database: MetricsDatabase?
+  private let sessionId: @Sendable () -> String
+
+  /// `database` is optional so a failed database open degrades to dropped rows instead of
+  /// blocking monitor start. `sessionId` is a closure so constructing the persistence doesn't
+  /// force the session machinery into existence before the app delegate finished wiring it.
+  init(database: MetricsDatabase?, sessionId: @escaping @Sendable () -> String) {
+    self.database = database
+    self.sessionId = sessionId
+  }
+
+  /// Persists one completed request as a span. Failures are logged and swallowed — persistence
+  /// must never break the monitor's fan-out to its delegates.
+  func persist(_ request: NetworkRequest) {
+    guard let database, let row = SpanRow.from(request: request, sessionId: sessionId()) else {
+      return
+    }
+    do {
+      try database.insert(span: row)
+    } catch {
+      logger.warn("[AppMetrics] Failed to persist a network request span: \(error.localizedDescription)")
+    }
+  }
+}
+
+extension SpanRow {
+  /// Builds a span row from a completed request snapshot, per the OTel HTTP semantic conventions
+  /// for a client span: the span is named after the method (`HTTP` for a nonstandard one), a
+  /// transport failure or a 4xx/5xx response makes it an ERROR, and each redirect hop becomes an
+  /// `expo.http.redirect` event.
+  ///
+  /// The attribute keys mirror the set the ingestion endpoint extracts into dedicated columns
+  /// (`http.request.method`, `url.full`, `server.address`, ...). `url.full` is redacted here, at
+  /// the instrumentation, as the conventions require: userinfo credentials and the default
+  /// sensitive query values never reach disk or the wire (ingestion redacts again as defense in
+  /// depth). An intentionally cancelled request keeps its span but stays UNSET with no
+  /// `error.type`, per the conventions — RN apps cancel routinely, and counting aborts as errors
+  /// would poison every error-rate view. `error.type` must stay low-cardinality: the captured
+  /// `domain:code` pair for a transport failure, or the bare status code when the response itself
+  /// was the error; the localized `errorDescription` goes to the status message instead.
+  ///
+  /// Returns `nil` when the snapshot carries no usable timestamps — without either endpoint of
+  /// the request window there is nothing to anchor a span to. The capture factory always sets
+  /// both, so this only guards directly constructed values.
+  static func from(request: NetworkRequest, sessionId: String) -> SpanRow? {
+    let start = request.timings.fetchStart
+    let end = request.timings.responseEnd
+    let duration = request.timings.totalDuration
+    guard
+      let resolvedStart = start ?? end?.addingTimeInterval(-duration),
+      let resolvedEnd = end ?? start?.addingTimeInterval(duration)
+    else {
+      return nil
+    }
+
+    // Case-sensitive per the conventions: an unknown or nonstandard method becomes `_OTHER`
+    // (verbatim value preserved in `http.request.method_original`) and names the span `HTTP`,
+    // so caller-controlled verbs can't mint unbounded span names.
+    let isKnownMethod = knownHttpMethods.contains(request.method)
+    var attributes: [String: Any] = [
+      "http.request.method": isKnownMethod ? request.method : "_OTHER",
+      "url.full": redactedUrlFull(request.url),
+    ]
+    if !isKnownMethod {
+      attributes["http.request.method_original"] = request.method
+    }
+    if let host = request.url.host {
+      attributes["server.address"] = host
+    }
+    if let port = request.url.port ?? defaultPort(forScheme: request.url.scheme) {
+      attributes["server.port"] = port
+    }
+    if let statusCode = request.statusCode {
+      attributes["http.response.status_code"] = statusCode
+    }
+    if let version = semconvProtocolVersion(request.networkProtocol) {
+      attributes["network.protocol.version"] = version
+    }
+    if let requestBytesSent = request.requestBytesSent {
+      attributes["http.request.size"] = requestBytesSent
+    }
+    if let responseBytesReceived = request.responseBytesReceived {
+      attributes["http.response.size"] = responseBytesReceived
+    }
+    let httpErrorStatus = (request.statusCode ?? 0) >= 400
+    // An intentional cancellation is not a failure: status stays UNSET and `error.type` is
+    // never set, per the conventions.
+    let cancelled = request.errorType == cancelledErrorType
+    if !cancelled, let errorType = request.errorType ?? (httpErrorStatus ? request.statusCode.map(String.init) : nil) {
+      attributes["error.type"] = errorType
+    }
+
+    let failed = !cancelled && (request.errorDescription != nil || request.errorType != nil || httpErrorStatus)
+    // The conventions model redirects as resent spans (`http.request.resend_count`), not
+    // events; one span per chain is a deliberate deviation for this pipeline. The event name is
+    // `expo.`-prefixed because semconv reserves the bare `http.` namespace for itself.
+    let events: [[String: Any]] = request.redirects.map { redirect in
+      return [
+        "name": "expo.http.redirect",
+        "attributes": [
+          "from": redirect.fromUrl.absoluteString,
+          "to": redirect.toUrl.absoluteString,
+          "statusCode": redirect.statusCode,
+        ],
+      ]
+    }
+
+    return SpanRow(
+      sessionId: sessionId,
+      name: isKnownMethod ? request.method : "HTTP",
+      kind: SpanRow.clientKind,
+      startTimestampMs: resolvedStart.unixMilliseconds,
+      endTimestampMs: resolvedEnd.unixMilliseconds,
+      statusCode: failed ? SpanRow.statusError : nil,
+      statusMessage: failed ? request.errorDescription : nil,
+      attributes: serializeJSON(attributes),
+      events: events.isEmpty ? nil : serializeJSON(events)
+    )
+  }
+
+  /// The standard method set per RFC 9110, matched case-sensitively as the conventions require.
+  private static let knownHttpMethods: Set<String> = [
+    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH",
+  ]
+
+  /// `errorType` value NSURLSession reports for an intentional cancellation
+  /// (`NSURLErrorCancelled`).
+  private static let cancelledErrorType = "NSURLErrorDomain:-999"
+
+  /// Query parameter names whose values are redacted by default, per the conventions' list for
+  /// `url.full` (signed-URL secrets: S3 presigned, GCS signed, SAS-style tokens). Compared
+  /// case-insensitively.
+  private static let sensitiveQueryParameters: Set<String> = [
+    "awsaccesskeyid", "signature", "sig", "x-amz-signature", "x-goog-signature",
+  ]
+
+  /// `url.full` with userinfo credentials replaced by `REDACTED:REDACTED` and default-sensitive
+  /// query values replaced by `REDACTED`, per the conventions — redaction is the
+  /// instrumentation's job, so secrets never reach the on-device database or the wire.
+  private static func redactedUrlFull(_ url: URL) -> String {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      // An unparseable URL can't prove it carries no secrets; drop the query outright.
+      return url.absoluteString.components(separatedBy: "?").first ?? url.absoluteString
+    }
+    // Rewrite the components only when something was actually redacted: reassigning
+    // `queryItems` re-encodes the whole query, and the round trip is not byte-faithful
+    // (`a%2Bb` decodes to `a+b` and re-encodes as a literal `+`, which backends read as a
+    // space). The common no-redaction path must return the URL exactly as sent.
+    var redactedAnything = false
+    if components.user != nil || components.password != nil {
+      components.user = "REDACTED"
+      components.password = "REDACTED"
+      redactedAnything = true
+    }
+    if let queryItems = components.queryItems, !queryItems.isEmpty {
+      var itemsChanged = false
+      let redactedItems = queryItems.map { item -> URLQueryItem in
+        guard sensitiveQueryParameters.contains(item.name.lowercased()), item.value != nil else {
+          return item
+        }
+        itemsChanged = true
+        return URLQueryItem(name: item.name, value: "REDACTED")
+      }
+      if itemsChanged {
+        components.queryItems = redactedItems
+        redactedAnything = true
+      }
+    }
+    guard redactedAnything else {
+      return url.absoluteString
+    }
+    return components.string ?? url.absoluteString
+  }
+
+  /// Scheme-default port per semconv's `server.port` (a Required attribute for HTTP client
+  /// spans), used when the URL carries no explicit port.
+  private static func defaultPort(forScheme scheme: String?) -> Int? {
+    switch scheme?.lowercased() {
+    case "https", "wss":
+      return 443
+    case "http", "ws":
+      return 80
+    default:
+      return nil
+    }
+  }
+
+  /// Bare protocol version per semconv's `network.protocol.version` ("1.1", "2", "3"), mapped
+  /// from the ALPN-style names the OS reports ("http/1.1", "h2", "h3"). Unrecognized values pass
+  /// through verbatim rather than being dropped.
+  private static func semconvProtocolVersion(_ networkProtocol: String?) -> String? {
+    switch networkProtocol {
+    case nil:
+      return nil
+    case "h2":
+      return "2"
+    case "h3":
+      return "3"
+    case .some(let other):
+      return other.hasPrefix("http/") ? String(other.dropFirst("http/".count)) : other
+    }
+  }
+
+  /// Serializes a JSON-compatible value built above; the inputs are all strings and numbers, so
+  /// a failure means a programming error and degrading to `nil` (dropped blob) is safe.
+  private static func serializeJSON(_ object: Any) -> String? {
+    guard let data = try? JSONSerialization.data(withJSONObject: object) else {
+      logger.warn("[AppMetrics] Failed to serialize span attributes")
+      return nil
+    }
+    return String(data: data, encoding: .utf8)
+  }
+}
+
+extension Date {
+  fileprivate var unixMilliseconds: Int64 {
+    return Int64((timeIntervalSince1970 * 1_000).rounded())
+  }
+}

--- a/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
+++ b/packages/expo-app-metrics/ios/NetworkRequests/NetworkRequestPersistence.swift
@@ -1,0 +1,242 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Records completed network requests as trace spans in the `spans` table.
+///
+/// Mirrors the Android `NetworkRequestPersistence`.
+@AppMetricsActor
+final class NetworkRequestPersistence: Sendable {
+  /// Optional so a failed database open degrades to dropped rows instead of blocking the
+  /// monitor from starting.
+  private let database: MetricsDatabase?
+
+  /// A closure so constructing this does not force the session machinery into existence before
+  /// the app delegate finished wiring it.
+  private let sessionId: @Sendable () -> String
+
+  init(database: MetricsDatabase?, sessionId: @escaping @Sendable () -> String) {
+    self.database = database
+    self.sessionId = sessionId
+  }
+
+  /// Records one completed request as a span.
+  func persist(_ request: NetworkRequest) {
+    guard let database, let row = SpanRow.from(request: request, sessionId: sessionId()) else {
+      return
+    }
+    do {
+      try database.insert(span: row)
+    } catch {
+      // Swallowed: recording telemetry must never break the monitor's fan-out to its delegates.
+      logger.warn("[AppMetrics] Failed to persist a network request span: \(error.localizedDescription)")
+    }
+  }
+}
+
+extension SpanRow {
+  /// Maps a completed request onto a client span, per the OTel HTTP semantic conventions.
+  ///
+  /// The attribute keys are the set the ingestion endpoint extracts into dedicated columns.
+  /// Returns `nil` when the snapshot has no usable timestamps, leaving nothing to anchor a span
+  /// to.
+  static func from(request: NetworkRequest, sessionId: String) -> SpanRow? {
+    let start = request.timings.fetchStart
+    let end = request.timings.responseEnd
+    let duration = request.timings.totalDuration
+    guard
+      let resolvedStart = start ?? end?.addingTimeInterval(-duration),
+      let resolvedEnd = end ?? start?.addingTimeInterval(duration)
+    else {
+      return nil
+    }
+
+    // Case-sensitive per the conventions: an unknown or nonstandard method becomes `_OTHER`
+    // (verbatim value preserved in `http.request.method_original`) and names the span `HTTP`,
+    // so caller-controlled verbs can't mint unbounded span names.
+    let isKnownMethod = knownHttpMethods.contains(request.method)
+    var attributes: [String: Any] = [
+      "http.request.method": isKnownMethod ? request.method : "_OTHER",
+      "url.full": redactedUrlFull(request.url),
+    ]
+    if !isKnownMethod {
+      attributes["http.request.method_original"] = request.method
+    }
+    if let host = request.url.host {
+      attributes["server.address"] = host
+    }
+    if let port = request.url.port ?? defaultPort(forScheme: request.url.scheme) {
+      attributes["server.port"] = port
+    }
+    if let statusCode = request.statusCode {
+      attributes["http.response.status_code"] = statusCode
+    }
+    if let version = semconvProtocolVersion(request.networkProtocol) {
+      attributes["network.protocol.version"] = version
+    }
+    if let requestBytesSent = request.requestBytesSent {
+      attributes["http.request.size"] = requestBytesSent
+    }
+    if let responseBytesReceived = request.responseBytesReceived {
+      attributes["http.response.size"] = responseBytesReceived
+    }
+    // Not a semconv attribute: a cached response is timestamped and byte-counted like a download,
+    // so without this a large cache hit reads as an impossible transfer rate. Omitted when the
+    // platform did not classify the fetch, so its absence never implies a network load.
+    if let fetchType = request.fetchType {
+      attributes["expo.http.resource.fetch_type"] = fetchType.rawValue
+    }
+    let httpErrorStatus = (request.statusCode ?? 0) >= 400
+    // A cancellation is not a failure, per the conventions, but an error status still wins: a
+    // request canceled while reading a 500 was answered with a 500.
+    let wasCanceled = request.errorType == canceledErrorType
+    let canceled = wasCanceled && !httpErrorStatus
+    // Must stay low-cardinality, so never the localized description.
+    let resolvedErrorType =
+      httpErrorStatus
+      ? request.statusCode.map(String.init)
+      : (wasCanceled ? nil : request.errorType)
+    if !canceled, let errorType = resolvedErrorType {
+      attributes["error.type"] = errorType
+    }
+
+    let failed = !canceled && (request.errorDescription != nil || request.errorType != nil || httpErrorStatus)
+    // A deliberate deviation: the conventions model redirects as resent spans
+    // (`http.request.resend_count`), but this pipeline records one span per chain.
+    let events: [[String: Any]] = request.redirects.map { redirect in
+      var event: [String: Any] = [
+        "name": "expo.http.redirect",
+        // `expo.`-namespaced: the naming guidelines advise against application-specific names
+        // under a semconv namespace. The status code reuses the registry attribute it matches.
+        "attributes": [
+          "expo.http.redirect.from": redirect.fromUrl.absoluteString,
+          "expo.http.redirect.to": redirect.toUrl.absoluteString,
+          "http.response.status_code": redirect.statusCode,
+        ],
+      ]
+      // An OTLP event outside its own span has no valid place on the timeline. Without a time
+      // the exporter anchors it to the span start.
+      if let respondedAt = redirect.respondedAt?.unixMilliseconds,
+        respondedAt >= resolvedStart.unixMilliseconds,
+        respondedAt <= resolvedEnd.unixMilliseconds
+      {
+        event["timeMs"] = respondedAt
+      }
+      return event
+    }
+
+    return SpanRow(
+      sessionId: sessionId,
+      name: isKnownMethod ? request.method : "HTTP",
+      kind: SpanRow.clientKind,
+      startTimestampMs: resolvedStart.unixMilliseconds,
+      endTimestampMs: resolvedEnd.unixMilliseconds,
+      statusCode: failed ? SpanRow.statusError : nil,
+      statusMessage: failed ? request.errorDescription : nil,
+      attributes: serializeJSON(attributes),
+      events: events.isEmpty ? nil : serializeJSON(events)
+    )
+  }
+
+  /// The conventions' known method set: RFC 9110's methods plus PATCH and QUERY, matched
+  /// case-sensitively as the conventions require.
+  private static let knownHttpMethods: Set<String> = [
+    "GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "QUERY",
+  ]
+
+  /// `errorType` value NSURLSession reports for an intentional cancellation
+  /// (`NSURLErrorCancelled`).
+  private static let canceledErrorType = "NSURLErrorDomain:-999"
+
+  /// The conventions' default-sensitive `url.full` parameters, plus the legacy S3 pair.
+  private static let sensitiveQueryParameters: Set<String> = [
+    "awsaccesskeyid", "signature", "sig", "x-amz-signature", "x-amz-credential", "x-amz-security-token",
+    "x-goog-signature",
+  ]
+
+  /// Redacts userinfo and default-sensitive query values, so secrets never reach disk or the
+  /// wire.
+  private static func redactedUrlFull(_ url: URL) -> String {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      // An unparseable URL can't prove it carries no secrets; drop the query outright.
+      return url.absoluteString.components(separatedBy: "?").first ?? url.absoluteString
+    }
+    // Uses `percentEncodedQueryItems`, not `queryItems`: the decoded form is not byte-faithful
+    // (`a%2Bb` becomes a literal `+`, which backends read as a space), which would corrupt the
+    // parameters this function keeps.
+    var redactedAnything = false
+    if components.user != nil || components.password != nil {
+      components.user = "REDACTED"
+      components.password = "REDACTED"
+      redactedAnything = true
+    }
+    if let queryItems = components.percentEncodedQueryItems, !queryItems.isEmpty {
+      var itemsChanged = false
+      let redactedItems = queryItems.map { item -> URLQueryItem in
+        // A valueless parameter (`?sig`) carries no secret, and giving it one would report a URL
+        // the app never sent.
+        // Match the decoded name: a server reads `%73ig` as `sig`.
+        let decodedName = item.name.removingPercentEncoding ?? item.name
+        guard sensitiveQueryParameters.contains(decodedName.lowercased()), item.value != nil else {
+          return item
+        }
+        itemsChanged = true
+        return URLQueryItem(name: item.name, value: "REDACTED")
+      }
+      if itemsChanged {
+        components.percentEncodedQueryItems = redactedItems
+        redactedAnything = true
+      }
+    }
+    guard redactedAnything else {
+      return url.absoluteString
+    }
+    return components.string ?? url.absoluteString
+  }
+
+  /// Scheme-default port per semconv's `server.port` (a Required attribute for HTTP client
+  /// spans), used when the URL carries no explicit port.
+  private static func defaultPort(forScheme scheme: String?) -> Int? {
+    switch scheme?.lowercased() {
+    case "https", "wss":
+      return 443
+    case "http", "ws":
+      return 80
+    default:
+      return nil
+    }
+  }
+
+  /// Bare protocol version per semconv's `network.protocol.version` ("1.1", "2", "3"), mapped
+  /// from the ALPN-style names the OS reports ("http/1.1", "h2", "h3"). Unrecognized values pass
+  /// through verbatim rather than being dropped.
+  private static func semconvProtocolVersion(_ networkProtocol: String?) -> String? {
+    switch networkProtocol {
+    case nil:
+      return nil
+    case "h2":
+      return "2"
+    case "h3":
+      return "3"
+    case .some(let other):
+      return other.hasPrefix("http/") ? String(other.dropFirst("http/".count)) : other
+    }
+  }
+
+  /// Serializes a JSON-compatible value built above; the inputs are all strings and numbers, so
+  /// a failure means a programming error and degrading to `nil` (dropped blob) is safe.
+  private static func serializeJSON(_ object: Any) -> String? {
+    guard let data = try? JSONSerialization.data(withJSONObject: object) else {
+      logger.warn("[AppMetrics] Failed to serialize span attributes")
+      return nil
+    }
+    return String(data: data, encoding: .utf8)
+  }
+}
+
+extension Date {
+  /// Unix-epoch milliseconds, the integer form the spans table and the JS redirect record use.
+  var unixMilliseconds: Int64 {
+    return Int64((timeIntervalSince1970 * 1_000).rounded())
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
@@ -1,0 +1,371 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+private let fixedStart = Date(timeIntervalSince1970: 1_782_131_895)
+
+private func makeTimings(
+  fetchStart: Date? = fixedStart,
+  responseEnd: Date? = fixedStart.addingTimeInterval(0.25),
+  totalDuration: TimeInterval = 0.25
+) -> NetworkRequest.Timings {
+  return NetworkRequest.Timings(
+    fetchStart: fetchStart,
+    domainLookupStart: nil,
+    domainLookupEnd: nil,
+    connectStart: nil,
+    connectEnd: nil,
+    secureConnectionStart: nil,
+    secureConnectionEnd: nil,
+    requestStart: nil,
+    requestEnd: nil,
+    responseStart: nil,
+    responseEnd: responseEnd,
+    measuredResponseEnd: responseEnd,
+    totalDuration: totalDuration
+  )
+}
+
+private func makeRequest(
+  url: String = "https://api.example.com/v1/items?page=2",
+  method: String = "GET",
+  statusCode: Int? = 200,
+  networkProtocol: String? = "h2",
+  requestBytesSent: Int64? = 412,
+  responseBytesReceived: Int64? = 8_192,
+  timings: NetworkRequest.Timings = makeTimings(),
+  errorDescription: String? = nil,
+  errorType: String? = nil,
+  redirects: [NetworkRequest.Redirect] = []
+) -> NetworkRequest {
+  return NetworkRequest(
+    id: UUID(),
+    url: URL(string: url)!,
+    method: method,
+    statusCode: statusCode,
+    networkProtocol: networkProtocol,
+    requestBytesSent: requestBytesSent,
+    responseBytesReceived: responseBytesReceived,
+    cameFromNetwork: true,
+    timings: timings,
+    errorDescription: errorDescription,
+    errorType: errorType,
+    redirects: redirects
+  )
+}
+
+private func makeSpan(_ request: NetworkRequest) throws -> SpanRow {
+  return try #require(SpanRow.from(request: request, sessionId: "s"))
+}
+
+/// Decodes the row's `attributes` JSON blob for assertions.
+private func attributesDict(_ row: SpanRow) throws -> [String: Any] {
+  let json = try #require(row.attributes)
+  let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+  return try #require(object as? [String: Any])
+}
+
+/// Decodes the row's `events` JSON blob for assertions.
+private func eventsArray(_ row: SpanRow) throws -> [[String: Any]] {
+  let json = try #require(row.events)
+  let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+  return try #require(object as? [[String: Any]])
+}
+
+@AppMetricsActor
+@Suite("NetworkRequest to SpanRow mapping")
+struct NetworkRequestSpanMappingTests {
+  @Test
+  func `converts a completed request into a client span with millisecond timestamps`() throws {
+    let row = try makeSpan(makeRequest(method: "POST"))
+    #expect(row.sessionId == "s")
+    #expect(row.name == "POST")
+    #expect(row.kind == SpanRow.clientKind)
+    #expect(row.startTimestampMs == 1_782_131_895_000)
+    #expect(row.endTimestampMs == 1_782_131_895_250)
+    #expect(row.parentSpanId == nil)
+    #expect(row.events == nil)
+  }
+
+  @Test
+  func `maps the HTTP semantic-convention attributes the server extracts to columns`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest()))
+    #expect(attributes["http.request.method"] as? String == "GET")
+    #expect(attributes["http.response.status_code"] as? Int == 200)
+    #expect(attributes["url.full"] as? String == "https://api.example.com/v1/items?page=2")
+    #expect(attributes["server.address"] as? String == "api.example.com")
+    #expect(attributes["http.request.size"] as? Int64 == 412)
+    #expect(attributes["http.response.size"] as? Int64 == 8_192)
+  }
+
+  @Test
+  func `normalizes the network protocol name to a semconv version`() throws {
+    // The OS reports `http/1.1`, `h2`, `h3`; semconv's `network.protocol.version` wants the
+    // bare version, and the server stores it in a LowCardinality column.
+    let expected = [
+      "http/1.1": "1.1",
+      "http/1.0": "1.0",
+      "h2": "2",
+      "h3": "3",
+    ]
+    for (reported, version) in expected {
+      let attributes = try attributesDict(makeSpan(makeRequest(networkProtocol: reported)))
+      #expect(attributes["network.protocol.version"] as? String == version)
+    }
+  }
+
+  @Test
+  func `omits attributes that were never measured`() throws {
+    // A request that died before headers has no status and no byte counts. Sending a
+    // placeholder would be indistinguishable from a genuine zero.
+    let request = makeRequest(
+      statusCode: nil,
+      networkProtocol: nil,
+      requestBytesSent: nil,
+      responseBytesReceived: nil
+    )
+    let attributes = try attributesDict(makeSpan(request))
+    #expect(attributes["http.response.status_code"] == nil)
+    #expect(attributes["network.protocol.version"] == nil)
+    #expect(attributes["http.request.size"] == nil)
+    #expect(attributes["http.response.size"] == nil)
+  }
+
+  @Test
+  func `keeps ordinary query values but redacts the default-sensitive ones`() throws {
+    // Redaction is the instrumentation's job per the conventions; signed-URL secrets must
+    // never reach the on-device database. Ordinary parameters stay, so ingestion can still
+    // group by them.
+    let url = "https://api.example.com/search?q=hello&sig=secret&X-Amz-Signature=abc"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(
+      attributes["url.full"] as? String
+        == "https://api.example.com/search?q=hello&sig=REDACTED&X-Amz-Signature=REDACTED"
+    )
+  }
+
+  @Test
+  func `leaves an unredacted URL byte-identical`() throws {
+    // Percent-encoding must survive: a decode/re-encode round trip would turn `a%2Bb` into a
+    // literal `+`, which backends read as a space.
+    let url = "https://api.example.com/search?q=a%2Bb&page=2"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(attributes["url.full"] as? String == url)
+  }
+
+  @Test
+  func `redacts userinfo credentials from the URL`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest(url: "https://user:pass@api.example.com/items")))
+    #expect(attributes["url.full"] as? String == "https://REDACTED:REDACTED@api.example.com/items")
+  }
+
+  @Test
+  func `records the server port, defaulting from the scheme`() throws {
+    let explicit = try attributesDict(makeSpan(makeRequest(url: "https://api.example.com:8443/x")))
+    #expect(explicit["server.port"] as? Int == 8443)
+    let https = try attributesDict(makeSpan(makeRequest(url: "https://api.example.com/x")))
+    #expect(https["server.port"] as? Int == 443)
+    let http = try attributesDict(makeSpan(makeRequest(url: "http://api.example.com/x")))
+    #expect(http["server.port"] as? Int == 80)
+  }
+
+  @Test
+  func `maps a nonstandard method to _OTHER and names the span HTTP`() throws {
+    // Case-sensitive per the conventions: even a lowercase standard verb is not "known", so
+    // caller-controlled method strings can't mint unbounded span names.
+    for method in ["PURGE", "get"] {
+      let row = try makeSpan(makeRequest(method: method))
+      let attributes = try attributesDict(row)
+      #expect(row.name == "HTTP")
+      #expect(attributes["http.request.method"] as? String == "_OTHER")
+      #expect(attributes["http.request.method_original"] as? String == method)
+    }
+  }
+
+  @Test
+  func `records a cancelled request without a status or error type`() throws {
+    // Intentional cancellations (AbortController, prefetch aborts) are routine in RN apps;
+    // per the conventions they keep their span but are not errors.
+    let row = try makeSpan(
+      makeRequest(
+        statusCode: nil,
+        errorDescription: "cancelled",
+        errorType: "NSURLErrorDomain:-999"
+      )
+    )
+    #expect(row.statusCode == nil)
+    #expect(row.statusMessage == nil)
+    #expect(try attributesDict(row)["error.type"] == nil)
+  }
+
+  @Test
+  func `leaves the status unset for a successful response`() throws {
+    // Semconv: a client span for a 2xx response carries no explicit status.
+    let row = try makeSpan(makeRequest(statusCode: 200))
+    #expect(row.statusCode == nil)
+    #expect(row.statusMessage == nil)
+  }
+
+  @Test
+  func `marks 4xx and 5xx responses as errors`() throws {
+    // Semconv makes any 4xx/5xx an error for a client span, unlike the server-span rule.
+    for statusCode in [400, 404, 429, 500, 503] {
+      let row = try makeSpan(makeRequest(statusCode: statusCode))
+      #expect(row.statusCode == SpanRow.statusError, "expected ERROR for status \(statusCode)")
+    }
+  }
+
+  @Test
+  func `marks a transport failure as an error with the description as the status message`() throws {
+    // `errorDescription` is localized free text, so it belongs in the status message. The
+    // low-cardinality `error.type` attribute gets a separate, predictable value.
+    let row = try makeSpan(
+      makeRequest(
+        statusCode: nil,
+        errorDescription: "The Internet connection appears to be offline.",
+        errorType: "NSURLErrorDomain:-1009"
+      )
+    )
+    #expect(row.statusCode == SpanRow.statusError)
+    #expect(row.statusMessage == "The Internet connection appears to be offline.")
+    let attributes = try attributesDict(row)
+    #expect(attributes["error.type"] as? String == "NSURLErrorDomain:-1009")
+  }
+
+  @Test
+  func `sets the error type to the status code for an HTTP error response`() throws {
+    // Semconv: when a request completes with an error status and no exception, `error.type`
+    // is the status code as a string.
+    let attributes = try attributesDict(makeSpan(makeRequest(statusCode: 503)))
+    #expect(attributes["error.type"] as? String == "503")
+  }
+
+  @Test
+  func `omits the error type on success`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest(statusCode: 204)))
+    #expect(attributes["error.type"] == nil)
+  }
+
+  @Test
+  func `maps each redirect hop onto an event`() throws {
+    let request = makeRequest(redirects: [
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/a")!,
+        toUrl: URL(string: "https://example.com/b")!,
+        statusCode: 301
+      ),
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/b")!,
+        toUrl: URL(string: "https://example.com/c")!,
+        statusCode: 302
+      ),
+    ])
+    let events = try eventsArray(makeSpan(request))
+    #expect(events.count == 2)
+    #expect(events.allSatisfy { $0["name"] as? String == "expo.http.redirect" })
+    let first = try #require(events.first?["attributes"] as? [String: Any])
+    #expect(first["from"] as? String == "https://example.com/a")
+    #expect(first["to"] as? String == "https://example.com/b")
+    #expect(first["statusCode"] as? Int == 301)
+  }
+
+  @Test
+  func `assigns generated identifiers to each span`() throws {
+    let first = try makeSpan(makeRequest())
+    let second = try makeSpan(makeRequest())
+    #expect(first.traceId.count == 32)
+    #expect(first.spanId.count == 16)
+    #expect(first.traceId != second.traceId)
+  }
+
+  @Test
+  func `derives a missing end timestamp from the total duration`() throws {
+    // The `setState:` fallback path can produce a snapshot before the OS reported a
+    // response end; the row still needs a usable window for the span.
+    let timings = makeTimings(fetchStart: fixedStart, responseEnd: nil, totalDuration: 1.5)
+    let row = try makeSpan(makeRequest(timings: timings))
+    #expect(row.startTimestampMs == 1_782_131_895_000)
+    #expect(row.endTimestampMs == 1_782_131_896_500)
+  }
+
+  @Test
+  func `returns nil when the request carries no usable timestamps`() {
+    // Without either endpoint of the window there is nothing to anchor a span to. The
+    // factory always sets both, so this only guards direct construction.
+    let timings = makeTimings(fetchStart: nil, responseEnd: nil, totalDuration: 0)
+    let row = SpanRow.from(request: makeRequest(timings: timings), sessionId: "s")
+    #expect(row == nil)
+  }
+}
+
+@AppMetricsActor
+@Suite("NetworkRequestPersistence")
+struct NetworkRequestPersistenceTests {
+  private func withTemporaryDatabase(_ body: (MetricsDatabase) throws -> Void) throws {
+    let directoryUrl = FileManager.default.temporaryDirectory
+      .appendingPathComponent("NetworkRequestPersistenceTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directoryUrl, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: directoryUrl)
+    }
+    let database = try MetricsDatabase(directoryUrl: directoryUrl)
+    try body(database)
+  }
+
+  private func insertSession(id: String, into database: MetricsDatabase) throws {
+    try database.insert(
+      session: SessionRow(
+        id: id,
+        type: "main",
+        startTimestamp: "2026-08-12T12:00:00Z",
+        isActive: true
+      )
+    )
+  }
+
+  @Test
+  func `persists a completed request as a span attributed to the provided session`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "main-session", into: database)
+      let persistence = NetworkRequestPersistence(database: database) {
+        return "main-session"
+      }
+      persistence.persist(makeRequest())
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.count == 1)
+      #expect(rows.first?.sessionId == "main-session")
+      #expect(rows.first?.name == "GET")
+      #expect(rows.first?.kind == SpanRow.clientKind)
+    }
+  }
+
+  @Test
+  func `persists each request the monitor records`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "main-session", into: database)
+      let monitor = NetworkRequestMonitor()
+      monitor.persistence = NetworkRequestPersistence(database: database) {
+        return "main-session"
+      }
+      monitor.record(makeRequest(method: "GET"))
+      monitor.record(makeRequest(method: "POST"))
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.map(\.name) == ["GET", "POST"])
+    }
+  }
+
+  @Test
+  func `drops a request whose session row does not exist yet`() throws {
+    // The sessions FK protects referential integrity; persistence must degrade to a dropped
+    // row rather than throw into the monitor's record path.
+    try withTemporaryDatabase { database in
+      let persistence = NetworkRequestPersistence(database: database) {
+        return "never-inserted"
+      }
+      persistence.persist(makeRequest())
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.isEmpty)
+    }
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestPersistenceTests.swift
@@ -1,0 +1,505 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+private let fixedStart = Date(timeIntervalSince1970: 1_782_131_895)
+
+private func makeTimings(
+  fetchStart: Date? = fixedStart,
+  responseEnd: Date? = fixedStart.addingTimeInterval(0.25),
+  totalDuration: TimeInterval = 0.25
+) -> NetworkRequest.Timings {
+  return NetworkRequest.Timings(
+    fetchStart: fetchStart,
+    domainLookupStart: nil,
+    domainLookupEnd: nil,
+    connectStart: nil,
+    connectEnd: nil,
+    secureConnectionStart: nil,
+    secureConnectionEnd: nil,
+    requestStart: nil,
+    requestEnd: nil,
+    responseStart: nil,
+    responseEnd: responseEnd,
+    measuredResponseEnd: responseEnd,
+    totalDuration: totalDuration
+  )
+}
+
+private func makeRequest(
+  url: String = "https://api.example.com/v1/items?page=2",
+  method: String = "GET",
+  statusCode: Int? = 200,
+  networkProtocol: String? = "h2",
+  requestBytesSent: Int64? = 412,
+  responseBytesReceived: Int64? = 8_192,
+  timings: NetworkRequest.Timings = makeTimings(),
+  errorDescription: String? = nil,
+  errorType: String? = nil,
+  fetchType: NetworkRequest.FetchType? = .network,
+  redirects: [NetworkRequest.Redirect] = []
+) -> NetworkRequest {
+  return NetworkRequest(
+    id: UUID(),
+    url: URL(string: url)!,
+    method: method,
+    statusCode: statusCode,
+    networkProtocol: networkProtocol,
+    requestBytesSent: requestBytesSent,
+    responseBytesReceived: responseBytesReceived,
+    fetchType: fetchType,
+    timings: timings,
+    errorDescription: errorDescription,
+    errorType: errorType,
+    redirects: redirects
+  )
+}
+
+private func makeSpan(_ request: NetworkRequest) throws -> SpanRow {
+  return try #require(SpanRow.from(request: request, sessionId: "s"))
+}
+
+/// Decodes the row's `attributes` JSON blob for assertions.
+private func attributesDict(_ row: SpanRow) throws -> [String: Any] {
+  let json = try #require(row.attributes)
+  let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+  return try #require(object as? [String: Any])
+}
+
+/// Decodes the row's `events` JSON blob for assertions.
+private func eventsArray(_ row: SpanRow) throws -> [[String: Any]] {
+  let json = try #require(row.events)
+  let object = try JSONSerialization.jsonObject(with: Data(json.utf8))
+  return try #require(object as? [[String: Any]])
+}
+
+@AppMetricsActor
+@Suite("NetworkRequest to SpanRow mapping")
+struct NetworkRequestSpanMappingTests {
+  @Test
+  func `converts a completed request into a client span with millisecond timestamps`() throws {
+    let row = try makeSpan(makeRequest(method: "POST"))
+    #expect(row.sessionId == "s")
+    #expect(row.name == "POST")
+    #expect(row.kind == SpanRow.clientKind)
+    #expect(row.startTimestampMs == 1_782_131_895_000)
+    #expect(row.endTimestampMs == 1_782_131_895_250)
+    #expect(row.parentSpanId == nil)
+    #expect(row.events == nil)
+  }
+
+  @Test
+  func `maps the HTTP semantic-convention attributes the server extracts to columns`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest()))
+    #expect(attributes["http.request.method"] as? String == "GET")
+    #expect(attributes["http.response.status_code"] as? Int == 200)
+    #expect(attributes["url.full"] as? String == "https://api.example.com/v1/items?page=2")
+    #expect(attributes["server.address"] as? String == "api.example.com")
+    #expect(attributes["http.request.size"] as? Int64 == 412)
+    #expect(attributes["http.response.size"] as? Int64 == 8_192)
+  }
+
+  @Test
+  func `normalizes the network protocol name to a semconv version`() throws {
+    // The OS reports `http/1.1`, `h2`, `h3`; semconv's `network.protocol.version` wants the
+    // bare version, and the server stores it in a LowCardinality column.
+    let expected = [
+      "http/1.1": "1.1",
+      "http/1.0": "1.0",
+      "h2": "2",
+      "h3": "3",
+    ]
+    for (reported, version) in expected {
+      let attributes = try attributesDict(makeSpan(makeRequest(networkProtocol: reported)))
+      #expect(attributes["network.protocol.version"] as? String == version)
+    }
+  }
+
+  @Test
+  func `omits attributes that were never measured`() throws {
+    // A request that died before headers has no status and no byte counts. Sending a
+    // placeholder would be indistinguishable from a genuine zero.
+    let request = makeRequest(
+      statusCode: nil,
+      networkProtocol: nil,
+      requestBytesSent: nil,
+      responseBytesReceived: nil
+    )
+    let attributes = try attributesDict(makeSpan(request))
+    #expect(attributes["http.response.status_code"] == nil)
+    #expect(attributes["network.protocol.version"] == nil)
+    #expect(attributes["http.request.size"] == nil)
+    #expect(attributes["http.response.size"] == nil)
+  }
+
+  @Test
+  func `keeps ordinary query values but redacts the default-sensitive ones`() throws {
+    // Redaction is the instrumentation's job per the conventions; signed-URL secrets must
+    // never reach the on-device database. Ordinary parameters stay, so ingestion can still
+    // group by them.
+    let url = "https://api.example.com/search?q=hello&sig=secret&X-Amz-Signature=abc"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(
+      attributes["url.full"] as? String
+        == "https://api.example.com/search?q=hello&sig=REDACTED&X-Amz-Signature=REDACTED"
+    )
+  }
+
+  @Test
+  func `redacts every default-sensitive query parameter of a presigned S3 URL`() throws {
+    // The `url.full` convention lists five default-sensitive parameters. `X-Amz-Credential`
+    // carries the access key id and `X-Amz-Security-Token` the session token; leaking either
+    // is as bad as leaking the signature.
+    let url =
+      "https://bucket.s3.amazonaws.com/key"
+      + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+      + "&X-Amz-Credential=AKIAEXAMPLE%2F20260907%2Fus-east-1%2Fs3%2Faws4_request"
+      + "&X-Amz-Security-Token=session-token"
+      + "&X-Amz-Signature=abc"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(
+      attributes["url.full"] as? String
+        == "https://bucket.s3.amazonaws.com/key"
+        + "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+        + "&X-Amz-Credential=REDACTED"
+        + "&X-Amz-Security-Token=REDACTED"
+        + "&X-Amz-Signature=REDACTED"
+    )
+  }
+
+  @Test
+  func `redacts a sensitive parameter whose name is percent-encoded`() throws {
+    // A server decodes `%73ig` back to `sig`, so a presigned URL spelled that way carries a real
+    // secret. Matching the encoded name against the plain-text list would miss it.
+    let url = "https://api.example.com/search?%73ig=secret&X%2DAmz%2DSignature=abc&q=hello"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(
+      attributes["url.full"] as? String
+        == "https://api.example.com/search?%73ig=REDACTED&X%2DAmz%2DSignature=REDACTED&q=hello"
+    )
+  }
+
+  @Test
+  func `leaves an unredacted URL byte-identical`() throws {
+    // Percent-encoding must survive: a decode/re-encode round trip would turn `a%2Bb` into a
+    // literal `+`, which backends read as a space.
+    let url = "https://api.example.com/search?q=a%2Bb&page=2"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(attributes["url.full"] as? String == url)
+  }
+
+  @Test
+  func `preserves percent-encoding in the parameters it keeps`() throws {
+    // Redaction must not disturb the values it leaves alone. Decoding and re-encoding the query
+    // turns `a%2Bb` into a literal `+`, which every backend reads as a space, so a search for
+    // "a+b" would silently become a search for "a b" on exactly the URLs that carry a secret.
+    let url = "https://api.example.com/search?q=a%2Bb&sig=secret"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(attributes["url.full"] as? String == "https://api.example.com/search?q=a%2Bb&sig=REDACTED")
+  }
+
+  @Test
+  func `keeps query parameters in the order they were sent`() throws {
+    // `url.full` is the key URL-level analysis groups on, so reordering splits one endpoint into
+    // several distinct strings depending on where the signed parameter happened to sit.
+    let url = "https://api.example.com/search?sig=secret&q=hello&page=2"
+    let attributes = try attributesDict(makeSpan(makeRequest(url: url)))
+    #expect(attributes["url.full"] as? String == "https://api.example.com/search?sig=REDACTED&q=hello&page=2")
+  }
+
+  @Test
+  func `redacts userinfo credentials from the URL`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest(url: "https://user:pass@api.example.com/items")))
+    #expect(attributes["url.full"] as? String == "https://REDACTED:REDACTED@api.example.com/items")
+  }
+
+  @Test
+  func `records the server port, defaulting from the scheme`() throws {
+    let explicit = try attributesDict(makeSpan(makeRequest(url: "https://api.example.com:8443/x")))
+    #expect(explicit["server.port"] as? Int == 8443)
+    let https = try attributesDict(makeSpan(makeRequest(url: "https://api.example.com/x")))
+    #expect(https["server.port"] as? Int == 443)
+    let http = try attributesDict(makeSpan(makeRequest(url: "http://api.example.com/x")))
+    #expect(http["server.port"] as? Int == 80)
+  }
+
+  @Test
+  func `records how the response was fetched, and omits it when the OS did not classify`() throws {
+    // A cache hit is timestamped and byte-counted like a download, so without this attribute a
+    // 7 MB response read off disk in 100 ms looks like an impossible transfer rate. `.unknown`
+    // (an `NSURLProtocol` subclass intercepted the task) omits the key rather than guessing.
+    let expected: [NetworkRequest.FetchType: String] = [
+      .network: "network",
+      .cache: "cache",
+      .serverPush: "server_push",
+    ]
+    for (fetchType, value) in expected {
+      let attributes = try attributesDict(makeSpan(makeRequest(fetchType: fetchType)))
+      #expect(attributes["expo.http.resource.fetch_type"] as? String == value)
+    }
+    let unknown = try attributesDict(makeSpan(makeRequest(fetchType: nil)))
+    #expect(unknown["expo.http.resource.fetch_type"] == nil)
+  }
+
+  @Test
+  func `keeps the conventions' known methods verbatim`() throws {
+    // The known set is RFC 9110's methods plus PATCH and QUERY. Each names the span and is
+    // recorded as `http.request.method` as sent, with no `method_original`.
+    for method in ["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PATCH", "QUERY"] {
+      let row = try makeSpan(makeRequest(method: method))
+      let attributes = try attributesDict(row)
+      #expect(row.name == method)
+      #expect(attributes["http.request.method"] as? String == method)
+      #expect(attributes["http.request.method_original"] == nil, "unexpected method_original for \(method)")
+    }
+  }
+
+  @Test
+  func `maps a nonstandard method to _OTHER and names the span HTTP`() throws {
+    // Case-sensitive per the conventions: even a lowercase standard verb is not "known", so
+    // caller-controlled method strings can't mint unbounded span names.
+    for method in ["PURGE", "get"] {
+      let row = try makeSpan(makeRequest(method: method))
+      let attributes = try attributesDict(row)
+      #expect(row.name == "HTTP")
+      #expect(attributes["http.request.method"] as? String == "_OTHER")
+      #expect(attributes["http.request.method_original"] as? String == method)
+    }
+  }
+
+  @Test
+  func `records a canceled request without a status or error type`() throws {
+    // Intentional cancellations (AbortController, prefetch aborts) are routine in RN apps;
+    // per the conventions they keep their span but are not errors.
+    let row = try makeSpan(
+      makeRequest(
+        statusCode: nil,
+        errorDescription: "canceled",
+        errorType: "NSURLErrorDomain:-999"
+      )
+    )
+    #expect(row.statusCode == nil)
+    #expect(row.statusMessage == nil)
+    #expect(try attributesDict(row)["error.type"] == nil)
+  }
+
+  @Test
+  func `keeps the error status when a request is canceled while reading an error response`() throws {
+    // A cancel that arrives after the server already answered must not erase that answer: the
+    // response was a 500 regardless of who hung up first. Android guards the same case.
+    let row = try makeSpan(
+      makeRequest(
+        statusCode: 500,
+        errorDescription: "canceled",
+        errorType: "NSURLErrorDomain:-999"
+      )
+    )
+    #expect(row.statusCode == SpanRow.statusError)
+    #expect(try attributesDict(row)["error.type"] as? String == "500")
+  }
+
+  @Test
+  func `leaves the status unset for a successful response`() throws {
+    // Semconv: a client span for a 2xx response carries no explicit status.
+    let row = try makeSpan(makeRequest(statusCode: 200))
+    #expect(row.statusCode == nil)
+    #expect(row.statusMessage == nil)
+  }
+
+  @Test
+  func `marks 4xx and 5xx responses as errors`() throws {
+    // Semconv makes any 4xx/5xx an error for a client span, unlike the server-span rule.
+    for statusCode in [400, 404, 429, 500, 503] {
+      let row = try makeSpan(makeRequest(statusCode: statusCode))
+      #expect(row.statusCode == SpanRow.statusError, "expected ERROR for status \(statusCode)")
+    }
+  }
+
+  @Test
+  func `marks a transport failure as an error with the description as the status message`() throws {
+    // `errorDescription` is localized free text, so it belongs in the status message. The
+    // low-cardinality `error.type` attribute gets a separate, predictable value.
+    let row = try makeSpan(
+      makeRequest(
+        statusCode: nil,
+        errorDescription: "The Internet connection appears to be offline.",
+        errorType: "NSURLErrorDomain:-1009"
+      )
+    )
+    #expect(row.statusCode == SpanRow.statusError)
+    #expect(row.statusMessage == "The Internet connection appears to be offline.")
+    let attributes = try attributesDict(row)
+    #expect(attributes["error.type"] as? String == "NSURLErrorDomain:-1009")
+  }
+
+  @Test
+  func `sets the error type to the status code for an HTTP error response`() throws {
+    // Semconv: when a request completes with an error status and no exception, `error.type`
+    // is the status code as a string.
+    let attributes = try attributesDict(makeSpan(makeRequest(statusCode: 503)))
+    #expect(attributes["error.type"] as? String == "503")
+  }
+
+  @Test
+  func `omits the error type on success`() throws {
+    let attributes = try attributesDict(makeSpan(makeRequest(statusCode: 204)))
+    #expect(attributes["error.type"] == nil)
+  }
+
+  @Test
+  func `maps each redirect hop onto an event`() throws {
+    let request = makeRequest(redirects: [
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/a")!,
+        toUrl: URL(string: "https://example.com/b")!,
+        statusCode: 301,
+        respondedAt: fixedStart.addingTimeInterval(0.1)
+      ),
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/b")!,
+        toUrl: URL(string: "https://example.com/c")!,
+        statusCode: 302,
+        respondedAt: nil
+      ),
+    ])
+    // Event and attribute names follow the naming guidelines: application-specific names live
+    // under the `expo.` namespace, and the hop's status reuses the registry's
+    // `http.response.status_code`.
+    let events = try eventsArray(makeSpan(request))
+    #expect(events.count == 2)
+    #expect(events.allSatisfy { $0["name"] as? String == "expo.http.redirect" })
+    let first = try #require(events.first?["attributes"] as? [String: Any])
+    #expect(first["expo.http.redirect.from"] as? String == "https://example.com/a")
+    #expect(first["expo.http.redirect.to"] as? String == "https://example.com/b")
+    #expect(first["http.response.status_code"] as? Int == 301)
+    #expect(first.count == 3, "unexpected attributes: \(first.keys.sorted())")
+    // A hop's arrival time becomes the event time; without one the exporter anchors the event
+    // to the span start, so the key is omitted rather than faked.
+    #expect(events[0]["timeMs"] as? Int64 == 1_782_131_895_100)
+    #expect(events[1]["timeMs"] == nil)
+  }
+
+  @Test
+  func `keeps redirect event times inside the span window`() throws {
+    // A hop that the platform timed before the span's own start has no valid place on the
+    // timeline: OTLP events must sit within their span. Rather than ship an event that precedes
+    // its span, drop the time and let the exporter anchor the event to the span start.
+    let request = makeRequest(redirects: [
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/a")!,
+        toUrl: URL(string: "https://example.com/b")!,
+        statusCode: 301,
+        respondedAt: fixedStart.addingTimeInterval(-0.5)
+      ),
+      NetworkRequest.Redirect(
+        fromUrl: URL(string: "https://example.com/b")!,
+        toUrl: URL(string: "https://example.com/c")!,
+        statusCode: 302,
+        respondedAt: fixedStart.addingTimeInterval(5)
+      ),
+    ])
+    let events = try eventsArray(makeSpan(request))
+    #expect(events[0]["timeMs"] == nil)
+    #expect(events[1]["timeMs"] == nil)
+  }
+
+  @Test
+  func `assigns generated identifiers to each span`() throws {
+    let first = try makeSpan(makeRequest())
+    let second = try makeSpan(makeRequest())
+    #expect(first.traceId.count == 32)
+    #expect(first.spanId.count == 16)
+    #expect(first.traceId != second.traceId)
+  }
+
+  @Test
+  func `derives a missing end timestamp from the total duration`() throws {
+    // The `setState:` fallback path can produce a snapshot before the OS reported a
+    // response end; the row still needs a usable window for the span.
+    let timings = makeTimings(fetchStart: fixedStart, responseEnd: nil, totalDuration: 1.5)
+    let row = try makeSpan(makeRequest(timings: timings))
+    #expect(row.startTimestampMs == 1_782_131_895_000)
+    #expect(row.endTimestampMs == 1_782_131_896_500)
+  }
+
+  @Test
+  func `returns nil when the request carries no usable timestamps`() {
+    // Without either endpoint of the window there is nothing to anchor a span to. The
+    // factory always sets both, so this only guards direct construction.
+    let timings = makeTimings(fetchStart: nil, responseEnd: nil, totalDuration: 0)
+    let row = SpanRow.from(request: makeRequest(timings: timings), sessionId: "s")
+    #expect(row == nil)
+  }
+}
+
+@AppMetricsActor
+@Suite("NetworkRequestPersistence")
+struct NetworkRequestPersistenceTests {
+  private func withTemporaryDatabase(_ body: (MetricsDatabase) throws -> Void) throws {
+    let directoryUrl = FileManager.default.temporaryDirectory
+      .appendingPathComponent("NetworkRequestPersistenceTests-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: directoryUrl, withIntermediateDirectories: true)
+    defer {
+      try? FileManager.default.removeItem(at: directoryUrl)
+    }
+    let database = try MetricsDatabase(directoryUrl: directoryUrl)
+    try body(database)
+  }
+
+  private func insertSession(id: String, into database: MetricsDatabase) throws {
+    try database.insert(
+      session: SessionRow(
+        id: id,
+        type: "main",
+        startTimestamp: "2026-08-12T12:00:00Z",
+        isActive: true
+      )
+    )
+  }
+
+  @Test
+  func `persists a completed request as a span attributed to the provided session`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "main-session", into: database)
+      let persistence = NetworkRequestPersistence(database: database) {
+        return "main-session"
+      }
+      persistence.persist(makeRequest())
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.count == 1)
+      #expect(rows.first?.sessionId == "main-session")
+      #expect(rows.first?.name == "GET")
+      #expect(rows.first?.kind == SpanRow.clientKind)
+    }
+  }
+
+  @Test
+  func `persists each request the monitor records`() throws {
+    try withTemporaryDatabase { database in
+      try insertSession(id: "main-session", into: database)
+      let monitor = NetworkRequestMonitor()
+      monitor.persistence = NetworkRequestPersistence(database: database) {
+        return "main-session"
+      }
+      monitor.record(makeRequest(method: "GET"))
+      monitor.record(makeRequest(method: "POST"))
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.map(\.name) == ["GET", "POST"])
+    }
+  }
+
+  @Test
+  func `drops a request whose session row does not exist yet`() throws {
+    // The sessions FK protects referential integrity; persistence must degrade to a dropped
+    // row rather than throw into the monitor's record path.
+    try withTemporaryDatabase { database in
+      let persistence = NetworkRequestPersistence(database: database) {
+        return "never-inserted"
+      }
+      persistence.persist(makeRequest())
+      let rows = try database.getSpans(afterId: -1)
+      #expect(rows.isEmpty)
+    }
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -86,6 +86,46 @@ struct NetworkRequestTests {
     // still has to carry one rather than passing for a success.
     #expect(snapshot.errorDescription != nil)
   }
+
+  @Test
+  func `captures the error domain and code as a low-cardinality error type`() {
+    // `errorDescription` is localized free text, unusable for grouping failures in telemetry.
+    // The domain:code pair is stable across locales, matching what OTel's `error.type`
+    // attribute (and the server's LowCardinality column) expects.
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(snapshot.errorType == "NSURLErrorDomain:-1009")
+  }
+
+  @Test
+  func `leaves the error type nil on success`() {
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: nil
+    )
+    #expect(snapshot.errorType == nil)
+  }
 }
 
 @AppMetricsActor
@@ -1071,6 +1111,7 @@ struct NetworkRequestSummaryTests {
         totalDuration: duration
       ),
       errorDescription: error,
+      errorType: error == nil ? nil : "TestErrorDomain:1",
       redirects: []
     )
   }
@@ -1122,6 +1163,7 @@ struct NetworkRequestMonitorWindowingTests {
         totalDuration: 0.1
       ),
       errorDescription: nil,
+      errorType: nil,
       redirects: []
     )
   }
@@ -1429,6 +1471,7 @@ struct NetworkRequestObserverTests {
         totalDuration: 0.5
       ),
       errorDescription: nil,
+      errorType: nil,
       redirects: [
         NetworkRequest.Redirect(
           fromUrl: URL(string: "https://expo.dev/a")!,
@@ -1489,6 +1532,7 @@ struct NetworkRequestObserverTests {
         totalDuration: 0.1
       ),
       errorDescription: "timed out",
+      errorType: "NSURLErrorDomain:-1001",
       redirects: []
     )
 

--- a/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkRequestTests.swift
@@ -86,6 +86,46 @@ struct NetworkRequestTests {
     // still has to carry one rather than passing for a success.
     #expect(snapshot.errorDescription != nil)
   }
+
+  @Test
+  func `captures the error domain and code as a low-cardinality error type`() {
+    // `errorDescription` is localized free text, unusable for grouping failures in telemetry.
+    // The domain:code pair is stable across locales, matching what OTel's `error.type`
+    // attribute (and the server's LowCardinality column) expects.
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: nil)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: error
+    )
+    #expect(snapshot.errorType == "NSURLErrorDomain:-1009")
+  }
+
+  @Test
+  func `leaves the error type nil on success`() {
+    let request = URLRequest(url: URL(string: "https://expo.dev/api")!)
+    let now = Date()
+    let snapshot = NetworkRequest.from(
+      id: UUID(),
+      request: request,
+      response: nil,
+      taskBytesSent: nil,
+      taskBytesReceived: nil,
+      metrics: nil,
+      fallbackStart: now,
+      fallbackEnd: now,
+      error: nil
+    )
+    #expect(snapshot.errorType == nil)
+  }
 }
 
 @AppMetricsActor
@@ -1054,7 +1094,7 @@ struct NetworkRequestSummaryTests {
       networkProtocol: nil,
       requestBytesSent: bytesSent,
       responseBytesReceived: bytesReceived,
-      cameFromNetwork: cameFromNetwork,
+      fetchType: cameFromNetwork.map { $0 ? .network : .cache },
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1071,6 +1111,7 @@ struct NetworkRequestSummaryTests {
         totalDuration: duration
       ),
       errorDescription: error,
+      errorType: error == nil ? nil : "TestErrorDomain:1",
       redirects: []
     )
   }
@@ -1105,7 +1146,7 @@ struct NetworkRequestMonitorWindowingTests {
       networkProtocol: nil,
       requestBytesSent: 0,
       responseBytesReceived: 0,
-      cameFromNetwork: true,
+      fetchType: .network,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1122,6 +1163,7 @@ struct NetworkRequestMonitorWindowingTests {
         totalDuration: 0.1
       ),
       errorDescription: nil,
+      errorType: nil,
       redirects: []
     )
   }
@@ -1412,7 +1454,7 @@ struct NetworkRequestObserverTests {
       networkProtocol: "h2",
       requestBytesSent: 123,
       responseBytesReceived: 4567,
-      cameFromNetwork: true,
+      fetchType: .network,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1429,12 +1471,19 @@ struct NetworkRequestObserverTests {
         totalDuration: 0.5
       ),
       errorDescription: nil,
+      errorType: nil,
       redirects: [
         NetworkRequest.Redirect(
           fromUrl: URL(string: "https://expo.dev/a")!,
           toUrl: URL(string: "https://expo.dev/b")!,
-          statusCode: 301
-        )
+          statusCode: 301,
+          respondedAt: Date(timeIntervalSinceReferenceDate: 2000.25)
+        ),
+        NetworkRequest.Redirect(
+          fromUrl: URL(string: "https://expo.dev/b")!,
+          toUrl: URL(string: "https://expo.dev/end")!,
+          statusCode: 302
+        ),
       ]
     )
 
@@ -1452,10 +1501,16 @@ struct NetworkRequestObserverTests {
     #expect(payload["totalDuration"] as? TimeInterval == 0.5)
 
     let redirects = payload["redirects"] as? [[String: Any?]]
-    #expect(redirects?.count == 1)
+    #expect(redirects?.count == 2)
     #expect(redirects?.first?["fromUrl"] as? String == "https://expo.dev/a")
     #expect(redirects?.first?["toUrl"] as? String == "https://expo.dev/b")
     #expect(redirects?.first?["statusCode"] as? Int == 301)
+    // Hop times use the same ISO 8601 UTC format as `startedAt`, but keep milliseconds because
+    // hops within one request are usually fractions of a second apart. An unreported time is
+    // `null`.
+    #expect(redirects?.first?["respondedAt"] as? String == "2001-01-01T00:33:20.250Z")
+    #expect(redirects?[1].keys.contains("respondedAt") == true)
+    #expect((redirects?[1]["respondedAt"] ?? nil) == nil)
   }
 
   @Test
@@ -1472,7 +1527,7 @@ struct NetworkRequestObserverTests {
       networkProtocol: nil,
       requestBytesSent: nil,
       responseBytesReceived: nil,
-      cameFromNetwork: nil,
+      fetchType: nil,
       timings: NetworkRequest.Timings(
         fetchStart: fetchStart,
         domainLookupStart: nil,
@@ -1489,6 +1544,7 @@ struct NetworkRequestObserverTests {
         totalDuration: 0.1
       ),
       errorDescription: "timed out",
+      errorType: "NSURLErrorDomain:-1001",
       redirects: []
     )
 

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -356,6 +356,13 @@ export type NetworkRequestRedirect = {
   toUrl: string;
   /** The 3xx status code (301, 302, 307, 308, …) returned by `fromUrl`. */
   statusCode: number;
+  /**
+   * ISO 8601 UTC timestamp of when `fromUrl` returned the 3xx response, or `null` when the
+   * platform did not report it. Includes milliseconds (for example `2026-09-07T12:00:00.250Z`),
+   * unlike the whole-second `startedAt`, because hops within one request are usually fractions of
+   * a second apart.
+   */
+  respondedAt: string | null;
 };
 
 /**


### PR DESCRIPTION
# Why

The spans table from #48861 has no producer yet. Network requests are the first one: they're already observed on both platforms, but only in memory, so nothing survives to be exported.

Closes ENG-26032.

# How

A persistence hook on `NetworkRequestMonitor` converts each completed request into a client span per the OTel HTTP semantic conventions, attributed to the main session. The mapping follows the conventions where they have teeth: `url.full` is redacted at the instrumentation (userinfo credentials and default-sensitive query values never reach disk), and only when something was actually redacted, so ordinary URLs keep their exact encoding; nonstandard methods become `_OTHER` with the verbatim value preserved; intentional cancellations keep their span but stay UNSET with no `error.type`, so routine `AbortController` use doesn't pollute error rates. The capture snapshot gains `errorType` (the stable `domain:code` pair on iOS, the exception class on Android), since localized descriptions can't feed a low-cardinality attribute.

Android's lifecycle needs extra care: installation drains the monitor's ring buffer once per process, with the drained flag flipped only after the batch completes (a JS reload that cancels the batch re-drains instead of losing the buffer), and the module uninstalls its producer on destroy so a reload can't keep writing rows against the torn-down session.

# Test Plan

Producer suites on both platforms cover the semconv mapping (redaction and byte-fidelity, `_OTHER`, cancellations, status rules, `server.port`, redirect events), persistence through the monitor, the backfill's at-least-once semantics across reloads, and FK degradation. `et native-unit-tests` passes on both platforms.

