### PR TITLE
[docs] Fix type errors in host, notifications, age-range, and svg examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -87,7 +87,7 @@ export default function App() {
       });
       setResult(ageRange);
     } catch (error) {
-      setResult({ error: error.message });
+      setResult({ error: error instanceof Error ? error.message : String(error) });
     }
   };
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -312,8 +312,10 @@ export default function App() {
 
           // Handle URL from expo push notifications
           const response = Notifications.getLastNotificationResponse();
-
-          return response?.notification.request.content.data.url;
+          const notificationUrl = response?.notification.request.content.data?.url;
+          if (typeof notificationUrl === 'string') {
+            return notificationUrl;
+          }
         },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
@@ -323,13 +325,15 @@ export default function App() {
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
-            const url = response.notification.request.content.data.url;
+            const url = response.notification.request.content.data?.url;
 
             // Any custom logic to see whether the URL needs to be handled
             //...
 
-            // Let React Navigation handle the URL
-            listener(url);
+            if (typeof url === 'string') {
+              // Let React Navigation handle the URL
+              listener(url);
+            }
 
             // Clear the stored response so the next getInitialURL call does not redirect to the same URL again
             Notifications.clearLastNotificationResponse();

--- a/docs/pages/versions/unversioned/sdk/svg.mdx
+++ b/docs/pages/versions/unversioned/sdk/svg.mdx
@@ -35,9 +35,9 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import Svg, { Circle, Rect } from 'react-native-svg';
+import Svg, { Circle, Rect, SvgProps } from 'react-native-svg';
 
-export default function SvgComponent(props) {
+export default function SvgComponent(props: SvgProps) {
   return (
     <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
       <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -36,9 +36,9 @@ export default function MatchContentsExample() {
       <Button
         onPress={() => {
           console.log('Pressed');
-        }}>
-        Click
-      </Button>
+        }}
+        label="Click"
+      />
     </Host>
   );
 }
@@ -79,9 +79,9 @@ export default function ExplicitSizingExample() {
         <Button
           onPress={() => {
             console.log('Pressed');
-          }}>
-          Click
-        </Button>
+          }}
+          label="Click"
+        />
       </VStack>
     </Host>
   );

--- a/docs/pages/versions/v57.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/age-range.mdx
@@ -87,7 +87,7 @@ export default function App() {
       });
       setResult(ageRange);
     } catch (error) {
-      setResult({ error: error.message });
+      setResult({ error: error instanceof Error ? error.message : String(error) });
     }
   };
 

--- a/docs/pages/versions/v57.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/notifications.mdx
@@ -309,8 +309,10 @@ export default function App() {
 
           // Handle URL from expo push notifications
           const response = Notifications.getLastNotificationResponse();
-
-          return response?.notification.request.content.data.url;
+          const notificationUrl = response?.notification.request.content.data?.url;
+          if (typeof notificationUrl === 'string') {
+            return notificationUrl;
+          }
         },
         subscribe(listener) {
           const onReceiveURL = ({ url }: { url: string }) => listener(url);
@@ -320,13 +322,15 @@ export default function App() {
 
           // Listen to expo push notifications
           const subscription = Notifications.addNotificationResponseReceivedListener(response => {
-            const url = response.notification.request.content.data.url;
+            const url = response.notification.request.content.data?.url;
 
             // Any custom logic to see whether the URL needs to be handled
             //...
 
-            // Let React Navigation handle the URL
-            listener(url);
+            if (typeof url === 'string') {
+              // Let React Navigation handle the URL
+              listener(url);
+            }
           });
 
           return () => {

--- a/docs/pages/versions/v57.0.0/sdk/svg.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/svg.mdx
@@ -35,9 +35,9 @@ The implementation is provided by [react-native-svg](https://github.com/react-na
 <SnackInline label='SVG' dependencies={['react-native-svg']}>
 
 ```tsx
-import Svg, { Circle, Rect } from 'react-native-svg';
+import Svg, { Circle, Rect, SvgProps } from 'react-native-svg';
 
-export default function SvgComponent(props) {
+export default function SvgComponent(props: SvgProps) {
   return (
     <Svg height="50%" width="50%" viewBox="0 0 100 100" {...props}>
       <Circle cx="50" cy="50" r="45" stroke="blue" strokeWidth="2.5" fill="green" />

--- a/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/swift-ui/host.mdx
@@ -36,9 +36,9 @@ export default function MatchContentsExample() {
       <Button
         onPress={() => {
           console.log('Pressed');
-        }}>
-        Click
-      </Button>
+        }}
+        label="Click"
+      />
     </Host>
   );
 }
@@ -79,9 +79,9 @@ export default function ExplicitSizingExample() {
         <Button
           onPress={() => {
             console.log('Pressed');
-          }}>
-          Click
-        </Button>
+          }}
+          label="Click"
+        />
       </VStack>
     </Host>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26007 ENG-25940

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix type errors in host, notifications, age-range, and svg examples. Changes applied to unversioned and SDK 57.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
