### PR TITLE
[docs][notifications] Document foreground notification behavior

### DIFF
--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -223,7 +223,7 @@ For more information on these objects, see [`Notification`](/versions/latest/sdk
 
 In SDK 57 and earlier, a foreground notification is not shown at all by default. To show it, you have to set a handler that asks for it using [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#present-incoming-notifications-when-the-app-is). A handler that does not respond within 3 seconds drops the notification.
 
-In SDK 58 and later, a notification that arrives while your app is **foregrounded** is shown with a banner, in the notification list, with a sound, and with the badge from the notification. A handler that does not respond within 3 seconds gets the same behavior.
+In SDK 58 and later, a notification that arrives while your app is **foregrounded** is shown by default. It plays a sound, shows a banner, appears in the notification list, and sets the app badge. A notification whose handler does not respond within 3 seconds is shown the same way.
 
 To change the behavior, use [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#present-incoming-notifications-when-the-app-is) with the `handleNotification()` callback to set the following options:
 
@@ -243,13 +243,15 @@ Notifications.setNotificationHandler({
 });
 ```
 
+### Disable the notification handler
+
 In SDK 58 and later, to stop `expo-notifications` from deciding whether an incoming notification shows, pass `null`:
 
 ```jsx
 Notifications.setNotificationHandler(null);
 ```
 
-On Android, the notification is then not shown while your app is in the foreground. On iOS, the decision goes to the `UNUserNotificationCenterDelegate` that another library set, and the notification is not shown if there is none.
+On Android, the notification is then not shown while your app is in the foreground. On iOS, the decision goes to the `UNUserNotificationCenterDelegate` that another library sets. If no library sets one, the notification is not shown.
 
 ## Closed notification behavior
 

--- a/docs/pages/push-notifications/receiving-notifications.mdx
+++ b/docs/pages/push-notifications/receiving-notifications.mdx
@@ -221,7 +221,11 @@ For more information on these objects, see [`Notification`](/versions/latest/sdk
 
 ## Foreground notification behavior
 
-To handle the behavior when notifications are received when your app is **foregrounded**, use [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#present-incoming-notifications-when-the-app-is) with the `handleNotification()` callback to set the following options:
+In SDK 57 and earlier, a foreground notification is not shown at all by default. To show it, you have to set a handler that asks for it using [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#present-incoming-notifications-when-the-app-is). A handler that does not respond within 3 seconds drops the notification.
+
+In SDK 58 and later, a notification that arrives while your app is **foregrounded** is shown with a banner, in the notification list, with a sound, and with the badge from the notification. A handler that does not respond within 3 seconds gets the same behavior.
+
+To change the behavior, use [`Notifications.setNotificationHandler`](/versions/latest/sdk/notifications/#present-incoming-notifications-when-the-app-is) with the `handleNotification()` callback to set the following options:
 
 - `shouldPlaySound`
 - `shouldSetBadge`
@@ -238,6 +242,14 @@ Notifications.setNotificationHandler({
   }),
 });
 ```
+
+In SDK 58 and later, to stop `expo-notifications` from deciding whether an incoming notification shows, pass `null`:
+
+```jsx
+Notifications.setNotificationHandler(null);
+```
+
+On Android, the notification is then not shown while your app is in the foreground. On iOS, the decision goes to the `UNUserNotificationCenterDelegate` that another library set, and the notification is not shown if there is none.
 
 ## Closed notification behavior
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -205,18 +205,6 @@ async function registerForPushNotificationsAsync() {
 ```ts
 import * as Notifications from 'expo-notifications';
 
-// First, set the handler that will cause the notification
-// to show the alert
-Notifications.setNotificationHandler({
-  handleNotification: async () => ({
-    shouldPlaySound: false,
-    shouldSetBadge: false,
-    shouldShowBanner: true,
-    shouldShowList: true,
-  }),
-});
-
-// Second, call scheduleNotificationAsync()
 Notifications.scheduleNotificationAsync({
   content: {
     title: 'Look at that notification',


### PR DESCRIPTION
# Why

replacement for https://github.com/expo/expo/pull/43118 
Stacked on top of #49072, which makes `expo-notifications` show a notification that arrives while the app is in the foreground. The guides still described the old behavior, where such a notification was dropped unless the app set a handler that asked for it.

this adds the docs 


# How

update docs

# Test Plan



# Checklist

- [x] Documentation is up to date to reflect these changes (this PR is the documentation).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [ ] `CHANGELOG.md` entry — not applicable; the changelog entry for this behavior ships in #49072.
- [ ] Ran `et check-packages` — not applicable; this PR changes no package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
