### PR TITLE
[ci][precompile] Rebuild external XCFrameworks when React Native changes

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -100,6 +100,22 @@ jobs:
           manifest="apps/bare-expo/package.json"
           changed=()
 
+          # A React Native bump changes the <rnVersion>/<hermesVersion> segments of
+          # every external artifact path, so the whole published set must be rebuilt.
+          # Read the version from `dependencies` only, mirroring the producer's source
+          # of truth in tools/src/prebuilds/Utils.ts (getVersionsInfoAsync).
+          before_rn="$(git show "$base:$manifest" 2>/dev/null \
+            | jq -r '.dependencies["react-native"] // empty')"
+          after_rn="$(jq -r '.dependencies["react-native"] // empty' "$manifest")"
+
+          if [ -z "$after_rn" ]; then
+            build_all "Could not read the react-native version from $manifest; building all external packages."
+          fi
+
+          if [ "$before_rn" != "$after_rn" ]; then
+            build_all "React Native changed (${before_rn:-unknown} -> $after_rn); every external artifact path is invalidated. Building all external packages."
+          fi
+
           # Derive the package -> patch-file map from pnpm's own source of truth
           # (the `patchedDependencies` block in pnpm-workspace.yaml) so adding a
           # patched package needs no edits here. Keys may carry an `@version`

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -104,8 +104,10 @@ jobs:
           # every external artifact path, so the whole published set must be rebuilt.
           # Read the version from `dependencies` only, mirroring the producer's source
           # of truth in tools/src/prebuilds/Utils.ts (getVersionsInfoAsync).
+          # `|| true` keeps a base commit without the manifest falling through to
+          # build_all; without it `pipefail` aborts the step with git's status.
           before_rn="$(git show "$base:$manifest" 2>/dev/null \
-            | jq -r '.dependencies["react-native"] // empty')"
+            | jq -r '.dependencies["react-native"] // empty' || true)"
           after_rn="$(jq -r '.dependencies["react-native"] // empty' "$manifest")"
 
           if [ -z "$after_rn" ]; then


### PR DESCRIPTION
# Why

Expo's EAS build service hosts prebuilt XCFramework versions of some of the main npm packages that are most often used in Expo projects to reduce build times (specifically reduces build times for C++ heavy packages).

A workflow exists to rebuild these when we change our versions of these packages in our repo (`.github/workflows/ios-prebuild-external-xcframeworks.yml`).

The problem with this is that our XCFrameworks are rebuilt only when the version of the package itself has changes, but not when React Native itself has changed.

Since the URLs for these packages includes a key on the RN version these packages will never be rebuilt when RN itself changes (without the 3rd part package itself is changed):

`<pkg>/output/<pkgVersion>/<rnVersion>/<hermesVersion>/<flavor>/xcframeworks/<Product>.tar.gz`

(Hermes version is always connected to the RN-version, so it could've been omitted here)

# How

Fix the detect logic in the workflow to also include the React Native version when testing if frameworks should be rebuilt, and then issue a rebuild all when RN's version changed.

# Test Plan

Replayed the detection logic against three different commits and verified that changes in RN version now results in rebuilding all packages.

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
