### PR TITLE
[android][dev-menu] Read the performance monitor state from hosts that replace the FPS overlay

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add a JavaScript API to show or hide the floating Tools button at runtime. ([#47746](https://github.com/expo/expo/pull/47746) by [@KevinvdBurg](https://github.com/KevinvdBurg))
 - Add Components section to swap the active AppRegistry component ([#46613](https://github.com/expo/expo/pull/46613) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Read the performance monitor state from hosts that replace the default FPS overlay with their own monitor.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuDevSettings.kt
@@ -1,6 +1,7 @@
 package expo.modules.devmenu
 
 import com.facebook.react.ReactHost
+import expo.modules.devmenu.api.CustomPerformanceMonitor
 import expo.modules.devmenu.devtools.DevMenuDevToolsDelegate
 import expo.modules.kotlin.weak
 
@@ -12,13 +13,16 @@ data class DevToolsSettings(
 
 object DevMenuDevSettings {
   fun getDevSettings(reactHost: ReactHost): DevToolsSettings {
-    val devDelegate = DevMenuDevToolsDelegate(requireNotNull(reactHost.devSupportManager).weak())
+    val devSupportManager = requireNotNull(reactHost.devSupportManager)
+    val devDelegate = DevMenuDevToolsDelegate(devSupportManager.weak())
     val devSettings = devDelegate.devSettings
 
     return DevToolsSettings(
       isElementInspectorShown = devSettings?.isElementInspectorEnabled ?: false,
       isHotLoadingEnabled = devSettings?.isHotModuleReplacementEnabled ?: true,
-      isPerfMonitorShown = devSettings?.isFpsDebugEnabled ?: false
+      isPerfMonitorShown = (devSupportManager as? CustomPerformanceMonitor)?.isPerformanceMonitorShown
+        ?: devSettings?.isFpsDebugEnabled
+        ?: false
     )
   }
 }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/CustomPerformanceMonitor.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/api/CustomPerformanceMonitor.kt
@@ -1,0 +1,10 @@
+package expo.modules.devmenu.api
+
+/**
+ * Implemented by a host's DevSupportManager when it replaces React Native's FPS overlay with its
+ * own performance monitor. The dev menu reads the monitor state from here, so the host can keep
+ * `DevSettings.isFpsDebugEnabled` false and the built-in overlay never shows.
+ */
+interface CustomPerformanceMonitor {
+  val isPerformanceMonitorShown: Boolean
+}

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/devtools/DevMenuDevToolsDelegate.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.HMRClient
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.devmenu.DevMenuSettings
+import expo.modules.devmenu.api.CustomPerformanceMonitor
 import expo.modules.devmenu.api.DevMenuApi
 import expo.modules.devmenu.compose.DevMenuAction
 import expo.modules.devmenu.websockets.DevMenuMetroClient
@@ -71,7 +72,9 @@ class DevMenuDevToolsDelegate(
     if (DevMenuSettings.performanceMonitorNeedsOverlayPermission) {
       requestOverlaysPermission(context)
     }
-    devSupportManager.setFpsDebugEnabled(!devSettings.isFpsDebugEnabled)
+    val isShown = (devSupportManager as? CustomPerformanceMonitor)?.isPerformanceMonitorShown
+      ?: devSettings.isFpsDebugEnabled
+    devSupportManager.setFpsDebugEnabled(!isShown)
   }
 
   fun toggleFastRefresh() {


### PR DESCRIPTION
# Why
Expo Go replaces React Native's FPS overlay with its own performance monitor, but the dev menu reads the monitor state from DevSettings.isFpsDebugEnabled. A host that keeps that flag false so RN's overlay never shows has no way to tell the menu its monitor is visible, so the toggle state goes stale.

# How

Adds a CustomPerformanceMonitor interface a host's DevSupportManager can implement. The two read sites check for it and fall back to isFpsDebugEnabled, so dev clients are unchanged.

# Test Plan
In a dev client, toggle the perf monitor from the dev menu and check RN's FPS overlay still appears and the toggle state tracks.
