### PR TITLE
[android][notifications] Fix fatal import in Expo Go from token listener

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))
 - [web] Fixed crash when browser storage is blocked (e.g. Safari's "Block All Cookies"), where reading `localStorage` throws a `SecurityError` instead of returning `null`. ([#48033](https://github.com/expo/expo/pull/48033) by [@Ignigena](https://github.com/Ignigena))
-- [Android] Fixed importing `expo-notifications` crashing the app in Expo Go.
+- [Android] Fixed importing `expo-notifications` crashing the app in Expo Go. ([#49062](https://github.com/expo/expo/pull/49062) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))
 - [web] Fixed crash when browser storage is blocked (e.g. Safari's "Block All Cookies"), where reading `localStorage` throws a `SecurityError` instead of returning `null`. ([#48033](https://github.com/expo/expo/pull/48033) by [@Ignigena](https://github.com/Ignigena))
+- [Android] Fixed importing `expo-notifications` crashing the app in Expo Go.
 
 ### 💡 Others
 

--- a/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
+++ b/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
@@ -99,8 +99,10 @@ export async function __handlePersistedRegistrationInfoAsync(
 }
 
 if (isRunningInExpoGo() && Platform.OS === 'android') {
-  // Push tokens are unavailable in Expo Go on Android since SDK 53;
-  // addPushTokenListener would throw and make the import fatal.
+  // Registering the module-scope push token listener would throw and make the import fatal.
+  console.warn(
+    '[expo-notifications] Push notifications (remote notifications) are unavailable in Expo Go on Android since SDK 53. Local notifications remain available. Use a development build for push notifications: https://docs.expo.dev/develop/development-builds/introduction/'
+  );
 } else if (ServerRegistrationModule.getRegistrationInfoAsync) {
   // A global scope (to get all the updates) device push token
   // subscription, never cleared.

--- a/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
+++ b/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
@@ -1,5 +1,5 @@
 import 'abort-controller/polyfill';
-import { UnavailabilityError } from 'expo';
+import { isRunningInExpoGo, Platform, UnavailabilityError } from 'expo';
 
 import ServerRegistrationModule from './ServerRegistrationModule';
 import { addPushTokenListener } from './TokenEmitter';
@@ -98,7 +98,10 @@ export async function __handlePersistedRegistrationInfoAsync(
   }
 }
 
-if (ServerRegistrationModule.getRegistrationInfoAsync) {
+if (isRunningInExpoGo() && Platform.OS === 'android') {
+  // Push tokens are unavailable in Expo Go on Android since SDK 53;
+  // addPushTokenListener would throw and make the import fatal.
+} else if (ServerRegistrationModule.getRegistrationInfoAsync) {
   // A global scope (to get all the updates) device push token
   // subscription, never cleared.
   addPushTokenListener(async (token) => {

--- a/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-expoGo-test.ts
+++ b/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-expoGo-test.ts
@@ -20,6 +20,9 @@ jest.mock('../ServerRegistrationModule', () => ({
 jest.mock('../utils/updateDevicePushTokenAsync');
 jest.mock('../getDevicePushTokenAsync');
 
-it('does not throw on import in Expo Go on Android', () => {
+it('warns instead of throwing on import in Expo Go on Android', () => {
+  const spy = jest.spyOn(console, 'warn').mockImplementation();
   expect(() => require('../DevicePushTokenAutoRegistration.fx')).not.toThrow();
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining('unavailable in Expo Go on Android'));
+  spy.mockRestore();
 });

--- a/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-expoGo-test.ts
+++ b/packages/expo-notifications/src/__tests__/DevicePushTokenAutoRegistration-expoGo-test.ts
@@ -1,0 +1,25 @@
+// Expo Go on Android ships the native server registration module, but push
+// token usage throws there.
+jest.mock('expo', () => {
+  const expo = jest.requireActual('expo');
+  return {
+    ...expo,
+    isRunningInExpoGo: () => true,
+    Platform: { ...expo.Platform, OS: 'android' },
+  };
+});
+jest.mock('../ServerRegistrationModule', () => ({
+  __esModule: true,
+  default: {
+    addListener: () => {},
+    removeListeners: () => {},
+    getRegistrationInfoAsync: jest.fn().mockResolvedValue(null),
+    setRegistrationInfoAsync: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+jest.mock('../utils/updateDevicePushTokenAsync');
+jest.mock('../getDevicePushTokenAsync');
+
+it('does not throw on import in Expo Go on Android', () => {
+  expect(() => require('../DevicePushTokenAutoRegistration.fx')).not.toThrow();
+});


### PR DESCRIPTION
# Why
Closes #49044

Importing expo-notifications crashes in Expo Go on Android

# How
The guard assumed Expo Go lacks that module, but Expo Go on Android ships ScopedServerRegistrationModule, so the guard passes. addPushTokenListener then calls warnOfExpoGoPushUsage(), which throws on Android.

The fix skips the auto-registration block when `isRunningInExpoGo() && Platform.OS === 'android'` and logs a warning instead

# Test Plan
Added new tests
