### PR TITLE
[plist] Fix DOMParser calls for @xmldom/xmldom 0.9.x

### DIFF
--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix plist parsing under `@xmldom/xmldom@0.9.x` by passing the now-required `mimeType` argument and trimming leading whitespace before parsing. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@arthurdbpt](https://github.com/arthurdbpt))
+- Fix plist parsing under `@xmldom/xmldom@0.9.x` by passing the now-required `mimeType` argument and trimming leading whitespace before parsing. ([#49100](https://github.com/expo/expo/pull/49100) by [@arthurdbpt](https://github.com/arthurdbpt))
 
 ### 💡 Others
 

--- a/packages/@expo/plist/CHANGELOG.md
+++ b/packages/@expo/plist/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix plist parsing under `@xmldom/xmldom@0.9.x` by passing the now-required `mimeType` argument and trimming leading whitespace before parsing. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@arthurdbpt](https://github.com/arthurdbpt))
+
 ### 💡 Others
 
 ## 0.8.1 - 2026-07-15

--- a/packages/@expo/plist/package.json
+++ b/packages/@expo/plist/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "pnpm run clean && pnpm run build"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.8",
+    "@xmldom/xmldom": "^0.8.8 || ^0.9.0",
     "base64-js": "^1.5.1",
     "xmlbuilder": "^15.1.1"
   },

--- a/packages/@expo/plist/src/__tests__/parse-test.ts
+++ b/packages/@expo/plist/src/__tests__/parse-test.ts
@@ -186,6 +186,26 @@ U=</data>
   });
 
   describe('integration', function () {
+    it('should parse a plist file with a leading newline before the XML declaration', function () {
+      const xml = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>com.apple.developer.associated-domains</key>
+          <array>
+            <string>applinks:example.com</string>
+          </array>
+        </dict>
+        </plist>
+        `;
+
+      const parsed = plist.parse('\n' + xml);
+      assert.deepEqual(parsed, {
+        'com.apple.developer.associated-domains': ['applinks:example.com'],
+      });
+    });
+
     it('should parse a plist file with XML comments', function () {
       const xml = `
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/@expo/plist/src/parse.ts
+++ b/packages/@expo/plist/src/parse.ts
@@ -69,7 +69,7 @@ function isEmptyNode(node: { [key: string]: any }): boolean {
 
 export function parse(xml: string): any {
   // prevent the parser from logging non-fatal errors
-  const doc = new DOMParser({ errorHandler() {} }).parseFromString(xml);
+  const doc = new DOMParser({ errorHandler() {} }).parseFromString(xml.trim(), 'text/xml');
   assert(
     doc.documentElement.nodeName === 'plist',
     'malformed document. First element should be <plist>'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2865,7 +2865,7 @@ importers:
   packages/@expo/plist:
     dependencies:
       '@xmldom/xmldom':
-        specifier: ^0.8.8
+        specifier: ^0.8.8 || ^0.9.0
         version: 0.8.11
       base64-js:
         specifier: ^1.5.1
@@ -10163,11 +10163,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agent-cli-detector@0.1.2:
-    resolution: {integrity: sha512-qdZ/9JFORtTKJNhT/IczMeEfEUbUU0K5umYeiIQHX+AjHs+Y9SXVzSgaYlpZeyNMrvuh2HpZiOTpvS57iPfBkQ==}
-    engines: {node: '>=18.18'}
-    hasBin: true
 
   agent-cli-detector@0.1.6:
     resolution: {integrity: sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==}
@@ -19091,8 +19086,6 @@ snapshots:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agent-cli-detector@0.1.2: {}
 
   agent-cli-detector@0.1.6: {}
 


### PR DESCRIPTION
# Why

`@expo/plist` (0.8.1) has never been adapted for `@xmldom/xmldom@0.9.x`'s
  breaking changes:
  - `DOMParser.parseFromString`'s `mimeType` argument became required in 0.9
  - 0.9's SAX parser is fatal on any character preceding the XML declaration —
    real Info.plist/.entitlements files commonly ship with a leading newline

  Both surface in `expo prebuild`'s iOS base mods, which read Info.plist and
  .entitlements through `@expo/plist`.

  Fixes #49095

# How

In `packages/@expo/plist/src/parse.ts`:

  ```diff
  - const doc = new DOMParser({ errorHandler() {} }).parseFromString(xml);
  + const doc = new DOMParser({ errorHandler() {} }).parseFromString(xml.trim(), 'text/xml');
   ```

  - 'text/xml' satisfies 0.9's now-required mimeType argument (no-op under 0.8.x).
  - .trim() strips the leading/trailing whitespace 0.9's stricter parser rejects.


  And in packages/@expo/plist/package.json, widen the range so both majors keep working:
  ```diff
  - "@xmldom/xmldom": "^0.8.8"
  + "@xmldom/xmldom": "^0.8.8 || ^0.9.0"
   ```

# Test Plan

- Added a unit test in src/__tests__/parse-test.ts covering a plist string
  with a leading newline before the XML declaration
  - pnpm run build && pnpm run typecheck && pnpm run lint && pnpm run test
  all pass for packages/@expo/plist
  - Full reproduction with @xmldom/xmldom forced to 0.9.11 via an
  overrides entry (this monorepo's own lockfile resolves the widened
  range down to 0.8.11, so the local test run above doesn't exercise
  0.9.x directly):
  https://github.com/arthurdbpt/expo-plist-xmldom-0.9-repro

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
