### PR TITLE
[sdk-57][cli] validate submit-expo-feedback messages

### DIFF
--- a/packages/submit-expo-feedback/package.json
+++ b/packages/submit-expo-feedback/package.json
@@ -36,7 +36,7 @@
     "@types/jest": "^29.2.1",
     "@types/prompts": "^2.0.6",
     "@vercel/ncc": "^0.38.3",
-    "agent-cli-detector": "^0.1.2",
+    "agent-cli-detector": "0.1.6",
     "arg": "^5.0.2",
     "chalk": "^4.0.0",
     "ci-info": "^3.3.0",

--- a/packages/submit-expo-feedback/src/__tests__/cli.test.ts
+++ b/packages/submit-expo-feedback/src/__tests__/cli.test.ts
@@ -39,6 +39,7 @@ jest.mock('ci-info', () => ({
 jest.mock('prompts');
 
 const mockPrompts = prompts as unknown as jest.Mock;
+const VALID_FEEDBACK = 'Please improve how error messages explain actionable next steps.';
 
 function createTempDir(): string {
   return mkdtemp(path.join(tmpdir(), 'submit-expo-feedback-test-'));
@@ -80,7 +81,12 @@ describe('help output', () => {
         '| unknown    | Concise Expo product, package, feature, or topic, or leave empty'
       );
       expect(helpOutput).toContain('--resume <feedbackId>');
-      expect(helpOutput).toContain('Feedback messages can be up to 5,000 characters.');
+      expect(helpOutput).toContain('npx submit-expo-feedback --message <message>');
+      expect(helpOutput).toContain('--message, -m <message>');
+      expect(helpOutput).toContain('Feedback messages must be between 40 and 5,000 characters.');
+      expect(helpOutput).toContain(
+        'Positional messages are temporarily supported for backwards compatibility.'
+      );
       expect(helpOutput).toContain(
         'Set DO_NOT_TRACK=1 or EXPO_NO_TELEMETRY=1 to prevent feedback submission'
       );
@@ -117,33 +123,55 @@ describe('feedback message resolution', () => {
     mockPrompts.mockReset();
   });
 
-  it('uses positional arguments as the feedback message', async () => {
-    await expect(resolveFeedbackAsync(['please', 'improve', 'errors'])).resolves.toEqual({
+  it('uses the explicit message option as the feedback message', async () => {
+    await expect(resolveFeedbackAsync([], undefined, `  ${VALID_FEEDBACK}  `)).resolves.toEqual({
       category: 'unknown',
-      feedback: 'please improve errors',
+      feedback: VALID_FEEDBACK,
     });
   });
 
-  it('uses a category supplied on the command line', async () => {
-    await expect(
-      resolveFeedbackAsync(['improve', 'the', 'controls'], 'simulator')
-    ).resolves.toEqual({
+  it('temporarily accepts positional arguments as the feedback message', async () => {
+    await expect(resolveFeedbackAsync(VALID_FEEDBACK.split(' '), 'simulator')).resolves.toEqual({
       category: 'simulator',
-      feedback: 'improve the controls',
+      feedback: VALID_FEEDBACK,
     });
   });
+
+  it('rejects feedback provided both explicitly and positionally', async () => {
+    await expect(resolveFeedbackAsync([VALID_FEEDBACK], undefined, VALID_FEEDBACK)).rejects.toThrow(
+      'Provide feedback with either --message or a positional argument, not both.'
+    );
+  });
+
+  it('accepts feedback at the minimum length', async () => {
+    const feedback = 'a'.repeat(40);
+
+    await expect(resolveFeedbackAsync([], undefined, feedback)).resolves.toEqual({
+      category: 'unknown',
+      feedback,
+    });
+  });
+
+  it.each(['init', 'connect', 'start', 'submit-expo-feedback', 'a'.repeat(39)])(
+    'rejects feedback under the minimum length: %p',
+    async (feedback) => {
+      await expect(resolveFeedbackAsync([], undefined, feedback)).rejects.toThrow(
+        'Feedback must be at least 40 characters.'
+      );
+    }
+  );
 
   it('accepts feedback at the maximum length', async () => {
     const feedback = 'a'.repeat(5_000);
 
-    await expect(resolveFeedbackAsync([feedback])).resolves.toEqual({
+    await expect(resolveFeedbackAsync([], undefined, feedback)).resolves.toEqual({
       category: 'unknown',
       feedback,
     });
   });
 
   it('rejects feedback over the maximum length', async () => {
-    await expect(resolveFeedbackAsync(['a'.repeat(5_001)])).rejects.toThrow(
+    await expect(resolveFeedbackAsync([], undefined, 'a'.repeat(5_001))).rejects.toThrow(
       'Feedback cannot exceed 5,000 characters.'
     );
   });
@@ -157,12 +185,12 @@ describe('feedback message resolution', () => {
   it('prompts for a category and message in interactive environments', async () => {
     const originalIsTTY = process.stdin.isTTY;
     Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
-    mockPrompts.mockResolvedValueOnce({ category: 'docs', feedback: 'Clarify this example.' });
+    mockPrompts.mockResolvedValueOnce({ category: 'docs', feedback: VALID_FEEDBACK });
 
     try {
       await expect(resolveFeedbackAsync([])).resolves.toEqual({
         category: 'docs',
-        feedback: 'Clarify this example.',
+        feedback: VALID_FEEDBACK,
       });
       expect(mockPrompts).toHaveBeenCalledWith(
         expect.arrayContaining([
@@ -185,7 +213,7 @@ describe('feedback message resolution', () => {
 
     try {
       await expect(resolveFeedbackAsync([])).rejects.toThrow(
-        'Feedback message is required in non-interactive environments.'
+        'Feedback message is required in non-interactive environments. Pass it with --message or -m.'
       );
       expect(mockPrompts).not.toHaveBeenCalled();
     } finally {
@@ -325,7 +353,7 @@ describe('feedback submission', () => {
     const metadata = await createFeedbackMetadataAsync(projectRoot, 'mcp', 'expo-mcp');
 
     await sendFeedbackAsync({
-      feedback: 'please make errors clearer',
+      feedback: VALID_FEEDBACK,
       metadata,
       session,
     });
@@ -339,7 +367,7 @@ describe('feedback submission', () => {
         'expo-session': 'session-secret',
       }),
       body: JSON.stringify({
-        feedback: 'please make errors clearer',
+        feedback: VALID_FEEDBACK,
         metadata,
       }),
     });
@@ -374,7 +402,7 @@ describe('feedback submission', () => {
     process.env.EXPO_FEEDBACK_API_BASE_URL = 'http://127.0.0.1:43210';
 
     await sendFeedbackAsync({
-      feedback: 'please make errors clearer',
+      feedback: VALID_FEEDBACK,
       metadata: await createFeedbackMetadataAsync(projectRoot),
     });
 
@@ -389,7 +417,7 @@ describe('feedback submission', () => {
     process.env.EXPO_FEEDBACK_API_BASE_URL = 'http://127.0.0.1:43210';
 
     await sendFeedbackAsync({
-      feedback: 'please make errors clearer',
+      feedback: VALID_FEEDBACK,
       metadata: await createFeedbackMetadataAsync(projectRoot),
     });
 
@@ -410,13 +438,24 @@ describe('feedback submission', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('does not submit feedback under the minimum length', async () => {
+    await expect(
+      sendFeedbackAsync({
+        feedback: 'init',
+        metadata: await createFeedbackMetadataAsync(projectRoot),
+      })
+    ).rejects.toThrow('Feedback must be at least 40 characters.');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('does not submit when telemetry is disabled at the submission boundary', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
     const metadata = await createFeedbackMetadataAsync(projectRoot);
     process.env.DO_NOT_TRACK = '1';
 
     await sendFeedbackAsync({
-      feedback: 'please make errors clearer',
+      feedback: VALID_FEEDBACK,
       metadata,
     });
 
@@ -435,7 +474,8 @@ describe('feedback submission', () => {
       'submit-expo-feedback',
       '--resume',
       'session_ABC-123',
-      'one more detail',
+      '--message',
+      VALID_FEEDBACK,
     ];
 
     try {
@@ -443,16 +483,38 @@ describe('feedback submission', () => {
 
       const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(requestBody).toMatchObject({
-        feedback: 'one more detail',
+        feedback: VALID_FEEDBACK,
         metadata: {
           feedbackId: 'session_ABC-123',
         },
       });
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-        'To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume session_ABC-123'
+        'To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume session_ABC-123 --message "<message>"'
       );
     } finally {
       process.argv = originalArgv;
+    }
+  });
+
+  it('temporarily submits positional feedback with a deprecation warning', async () => {
+    const originalArgv = process.argv;
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+    process.argv = ['node', 'submit-expo-feedback', VALID_FEEDBACK];
+
+    try {
+      await runExpoFeedbackAsync();
+
+      const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(requestBody.feedback).toBe(VALID_FEEDBACK);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Passing feedback as a positional argument is deprecated. Use --message or -m instead.'
+      );
+    } finally {
+      process.argv = originalArgv;
+      consoleLogSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
     }
   });
 
@@ -460,7 +522,7 @@ describe('feedback submission', () => {
     const originalArgv = process.argv;
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
     jest.spyOn(process, 'cwd').mockReturnValue(projectRoot);
-    process.argv = ['node', 'submit-expo-feedback', '--resume', 'invalid/id', 'one more detail'];
+    process.argv = ['node', 'submit-expo-feedback', '--resume', 'invalid/id', '-m', VALID_FEEDBACK];
 
     try {
       await runExpoFeedbackAsync();
@@ -472,7 +534,7 @@ describe('feedback submission', () => {
         `The provided feedback ID is invalid, so a new one was generated: ${feedbackId}`
       );
       expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
-        `npx submit-expo-feedback@latest --resume ${feedbackId}`
+        `npx submit-expo-feedback@latest --resume ${feedbackId} --message "<message>"`
       );
     } finally {
       process.argv = originalArgv;

--- a/packages/submit-expo-feedback/src/cli.ts
+++ b/packages/submit-expo-feedback/src/cli.ts
@@ -14,6 +14,7 @@ import { detectSandbox } from 'sandbox-cli-detector';
 import {
   CLI_FEEDBACK_CATEGORIES,
   CLI_FEEDBACK_MAX_LENGTH,
+  CLI_FEEDBACK_MIN_LENGTH,
   type CliFeedbackCategory,
   type CliFeedbackContextMetadata,
   type CliFeedbackMetadata,
@@ -67,11 +68,13 @@ async function runAsync(): Promise<void> {
     {
       '--help': Boolean,
       '--version': Boolean,
+      '--message': String,
       '--category': String,
       '--subject': String,
       '--resume': String,
       '-h': '--help',
       '-v': '--version',
+      '-m': '--message',
       '-c': '--category',
       '-s': '--subject',
     },
@@ -96,7 +99,19 @@ async function runAsync(): Promise<void> {
     return;
   }
 
-  const { category, feedback } = await resolveFeedbackAsync(args._, args['--category']);
+  if (args._.length > 0 && args['--message'] === undefined) {
+    console.warn(
+      chalk.yellow(
+        'Passing feedback as a positional argument is deprecated. Use --message or -m instead.'
+      )
+    );
+  }
+
+  const { category, feedback } = await resolveFeedbackAsync(
+    args._,
+    args['--category'],
+    args['--message']
+  );
   const session = getSession();
   const metadata = await createFeedbackMetadataAsync(
     process.cwd(),
@@ -125,23 +140,38 @@ async function runAsync(): Promise<void> {
 
   console.log(chalk.green('Thanks for the feedback!'));
   console.log(
-    `To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume ${metadata.feedbackId}`
+    `To continue the feedback session use:\nnpx submit-expo-feedback@latest --resume ${metadata.feedbackId} --message "<message>"`
   );
 }
 
 export async function resolveFeedbackAsync(
   messageParts: string[],
-  categoryValue?: string
+  categoryValue?: string,
+  messageValue?: string
 ): Promise<{ category: CliFeedbackCategory; feedback: string }> {
   const category = resolveFeedbackCategory(categoryValue);
-  const feedback = messageParts.join(' ').trim();
-  if (feedback) {
+  const positionalFeedback = messageParts.join(' ').trim();
+  if (messageValue !== undefined && positionalFeedback) {
+    throw new CommandError(
+      'Provide feedback with either --message or a positional argument, not both.'
+    );
+  }
+
+  if (messageValue !== undefined) {
+    const feedback = messageValue.trim();
     validateFeedback(feedback);
     return { category, feedback };
   }
 
+  if (positionalFeedback) {
+    validateFeedback(positionalFeedback);
+    return { category, feedback: positionalFeedback };
+  }
+
   if (ciInfo.isCI || !process.stdin.isTTY) {
-    throw new CommandError('Feedback message is required in non-interactive environments.');
+    throw new CommandError(
+      'Feedback message is required in non-interactive environments. Pass it with --message or -m.'
+    );
   }
 
   const response = await prompts(
@@ -443,11 +473,12 @@ function getExpoApiBaseUrl(): string {
 function printHelp(): void {
   console.log(chalk`
   {bold Usage}
-    {dim $} npx submit-expo-feedback {dim <message>}
+    {dim $} npx submit-expo-feedback {dim --message <message>}
 
   {bold Info}
     Send feedback to the Expo team. If no message is provided, you will be prompted.
-    Feedback messages can be up to ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.
+    Feedback messages must be between ${CLI_FEEDBACK_MIN_LENGTH.toLocaleString('en-US')} and ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.
+    Positional messages are temporarily supported for backwards compatibility.
 
   {bold Data collection}
     Feedback includes detected agent, sandbox and environment
@@ -457,6 +488,7 @@ function printHelp(): void {
     and all network requests.
 
   {bold Options}
+    --message, -m <message>    Feedback message
     --category, -c <category>  Feedback category (${CLI_FEEDBACK_CATEGORIES.join(', ')})
     --subject, -s <subject>    Exact item the feedback is about, based on the category
     --resume <feedbackId>      Continue a feedback session using its ID
@@ -500,8 +532,12 @@ function validateFeedback(feedback: string): void {
 }
 
 function getFeedbackValidationError(feedback: string): string | null {
-  if (!feedback) {
+  const trimmedFeedback = feedback.trim();
+  if (!trimmedFeedback) {
     return 'Feedback cannot be empty.';
+  }
+  if (trimmedFeedback.length < CLI_FEEDBACK_MIN_LENGTH) {
+    return `Feedback must be at least ${CLI_FEEDBACK_MIN_LENGTH.toLocaleString('en-US')} characters.`;
   }
   if (feedback.length > CLI_FEEDBACK_MAX_LENGTH) {
     return `Feedback cannot exceed ${CLI_FEEDBACK_MAX_LENGTH.toLocaleString('en-US')} characters.`;

--- a/packages/submit-expo-feedback/src/types.ts
+++ b/packages/submit-expo-feedback/src/types.ts
@@ -1,3 +1,4 @@
+export const CLI_FEEDBACK_MIN_LENGTH = 40;
 export const CLI_FEEDBACK_MAX_LENGTH = 5_000;
 export const CLI_FEEDBACK_CATEGORIES = [
   'skills',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6215,8 +6215,8 @@ importers:
         specifier: ^0.38.3
         version: 0.38.4
       agent-cli-detector:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: 0.1.6
+        version: 0.1.6
       arg:
         specifier: ^5.0.2
         version: 5.0.2


### PR DESCRIPTION
Backports #49031 to `sdk-57`.

We keep receiving feedback messages like "init", "connect", and "submit" as agents and humans test the command structure. This backport updates `submit-expo-feedback` to prefer an explicit `--message`/`-m`, while temporarily retaining the positional message argument with a deprecation warning.

It also requires feedback messages to contain at least 40 characters, reducing accidental submissions, and pins `agent-cli-detector` to `0.1.6` to detect OpenCode and Muse Code.

Validation:
- `pnpm --filter submit-expo-feedback test --runInBand` (36 tests)
- `pnpm --filter submit-expo-feedback typecheck`
- `pnpm --filter submit-expo-feedback lint`
- Prettier check for changed package files
- `pnpm --filter submit-expo-feedback build`
- `git diff --check origin/sdk-57...HEAD`