### PR TITLE
[widgets][ios] Add @available(iOS 16.1, *) to getLiveActivityEnvironment so XCFramework precompilation succeeds

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1.
 - [iOS] Fix `LiveActivityFactory.getInstances()` returning live activities that belong to other factories or that have already ended. ([#48489](https://github.com/expo/expo/pull/48489) by [@huextrat](https://github.com/huextrat))
 - [iOS] Deliver the Live Activity `start()` URL to the Lock Screen banner, and scope it to the activity that set it instead of storing it globally per factory name. ([#48489](https://github.com/expo/expo/pull/48489) by [@huextrat](https://github.com/huextrat))
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1.
+- [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1. ([#49076](https://github.com/expo/expo/pull/49076) by [@brentvatne](https://github.com/brentvatne))
 - [iOS] Fix `LiveActivityFactory.getInstances()` returning live activities that belong to other factories or that have already ended. ([#48489](https://github.com/expo/expo/pull/48489) by [@huextrat](https://github.com/huextrat))
 - [iOS] Deliver the Live Activity `start()` URL to the Lock Screen banner, and scope it to the activity that set it instead of storing it globally per factory name. ([#48489](https://github.com/expo/expo/pull/48489) by [@huextrat](https://github.com/huextrat))
 - [Android] Add 16KB page size support. ([#47135](https://github.com/expo/expo/pull/47135) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -119,19 +119,19 @@ public func getWidgetEnvironment(environment: EnvironmentValues) -> [String: Any
   return env
 }
 
+// ActivityViewContext requires iOS 16.1. Without the availability attribute, precompiling
+// this package fails: the SwiftPM prebuild targets iOS 16.0 (spm.config.json), unlike the
+// podspec (16.4). Both callers live in @available(iOS 16.1, *) views.
+@available(iOS 16.1, *)
 func getLiveActivityEnvironment(for environment: EnvironmentValues, in context: ActivityViewContext<LiveActivityAttributes>) -> [String: Any] {
   var env: [String: Any] = [
     "colorScheme": "\(environment.colorScheme)"
   ]
 
-  if #available(iOS 16.0, *) {
-    env["isLuminanceReduced"] = environment.isLuminanceReduced
-  }
+  env["isLuminanceReduced"] = environment.isLuminanceReduced
+  env["isActivityFullscreen"] = environment.isActivityFullscreen
   if #available(iOS 16.2, *) {
     env["isStale"] = context.isStale
-  }
-  if #available(iOS 16.1, *) {
-    env["isActivityFullscreen"] = environment.isActivityFullscreen
   }
   if #available(iOS 18.0, *) {
     env["isActivityUpdateReduced"] = environment.isActivityUpdateReduced


### PR DESCRIPTION
# Why

The `Smoke Test Precompiled iOS XCFrameworks` workflow fails for every PR that touches `packages/expo-widgets/` since #48303 merged. The failing build step ends with:

```
…/ExpoWidgets/Widgets/Utils.swift:122:81: error: 'ActivityViewContext' is only available in iOS 16.1 or newer
❌ [expo-widgets/ExpoWidgets] Build Swift package failed: xcodebuild …
```

First observed on #48747 ([errored job](https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019ff92a-9f76-7968-8950-d88f669ae073#job-019ff92a-a2ba-723a-8247-0bcbc06bd96a)) — that PR was the first to touch `packages/expo-widgets/` after #48303 landed, so it was the first to trigger this build. The failure comes from `main`, not from that PR.

# How

#48303 gave `getLiveActivityEnvironment` an `ActivityViewContext<LiveActivityAttributes>` parameter. `ActivityViewContext` requires iOS 16.1, and the declaration carries no availability attribute. The CocoaPods build never notices because `ExpoWidgets.podspec` targets iOS 16.4 — but the SwiftPM prebuild compiles the package at iOS 16.0 (`spm.config.json`: `iOS(.v16)`), where the unguarded declaration is a hard error.

This PR adds `@available(iOS 16.1, *)` to the declaration. Both callers already live inside `@available(iOS 16.1, *)` views (`WidgetLiveActivity`, lines 34 and 49), so no call site changes. The `#available(iOS 16.0, *)` and `#available(iOS 16.1, *)` guards inside the function body are folded into plain statements — the attribute makes them always true, and leaving them would emit "unnecessary check" warnings. The `16.2`/`18.0`/`26.0` guards stay.

# Test Plan

This PR touches `packages/expo-widgets/`, so the smoke-test workflow builds `expo-modules-core expo-widgets` on this very PR — the previously failing arm is the verification. `swiftc -parse` passes locally. I could not run the full SwiftPM prebuild locally; the workflow run on this PR is the real check.
