### PR TITLE
[ios][screen-capture] Alternative fix for dropped draws on reparenting window

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -596,6 +596,8 @@ PODS:
     - RNScreens
   - ExpoScreenCapture (57.0.1):
     - ExpoModulesCore
+  - ExpoScreenCapture/Tests (57.0.1):
+    - ExpoModulesCore
   - ExpoScreenOrientation (57.0.1):
     - ExpoModulesCore
     - hermes-engine
@@ -3417,6 +3419,7 @@ DEPENDENCIES:
   - ExpoRouter (from `../../../packages/expo-router/ios`)
   - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
   - ExpoScreenCapture (from `../../../packages/expo-screen-capture/ios`)
+  - ExpoScreenCapture/Tests (from `../../../packages/expo-screen-capture/ios`)
   - ExpoScreenOrientation (from `../../../packages/expo-screen-orientation/ios`)
   - ExpoSecureStore (from `../../../packages/expo-secure-store/ios`)
   - ExpoSensors (from `../../../packages/expo-sensors/ios`)
@@ -4060,7 +4063,7 @@ SPEC CHECKSUMS:
   ExpoHaptics: 4503d2da51ff7109712ccdfe0e4939f66818183e
   ExpoImage: 4c1e7634db6033185a98959fb028d8d4b1c89695
   ExpoImageManipulator: 40455ca0112c38e41defb14cb323c6372134eeac
-  ExpoImagePicker: ba36db5da890daafa3da9e061497df47e2252ee4
+  ExpoImagePicker: 8c6898eba27bb4086c4970ce5599e50bce5d7c80
   ExpoInsights: c7b7de693d2e81734a650086884016708e9d57ab
   ExpoKeepAwake: c26f14275017370cc8a4b7b43a0e23361f2053a5
   ExpoLinearGradient: 903b3f5fe566c666ff78b2599add51d094483613
@@ -4084,7 +4087,7 @@ SPEC CHECKSUMS:
   ExpoObserve: 161dcf385e295808637a06d20d4073ce4222e0cb
   ExpoPrint: 7e7a9bc7c12b9b336f34c4458d0c9ba14f243759
   ExpoRouter: 224087330cc8f5a39700e6f4d7a55f55ecb2f90d
-  ExpoScreenCapture: 1728376b2a32a05dc1f6bae6a8d19b1bd33926f9
+  ExpoScreenCapture: 387b18f4a51561916cbff71d6e0e7b386af31171
   ExpoScreenOrientation: 17fd81b2bdb7615b4b540335673aaf98a358281f
   ExpoSecureStore: 94793113049a2d7478dfe1a13aa15081e9f61755
   ExpoSensors: e71c7b6cb0c09d3427ef6ae29c69532a10c86b05
@@ -4092,7 +4095,7 @@ SPEC CHECKSUMS:
   ExpoSMS: ac35f6c85b72ee5b18a7c6bb06550fbd4a683775
   ExpoSpeech: 0e90904e2af5d6f166d4d2ffbdab535686597938
   ExpoSplashScreen: 247464c0fe484f766892db0d66c3fe54f92a624e
-  ExpoSQLite: ddd65ed74bdebcff20f6766e682f9321ecb28ab8
+  ExpoSQLite: 7ea4f5b0ebd0b6f15927c2349db7624a5abf6beb
   ExpoStoreReview: 2a0f6b8e04112aea2f6e3e1cb84109d78f4d041f
   ExpoSymbols: 7c7c7bd3c52f0b6dcbba6e8af4088b0dc1ea7d29
   ExpoSystemUI: ff3142b323ae7b4d11dc0b1dc4acfa30d92be7dc
@@ -4104,10 +4107,10 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 0a7d37113fe51af5c302461ad0344dc529161316
   ExpoWebBrowser: 9b98d939d5f1c5dd8f523f0a0683056fb1204434
   EXStructuredHeaders: 1423c3602a30eb078e03b63b251ef912267dd4c0
-  EXUpdates: 01f1b6c3ef1df0a981f84af9a91dc027baed4a07
+  EXUpdates: e8c071fa483afb3d9d1de09e8f4f9427278af0a1
   EXUpdatesInterface: 92d2aa5194b6fb93ca8ab749db75665cb28b2e60
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: ebe8b908c0614fa2c4e3655af31dcbadd9e73c67
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   JestMockSchema: 96b4cfec246644f6323d1c30693b6a02044be1e6
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/apps/native-component-list/src/navigation/apiScreens.ts
+++ b/apps/native-component-list/src/navigation/apiScreens.ts
@@ -411,6 +411,12 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/ScreenCaptureAdvancedScreen'));
+    },
+    name: 'ScreenCaptureAdvanced',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/SensorScreen'));
     },
     name: 'Sensor',

--- a/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
@@ -1,0 +1,134 @@
+import * as ScreenCapture from 'expo-screen-capture';
+import React from 'react';
+import { Button, ScrollView, StyleSheet, View } from 'react-native';
+import Svg, { Circle, Path, Rect } from 'react-native-svg';
+
+import { BodyText } from '../components/BodyText';
+import HeadingText from '../components/HeadingText';
+import TitleSwitch from '../components/TitledSwitch';
+
+function GuardedSvgSheet({ onClose }: { onClose: () => void }) {
+  ScreenCapture.usePreventScreenCapture('guarded-sheet');
+
+  return (
+    <View style={styles.sheet}>
+      <View style={styles.svgGrid}>
+        {Array.from({ length: 12 }, (_, index) => (
+          <Svg key={index} width={72} height={48}>
+            <Rect x={0} y={0} width={72} height={48} rx={8} fill="#4630eb" />
+            <Circle cx={16} cy={24} r={10} fill="#fc0" />
+            <Path d="M30 38 L42 10 L54 38 Z" fill="#0f9" />
+            <Path d="M56 12 h12 v24 h-12 Z" fill="#f36" stroke="#fff" strokeWidth={2} />
+          </Svg>
+        ))}
+      </View>
+      <BodyText style={styles.description}>
+        Every tile must show all four shapes each time this sheet opens.
+      </BodyText>
+      <Button title="Close guarded sheet" onPress={onClose} />
+    </View>
+  );
+}
+
+function KeyedProtectionSwitch({ holderKey }: { holderKey: string }) {
+  const [isHolding, setHolding] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isHolding) {
+      ScreenCapture.preventScreenCaptureAsync(holderKey);
+    } else {
+      ScreenCapture.allowScreenCaptureAsync(holderKey);
+    }
+  }, [isHolding]);
+
+  React.useEffect(() => {
+    return () => {
+      ScreenCapture.allowScreenCaptureAsync(holderKey);
+    };
+  }, []);
+
+  return (
+    <TitleSwitch
+      title={`Hold protection with key '${holderKey}'`}
+      value={isHolding}
+      setValue={setHolding}
+      style={styles.switchSpacing}
+    />
+  );
+}
+
+export default function ScreenCaptureAdvancedScreen() {
+  const [isSheetVisible, setSheetVisible] = React.useState(false);
+  const [isAutoCycling, setAutoCycling] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isAutoCycling) {
+      return;
+    }
+    const interval = setInterval(() => setSheetVisible((visible) => !visible), 1200);
+    return () => clearInterval(interval);
+  }, [isAutoCycling]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <HeadingText style={styles.heading}>Draw-Backed Content Under Protection</HeadingText>
+      <BodyText style={styles.description}>
+        The sheet arms screenshot prevention while SVG content mounts. The content must render fully
+        every time it opens, and screenshots of it must be blank.
+      </BodyText>
+      <Button
+        title={isSheetVisible ? 'Hide guarded SVG sheet' : 'Show guarded SVG sheet'}
+        onPress={() => setSheetVisible((visible) => !visible)}
+      />
+      <TitleSwitch
+        title="Auto cycle sheet"
+        value={isAutoCycling}
+        setValue={setAutoCycling}
+        style={styles.switchSpacing}
+      />
+      {isSheetVisible && <GuardedSvgSheet onClose={() => setSheetVisible(false)} />}
+
+      <HeadingText style={styles.heading}>Multiple Protection Holders</HeadingText>
+      <BodyText style={styles.description}>
+        Each key holds protection independently. Screenshots stay blank, and the app keeps
+        rendering, while any key is held.
+      </BodyText>
+      <KeyedProtectionSwitch holderKey="a" />
+      <KeyedProtectionSwitch holderKey="b" />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 16,
+    alignItems: 'center',
+  },
+  description: {
+    padding: 8,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  switchSpacing: {
+    marginTop: 16,
+  },
+  sheet: {
+    alignItems: 'center',
+    marginTop: 8,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: '#00000010',
+  },
+  svgGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 4,
+    maxWidth: 320,
+  },
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+  },
+});

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected.
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected.
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
+++ b/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
@@ -20,8 +20,18 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = 'Tests/'
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.requires_app_host = false
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
+  end
 end

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -6,8 +6,7 @@ public final class ScreenCaptureModule: Module {
   private var isBeingObserved = false
   private var isListening = false
   private var blockView: UIView?
-  private var protectionTextField: UITextField?
-  private var originalParent: CALayer?
+  private var secureCanvas: SecureWindowCanvas?
   private var blurEffectView: AnimatedBlurEffectView?
   private var blurIntensity: CGFloat = 0.5
   private var keyWindow: UIWindow? {
@@ -20,7 +19,11 @@ public final class ScreenCaptureModule: Module {
     Events(onScreenshotEventName)
 
     OnDestroy {
-      allowScreenshots()
+      let canvas = self.secureCanvas
+      self.secureCanvas = nil
+      DispatchQueue.main.async {
+        canvas?.restore()
+      }
       disableAppSwitcherProtection()
     }
 
@@ -34,7 +37,7 @@ public final class ScreenCaptureModule: Module {
 
     AsyncFunction("preventScreenCapture") {
       self.preventScreenRecording()
-      self.preventScreenshots()
+      try self.preventScreenshots()
 
       NotificationCenter.default.addObserver(
         self,
@@ -121,41 +124,29 @@ public final class ScreenCaptureModule: Module {
     return blockView
   }
 
-  private func preventScreenshots() {
-    guard let keyWindow = keyWindow else {
-      return
+  private func preventScreenshots() throws {
+    if let canvas = secureCanvas {
+      if let protected = canvas.window, protected === keyWindow {
+        return
+      }
+      // The protected window changed or died; move protection to the current key window.
+      canvas.restore()
+      secureCanvas = nil
     }
 
-    let textField = UITextField()
-    textField.isSecureTextEntry = true
-    textField.isUserInteractionEnabled = false
-    textField.backgroundColor = UIColor.clear
-    textField.frame = UIScreen.main.bounds
-
-    originalParent = keyWindow.layer.superlayer
-
-    keyWindow.layer.superlayer?.addSublayer(textField.layer)
-
-    if let firstTextFieldSublayer = textField.layer.sublayers?.first {
-      keyWindow.layer.removeFromSuperlayer()
-      firstTextFieldSublayer.addSublayer(keyWindow.layer)
+    guard let keyWindow else {
+      throw NoKeyWindowException()
     }
 
-    protectionTextField = textField
+    guard let canvas = SecureWindowCanvas(protecting: keyWindow) else {
+      throw SecureCanvasAttachmentException()
+    }
+    secureCanvas = canvas
   }
 
   private func allowScreenshots() {
-    guard let textField = protectionTextField,
-      let window = keyWindow,
-      let originalParentLayer = originalParent else {
-      return
-    }
-
-    window.layer.removeFromSuperlayer()
-    originalParentLayer.addSublayer(window.layer)
-    textField.layer.removeFromSuperlayer()
-    protectionTextField = nil
-    originalParent = nil
+    secureCanvas?.restore()
+    secureCanvas = nil
   }
 
   private func enableAppSwitcherProtection() {
@@ -244,5 +235,17 @@ public final class ScreenCaptureModule: Module {
         self.blurEffectView = nil
       }
     )
+  }
+}
+
+internal final class NoKeyWindowException: Exception {
+  override var reason: String {
+    "Screenshots cannot be prevented because the app has no key window yet. Retry after the app's first window is visible, for example after the first render"
+  }
+}
+
+internal final class SecureCanvasAttachmentException: Exception {
+  override var reason: String {
+    "Screenshots cannot be prevented because the window is not attached to the screen yet, so the secure canvas could not be installed. Screenshots remain possible. Retry after the window is fully presented"
   }
 }

--- a/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
+++ b/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
@@ -1,0 +1,77 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import UIKit
+
+/**
+ Hides a window from screenshots by re-parenting its layer into the canvas layer of a
+ secure-entry `UITextField`. The init either fully attaches the canvas or fails without
+ mutating the layer hierarchy. Main thread only.
+ */
+internal final class SecureWindowCanvas {
+  private let textField: UITextField
+  private let originalParent: CALayer
+  private(set) weak var window: UIWindow?
+
+  init?(protecting window: UIWindow) {
+    guard let originalParent = window.layer.superlayer else {
+      return nil
+    }
+
+    let textField = UITextField()
+    textField.isSecureTextEntry = true
+    textField.isUserInteractionEnabled = false
+    textField.backgroundColor = .clear
+    textField.frame = UIScreen.main.bounds
+
+    originalParent.addSublayer(textField.layer)
+
+    guard let canvasLayer = textField.layer.sublayers?.first else {
+      textField.layer.removeFromSuperlayer()
+      return nil
+    }
+
+    Self.reparent(window, into: canvasLayer)
+
+    self.textField = textField
+    self.originalParent = originalParent
+    self.window = window
+  }
+
+  func restore() {
+    defer {
+      textField.layer.removeFromSuperlayer()
+    }
+    guard let window else {
+      return
+    }
+    Self.reparent(window, into: originalParent)
+  }
+
+  /**
+   Re-parenting drops pending display work on `drawRect`-backed views (for example
+   `react-native-svg` surfaces), leaving them blank until the next display pass. Complete
+   pending draws first so nothing is in flight, and re-issue display work once the commit
+   containing the re-parent lands, covering draws scheduled later in the same turn.
+   */
+  private static func reparent(_ window: UIWindow, into parent: CALayer) {
+    displayPendingDraws(in: window.layer)
+    window.layer.removeFromSuperlayer()
+    parent.addSublayer(window.layer)
+    CATransaction.setCompletionBlock { [weak window] in
+      window.map { setNeedsDisplayRecursively(in: $0) }
+    }
+  }
+
+  // `displayIfNeeded` is not recursive; walk the subtree so dirty descendants display too.
+  private static func displayPendingDraws(in layer: CALayer) {
+    layer.displayIfNeeded()
+    layer.sublayers?.forEach { displayPendingDraws(in: $0) }
+  }
+
+  private static func setNeedsDisplayRecursively(in view: UIView) {
+    view.setNeedsDisplay()
+    for subview in view.subviews {
+      setNeedsDisplayRecursively(in: subview)
+    }
+  }
+}

--- a/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
+++ b/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
@@ -1,0 +1,145 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+import UIKit
+
+@testable import ExpoScreenCapture
+
+private final class DrawSpyView: UIView {
+  var drawCount = 0
+
+  override func draw(_ rect: CGRect) {
+    drawCount += 1
+  }
+}
+
+@Suite("SecureWindowCanvas", .serialized)
+@MainActor
+struct SecureWindowCanvasTests {
+  /// Simulates an on-screen window: on device the window layer lives inside a host layer.
+  private func makeAttachedWindow() -> (window: UIWindow, parent: CALayer) {
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    let parent = CALayer()
+    parent.addSublayer(window.layer)
+    return (window, parent)
+  }
+
+  /// UIKit attaches a new window's layer to a host layer even off screen, so detach it
+  /// to simulate a window whose layer host is not set up yet.
+  private func makeDetachedWindow() -> UIWindow {
+    let window = UIWindow(frame: .zero)
+    window.layer.removeFromSuperlayer()
+    return window
+  }
+
+  @Test
+  func `init fails when the window layer has no superlayer`() {
+    let window = makeDetachedWindow()
+
+    #expect(SecureWindowCanvas(protecting: window) == nil)
+  }
+
+  @Test
+  func `failed init leaves the window untouched`() {
+    let window = makeDetachedWindow()
+
+    _ = SecureWindowCanvas(protecting: window)
+
+    #expect(window.layer.superlayer == nil)
+  }
+
+  @Test
+  func `init re-parents the window layer into a secure canvas under the original parent`() throws {
+    let (window, parent) = makeAttachedWindow()
+
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(canvas.window === window)
+    #expect(window.layer.superlayer !== parent)
+
+    var ancestor = window.layer.superlayer
+    var reachedOriginalParent = false
+    while let layer = ancestor {
+      if layer === parent {
+        reachedOriginalParent = true
+        break
+      }
+      ancestor = layer.superlayer
+    }
+    #expect(reachedOriginalParent)
+  }
+
+  @Test
+  func `restore returns the window layer to its original parent and removes the canvas`() throws {
+    let (window, parent) = makeAttachedWindow()
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+
+    canvas.restore()
+
+    #expect(window.layer.superlayer === parent)
+    #expect(parent.sublayers?.count == 1)
+  }
+
+  @Test
+  func `restore removes the secure canvas when the window is gone`() throws {
+    let parent = CALayer()
+    var window: UIWindow? = UIWindow(frame: UIScreen.main.bounds)
+    parent.addSublayer(window!.layer)
+    let canvas = try #require(SecureWindowCanvas(protecting: window!))
+
+    window = nil
+    #expect(canvas.window == nil)
+
+    canvas.restore()
+
+    #expect(parent.sublayers?.isEmpty != false)
+  }
+
+  /// Adds a draw-recording view nested inside the window, mirroring a `drawRect`-backed
+  /// view (like a react-native-svg surface) whose display work is pending at re-parent time.
+  private func addDrawSpy(to window: UIWindow) -> DrawSpyView {
+    let container = UIView()
+    let spy = DrawSpyView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    container.addSubview(spy)
+    window.addSubview(container)
+    return spy
+  }
+
+  @Test
+  func `protecting a window completes pending draws instead of dropping them`() throws {
+    let (window, _) = makeAttachedWindow()
+    let spy = addDrawSpy(to: window)
+    spy.setNeedsDisplay()
+    let pendingCount = spy.drawCount
+
+    _ = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(spy.drawCount == pendingCount + 1)
+  }
+
+  @Test
+  func `restoring a window completes pending draws instead of dropping them`() throws {
+    let (window, _) = makeAttachedWindow()
+    let spy = addDrawSpy(to: window)
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+    spy.setNeedsDisplay()
+    let pendingCount = spy.drawCount
+
+    canvas.restore()
+
+    #expect(spy.drawCount == pendingCount + 1)
+  }
+
+  @Test
+  func `a window can be protected again after restore`() throws {
+    let (window, parent) = makeAttachedWindow()
+    let first = try #require(SecureWindowCanvas(protecting: window))
+    first.restore()
+
+    let second = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(second.window === window)
+    second.restore()
+    #expect(window.layer.superlayer === parent)
+  }
+}

--- a/packages/expo-screen-capture/src/ScreenCapture.ts
+++ b/packages/expo-screen-capture/src/ScreenCapture.ts
@@ -46,7 +46,12 @@ export async function preventScreenCaptureAsync(key: string = 'default'): Promis
 
   if (!activeTags.has(key)) {
     activeTags.add(key);
-    await ExpoScreenCapture.preventScreenCapture();
+    try {
+      await ExpoScreenCapture.preventScreenCapture();
+    } catch (error) {
+      activeTags.delete(key);
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
# Why
Closes #48985
Supersedes #49087 

`preventScreenCaptureAsync` on iOS re-parents the key window's layer into the secure canvas of a UITextField. This re-parent drops pending display work on drawRect-backed views (react-native-svg), which intermittently left them blank on physical devices until something forced a redraw.

The old implementation also had no re-entrancy guard. A second preventScreenCapture call with a new key nested one secure canvas inside another, overwrote the only reference to the window layer's superlayer, and permanently black screened the app. 

# How
- Moved the re-parenting into a new `SecureWindowCanvas` class. Its init either fully attaches the secure canvas or fails without mutating the layer hierarchy.
- Before re-parenting, complete pending draws in the window's tree. After the commit containing the re-parent lands, issue display work with CATransaction completion block. This covers draws scheduled later in the same runloop.
- `preventScreenshots()` now returns early when a canvas already protects the current key window, so a repeated call can no longer nest canvases. If the key window changed, protection moves to the current key window.
- OnDestroy restores the canvas on the main queue.

# Test Plan
- Added `SecureWindowCanvasTests`
- Verified the re-entrancy sequence on a Release build on device
 
Could not reproduce the behaviour from #49088 so I would like to get verification from @maxlapides
