### PR TITLE
[audio] Add `doNotMixPersistent` interruption mode

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioControlsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioControlsScreen.tsx
@@ -40,7 +40,7 @@ export default function AudioControlsScreen(props: any) {
   React.useLayoutEffect(() => {
     AudioModule.setAudioModeAsync({
       shouldPlayInBackground: true,
-      interruptionMode: 'doNotMix',
+      interruptionMode: 'doNotMixPersistent',
       playsInSilentMode: true,
       allowsRecording: false,
     }).catch((error: unknown) =>

--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
@@ -118,6 +118,10 @@ export default function AudioModeSelector() {
         value: 'doNotMix',
       })}
       {renderModeSelector({
+        title: 'Do not mix (persistent)',
+        value: 'doNotMixPersistent',
+      })}
+      {renderModeSelector({
         title: 'Duck others',
         value: 'duckOthers',
       })}

--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.ios.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.ios.tsx
@@ -131,6 +131,10 @@ export default function AudioModeSelector() {
         value: 'doNotMix',
       })}
       {renderModeSelector({
+        title: 'Do not mix (persistent)',
+        value: 'doNotMixPersistent',
+      })}
+      {renderModeSelector({
         disabled: state.next.playsInSilentMode === false,
         title: 'Duck others',
         value: 'duckOthers',

--- a/apps/native-component-list/src/screens/Audio/AudioPlaylistScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioPlaylistScreen.tsx
@@ -91,7 +91,7 @@ export default function AudioPlaylistScreen() {
   useEffect(() => {
     setAudioModeAsync({
       shouldPlayInBackground: true,
-      interruptionMode: 'doNotMix',
+      interruptionMode: 'doNotMixPersistent',
       playsInSilentMode: true,
       allowsRecording: false,
     }).catch((error: unknown) =>

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### 🛠 Breaking changes
 
+- [Android] Aligned the default audio focus request on Android 7.0–7.1 with newer versions by using transient exclusive focus when no interruption mode has been configured. ([#49101](https://github.com/expo/expo/pull/49101) by [@behenate](https://github.com/behenate))
+
 ### 🎉 New features
 
+- Added the `doNotMixPersistent` interruption mode. ([#49101](https://github.com/expo/expo/pull/49101) by [@behenate](https://github.com/behenate))
 - Added `fileName` option to `RecordingOptions` to allow specifying the recording file basename on Android and iOS. ([#47265](https://github.com/expo/expo/pull/47265) by [@silwalprabin](https://github.com/silwalprabin))
 - Support lockscreen controls with playlists. ([#46020](https://github.com/expo/expo/pull/46020) by [@alanjhughes](https://github.com/alanjhughes))
 - Added a `fileSize` field to `RecorderState` reporting the current size of the recording file in bytes. ([#46808](https://github.com/expo/expo/pull/46808) by [@behenate](https://github.com/behenate))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -84,12 +84,21 @@ class AudioModule : Module() {
   }
 
   private var audioFocusRequest: AudioFocusRequest? = null
+  private var focusRequestRegistered = false
+  private var registeredAudioFocusGain: Int? = null
+  private var shouldRefreshFocusOnGain = false
   private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
     appContext.mainQueue.launch {
+      if (!focusRequestRegistered) {
+        return@launch
+      }
       when (focusChange) {
         AudioManager.AUDIOFOCUS_LOSS -> {
-          focusAcquired = false
-          allPlayables.forEach { it.pause() }
+          releaseAudioFocus()
+          allPlayables.forEach { playable ->
+            playable.isPaused = false
+            playable.pause()
+          }
         }
 
         AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> {
@@ -105,12 +114,10 @@ class AudioModule : Module() {
         AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
           if (interruptionMode == InterruptionMode.DUCK_OTHERS) {
             allPlayables.forEach { playable ->
-              if (playable.previousVolume != playable.volume) {
-                playable.previousVolume = playable.volume
-              }
-              playable.setVolume(playable.previousVolume * 0.5f)
+              playable.setVolume(playable.previousVolume * 0.5f, rememberVolume = false)
             }
           } else {
+            focusAcquired = false
             allPlayables.forEach { playable ->
               if (playable.isPlaying) {
                 playable.isPaused = true
@@ -123,7 +130,42 @@ class AudioModule : Module() {
         AudioManager.AUDIOFOCUS_GAIN -> {
           focusAcquired = true
 
-          if (!shouldPlayInSilentMode()) {
+          if (shouldRefreshFocusOnGain) {
+            val playablesToResume = allPlayables.filter { it.shouldResumeAfterFocus() }.toList()
+            shouldRefreshFocusOnGain = false
+            releaseAudioFocus()
+            allPlayables.forEach { playable ->
+              playable.setVolume(playable.previousVolume)
+            }
+
+            if (playablesToResume.isEmpty()) {
+              return@launch
+            }
+
+            if (!audioEnabled || !shouldPlayInSilentMode()) {
+              playablesToResume.forEach { playable ->
+                playable.isPaused = false
+                playable.pause()
+              }
+              return@launch
+            }
+
+            when (requestAudioFocus()) {
+              AudioFocusResult.GRANTED,
+              AudioFocusResult.NOT_REQUESTED -> resumeInterruptedPlayables(playablesToResume)
+              AudioFocusResult.DELAYED -> playablesToResume.forEach { playable ->
+                playable.isPaused = true
+                playable.pause()
+              }
+              AudioFocusResult.FAILED -> playablesToResume.forEach { playable ->
+                playable.isPaused = false
+                playable.pause()
+              }
+            }
+            return@launch
+          }
+
+          if (!audioEnabled || !shouldPlayInSilentMode()) {
             return@launch
           }
 
@@ -140,7 +182,17 @@ class AudioModule : Module() {
   }
 
   private fun shouldReleaseFocus(): Boolean {
-    return allPlayables.none { it.isPlaying }
+    return focusAcquired && allPlayables.none { it.isPlaying }
+  }
+
+  private fun Playable.hasActivePlaybackIntent(): Boolean {
+    return player.playWhenReady &&
+      player.playerError == null &&
+      (player.playbackState == Player.STATE_BUFFERING || player.playbackState == Player.STATE_READY)
+  }
+
+  private fun Playable.shouldResumeAfterFocus(): Boolean {
+    return isPaused || hasActivePlaybackIntent()
   }
 
   private fun shouldPlayInSilentMode(): Boolean {
@@ -149,22 +201,22 @@ class AudioModule : Module() {
 
   private enum class AudioFocusResult { GRANTED, DELAYED, FAILED, NOT_REQUESTED }
 
+  private fun audioFocusGainForMode(mode: InterruptionMode?): Int? = when (mode) {
+    null -> AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+    else -> mode.toAudioFocusGain()
+  }
+
   private fun requestAudioFocus(): AudioFocusResult {
     if (focusAcquired) {
       return AudioFocusResult.GRANTED
     }
-    if (!audioEnabled || interruptionMode == InterruptionMode.MIX_WITH_OTHERS) {
+    if (!audioEnabled) {
       return AudioFocusResult.NOT_REQUESTED
     }
 
+    val requestType = audioFocusGainForMode(interruptionMode) ?: return AudioFocusResult.NOT_REQUESTED
+
     val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      val requestType = interruptionMode?.let {
-        if (it == InterruptionMode.DO_NOT_MIX) {
-          AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
-        } else {
-          AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
-        }
-      } ?: AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
       audioFocusRequest = AudioFocusRequest.Builder(requestType).run {
         setAudioAttributes(
           AudioAttributes.Builder()
@@ -180,21 +232,25 @@ class AudioModule : Module() {
       } ?: AudioManager.AUDIOFOCUS_REQUEST_FAILED
     } else {
       @Suppress("DEPRECATION")
-      val requestType = if (interruptionMode == InterruptionMode.DO_NOT_MIX) {
-        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
-      } else {
-        AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
-      }
       audioManager.requestAudioFocus(audioFocusChangeListener, AudioManager.STREAM_MUSIC, requestType)
     }
 
     return when (result) {
       AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+        shouldRefreshFocusOnGain = false
+        focusRequestRegistered = true
+        registeredAudioFocusGain = requestType
         focusAcquired = true
         AudioFocusResult.GRANTED
       }
       // The system can grant focus later through the listener, so this is not a failure.
-      AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> AudioFocusResult.DELAYED
+      AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
+        shouldRefreshFocusOnGain = false
+        focusRequestRegistered = true
+        registeredAudioFocusGain = requestType
+        focusAcquired = false
+        AudioFocusResult.DELAYED
+      }
       else -> {
         appContext.jsLogger?.warn(
           "expo-audio couldn't acquire audio focus, so playback won't start. On Android an app can't " +
@@ -207,19 +263,85 @@ class AudioModule : Module() {
   }
 
   private fun releaseAudioFocus() {
-    if (!focusAcquired) {
-      return
-    }
-
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       audioFocusRequest?.let {
         audioManager.abandonAudioFocusRequest(it)
       }
+      audioFocusRequest = null
     } else {
-      @Suppress("DEPRECATION")
-      audioManager.abandonAudioFocus(audioFocusChangeListener)
+      if (focusRequestRegistered) {
+        @Suppress("DEPRECATION")
+        audioManager.abandonAudioFocus(audioFocusChangeListener)
+      }
     }
+    focusRequestRegistered = false
+    registeredAudioFocusGain = null
+    shouldRefreshFocusOnGain = false
     focusAcquired = false
+  }
+
+  private fun releasePendingAudioFocusIfUnused() {
+    if (focusRequestRegistered && !focusAcquired && allPlayables.none { it.shouldResumeAfterFocus() }) {
+      releaseAudioFocus()
+    }
+  }
+
+  private fun updateAudioFocusForModeChange(previousMode: InterruptionMode?) {
+    if (audioFocusGainForMode(previousMode) == audioFocusGainForMode(interruptionMode)) {
+      return
+    }
+
+    runOnMain {
+      if (focusRequestRegistered && !focusAcquired) {
+        val hasPlaybackIntent = allPlayables.any { it.shouldResumeAfterFocus() }
+        if (!hasPlaybackIntent) {
+          releaseAudioFocus()
+          return@runOnMain
+        }
+        shouldRefreshFocusOnGain = registeredAudioFocusGain != audioFocusGainForMode(interruptionMode)
+        return@runOnMain
+      }
+
+      val playablesWithPlaybackIntent = allPlayables.filter { it.hasActivePlaybackIntent() }.toList()
+      if (playablesWithPlaybackIntent.isEmpty() && !focusAcquired) {
+        return@runOnMain
+      }
+      releaseAudioFocus()
+
+      if (playablesWithPlaybackIntent.isNotEmpty()) {
+        val focusResult = requestAudioFocus()
+        allPlayables.forEach { playable ->
+          playable.setVolume(playable.previousVolume)
+        }
+        when (focusResult) {
+          AudioFocusResult.GRANTED,
+          AudioFocusResult.NOT_REQUESTED -> Unit
+          AudioFocusResult.DELAYED -> {
+            playablesWithPlaybackIntent.forEach { playable ->
+              playable.isPaused = true
+              playable.pause()
+            }
+          }
+          AudioFocusResult.FAILED -> {
+            playablesWithPlaybackIntent.forEach { playable ->
+              playable.isPaused = false
+              playable.pause()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private fun resumeInterruptedPlayables(playables: List<Playable>) {
+    val canResume = audioEnabled && shouldPlayInSilentMode()
+    playables.forEach { playable ->
+      playable.setVolume(playable.previousVolume)
+      playable.isPaused = false
+      if (canResume) {
+        playable.play()
+      }
+    }
   }
 
   @OptIn(DelicateCoroutinesApi::class)
@@ -232,8 +354,9 @@ class AudioModule : Module() {
     }
 
     AsyncFunction("setAudioModeAsync") { mode: AudioMode ->
+      val previousInterruptionMode = interruptionMode
       shouldPlayInBackground = mode.shouldPlayInBackground
-      interruptionMode = mode.interruptionMode
+      interruptionMode = mode.interruptionMode ?: previousInterruptionMode
       playsInSilentMode = mode.playsInSilentMode
       updatePlaySoundThroughEarpiece(mode.shouldRouteThroughEarpiece ?: false)
       allowsBackgroundRecording = mode.allowsBackgroundRecording
@@ -256,14 +379,17 @@ class AudioModule : Module() {
           }
         }
       }
+
+      updateAudioFocusForModeChange(previousInterruptionMode)
     }
 
     AsyncFunction("setIsAudioActiveAsync") { enabled: Boolean ->
       audioEnabled = enabled
       if (!enabled) {
-        releaseAudioFocus()
         runOnMain {
+          releaseAudioFocus()
           allPlayables.forEach {
+            it.isPaused = false
             if (it.isPlaying) {
               it.pause()
             }
@@ -331,14 +457,13 @@ class AudioModule : Module() {
           return@OnActivityEntersForeground
         }
 
-        if (allPlayables.any { it.isPaused }) {
-          requestAudioFocus()
-        }
-
-        allPlayables.forEach { playable ->
-          if (playable.isPaused) {
-            playable.isPaused = false
-            playable.play()
+        val interruptedPlayables = allPlayables.filter { it.isPaused }.toList()
+        if (interruptedPlayables.isNotEmpty()) {
+          when (requestAudioFocus()) {
+            AudioFocusResult.GRANTED,
+            AudioFocusResult.NOT_REQUESTED -> resumeInterruptedPlayables(interruptedPlayables)
+            AudioFocusResult.DELAYED -> Unit
+            AudioFocusResult.FAILED -> interruptedPlayables.forEach { it.isPaused = false }
           }
         }
       }
@@ -386,8 +511,12 @@ class AudioModule : Module() {
             bufferDurationMs
           )
           player.onPlaybackStateChange = { isPlaying ->
-            if (!isPlaying && shouldReleaseFocus()) {
-              releaseAudioFocus()
+            if (!isPlaying) {
+              if (shouldReleaseFocus()) {
+                releaseAudioFocus()
+              } else {
+                releasePendingAudioFocusIfUnused()
+              }
             }
           }
           players[player.id] = player
@@ -505,7 +634,9 @@ class AudioModule : Module() {
 
       Function("pause") { player: AudioPlayer ->
         runOnMain {
+          player.isPaused = false
           player.ref.pause()
+          releasePendingAudioFocusIfUnused()
         }
       }
 
@@ -514,6 +645,8 @@ class AudioModule : Module() {
           if (player.ref.availableCommands.contains(Player.COMMAND_CHANGE_MEDIA_ITEMS)) {
             if (source == null) {
               player.clearMediaSource()
+              player.isPaused = false
+              releasePendingAudioFocusIfUnused()
               return@runOnMain
             }
             val mediaSource = createMediaItem(source)
@@ -569,7 +702,10 @@ class AudioModule : Module() {
       }
 
       Function("remove") { player: AudioPlayer ->
-        players.remove(player.id)
+        runOnMain {
+          players.remove(player.id)
+          releasePendingAudioFocusIfUnused()
+        }
       }
     }
 
@@ -741,8 +877,12 @@ class AudioModule : Module() {
           }
           playlist.loadInitialPlaylist()
           playlist.onPlaybackStateChange = { isPlaying ->
-            if (!isPlaying && shouldReleaseFocus()) {
-              releaseAudioFocus()
+            if (!isPlaying) {
+              if (shouldReleaseFocus()) {
+                releaseAudioFocus()
+              } else {
+                releasePendingAudioFocusIfUnused()
+              }
             }
           }
           playlists[playlist.id] = playlist
@@ -858,7 +998,9 @@ class AudioModule : Module() {
 
       Function("pause") { playlist: AudioPlaylist ->
         runOnMain {
+          playlist.isPaused = false
           playlist.ref.pause()
+          releasePendingAudioFocusIfUnused()
         }
       }
 
@@ -899,12 +1041,18 @@ class AudioModule : Module() {
       Function("remove") { playlist: AudioPlaylist, index: Int ->
         runOnMain {
           playlist.remove(index)
+          if (playlist.trackCount == 0) {
+            playlist.isPaused = false
+            releasePendingAudioFocusIfUnused()
+          }
         }
       }
 
       Function("clear") { playlist: AudioPlaylist ->
         runOnMain {
           playlist.clear()
+          playlist.isPaused = false
+          releasePendingAudioFocusIfUnused()
         }
       }
 
@@ -929,8 +1077,9 @@ class AudioModule : Module() {
       Function("destroy") { playlist: AudioPlaylist ->
         runOnMain {
           playlist.clearLockScreenControls()
+          playlists.remove(playlist.id)
+          releasePendingAudioFocusIfUnused()
         }
-        playlists.remove(playlist.id)
       }
     }
   }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -1,5 +1,6 @@
 package expo.modules.audio
 
+import android.media.AudioManager
 import android.media.MediaRecorder
 import android.os.Build
 import expo.modules.kotlin.records.Field
@@ -118,8 +119,16 @@ class AudioLockScreenOptions(
 
 enum class InterruptionMode(val value: String) : Enumerable {
   DO_NOT_MIX("doNotMix"),
+  DO_NOT_MIX_PERSISTENT("doNotMixPersistent"),
   DUCK_OTHERS("duckOthers"),
-  MIX_WITH_OTHERS("mixWithOthers")
+  MIX_WITH_OTHERS("mixWithOthers");
+
+  fun toAudioFocusGain(): Int? = when (this) {
+    DO_NOT_MIX_PERSISTENT -> AudioManager.AUDIOFOCUS_GAIN
+    DO_NOT_MIX -> AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+    DUCK_OTHERS -> AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK
+    MIX_WITH_OTHERS -> null
+  }
 }
 
 @OptimizedRecord

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/Playable.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/Playable.kt
@@ -30,15 +30,17 @@ interface Playable {
 
   fun seekTo(seconds: Double) = player.seekTo((seconds * 1000L).toLong())
 
-  fun setVolume(volume: Float?) = appContext?.mainQueue?.launch {
+  fun setVolume(volume: Float?, rememberVolume: Boolean = true) = appContext?.mainQueue?.launch {
     val boundedVolume = volume?.coerceIn(0f, 1f) ?: 1f
     if (isMuted) {
-      if (boundedVolume > 0f) {
+      if (rememberVolume && boundedVolume > 0f) {
         previousVolume = boundedVolume
       }
       player.volume = 0f
     } else {
-      previousVolume = boundedVolume
+      if (rememberVolume) {
+        previousVolume = boundedVolume
+      }
       player.volume = boundedVolume
     }
   }

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -659,7 +659,7 @@ public class AudioModule: Module {
         case .duckOthers:
           playerVolumes[playable.id] = playable.volume
           playable.volume *= 0.5
-        case .doNotMix, .mixWithOthers:
+        case .doNotMix, .doNotMixPersistent, .mixWithOthers:
           playable.pause()
         }
       }
@@ -748,7 +748,7 @@ public class AudioModule: Module {
           if let originalVolume = playerVolumes[playable.id] {
             playable.volume = originalVolume
           }
-        case .doNotMix, .mixWithOthers:
+        case .doNotMix, .doNotMixPersistent, .mixWithOthers:
           playable.resumePlayback()
         }
       }
@@ -820,7 +820,7 @@ public class AudioModule: Module {
 
     do {
       try sessionQueue.sync {
-        try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
+        try AVAudioSession.sharedInstance().setActive(isActive, options: activationOptions(isActive: isActive))
         self.sessionIsActive = isActive
       }
     } catch {
@@ -856,7 +856,7 @@ public class AudioModule: Module {
     #endif
 
     if !mode.playsInSilentMode {
-      if mode.interruptionMode == .doNotMix {
+      if mode.interruptionMode.preventsMixing {
         category = .soloAmbient
       } else {
         category = .ambient
@@ -867,7 +867,7 @@ public class AudioModule: Module {
 
       var categoryOptions: AVAudioSession.CategoryOptions = []
       switch mode.interruptionMode {
-      case .doNotMix:
+      case .doNotMix, .doNotMixPersistent:
         break
       case .duckOthers:
         categoryOptions.insert(.duckOthers)
@@ -915,6 +915,14 @@ public class AudioModule: Module {
     }
   }
 
+  private func activationOptions(isActive: Bool) -> AVAudioSession.SetActiveOptions {
+    guard !isActive, interruptionMode.shouldNotifyOthersOnDeactivation else {
+      return []
+    }
+
+    return [.notifyOthersOnDeactivation]
+  }
+
   private func deactivateSession() {
     sessionQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
       guard let self, self.sessionIsActive, !self.isSessionInUse else {
@@ -927,7 +935,7 @@ public class AudioModule: Module {
   @discardableResult
   private func applySessionActive(_ isActive: Bool) -> Bool {
     do {
-      try AVAudioSession.sharedInstance().setActive(isActive, options: isActive ? [] : [.notifyOthersOnDeactivation])
+      try AVAudioSession.sharedInstance().setActive(isActive, options: activationOptions(isActive: isActive))
       sessionIsActive = isActive
       return true
     } catch {

--- a/packages/expo-audio/ios/AudioRecords.swift
+++ b/packages/expo-audio/ios/AudioRecords.swift
@@ -12,7 +12,16 @@ struct AudioMode: Record {
 enum InterruptionMode: String, Enumerable {
   case mixWithOthers
   case doNotMix
+  case doNotMixPersistent
   case duckOthers
+
+  var preventsMixing: Bool {
+    self == .doNotMix || self == .doNotMixPersistent
+  }
+
+  var shouldNotifyOthersOnDeactivation: Bool {
+    self != .doNotMixPersistent
+  }
 }
 
 enum LoopMode: String, Enumerable {

--- a/packages/expo-audio/src/Audio.types.ts
+++ b/packages/expo-audio/src/Audio.types.ts
@@ -599,11 +599,17 @@ export type AudioMode = {
   /**
    * Determines how the audio session interacts with other audio sessions.
    *
-   * - `'doNotMix'`: Requests exclusive audio focus. Other apps will pause their audio.
+   * - `'doNotMix'`: Requests transient exclusive audio focus. Other apps will pause their audio
+   *   and may resume when your app no longer needs focus.
+   * - `'doNotMixPersistent'`: Requests persistent exclusive audio focus. Other apps will pause
+   *   their audio and should not automatically resume when your app no longer needs focus.
    * - `'duckOthers'`: Requests audio focus with ducking. Other apps lower their volume but continue playing.
    * - `'mixWithOthers'`: Audio plays alongside other apps without interrupting them.
    *   On Android, this means no audio focus is requested. Best suited for sound effects,
    *   UI feedback, or short audio clips.
+   *
+   * > **Note:** `doNotMixPersistent` does not keep the audio session active after playback
+   * > stops by itself. Set **keepAudioSessionActive** to `true` to keep it active.
    *
    * @default 'mixWithOthers'
    */
@@ -651,7 +657,10 @@ export type AudioMode = {
  *
  * Controls how your app's audio interacts with other apps' audio.
  *
- * - `'doNotMix'`: Requests exclusive audio focus. Other apps will pause their audio.
+ * - `'doNotMix'`: Requests transient exclusive audio focus. Other apps will pause their audio
+ *   and may resume when your app no longer needs focus.
+ * - `'doNotMixPersistent'`: Requests persistent exclusive audio focus. Other apps will pause
+ *   their audio and should not automatically resume when your app no longer needs focus.
  * - `'duckOthers'`: Requests audio focus with ducking. Other apps lower their volume but continue playing.
  * - `'mixWithOthers'`: Audio plays alongside other apps without interrupting them.
  *
@@ -659,11 +668,12 @@ export type AudioMode = {
  *   UI feedback, or short audio clips. Note that on Android your app won't receive
  *   audio focus loss callbacks (for example, during phone calls) when using this mode.
  *
- *  > **Note:** When using `setActiveForLockScreen`, this must be set to `doNotMix`.
+ *  > **Note:** When using `setActiveForLockScreen`, this must be set to `doNotMix` or
+ *  > `doNotMixPersistent`.
  *
  * @default 'mixWithOthers'
  */
-export type InterruptionMode = 'mixWithOthers' | 'doNotMix' | 'duckOthers';
+export type InterruptionMode = 'mixWithOthers' | 'doNotMix' | 'doNotMixPersistent' | 'duckOthers';
 
 /**
  * @deprecated Use `InterruptionMode` instead, which now works on both platforms.

--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -213,7 +213,7 @@ export declare class AudioPlayer extends SharedObject<AudioEvents> {
    * Sets or removes this audio player as the active player for lock screen controls.
    * Only one player can control the lock screen at a time.
    *
-   * > **Note:** For lock screen controls to work correctly, [`interruptionMode`](#interruptionmode) must be set to `doNotMix` using [`setAudioModeAsync`](#audiosetaudiomodeasyncmode).
+   * > **Note:** For lock screen controls to work correctly, [`interruptionMode`](#interruptionmode) must be set to `doNotMix` or `doNotMixPersistent` using [`setAudioModeAsync`](#audiosetaudiomodeasyncmode).
    * > Without this, the OS might not associate lock screen controls with your player.
    *
    * @param active Whether this player should be active for lock screen controls.
@@ -536,7 +536,7 @@ export declare class AudioPlaylist extends SharedObject<AudioPlaylistEvents> {
    * Sets or removes this audio playlist as the active playlist for lock screen controls.
    * Only one audio player or playlist can control the lock screen at a time.
    *
-   * > **Note:** For lock screen controls to work correctly, [`interruptionMode`](#interruptionmode) must be set to `doNotMix` using [`setAudioModeAsync`](#audiosetaudiomodeasyncmode).
+   * > **Note:** For lock screen controls to work correctly, [`interruptionMode`](#interruptionmode) must be set to `doNotMix` or `doNotMixPersistent` using [`setAudioModeAsync`](#audiosetaudiomodeasyncmode).
    * > Without this, the OS might not associate lock screen controls with your playlist.
    *
    * @param active Whether this playlist should be active for lock screen controls.


### PR DESCRIPTION
# Why

`doNotMix` uses transient audio focus, allowing interrupted audio from other apps to resume after focus is released. Add a persistent mode for apps that need exclusive focus without triggering automatic resumption.

# How

Add `doNotMixPersistent` across platforms. Android uses `AUDIOFOCUS_GAIN` and refreshes active or delayed focus requests when the mode changes. iOS uses the non-mixing category without `.notifyOthersOnDeactivation`. Preserve playback intent, paused state, and ducked volume throughout focus changes.

There is a lot more changes on Android - the automated review I was running locally kept finding a lot of related or semi-related edge cases. Right now the focus management seems to be working quite well.

# Test Plan

Tested manually in NCL on iOS and Android by interrupting other audio source playing in the background.