### PR TITLE
[docs] Add aria-hidden to decorative icons failing svg-img-alt

### DIFF
--- a/docs/pages/guides/overview.mdx
+++ b/docs/pages/guides/overview.mdx
@@ -11,19 +11,19 @@ import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 
 This section contains information about the development with Expo and Expo Application Services (EAS):
 
-## <span className="inline-flex items-center gap-2"><CodeSquare01Icon />Development process</span>
+## <span className="inline-flex items-center gap-2"><CodeSquare01Icon aria-hidden="true" />Development process</span>
 
 Learn about the process of [building an app with Expo](/workflow/overview/) to help understand the mental model of the core development loop. This section also dives into additional configurations and workflows you may require during the development process to help you develop, deploy, and maintain your app. It contains in-depth information about [app config](/workflow/configuration/), [permissions](/guides/permissions/), [universal links](/linking/into-your-app/), [custom native code](/workflow/continuous-native-generation/), [web](/workflow/web/), and more.
 
-## <span className="inline-flex items-center gap-2"><RouterLogo />Expo Router</span>
+## <span className="inline-flex items-center gap-2"><RouterLogo aria-hidden="true" />Expo Router</span>
 
 Learn about using different navigation functionalities from the [Expo Router](/router/introduction/) library. It also covers a comprehensive [Hooks API](/versions/latest/sdk/router/#hooks) that the library provides and other aspects of navigation such as [Authentication](/router/advanced/authentication/), [Redirects](/router/reference/redirects/), [Testing](/router/reference/testing/), and more.
 
-## <span className="inline-flex items-center gap-2"><CpuChip01Icon />Expo Modules API</span>
+## <span className="inline-flex items-center gap-2"><CpuChip01Icon aria-hidden="true" />Expo Modules API</span>
 
 Learn how to add and use native modules in your app using [Expo Modules API](/modules/overview/).
 
-## <span className="inline-flex items-center gap-2"><GraduationHat02DuotoneIcon />Tutorials</span>
+## <span className="inline-flex items-center gap-2"><GraduationHat02DuotoneIcon aria-hidden="true" />Tutorials</span>
 
 If you're looking for step-by-step tutorials for Expo and EAS, see the [Tutorial section](/tutorial/overview/) which includes comprehensive tutorials for both [building apps with Expo](/tutorial/introduction/) and [using EAS services](/tutorial/eas/introduction/).
 

--- a/docs/pages/router/advanced/authentication-rewrites.mdx
+++ b/docs/pages/router/advanced/authentication-rewrites.mdx
@@ -34,14 +34,14 @@ It's common to restrict specific routes to users who are not authenticated. This
     [
       'app/sign-in.tsx',
       <span>
-        Always accessible <LockUnlocked01Icon className="mb-1 inline" />
+        Always accessible <LockUnlocked01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
     ['app/(app)/_layout.tsx', <span>Protects child routes</span>],
     [
       'app/(app)/index.tsx',
       <span>
-        Requires authorization <Lock01Icon className="mb-1 inline" />
+        Requires authorization <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
   ]}
@@ -305,7 +305,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
     [
       'app/(app)/(root)/index.tsx',
       <span>
-        Requires authorization <Lock01Icon className="mb-1 inline" />
+        Requires authorization <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
   ]}

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -27,13 +27,13 @@ With Expo Router, all routes are always defined and accessible. You can use runt
     [
       'src/app/sign-in.tsx',
       <span>
-        Always accessible <LockUnlocked01Icon className="mb-1 inline" />
+        Always accessible <LockUnlocked01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
     [
       'src/app/(app)/_layout.tsx',
       <span>
-        Requires authorization <Lock01Icon className="mb-1 inline" />
+        Requires authorization <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
     ['src/app/(app)/index.tsx', <span>Should be protected by the (app)/_layout</span>],
@@ -335,7 +335,7 @@ Another common pattern is to render a sign-in modal over the top of the app. Thi
     [
       'src/app/(app)/(root)/index.tsx',
       <span>
-        Requires authorization <Lock01Icon className="mb-1 inline" />
+        Requires authorization <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
   ]}

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -203,13 +203,13 @@ For example, consider the following navigation tree in which you have a bottom t
     [
       'src/app/(tabs)/index.tsx',
       <span>
-        Protected <Lock01Icon className="mb-1 inline" />
+        Protected <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
     [
       'src/app/(tabs)/settings.tsx',
       <span>
-        Protected <Lock01Icon className="mb-1 inline" />
+        Protected <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
     ['src/app/sign-in.tsx'],
@@ -217,7 +217,7 @@ For example, consider the following navigation tree in which you have a bottom t
     [
       'src/app/modal.tsx',
       <span>
-        Protected <Lock01Icon className="mb-1 inline" />
+        Protected <Lock01Icon aria-hidden="true" className="mb-1 inline" />
       </span>,
     ],
   ]}

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -107,7 +107,10 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
+<CornerDownRightIcon
+  aria-hidden="true"
+  className="icon-sm text-icon-secondary mr-2 inline-block align-middle"
+/>
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,10 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
+<CornerDownRightIcon
+  aria-hidden="true"
+  className="icon-sm text-icon-secondary mr-2 inline-block align-middle"
+/>
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,10 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
+<CornerDownRightIcon
+  aria-hidden="true"
+  className="icon-sm text-icon-secondary mr-2 inline-block align-middle"
+/>
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v56.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,10 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
+<CornerDownRightIcon
+  aria-hidden="true"
+  className="icon-sm text-icon-secondary mr-2 inline-block align-middle"
+/>
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/pages/versions/v57.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/safe-area-context.mdx
@@ -107,7 +107,10 @@ function HookComponent() {
 
 <APIBoxSectionHeader text="Returns" />
 
-<CornerDownRightIcon className="icon-sm text-icon-secondary mr-2 inline-block align-middle" />
+<CornerDownRightIcon
+  aria-hidden="true"
+  className="icon-sm text-icon-secondary mr-2 inline-block align-middle"
+/>
 [`EdgeInsets`](#edgeinsets)
 
 </PaddedAPIBox>

--- a/docs/scenes/develop/development-builds/MethodSelectCard.tsx
+++ b/docs/scenes/develop/development-builds/MethodSelectCard.tsx
@@ -25,6 +25,7 @@ export function MethodSelectCard({ Icon, title, description, isSelected, onClick
             isSelected ? 'bg-linear-to-b from-palette-blue3 to-palette-blue4' : 'bg-subtle'
           )}>
           <Icon
+            aria-hidden="true"
             style={{ width: 56, height: 56 }}
             className={isSelected ? 'text-link' : 'text-icon-default'}
           />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26024

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `aria-hidden` to decorative icons failing svg-img-alt in multiple MDX files and one scenes file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
