### PR TITLE
[image][Android] Report the pre-downsample source size to the Observe integration

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [Android] Replaced the deprecated RenderScript-based `blurRadius` blur with a software stack blur to fix a use-after-free crash under concurrent image loads (aborts under GrapheneOS hardened_malloc). ([#PR](https://github.com/expo/expo/pull/PR) by [@DimitrisTzimikas](https://github.com/DimitrisTzimikas))
 - [Web] Use `textContent` instead of `innerHTML` when injecting image styles, so the style tag is not a Trusted Types sink. ([#48649](https://github.com/expo/expo/pull/48649) by [@VoulgarisLeoni](https://github.com/VoulgarisLeoni))
 - [iOS] Fixed `generateBlurhashAsync` and `generateThumbhashAsync` never settling when the image could not be downloaded. ([#PR](https://github.com/expo/expo/pull/PR) ([#48894](https://github.com/expo/expo/pull/48894) by [@vonovak](https://github.com/vonovak))
+- [Android] Fixed the expo-observe integration measuring the downscaled bitmap instead of the source image, which prevented oversized images from being reported. ([#49084](https://github.com/expo/expo/pull/49084) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/CustomDownsampleStrategy.kt
@@ -80,6 +80,8 @@ class ContentFitDownsampleStrategy(
     if (!wasTriggered) {
       target.sourceWidth = sourceWidth
       target.sourceHeight = sourceHeight
+      target.decodeSourceWidth = sourceWidth
+      target.decodeSourceHeight = sourceHeight
       wasTriggered = true
     }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -570,6 +570,12 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
       }
       newTarget.hasSource = sourceToLoad != null
       newTarget.cacheType = ImageCacheType.NONE
+      // Targets alternate between loads; clear the previous load's decode-time source size so a
+      // cache hit (which skips decoding) can't report the dimensions of an earlier image. The
+      // layout-facing sourceWidth/sourceHeight pair is deliberately left alone: the scale-down
+      // transformation matrix reads it, and this reporting fix must not change layout input.
+      newTarget.decodeSourceWidth = -1
+      newTarget.decodeSourceHeight = -1
 
       val downsampleStrategy = createDownsampleStrategy(newTarget)
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ImageViewWrapperTarget.kt
@@ -59,6 +59,20 @@ class ImageViewWrapperTarget(
   var sourceWidth = -1
 
   /**
+   * The main source height recorded at decode time for the observe `imageLoaded` report, where -1
+   * means the decode was skipped (such as on a cache hit). Unlike [sourceHeight], this is cleared
+   * when the target is reused for a new load, so a stale value is never reported.
+   */
+  var decodeSourceHeight = -1
+
+  /**
+   * The main source width recorded at decode time for the observe `imageLoaded` report, where -1
+   * means the decode was skipped (such as on a cache hit). Unlike [sourceWidth], this is cleared
+   * when the target is reused for a new load, so a stale value is never reported.
+   */
+  var decodeSourceWidth = -1
+
+  /**
    * The placeholder height where -1 means unknown
    */
   var placeholderHeight = -1

--- a/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/events/GlideRequestListener.kt
@@ -71,6 +71,14 @@ class GlideRequestListener(
 
     val imageWrapper = expoImageViewWrapper.get() ?: return false
     val appContext = imageWrapper.appContext
+    // The drawable may already be downsampled to the view size, so prefer the source dimensions
+    // recorded at decode time; an oversized source would otherwise never measure as oversized.
+    // Cache hits skip decoding and fall back to the drawable size. Captured before the main-queue
+    // hop, because a new load can reuse this target and clear the recorded size (or a new decode
+    // overwrite it) before the coroutine below runs.
+    val wrapperTarget = target as? ImageViewWrapperTarget
+    val sourceWidth = wrapperTarget?.decodeSourceWidth?.takeIf { it > 0 } ?: intrinsicWidth
+    val sourceHeight = wrapperTarget?.decodeSourceHeight?.takeIf { it > 0 } ?: intrinsicHeight
     appContext.mainQueue.launch {
       imageWrapper.onLoad.invoke(
         ImageLoadEvent(
@@ -90,7 +98,7 @@ class GlideRequestListener(
       if (model !is DecodedModel) {
         appContext.registry
           .getModule<ExpoImageModule>()
-          ?.emitImageLoaded(model.toString(), intrinsicWidth, intrinsicHeight)
+          ?.emitImageLoaded(model.toString(), sourceWidth, sourceHeight)
       }
     }
 


### PR DESCRIPTION
# Why

The expo-observe oversized-image check was effectively dead on Android for its main case (a large image in a small view): Glide downscales the bitmap to the view size at decode time, so the drawable's intrinsic size never exceeded the screen budget. Flagged in the review of the integration (ENG-26040).

# How

`ContentFitDownsampleStrategy` records the source dimensions at decode time into a dedicated `decodeSourceWidth`/`decodeSourceHeight` pair on the target, and the listener reports those instead of the drawable size, falling back to the drawable size when decoding was skipped (cache hits). The dedicated pair keeps this a pure reporting change: it's cleared when a target is reused so a cache hit can't report an earlier image's dimensions, while the layout-facing `sourceWidth`/`sourceHeight` (which the `scale-down` transformation matrix reads) keeps its shipped lifecycle. The listener captures the values before its main-queue hop, since a new load can reuse the target and clear them in that gap.

Known false negatives, unchanged by this PR: loads that skip the full decode and aren't deduped in the current session (a local image whose downscaled resource is served from Glide's disk cache across app runs, or an image cached before the integration was configured) still report the drawable size.

# Test Plan

expo-image has no Kotlin test harness, so this was verified by inspection of the Glide decode path; the review bot additionally ran the real `ContentFitDownsampleStrategy` against Glide 5.0.5 on a JVM and confirmed the recorded values and the before/after verdicts. `et check-packages expo-image` passes.
