### PR TITLE
[router] Remove `getRehydratedState` from router

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Require complete state in `CommonActions.reset` and `resetRoot`, and remove `Router.getRehydratedState` from `expo-router/react-navigation`.
 - Remove `NavigatorScreenParams`, `getActionFromState`, and `LinkingOptions.getActionFromState` from `expo-router/react-navigation`.
 - Represent nested navigation only as navigation state. The `screen`, `params`, and `initial` params are now ordinary user params
 - Remove the deprecated `Link` and `useLinkProps` exports from `expo-router/react-navigation`. Use `Link` from `expo-router` with an `href` instead. ([#48895](https://github.com/expo/expo/pull/48895) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
@@ -1,6 +1,7 @@
 import { act, render, waitFor } from '@testing-library/react-native';
 
 import type { RouteNode } from '../../Route';
+import { expectCompleteStateToMatch } from '../../__tests__/assertCompleteState';
 import { RouterRegistryProvider } from '../../global-state/routerRegistry';
 import { routingQueue } from '../../global-state/routingQueue';
 import { Screen } from '../../react-navigation/core/Screen';
@@ -68,6 +69,7 @@ beforeEach(() => {
 const webTest = typeof window === 'undefined' ? test.skip : test;
 
 webTest('queues forward history and restores saved, parsed, and initial state', () => {
+  mockStoreEnabled = true;
   let historyListener: (() => void) | undefined;
   let historyIndex = 3;
   jest.mocked(createMemoryHistory).mockReturnValueOnce({
@@ -127,11 +129,16 @@ webTest('queues forward history and restores saved, parsed, and initial state', 
   history.get.mockReturnValueOnce({ path: '/other' });
   Object.assign(globalThis.location, { pathname: '/parsed', search: '', hash: '' });
   act(() => historyListener?.());
-  expect(routingQueue.queue[2]).toMatchObject({
+  const parsedIntent = routingQueue.queue[2];
+  expect(parsedIntent).toMatchObject({
     type: 'ACTION',
-    payload: { action: { type: 'RESET', payload: parsedState, target: 'root' } },
+    payload: { action: { type: 'RESET', target: expect.any(String) } },
     metadata: { history: { id: 2, path: '/parsed' } },
   });
+  const parsedPayload =
+    parsedIntent?.type === 'ACTION' ? parsedIntent.payload.action.payload : undefined;
+  // `NavigationAction` exposes its payload only as `object`.
+  expectCompleteStateToMatch(parsedPayload as NavigationState | undefined, parsedState);
 
   const initialState = { routes: [{ key: 'initial', name: 'home' }] };
   getStateFromPath.mockReturnValueOnce(undefined as never);

--- a/packages/expo-router/src/fork/getPathFromState-forks.ts
+++ b/packages/expo-router/src/fork/getPathFromState-forks.ts
@@ -152,7 +152,7 @@ export function getPathWithConventionsCollapsed({
         }
         return '';
       }
-      // Preserve dynamic syntax for rehydration
+      // Preserve dynamic syntax so the path can be parsed back into state
       return shouldEncodeURISegment ? encodeURISegment(p, { preserveBrackets: true }) : p;
     })
     .map((v) => v ?? '')

--- a/packages/expo-router/src/fork/useBrowserHistorySync.ts
+++ b/packages/expo-router/src/fork/useBrowserHistorySync.ts
@@ -1,6 +1,10 @@
 import isEqual from 'fast-deep-equal';
 import { type RefObject, useEffect, useRef, useState } from 'react';
 
+import {
+  completeParsedState,
+  createSeededRootState,
+} from '../global-state/createSeededNavigationState';
 import { routingQueue, type RoutingIntent } from '../global-state/routingQueue';
 import { useExpoRouterStore } from '../global-state/storeContext';
 import { getRootStackRouteNames } from '../global-state/utils';
@@ -141,12 +145,18 @@ export function useBrowserHistorySync({
         return;
       }
 
-      const state = getStateFromPathRef.current(path, configRef.current);
-      if (state) {
+      const parsedState = getStateFromPathRef.current(path, configRef.current);
+      if (parsedState) {
         onUnhandledLinking(path);
         // Expo Router's root navigator contains only the internal slot route.
         const routeNames = getRootStackRouteNames();
-        if (state.routes.some((route) => !routeNames.includes(route.name))) {
+        if (parsedState.routes.some((route) => !routeNames.includes(route.name))) {
+          return;
+        }
+        const state = store.routeNode
+          ? createSeededRootState(parsedState, store.routeNode)
+          : completeParsedState(parsedState);
+        if (!state) {
           return;
         }
 

--- a/packages/expo-router/src/global-state/createSeededNavigationState.ts
+++ b/packages/expo-router/src/global-state/createSeededNavigationState.ts
@@ -16,7 +16,7 @@ type SeedState = NavigationState | PartialState<NavigationState>;
 
 /**
  * Completes the partial state parsed from the initial URL by `getStateFromPath` with keys,
- * route names, anchor routes, and `stale: false` so navigators adopt it without rehydration.
+ * route names, anchor routes, and `stale: false` so navigators can adopt it directly.
  *
  * @param targetState The partial state the app should start in, parsed from the initial URL by
  * `getStateFromPath`.

--- a/packages/expo-router/src/link/zoom/__tests__/ZoomTransitionEnabler.e2e.test.ios.tsx
+++ b/packages/expo-router/src/link/zoom/__tests__/ZoomTransitionEnabler.e2e.test.ios.tsx
@@ -168,8 +168,7 @@ describe('ZoomTransitionEnabler with gestureEnabled', () => {
 function navigateViaPreviewZoomLink() {
   // Simulate preview navigation: navigate with __internal__PreviewKey which sets
   // INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME on the route params.
-  // The zoom source ID is included as a param so the stack's getRehydratedState
-  // will attach the screen ID automatically.
+  // The zoom source ID is included as a param so Expo's stack router override attaches the screen ID.
   act(() =>
     router.navigate(
       {

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -244,7 +244,7 @@ test('handle dispatching with ref', () => {
   });
 });
 
-test('handle resetting state with ref', () => {
+test('handles resetting to a complete state with ref', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -287,12 +287,18 @@ test('handle resetting state with ref', () => {
   render(element).update(element);
 
   const state = {
+    stale: false as const,
+    type: 'test',
+    key: 'navigator-3',
     index: 1,
+    routeNames: ['foo', 'foo2', 'bar', 'baz'],
     routes: [
       {
         key: 'baz',
         name: 'baz',
         state: {
+          stale: false as const,
+          type: 'test',
           index: 0,
           key: '4',
           routeNames: ['qux2', 'lex2'],
@@ -312,30 +318,29 @@ test('handle resetting state with ref', () => {
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenLastCalledWith({
+    stale: false,
+    type: 'test',
     index: 1,
-    key: '0',
+    key: 'navigator-3',
     routeNames: ['foo', 'foo2', 'bar', 'baz'],
     routes: [
       {
         key: 'baz',
         name: 'baz',
-        params: undefined,
         state: {
-          index: 0,
-          key: '1',
-          routeNames: ['qux2', 'lex2'],
-          routes: [
-            { key: 'qux2', name: 'qux2', params: undefined },
-            { key: 'lex2', name: 'lex2', params: undefined },
-          ],
           stale: false,
           type: 'test',
+          index: 0,
+          key: '4',
+          routeNames: ['qux2', 'lex2'],
+          routes: [
+            { key: 'qux2', name: 'qux2' },
+            { key: 'lex2', name: 'lex2' },
+          ],
         },
       },
-      { key: 'bar', name: 'bar', params: undefined },
+      { key: 'bar', name: 'bar' },
     ],
-    stale: false,
-    type: 'test',
   });
 });
 
@@ -501,6 +506,7 @@ test('emits state events when the state changes', () => {
   expect(listener).toHaveBeenCalledTimes(1);
   expect(listener.mock.calls[0]![0].data.state).toEqual({
     stale: false,
+    type: 'test',
     index: 1,
     key: 'navigator-3',
     routeNames: ['foo', 'bar', 'baz'],
@@ -517,6 +523,7 @@ test('emits state events when the state changes', () => {
   expect(listener).toHaveBeenCalledTimes(2);
   expect(listener.mock.calls[1]![0].data.state).toEqual({
     stale: false,
+    type: 'test',
     index: 2,
     key: 'navigator-3',
     routeNames: ['foo', 'bar', 'baz'],
@@ -954,6 +961,7 @@ test('works with state change events in independent nested container', () => {
       { key: 'lex-0', name: 'lex', params: undefined },
     ],
     stale: false,
+    type: 'test',
   });
 
   expect(ref.current?.getRootState()).toEqual({
@@ -965,6 +973,7 @@ test('works with state change events in independent nested container', () => {
       { key: 'lex-0', name: 'lex', params: undefined },
     ],
     stale: false,
+    type: 'test',
   });
 });
 

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/MockRouter.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/MockRouter.tsx
@@ -3,7 +3,6 @@ import {
   type CommonNavigationAction,
   type DefaultRouterOptions,
   type NavigationState,
-  type Route,
   type Router,
 } from '../../../routers';
 
@@ -28,51 +27,6 @@ export function MockRouter(_options: DefaultRouterOptions) {
 
     getStateForDeclaredRoutes: BaseRouter.getStateForDeclaredRoutes,
 
-    getRehydratedState(partialState, { routeNames }) {
-      const state = partialState;
-
-      if (state.stale === false) {
-        return state as NavigationState;
-      }
-
-      const routes = state.routes
-        .filter((route) => routeNames.includes(route.name))
-        .map(
-          (route) =>
-            ({
-              ...route,
-              key: route.key || `${route.name}-${MockRouterKey.current++}`,
-            }) as Route<string>
-        );
-
-      if (routes.length === 0) {
-        routes.push({
-          name: routeNames[0]!,
-          key: `${routeNames[0]}-${MockRouterKey.current++}`,
-        });
-      }
-
-      const previousIndex = state.index;
-      const index = Math.min(
-        Math.max(
-          previousIndex != null
-            ? routes.findIndex((route) => route.name === state.routes[previousIndex]?.name)
-            : 0,
-          0
-        ),
-        routes.length - 1
-      );
-
-      return {
-        stale: false,
-        type: 'test',
-        key: String(MockRouterKey.current++),
-        index,
-        routeNames,
-        routes,
-      };
-    },
-
     getStateForRouteFocus(state, key) {
       const index = state.routes.findIndex((r) => r.key === key);
 
@@ -84,6 +38,8 @@ export function MockRouter(_options: DefaultRouterOptions) {
     },
 
     getStateForAction(state, action) {
+      state = state.type === 'test' ? state : { ...state, type: 'test' };
+
       switch (action.type) {
         case 'ROUTE_NAMES_CHANGED': {
           const nextState = getStateForRouteNamesChange(state, action.payload.routeNames);
@@ -174,8 +130,12 @@ export function MockRouter(_options: DefaultRouterOptions) {
           };
         }
 
-        default:
-          return BaseRouter.getStateForAction(state, action);
+        default: {
+          const result = BaseRouter.getStateForAction(state, action);
+          return result === null
+            ? null
+            : { ...result, state: { ...result.state, type: 'test' } };
+        }
       }
     },
 

--- a/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
@@ -99,6 +99,7 @@ test('initializes state for a navigator on navigation', () => {
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar', 'baz'],
@@ -165,7 +166,7 @@ test('throws for incorrect initialRouteName', () => {
   ).not.toThrow();
 });
 
-test('rehydrates state for a navigator on navigation', () => {
+test('preserves a complete navigator state on navigation', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -209,15 +210,15 @@ test('rehydrates state for a navigator on navigation', () => {
     key: '0',
     routeNames: ['foo', 'bar'],
     routes: [
-      { key: 'foo', name: 'foo', params: undefined },
-      { key: 'bar', name: 'bar', params: undefined },
+      { key: 'foo', name: 'foo' },
+      { key: 'bar', name: 'bar' },
     ],
     stale: false,
     type: 'test',
   });
 });
 
-test("doesn't rehydrate state if the type of state didn't match router", () => {
+test('initializes fresh state when the state type does not match the router', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -263,6 +264,7 @@ test("doesn't rehydrate state if the type of state didn't match router", () => {
     routeNames: ['foo', 'bar'],
     routes: [{ key: 'foo-1', name: 'foo' }],
     stale: false,
+    type: 'test',
   });
 });
 
@@ -303,6 +305,7 @@ test('initializes state for nested screens in React.Fragment', () => {
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar', 'baz'],
@@ -347,6 +350,7 @@ test('initializes state for nested screens in Group', () => {
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar', 'baz'],
@@ -404,6 +408,7 @@ test('initializes state for nested navigator on navigation', () => {
         name: 'baz',
         state: {
           stale: false,
+          type: 'test',
           index: 0,
           key: 'navigator-6',
           routeNames: ['qux'],
@@ -414,7 +419,7 @@ test('initializes state for nested navigator on navigation', () => {
   });
 });
 
-test("doesn't update state if nothing changed", () => {
+test('adds the router type if nothing else changed', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -425,6 +430,7 @@ test("doesn't update state if nothing changed", () => {
 
   const FooScreen = (props: any) => {
     React.useEffect(() => {
+      props.navigation.dispatch({ type: 'NOOP' });
       props.navigation.dispatch({ type: 'NOOP' });
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -443,7 +449,15 @@ test("doesn't update state if nothing changed", () => {
     </BaseNavigationContainer>
   );
 
-  expect(onStateChange).toHaveBeenCalledTimes(0);
+  expect(onStateChange).toHaveBeenCalledTimes(1);
+  expect(onStateChange).toHaveBeenCalledWith({
+    stale: false,
+    type: 'test',
+    index: 0,
+    key: 'navigator-2',
+    routeNames: ['foo', 'bar'],
+    routes: [{ key: 'foo-1', name: 'foo' }],
+  });
 });
 
 test("doesn't update state if action wasn't handled", () => {
@@ -523,6 +537,7 @@ test('cleans up state when the navigator unmounts', () => {
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenLastCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -577,6 +592,7 @@ test('allows state updates by dispatching a function returning an action', () =>
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 1,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -682,6 +698,7 @@ test('updates route params with setParams', () => {
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenLastCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -693,6 +710,7 @@ test('updates route params with setParams', () => {
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onStateChange).toHaveBeenLastCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -741,6 +759,7 @@ test('updates route params with setParams applied to parent', () => {
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenLastCalledWith({
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -765,6 +784,7 @@ test('updates route params with setParams applied to parent', () => {
 
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onStateChange).toHaveBeenLastCalledWith({
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],
@@ -815,6 +835,7 @@ test('handles change in route names', () => {
 
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['foo', 'baz', 'qux'],
@@ -849,6 +870,7 @@ test('reconciles route names when no previous route survives', () => {
 
   expect(onStateChange).toHaveBeenCalledWith({
     stale: false,
+    type: 'test',
     index: 0,
     key: 'navigator-2',
     routeNames: ['baz', 'qux'],
@@ -886,6 +908,7 @@ test('does not clear params if there is no nested navigator', () => {
   );
 
   expect(navigation.getRootState()).toEqual({
+    type: 'test',
     index: 1,
     key: 'navigator-2',
     routeNames: ['foo', 'bar'],

--- a/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/typelessRouter.test.ios.tsx
@@ -10,17 +10,27 @@ beforeEach(() => {
   MockRouterKey.current = 0;
 });
 
-// `MockRouter` with `type` dropped from every state it produces.
+// `MockRouter` with `type` dropped from action results.
 function StateWithoutTypeRouter(options: DefaultRouterOptions) {
-  const { getRehydratedState, ...router } = MockRouter(options);
+  const router = MockRouter(options);
+  const getStateForAction = router.getStateForAction;
 
-  // `MockRouter` always sets a type, so the result is only a `NavigationState` because `type` is optional.
+  // `MockRouter` adds `type`, but this fixture intentionally models state without router metadata.
   const omitType = ({ type: _stateType, ...state }: NavigationState) => state as NavigationState;
 
   return {
     ...router,
-    getRehydratedState: (...args: Parameters<typeof getRehydratedState>) =>
-      omitType(getRehydratedState(...args)),
+    getStateForAction: (...args: Parameters<typeof getStateForAction>) => {
+      const result = getStateForAction(...args);
+
+      return result === null
+        ? null
+        : {
+            ...result,
+            // MockRouter only returns complete states.
+            state: omitType(result.state as NavigationState),
+          };
+    },
   };
 }
 

--- a/packages/expo-router/src/react-navigation/core/createInitialState.tsx
+++ b/packages/expo-router/src/react-navigation/core/createInitialState.tsx
@@ -25,8 +25,8 @@ export function createInitialState<State extends NavigationState = NavigationSta
     });
   }
 
-  // TODO(@ubax): Improve these typings by distinguishing initial state from hydrated state types.
-  // Router state types may narrow the shared metadata added later by rehydration and actions.
+  // TODO(@ubax): Improve these typings by distinguishing initial state from complete state types.
+  // Router state types may narrow the shared metadata added later by actions.
   return {
     stale: false,
     key: `navigator-${nanoid()}`,

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -774,7 +774,7 @@ export type NavigationContainerRef<ParamList extends {}> = NavigationHelpers<Par
      */
     resetRoot(state?: PartialState<NavigationState> | NavigationState): void;
     /**
-     * Get the rehydrated navigation state of the navigation tree.
+     * Get the current state of the navigation tree.
      */
     getRootState(): NavigationState;
     /**

--- a/packages/expo-router/src/react-navigation/core/useKeyedChildListeners.tsx
+++ b/packages/expo-router/src/react-navigation/core/useKeyedChildListeners.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import type { KeyedListenerMap } from './NavigationBuilderContext';
 
 /**
- * Hook which lets child navigators add getters to be called for obtaining rehydrated state.
+ * Hook which lets child navigators add keyed listeners.
  */
 export function useKeyedChildListeners() {
   const { current: keyedListeners } = React.useRef<{

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -333,8 +333,15 @@ export function useNavigationBuilder<
   );
 
   const isStateInitialized = React.useCallback(
-    <T extends NavigationState>(state: T | PartialState<T> | undefined): state is T =>
-      state !== undefined && state.stale === false && isStateValid(state),
+    <T extends NavigationState>(state: T | PartialState<T> | undefined): state is T => {
+      if (process.env.NODE_ENV !== 'production' && state?.stale === true) {
+        throw new Error(
+          'Navigation state must be complete before it reaches a navigator. Partial state can no longer be completed during render.'
+        );
+      }
+
+      return state !== undefined && isStateValid(state);
+    },
     [isStateValid]
   );
 
@@ -370,48 +377,34 @@ export function useNavigationBuilder<
     // It likely got cleaned up due to `<Activity mode="hidden">`
     // We should reuse this state to avoid remounting screens
     if (stateCleanupRef.current && lastStateRef.current && isStateValid(lastStateRef.current)) {
-      const state: State = isStateInitialized(lastStateRef.current)
-        ? lastStateRef.current
-        : router.getRehydratedState(lastStateRef.current, {
-            routeNames,
-            routeGetIdList,
-          });
-
-      return state;
+      // State producers guarantee the stored state is complete.
+      return lastStateRef.current as State;
     }
 
-    // If the current state isn't initialized on first render, we initialize it
-    // We also need to re-initialize it if the state passed from parent was changed (maybe due to reset)
-    // Otherwise assume that the state was provided as initial state
-    // So we need to rehydrate it to make it usable
+    // Initialize when there is no state or the state belongs to a different router.
     if (currentState === undefined || !isStateValid(currentState)) {
       return createInitialState<State>({
         routeNames,
         initialRouteName: rest.initialRouteName,
       });
     } else {
-      // The context state belongs to this navigator when its router type matches.
-      return router.getRehydratedState(currentState as State | PartialState<State>, {
-        routeNames,
-        routeGetIdList,
-      });
+      // The producer contract guarantees valid context state is complete.
+      return currentState as State;
     }
     // Route configuration changes are reconciled below instead of forcing initialization.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentState, router, isStateValid]);
 
-  let state =
-    // If the state isn't initialized, or stale, use the state we initialized instead
+  const uncommittedState =
+    // If the state isn't initialized, use the state we initialized instead
     // The state won't update until there's a change needed in the state we have initialized locally
-    // So it'll be `undefined` or stale until the first navigation event happens
+    // So it'll be `undefined` until the first navigation event happens
     isStateInitialized(currentState) ? (currentState as State) : (initializedState as State);
-
-  const uncommittedState = state;
 
   // Keep render consumers safe without committing a state outside the action pipeline. The router
   // decides which survivor takes focus, so the interim render agrees with the state that
   // `ROUTE_NAMES_CHANGED` commits and no screen is focused only to be unfocused again.
-  state = router.getStateForDeclaredRoutes(state, routeNames);
+  const state = router.getStateForDeclaredRoutes(uncommittedState, routeNames);
 
   // TODO(@ubax): find a better way to implement this then ref approach
   const registryConfigRef = React.useRef({ routeNames, routeGetIdList });

--- a/packages/expo-router/src/react-navigation/core/useOnGetState.tsx
+++ b/packages/expo-router/src/react-navigation/core/useOnGetState.tsx
@@ -17,7 +17,7 @@ export function useOnGetState({ getState, getStateListeners }: Options) {
   const route = use(NavigationRouteContext);
   const key = route ? route.key : 'root';
 
-  const getRehydratedState = React.useCallback(() => {
+  const getStateWithChildren = React.useCallback(() => {
     const state = getState();
 
     // Avoid returning new route objects if we don't need to
@@ -45,6 +45,6 @@ export function useOnGetState({ getState, getStateListeners }: Options) {
   }, [getState, getStateListeners]);
 
   React.useEffect(() => {
-    return addKeyedListener?.('getState', key, getRehydratedState);
-  }, [addKeyedListener, getRehydratedState, key]);
+    return addKeyedListener?.('getState', key, getStateWithChildren);
+  }, [addKeyedListener, getStateWithChildren, key]);
 }

--- a/packages/expo-router/src/react-navigation/routers/BaseRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/BaseRouter.tsx
@@ -102,11 +102,10 @@ export const BaseRouter = {
           };
         }
 
-        return {
-          state: nextState,
-          affectedRouteKey:
-            nextState.index === undefined ? undefined : nextState.routes[nextState.index]?.key,
-        };
+        // TODO: support completing partial reset payloads at dispatch (follow-up PR).
+        throw new Error(
+          'The RESET action payload must contain a complete navigation state. Partial states can no longer be completed during render. Include `key`, `index`, `routeNames`, and `stale: false` when resetting.'
+        );
       }
 
       default:

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -1,5 +1,3 @@
-import { nanoid } from 'nanoid/non-secure';
-
 import {
   ensureStateHistory,
   type TabActionHelpers,
@@ -10,7 +8,7 @@ import {
   type TabRouterOptions,
 } from './TabRouter';
 import { ensureStateType } from './ensureStateType';
-import type { CommonNavigationAction, ParamListBase, PartialState, Router } from './types';
+import type { CommonNavigationAction, ParamListBase, Router } from './types';
 export type DrawerStatus = 'open' | 'closed';
 
 export type DrawerActionType =
@@ -95,9 +93,8 @@ export function DrawerRouter({
       initialRouteName
     ) as unknown as DrawerNavigationState<ParamListBase>;
 
-  const isDrawerInHistory = (
-    state: DrawerNavigationState<ParamListBase> | PartialState<DrawerNavigationState<ParamListBase>>
-  ) => Boolean(state.history?.some((it) => it.type === 'drawer'));
+  const isDrawerInHistory = (state: DrawerNavigationState<ParamListBase>) =>
+    Boolean(state.history?.some((it) => it.type === 'drawer'));
 
   const addDrawerToHistory = (
     state: DrawerNavigationState<ParamListBase>
@@ -155,29 +152,6 @@ export function DrawerRouter({
     ...router,
 
     type: 'drawer',
-
-    getRehydratedState(partialState, { routeNames, routeGetIdList }) {
-      if (partialState.stale === false) {
-        return partialState;
-      }
-
-      let state = router.getRehydratedState(partialState, {
-        routeNames,
-        routeGetIdList,
-      });
-
-      if (isDrawerInHistory(partialState)) {
-        // Re-sync the drawer entry in history to correct it if it was wrong
-        state = removeDrawerFromHistory(state);
-        state = addDrawerToHistory(state);
-      }
-
-      return {
-        ...state,
-        type: 'drawer',
-        key: `drawer-${nanoid()}`,
-      };
-    },
 
     getStateForRouteFocus(state, key) {
       const result = router.getStateForRouteFocus(ensureDrawerStateOptionalProperties(state), key);

--- a/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/StackRouter.tsx
@@ -193,59 +193,7 @@ export function StackRouter(options: StackRouterOptions) {
   > = {
     ...BaseRouter,
 
-    // TODO: Keep this value in sync with the `ensureStateType` calls below.
     type: 'stack',
-
-    getRehydratedState(partialState, { routeNames }) {
-      const state = partialState;
-
-      if (state.stale === false) {
-        return state;
-      }
-
-      const index = state.index ?? state.routes.length - 1;
-      const activeRoutes = state.routes.slice(0, index + 1);
-      const stalePreloadedRoutes = state.routes.slice(index + 1);
-
-      const routes: Route<string>[] = activeRoutes
-        .filter((route) => routeNames.includes(route.name))
-        .map((route) => ({
-          ...route,
-          key: route.key || `${route.name}-${nanoid()}`,
-        }));
-
-      const preloadedRoutes =
-        stalePreloadedRoutes
-          ?.filter((route) => routeNames.includes(route.name))
-          .map(
-            (route) =>
-              ({
-                ...route,
-                key: route.key || `${route.name}-${nanoid()}`,
-              }) as Route<string>
-          ) ?? [];
-
-      if (routes.length === 0) {
-        const initialRouteName =
-          options.initialRouteName !== undefined ? options.initialRouteName : routeNames[0]!;
-
-        routes.push({
-          key: `${initialRouteName}-${nanoid()}`,
-          name: initialRouteName,
-        });
-      }
-
-      return ensureStateType(
-        {
-          stale: false,
-          key: `stack-${nanoid()}`,
-          index: routes.length - 1,
-          routeNames,
-          routes: routes.concat(preloadedRoutes),
-        },
-        'stack'
-      );
-    },
 
     getStateForDeclaredRoutes(state, routeNames) {
       const filteredState = BaseRouter.getStateForDeclaredRoutes(state, routeNames);
@@ -685,7 +633,7 @@ export function StackRouter(options: StackRouterOptions) {
         default: {
           const result = BaseRouter.getStateForAction(state, action);
 
-          if (result === null || result.state.stale !== false) {
+          if (result === null) {
             return result;
           }
 

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -11,7 +11,6 @@ import type {
   DefaultRouterOptions,
   NavigationState,
   ParamListBase,
-  PartialState,
   Route,
   Router,
 } from './types';
@@ -305,48 +304,6 @@ export function TabRouter({
     ...BaseRouter,
 
     type: 'tab',
-
-    getRehydratedState(partialState, { routeNames }) {
-      const state = partialState;
-
-      if (state.stale === false) {
-        return state;
-      }
-
-      const partialRoutes = (state as PartialState<TabNavigationState<ParamListBase>>).routes;
-      const filteredRoutes = partialRoutes
-        .filter((route) => routeNames.includes(route.name))
-        .map((route) => ({
-          ...route,
-          key: route.key || `${route.name}-${nanoid()}`,
-        }));
-      const routes = addFallbackRouteIfEmpty(filteredRoutes, routeNames, initialRouteName);
-
-      const focusedName = state.routes[state.index ?? 0]?.name;
-      const focusedIndex = routes.findIndex((route) => route.name === focusedName);
-      const index = Math.min(Math.max(focusedIndex, 0), routes.length - 1);
-
-      const routeKeys = routes.map((route) => route.key);
-
-      const history = state.history?.filter((it) => routeKeys.includes(it.key)) ?? [];
-
-      return changeIndex(
-        ensureStateType(
-          {
-            stale: false,
-            key: `tab-${nanoid()}`,
-            index,
-            routeNames,
-            history,
-            routes,
-          },
-          'tab'
-        ),
-        index,
-        backBehavior,
-        initialRouteName
-      );
-    },
 
     getStateForRouteFocus(inputState, key) {
       const state = ensureStateType(
@@ -727,14 +684,19 @@ export function TabRouter({
         default: {
           const result = BaseRouter.getStateForAction(state, action);
 
-          if (result === null || result.state.stale !== false) {
+          if (result === null) {
             return result;
           }
 
           return {
             ...result,
             state: ensureStateType(
-              ensureStateHistory(result.state, backBehavior, initialRouteName),
+              ensureStateHistory(
+                // BaseRouter throws instead of returning partial RESET payloads.
+                result.state as TabNavigationState<ParamListBase>,
+                backBehavior,
+                initialRouteName
+              ),
               state.type
             ),
           };

--- a/packages/expo-router/src/react-navigation/routers/__tests__/BaseRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/BaseRouter.test.tsx
@@ -155,7 +155,7 @@ test("doesn't handle REPLACE_PARAMS if source key isn't present", () => {
   expect(result).toBeNull();
 });
 
-test('resets state to new state with RESET', () => {
+test('resets to a complete state with RESET', () => {
   const routes = [
     { key: 'foo', name: 'foo' },
     { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
@@ -166,22 +166,20 @@ test('resets state to new state with RESET', () => {
   const result = BaseRouter.getStateForAction(
     STATE,
     CommonActions.reset({
+      ...STATE,
       index: 0,
       routes,
     })
   );
 
-  expect(result?.state).toEqual({ index: 0, routes });
+  expect(result?.state).toEqual({ ...STATE, index: 0, routes });
   expect(result?.affectedRouteKey).toBe('foo');
 });
 
-test('returns no route key when a partial RESET has no index', () => {
-  const result = BaseRouter.getStateForAction(
-    STATE,
-    CommonActions.reset({ routes: [{ name: 'foo' }] })
-  );
-
-  expect(result?.affectedRouteKey).toBeUndefined();
+test('throws for a partial RESET state', () => {
+  expect(() =>
+    BaseRouter.getStateForAction(STATE, CommonActions.reset({ routes: [{ name: 'foo' }] }))
+  ).toThrow('The RESET action payload must contain a complete navigation state.');
 });
 
 test('adds keys to routes missing keys during RESET', () => {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -61,8 +61,7 @@ test('route focus returns drawer metadata for state without router metadata', ()
   });
 });
 
-test('passes partial RESET state through unchanged', () => {
-  const partialState = { routes: [{ name: 'bar' }] };
+test('throws for partial RESET state', () => {
   const state: DrawerNavigationState<ParamListBase> = {
     stale: false,
     key: 'root',
@@ -70,12 +69,12 @@ test('passes partial RESET state through unchanged', () => {
     routeNames: ['bar'],
     routes: [{ key: 'bar', name: 'bar' }],
   };
-  const result = DrawerRouter({}).getStateForAction(state, CommonActions.reset(partialState), {
-    routeNames: ['bar'],
-    routeGetIdList: {},
-  });
-
-  expect(result?.state).toBe(partialState);
+  expect(() =>
+    DrawerRouter({}).getStateForAction(state, CommonActions.reset({ routes: [{ name: 'bar' }] }), {
+      routeNames: ['bar'],
+      routeGetIdList: {},
+    })
+  ).toThrow('The RESET action payload must contain a complete navigation state.');
 });
 
 type DrawerHistory = NonNullable<DrawerNavigationState<ParamListBase>['history']>;
@@ -280,10 +279,14 @@ test('PRELOAD rebuilds route history without dropping drawer status', () => {
     routeNames: ['bar', 'baz', 'qux'],
     routeGetIdList: {},
   };
-  const focusedState = router.getRehydratedState(
-    { routes: [{ key: 'qux-key', name: 'qux' }] },
-    options
-  ) as DrawerNavigationState<ParamListBase>;
+  const focusedState: DrawerNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'drawer',
+    key: 'drawer-test',
+    index: 0,
+    routeNames: options.routeNames,
+    routes: [{ key: 'qux-key', name: 'qux' }],
+  };
   const openState = router.getStateForAction(
     focusedState,
     DrawerActions.openDrawer(),
@@ -301,157 +304,6 @@ test('PRELOAD rebuilds route history without dropping drawer status', () => {
     { type: 'route', key: 'qux-key' },
     { type: 'drawer', status: 'open' },
   ]);
-});
-
-test('gets rehydrated state from partial state', () => {
-  const router = DrawerRouter({});
-
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'qux-1', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'qux-1', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        routes: [{ key: 'baz-0', name: 'baz' }],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'baz-0', name: 'baz' }],
-    history: [{ type: 'route', key: 'baz-0' }],
-    stale: false,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-1', name: 'baz' },
-          { key: 'qux-2', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 2,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-1', name: 'baz' },
-      { key: 'qux-2', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
-    ],
-    stale: false,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 4,
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
-    history: [{ type: 'route', key: 'bar-test' }],
-    stale: false,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 1,
-        history: [
-          { type: 'route', key: 'bar-test' },
-          { type: 'route', key: 'qux-test' },
-          { type: 'route', key: 'foo-test' },
-          { type: 'drawer', status: 'open' },
-        ],
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'drawer', status: 'open' },
-    ],
-    stale: false,
-    type: 'drawer',
-  });
-});
-
-test("doesn't rehydrate state if it's not stale", () => {
-  const router = DrawerRouter({});
-
-  const state: DrawerNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'drawer', status: 'open' },
-    ],
-    stale: false as const,
-    type: 'drawer' as const,
-  };
-
-  expect(
-    router.getRehydratedState(state, {
-      routeNames: [],
-      routeGetIdList: {},
-    })
-  ).toBe(state);
 });
 
 test('handles navigate action', () => {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/StackRouter.test.tsx
@@ -67,170 +67,31 @@ describe('state without router type', () => {
     expect(result?.state.type).toBe('stack');
   });
 
-  test('passes partial RESET state through unchanged', () => {
-    const partialState = { routes: [{ name: 'bar' }] };
-    const result = StackRouter({}).getStateForAction(
-      createState(),
-      CommonActions.reset(partialState),
-      options
-    );
-
-    expect(result?.state).toBe(partialState);
+  test('throws for partial RESET state', () => {
+    expect(() =>
+      StackRouter({}).getStateForAction(
+        createState(),
+        CommonActions.reset({ routes: [{ name: 'bar' }] }),
+        options
+      )
+    ).toThrow('The RESET action payload must contain a complete navigation state.');
   });
 });
 
-test('gets rehydrated state from partial state', () => {
-  const router = StackRouter({});
-
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 1,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'qux-1', name: 'qux' },
-          { name: 'baz', key: 'baz-test' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 1,
-    key: 'stack-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'qux-1', name: 'qux' },
-      { name: 'baz', key: 'baz-test' },
-    ],
-    stale: false,
-    type: 'stack',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-1', name: 'baz' },
-          { key: 'qux-2', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 2,
-    key: 'stack-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-1', name: 'baz' },
-      { key: 'qux-2', name: 'qux' },
-    ],
-    stale: false,
-    type: 'stack',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 4,
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'stack-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
-    stale: false,
-    type: 'stack',
-  });
-});
-
-test('treats all routes as active when rehydrating state without an index', () => {
-  const router = StackRouter({});
-
-  expect(
-    router.getRehydratedState(
-      {
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          {
-            key: 'baz-1',
-            name: 'baz',
-            params: { id: '42' },
-            path: '/42',
-            state: { routes: [{ name: 'qux' }] },
-          },
-        ],
-      },
-      {
-        routeNames: ['bar', 'baz'],
-        routeGetIdList: {},
-      }
-    )
-  ).toEqual({
-    index: 1,
-    key: 'stack-test',
-    routeNames: ['bar', 'baz'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      {
-        key: 'baz-1',
-        name: 'baz',
-        params: { id: '42' },
-        path: '/42',
-        state: { routes: [{ name: 'qux' }] },
-      },
-    ],
-    stale: false,
-    type: 'stack',
-  });
-});
-
-test("doesn't rehydrate state if it's not stale", () => {
-  const router = StackRouter({});
-
+test('getStateForDeclaredRoutes keeps focus when an earlier active route is removed', () => {
   const state = {
-    index: 0,
-    key: 'stack-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
     stale: false as const,
     type: 'stack' as const,
+    key: 'stack-test',
+    index: 1,
+    routeNames: ['removed', 'focused', 'preloaded'],
+    routes: [
+      { key: 'removed', name: 'removed' },
+      { key: 'focused', name: 'focused' },
+      { key: 'preloaded', name: 'preloaded' },
+    ],
   };
-
-  expect(
-    router.getRehydratedState(state, {
-      routeNames: [],
-      routeGetIdList: {},
-    })
-  ).toBe(state);
-});
-
-test('keeps the focused route when rehydration filters an earlier active route', () => {
-  const result = StackRouter({}).getRehydratedState(
-    {
-      index: 1,
-      routes: [
-        { key: 'removed', name: 'removed' },
-        { key: 'focused', name: 'focused' },
-        { key: 'preloaded', name: 'preloaded' },
-      ],
-    },
-    {
-      routeNames: ['focused', 'preloaded'],
-      routeGetIdList: {},
-    }
-  );
+  const result = StackRouter({}).getStateForDeclaredRoutes(state, ['focused', 'preloaded']);
 
   expect(result.index).toBe(0);
   expect(result.routes.map((route) => route.key)).toEqual(['focused', 'preloaded']);

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -54,15 +54,14 @@ describe('state without router metadata', () => {
     });
   });
 
-  test('passes partial RESET state through unchanged', () => {
-    const partialState = { routes: [{ name: 'bar' }] };
-    const result = TabRouter({}).getStateForAction(
-      createState(),
-      CommonActions.reset(partialState),
-      options
-    );
-
-    expect(result?.state).toBe(partialState);
+  test('throws for partial RESET state', () => {
+    expect(() =>
+      TabRouter({}).getStateForAction(
+        createState(),
+        CommonActions.reset({ routes: [{ name: 'bar' }] }),
+        options
+      )
+    ).toThrow('The RESET action payload must contain a complete navigation state.');
   });
 
   test('route focus returns tab type and history', () => {
@@ -129,11 +128,6 @@ test('handles empty tab states', () => {
     routeGetIdList: {},
   });
 
-  expect(router.getRehydratedState({ routes: [] }, emptyOptions)).toMatchObject({
-    index: -1,
-    routes: [],
-    history: [],
-  });
   const emptyState = router.getStateForAction(
     state,
     { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: [] } },
@@ -141,152 +135,6 @@ test('handles empty tab states', () => {
   )!.state as TabNavigationState<ParamListBase>;
   expect(emptyState).toMatchObject({ index: -1, routes: [], history: [] });
   expect(router.getStateForAction(emptyState, CommonActions.goBack(), emptyOptions)).toBeNull();
-});
-
-test('gets rehydrated state from partial state', () => {
-  const router = TabRouter({});
-
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'qux-1', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'qux-1', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false,
-    type: 'tab',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        routes: [{ key: 'baz-0', name: 'baz' }],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'baz-0', name: 'baz' }],
-    history: [{ type: 'route', key: 'baz-0' }],
-    stale: false,
-    type: 'tab',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-1', name: 'baz' },
-          { key: 'qux-2', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 2,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-1', name: 'baz' },
-      { key: 'qux-2', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
-    ],
-    stale: false,
-    type: 'tab',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 1,
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'qux-2', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    index: 1,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'qux-2', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'qux-2' },
-    ],
-    stale: false,
-    type: 'tab',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 4,
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
-    history: [{ type: 'route', key: 'bar-test' }],
-    stale: false,
-    type: 'tab',
-  });
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 1,
-        history: [
-          { type: 'route', key: 'bar-test' },
-          { type: 'route', key: 'qux-test' },
-          { type: 'route', key: 'foo-test' },
-        ],
-        routes: [],
-      },
-      options
-    )
-  ).toEqual({
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [{ key: 'bar-test', name: 'bar' }],
-    history: [{ type: 'route', key: 'bar-test' }],
-    stale: false,
-    type: 'tab',
-  });
 });
 
 test.each([
@@ -651,7 +499,14 @@ test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>
     routeNames: ['bar', 'baz', 'qux'],
     routeGetIdList: {},
   };
-  const state = router.getRehydratedState({ routes: [{ key: 'qux-key', name: 'qux' }] }, options);
+  const state: TabNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 0,
+    routeNames: options.routeNames,
+    routes: [{ key: 'qux-key', name: 'qux' }],
+  };
 
   const result = router.getStateForAction(state, CommonActions.goBack(), options)!.state;
 
@@ -669,10 +524,14 @@ test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>
     routeNames: ['bar', 'baz', 'qux'],
     routeGetIdList: {},
   };
-  const focusedState = router.getRehydratedState(
-    { routes: [{ key: 'qux-key', name: 'qux' }] },
-    options
-  );
+  const focusedState: TabNavigationState<ParamListBase> = {
+    stale: false,
+    type: 'tab',
+    key: 'root',
+    index: 0,
+    routeNames: options.routeNames,
+    routes: [{ key: 'qux-key', name: 'qux' }],
+  };
   const state = router.getStateForAction(
     focusedState,
     { type: 'PRELOAD', payload: { name } },
@@ -688,269 +547,6 @@ test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>
 
   expect(result.state.routes[result.state.index!]!.name).toBe(name);
   expect(result.state.history).toEqual([{ type: 'route', key: `${name}-test` }]);
-});
-
-test("doesn't rehydrate state if it's not stale", () => {
-  const router = TabRouter({});
-
-  const state: TabNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'tab-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-    stale: false,
-    type: 'tab',
-  };
-
-  expect(
-    router.getRehydratedState(state, {
-      routeNames: [],
-      routeGetIdList: {},
-    })
-  ).toBe(state);
-});
-
-test('restores correct history on rehydrating with backBehavior: order', () => {
-  const router = TabRouter({ backBehavior: 'order' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { key: 'foo-0', type: 'route' },
-      { key: 'bar-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
-    stale: false,
-    type: 'tab',
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    type: 'tab',
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    type: 'tab',
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: firstRoute', () => {
-  const router = TabRouter({
-    backBehavior: 'firstRoute',
-    initialRouteName: 'bar',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { key: 'foo-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
-    stale: false,
-    type: 'tab',
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: initialRoute', () => {
-  const router = TabRouter({
-    backBehavior: 'initialRoute',
-    initialRouteName: 'bar',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { key: 'bar-0', type: 'route' },
-      { key: 'baz-0', type: 'route' },
-    ],
-    stale: false,
-    type: 'tab',
-  });
-});
-
-test('restores correct history on rehydrating with backBehavior: none', () => {
-  const router = TabRouter({ backBehavior: 'none' });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getRehydratedState(
-      {
-        index: 2,
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      },
-      options
-    )
-  ).toEqual({
-    key: 'tab-test',
-    index: 2,
-    routeNames: ['foo', 'bar', 'baz', 'qux'],
-    routes: [
-      { key: 'foo-0', name: 'foo' },
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ key: 'baz-0', type: 'route' }],
-    stale: false,
-    type: 'tab',
-  });
 });
 
 test('gets state on route names change', () => {
@@ -1133,28 +729,6 @@ test('falls back to the first surviving route in state order', () => {
     },
     options
   )!.state;
-
-  expect(result.routes[result.index!]!.name).toBe('bar');
-});
-
-test('rehydration falls back to the first surviving route in state order', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['qux', 'bar'],
-    routeGetIdList: {},
-  };
-
-  const result = router.getRehydratedState(
-    {
-      routes: [
-        { key: 'bar-test', name: 'bar' },
-        { key: 'removed-test', name: 'removed' },
-        { key: 'qux-test', name: 'qux' },
-      ],
-      index: 1,
-    },
-    options
-  );
 
   expect(result.routes[result.index!]!.name).toBe('bar');
 });
@@ -3291,14 +2865,36 @@ describe('state without history', () => {
     expect(result?.state.history).toBeDefined();
   });
 
-  test('handles route focus', () => {
-    const router = TabRouter({ backBehavior: 'history' });
+  test.each<[Parameters<typeof TabRouter>[0]['backBehavior'], string | undefined, string[]]>([
+    ['order', undefined, ['foo-0', 'bar-0', 'baz-0']],
+    ['history', undefined, ['baz-0']],
+    ['fullHistory', undefined, ['baz-0']],
+    ['firstRoute', 'bar', ['foo-0', 'baz-0']],
+    ['initialRoute', 'bar', ['bar-0', 'baz-0']],
+    ['none', undefined, ['baz-0']],
+  ])(
+    'reconstructs history during route focus with backBehavior: %s',
+    (backBehavior, initialRouteName, keys) => {
+      const router = TabRouter({ backBehavior, initialRouteName });
+      const state: TabNavigationState<ParamListBase> = {
+        stale: false,
+        type: 'tab',
+        key: 'tab-test',
+        index: 2,
+        routeNames: ['foo', 'bar', 'baz', 'qux'],
+        routes: [
+          { key: 'foo-0', name: 'foo' },
+          { key: 'bar-0', name: 'bar' },
+          { key: 'baz-0', name: 'baz' },
+          { key: 'qux-0', name: 'qux' },
+        ],
+      };
 
-    expect(router.getStateForRouteFocus(createState(), 'qux').history).toEqual([
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'qux' },
-    ]);
-  });
+      expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual(
+        keys.map((key) => ({ type: 'route', key }))
+      );
+    }
+  );
 
   test('preserves params when reconstructing full history', () => {
     const router = TabRouter({ backBehavior: 'fullHistory' });

--- a/packages/expo-router/src/react-navigation/routers/types.tsx
+++ b/packages/expo-router/src/react-navigation/routers/types.tsx
@@ -34,15 +34,11 @@ export type NavigationState<ParamList extends ParamListBase = ParamListBase> = R
   routes: NavigationRoute<ParamList, keyof ParamList>[];
   /**
    * Custom type for the state, whether it's for tab, stack, drawer etc.
-   * During rehydration, the state will be discarded if type doesn't match with router type.
-   * It can also be used to detect the type of the navigator we're dealing with. Note that initial
-   * state does not include type, so an action needs to be dispatched in a navigator, in order
-   * for the type to be set
+   * A navigator discards state whose type doesn't match its router type.
+   * It can also be used to detect the type of the navigator we're dealing with.
    */
   type?: string;
-  /**
-   * Whether the navigation state has been rehydrated.
-   */
+  // TODO: Remove `stale` in a follow-up after partial navigation states are removed.
   stale: false;
 }>;
 
@@ -57,6 +53,7 @@ export type PartialRoute<R extends Route<string>> = Omit<R, 'key'> & {
   state?: PartialState<NavigationState>;
 };
 
+// TODO: Remove `PartialState` in a follow-up once all state producers return complete states.
 export type PartialState<State extends NavigationState> = Partial<Omit<State, 'stale' | 'routes'>> &
   Readonly<{
     stale?: true;
@@ -144,7 +141,7 @@ export type RouterConfigOptions = {
 
 /**
  * Type of the router. Should match the `type` property in state.
- * If the type doesn't match, the state will be discarded during rehydration.
+ * If the type doesn't match, the state will be discarded.
  * Only routers whose state has no `type` may omit it, since a state without a `type`
  * is accepted by every router.
  */
@@ -156,17 +153,6 @@ export type Router<
   State extends NavigationState,
   Action extends NavigationAction,
 > = RouterType<State> & {
-  /**
-   * Rehydrate the full navigation state from a given partial state.
-   *
-   * @param partialState Navigation state to rehydrate from.
-   * @param options.routeNames List of valid route names as defined in the screen components.
-   */
-  getRehydratedState(
-    partialState: PartialState<State> | State,
-    options: RouterConfigOptions
-  ): State;
-
   /**
    * Take the current state and the route names the navigator declares, and return the state to
    * render until `ROUTE_NAMES_CHANGED` has been reconciled.

--- a/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/types.test.tsx
@@ -89,9 +89,6 @@ const TypelessRouter: RouterFactory<
   NavigationAction,
   DefaultRouterOptions
 > = () => ({
-  getRehydratedState: () => {
-    throw new Error('Type test only');
-  },
   getStateForDeclaredRoutes: (state) => state,
   getStateForRouteFocus: (state) => state,
   getStateForAction: (state) => ({
@@ -103,8 +100,7 @@ const TypelessRouter: RouterFactory<
 
 unstable_createStandardRouterNavigator(Content, TypelessRouter);
 
-// A router may omit `type` only when its state has none. Otherwise initialization accepts the
-// typeless state, rehydration adds a type, and `isStateValid` rejects it in a loop.
+// A router may omit `type` only when its state has none.
 export type _BaseRouterTypeIsOptional = Expect<
   Equal<Pick<Router<NavigationState, NavigationAction>, 'type'>, { type?: string }>
 >;

--- a/packages/expo-router/src/ui/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/ui/__tests__/TabRouter.test.tsx
@@ -1,7 +1,23 @@
 import { expect, test } from '@jest/globals';
 
+import type { ParamListBase, TabNavigationState } from '../../react-navigation/native';
 import { ExpoTabRouter } from '../TabRouter';
 import type { TriggerMap } from '../common';
+
+function buildTabState(
+  routes: TabNavigationState<ParamListBase>['routes'],
+  index: number
+): TabNavigationState<ParamListBase> {
+  return {
+    stale: false,
+    type: 'tab',
+    key: 'tabs',
+    index,
+    routeNames: routes.map((route) => route.name),
+    routes,
+    history: [{ type: 'route', key: routes[0]!.key }],
+  };
+}
 
 test('reselecting a seeded tab returns tab metadata', () => {
   const router = ExpoTabRouter({ triggerMap: {} });
@@ -31,19 +47,16 @@ test('reports the key selected when preserving nested tab state', () => {
   const triggerMap: TriggerMap = {};
   const router = ExpoTabRouter({ triggerMap });
   const options = { routeNames: ['first', 'second'], routeGetIdList: {} };
-  const state = router.getRehydratedState(
-    {
-      index: 0,
-      routes: [
-        { key: 'first-key', name: 'first' },
-        {
-          key: 'second-key',
-          name: 'second',
-          state: { routes: [{ name: 'child' }] },
-        },
-      ],
-    },
-    options
+  const state = buildTabState(
+    [
+      { key: 'first-key', name: 'first' },
+      {
+        key: 'second-key',
+        name: 'second',
+        state: { routes: [{ name: 'child' }] },
+      },
+    ],
+    0
   );
 
   const result = router.getStateForAction(
@@ -64,15 +77,12 @@ test('reselecting a tab with matching carried state preserves its history', () =
     index: 1,
     __internal__routerActionState: true as const,
   };
-  const state = router.getRehydratedState(
-    {
-      index: 1,
-      routes: [
-        { key: 'first-key', name: 'first' },
-        { key: 'second-key', name: 'second', state: childState },
-      ],
-    },
-    options
+  const state = buildTabState(
+    [
+      { key: 'first-key', name: 'first' },
+      { key: 'second-key', name: 'second', state: childState },
+    ],
+    1
   );
 
   const result = router.getStateForAction(
@@ -95,15 +105,12 @@ test('replaces a tab child state when trusted carried state differs', () => {
     routes: [{ name: 'replacement' }],
     __internal__routerActionState: true as const,
   };
-  const state = router.getRehydratedState(
-    {
-      index: 0,
-      routes: [
-        { key: 'first-key', name: 'first' },
-        { key: 'second-key', name: 'second', state: { routes: [{ name: 'child' }] } },
-      ],
-    },
-    options
+  const state = buildTabState(
+    [
+      { key: 'first-key', name: 'first' },
+      { key: 'second-key', name: 'second', state: { routes: [{ name: 'child' }] } },
+    ],
+    0
   );
 
   const result = router.getStateForAction(
@@ -122,15 +129,12 @@ test('resetOnFocus preserves child state when reselecting the focused tab', () =
   const router = ExpoTabRouter({ triggerMap: {} });
   const options = { routeNames: ['first', 'second'], routeGetIdList: {} };
   const childState = { routes: [{ name: 'child' }, { name: 'details' }], index: 1 };
-  const state = router.getRehydratedState(
-    {
-      index: 1,
-      routes: [
-        { key: 'first-key', name: 'first' },
-        { key: 'second-key', name: 'second', state: childState },
-      ],
-    },
-    options
+  const state = buildTabState(
+    [
+      { key: 'first-key', name: 'first' },
+      { key: 'second-key', name: 'second', state: childState },
+    ],
+    1
   );
 
   const result = router.getStateForAction(

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -231,9 +231,8 @@ export function useTriggersToScreens(
 
     if (config.type === 'internal') {
       // TODO(https://github.com/expo/expo/pull/48756): Resolved internal-trigger href params need
-      // to flow through ExpoTabRouter to placeholder and fallback routes, action-recreated routes,
-      // and stale-state rehydration without restoring Screen.initialParams. Explicit action params
-      // must override these defaults.
+      // to flow through ExpoTabRouter to placeholder, fallback, and action-recreated routes without
+      // restoring Screen.initialParams. Explicit action params must override these defaults.
       screenProps.push({ name: config.routeNode.route });
     }
   }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>