### PR TITLE
[notifications] Drop usage of the deprecated LegacyEventEmitter

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 💡 Others
 
+- Drop usage of the deprecated `LegacyEventEmitter`. ([#49080](https://github.com/expo/expo/pull/49080) by [@vonovak](https://github.com/vonovak))
+
 ## 57.0.8 - 2026-07-29
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-notifications/src/NotificationsEmitter.ts
+++ b/packages/expo-notifications/src/NotificationsEmitter.ts
@@ -1,12 +1,8 @@
 import { type EventSubscription, UnavailabilityError } from 'expo';
-import { LegacyEventEmitter } from 'expo-modules-core';
 
 import type { Notification, NotificationResponse } from './Notifications.types';
 import NotificationsEmitterModule from './NotificationsEmitterModule';
 import { mapNotification, mapNotificationResponse } from './utils/mapNotificationResponse';
-
-// Web uses SyntheticEventEmitter
-const emitter = new LegacyEventEmitter(NotificationsEmitterModule);
 
 const didReceiveNotificationEventName = 'onDidReceiveNotification';
 const didDropNotificationsEventName = 'onNotificationsDeleted';
@@ -43,7 +39,7 @@ export const DEFAULT_ACTION_IDENTIFIER = 'expo.modules.notifications.actions.DEF
 export function addNotificationReceivedListener(
   listener: (event: Notification) => void
 ): EventSubscription {
-  return emitter.addListener<Notification>(
+  return NotificationsEmitterModule.addListener(
     didReceiveNotificationEventName,
     (notification: Notification) => {
       const mappedNotification = mapNotification(notification);
@@ -61,7 +57,7 @@ export function addNotificationReceivedListener(
  * @header listen
  */
 export function addNotificationsDroppedListener(listener: () => void): EventSubscription {
-  return emitter.addListener<void>(didDropNotificationsEventName, listener);
+  return NotificationsEmitterModule.addListener(didDropNotificationsEventName, listener);
 }
 
 /**
@@ -93,7 +89,7 @@ export function addNotificationsDroppedListener(listener: () => void): EventSubs
 export function addNotificationResponseReceivedListener(
   listener: (event: NotificationResponse) => void
 ): EventSubscription {
-  return emitter.addListener<NotificationResponse>(
+  return NotificationsEmitterModule.addListener(
     didReceiveNotificationResponseEventName,
     (response: NotificationResponse) => {
       const mappedResponse = mapNotificationResponse(response);
@@ -162,12 +158,12 @@ export function clearLastNotificationResponse(): void {
   }
   NotificationsEmitterModule.clearLastNotificationResponse();
   // Emit event to clear any useLastNotificationResponse hooks, after native call succeeds
-  emitter.emit(didClearNotificationResponseEventName, []);
+  NotificationsEmitterModule.emit(didClearNotificationResponseEventName);
 }
 
 /**
  * @hidden
  */
 export function addNotificationResponseClearedListener(listener: () => void): EventSubscription {
-  return emitter.addListener<void>(didClearNotificationResponseEventName, listener);
+  return NotificationsEmitterModule.addListener(didClearNotificationResponseEventName, listener);
 }

--- a/packages/expo-notifications/src/NotificationsEmitterModule.ts
+++ b/packages/expo-notifications/src/NotificationsEmitterModule.ts
@@ -12,6 +12,12 @@ export default {
       );
       warningHasBeenShown = true;
     }
+    return {
+      remove: () => {},
+    };
   },
-  removeListeners: () => {},
+  removeListener: () => {},
+  removeAllListeners: () => {},
+  emit: () => {},
+  listenerCount: () => 0,
 } as NotificationsEmitterModule;

--- a/packages/expo-notifications/src/NotificationsEmitterModule.types.ts
+++ b/packages/expo-notifications/src/NotificationsEmitterModule.types.ts
@@ -1,8 +1,15 @@
-import type { ProxyNativeModule } from 'expo-modules-core';
+import { NativeModule } from 'expo';
 
-import type { NotificationResponse } from './Notifications.types';
+import type { Notification, NotificationResponse } from './Notifications.types';
 
-export interface NotificationsEmitterModule extends ProxyNativeModule {
+export type NotificationsEmitterModuleEvents = {
+  onDidReceiveNotification: (notification: Notification) => void;
+  onNotificationsDeleted: () => void;
+  onDidReceiveNotificationResponse: (response: NotificationResponse) => void;
+  onDidClearNotificationResponse: () => void;
+};
+
+export class NotificationsEmitterModule extends NativeModule<NotificationsEmitterModuleEvents> {
   getLastNotificationResponse?: () => NotificationResponse | null;
   clearLastNotificationResponse?: () => void;
 }

--- a/packages/expo-notifications/src/NotificationsHandler.ts
+++ b/packages/expo-notifications/src/NotificationsHandler.ts
@@ -1,5 +1,4 @@
 import { type EventSubscription, CodedError, Platform, UnavailabilityError } from 'expo';
-import { LegacyEventEmitter } from 'expo-modules-core';
 
 import type { Notification, NotificationBehavior } from './Notifications.types';
 import NotificationsHandlerModule from './NotificationsHandlerModule';
@@ -38,16 +37,6 @@ export interface NotificationHandler {
    */
   handleError?: (notificationId: string, error: NotificationHandlingError) => void;
 }
-
-type HandleNotificationEvent = {
-  id: string;
-  notification: Notification;
-};
-
-type HandleNotificationTimeoutEvent = HandleNotificationEvent;
-
-// Web uses SyntheticEventEmitter
-const notificationEmitter = new LegacyEventEmitter(NotificationsHandlerModule);
 
 const handleNotificationEventName = 'onHandleNotification';
 const handleNotificationTimeoutEventName = 'onHandleNotificationTimeout';
@@ -116,7 +105,7 @@ export function setNotificationHandler(handler: NotificationHandler | null): voi
 }
 
 function subscribe(activeHandler: NotificationHandler): void {
-  handleSubscription = notificationEmitter.addListener<HandleNotificationEvent>(
+  handleSubscription = NotificationsHandlerModule.addListener(
     handleNotificationEventName,
     async ({ id, notification }) => {
       if (!NotificationsHandlerModule.handleNotificationAsync) {
@@ -145,7 +134,7 @@ function subscribe(activeHandler: NotificationHandler): void {
     }
   );
 
-  handleTimeoutSubscription = notificationEmitter.addListener<HandleNotificationTimeoutEvent>(
+  handleTimeoutSubscription = NotificationsHandlerModule.addListener(
     handleNotificationTimeoutEventName,
     ({ id, notification }) =>
       activeHandler.handleError?.(

--- a/packages/expo-notifications/src/NotificationsHandlerModule.ts
+++ b/packages/expo-notifications/src/NotificationsHandlerModule.ts
@@ -12,6 +12,12 @@ export default {
       );
       warningHasBeenShown = true;
     }
+    return {
+      remove: () => {},
+    };
   },
-  removeListeners: () => {},
+  removeListener: () => {},
+  removeAllListeners: () => {},
+  emit: () => {},
+  listenerCount: () => 0,
 } as NotificationsHandlerModule;

--- a/packages/expo-notifications/src/NotificationsHandlerModule.types.ts
+++ b/packages/expo-notifications/src/NotificationsHandlerModule.types.ts
@@ -1,8 +1,13 @@
-import type { ProxyNativeModule } from 'expo-modules-core';
+import { NativeModule } from 'expo';
 
-import type { NotificationBehavior } from './Notifications.types';
+import type { Notification, NotificationBehavior } from './Notifications.types';
 
-export interface NotificationsHandlerModule extends ProxyNativeModule {
+export type NotificationsHandlerModuleEvents = {
+  onHandleNotification: (event: { id: string; notification: Notification }) => void;
+  onHandleNotificationTimeout: (event: { id: string; notification: Notification }) => void;
+};
+
+export class NotificationsHandlerModule extends NativeModule<NotificationsHandlerModuleEvents> {
   handleNotificationAsync?: (
     notificationId: string,
     notificationBehavior: NotificationBehavior


### PR DESCRIPTION
# Why

`expo-notifications` still wrapped `NotificationsEmitterModule` and `NotificationsHandlerModule` in the deprecated `LegacyEventEmitter`

# How

migrate away from it

# Test Plan

- Built and ran `apps/notification-tester` on an iOS simulator and drove it through a few test cases


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
