### PR TITLE
[router] Fix warnings in tests

### DIFF
--- a/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
@@ -4,7 +4,7 @@ import { Text, View } from 'react-native';
 
 import type { SuspenseFallbackProps } from '../exports';
 import { Slot } from '../exports';
-import { renderRouter } from '../testing-library';
+import { renderRouterAsync } from '../testing-library';
 
 const renderFallback = (route: string, testID = 'custom-fallback') => (
   <View testID={testID}>
@@ -12,7 +12,7 @@ const renderFallback = (route: string, testID = 'custom-fallback') => (
   </View>
 );
 
-it('inherits `<SuspenseFallback>` from the nearest layout in sync mode', () => {
+it('inherits `<SuspenseFallback>` from the nearest layout in sync mode', async () => {
   const pending = new Promise<string>(() => {});
 
   function SuspendingRoute() {
@@ -24,7 +24,7 @@ it('inherits `<SuspenseFallback>` from the nearest layout in sync mode', () => {
     renderFallback(route, 'layout-fallback')
   );
 
-  renderRouter(
+  await renderRouterAsync(
     {
       '(app)/_layout': {
         default: () => <Slot />,
@@ -41,7 +41,7 @@ it('inherits `<SuspenseFallback>` from the nearest layout in sync mode', () => {
   expect(LayoutFallback).toHaveBeenCalledTimes(1);
 });
 
-it('uses the nearest layout `<SuspenseFallback>` in sync mode', () => {
+it('uses the nearest layout `<SuspenseFallback>` in sync mode', async () => {
   const pending = new Promise<string>(() => {});
 
   function SuspendingRoute() {
@@ -54,7 +54,7 @@ it('uses the nearest layout `<SuspenseFallback>` in sync mode', () => {
   const NestedFallback = ({ route }: SuspenseFallbackProps) =>
     renderFallback(route, 'nested-layout-fallback');
 
-  renderRouter(
+  await renderRouterAsync(
     {
       _layout: {
         default: () => <Slot />,
@@ -75,7 +75,7 @@ it('uses the nearest layout `<SuspenseFallback>` in sync mode', () => {
   expect(screen.getByText('Loading ./(app)/profile/[id].js...')).toBeOnTheScreen();
 });
 
-it('passes route params to layout-level `<SuspenseFallback>`', () => {
+it('passes route params to layout-level `<SuspenseFallback>`', async () => {
   const pending = new Promise<string>(() => {});
 
   function SuspendingRoute() {
@@ -91,7 +91,7 @@ it('passes route params to layout-level `<SuspenseFallback>`', () => {
     </View>
   ));
 
-  renderRouter(
+  await renderRouterAsync(
     {
       '(app)/_layout': {
         default: () => <Slot />,
@@ -116,7 +116,7 @@ it('passes route params to layout-level `<SuspenseFallback>`', () => {
   );
 });
 
-it('renders default `<SuspenseFallback>` when one is not available', () => {
+it('renders default `<SuspenseFallback>` when one is not available', async () => {
   const pending = new Promise<string>(() => {}); // Promise that never resolves
 
   function SuspendingRoute() {
@@ -124,7 +124,7 @@ it('renders default `<SuspenseFallback>` when one is not available', () => {
     return <Text testID="route-content">{value}</Text>;
   }
 
-  renderRouter({
+  await renderRouterAsync({
     index: SuspendingRoute,
   });
 

--- a/packages/expo-router/src/hooks/__tests__/renderHook.tsx
+++ b/packages/expo-router/src/hooks/__tests__/renderHook.tsx
@@ -1,4 +1,7 @@
-import { renderHook as tlRenderHook } from '@testing-library/react-native';
+import {
+  renderHook as tlRenderHook,
+  renderHookAsync as tlRenderHookAsync,
+} from '@testing-library/react-native';
 import React from 'react';
 
 import { ExpoRoot } from '../../exports';
@@ -18,22 +21,41 @@ export function renderHook<T>(
   }: { initialUrl?: string; wrapper?: React.ComponentType<{ children: React.ReactNode }> } = {}
 ) {
   return tlRenderHook(renderCallback, {
-    wrapper: function Wrapper({ children }) {
-      const context: MemoryContext = {};
-      for (const key of routes) {
-        context[key] = () => <>{children}</>;
-      }
-
-      const root = (
-        <ExpoRoot
-          context={inMemoryContext(context)}
-          location={new URL(initialUrl, 'test://test')}
-        />
-      );
-
-      return RootWrapper ? <RootWrapper>{root}</RootWrapper> : root;
-    },
+    wrapper: createWrapper(routes, initialUrl, RootWrapper),
   });
+}
+
+export function renderHookAsync<T>(
+  renderCallback: () => T,
+  routes: string[] = ['index'],
+  {
+    initialUrl = '/',
+    wrapper: RootWrapper,
+  }: { initialUrl?: string; wrapper?: React.ComponentType<{ children: React.ReactNode }> } = {}
+) {
+  // TODO: Remove `renderHookAsync` when we migrate to RNTL v14.
+  return tlRenderHookAsync(renderCallback, {
+    wrapper: createWrapper(routes, initialUrl, RootWrapper),
+  });
+}
+
+function createWrapper(
+  routes: string[],
+  initialUrl: string,
+  RootWrapper?: React.ComponentType<{ children: React.ReactNode }>
+) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    const context: MemoryContext = {};
+    for (const key of routes) {
+      context[key] = () => <>{children}</>;
+    }
+
+    const root = (
+      <ExpoRoot context={inMemoryContext(context)} location={new URL(initialUrl, 'test://test')} />
+    );
+
+    return RootWrapper ? <RootWrapper>{root}</RootWrapper> : root;
+  };
 }
 
 export function renderHookOnce<T>(

--- a/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLoaderData.test.ios.tsx
@@ -1,6 +1,6 @@
-import { act } from '@testing-library/react-native';
+import { act, fireEvent, screen } from '@testing-library/react-native';
 import { expectTypeOf } from 'expect-type';
-import { type ReactNode, useLayoutEffect } from 'react';
+import { type ReactNode, useLayoutEffect, useState } from 'react';
 import { Text } from 'react-native';
 
 import { router, Slot } from '../../exports';
@@ -13,9 +13,9 @@ import {
 } from '../../loaders/LoaderContext';
 import { ServerDataLoaderContext } from '../../loaders/ServerDataLoaderContext';
 import { fetchLoader } from '../../loaders/utils';
-import { renderRouter } from '../../testing-library';
+import { renderRouter, renderRouterAsync } from '../../testing-library';
 import { useLoaderData } from '../useLoaderData';
-import { renderHook } from './renderHook';
+import { renderHook, renderHookAsync } from './renderHook';
 
 jest.mock('../../loaders/utils', () => ({
   fetchLoader: jest.fn(),
@@ -120,7 +120,8 @@ describe(useLoaderData, () => {
     await act(async () => {});
     expect(ctx.store.get('/index')).toBeUndefined();
 
-    renderHook(() => useLoaderData(), ['index'], {
+    // TODO: Remove `renderHookAsync` when we migrate to RNTL v14.
+    await renderHookAsync(() => useLoaderData(), ['index'], {
       initialUrl: '/',
       wrapper: LoaderWrapper,
     });
@@ -138,7 +139,8 @@ describe(useLoaderData, () => {
 
     const { ctx, LoaderWrapper } = createLoaderTestContext();
 
-    renderHook(() => useLoaderData(), ['users/[id]'], {
+    // TODO: Remove `renderHookAsync` when we migrate to RNTL v14.
+    await renderHookAsync(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
       wrapper: LoaderWrapper,
     });
@@ -154,7 +156,7 @@ describe(useLoaderData, () => {
     });
   });
 
-  it('retrieves settled data from the Suspense store without fetching', () => {
+  it('retrieves settled data from the Suspense store without fetching', async () => {
     globalThis.__EXPO_ROUTER_LOADER_DATA__ = {
       '/users/123': { fromHydration: true },
     };
@@ -162,7 +164,8 @@ describe(useLoaderData, () => {
     const { ctx, LoaderWrapper } = createLoaderTestContext();
     ctx.store.set('/users/123', { data: { fromStore: true } });
 
-    const { result } = renderHook(() => useLoaderData(), ['users/[id]'], {
+    // TODO: Remove `renderHookAsync` when we migrate to RNTL v14.
+    const { result } = await renderHookAsync(() => useLoaderData(), ['users/[id]'], {
       initialUrl: '/users/123',
       wrapper: LoaderWrapper,
     });
@@ -200,24 +203,41 @@ describe(useLoaderData, () => {
     const { ctx, LoaderWrapper } = createLoaderTestContext();
     ctx.store.seed('/index', { shared: true });
 
-    const first = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-      wrapper: LoaderWrapper,
-    });
-    const second = renderHook(() => useLoaderData(), ['index'], {
-      initialUrl: '/',
-      wrapper: LoaderWrapper,
-    });
+    function Reader({ testID }: { testID: string }) {
+      const data = useLoaderData();
+      return <Text testID={testID}>{JSON.stringify(data)}</Text>;
+    }
 
-    first.unmount();
+    function SiblingReaders() {
+      const [showFirst, setShowFirst] = useState(true);
+      return (
+        <>
+          {showFirst && <Reader key="first" testID="first-reader" />}
+          <Reader key="second" testID="second-reader" />
+          <Text onPress={() => setShowFirst(false)}>Remove first</Text>
+        </>
+      );
+    }
+
+    const root = await renderRouterAsync(
+      {
+        index: SiblingReaders,
+      },
+      { wrapper: LoaderWrapper }
+    );
+    jest.useRealTimers();
+
+    expect(screen.getByTestId('first-reader')).toHaveTextContent('{"shared":true}');
+    fireEvent.press(screen.getByText('Remove first'));
     await act(async () => {});
-    expect(second.result.current).toEqual({ shared: true });
+
+    expect(screen.queryByTestId('first-reader')).toBeNull();
+    expect(screen.getByTestId('second-reader')).toHaveTextContent('{"shared":true}');
     expect(ctx.store.get('/index')).toEqual({
       data: { shared: true },
     });
 
-    second.unmount();
-    await act(async () => {});
+    await root.unmountAsync();
     expect(ctx.store.get('/index')).toBeUndefined();
   });
 

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/index.test.ios.tsx
@@ -6,6 +6,9 @@ import { NavigationContainer } from '../../../fork/NavigationContainer';
 import { Text, useHeaderHeight } from '../../elements';
 import { createNativeStackNavigator, type NativeStackScreenProps } from '../index';
 
+// The native screens debug container mounts React Native's unrelated LogBox subscription UI.
+jest.mock('react-native/Libraries/LogBox/LogBoxNotificationContainer', () => () => null);
+
 type StackParamList = {
   A: undefined;
   B: undefined;

--- a/packages/expo-router/src/testing-library/index.tsx
+++ b/packages/expo-router/src/testing-library/index.tsx
@@ -60,6 +60,12 @@ export type RenderRouterOptions = Parameters<typeof rnTestingLibrary.render>[1] 
   linking?: Partial<ExpoLinkingOptions>;
 };
 
+// TODO: Remove `renderAsync` when we migrate to RNTL v14.
+export type RenderRouterAsyncOptions = Parameters<typeof rnTestingLibrary.renderAsync>[1] & {
+  initialUrl?: any;
+  linking?: Partial<ExpoLinkingOptions>;
+};
+
 type Result = ReturnType<typeof rnTestingLibrary.render> & {
   getPathname(): string;
   getPathnameWithParams(): string;
@@ -113,6 +119,27 @@ export function renderRouter(
       return store.state;
     },
   });
+}
+
+export async function renderRouterAsync(
+  context: MockContextConfig = './app',
+  { initialUrl = '/', linking, ...options }: RenderRouterAsyncOptions = {}
+): Promise<Awaited<ReturnType<typeof rnTestingLibrary.renderAsync>>> {
+  const systemTime = Date.now();
+  jest.useFakeTimers();
+  try {
+    jest.setSystemTime(systemTime);
+  } catch {
+    // Legacy fake timers don't support `setSystemTime` (and don't mock the clock), so there's nothing to restore.
+  }
+
+  process.env.EXPO_ROUTER_IMPORT_MODE = 'sync';
+
+  // TODO: Remove `renderAsync` when we migrate to RNTL v14.
+  return rnTestingLibrary.renderAsync(
+    <ExpoRoot context={getMockContext(context)} location={initialUrl} linking={linking} />,
+    options
+  );
 }
 
 export const testRouter = {


### PR DESCRIPTION
# Why

There are multiple warnings which pollute the test output in router

# How

1. Solve suspense warnings by using `renderAsync`/`renderHookAsync` function from `testing-library`
2. Ignore `LogBoxNotificationContainer` warning
3. Add `renderRouterAsync` utility

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>