### PR TITLE
[router] Queue navigation dispatches after commit

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Queue `navigation.dispatch` and navigation helper actions until after commit, add synchronous `navigation.dispatchSync`, and require functional actions to use `dispatchSync`.
 - Require complete state in `CommonActions.reset` and `resetRoot`, and remove `Router.getRehydratedState` from `expo-router/react-navigation`.
 - Remove `NavigatorScreenParams`, `getActionFromState`, and `LinkingOptions.getActionFromState` from `expo-router/react-navigation`.
 - Represent nested navigation only as navigation state. The `screen`, `params`, and `initial` params are now ordinary user params

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -3,7 +3,7 @@ import { I18nManager } from 'react-native';
 
 import { seedStoreState } from '../global-state/store';
 import { useExpoRouterStore } from '../global-state/storeContext';
-import { useImperativeApiEmitter } from '../imperative-api';
+import { ImperativeApiEmitter } from '../imperative-api';
 import type {
   DocumentTitleOptions,
   LinkingOptions,
@@ -85,7 +85,6 @@ function NavigationContainerInner(
 
   useBackButton(refContainer);
   useDocumentTitle(refContainer, documentTitle);
-  useImperativeApiEmitter(refContainer);
 
   const [lastUnhandledLink, setLastUnhandledLink] = React.useState<string | undefined>();
 
@@ -170,6 +169,7 @@ function NavigationContainerInner(
     <LocaleDirContext.Provider value={direction}>
       <UnhandledLinkingContext.Provider value={unhandledLinkingContext}>
         <LinkingContext.Provider value={linkingContext}>
+          <ImperativeApiEmitter navigationRef={refContainer} />
           <BaseNavigationContainer
             {...rest}
             theme={theme}

--- a/packages/expo-router/src/fork/__tests__/useBackButton.test.ios.tsx
+++ b/packages/expo-router/src/fork/__tests__/useBackButton.test.ios.tsx
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react-native';
+import type { RefObject } from 'react';
+import { BackHandler } from 'react-native';
+
+import type { NavigationContainerRef, ParamListBase } from '../../react-navigation/native';
+import { useBackButton } from '../useBackButton';
+
+test('a second hardware back press observes the first synchronous pop', () => {
+  let onBackPress: (() => boolean | null | undefined) | undefined;
+  const remove = jest.fn();
+  jest.spyOn(BackHandler, 'addEventListener').mockImplementation((_, listener) => {
+    // The hook ignores React Native's hardware event payload.
+    onBackPress = () => listener({} as never);
+    return { remove };
+  });
+
+  let canGoBack = true;
+  const dispatchSync = jest.fn(() => {
+    canGoBack = false;
+  });
+  const ref = {
+    current: {
+      canGoBack: () => canGoBack,
+      dispatchSync,
+    } as unknown as NavigationContainerRef<ParamListBase>,
+  } as RefObject<NavigationContainerRef<ParamListBase>>;
+
+  const { unmount } = renderHook(() => useBackButton(ref));
+
+  expect(onBackPress?.()).toBe(true);
+  expect(onBackPress?.()).toBe(false);
+  expect(dispatchSync).toHaveBeenCalledTimes(1);
+
+  unmount();
+  expect(remove).toHaveBeenCalledTimes(1);
+});

--- a/packages/expo-router/src/fork/useBackButton.native.ts
+++ b/packages/expo-router/src/fork/useBackButton.native.ts
@@ -4,7 +4,11 @@
 import * as React from 'react';
 import { BackHandler } from 'react-native';
 
-import type { NavigationContainerRef, ParamListBase } from '../react-navigation/native';
+import {
+  CommonActions,
+  type NavigationContainerRef,
+  type ParamListBase,
+} from '../react-navigation/native';
 
 export function useBackButton(ref: React.RefObject<NavigationContainerRef<ParamListBase>>) {
   React.useEffect(() => {
@@ -16,7 +20,7 @@ export function useBackButton(ref: React.RefObject<NavigationContainerRef<ParamL
       }
 
       if (navigation.canGoBack()) {
-        navigation.goBack();
+        navigation.dispatchSync(CommonActions.goBack());
 
         return true;
       }

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -16,6 +16,7 @@ function makeRef(
   return {
     current: {
       dispatch: jest.fn(),
+      dispatchSync: jest.fn(),
       navigate: jest.fn(),
       reset: jest.fn(),
       goBack: jest.fn(),
@@ -107,7 +108,7 @@ describe('routingQueue', () => {
 
     routingQueue.run(ref);
 
-    expect(ref.current!.dispatch).toHaveBeenCalledWith(action);
+    expect(ref.current!.dispatchSync).toHaveBeenCalledWith(action);
   });
 
   it('run() converts NAVIGATE_TO_HREF intents via getNavigateAction then dispatches', () => {
@@ -139,7 +140,7 @@ describe('routingQueue', () => {
       undefined,
       false
     );
-    expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
+    expect(ref.current!.dispatchSync).toHaveBeenCalledWith(navigateAction);
   });
 
   it('run() dispatches mixed NAVIGATE_TO_HREF and ACTION intents in queue order', () => {
@@ -156,8 +157,55 @@ describe('routingQueue', () => {
 
     routingQueue.run(ref);
 
-    const dispatch = ref.current!.dispatch as jest.Mock;
+    const dispatch = ref.current!.dispatchSync as jest.Mock;
     expect(dispatch.mock.calls).toEqual([[navigateAction], [{ type: 'GO_BACK' }]]);
+  });
+
+  it('run() dispatches NAVIGATOR_ACTION through the dispatcher captured at enqueue', () => {
+    const ref = makeRef();
+    const dispatchSync = jest.fn();
+    const action = { type: 'GO_BACK' };
+
+    routingQueue.add({
+      type: 'NAVIGATOR_ACTION',
+      payload: { action, dispatchSync },
+    });
+
+    routingQueue.run(ref);
+
+    expect(dispatchSync).toHaveBeenCalledWith(action);
+    expect(ref.current!.dispatchSync).not.toHaveBeenCalled();
+  });
+
+  it('run() preserves FIFO across navigator and root actions', () => {
+    const calls: string[] = [];
+    const ref = makeRef({ dispatchSync: jest.fn(() => calls.push('root')) });
+
+    routingQueue.add({
+      type: 'NAVIGATOR_ACTION',
+      payload: {
+        action: { type: 'NAVIGATE' },
+        dispatchSync: () => calls.push('navigator'),
+      },
+    });
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+
+    routingQueue.run(ref);
+
+    expect(calls).toEqual(['navigator', 'root']);
+  });
+
+  it('run() does not re-enqueue root actions', () => {
+    const ref = makeRef({
+      dispatch: jest.fn((action) => routingQueue.add({ type: 'ACTION', payload: { action } })),
+    });
+
+    routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
+
+    routingQueue.run(ref);
+
+    expect(ref.current!.dispatch).not.toHaveBeenCalled();
+    expect(routingQueue.queue).toHaveLength(0);
   });
 
   it('run() reports the queued action when handling fails', () => {
@@ -187,7 +235,7 @@ describe('routingQueue', () => {
 
   it('run() invokes onDispatch immediately before dispatching', () => {
     const calls: string[] = [];
-    const ref = makeRef({ dispatch: jest.fn(() => calls.push('dispatch')) });
+    const ref = makeRef({ dispatchSync: jest.fn(() => calls.push('dispatch')) });
     const action = { type: 'RESET', payload: undefined };
 
     routingQueue.add({
@@ -314,23 +362,23 @@ describe('routingQueue', () => {
 
     routingQueue.run(ref);
 
-    expect(ref.current!.dispatch).toHaveBeenCalledWith(nextAction);
+    expect(ref.current!.dispatchSync).toHaveBeenCalledWith(nextAction);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('malformed'));
     warn.mockRestore();
   });
 
   it('run() continues after an item throws during dispatch', () => {
-    const dispatch = jest.fn().mockImplementationOnce(() => {
+    const dispatchSync = jest.fn().mockImplementationOnce(() => {
       throw new Error('dispatch failed');
     });
-    const ref = makeRef({ dispatch });
+    const ref = makeRef({ dispatchSync });
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     routingQueue.add({ type: 'ACTION', payload: { action: { type: 'GO_BACK' } } });
     routingQueue.add({ type: 'ACTION', payload: { action: { type: 'POP_TO_TOP' } } });
 
     routingQueue.run(ref);
 
-    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatchSync).toHaveBeenCalledTimes(2);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('dispatch failed'));
     warn.mockRestore();
   });

--- a/packages/expo-router/src/global-state/routerRegistry.tsx
+++ b/packages/expo-router/src/global-state/routerRegistry.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { createContext, use, useMemo, useState, type PropsWithChildren } from 'react';
+import {
+  createContext,
+  use,
+  useMemo,
+  useRef,
+  useState,
+  type PropsWithChildren,
+  type RefObject,
+} from 'react';
 
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
 import type {
@@ -28,10 +36,15 @@ type RouterRegistrySetters = {
 
 // React components read this map during render, so React state is intentional.
 export const RouterRegistryContext = createContext<RouterRegistry | undefined>(undefined);
+export const RouterRegistryRefContext = createContext<RefObject<RouterRegistry> | undefined>(
+  undefined
+);
 const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(undefined);
 
 export function RouterRegistryProvider({ children }: PropsWithChildren) {
   const [registry, setRegistry] = useState<RouterRegistry>(() => new Map());
+  const registryRef = useRef(registry);
+  registryRef.current = registry;
   const setters = useMemo<RouterRegistrySetters>(
     () => ({
       register(stateKey, entry) {
@@ -60,7 +73,9 @@ export function RouterRegistryProvider({ children }: PropsWithChildren) {
 
   return (
     <RouterRegistrySettersContext.Provider value={setters}>
-      <RouterRegistryContext.Provider value={registry}>{children}</RouterRegistryContext.Provider>
+      <RouterRegistryRefContext.Provider value={registryRef}>
+        <RouterRegistryContext.Provider value={registry}>{children}</RouterRegistryContext.Provider>
+      </RouterRegistryRefContext.Provider>
     </RouterRegistrySettersContext.Provider>
   );
 }

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -30,6 +30,15 @@ interface RoutingIntentMetadata {
 export type RoutingIntent =
   | NavigateToHrefIntent
   | {
+      type: 'NAVIGATOR_ACTION';
+      payload: {
+        action: NavigationAction;
+        dispatchSync: (action: NavigationAction) => void;
+      };
+      metadata?: RoutingIntentMetadata;
+      onDispatch?: (metadata: RoutingIntentMetadata | undefined) => void;
+    }
+  | {
       type: 'ACTION';
       payload: { action: NavigationAction };
       metadata?: RoutingIntentMetadata;
@@ -49,7 +58,7 @@ export const routingQueue = {
     return routingQueue.queue;
   },
   add(intent: RoutingIntent) {
-    routingQueue.queue.push(intent);
+    routingQueue.queue = [...routingQueue.queue, intent];
     for (const callback of routingQueue.subscribers) {
       callback();
     }
@@ -116,7 +125,11 @@ export const routingQueue = {
         }
 
         intent.onDispatch?.(intent.metadata);
-        ref.current.dispatch(dispatchAction);
+        if (intent.type === 'NAVIGATOR_ACTION') {
+          intent.payload.dispatchSync(dispatchAction);
+        } else {
+          ref.current.dispatchSync(dispatchAction);
+        }
       } catch (error) {
         const message =
           typeof error === 'object' && error != null && 'message' in error ? error.message : error;

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -9,9 +9,11 @@ import type { NavigationContainerRef, ParamListBase } from './react-navigation/n
 export type { ImperativeRouter };
 export { router };
 
-export function useImperativeApiEmitter(
-  ref: RefObject<NavigationContainerRef<ParamListBase> | null>
-) {
+export function ImperativeApiEmitter({
+  navigationRef,
+}: {
+  navigationRef: RefObject<NavigationContainerRef<ParamListBase> | null>;
+}) {
   const registry = use(RouterRegistryContext);
   const events = useSyncExternalStore(
     routingQueue.subscribe,
@@ -19,7 +21,9 @@ export function useImperativeApiEmitter(
     routingQueue.snapshot
   );
   useEffect(() => {
-    routingQueue.run(ref, registry);
-  }, [events, ref, registry]);
+    if (events.length) {
+      routingQueue.run(navigationRef, registry);
+    }
+  }, [events, navigationRef, registry]);
   return null;
 }

--- a/packages/expo-router/src/layouts/StackClient.tsx
+++ b/packages/expo-router/src/layouts/StackClient.tsx
@@ -89,8 +89,8 @@ const RNStack = unstable_integrateWithRouter<
   StackRouterOptions,
   NativeStackNavigatorCreateProps
 >(createStandardNativeStackNavigator, StackRouter, {
-  createProps: ({ state, dispatch, navigation }) => ({
-    pop: makePopAction(dispatch, state.key),
+  createProps: ({ state, dispatch, dispatchSync, navigation }) => ({
+    pop: makePopAction(dispatchSync, state.key),
     removeRoutes: (routeNames) => dispatch({ type: 'REMOVE_ROUTES', payload: { routeNames } }),
     subscribePopToTopOnParentTabPress: () =>
       // @ts-expect-error: there may not be a tab navigator in parent

--- a/packages/expo-router/src/layouts/TopTabsClient.tsx
+++ b/packages/expo-router/src/layouts/TopTabsClient.tsx
@@ -12,6 +12,7 @@ import type {
   MaterialTopTabNavigationOptions,
 } from '../react-navigation/material-top-tabs/types';
 import {
+  CommonActions,
   type ParamListBase,
   type TabNavigationState,
   TabRouter,
@@ -36,9 +37,10 @@ const TopTabs = unstable_integrateWithRouter<
 >(createStandardMaterialTopTabNavigator, TabRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
   processState: appendMissingPlaceholderTabRoutes,
-  createProps: ({ state, dispatch }) => ({
+  createProps: ({ state, dispatch, dispatchSync }) => ({
     routeNames: state.routeNames,
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),
+    navigateToTabSync: (name, params) => dispatchSync(CommonActions.navigate(name, params)),
   }),
 });
 

--- a/packages/expo-router/src/layouts/experimental-stack/ExperimentalStackView.tsx
+++ b/packages/expo-router/src/layouts/experimental-stack/ExperimentalStackView.tsx
@@ -83,7 +83,7 @@ export function ExperimentalStackView({ state, navigation, descriptors }: Props)
                 // Native dismissal (e.g. swipe-to-dismiss). JS state still has the route —
                 // catch up by dispatching pop and arming useDismissedRouteError so a stale
                 // `usePreventRemove` surfaces an actionable console.error.
-                navigation.dispatch({
+                navigation.dispatchSync({
                   ...StackActions.pop(),
                   source: route.key,
                   target: state.key,
@@ -94,7 +94,7 @@ export function ExperimentalStackView({ state, navigation, descriptors }: Props)
                 if (preventFromContext) {
                   // A real pop runs child-first prevention checks and notifies the nested route
                   // that owns the guard; emitting directly here would only reach this route.
-                  navigation.dispatch({
+                  navigation.dispatchSync({
                     ...StackActions.pop(),
                     source: route.key,
                     target: state.key,

--- a/packages/expo-router/src/modal/web/ModalStack.tsx
+++ b/packages/expo-router/src/modal/web/ModalStack.tsx
@@ -94,7 +94,7 @@ const ModalStackView = ({ state, navigation, descriptors }: ModalStackViewProps)
     index: nonModalIndex,
   };
 
-  const pop = makePopAction(navigation.dispatch, state.key);
+  const pop = makePopAction(navigation.dispatchSync, state.key);
 
   const dismiss = useCallback(() => {
     navigation.goBack();

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -2,10 +2,11 @@
 
 import React, { use, useCallback, useMemo, useRef } from 'react';
 
-import type {
-  ParamListBase,
-  TabNavigationState,
-  TabRouterOptions,
+import {
+  CommonActions,
+  type ParamListBase,
+  type TabNavigationState,
+  type TabRouterOptions,
 } from '../react-navigation/native';
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
 import {
@@ -37,15 +38,17 @@ export const NativeTabsContext = React.createContext<boolean>(false);
 export interface NativeTabsNavigatorCreateProps {
   routeNames: string[];
   preload: (name: string) => void;
+  navigateSync: (name: string) => void;
 }
 
 function NativeTabsContent({
   state,
   routeNames,
   descriptors,
-  actions,
+  actions: _actions,
   emitter,
   preload,
+  navigateSync,
   // These per-tab style props are folded into `screenOptions` by `NativeTabsNavigatorWrapper` and
   // read back per-tab from `descriptors`. Pull them out of `rest` so they aren't forwarded to
   // `NativeTabsView` as top-level props.
@@ -144,10 +147,10 @@ function NativeTabsContent({
             isPrevented: false,
           },
         });
-        actions.navigate(selectedRoute.name);
+        navigateSync(selectedRoute.name);
       }
     },
-    [routes, actions, emitter]
+    [routes, navigateSync, emitter]
   );
 
   // Compile-time guard: everything spread onto `<NativeTabsView>` must be a prop it declares. The
@@ -190,9 +193,10 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
 >(NativeTabsContent, NativeBottomTabsRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
   processState: appendMissingPlaceholderTabRoutes,
-  createProps: ({ state, dispatch }) => ({
+  createProps: ({ state, dispatch, dispatchSync }) => ({
     routeNames: state.routeNames,
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),
+    navigateSync: (name) => dispatchSync(CommonActions.navigate(name)),
   }),
 });
 

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -121,7 +121,7 @@ describe('Tabs visibility', () => {
     expect(screen.getByTestId('index')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
     expect(screen.queryByTestId('third')).toBeNull();
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
+    expect(TabsScreen).toHaveBeenCalledTimes(6);
   });
 
   it('does not render hidden tabs', () => {
@@ -146,7 +146,7 @@ describe('Tabs visibility', () => {
     expect(screen.queryByTestId('third')).toBeNull();
     expect(screen.queryByTestId('fourth')).toBeNull();
     expect(screen.getByTestId('fifth')).toBeVisible();
-    expect(TabsScreen).toHaveBeenCalledTimes(6);
+    expect(TabsScreen).toHaveBeenCalledTimes(9);
   });
 
   it('does not render tabs, when route does not exist', () => {
@@ -206,10 +206,10 @@ describe('First focused tab', () => {
 
     expect(screen.getByTestId('index')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
+    expect(TabsScreen).toHaveBeenCalledTimes(6);
     expect(TabsScreen.mock.calls[0][0].screenKey).toBe('index');
     expect(TabsScreen.mock.calls[1][0].screenKey).toBe('second');
-    expect(TabsHost).toHaveBeenCalledTimes(2);
+    expect(TabsHost).toHaveBeenCalledTimes(3);
     expect(TabsHost.mock.calls[0][0].navStateRequest.selectedScreenKey).toBe('index');
   });
 
@@ -247,9 +247,8 @@ describe('First focused tab', () => {
       expect(screen.getByTestId('first')).toBeVisible();
       expect(screen.getByTestId('second')).toBeVisible();
       expect(screen.queryByTestId('index')).toBeNull();
-      // Two renders: the hidden `index` route is registered and initially focused, then the
-      // navigator redirects to the first visible tab.
-      expect(NativeTabsView).toHaveBeenCalledTimes(2);
+      // The queued redirect is applied before the native view renders.
+      expect(NativeTabsView).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -31,6 +31,7 @@ import type {
 import { useChildListeners } from './useChildListeners';
 import { useEventEmitter } from './useEventEmitter';
 import { useKeyedChildListeners } from './useKeyedChildListeners';
+import { FUNCTIONAL_DISPATCH_ERROR } from './useNavigationHelpers';
 import { useNavigationIndependentTree } from './useNavigationIndependentTree';
 import { useOptionsGetters } from './useOptionsGetters';
 import { useSyncState } from './useSyncState';
@@ -111,12 +112,24 @@ export function BaseNavigationContainer({
 
   const { keyedListeners, addKeyedListener } = useKeyedChildListeners();
 
-  const dispatch = useLatestCallback(
+  const dispatch = useLatestCallback((action: NavigationAction) => {
+    if (typeof action === 'function') {
+      throw new Error(FUNCTIONAL_DISPATCH_ERROR);
+    }
+
+    if (listeners.focus[0] == null) {
+      console.error(NOT_INITIALIZED_ERROR);
+    } else {
+      listeners.focus[0]((navigation) => navigation.dispatch(action));
+    }
+  });
+
+  const dispatchSync = useLatestCallback(
     (action: NavigationAction | ((state: NavigationState) => NavigationAction)) => {
       if (listeners.focus[0] == null) {
         console.error(NOT_INITIALIZED_ERROR);
       } else {
-        listeners.focus[0]((navigation) => navigation.dispatch(action));
+        listeners.focus[0]((navigation) => navigation.dispatchSync(action));
       }
     }
   );
@@ -182,6 +195,7 @@ export function BaseNavigationContainer({
       }, {}),
       ...emitter.create('root'),
       dispatch,
+      dispatchSync,
       resetRoot,
       isFocused: () => true,
       canGoBack,
@@ -198,6 +212,7 @@ export function BaseNavigationContainer({
     [
       canGoBack,
       dispatch,
+      dispatchSync,
       emitter,
       getCurrentOptions,
       getCurrentRoute,

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -2,7 +2,9 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
+import { routingQueue } from '../../../global-state/routingQueue';
 import {
+  CommonActions,
   type DefaultRouterOptions,
   type NavigationState,
   type ParamListBase,
@@ -28,6 +30,7 @@ jest.mock('nanoid/non-secure', () => {
 
 beforeEach(() => {
   MockRouterKey.current = 0;
+  routingQueue.queue = [];
 
   require('nanoid/non-secure').__key = 0;
 });
@@ -214,14 +217,19 @@ test('handle dispatching with ref', () => {
   };
 
   const element = (
-    <BaseNavigationContainer ref={ref} initialState={initialState} onStateChange={onStateChange}>
-      <RootNavigator>
-        <Screen name="foo">{() => null}</Screen>
-        <Screen name="foo2">{() => null}</Screen>
-        <Screen name="bar">{() => null}</Screen>
-        <Screen name="baz">{() => null}</Screen>
-      </RootNavigator>
-    </BaseNavigationContainer>
+    <RouterRegistryProvider>
+      <RawBaseNavigationContainer
+        ref={ref}
+        initialState={initialState}
+        onStateChange={onStateChange}>
+        <RootNavigator>
+          <Screen name="foo">{() => null}</Screen>
+          <Screen name="foo2">{() => null}</Screen>
+          <Screen name="bar">{() => null}</Screen>
+          <Screen name="baz">{() => null}</Screen>
+        </RootNavigator>
+      </RawBaseNavigationContainer>
+    </RouterRegistryProvider>
   );
 
   render(element).update(element);
@@ -229,6 +237,11 @@ test('handle dispatching with ref', () => {
   act(() => {
     ref.current?.dispatch({ type: 'REVERSE' });
   });
+
+  expect(onStateChange).not.toHaveBeenCalled();
+  expect(routingQueue.queue).toHaveLength(1);
+
+  act(() => routingQueue.run(ref));
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenLastCalledWith({
@@ -242,6 +255,67 @@ test('handle dispatching with ref', () => {
       { key: 'baz', name: 'baz' },
     ],
   });
+
+  act(() => {
+    ref.current?.dispatchSync({ type: 'REVERSE' });
+  });
+
+  expect(onStateChange).toHaveBeenCalledTimes(2);
+  expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['baz', 'bar']);
+});
+
+test('rejects functional ref dispatch and supports functional dispatchSync', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  const RootNavigator = (props: any) => {
+    const { descriptors, state, NavigationContent } = useNavigationBuilder(MockRouter, props);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  };
+
+  render(
+    <BaseNavigationContainer ref={ref}>
+      <RootNavigator>
+        <Screen name="foo">{() => null}</Screen>
+      </RootNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(() =>
+    // @ts-expect-error: Functional dispatch is rejected at runtime with migration guidance.
+    ref.current?.dispatch((state) => ({ type: 'SET_STATE', payload: state }))
+  ).toThrow('dispatchSync');
+
+  expect(() => act(() => ref.current?.dispatchSync(() => ({ type: 'NOOP' })))).not.toThrow();
+});
+
+test('rejects dispatchSync from an unregistered navigator', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  const RootNavigator = (props: any) => {
+    const { descriptors, state, NavigationContent } = useNavigationBuilder(MockRouter, props);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  };
+
+  render(
+    <RawBaseNavigationContainer ref={ref}>
+      <RootNavigator>
+        <Screen name="foo">{() => null}</Screen>
+      </RootNavigator>
+    </RawBaseNavigationContainer>
+  );
+
+  expect(() => ref.current?.dispatchSync({ type: 'NOOP' })).toThrow('not registered');
+  warn.mockRestore();
 });
 
 test('handles resetting to a complete state with ref', () => {
@@ -314,6 +388,7 @@ test('handles resetting to a complete state with ref', () => {
 
   act(() => {
     ref.current?.resetRoot(state);
+    routingQueue.run(ref);
   });
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
@@ -500,7 +575,7 @@ test('emits state events when the state changes', () => {
   expect(listener).not.toHaveBeenCalled();
 
   act(() => {
-    ref.current?.navigate('bar');
+    ref.current?.dispatchSync(CommonActions.navigate('bar'));
   });
 
   expect(listener).toHaveBeenCalledTimes(1);
@@ -518,6 +593,7 @@ test('emits state events when the state changes', () => {
 
   act(() => {
     ref.current?.navigate('baz', { answer: 42 });
+    routingQueue.run(ref);
   });
 
   expect(listener).toHaveBeenCalledTimes(2);
@@ -682,7 +758,7 @@ test('emits option events when options change with tab router', () => {
   ref.current?.addListener('options', listener);
 
   act(() => {
-    ref.current?.navigate('bar');
+    ref.current?.dispatchSync(CommonActions.navigate('bar'));
   });
 
   expect(listener).toHaveBeenCalledTimes(1);
@@ -696,7 +772,7 @@ test('emits option events when options change with tab router', () => {
   ref.current?.addListener('options', listener2);
 
   act(() => {
-    ref.current?.navigate('baz');
+    ref.current?.dispatchSync(CommonActions.navigate('baz'));
   });
 
   expect(listener2).toHaveBeenCalledTimes(1);
@@ -704,7 +780,7 @@ test('emits option events when options change with tab router', () => {
   expect(ref.current?.getCurrentOptions()).toEqual({ g: 5 });
 
   act(() => {
-    ref.current?.navigate('quxx');
+    ref.current?.dispatchSync(CommonActions.navigate('quxx'));
   });
 
   expect(listener2).toHaveBeenCalledTimes(2);
@@ -757,7 +833,7 @@ test('emits option events when options change with stack router', () => {
   ref.current?.addListener('options', listener);
 
   act(() => {
-    ref.current?.navigate('bar');
+    ref.current?.dispatchSync(CommonActions.navigate('bar'));
   });
 
   expect(listener).toHaveBeenCalledTimes(1);
@@ -771,7 +847,7 @@ test('emits option events when options change with stack router', () => {
   ref.current?.addListener('options', listener2);
 
   act(() => {
-    ref.current?.navigate('baz');
+    ref.current?.dispatchSync(CommonActions.navigate('baz'));
   });
 
   expect(listener2).toHaveBeenCalledTimes(1);
@@ -779,7 +855,7 @@ test('emits option events when options change with stack router', () => {
   expect(ref.current?.getCurrentOptions()).toEqual({ g: 5 });
 
   act(() => {
-    ref.current?.navigate('quxx');
+    ref.current?.dispatchSync(CommonActions.navigate('quxx'));
   });
 
   expect(listener2).toHaveBeenCalledTimes(2);
@@ -904,8 +980,14 @@ test('invokes the unhandled action listener with the unhandled action', () => {
     </BaseNavigationContainer>
   );
 
-  act(() => ref.current!.navigate('bar'));
-  act(() => ref.current!.navigate('baz'));
+  act(() => {
+    ref.current!.navigate('bar');
+    routingQueue.run(ref);
+  });
+  act(() => {
+    ref.current!.navigate('baz');
+    routingQueue.run(ref);
+  });
 
   expect(fn).toHaveBeenCalledWith({
     payload: {
@@ -950,7 +1032,10 @@ test('works with state change events in independent nested container', () => {
     </BaseNavigationContainer>
   );
 
-  act(() => ref.current?.navigate('lex'));
+  act(() => {
+    ref.current?.navigate('lex');
+    routingQueue.run(ref);
+  });
 
   expect(onStateChange).toHaveBeenCalledWith({
     index: 1,

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
 import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
-import type { InitialState } from '../../types';
+import { ImperativeApiEmitter } from '../../../../imperative-api';
+import type { ParamListBase } from '../../../routers';
+import type { InitialState, NavigationContainerRef } from '../../types';
 import { BaseNavigationContainer as BaseNavigationContainerImpl } from '../../BaseNavigationContainer';
 import { MockRouterKey } from './MockRouter';
 
@@ -34,9 +36,29 @@ function completeState(
 export function BaseNavigationContainer(
   props: React.ComponentProps<typeof BaseNavigationContainerImpl>
 ) {
+  const { ref, ...rest } = props;
+  const navigationRef = React.useRef<NavigationContainerRef<ParamListBase> | null>(null);
+
+  const setRef = React.useCallback(
+    (navigation: NavigationContainerRef<ParamListBase> | null) => {
+      navigationRef.current = navigation;
+      if (typeof ref === 'function') {
+        ref(navigation);
+      } else if (ref) {
+        ref.current = navigation;
+      }
+    },
+    [ref]
+  );
+
   return (
     <RouterRegistryProvider>
-      <BaseNavigationContainerImpl {...props} initialState={completeState(props.initialState)} />
+      <ImperativeApiEmitter navigationRef={navigationRef} />
+      <BaseNavigationContainerImpl
+        {...rest}
+        ref={setRef}
+        initialState={completeState(props.initialState)}
+      />
     </RouterRegistryProvider>
   );
 }

--- a/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/createNavigationContainerRef.test.ios.tsx
@@ -58,3 +58,12 @@ test('removal of non-existing listener should not break updating ref', () => {
     ref.current = createNavigationContainerRef<ParamListBase>();
   }).not.toThrow();
 });
+
+test('rejects functional dispatch before the container is mounted', () => {
+  const ref = createNavigationContainerRef<ParamListBase>();
+
+  expect(() =>
+    // @ts-expect-error: Functional dispatch is rejected at runtime with migration guidance.
+    ref.dispatch(() => ({ type: 'NOOP' }))
+  ).toThrow('dispatchSync');
+});

--- a/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/index.test.ios.tsx
@@ -553,6 +553,7 @@ test('cleans up state when the navigator unmounts', () => {
 });
 
 test('allows state updates by dispatching a function returning an action', () => {
+  let dispatchSync: (action: (state: NavigationState) => NavigationAction) => void;
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
 
@@ -562,14 +563,7 @@ test('allows state updates by dispatching a function returning an action', () =>
   };
 
   const FooScreen = (props: any) => {
-    React.useEffect(() => {
-      props.navigation.dispatch((state: NavigationState) =>
-        state.index === 0
-          ? { type: 'NAVIGATE', payload: { name: state.routeNames[1] } }
-          : { type: 'NOOP' }
-      );
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    dispatchSync = props.navigation.dispatchSync;
 
     return null;
   };
@@ -587,7 +581,15 @@ test('allows state updates by dispatching a function returning an action', () =>
     </BaseNavigationContainer>
   );
 
-  render(element).update(element);
+  const root = render(element);
+  act(() =>
+    dispatchSync((state) =>
+      state.index === 0
+        ? { type: 'NAVIGATE', payload: { name: state.routeNames[1] } }
+        : { type: 'NOOP' }
+    )
+  );
+  root.update(element);
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith({

--- a/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.ios.tsx
@@ -2,7 +2,7 @@ import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
 import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
-import { type ParamListBase, StackActions, StackRouter } from '../../routers';
+import { CommonActions, type ParamListBase, StackActions, StackRouter } from '../../routers';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
 import { useNavigationBuilder } from '../useNavigationBuilder';
@@ -68,7 +68,7 @@ test('blocks removal with the hook and emits removePrevented', () => {
   expect(beforeRemove).not.toHaveBeenCalled();
 
   act(() => setPreventRemove(false));
-  expect(() => act(() => ref.current?.goBack())).toThrow(
+  expect(() => act(() => ref.current?.dispatchSync(CommonActions.goBack()))).toThrow(
     '`beforeRemove` is a notification-only event and cannot prevent screen removal. Use `usePreventRemove` with the `removePrevented` event instead.'
   );
 
@@ -87,7 +87,7 @@ test('blocks synchronous redispatch from removePrevented without re-emitting', (
     );
   };
   const ref = createNavigationContainerRef<ParamListBase>();
-  const removePrevented = jest.fn(({ data }) => ref.current?.dispatch(data.action));
+  const removePrevented = jest.fn(({ data }) => ref.current?.dispatchSync(data.action));
   const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
   const TestScreen = () => {
@@ -107,7 +107,7 @@ test('blocks synchronous redispatch from removePrevented without re-emitting', (
     );
 
     act(() => ref.current?.navigate('bar'));
-    act(() => ref.current?.goBack());
+    act(() => ref.current?.dispatchSync(CommonActions.goBack()));
 
     expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['foo', 'bar']);
     expect(removePrevented).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.web.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/removePrevented.test.web.tsx
@@ -8,6 +8,7 @@ import { store } from '../../../global-state/router-store';
 import { router } from '../../../imperative-api';
 import Stack from '../../../layouts/StackClient';
 import { getMockContext } from '../../../testing-library/mock-config';
+import { CommonActions } from '../../routers';
 import { useNavigation } from '../useNavigation';
 import { usePreventRemove } from '../usePreventRemove';
 
@@ -87,7 +88,7 @@ test('throws a descriptive error when beforeRemove calls preventDefault', () => 
   let goBack: () => void;
   const Form = () => {
     const navigation = useNavigation();
-    goBack = navigation.goBack;
+    goBack = () => navigation.dispatchSync(CommonActions.goBack());
     React.useEffect(
       () =>
         navigation.addListener('beforeRemove', (event) => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
+import { routingQueue } from '../../../global-state/routingQueue';
 import {
   CommonActions,
   type NavigationState,
@@ -309,17 +310,34 @@ test('ignores dispatches from a preloaded stack screen until it is promoted', ()
   act(() => ref.current?.dispatch(CommonActions.preload('second')));
   const preloadedNavigation = navigation;
   const preloadedState = ref.current?.getRootState();
+  const add = jest.spyOn(routingQueue, 'add');
 
   act(() => preloadedNavigation.goBack());
 
   expect(warn).toHaveBeenCalledWith(
     "Ignored a navigation action dispatched from the preloaded screen 'second'. The screen is rendered for preloading and is not focused, so its actions would unexpectedly modify the visible stack. Wait until the screen is focused before dispatching."
   );
+  expect(add).not.toHaveBeenCalled();
   expect(ref.current?.getRootState()).toEqual(preloadedState);
+
+  expect(() => preloadedNavigation.dispatch(() => CommonActions.goBack())).toThrow('dispatchSync');
 
   act(() => ref.current?.navigate('second'));
 
   expect(navigation).toBe(preloadedNavigation);
-  act(() => preloadedNavigation.goBack());
+  add.mockClear();
+
+  act(() => preloadedNavigation.dispatch(CommonActions.goBack()));
+
+  expect(add).toHaveBeenCalledTimes(1);
+  expect(add).toHaveBeenCalledWith({
+    type: 'NAVIGATOR_ACTION',
+    payload: expect.objectContaining({
+      action: expect.objectContaining({
+        source: expect.any(String),
+        type: 'GO_BACK',
+      }),
+    }),
+  });
   expect(ref.current?.getRootState().routes.map((route) => route.name)).toEqual(['first']);
 });

--- a/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useOnAction.test.ios.tsx
@@ -67,7 +67,7 @@ test("lets parent handle the action if child didn't", () => {
 
   let dispatch: (action: { type: 'REVERSE' }) => void;
   const TestScreen = (props: any) => {
-    dispatch = props.navigation.dispatch;
+    dispatch = props.navigation.dispatchSync;
     return null;
   };
 
@@ -147,7 +147,7 @@ test('handles an unsupported targeted action as a no-op without bubbling', () =>
 
   const state = ref.current!.getRootState();
 
-  act(() => ref.dispatch({ type: 'POP_TO_TOP', target: state.key }));
+  act(() => ref.dispatchSync({ type: 'POP_TO_TOP', target: state.key }));
 
   expect(ref.current!.getRootState()).toBe(state);
   expect(onUnhandledAction).not.toHaveBeenCalled();
@@ -416,7 +416,7 @@ test('action goes to correct child navigator if target is specified', () => {
   render(element).update(element);
 
   act(() => {
-    ref.dispatch({ type: 'REVERSE', target: '1' });
+    ref.dispatchSync({ type: 'REVERSE', target: '1' });
   });
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
@@ -628,7 +628,7 @@ test("prevents removing a screen with 'removePrevented' event", () => {
     });
     React.useEffect(() => {
       if (!preventRemove && blockedAction) {
-        ref.current?.dispatch(blockedAction);
+        ref.current?.dispatchSync(blockedAction);
       }
     }, [blockedAction, preventRemove]);
 
@@ -687,7 +687,7 @@ test("prevents removing a screen with 'removePrevented' event", () => {
     stale: false,
   });
 
-  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+  act(() => ref.current?.dispatchSync(StackActions.popTo('foo')));
 
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onBeforeRemove).toHaveBeenCalledTimes(1);
@@ -745,7 +745,7 @@ test("prevents removing a child screen with 'removePrevented' event", () => {
     });
     React.useEffect(() => {
       if (!preventRemove && blockedAction) {
-        ref.current?.dispatch(blockedAction);
+        ref.current?.dispatchSync(blockedAction);
       }
     }, [blockedAction, preventRemove]);
 
@@ -818,7 +818,7 @@ test("prevents removing a child screen with 'removePrevented' event", () => {
     stale: false,
   });
 
-  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+  act(() => ref.current?.dispatchSync(StackActions.popTo('foo')));
 
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onBeforeRemove).toHaveBeenCalledTimes(1);
@@ -886,7 +886,7 @@ test("prevents removing a grand child screen with 'removePrevented' event", () =
     });
     React.useEffect(() => {
       if (!preventRemove && blockedAction) {
-        ref.current?.dispatch(blockedAction);
+        ref.current?.dispatchSync(blockedAction);
       }
     }, [blockedAction, preventRemove]);
 
@@ -976,7 +976,7 @@ test("prevents removing a grand child screen with 'removePrevented' event", () =
     stale: false,
   });
 
-  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+  act(() => ref.current?.dispatchSync(StackActions.popTo('foo')));
 
   expect(onStateChange).toHaveBeenCalledTimes(2);
   expect(onBeforeRemove).toHaveBeenCalledTimes(1);
@@ -1061,7 +1061,7 @@ test("prevents removing by multiple screens with 'removePrevented' event", () =>
     });
     React.useEffect(() => {
       if (!preventRemove && blockedAction) {
-        ref.current?.dispatch(blockedAction);
+        ref.current?.dispatchSync(blockedAction);
       }
     }, [blockedAction, preventRemove]);
 
@@ -1108,7 +1108,7 @@ test("prevents removing by multiple screens with 'removePrevented' event", () =>
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onStateChange).toHaveBeenCalledWith(preventedState);
 
-  act(() => ref.current?.dispatch(StackActions.popTo('foo')));
+  act(() => ref.current?.dispatchSync(StackActions.popTo('foo')));
 
   expect(onStateChange).toHaveBeenCalledTimes(1);
   expect(onBeforeRemove.lex).toHaveBeenCalledTimes(1);

--- a/packages/expo-router/src/react-navigation/core/createNavigationContainerRef.tsx
+++ b/packages/expo-router/src/react-navigation/core/createNavigationContainerRef.tsx
@@ -5,6 +5,7 @@ import type {
   NavigationContainerRef,
   NavigationContainerRefWithCurrent,
 } from './types';
+import { FUNCTIONAL_DISPATCH_ERROR } from './useNavigationHelpers';
 
 export const NOT_INITIALIZED_ERROR =
   "The 'navigation' object hasn't been initialized yet. This might happen if you don't have a navigator mounted, or if the navigator hasn't finished mounting. See https://reactnavigation.org/docs/navigating-without-navigation-prop#handling-initialization for more details.";
@@ -18,6 +19,7 @@ export function createNavigationContainerRef<
     'removeListener',
     'resetRoot',
     'dispatch',
+    'dispatchSync',
     'isFocused',
     'canGoBack',
     'getRootState',
@@ -61,6 +63,10 @@ export function createNavigationContainerRef<
     },
     ...methods.reduce<any>((acc, name) => {
       acc[name] = (...args: any[]) => {
+        if (name === 'dispatch' && typeof args[0] === 'function') {
+          throw new Error(FUNCTIONAL_DISPATCH_ERROR);
+        }
+
         if (current == null) {
           switch (name) {
             case 'addListener': {

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -219,12 +219,20 @@ type NavigationHelpersCommon<
   State extends NavigationState = NavigationState,
 > = {
   /**
-   * Dispatch an action or an update function to the router.
-   * The update function will receive the current state,
+   * Queues an action to be dispatched after the current React commit.
    *
-   * @param action Action object or update function.
+   * @param action Action object to dispatch.
    */
-  dispatch(action: NavigationAction | ((state: Readonly<State>) => NavigationAction)): void;
+  dispatch(action: NavigationAction): void;
+
+  /**
+   * Dispatches an action synchronously.
+   * Functional actions receive the current navigation state. Prefer `dispatch` unless the caller
+   * must reconcile state synchronously with a native event or gesture.
+   *
+   * @param action Action object or update function to dispatch synchronously.
+   */
+  dispatchSync(action: NavigationAction | ((state: Readonly<State>) => NavigationAction)): void;
 
   /**
    * Navigate to a screen in the current or parent navigator.

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -5,7 +5,12 @@ import { use } from 'react';
 import { isValidElementType } from 'react-is';
 
 import { useComponent } from '../../fork/useComponent';
-import { type RouterRegistryEntry, useRegisterRouter } from '../../global-state/routerRegistry';
+import {
+  RouterRegistryRefContext,
+  type RouterRegistry,
+  type RouterRegistryEntry,
+  useRegisterRouter,
+} from '../../global-state/routerRegistry';
 import useLatestCallback from '../../utils/useLatestCallback';
 import {
   type DefaultRouterOptions,
@@ -59,6 +64,10 @@ import { useRegisterNavigator } from './useRegisterNavigator';
 // This is to make TypeScript compiler happy
 // eslint-disable-next-line @typescript-eslint/no-unused-expressions
 PrivateValueStore;
+
+const EMPTY_ROUTER_REGISTRY_REF: React.RefObject<RouterRegistry | undefined> = {
+  current: undefined,
+};
 
 const isScreen = (
   child: React.ReactElement<unknown>
@@ -258,6 +267,7 @@ export function useNavigationBuilder<
   > &
     RouterOptions
 ) {
+  const registryRef = use(RouterRegistryRefContext);
   const navigatorKey = useRegisterNavigator();
 
   const route = use(NavigationRouteContext);
@@ -612,6 +622,7 @@ export function useNavigationBuilder<
     emitter,
     router,
     stateRef,
+    registryRef: registryRef ?? EMPTY_ROUTER_REGISTRY_REF,
   });
 
   useFocusedListenersChildrenAdapter({

--- a/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
@@ -13,6 +13,7 @@ import {
 import { NavigationBuilderContext } from './NavigationBuilderContext';
 import type { NavigationHelpers, NavigationProp } from './types';
 import type { NavigationEventEmitter } from './useEventEmitter';
+import { FUNCTIONAL_DISPATCH_ERROR } from './useNavigationHelpers';
 
 type Options<
   State extends NavigationState,
@@ -82,7 +83,7 @@ export function useNavigationCache<
   const createNavigation = (route: { key: string; name: string }) => {
     type Thunk = NavigationAction | ((state: State) => NavigationAction | null | undefined);
 
-    const dispatch = (thunk: Thunk) => {
+    const dispatchSync = (thunk: Thunk) => {
       const state = getState();
 
       if (isRoutePreloadedInStack(state, route)) {
@@ -98,8 +99,26 @@ export function useNavigationCache<
 
       if (action != null) {
         // TODO(@ubax): https://github.com/expo/expo/pull/48618#discussion_r3735996416
-        navigation.dispatch({ source: route.key, ...action });
+        navigation.dispatchSync({ source: route.key, ...action });
       }
+    };
+
+    const dispatch = (action: NavigationAction) => {
+      if (typeof action === 'function') {
+        throw new Error(FUNCTIONAL_DISPATCH_ERROR);
+      }
+
+      const state = getState();
+      if (isRoutePreloadedInStack(state, route)) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            `Ignored a navigation action dispatched from the preloaded screen '${route.name}'. The screen is rendered for preloading and is not focused, so its actions would unexpectedly modify the visible stack. Wait until the screen is focused before dispatching.`
+          );
+        }
+        return;
+      }
+
+      navigation.dispatch({ source: route.key, ...action });
     };
 
     const withStack = (callback: () => void) => {
@@ -143,7 +162,8 @@ export function useNavigationCache<
       ...helpers,
       // FIXME: too much work to fix the types for now
       ...(emitter.create(route.key) as any),
-      dispatch: (thunk: Thunk) => withStack(() => dispatch(thunk)),
+      dispatch: (action: NavigationAction) => withStack(() => dispatch(action)),
+      dispatchSync: (thunk: Thunk) => withStack(() => dispatchSync(thunk)),
       getParent: (id?: string) => {
         if (id !== undefined && id === rest.getId()) {
           // If the passed id is the same as the current navigation id,

--- a/packages/expo-router/src/react-navigation/core/useNavigationHelpers.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationHelpers.tsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { use } from 'react';
 
+import type { RouterRegistry } from '../../global-state/routerRegistry';
+import { routingQueue } from '../../global-state/routingQueue';
 import {
   CommonActions,
   type NavigationAction,
@@ -25,7 +27,11 @@ type Options<State extends NavigationState, Action extends NavigationAction> = {
   emitter: NavigationEventEmitter<any>;
   router: Router<State, Action>;
   stateRef: React.RefObject<State | null>;
+  registryRef: React.RefObject<RouterRegistry | undefined>;
 };
+
+export const FUNCTIONAL_DISPATCH_ERROR =
+  '`navigation.dispatch` only accepts plain actions because actions are queued until after React commits. Functional actions depend on synchronous state. Use `navigation.dispatchSync((state) => action)` instead.';
 
 /**
  * Navigation object with helper methods to be used by a navigator.
@@ -44,18 +50,41 @@ export function useNavigationHelpers<
   emitter,
   router,
   stateRef,
+  registryRef,
 }: Options<State, Action>) {
   const parentNavigationHelpers = use(NavigationContext);
 
   return React.useMemo(() => {
-    const dispatch = (op: Action | ((state: State) => Action)) => {
-      const action = typeof op === 'function' ? op(getState()) : op;
+    const dispatchSync = (op: Action | ((state: State) => Action)) => {
+      const state = getState();
+      if (!registryRef.current?.has(state.key)) {
+        throw new Error(
+          `Cannot dispatch synchronously because navigator '${state.key}' is not registered. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues.`
+        );
+      }
+
+      const action = typeof op === 'function' ? op(state) : op;
 
       const handled = onAction(action);
 
       if (!handled) {
         onUnhandledAction?.(action);
       }
+    };
+
+    const dispatch = (action: Action) => {
+      if (typeof action === 'function') {
+        throw new Error(FUNCTIONAL_DISPATCH_ERROR);
+      }
+
+      routingQueue.add({
+        type: 'NAVIGATOR_ACTION',
+        payload: {
+          action,
+          // The queued action was already constrained to this navigator's action type.
+          dispatchSync: (queuedAction) => dispatchSync(queuedAction as Action),
+        },
+      });
     };
 
     const actions = {
@@ -73,6 +102,7 @@ export function useNavigationHelpers<
       ...parentNavigationHelpers,
       ...helpers,
       dispatch,
+      dispatchSync,
       emit: emitter.emit,
       isFocused: parentNavigationHelpers ? parentNavigationHelpers.isFocused : () => true,
       canGoBack: () => {
@@ -125,5 +155,6 @@ export function useNavigationHelpers<
     onUnhandledAction,
     navigatorId,
     stateRef,
+    registryRef,
   ]);
 }

--- a/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
@@ -59,6 +59,8 @@ export const shouldPreventRemove = (
     }
 
     if (isRoutePrevented(route.key)) {
+      // TODO: Queued redispatch runs after this callback and bypasses this re-entrancy guard.
+      // Check whether the guard is still needed now that only `dispatchSync` can re-enter it.
       if (emittingRemovePreventedKeys.has(route.key)) {
         if (__DEV__) {
           console.warn(

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -115,14 +115,14 @@ function DrawerViewBase({
   const drawerStatus = getDrawerStatusFromState(state, defaultStatus);
 
   const handleDrawerOpen = useLatestCallback(() => {
-    navigation.dispatch({
+    navigation.dispatchSync({
       ...DrawerActions.openDrawer(),
       target: state.key,
     });
   });
 
   const handleDrawerClose = useLatestCallback(() => {
-    navigation.dispatch({
+    navigation.dispatchSync({
       ...DrawerActions.closeDrawer(),
       target: state.key,
     });

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -16,6 +16,7 @@ import { MaterialTopTabView } from '../views/MaterialTopTabView';
 export interface MaterialTopTabNavigatorCreateProps {
   routeNames: string[];
   preload: (name: string) => void;
+  navigateToTabSync: (name: string, params: object | undefined) => void;
 }
 
 export type MaterialTopTabNavigatorContentProps = MaterialTopTabNavigationConfig &
@@ -35,6 +36,7 @@ function MaterialTopTabNavigatorContent({
   emitter,
   routeNames,
   preload,
+  navigateToTabSync,
   ...rest
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
@@ -80,6 +82,12 @@ function MaterialTopTabNavigatorContent({
       descriptors={topTabDescriptors}
       emitter={emitter}
       navigateToTab={navigateToTab}
+      navigateToTabSync={(routeKey) => {
+        const route = state.routes.find((route) => route.key === routeKey);
+        if (route) {
+          navigateToTabSync(route.name, route.params);
+        }
+      }}
     />
   );
 }

--- a/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/views/MaterialTopTabView.tsx
@@ -28,6 +28,7 @@ type Props = MaterialTopTabNavigationConfig & {
   descriptors: MaterialTopTabDescriptorMap;
   emitter: MaterialTopTabEmitter;
   navigateToTab: (routeKey: string) => void;
+  navigateToTabSync: (routeKey: string) => void;
 };
 
 const renderTabBarDefault = (props: MaterialTopTabBarProps) => <MaterialTopTabBar {...props} />;
@@ -38,6 +39,7 @@ export function MaterialTopTabView({
   descriptors,
   emitter,
   navigateToTab,
+  navigateToTabSync,
   ...rest
 }: Props) {
   const { colors } = useTheme();
@@ -66,7 +68,7 @@ export function MaterialTopTabView({
   return (
     <TabView<Route<string>>
       {...rest}
-      onIndexChange={(index: number) => navigateToTab(state.routes[index]!.key)}
+      onIndexChange={(index: number) => navigateToTabSync(state.routes[index]!.key)}
       renderScene={({ route, position }) => (
         <TabAnimationContext.Provider value={{ position }}>
           {descriptors[route.key]!.render()}

--- a/packages/expo-router/src/react-navigation/native-stack/navigators/createNativeStackNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/navigators/createNativeStackNavigator.tsx
@@ -81,7 +81,7 @@ function NativeStackNavigator({
     });
   }, [meta, navigation, state.index, state.key]);
 
-  const pop = makePopAction(navigation.dispatch, state.key);
+  const pop = makePopAction(navigation.dispatchSync, state.key);
 
   return (
     <NavigationContent>

--- a/packages/expo-router/src/react-navigation/stack/views/Header/Header.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Header/Header.tsx
@@ -35,7 +35,7 @@ export const Header = React.memo(function Header({
   const goBack = React.useCallback(
     throttle(() => {
       if (navigation.isFocused() && navigation.canGoBack()) {
-        navigation.dispatch({
+        navigation.dispatchSync({
           ...StackActions.pop(),
           source: route.key,
         });

--- a/packages/expo-router/src/react-navigation/stack/views/Stack/StackView.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Stack/StackView.tsx
@@ -322,7 +322,7 @@ export class StackView extends React.Component<Props, State> {
     ) {
       // If route isn't present in current state, but was closing, assume that a close animation was cancelled
       // So we need to add this route back to the state
-      navigation.dispatch((state) => {
+      navigation.dispatchSync((state) => {
         const activeRoutes = state.routes
           .slice(0, state.index + 1)
           .filter((r) => r.key !== route.key);
@@ -372,7 +372,7 @@ export class StackView extends React.Component<Props, State> {
       // If a route exists in state, trigger a pop
       // This will happen in when the route was closed from the card component
       // e.g. When the close animation triggered from a gesture ends
-      navigation.dispatch({
+      navigation.dispatchSync({
         ...StackActions.pop(),
         source: route.key,
         target: state.key,

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -190,7 +190,7 @@ export function unstable_integrateWithRouter<
       EventMap
     >(router, useNavigationBuilderProps);
 
-    const { dispatch } = navigation;
+    const { dispatch, dispatchSync } = navigation;
 
     const processedDescriptors = useMemo(
       () =>
@@ -205,8 +205,9 @@ export function unstable_integrateWithRouter<
     );
 
     const derivedProps = useMemo<Partial<CreateProps>>(
-      () => options?.createProps?.({ state: processedState, dispatch, navigation }) ?? {},
-      [processedState, dispatch, navigation, options]
+      () =>
+        options?.createProps?.({ state: processedState, dispatch, dispatchSync, navigation }) ?? {},
+      [processedState, dispatch, dispatchSync, navigation, options]
     );
 
     const standardArgs: NavigatorArgs<NavigatorOptions, EventMap> = {

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -62,6 +62,7 @@ export type StandardUseNavigationBuilderOptions<
 export interface StandardNavigatorCreatePropsFactoryDeps<State extends NavigationState> {
   state: State;
   dispatch: (action: NavigationAction) => void;
+  dispatchSync: (action: NavigationAction) => void;
   navigation: NavigationHelpers<ParamListBase>;
 }
 

--- a/packages/expo-router/src/testing-library/index.tsx
+++ b/packages/expo-router/src/testing-library/index.tsx
@@ -172,7 +172,7 @@ export const testRouter = {
   },
   /** Update the current route query params and assert the new pathname */
   setParams(params: Record<string, string>, path?: string) {
-    router.setParams(params);
+    rnTestingLibrary.act(() => router.setParams(params));
     if (path) {
       expect(screen).toHavePathnameWithParams(path);
     }

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -212,10 +212,10 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
             return;
           }
           const action = buildTabAction(config, owningState, registry, options?.resetOnFocus);
-          return navigation?.dispatch(action);
+          return navigation?.dispatchSync(action);
         }
       } else {
-        return navigation?.dispatch({
+        return navigation?.dispatchSync({
           type: 'JUMP_TO',
           payload: {
             name,

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -28,6 +28,7 @@ import {
 import { Screen } from './primitives';
 import type { BottomTabNavigationEventMap } from './react-navigation/bottom-tabs';
 import {
+  CommonActions,
   useStateForPath,
   type DescriptorRouteProp,
   type EventConsumer,
@@ -340,8 +341,10 @@ export function getQualifiedRouteComponent(value: RouteNode) {
           // When navigating to a screen, remove the no animation param to re-enable animations
           // Otherwise the navigation back would also have no animation
           if (hasParam(route?.params, INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME)) {
-            navigation.replaceParams(
-              removeParams(route?.params, [INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME])
+            navigation.dispatchSync(
+              CommonActions.replaceParams(
+                removeParams(route?.params, [INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME])!
+              )
             );
           }
         }


### PR DESCRIPTION
## Accepted breaking changes

- `navigation.dispatch` and navigation helper methods now apply after the current React commit. Immediate `getState()` and `canGoBack()` reads observe the pre-dispatch state.
- Functional actions are no longer accepted by `navigation.dispatch`; use `navigation.dispatchSync` when a functional action or synchronous application is required.