### PR TITLE
[ios][updates] Fix flaky lastAccessed assertion

### DIFF
--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
@@ -100,6 +100,7 @@ class AppLauncherWithDatabaseTests {
       logger: UpdatesLogger()
     )
 
+    let beforeLaunch = Date(timeIntervalSince1970: floor(Date().timeIntervalSince1970 * 1000) / 1000)
     let success = await withCheckedContinuation { continuation in
       launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config)) { error, success in
         continuation.resume(returning: success)
@@ -110,10 +111,9 @@ class AppLauncherWithDatabaseTests {
 
     db.databaseQueue.sync {
       let sameUpdate = try! db.update(withId: testUpdate.updateId, config: config)
-      #expect(yesterday != sameUpdate?.lastAccessed)
-      // `lastAccessed` should have been bumped to roughly "now". Use a generous tolerance
-      // so the assertion doesn't flake on slow CI runners where `launchUpdate` takes longer.
-      #expect(abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) < 60)
+      // `lastAccessed` should have been bumped from yesterday to launch time. Bounding from
+      // `beforeLaunch` keeps the assertion valid however long the launch takes on CI.
+      #expect(sameUpdate!.lastAccessed >= beforeLaunch)
     }
   }
 }


### PR DESCRIPTION
# Why
The  test in `AppLauncherWithDatabaseTests` is flaky on CI. It asserted that `lastAccessed` was within 60 seconds of the assertion time.   On a loaded runner, more than 60 seconds can pass between the lastAccessed bump and the assertion. This failed an iOS Unit Tests run on #47290 with a measured gap of 66.7 seconds. Any fixed tolerance around "now" fails when the runner is slow enough.

# How
Capture a timestamp immediately before the launchUpdate call, then assert lastAccessed >= beforeLaunch. This bounds the timestamp from the side the test controls, so runner speed can no longer affect the result.

# Test Plan
CI
Tests passing locally
