### PR TITLE
[android][ios][file-system] Fix File.size returning null

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -1875,11 +1875,9 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(error).not.toBeNull();
       });
 
-      it('returns null size and md5 for nonexistent files', async () => {
+      it('returns zero size and null md5 for nonexistent files', async () => {
         const file = new File(testDirectory, 'file2.txt');
-        // @ts-expect-error `size` is typed `number`, but a nonexistent file reports
-        // `null`, which is what this spec checks.
-        expect(file.size).toBe(null);
+        expect(file.size).toBe(0);
         expect(file.md5).toBe(null);
       });
     });

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file.
+- [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file. ([#49086](https://github.com/expo/expo/pull/49086)) by [@ACHP](https://github.com/ACHP))
 - [iOS] Fix wrong permissions for text() and bytes(). ([#42422](https://github.com/expo/expo/pull/42422)) by [@simoneldevig](https://github.com/simoneldevig))
 - Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#48248](https://github.com/expo/expo/pull/48248) by [@CoffeeFlux](https://github.com/CoffeeFlux))
 - Fixed iOS file previews rejecting a new preview while the previous Quick Look dismissal animation is still finishing. ([#47947](https://github.com/expo/expo/pull/47947) by [@eliotgevers](https://github.com/eliotgevers))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file.
 - [iOS] Fix wrong permissions for text() and bytes(). ([#42422](https://github.com/expo/expo/pull/42422)) by [@simoneldevig](https://github.com/simoneldevig))
 - Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#48248](https://github.com/expo/expo/pull/48248) by [@CoffeeFlux](https://github.com/CoffeeFlux))
 - Fixed iOS file previews rejecting a new preview while the previous Quick Look dismissal animation is still finishing. ([#47947](https://github.com/expo/expo/pull/47947) by [@eliotgevers](https://github.com/eliotgevers))

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -293,9 +293,9 @@ class FileSystemModule : Module() {
 
       Property("size") { file ->
         try {
-          file.size
+          file.size ?: 0
         } catch (e: Exception) {
-          null
+          0
         }
       }
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -336,7 +336,7 @@ public final class FileSystemModule: Module {
       }
 
       Property("size") { file in
-        try? file.size
+        (try? file.size) ?? 0
       }
 
       Property("md5") { file in


### PR DESCRIPTION
# Why

File.size is typed as number, but native Android and iOS bridges returned null when the file was missing or unreadable. For instance here on android (https://github.com/expo/expo/blob/main/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt#L205-L211).

But TS type it as `number`

https://github.com/ACHP/expo/blob/5ff5560a425024bfc2f7bba3c67e83498cca1eaf/packages/expo-file-system/src/internal/NativeFileSystem.types.ts#L323

<img width="764" height="139" alt="image" src="https://github.com/user-attachments/assets/351828ea-6115-4c1c-ad4b-1aff388f1e18" />


# How

Return 0 from both native bridges for those cases. File implements Blob, whose size must be a number, so number | null is not possible.

# Test Plan

Ran pnpm exec et check-packages expo-file-system.

# Checklist

- [x] I added a changelog.md entry and rebuilt the package sources according to this
    short guide (https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)

- [x] This diff will work correctly for npx expo prebuild & EAS Build (eg: updated a
    module plugin).

- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
