### PR TITLE
[sqlite] Fix leaking devtools client in dev-plugin-webui tests

### DIFF
--- a/packages/expo-sqlite/dev-plugin-webui/src/hooks/__tests__/useSQLiteDatabase.test.ts
+++ b/packages/expo-sqlite/dev-plugin-webui/src/hooks/__tests__/useSQLiteDatabase.test.ts
@@ -25,6 +25,12 @@ jest.mock('../../../../src/ExpoSQLite', () =>
 // Mock sqliteDump
 jest.mock('@/lib/sqliteDump');
 
+// `openDatabaseAsync` registers the database with devtools without awaiting it.
+// Left unmocked, that opens a real WebSocket whose retry timers outlive the test.
+jest.mock('expo/devtools', () => ({
+  getDevToolsPluginClientAsync: jest.fn(),
+}));
+
 const mockImportDatabase = sqliteDump.importDatabase as jest.MockedFunction<
   typeof sqliteDump.importDatabase
 >;

--- a/packages/expo-sqlite/dev-plugin-webui/src/lib/__tests__/sqliteDump.integration.test.ts
+++ b/packages/expo-sqlite/dev-plugin-webui/src/lib/__tests__/sqliteDump.integration.test.ts
@@ -8,6 +8,12 @@ jest.mock('../../../../src/ExpoSQLite', () =>
   require('../../../../src/__mocks__/ExpoSQLite')
 );
 
+// `openDatabaseAsync` registers the database with devtools without awaiting it.
+// Left unmocked, that opens a real WebSocket whose retry timers outlive the test.
+jest.mock('expo/devtools', () => ({
+  getDevToolsPluginClientAsync: jest.fn(),
+}));
+
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 const originalConsoleLog = console.log;


### PR DESCRIPTION
# Why

`sqlite-inspector-webui#test` is failing. All 108 tests pass, but Jest still exits 1 or hangs. It hit main in https://github.com/expo/expo/actions/runs/32104537925 and again in https://github.com/expo/expo/actions/runs/32106239384, and it also blocks #48544.

The package and its `test` task are new in #48542. That task runs under `--affected`, so it only fires on PRs that touch `expo-sqlite`. The leak behind it is timing dependent, so it does not fail every time.

The real error sits far below the passing tests:

```
ReferenceError: You are trying to `import` a file after the Jest environment
has been torn down. From src/lib/__tests__/sqliteDump.integration.test.ts.
  at require (../src/SQLiteDevToolsClient.ts:67:7)
```

# How

Two webui test files mock `ExpoSQLite` but not `expo/devtools`. Opening a database calls `registerDatabaseForDevToolsAsync(database)` without awaiting it, so those tests built a real devtools client. It tried to open a WebSocket, found no dev server, and kept retrying on timers that outlived the test. The late `require('expo/devtools')` then ran against a torn-down environment.

Both files now mock `expo/devtools`, which is what every other test that opens a database already does. See `SQLiteDatabase-test.ios.ts`.

I skipped the changelog entry. This only touches tests in a private package, so there is nothing to publish or bump.

# Test Plan

On the parent commit, `sqliteDump.integration.test.ts` and `useSQLiteDatabase.test.ts` each hang until killed when run alone.

With this change, from `packages/expo-sqlite/dev-plugin-webui`:

- `npx jest` three times: 108 passed, exit 0, no leak warning
- each of the 5 suites run alone: exit 0, no leak warning
- `npx tsc`, `npx oxfmt --check`, and `npx oxlint`: clean

`test` is uncached in `turbo.json`, so the green `check-packages` run on this PR really did execute the suite.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
