### PR TITLE
[ios][screen-capture] Redraw the window after secure-canvas re-parenting and harden the protect/restore state machine

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank when screenshot prevention re-parents the window layer while their display work is pending, and hardened the protect/restore state machine so a failed re-parent can no longer permanently disable protection or restore the wrong window.
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank when screenshot prevention re-parents the window layer while their display work is pending, and hardened the protect/restore state machine so a failed re-parent can no longer permanently disable protection or restore the wrong window. ([#49088](https://github.com/expo/expo/pull/49088) by [@maxlapides](https://github.com/maxlapides))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank when screenshot prevention re-parents the window layer while their display work is pending, and hardened the protect/restore state machine so a failed re-parent can no longer permanently disable protection or restore the wrong window.
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -8,6 +8,7 @@ public final class ScreenCaptureModule: Module {
   private var blockView: UIView?
   private var protectionTextField: UITextField?
   private var originalParent: CALayer?
+  private weak var reparentedWindow: UIWindow?
   private var blurEffectView: AnimatedBlurEffectView?
   private var blurIntensity: CGFloat = 0.5
   private var keyWindow: UIWindow? {
@@ -122,6 +123,13 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func preventScreenshots() {
+    // Protection is already active. Re-parenting again would nest the window layer
+    // inside a second secure canvas and overwrite `originalParent`, making the
+    // original layer hierarchy unrecoverable.
+    guard protectionTextField == nil else {
+      return
+    }
+
     guard let keyWindow = keyWindow else {
       return
     }
@@ -132,30 +140,78 @@ public final class ScreenCaptureModule: Module {
     textField.backgroundColor = UIColor.clear
     textField.frame = UIScreen.main.bounds
 
-    originalParent = keyWindow.layer.superlayer
-
-    keyWindow.layer.superlayer?.addSublayer(textField.layer)
-
-    if let firstTextFieldSublayer = textField.layer.sublayers?.first {
-      keyWindow.layer.removeFromSuperlayer()
-      firstTextFieldSublayer.addSublayer(keyWindow.layer)
+    guard let originalParentLayer = keyWindow.layer.superlayer else {
+      return
     }
 
+    originalParentLayer.addSublayer(textField.layer)
+
+    guard let firstTextFieldSublayer = textField.layer.sublayers?.first else {
+      textField.layer.removeFromSuperlayer()
+      return
+    }
+
+    keyWindow.layer.removeFromSuperlayer()
+    firstTextFieldSublayer.addSublayer(keyWindow.layer)
+    // Latch the protection state only after the re-parent actually happened, so a
+    // failed attempt leaves the module able to retry instead of permanently
+    // blocking future calls behind the guard above.
     protectionTextField = textField
+    originalParent = originalParentLayer
+    reparentedWindow = keyWindow
+    setNeedsDisplayRecursively(in: keyWindow)
+    DispatchQueue.main.async { [weak self] in
+      self?.setNeedsDisplayRecursively(in: keyWindow)
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.setNeedsDisplayRecursively(in: keyWindow)
+    }
   }
 
   private func allowScreenshots() {
+    defer {
+      protectionTextField = nil
+      originalParent = nil
+      reparentedWindow = nil
+    }
+
     guard let textField = protectionTextField,
-      let window = keyWindow,
       let originalParentLayer = originalParent else {
       return
     }
 
-    window.layer.removeFromSuperlayer()
-    originalParentLayer.addSublayer(window.layer)
-    textField.layer.removeFromSuperlayer()
-    protectionTextField = nil
-    originalParent = nil
+    if let window = reparentedWindow {
+      window.layer.removeFromSuperlayer()
+      originalParentLayer.addSublayer(window.layer)
+      textField.layer.removeFromSuperlayer()
+      setNeedsDisplayRecursively(in: window)
+      DispatchQueue.main.async { [weak self] in
+        self?.setNeedsDisplayRecursively(in: window)
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+        self?.setNeedsDisplayRecursively(in: window)
+      }
+    } else {
+      textField.layer.removeFromSuperlayer()
+    }
+  }
+
+  private func setNeedsDisplayRecursively(in view: UIView) {
+    guard Thread.isMainThread else {
+      DispatchQueue.main.async { [weak self] in
+        self?.setNeedsDisplayRecursively(in: view)
+      }
+      return
+    }
+
+    // Re-parenting the window layer can drop display work that views relying on
+    // `drawRect`-style rendering (for example `react-native-svg` surfaces) had
+    // pending, leaving them blank until something else forces a redraw. Re-issue
+    // the display work after each re-parent; callers repeat this on the next
+    // run-loop turn for same-turn commits and after 0.1 seconds for work issued
+    // by the JS layout/props cycle that follows.
+    view.setNeedsDisplay()
+    view.subviews.forEach { setNeedsDisplayRecursively(in: $0) }
   }
 
   private func enableAppSwitcherProtection() {


### PR DESCRIPTION
# Why

`preventScreenshots()` re-parents the entire key-window layer into a secure `UITextField` canvas. Display work that is pending on `drawRect`-backed views at that moment — for example `react-native-svg` surfaces — can be dropped by the re-parent. `react-native-svg` latches its internal `dirty` flag until an actual draw happens (`RNSVGRenderable.invalidate` early-returns while dirty), so once the draw is lost the content stays blank against every subsequent JS-driven invalidation until something else forces a redraw.

We hit this in production: a sheet guarded by `usePreventScreenCapture` intermittently opened with all of its SVG-drawn backgrounds invisible (everything else rendered fine), and tapping anywhere instantly restored all of them — the tap gives UIKit another display pass. It reproduced only on physical devices, because the failure is a race between the re-parent and the pending display work.

While fixing this we also found that the protect/restore state machine can wedge:

- `protectionTextField` is latched even when the re-parent never happened (nil `superlayer`, or an empty `textField.layer.sublayers`), and a failed restore skips the state reset. Combined with a re-entrancy guard (as proposed in #49087 for #48985) this would permanently disable screenshot protection for the rest of the process with no error surfaced to JS.
- `allowScreenshots()` re-resolves the key window at restore time instead of remembering which window it re-parented, so it can restore the wrong window if key-window status changed in between.

Related: #48985 / #49087 cover the re-entrancy half of this. This PR includes the same guard because the state-machine hardening here is what makes that guard safe (latch-only-on-success + unconditional reset ensure the guard can never permanently block re-arming). Happy to rebase on #49087 if it lands first.

# How

In `ScreenCaptureModule.swift`:

- After both re-parents (protect and restore), call a new `setNeedsDisplayRecursively(in:)` over the re-parented window, plus deferred passes one run-loop turn later and 0.1s later to also cover display work issued immediately after the re-parent (e.g. the React Native layout/props cycle that follows). The helper marshals itself to the main thread, which also covers the `OnDestroy` → `allowScreenshots()` path that does not run on the main queue.
- `preventScreenshots()` now returns early if protection is already active, uses guarded early-returns that clean up the just-added text-field layer when the re-parent cannot happen, and latches `protectionTextField` / `originalParent` / `reparentedWindow` only after the re-parent succeeded.
- `allowScreenshots()` resets all protection state unconditionally via `defer`, and restores the recorded re-parented window (held weakly) rather than the current key window, with a fallback that removes the secure canvas if the window is gone.

# Test Plan

- `xcrun swiftc -parse` passes on the modified file.
- The state machine was walked across all paths: successful re-parent, nil `superlayer`, empty `sublayers`, deallocated window, repeated prevent (guard), allow-without-prevent (no-op), and prevent → allow → prevent cycles.
- The same change (as a package patch against `expo-screen-capture@57.0.1`) is running in our app; sweeps fire on protect/release of the guarded sheet with no visual or performance regressions in the surrounding flows. The production race is intermittent and physical-device-only, so we are continuing to soak it on devices.
- Reviewer reproduction: mount a screen containing `react-native-svg` content whose props/layout change in the same commit that mounts `usePreventScreenCapture` (i.e. reveal data and the guard together). Without this change, on a physical device the SVG content intermittently stays blank until touched; with it, the deferred sweeps restore the pending draws. The #48985 repro app covers the re-entrancy path deterministically.

# Checklist

- [x] I added a `CHANGELOG.md` entry (no package sources need rebuilding — native-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (no config plugin changes)
- [ ] Conforms with the Documentation Writing Style Guide (no docs changes)