### PR TITLE
[brownfield][Android] Tie React Native surface lifetime to its container

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -6,12 +6,12 @@
 
 ### 🎉 New features
 
-- [android] Add `ReactNativeViewFactory.createSurface`, returning a `ReactNativeSurfaceHandle` the host disposes when its container goes away.
+- [android] Add `ReactNativeViewFactory.createSurface`, returning a `ReactNativeSurfaceHandle` the host disposes when its container goes away. ([#49094](https://github.com/expo/expo/pull/49094) by [@josefnorlin-svt](https://github.com/josefnorlin-svt))
 
 ### 🐛 Bug fixes
 
-- [android] Stop React Native surfaces when their container is destroyed instead of when the Activity is, so embedding a surface in a Compose node, fragment or tab no longer leaves it running off screen while a second one is created.
-- [android] Fix `ReactDelegate.onHostResume()` throwing in host Activities that don't implement `DefaultHardwareBackBtnHandler`.
+- [android] Stop React Native surfaces when their container is destroyed instead of when the Activity is, so embedding a surface in a Compose node, fragment or tab no longer leaves it running off screen while a second one is created. ([#49094](https://github.com/expo/expo/pull/49094) by [@josefnorlin-svt](https://github.com/josefnorlin-svt))
+- [android] Fix `ReactDelegate.onHostResume()` throwing in host Activities that don't implement `DefaultHardwareBackBtnHandler`. ([#49094](https://github.com/expo/expo/pull/49094) by [@josefnorlin-svt](https://github.com/josefnorlin-svt))
 - [android] Fix `brownfield.fused.strip-packages` corrupting the generated `ExpoModulesPackageList.kt` when given a broad prefix (e.g. `expo.modules`). ([@gabrieldonadel](https://github.com/gabrieldonadel)) ([#48118](https://github.com/expo/expo/pull/48118) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix `ARG_MAX` error when using `multipleFrameworks`. ([#47999](https://github.com/expo/expo/pull/47999) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -6,8 +6,12 @@
 
 ### 🎉 New features
 
+- [android] Add `ReactNativeViewFactory.createSurface`, returning a `ReactNativeSurfaceHandle` the host disposes when its container goes away.
+
 ### 🐛 Bug fixes
 
+- [android] Stop React Native surfaces when their container is destroyed instead of when the Activity is, so embedding a surface in a Compose node, fragment or tab no longer leaves it running off screen while a second one is created.
+- [android] Fix `ReactDelegate.onHostResume()` throwing in host Activities that don't implement `DefaultHardwareBackBtnHandler`.
 - [android] Fix `brownfield.fused.strip-packages` corrupting the generated `ExpoModulesPackageList.kt` when given a broad prefix (e.g. `expo.modules`). ([@gabrieldonadel](https://github.com/gabrieldonadel)) ([#48118](https://github.com/expo/expo/pull/48118) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix `ARG_MAX` error when using `multipleFrameworks`. ([#47999](https://github.com/expo/expo/pull/47999) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeFragment.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeFragment.kt
@@ -10,17 +10,31 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commit
 
 class ReactNativeFragment : Fragment() {
+  private var surface: ReactNativeSurfaceHandle? = null
+
   override fun onCreateView(
       inflater: LayoutInflater,
       container: ViewGroup?,
       savedInstanceState: Bundle?,
   ): FrameLayout {
     val rootComponent = arguments?.getString("rootComponentName") ?: "main"
-    return ReactNativeViewFactory.createFrameLayout(
-        requireContext(),
-        requireActivity(),
-        rootComponent,
-    )
+    val surface =
+        ReactNativeViewFactory.createSurface(
+            requireContext(),
+            requireActivity(),
+            rootComponent,
+        )
+    this.surface = surface
+    return surface.view
+  }
+
+  // The fragment's view is destroyed while the Activity stays up, so the surface
+  // has to end here — otherwise it keeps running and the next onCreateView starts
+  // a second one.
+  override fun onDestroyView() {
+    super.onDestroyView()
+    surface?.dispose()
+    surface = null
   }
 
   companion object {

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeViewFactory.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeViewFactory.kt
@@ -7,38 +7,119 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.facebook.react.ReactDelegate
-import com.facebook.react.ReactInstanceManager
-import com.facebook.react.ReactRootView
+import com.facebook.react.ReactHost
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
+import java.util.Collections
+import java.util.WeakHashMap
+
+/**
+ * A mounted React Native surface, owned by whoever created it.
+ *
+ * [dispose] stops the surface, which unmounts its JS component tree so anything
+ * that tree holds — message listeners, timers, media players — is released. A
+ * host that embeds a surface somewhere shorter-lived than the Activity (a Compose
+ * node, a fragment, a tab) must dispose it, or the surface keeps running off
+ * screen and a second one is created the next time the container appears.
+ */
+class ReactNativeSurfaceHandle
+internal constructor(
+    val view: FrameLayout,
+    private val onDispose: () -> Unit,
+) {
+  private var isDisposed = false
+
+  /** Stops the surface. Idempotent. */
+  fun dispose() {
+    if (isDisposed) {
+      return
+    }
+    isDisposed = true
+    onDispose()
+  }
+}
 
 object ReactNativeViewFactory {
+  // The ReactHost belongs to the Activity and outlives any single surface, so its
+  // lifecycle forwarding is registered once per Activity, not once per surface.
+  private val hostBoundActivities: MutableSet<FragmentActivity> =
+      Collections.newSetFromMap(WeakHashMap<FragmentActivity, Boolean>())
+
+  /**
+   * Mounts [rootComponent] and returns a surface whose lifetime the caller owns.
+   *
+   * Use this when the surface can go away while the Activity stays up, and call
+   * [ReactNativeSurfaceHandle.dispose] when it does.
+   */
+  fun createSurface(
+      context: Context,
+      activity: FragmentActivity,
+      rootComponent: String,
+      launchOptions: Bundle? = null,
+  ): ReactNativeSurfaceHandle {
+    val reactHost = ReactNativeHostManager.shared.getReactHost()!!
+    bindHostLifecycle(activity, reactHost)
+
+    val reactDelegate = ReactDelegate(activity, reactHost, rootComponent, launchOptions)
+    reactDelegate.loadApp()
+
+    return ReactNativeSurfaceHandle(reactDelegate.reactRootView!!) { reactDelegate.unloadApp() }
+  }
+
+  /**
+   * Mounts [rootComponent] for the whole life of [activity].
+   *
+   * Prefer [createSurface] unless the Activity exists solely to show this surface.
+   */
   fun createFrameLayout(
       context: Context,
       activity: FragmentActivity,
       rootComponent: String,
       launchOptions: Bundle? = null,
   ): FrameLayout {
-    val reactHost = ReactNativeHostManager.shared.getReactHost()
-    val reactDelegate = ReactDelegate(activity, reactHost!!, rootComponent, launchOptions)
+    val surface = createSurface(context, activity, rootComponent, launchOptions)
 
     activity.lifecycle.addObserver(
         object : DefaultLifecycleObserver {
-          override fun onResume(owner: LifecycleOwner) {
-            reactDelegate.onHostResume()
-          }
-
-          override fun onPause(owner: LifecycleOwner) {
-            reactDelegate.onHostPause()
-          }
-
           override fun onDestroy(owner: LifecycleOwner) {
-            reactDelegate.onHostDestroy()
+            surface.dispose()
             owner.lifecycle.removeObserver(this) // Cleanup to avoid leaks
           }
         }
     )
 
-    reactDelegate.loadApp()
-    return reactDelegate.reactRootView!!
+    return surface.view
+  }
 
+  private fun bindHostLifecycle(activity: FragmentActivity, reactHost: ReactHost) {
+    if (!hostBoundActivities.add(activity)) {
+      return
+    }
+
+    // `ReactDelegate.onHostResume()` throws unless the host Activity implements
+    // `DefaultHardwareBackBtnHandler`. In a brownfield app the surface is usually
+    // embedded in an existing Activity that does not implement it, so resume the
+    // host directly with a handler backed by the Activity's OnBackPressedDispatcher
+    // (used only if the Activity itself isn't one).
+    val backBtnHandler =
+        activity as? DefaultHardwareBackBtnHandler
+            ?: DefaultHardwareBackBtnHandler { activity.onBackPressedDispatcher.onBackPressed() }
+
+    activity.lifecycle.addObserver(
+        object : DefaultLifecycleObserver {
+          override fun onResume(owner: LifecycleOwner) {
+            reactHost.onHostResume(activity, backBtnHandler)
+          }
+
+          override fun onPause(owner: LifecycleOwner) {
+            reactHost.onHostPause(activity)
+          }
+
+          override fun onDestroy(owner: LifecycleOwner) {
+            reactHost.onHostDestroy(activity)
+            hostBoundActivities.remove(activity)
+            owner.lifecycle.removeObserver(this) // Cleanup to avoid leaks
+          }
+        }
+    )
   }
 }


### PR DESCRIPTION
# Why

`ReactNativeViewFactory.createFrameLayout` starts a React Native surface and ends it only when the **Activity** is destroyed:

```kotlin
activity.lifecycle.addObserver(
    object : DefaultLifecycleObserver {
      override fun onDestroy(owner: LifecycleOwner) {
        reactDelegate.onHostDestroy()
        ...
```

That is correct for an Activity dedicated to the surface, which is what `BrownfieldActivity` and `showReactNativeFragment` give you. But a brownfield host usually embeds a surface in something shorter-lived than the Activity — a Compose node, a fragment, one tab of an existing screen. When that container goes away, nothing calls `ReactDelegate.unloadApp()`, so:

- the surface stays started and its JS component tree stays mounted, which means anything that tree holds — `expo-brownfield` message listeners, timers, video players — keeps running off screen;
- the next time the container appears, `createFrameLayout` builds another `ReactDelegate` and starts an **additional** surface;
- each call also registers another Activity-lifecycle observer, so the observers accumulate too.

`expo-brownfield`'s own `ReactNativeFragment` has this problem: a fragment's view is destroyed while its Activity stays up, so `onCreateView` → `createFrameLayout` leaks a surface per view recreation.

Nothing fails loudly, which is why it's easy to miss: the newest surface is the attached one and it renders correctly. What we saw in a host that embeds the surface in a Compose tab was that messages broadcast to the surfaces (`expo-brownfield`'s bus is app-wide) were answered by the orphaned ones too, so state pushed for the visible feed also resumed video playback in surfaces that were no longer on screen.

iOS is unaffected, and for a structural reason rather than luck: `ReactNativeHostManager.loadView` returns the root view to the caller and keeps no reference of its own, so ARC releases the surface along with the view controller.

Related: #45813 notes that in brownfield hosts "every remount is a fresh surface" for `ReactDelegate`s sharing a `ReactHost`. This is the other half of that picture — the old surfaces are never stopped.

# How

**`createSurface` (new).** Mounts the component and returns a `ReactNativeSurfaceHandle` exposing the `FrameLayout` and an idempotent `dispose()` that calls `ReactDelegate.unloadApp()`. Hosts that embed a surface call `dispose()` when their container is destroyed. From Compose that is one line:

```kotlin
AndroidView(
    factory = { context ->
        ReactNativeViewFactory.createSurface(context, activity, "main", initialProps)
            .also { surfaceRef.handle = it }
            .view
    },
    onRelease = { surfaceRef.handle?.dispose() },
)
```

**`createFrameLayout` (unchanged behaviour).** Now implemented on top of `createSurface`, disposing its own handle when the Activity is destroyed. Existing callers keep working, including the dev-menu path in `plugin/templates/patches/ReactNativeHostManager.patch`, where the surface really is the Activity's content view.

**`ReactNativeFragment`.** Switched to `createSurface` and disposes in `onDestroyView`.

**Activity lifecycle forwarding.** The `ReactHost` is Activity-scoped and outlives any individual surface, so it is now bound once per Activity (tracked in a `WeakHashMap`-backed set) instead of once per surface. Two notes on the move:

- Resume now goes through `ReactHost.onHostResume(activity, handler)` rather than `ReactDelegate.onHostResume()`. The latter throws unless the host Activity implements `DefaultHardwareBackBtnHandler` — which an Activity that predates the RN integration has no reason to do — so the handler falls back to the Activity's `OnBackPressedDispatcher`. This was the second thing blocking us from using the templates unmodified.
- Pause is behaviour-preserving: `ReactDelegate.onHostPause()` already forwards to `ReactHost.onHostPause(activity)` under the new architecture.

# Test Plan

Verified against SDK 56 (`expo-brownfield@56.0.16`, `react-native-tvos@0.85.3-0`, new architecture, Hermes) in a native Android app that embeds the surface in a Jetpack Compose tab of an existing Activity, published as an AAR via `build:android`:

- both templates compile as part of the generated AAR module;
- entering the tab, opening a native screen, and returning re-mounts the surface and re-runs the `ready` handshake as before;
- leaving the tab now stops the previous surface, so re-entering no longer leaves an orphaned surface responding to broadcast messages;
- `createFrameLayout` and `showReactNativeFragment` behave as before, including the debug dev-menu path.

Not covered: I don't have a project exercising `ReactNativeFragment` directly, so that hunk is reviewed-by-inspection plus compilation.

# Checklist

- [ ] Documentation is up to date to reflect these changes (the Android embedding API isn't currently documented on the brownfield SDK page, so nothing to change there — happy to add a short section on surface ownership if you'd like it).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [ ] This diff will work correctly for `npx expo prebuild` (template changes take effect on the next prebuild).

---

Note before opening: the CHANGELOG entries need your handle and this PR's number appended in the project's `([#NNNNN](...) by [@you](...))` format.
