### PR TITLE
[router] Remove linking.enabled option

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -61,7 +61,7 @@
 
 ### 💡 Others
 
-- Remove the ignored `linking.enabled` option.
+- Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))
 - Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ### 💡 Others
 
+- Remove the ignored `linking.enabled` option.
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))
 - Integrate native stack with standard navigation ([#48114](https://github.com/expo/expo/pull/48114) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -75,7 +75,6 @@ function NavigationContainerInner(
   }: Props<ParamListBase>,
   ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>
 ) {
-
   if (linking?.config) {
     validatePathConfig(linking.config);
   }

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -56,7 +56,7 @@ type Props<ParamList extends object> = NavigationContainerProps & {
  * @param props.onUnhandledAction Callback which is called when an action is not handled.
  * @param props.direction Text direction of the components. Defaults to `'ltr'`.
  * @param props.theme Theme object for the UI elements.
- * @param props.linking Options for deep linking. Deep link handling is enabled when this prop is provided, unless `linking.enabled` is `false`.
+ * @param props.linking Options for deep linking. Deep link handling is enabled when this prop is provided.
  * @param props.fallback Fallback component to render until we have finished getting initial state when linking is enabled. Defaults to `null`.
  * @param props.documentTitle Options to configure the document title on Web. Updating document title is handled by default unless `documentTitle.enabled` is `false`.
  * @param props.children Child elements to render the content.
@@ -75,7 +75,6 @@ function NavigationContainerInner(
   }: Props<ParamListBase>,
   ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>
 ) {
-  const isLinkingEnabled = linking ? linking.enabled !== false : false;
 
   if (linking?.config) {
     validatePathConfig(linking.config);
@@ -89,15 +88,7 @@ function NavigationContainerInner(
 
   const [lastUnhandledLink, setLastUnhandledLink] = React.useState<string | undefined>();
 
-  const { getInitialState } = useLinking(
-    refContainer,
-    {
-      enabled: isLinkingEnabled,
-      prefixes: [],
-      ...linking,
-    },
-    setLastUnhandledLink
-  );
+  const { getInitialState } = useLinking(refContainer, linking, setLastUnhandledLink);
 
   const linkingContext = React.useMemo(() => ({ options: linking }), [linking]);
 
@@ -139,7 +130,6 @@ function NavigationContainerInner(
         get linking() {
           return {
             ...linking,
-            enabled: isLinkingEnabled,
             prefixes: linking?.prefixes ?? [],
             getStateFromPath: linking?.getStateFromPath ?? getStateFromPath,
             getPathFromState: linking?.getPathFromState ?? getPathFromState,
@@ -154,7 +144,7 @@ function NavigationContainerInner(
 
   React.useImperativeHandle(ref, () => refContainer.current!);
 
-  const isLinkingReady = rest.initialState != null || !isLinkingEnabled || isResolved;
+  const isLinkingReady = rest.initialState != null || !linking || isResolved;
 
   if (!isLinkingReady) {
     // This is temporary until we have Suspense for data-fetching

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -20,13 +20,17 @@ const linkingHandlers: symbol[] = [];
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase>>,
-  {
-    enabled = true,
-    prefixes,
-    filter,
-    config,
-    getInitialURL = () => getInitialURLWithTimeout(),
-    subscribe = (listener) => {
+  options: Options | undefined,
+  onUnhandledLinking: (lastUnhandledLining: string | undefined) => void
+) {
+  const enabled = options !== undefined;
+  const prefixes = options?.prefixes ?? [];
+  const filter = options?.filter;
+  const config = options?.config;
+  const getInitialURL = options?.getInitialURL ?? (() => getInitialURLWithTimeout());
+  const subscribe =
+    options?.subscribe ??
+    ((listener) => {
       const callback = ({ url }: { url: string }) => listener(url);
 
       const subscription = Linking.addEventListener('url', callback) as
@@ -45,12 +49,9 @@ export function useLinking(
           removeEventListener?.('url', callback);
         }
       };
-    },
-    getStateFromPath = getStateFromPathDefault,
-    getActionFromState = getActionFromStateDefault,
-  }: Options,
-  onUnhandledLinking: (lastUnhandledLining: string | undefined) => void
-) {
+    });
+  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
 
   useEffect(() => {
@@ -62,7 +63,7 @@ export function useLinking(
       return undefined;
     }
 
-    if (enabled !== false && linkingHandlers.length) {
+    if (enabled && linkingHandlers.length) {
       console.error(
         [
           'Looks like you have configured linking in multiple places. This is likely an error since deep links should only be handled in one place to avoid conflicts. Make sure that:',
@@ -76,7 +77,7 @@ export function useLinking(
 
     const handler = Symbol();
 
-    if (enabled !== false) {
+    if (enabled) {
       linkingHandlers.push(handler);
     }
 

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -78,15 +78,14 @@ type Options = LinkingOptions<ParamListBase>;
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
-  {
-    enabled = true,
-    config,
-    getStateFromPath = getStateFromPathDefault,
-    getPathFromState = getPathFromStateDefault,
-    getActionFromState = getActionFromStateDefault,
-  }: Options,
+  options: Options | undefined,
   onUnhandledLinking: (lastUnhandledLining: string | undefined) => void
 ) {
+  const enabled = options !== undefined;
+  const config = options?.config;
+  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
+  const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
 
   const store = useExpoRouterStore();
@@ -100,7 +99,7 @@ export function useLinking(
       return undefined;
     }
 
-    if (enabled !== false && linkingHandlers.length) {
+    if (enabled && linkingHandlers.length) {
       console.error(
         [
           'Looks like you have configured linking in multiple places. This is likely an error since deep links should only be handled in one place to avoid conflicts. Make sure that:',
@@ -114,7 +113,7 @@ export function useLinking(
 
     const handler = Symbol();
 
-    if (enabled !== false) {
+    if (enabled) {
       linkingHandlers.push(handler);
     }
 

--- a/packages/expo-router/src/react-navigation/native/types.tsx
+++ b/packages/expo-router/src/react-navigation/native/types.tsx
@@ -59,11 +59,6 @@ export type LocaleDirection = 'ltr' | 'rtl';
 
 export type LinkingOptions<ParamList extends object> = {
   /**
-   * Whether deep link handling should be enabled.
-   * Defaults to true.
-   */
-  enabled?: boolean;
-  /**
    * The prefixes are stripped from the URL before parsing them.
    * Usually they are the `scheme` + `host` (e.g. `myapp://chat?user=jane`)
    *

--- a/packages/expo-router/src/react-navigation/native/useLinkBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/native/useLinkBuilder.tsx
@@ -33,10 +33,6 @@ export function useBuildHref() {
 
   const buildHref = React.useCallback(
     (name: string, params?: object) => {
-      if (options?.enabled === false) {
-        return undefined;
-      }
-
       // Check that we're inside:
       // - navigator's context
       // - route context of the navigator (could be a screen, tab, etc.)
@@ -86,14 +82,7 @@ export function useBuildHref() {
 
       return path;
     },
-    [
-      options?.enabled,
-      options?.config,
-      route?.key,
-      navigation,
-      focusedRouteState,
-      getPathFromStateHelper,
-    ]
+    [options?.config, route?.key, navigation, focusedRouteState, getPathFromStateHelper]
   );
 
   return buildHref;

--- a/packages/expo-router/src/react-navigation/native/useRoutePath.tsx
+++ b/packages/expo-router/src/react-navigation/native/useRoutePath.tsx
@@ -24,14 +24,10 @@ export function useRoutePath() {
   const getPathFromStateHelper = options?.getPathFromState ?? getPathFromState;
 
   const path = React.useMemo(() => {
-    if (options?.enabled === false) {
-      return undefined;
-    }
-
     const path = getPathFromStateHelper(state, options?.config);
 
     return path;
-  }, [options?.enabled, options?.config, state, getPathFromStateHelper]);
+  }, [options?.config, state, getPathFromStateHelper]);
 
   return path;
 }


### PR DESCRIPTION
# Why

Linking is always enabled in expo-router, so we can remove the checks and logic for when it is not enabled

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)