### PR TITLE
[image] Sanitize URLs in Observe oversized-image reports

### DIFF
--- a/apps/observe-tester/app/(tabs)/examples/expo-image/too-big.tsx
+++ b/apps/observe-tester/app/(tabs)/examples/expo-image/too-big.tsx
@@ -8,8 +8,12 @@ import { useTheme } from '@/utils/theme';
 // area against the screen budget (screen point area × pixel ratio² × 1.5) and logs an
 // `expo-image.oversized` warning because it is far beyond what any full-screen image needs. Use
 // `maxWidth`/`maxHeight` (see the "Correctly sized" page) to avoid this.
+// The fake signing params exercise URL sanitization: the logged event reports the URL without the
+// query and fragment (with `urlSanitized: true`) unless the integration is configured with
+// `includeUrlParams: true`. Picsum ignores the unknown params, so the image still loads.
 const SIZE = 220;
-const SOURCE = 'https://picsum.photos/seed/expo-image-too-big/4000/4000';
+const SOURCE =
+  'https://picsum.photos/seed/expo-image-too-big/4000/4000?token=super-secret&sig=deadbeef#preview';
 
 export default function TooBigImage() {
   const theme = useTheme();
@@ -27,7 +31,9 @@ export default function TooBigImage() {
         A 4000×4000px image loaded with no size constraints. Decoded:{' '}
         {image ? `${image.width * image.scale}×${image.height * image.scale}px` : '…'} — far beyond
         this device's screen ({Math.round(screen.width)}×{Math.round(screen.height)}pt @
-        {PixelRatio.get()}x), so an `expo-image.oversized` warning is logged. Check the Sessions
+        {PixelRatio.get()}x), so an `expo-image.oversized` warning is logged. The source URL
+        carries fake signing params; the event reports it without them and with `urlSanitized:
+        true`, unless `includeUrlParams` is enabled in the integration config. Check the Sessions
         tab.
       </Text>
       {failed ? (

--- a/apps/observe-tester/app/_layout.tsx
+++ b/apps/observe-tester/app/_layout.tsx
@@ -11,6 +11,7 @@ Observe.configure({
     'expo-router': { filteredParams: ['accountId', 'firstName'] },
     'expo-image': {
       oversizeThreshold: 1.5,
+      includeUrlParams: false,
     },
   },
 });

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 - [iOS][Android] Added a `skipOnCacheHit` field to `transition` that skips the fade the first time a cached image appears (`'memory'` for memory-cache hits, `'all'` for any cache hit), so already-loaded images don't re-animate on mount, tab change, or when scrolling back into view. A transition from a `source` change still plays. ([#48181](https://github.com/expo/expo/pull/48181) by [@janicduplessis](https://github.com/janicduplessis))
+- Added an `includeUrlParams` option to the expo-observe integration; reported image URLs now have their query string and fragment removed unless it is enabled, basic-auth credentials are always removed, and only `http(s)`, `file`, and `android.resource` URLs are reported. ([#49083](https://github.com/expo/expo/pull/49083) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-image/src/__tests__/observe.test.ts
+++ b/packages/expo-image/src/__tests__/observe.test.ts
@@ -299,6 +299,34 @@ describe('reportIfOversized', () => {
     expect(appMetrics.logEvent).not.toHaveBeenCalled();
   });
 
+  it('flags a query-stripped url with urlSanitized', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(
+      state({ appMetrics }),
+      image(1000, 1000, 'https://example.com/a.png?token=1')
+    );
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.urlSanitized).toBe(true);
+  });
+
+  it('flags a credential-stripped url with urlSanitized even when includeUrlParams is enabled', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'https://user:pass@example.com/a.png?w=4000'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.urlSanitized).toBe(true);
+  });
+
+  it('omits urlSanitized when the url is reported unchanged', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(state({ appMetrics }), image(1000, 1000, 'https://example.com/a.png'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes).not.toHaveProperty('urlSanitized');
+  });
+
   it('never reports data: urls', () => {
     const appMetrics = makeAppMetrics();
 

--- a/packages/expo-image/src/__tests__/observe.test.ts
+++ b/packages/expo-image/src/__tests__/observe.test.ts
@@ -388,8 +388,27 @@ describe('reportIfOversized', () => {
       'https://example.com/img@2x.png'
     );
     expect(appMetrics.logEvent.mock.calls[1][1].attributes.url).toBe(
-      'https://example.com?email=a@b.com'
+      'https://example.com/?email=a@b.com'
     );
+  });
+
+  it('reports urls in normalized form without flagging them as sanitized', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(state({ appMetrics }), image(1000, 1000, 'HTTPS://EXAMPLE.com/a.png'));
+
+    const attributes = appMetrics.logEvent.mock.calls[0][1].attributes;
+    expect(attributes.url).toBe('https://example.com/a.png');
+    expect(attributes).not.toHaveProperty('urlSanitized');
+  });
+
+  it('never reports an unparseable url', () => {
+    const appMetrics = makeAppMetrics();
+
+    // The scheme-less name React Native gives a bundled asset on Android in release builds.
+    reportIfOversized(state({ appMetrics }), image(1000, 1000, 'src_assets_hero'));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
   });
 
   it('does not throw when logEvent fails', () => {

--- a/packages/expo-image/src/__tests__/observe.test.ts
+++ b/packages/expo-image/src/__tests__/observe.test.ts
@@ -319,12 +319,12 @@ describe('reportIfOversized', () => {
     expect(appMetrics.logEvent.mock.calls[0][1].attributes.urlSanitized).toBe(true);
   });
 
-  it('omits urlSanitized when the url is reported unchanged', () => {
+  it('reports urlSanitized as false when the url is unchanged', () => {
     const appMetrics = makeAppMetrics();
 
     reportIfOversized(state({ appMetrics }), image(1000, 1000, 'https://example.com/a.png'));
 
-    expect(appMetrics.logEvent.mock.calls[0][1].attributes).not.toHaveProperty('urlSanitized');
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.urlSanitized).toBe(false);
   });
 
   it('never reports data: urls', () => {
@@ -399,7 +399,7 @@ describe('reportIfOversized', () => {
 
     const attributes = appMetrics.logEvent.mock.calls[0][1].attributes;
     expect(attributes.url).toBe('https://example.com/a.png');
-    expect(attributes).not.toHaveProperty('urlSanitized');
+    expect(attributes.urlSanitized).toBe(false);
   });
 
   it('never reports an unparseable url', () => {

--- a/packages/expo-image/src/__tests__/observe.test.ts
+++ b/packages/expo-image/src/__tests__/observe.test.ts
@@ -101,6 +101,7 @@ function state(
   over: Partial<{
     enabled: boolean;
     threshold: number;
+    includeUrlParams: boolean;
     reported: Set<string>;
     subscription: { remove: () => void } | null;
     appMetrics: FakeAppMetrics | null;
@@ -110,6 +111,7 @@ function state(
   return {
     enabled: true,
     threshold: 2,
+    includeUrlParams: false,
     reported: new Set<string>(),
     subscription: null,
     appMetrics: makeAppMetrics(),
@@ -221,6 +223,147 @@ describe('reportIfOversized', () => {
     expect(() => reportIfOversized(state({ appMetrics: null }), image(1000))).not.toThrow();
   });
 
+  it('strips the query and fragment from the reported url by default', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(
+      state({ appMetrics }),
+      image(1000, 1000, 'https://example.com/a.png?token=secret#frag')
+    );
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe('https://example.com/a.png');
+  });
+
+  it('dedups on the stripped url so signed variants of one image report once', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics });
+
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png?token=1'));
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png?token=2'));
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the full url when includeUrlParams is enabled', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png?w=4000'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe(
+      'https://example.com/a.png?w=4000'
+    );
+  });
+
+  it('dedups on the full url when includeUrlParams is enabled', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png?id=1'));
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/a.png?id=2'));
+
+    expect(appMetrics.logEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports file: urls', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(state({ appMetrics }), image(1000, 1000, 'file:///var/app/assets/hero.png'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe(
+      'file:///var/app/assets/hero.png'
+    );
+  });
+
+  it('reports bundled android.resource: urls', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(
+      state({ appMetrics }),
+      image(1000, 1000, 'android.resource://com.example.app/2131165280')
+    );
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe(
+      'android.resource://com.example.app/2131165280'
+    );
+  });
+
+  it('never reports urls outside the http, https, file, and android.resource schemes', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics });
+
+    reportIfOversized(s, image(1000, 1000, 'ph://ED7AC36B-A150-4C38-BB8C-B6D696F4F2ED/L0/001'));
+    reportIfOversized(s, image(1000, 1000, 'content://media/external/images/media/12'));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('never reports data: urls', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(state({ appMetrics }), image(1000, 1000, 'data:image/png;base64,aGVsbG8='));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('never reports data: urls even when includeUrlParams is enabled', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'data:image/png;base64,aGVsbG8='));
+
+    expect(appMetrics.logEvent).not.toHaveBeenCalled();
+  });
+
+  it('strips basic-auth credentials from the reported url', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(
+      state({ appMetrics }),
+      image(1000, 1000, 'https://user:pass@example.com/a.png?token=1')
+    );
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe('https://example.com/a.png');
+  });
+
+  it('strips credentials that contain an unencoded @', () => {
+    const appMetrics = makeAppMetrics();
+
+    reportIfOversized(
+      state({ appMetrics }),
+      image(1000, 1000, 'https://user:pa@ss@example.com/a.png')
+    );
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe('https://example.com/a.png');
+  });
+
+  it('strips credentials even when includeUrlParams is enabled', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'https://user:pass@example.com/a.png?w=4000'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe(
+      'https://example.com/a.png?w=4000'
+    );
+  });
+
+  it('keeps an @ that is part of the path or query', () => {
+    const appMetrics = makeAppMetrics();
+    const s = state({ appMetrics, includeUrlParams: true });
+
+    reportIfOversized(s, image(1000, 1000, 'https://example.com/img@2x.png'));
+    reportIfOversized(s, image(1000, 1000, 'https://example.com?email=a@b.com'));
+
+    expect(appMetrics.logEvent.mock.calls[0][1].attributes.url).toBe(
+      'https://example.com/img@2x.png'
+    );
+    expect(appMetrics.logEvent.mock.calls[1][1].attributes.url).toBe(
+      'https://example.com?email=a@b.com'
+    );
+  });
+
   it('does not throw when logEvent fails', () => {
     const appMetrics: FakeAppMetrics = {
       logEvent: jest.fn(() => {
@@ -274,6 +417,24 @@ describe('activate', () => {
 
     expect(s.enabled).toBe(true);
     expect(s.threshold).toBe(1.5);
+  });
+
+  it('keeps url params disabled by default', () => {
+    const s = state({ enabled: false, includeUrlParams: true });
+
+    activate(s, { 'expo-image': true });
+    expect(s.includeUrlParams).toBe(false);
+
+    activate(s, { 'expo-image': { oversizeThreshold: 3 } });
+    expect(s.includeUrlParams).toBe(false);
+  });
+
+  it('reads includeUrlParams from an object config', () => {
+    const s = state({ enabled: false });
+
+    activate(s, { 'expo-image': { includeUrlParams: true } });
+
+    expect(s.includeUrlParams).toBe(true);
   });
 
   it('does not enable or subscribe when the config is absent', () => {

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -121,6 +121,14 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
   if (!image.url || !(width > 0) || !(height > 0)) {
     return;
   }
+  // Screen area is in points; the decoded image is in pixels, so convert with pixelRatio² to get
+  // the screen's physical pixel count.
+  const budget = screenWidth * screenHeight * pixelRatio * pixelRatio;
+  if (!(budget > 0) || width * height <= budget * state.threshold) {
+    return;
+  }
+  // Sanitizing after the size check keeps the common per-load path cheap: only oversized images
+  // pay for the URL parse.
   const sanitizedUrl = sanitizeUrl(image.url, state.includeUrlParams);
   if (!sanitizedUrl) {
     return;
@@ -129,12 +137,6 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
   // query parameters (such as rotating signed URLs) into a single event.
   const url = sanitizedUrl.url;
   if (state.reported.has(url)) {
-    return;
-  }
-  // Screen area is in points; the decoded image is in pixels, so convert with pixelRatio² to get
-  // the screen's physical pixel count.
-  const budget = screenWidth * screenHeight * pixelRatio * pixelRatio;
-  if (!(budget > 0) || width * height <= budget * state.threshold) {
     return;
   }
   state.reported.add(url);

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -33,7 +33,8 @@ export type ExpoImageIntegrationConfig = {
    * sensitive values such as signing tokens or API keys. Enable this only when your image URLs
    * are safe to send off-device in full. Regardless of this setting, basic-auth credentials are
    * always removed from the URL, and only `http(s)`, `file`, and `android.resource` URLs are
-   * reported (other schemes, such as `data:` or `ph://`, never leave the device).
+   * reported (other schemes, such as `data:` or `ph://`, never leave the device). An event whose
+   * URL was modified before sending carries a `urlSanitized: true` attribute.
    *
    * @default false
    */
@@ -127,6 +128,9 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
       body: `Image loaded at ${width}×${height}px is far larger than this device's screen (${screenWidth}×${screenHeight}pt @${pixelRatio}x). Constrain it with the maxWidth/maxHeight load options.`,
       attributes: {
         url,
+        // Present only when sanitization changed the URL, mirroring the navigation integration's
+        // `urlHidden` attribute.
+        ...(url !== image.url ? { urlSanitized: true } : {}),
         imageWidth: width,
         imageHeight: height,
         screenWidth,

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -34,8 +34,8 @@ export type ExpoImageIntegrationConfig = {
    * are safe to send off-device in full. Regardless of this setting, basic-auth credentials are
    * always removed from the URL, and only `http(s)`, `file`, and `android.resource` URLs are
    * reported (other schemes, such as `data:` or `ph://`, never leave the device). URLs are
-   * reported in normalized (WHATWG) form, and an event whose URL was modified beyond that carries
-   * a `urlSanitized: true` attribute.
+   * reported in normalized (WHATWG) form, and the event's `urlSanitized` attribute tells whether
+   * the URL was modified beyond that.
    *
    * @default false
    */
@@ -145,9 +145,8 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
       body: `Image loaded at ${width}×${height}px is far larger than this device's screen (${screenWidth}×${screenHeight}pt @${pixelRatio}x). Constrain it with the maxWidth/maxHeight load options.`,
       attributes: {
         url,
-        // Present only when sanitization changed the URL, mirroring the navigation integration's
-        // `urlHidden` attribute.
-        ...(sanitizedUrl.sanitized ? { urlSanitized: true } : {}),
+        // True when sanitization changed the URL; WHATWG normalization alone does not count.
+        urlSanitized: sanitizedUrl.sanitized,
         imageWidth: width,
         imageHeight: height,
         screenWidth,

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -33,8 +33,9 @@ export type ExpoImageIntegrationConfig = {
    * sensitive values such as signing tokens or API keys. Enable this only when your image URLs
    * are safe to send off-device in full. Regardless of this setting, basic-auth credentials are
    * always removed from the URL, and only `http(s)`, `file`, and `android.resource` URLs are
-   * reported (other schemes, such as `data:` or `ph://`, never leave the device). An event whose
-   * URL was modified before sending carries a `urlSanitized: true` attribute.
+   * reported (other schemes, such as `data:` or `ph://`, never leave the device). URLs are
+   * reported in normalized (WHATWG) form, and an event whose URL was modified beyond that carries
+   * a `urlSanitized: true` attribute.
    *
    * @default false
    */
@@ -75,21 +76,40 @@ export type LoadedImage = {
   pixelRatio: number;
 };
 
-// Truncates a URL at its query string and fragment (unless `includeUrlParams` opts in) and always
-// removes userinfo credentials from the authority, so values like signing tokens, API keys, or
-// basic-auth passwords never leave the device.
-function sanitizeUrl(url: string, includeUrlParams: boolean): string {
-  let sanitized = url;
-  if (!includeUrlParams) {
-    const paramsStart = sanitized.search(/[?#]/);
-    if (paramsStart !== -1) {
-      sanitized = sanitized.slice(0, paramsStart);
-    }
+// Only remote images, local files, and bundled Android resources are reported: those URLs
+// identify developer-owned content that the developer can act on. Every other scheme fails safe,
+// because it carries device-local or user-library content (the whole payload for `data:`, a
+// stable personal-photo identifier for `ph://` and `content://`).
+const REPORTABLE_PROTOCOLS = new Set(['http:', 'https:', 'file:', 'android.resource:']);
+
+// Prepares a loaded image's URL for sending off-device, or returns `null` when the image must not
+// be reported at all (a disallowed scheme, or a string the WHATWG parser rejects). Basic-auth
+// credentials are always removed, and the query string and fragment too unless `includeUrlParams`
+// opts in, so values like signing tokens or API keys never leave the device. The returned URL is
+// in normalized (WHATWG) form; `sanitized` is true only when something was removed, not when
+// normalization alone changed the string.
+function sanitizeUrl(
+  rawUrl: string,
+  includeUrlParams: boolean
+): { url: string; sanitized: boolean } | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
   }
-  // Userinfo ends at the last `@` before the authority ends (matching WHATWG parsing, so an
-  // unencoded `@` inside a password is consumed too), while `/`, `?`, and `#` bound the match, so
-  // an `@` later in the path or query never matches.
-  return sanitized.replace(/^([^:/?#]+:\/\/)[^/?#]*@/, '$1');
+  if (!REPORTABLE_PROTOCOLS.has(url.protocol)) {
+    return null;
+  }
+  const normalized = url.toString();
+  url.username = '';
+  url.password = '';
+  if (!includeUrlParams) {
+    url.search = '';
+    url.hash = '';
+  }
+  const result = url.toString();
+  return { url: result, sanitized: result !== normalized };
 }
 
 // Exported for testing purposes only.
@@ -101,16 +121,13 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
   if (!image.url || !(width > 0) || !(height > 0)) {
     return;
   }
-  // Only remote images, local files, and bundled Android resources are reported: those URLs
-  // identify developer-owned content that the developer can act on. Every other scheme fails safe
-  // regardless of `includeUrlParams`, because it carries device-local or user-library content (the
-  // whole payload for `data:`, a stable personal-photo identifier for `ph://` and `content://`).
-  if (!/^(https?|file|android\.resource):/i.test(image.url)) {
+  const sanitizedUrl = sanitizeUrl(image.url, state.includeUrlParams);
+  if (!sanitizedUrl) {
     return;
   }
   // Deduping on the reported form also collapses variants of one image that differ only in their
   // query parameters (such as rotating signed URLs) into a single event.
-  const url = sanitizeUrl(image.url, state.includeUrlParams);
+  const url = sanitizedUrl.url;
   if (state.reported.has(url)) {
     return;
   }
@@ -130,7 +147,7 @@ export function reportIfOversized(state: IntegrationState, image: LoadedImage): 
         url,
         // Present only when sanitization changed the URL, mirroring the navigation integration's
         // `urlHidden` attribute.
-        ...(url !== image.url ? { urlSanitized: true } : {}),
+        ...(sanitizedUrl.sanitized ? { urlSanitized: true } : {}),
         imageWidth: width,
         imageHeight: height,
         screenWidth,

--- a/packages/expo-image/src/observe.ts
+++ b/packages/expo-image/src/observe.ts
@@ -27,6 +27,17 @@ export type ExpoImageIntegrationConfig = {
    * @default 1.5
    */
   oversizeThreshold?: number;
+  /**
+   * Whether reported events include the image URL's query string and fragment. By default the URL
+   * is truncated at them before it leaves the device, because query parameters often carry
+   * sensitive values such as signing tokens or API keys. Enable this only when your image URLs
+   * are safe to send off-device in full. Regardless of this setting, basic-auth credentials are
+   * always removed from the URL, and only `http(s)`, `file`, and `android.resource` URLs are
+   * reported (other schemes, such as `data:` or `ph://`, never leave the device).
+   *
+   * @default false
+   */
+  includeUrlParams?: boolean;
 };
 
 const DEFAULT_OVERSIZE_THRESHOLD = 1.5;
@@ -38,7 +49,9 @@ let initialized = false;
 export type IntegrationState = {
   enabled: boolean;
   threshold: number;
-  // URLs already reported under the current configuration. Only oversized images are added.
+  includeUrlParams: boolean;
+  // URLs already reported under the current configuration, as they were reported (so without
+  // query and fragment unless `includeUrlParams` is set). Only oversized images are added.
   reported: Set<string>;
   // Subscription to the native `imageLoaded` event, held only while the integration is enabled.
   subscription: { remove: () => void } | null;
@@ -61,15 +74,42 @@ export type LoadedImage = {
   pixelRatio: number;
 };
 
+// Truncates a URL at its query string and fragment (unless `includeUrlParams` opts in) and always
+// removes userinfo credentials from the authority, so values like signing tokens, API keys, or
+// basic-auth passwords never leave the device.
+function sanitizeUrl(url: string, includeUrlParams: boolean): string {
+  let sanitized = url;
+  if (!includeUrlParams) {
+    const paramsStart = sanitized.search(/[?#]/);
+    if (paramsStart !== -1) {
+      sanitized = sanitized.slice(0, paramsStart);
+    }
+  }
+  // Userinfo ends at the last `@` before the authority ends (matching WHATWG parsing, so an
+  // unencoded `@` inside a password is consumed too), while `/`, `?`, and `#` bound the match, so
+  // an `@` later in the path or query never matches.
+  return sanitized.replace(/^([^:/?#]+:\/\/)[^/?#]*@/, '$1');
+}
+
 // Exported for testing purposes only.
 export function reportIfOversized(state: IntegrationState, image: LoadedImage): void {
   if (!state.enabled || !state.appMetrics) {
     return;
   }
-  const { url, width, height, screenWidth, screenHeight, pixelRatio } = image;
-  if (!url || !(width > 0) || !(height > 0)) {
+  const { width, height, screenWidth, screenHeight, pixelRatio } = image;
+  if (!image.url || !(width > 0) || !(height > 0)) {
     return;
   }
+  // Only remote images, local files, and bundled Android resources are reported: those URLs
+  // identify developer-owned content that the developer can act on. Every other scheme fails safe
+  // regardless of `includeUrlParams`, because it carries device-local or user-library content (the
+  // whole payload for `data:`, a stable personal-photo identifier for `ph://` and `content://`).
+  if (!/^(https?|file|android\.resource):/i.test(image.url)) {
+    return;
+  }
+  // Deduping on the reported form also collapses variants of one image that differ only in their
+  // query parameters (such as rotating signed URLs) into a single event.
+  const url = sanitizeUrl(image.url, state.includeUrlParams);
   if (state.reported.has(url)) {
     return;
   }
@@ -122,11 +162,10 @@ export function activate(
   handle = handleImageLoaded
 ): void {
   const config = integrations['expo-image'];
+  const configObject = typeof config === 'object' && config !== null ? config : {};
   state.enabled = !!config;
-  state.threshold =
-    typeof config === 'object' && config !== null
-      ? (config.oversizeThreshold ?? DEFAULT_OVERSIZE_THRESHOLD)
-      : DEFAULT_OVERSIZE_THRESHOLD;
+  state.threshold = configObject.oversizeThreshold ?? DEFAULT_OVERSIZE_THRESHOLD;
+  state.includeUrlParams = configObject.includeUrlParams ?? false;
   // A new configure may change the threshold (or enable the integration), so start a fresh dedup
   // set: images already reported under the previous settings become eligible to report again.
   state.reported = new Set<string>();
@@ -151,6 +190,7 @@ export function initObserveIntegrationIfNeededImpl(
   const state: IntegrationState = {
     enabled: false,
     threshold: DEFAULT_OVERSIZE_THRESHOLD,
+    includeUrlParams: false,
     reported: new Set<string>(),
     subscription: null,
     appMetrics: requireOptionalNativeModule<ExpoAppMetricsModuleType>('ExpoAppMetrics'),


### PR DESCRIPTION
# Why

Oversized-image events from the expo-observe integration send the full image URL off-device, so secrets embedded in it (signing tokens or API keys in query params, basic-auth credentials, the entire payload of a `data:` URL, or a personal-photo identifier in a `ph://` URL) leak into the reports. Flagged in the review of the integration (ENG-26040).

# How

Only `http(s)`, `file`, and `android.resource` URLs are reported at all: those identify developer-owned content the developer can act on (`android.resource://` is how a bundled static image surfaces on Android in release builds), while other schemes carry device-local or user-library content and fail safe. URLs are parsed with the built-in WHATWG parser (installed globally by the expo winter runtime) and reported in normalized form, with the query string and fragment removed before they leave the device, and dedup uses the reported form so rotating signed variants of one image produce a single event. The new `includeUrlParams` integration option restores the query string and fragment for setups where that's safe; basic-auth credentials are removed regardless. Every event carries a `urlSanitized` attribute that tells whether the URL was modified beyond WHATWG normalization.

One residual risk we accept: `file` URLs can contain user-chosen filenames (a downloaded image saved under a meaningful name). We keep them because an oversized bundled asset is a common developer mistake and the path is what identifies it.

# Test Plan

Unit tests cover the scheme allowlist, the query and fragment stripping, credential removal, the `urlTruncated` attribute, the dedup behavior, and the `includeUrlParams` option. `et check-packages expo-image` passes. In observe-tester, the expo-image "Too big" example now loads its image with fake signing params in the URL, so the Sessions tab shows the sanitized URL and `urlSanitized` live; `includeUrlParams` can be flipped in the app's `Observe.configure` call.






