### PR TITLE
[audio] Add support for `keepAudioSessionActive` on Android, improve iOS behavior

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.android.tsx
@@ -5,7 +5,15 @@ import { PixelRatio, Switch, Text, View } from 'react-native';
 import Button from '../../components/Button';
 import ListButton from '../../components/ListButton';
 
-export default function AudioModeSelector() {
+export type AudioModeSelectorProps = {
+  keepAudioSessionActive?: boolean;
+  onKeepAudioSessionActiveChange?: (value: boolean) => void;
+};
+
+export default function AudioModeSelector({
+  keepAudioSessionActive,
+  onKeepAudioSessionActiveChange,
+}: AudioModeSelectorProps = {}) {
   const [state, setState] = React.useState<{
     next: Partial<AudioMode>;
     current: Partial<AudioMode>;
@@ -50,11 +58,13 @@ export default function AudioModeSelector() {
     disabled,
     valueName,
     value,
+    onValueChange,
   }: {
     title: string;
     disabled?: boolean;
-    valueName: keyof AudioMode;
+    valueName?: keyof AudioMode;
     value?: boolean;
+    onValueChange?: (value: boolean) => void;
   }) => (
     <View
       style={{
@@ -68,13 +78,20 @@ export default function AudioModeSelector() {
       <Text style={{ flex: 1, fontSize: 16 }}>{title}</Text>
       <Switch
         disabled={disabled}
-        value={value !== undefined ? value : Boolean(state.next[valueName])}
-        onValueChange={() =>
+        value={value ?? (valueName ? Boolean(state.next[valueName]) : false)}
+        onValueChange={(nextValue) => {
+          if (onValueChange) {
+            onValueChange(nextValue);
+            return;
+          }
+          if (!valueName) {
+            return;
+          }
           setState((state) => ({
             ...state,
-            next: { ...state.next, [valueName]: !state.next[valueName] },
-          }))
-        }
+            next: { ...state.next, [valueName]: nextValue },
+          }));
+        }}
       />
     </View>
   );
@@ -113,6 +130,13 @@ export default function AudioModeSelector() {
         title: 'Allow background recording',
         valueName: 'allowsBackgroundRecording',
       })}
+      {keepAudioSessionActive !== undefined &&
+        onKeepAudioSessionActiveChange &&
+        renderToggle({
+          title: 'keepAudioSessionActive',
+          value: keepAudioSessionActive,
+          onValueChange: onKeepAudioSessionActiveChange,
+        })}
       {renderModeSelector({
         title: 'Do not mix',
         value: 'doNotMix',

--- a/apps/native-component-list/src/screens/Audio/AudioModeSelector.ios.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioModeSelector.ios.tsx
@@ -6,7 +6,15 @@ import { BodyText } from '../../components/BodyText';
 import Button from '../../components/Button';
 import ListButton from '../../components/ListButton';
 
-export default function AudioModeSelector() {
+export type AudioModeSelectorProps = {
+  keepAudioSessionActive?: boolean;
+  onKeepAudioSessionActiveChange?: (value: boolean) => void;
+};
+
+export default function AudioModeSelector({
+  keepAudioSessionActive,
+  onKeepAudioSessionActiveChange,
+}: AudioModeSelectorProps = {}) {
   const [state, setState] = React.useState<{
     next: Partial<AudioMode>;
     current: Partial<AudioMode>;
@@ -53,11 +61,13 @@ export default function AudioModeSelector() {
     disabled,
     valueName,
     value,
+    onValueChange,
   }: {
     title: string;
     disabled?: boolean;
-    valueName: keyof AudioMode;
+    valueName?: keyof AudioMode;
     value?: boolean;
+    onValueChange?: (value: boolean) => void;
   }) => (
     <View
       style={{
@@ -71,13 +81,20 @@ export default function AudioModeSelector() {
       <BodyText style={{ flex: 1, fontSize: 16 }}>{title}</BodyText>
       <Switch
         disabled={disabled}
-        value={value !== undefined ? value : Boolean(state.next[valueName])}
-        onValueChange={() =>
+        value={value ?? (valueName ? Boolean(state.next[valueName]) : false)}
+        onValueChange={(nextValue) => {
+          if (onValueChange) {
+            onValueChange(nextValue);
+            return;
+          }
+          if (!valueName) {
+            return;
+          }
           setState((state) => ({
             ...state,
-            next: { ...state.next, [valueName]: !state.next[valueName] },
-          }))
-        }
+            next: { ...state.next, [valueName]: nextValue },
+          }));
+        }}
       />
     </View>
   );
@@ -122,6 +139,13 @@ export default function AudioModeSelector() {
         disabled: !state.next.allowsRecording,
         value: !state.next.allowsRecording ? false : undefined,
       })}
+      {keepAudioSessionActive !== undefined &&
+        onKeepAudioSessionActiveChange &&
+        renderToggle({
+          title: 'keepAudioSessionActive',
+          value: keepAudioSessionActive,
+          onValueChange: onKeepAudioSessionActiveChange,
+        })}
       {renderModeSelector({
         title: 'Mix with others',
         value: 'mixWithOthers',

--- a/apps/native-component-list/src/screens/Audio/AudioPlayer.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioPlayer.tsx
@@ -10,6 +10,7 @@ type AudioPlayerProps = {
   style?: StyleProp<ViewStyle>;
   downloadFirst?: boolean;
   crossOrigin?: 'anonymous' | 'use-credentials';
+  keepAudioSessionActive?: boolean;
 };
 
 const localSource = require('../../../assets/sounds/polonez.mp3');
@@ -20,9 +21,14 @@ export default function AudioPlayer({
   style,
   downloadFirst = false,
   crossOrigin,
+  keepAudioSessionActive = false,
 }: AudioPlayerProps) {
   const [currentSource, setCurrentSource] = React.useState(source);
-  const player = useAudioPlayer(source, { downloadFirst, crossOrigin });
+  const player = useAudioPlayer(source, {
+    downloadFirst,
+    crossOrigin,
+    keepAudioSessionActive,
+  });
   const status = useAudioPlayerStatus(player);
 
   const setVolume = (volume: number) => {

--- a/apps/native-component-list/src/screens/Audio/AudioPlayerScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioPlayerScreen.tsx
@@ -2,12 +2,15 @@ import { setIsAudioActiveAsync } from 'expo-audio';
 import React from 'react';
 import { PixelRatio, ScrollView, StyleSheet } from 'react-native';
 
+import { BodyText } from '../../components/BodyText';
 import HeadingText from '../../components/HeadingText';
 import ListButton from '../../components/ListButton';
 import AudioModeSelector from './AudioModeSelector';
 import AudioPlayer from './AudioPlayer';
 
 export default function AudioScreen(props: any) {
+  const [keepAudioSessionActive, setKeepAudioSessionActive] = React.useState(false);
+
   React.useLayoutEffect(() => {
     props.navigation.setOptions({
       title: 'Audio (expo-audio)',
@@ -20,7 +23,15 @@ export default function AudioScreen(props: any) {
       <ListButton title="Activate Audio" onPress={() => setIsAudioActiveAsync(true)} />
       <ListButton title="Deactivate Audio" onPress={() => setIsAudioActiveAsync(false)} />
       <HeadingText>Audio mode</HeadingText>
-      <AudioModeSelector />
+      <AudioModeSelector
+        keepAudioSessionActive={keepAudioSessionActive}
+        onKeepAudioSessionActiveChange={setKeepAudioSessionActive}
+      />
+      <AudioPlayer
+        source={require('../../../assets/sounds/polonez.mp3')}
+        keepAudioSessionActive={keepAudioSessionActive}
+        style={styles.player}
+      />
       <HeadingText>HTTP player</HeadingText>
       <AudioPlayer
         source={{
@@ -59,5 +70,8 @@ const styles = StyleSheet.create({
   player: {
     borderBottomWidth: 1.0 / PixelRatio.get(),
     borderBottomColor: '#cccccc',
+  },
+  testInstructions: {
+    marginVertical: 8,
   },
 });

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [Android] Added support for `keepAudioSessionActive`. ([#49108](https://github.com/expo/expo/pull/49108) by [@behenate](https://github.com/behenate))
 - Added the `doNotMixPersistent` interruption mode. ([#49101](https://github.com/expo/expo/pull/49101) by [@behenate](https://github.com/behenate))
 - Added `fileName` option to `RecordingOptions` to allow specifying the recording file basename on Android and iOS. ([#47265](https://github.com/expo/expo/pull/47265) by [@silwalprabin](https://github.com/silwalprabin))
 - Support lockscreen controls with playlists. ([#46020](https://github.com/expo/expo/pull/46020) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -87,6 +87,7 @@ class AudioModule : Module() {
   private var focusRequestRegistered = false
   private var registeredAudioFocusGain: Int? = null
   private var shouldRefreshFocusOnGain = false
+  private val audioSessionActivityKeepers = mutableSetOf<String>()
   private val audioFocusChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
     appContext.mainQueue.launch {
       if (!focusRequestRegistered) {
@@ -138,7 +139,7 @@ class AudioModule : Module() {
               playable.setVolume(playable.previousVolume)
             }
 
-            if (playablesToResume.isEmpty()) {
+            if (playablesToResume.isEmpty() && audioSessionActivityKeepers.isEmpty()) {
               return@launch
             }
 
@@ -181,8 +182,19 @@ class AudioModule : Module() {
     }
   }
 
-  private fun shouldReleaseFocus(): Boolean {
-    return focusAcquired && allPlayables.none { it.isPlaying }
+  private fun releaseAudioFocusIfUnused() {
+    if (!focusRequestRegistered || audioSessionActivityKeepers.isNotEmpty()) {
+      return
+    }
+
+    val focusIsStillNeeded = if (focusAcquired) {
+      allPlayables.any { it.isPlaying || it.hasActivePlaybackIntent() }
+    } else {
+      allPlayables.any { it.shouldResumeAfterFocus() }
+    }
+    if (!focusIsStillNeeded) {
+      releaseAudioFocus()
+    }
   }
 
   private fun Playable.hasActivePlaybackIntent(): Boolean {
@@ -280,10 +292,16 @@ class AudioModule : Module() {
     focusAcquired = false
   }
 
-  private fun releasePendingAudioFocusIfUnused() {
-    if (focusRequestRegistered && !focusAcquired && allPlayables.none { it.shouldResumeAfterFocus() }) {
-      releaseAudioFocus()
+  private fun registerAudioSessionActivityKeeper(player: AudioPlayer) {
+    if (player.keepAudioSessionActive) {
+      audioSessionActivityKeepers.add(player.id)
     }
+  }
+
+  private fun removePlayer(playerId: String) {
+    players.remove(playerId)
+    audioSessionActivityKeepers.remove(playerId)
+    releaseAudioFocusIfUnused()
   }
 
   private fun updateAudioFocusForModeChange(previousMode: InterruptionMode?) {
@@ -293,7 +311,7 @@ class AudioModule : Module() {
 
     runOnMain {
       if (focusRequestRegistered && !focusAcquired) {
-        val hasPlaybackIntent = allPlayables.any { it.shouldResumeAfterFocus() }
+        val hasPlaybackIntent = audioSessionActivityKeepers.isNotEmpty() || allPlayables.any { it.shouldResumeAfterFocus() }
         if (!hasPlaybackIntent) {
           releaseAudioFocus()
           return@runOnMain
@@ -303,12 +321,12 @@ class AudioModule : Module() {
       }
 
       val playablesWithPlaybackIntent = allPlayables.filter { it.hasActivePlaybackIntent() }.toList()
-      if (playablesWithPlaybackIntent.isEmpty() && !focusAcquired) {
+      if (playablesWithPlaybackIntent.isEmpty() && audioSessionActivityKeepers.isEmpty() && !focusAcquired) {
         return@runOnMain
       }
       releaseAudioFocus()
 
-      if (playablesWithPlaybackIntent.isNotEmpty()) {
+      if (playablesWithPlaybackIntent.isNotEmpty() || audioSessionActivityKeepers.isNotEmpty()) {
         val focusResult = requestAudioFocus()
         allPlayables.forEach { playable ->
           playable.setVolume(playable.previousVolume)
@@ -387,6 +405,7 @@ class AudioModule : Module() {
       audioEnabled = enabled
       if (!enabled) {
         runOnMain {
+          audioSessionActivityKeepers.clear()
           releaseAudioFocus()
           allPlayables.forEach {
             it.isPaused = false
@@ -434,7 +453,9 @@ class AudioModule : Module() {
 
     OnActivityEntersBackground {
       if (!shouldPlayInBackground) {
-        releaseAudioFocus()
+        if (audioSessionActivityKeepers.isEmpty()) {
+          releaseAudioFocus()
+        }
         allPlayables.forEach { playable ->
           if (playable.isPlaying) {
             playable.isPaused = true
@@ -482,6 +503,7 @@ class AudioModule : Module() {
     OnDestroy {
       context.unregisterReceiver(ringerModeReceiver)
       GlobalScope.launch(Dispatchers.Main) {
+        audioSessionActivityKeepers.clear()
         releaseAudioFocus()
         players.values.forEach {
           it.ref.stop()
@@ -510,13 +532,19 @@ class AudioModule : Module() {
             updateInterval,
             bufferDurationMs
           )
+          player.keepAudioSessionActive = keepAudioSessionActive
+
+          val playerId = player.id
+          player.onRelease = {
+            // The app context's main queue is cancelled during reload, so release bookkeeping must
+            // use the same reload-safe scope as BaseAudioPlayer.sharedObjectDidRelease().
+            GlobalScope.launch(Dispatchers.Main) {
+              removePlayer(playerId)
+            }
+          }
           player.onPlaybackStateChange = { isPlaying ->
             if (!isPlaying) {
-              if (shouldReleaseFocus()) {
-                releaseAudioFocus()
-              } else {
-                releasePendingAudioFocusIfUnused()
-              }
+              releaseAudioFocusIfUnused()
             }
           }
           players[player.id] = player
@@ -625,9 +653,10 @@ class AudioModule : Module() {
           return@Function
         }
         runOnMain {
-          if (!focusAcquired && requestAudioFocus() == AudioFocusResult.FAILED) {
+          if (requestAudioFocus() == AudioFocusResult.FAILED) {
             return@runOnMain
           }
+          registerAudioSessionActivityKeeper(player)
           player.ref.play()
         }
       }
@@ -636,7 +665,7 @@ class AudioModule : Module() {
         runOnMain {
           player.isPaused = false
           player.ref.pause()
-          releasePendingAudioFocusIfUnused()
+          releaseAudioFocusIfUnused()
         }
       }
 
@@ -646,7 +675,7 @@ class AudioModule : Module() {
             if (source == null) {
               player.clearMediaSource()
               player.isPaused = false
-              releasePendingAudioFocusIfUnused()
+              releaseAudioFocusIfUnused()
               return@runOnMain
             }
             val mediaSource = createMediaItem(source)
@@ -703,8 +732,7 @@ class AudioModule : Module() {
 
       Function("remove") { player: AudioPlayer ->
         runOnMain {
-          players.remove(player.id)
-          releasePendingAudioFocusIfUnused()
+          removePlayer(player.id)
         }
       }
     }
@@ -878,11 +906,7 @@ class AudioModule : Module() {
           playlist.loadInitialPlaylist()
           playlist.onPlaybackStateChange = { isPlaying ->
             if (!isPlaying) {
-              if (shouldReleaseFocus()) {
-                releaseAudioFocus()
-              } else {
-                releasePendingAudioFocusIfUnused()
-              }
+              releaseAudioFocusIfUnused()
             }
           }
           playlists[playlist.id] = playlist
@@ -1000,7 +1024,7 @@ class AudioModule : Module() {
         runOnMain {
           playlist.isPaused = false
           playlist.ref.pause()
-          releasePendingAudioFocusIfUnused()
+          releaseAudioFocusIfUnused()
         }
       }
 
@@ -1043,7 +1067,7 @@ class AudioModule : Module() {
           playlist.remove(index)
           if (playlist.trackCount == 0) {
             playlist.isPaused = false
-            releasePendingAudioFocusIfUnused()
+            releaseAudioFocusIfUnused()
           }
         }
       }
@@ -1052,7 +1076,7 @@ class AudioModule : Module() {
         runOnMain {
           playlist.clear()
           playlist.isPaused = false
-          releasePendingAudioFocusIfUnused()
+          releaseAudioFocusIfUnused()
         }
       }
 
@@ -1078,7 +1102,7 @@ class AudioModule : Module() {
         runOnMain {
           playlist.clearLockScreenControls()
           playlists.remove(playlist.id)
-          releasePendingAudioFocusIfUnused()
+          releaseAudioFocusIfUnused()
         }
       }
     }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -60,6 +60,7 @@ class AudioPlayer(
 ),
   LockScreenPlayable {
   var preservesPitch = true
+  var keepAudioSessionActive = false
 
   // Lock screen controls
   override var isActiveForLockScreen = false

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/BaseAudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/BaseAudioPlayer.kt
@@ -40,6 +40,7 @@ abstract class BaseAudioPlayer(
   override var isMuted = false
   override var previousVolume = 1f
   override var onPlaybackStateChange: ((Boolean) -> Unit)? = null
+  override var onRelease: (() -> Unit)? = null
   override val player get() = ref
 
   protected var playerScope = CoroutineScope(Dispatchers.Main)
@@ -152,6 +153,8 @@ abstract class BaseAudioPlayer(
 
   @OptIn(DelicateCoroutinesApi::class)
   override fun sharedObjectDidRelease() {
+    onRelease?.invoke()
+    onRelease = null
     super.sharedObjectDidRelease()
     // Run on GlobalScope (not appContext.mainQueue) so that reloading doesn't cancel the release process
     GlobalScope.launch(Dispatchers.Main) {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/Playable.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/Playable.kt
@@ -15,6 +15,7 @@ interface Playable {
   var isMuted: Boolean
   var previousVolume: Float
   var onPlaybackStateChange: ((Boolean) -> Unit)?
+  var onRelease: (() -> Unit)?
 
   val player: Player
   val appContext: AppContext?

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -6,6 +6,7 @@ public class AudioModule: Module {
 
   private let sessionQueue = DispatchQueue(label: "expo.modules.audio.session", qos: .userInitiated)
   private var sessionIsActive = false
+  private var audioSessionActivityKeepers = Set<String>()
   private let audioEnabled = OSAllocatedUnfairLock(initialState: true)
 
   // MARK: Properties
@@ -97,6 +98,12 @@ public class AudioModule: Module {
       registry.removeAllPreloadedPlayers()
       registry.removeAll()
       NotificationCenter.default.removeObserver(self)
+      sessionQueue.async {
+        self.audioSessionActivityKeepers.removeAll()
+        if self.sessionIsActive {
+          self.applySessionActive(false)
+        }
+      }
     }
 
     OnAppEntersBackground {
@@ -137,6 +144,10 @@ public class AudioModule: Module {
         let player = AudioPlayer(avPlayer, interval: updateInterval, source: source)
         player.owningRegistry = self.registry
         player.keepAudioSessionActive = keepAudioSessionActive
+        let playerId = player.id
+        player.onRelease = { [weak audioModule = self] in
+          audioModule?.unregisterAudioSessionActivityKeeper(playerId)
+        }
         player.onPlaybackComplete = { [weak self] in
           if !keepAudioSessionActive {
             self?.deactivateSession()
@@ -220,7 +231,7 @@ public class AudioModule: Module {
         }
         let rate = player.currentRate > 0 ? player.currentRate : 1.0
         player.play(at: rate)
-        self.activateSession()
+        self.activateSession(for: player)
       }
 
       Function("setPlaybackRate") { (player, rate: Double, pitchCorrectionQuality: PitchCorrectionQuality?) in
@@ -258,6 +269,7 @@ public class AudioModule: Module {
 
       Function("remove") { player in
         self.registry.remove(player)
+        self.unregisterAudioSessionActivityKeeper(player.id)
       }
 
       Function("setAudioSamplingEnabled") { (player, enabled: Bool) in
@@ -473,7 +485,15 @@ public class AudioModule: Module {
       }
 
       AsyncFunction("prepareToRecordAsync") { (recorder, options: RecordingOptions?) in
-        try recorder.prepare(options: options, sessionOptions: sessionOptions)
+        let deactivateSessionOnFailure = sessionQueue.sync {
+          !sessionIsActive && audioSessionActivityKeepers.isEmpty
+        }
+        try recorder.prepare(
+          options: options,
+          sessionOptions: sessionOptions,
+          deactivateSessionOnFailure: deactivateSessionOnFailure
+        )
+        recordSessionActive(true)
       }
 
       Function("record") { (recorder: AudioRecorder, options: RecordOptions?) in
@@ -822,6 +842,9 @@ public class AudioModule: Module {
       try sessionQueue.sync {
         try AVAudioSession.sharedInstance().setActive(isActive, options: activationOptions(isActive: isActive))
         self.sessionIsActive = isActive
+        if !isActive {
+          audioSessionActivityKeepers.removeAll()
+        }
       }
     } catch {
       throw AudioStateException(error.localizedDescription)
@@ -915,6 +938,24 @@ public class AudioModule: Module {
     }
   }
 
+  private func activateSession(for player: AudioPlayer) {
+    let playerId = player.id
+    let shouldKeepSessionActive = player.keepAudioSessionActive
+    sessionQueue.async { [weak self] in
+      guard let self, self.audioEnabled.withLock({ $0 }) else {
+        return
+      }
+
+      let didRegisterActivityKeeper = shouldKeepSessionActive && self.registerAudioSessionActivityKeeper(playerId)
+      guard !self.sessionIsActive else {
+        return
+      }
+      if !self.applySessionActive(true), didRegisterActivityKeeper {
+        self.audioSessionActivityKeepers.remove(playerId)
+      }
+    }
+  }
+
   private func activationOptions(isActive: Bool) -> AVAudioSession.SetActiveOptions {
     guard !isActive, interruptionMode.shouldNotifyOthersOnDeactivation else {
       return []
@@ -925,10 +966,26 @@ public class AudioModule: Module {
 
   private func deactivateSession() {
     sessionQueue.asyncAfter(deadline: .now() + .milliseconds(100)) { [weak self] in
-      guard let self, self.sessionIsActive, !self.isSessionInUse else {
+      guard let self,
+        self.sessionIsActive,
+        self.audioSessionActivityKeepers.isEmpty,
+        !self.isSessionInUse else {
         return
       }
       self.applySessionActive(false)
+    }
+  }
+
+  private func registerAudioSessionActivityKeeper(_ playerId: String) -> Bool {
+    return audioSessionActivityKeepers.insert(playerId).inserted
+  }
+
+  private func unregisterAudioSessionActivityKeeper(_ playerId: String) {
+    sessionQueue.async { [weak self] in
+      guard let self, self.audioSessionActivityKeepers.remove(playerId) != nil else {
+        return
+      }
+      self.deactivateSession()
     }
   }
 

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -25,6 +25,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
   var samplingEnabled = false
   var keepAudioSessionActive = false
+  var onRelease: (() -> Void)?
 
   var isLooping = false {
     didSet {
@@ -510,6 +511,8 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   }
 
   public override func sharedObjectWillRelease() {
+    onRelease?()
+    onRelease = nil
     ref.currentItem?.cancelPendingSeeks()
     owningRegistry?.remove(self)
 

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -76,7 +76,11 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     }
   }
 
-  func prepare(options: RecordingOptions?, sessionOptions: AVAudioSession.CategoryOptions = []) throws {
+  func prepare(
+    options: RecordingOptions?,
+    sessionOptions: AVAudioSession.CategoryOptions = [],
+    deactivateSessionOnFailure: Bool = true
+  ) throws {
     if currentState == .recording {
       ref.stop()
     }
@@ -98,7 +102,9 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
         newRecorder = try AudioUtils.createRecorder(directory: recordingDirectory(for: options), with: options)
       } catch {
         currentState = .error
-        try? session.setActive(false)
+        if deactivateSessionOnFailure {
+          try? session.setActive(false)
+        }
         throw error
       }
 

--- a/packages/expo-audio/src/Audio.types.ts
+++ b/packages/expo-audio/src/Audio.types.ts
@@ -112,15 +112,18 @@ export type AudioPlayerOptions = {
    */
   crossOrigin?: 'anonymous' | 'use-credentials';
   /**
-   * If set to `true`, the audio session will not be deactivated when this player pauses or finishes playback.
-   * This prevents interrupting other audio sources (like videos) when the audio ends.
+   * If set to `true`, the audio session (iOS) or audio focus (Android) will remain active when this
+   * player pauses or finishes playback.
    *
-   * Useful for sound effects that should not interfere with ongoing video playback or other audio.
-   * The audio session for this player will not be deactivated automatically when the player finishes playback.
+   * On iOS, the `AVAudioSession` stays active. On Android, any audio focus acquired by the player is
+   * retained. Android does not request audio focus in modes that mix with other audio, but the player
+   * will retain focus if a later audio mode change causes it to be acquired.
    *
-   * > **Note:** If needed, you can manually deactivate the audio session using `setIsAudioActiveAsync(false)`.
+   * > **Note:** If needed, you can manually deactivate audio and release focus using
+   * > `setIsAudioActiveAsync(false)`.
    *
    * @platform ios
+   * @platform android
    * @default false
    */
   keepAudioSessionActive?: boolean;


### PR DESCRIPTION
# Why

`keepAudioSessionActive` only worked on iOS, so Android released audio focus when a player paused or finished and previously interrupted audio could resume.
The existing iOS implementation only guarded deactivation triggered by that player. Another expo-audio component could still deactivate the shared session.

# How

Register keep-active players when they start playback and remove them when the player is released.

On both platforms the `keepAudioSessionActive` now keeps the  acquired or pending audio focus while a keeper exists and accounts for keepers during mode changes, background transitions, and normal focus cleanup.

Explicit `setIsAudioActiveAsync(false)` calls and module destruction still release the session or focus.


# Test Plan

Tested on Android and iOS in BareExpo by testing app's interaction with 3rd party apps playing background audio.



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>