### PR TITLE
[android][expo-go] Own the performance monitor state outside RN's dev settings

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/modules/perfmonitor/ExpoBridgelessDevSupportManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager
 import com.facebook.react.devsupport.interfaces.RedBoxHandler
 import com.facebook.react.packagerconnection.RequestHandler
+import expo.modules.devmenu.api.CustomPerformanceMonitor
 import host.exp.exponent.factories.ExpoGoDevSupportManager
 import host.exp.exponent.kernel.Kernel
 
@@ -43,10 +44,30 @@ internal class ExpoBridgelessDevSupportManager(
     devLoadingViewManager,
     pausedInDebuggerOverlayManager
   ),
-  ExpoGoDevSupportManager {
+  ExpoGoDevSupportManager,
+  CustomPerformanceMonitor {
 
   private val perfController = PerfMonitorController(applicationContext) {
-    devSettings.isFpsDebugEnabled = false
+    setFpsDebugEnabled(false)
+  }
+
+  // Expo Go's monitor state lives in its own preferences. RN's isFpsDebugEnabled must stay false,
+  // because DevSupportManagerBase shows its own FPS overlay whenever that flag is true on reload.
+  private val perfMonitorState =
+    applicationContext.getSharedPreferences("expo.perfmonitor", Context.MODE_PRIVATE)
+
+  override val isPerformanceMonitorShown: Boolean
+    get() = perfMonitorState.getBoolean("enabled", false)
+
+  init {
+    // Older versions stored the monitor state in RN's flag. Clear it so the built-in overlay
+    // never shows, and carry the enabled state over.
+    UiThreadUtil.runOnUiThread {
+      if (devSettings.isFpsDebugEnabled) {
+        devSettings.isFpsDebugEnabled = false
+        perfMonitorState.edit().putBoolean("enabled", true).apply()
+      }
+    }
   }
 
   override var exponentActivityId: Int = -1
@@ -106,18 +127,22 @@ internal class ExpoBridgelessDevSupportManager(
     super.handleException(e)
   }
 
+  // The packager command handler calls this from the WebSocket thread, and the controller
+  // attaches views, so hop to the UI thread first.
   override fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean) {
-    devSettings.isFpsDebugEnabled = isFpsDebugEnabled
-    perfController.syncEnabledState(
-      isFpsDebugEnabled,
-      currentReactContext
-    )
+    UiThreadUtil.runOnUiThread {
+      perfMonitorState.edit().putBoolean("enabled", isFpsDebugEnabled).apply()
+      perfController.syncEnabledState(
+        isFpsDebugEnabled,
+        currentReactContext
+      )
+    }
   }
 
   override fun onNewReactContextCreated(reactContext: ReactContext) {
     super.onNewReactContextCreated(reactContext)
     perfController.onContextCreated(reactContext)
-    if (devSettings.isFpsDebugEnabled) {
+    if (isPerformanceMonitorShown) {
       perfController.enable(reactContext)
     }
   }

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/VersionedUtils.kt
@@ -1,15 +1,12 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package versioned.host.exp.exponent
 
-import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.packagerconnection.NotificationOnlyHandler
 import com.facebook.react.packagerconnection.RequestHandler
+import expo.modules.devmenu.api.CustomPerformanceMonitor
 import expo.modules.jsonutils.getNullable
 import host.exp.exponent.experience.ExperienceActivity
 import host.exp.exponent.experience.ReactNativeActivity
@@ -65,26 +62,6 @@ object VersionedUtils {
     devSupportManager.toggleElementInspector()
   }
 
-  private fun requestOverlayPermission(context: Context) {
-    // From the unexposed DebugOverlayController static helper
-    // Get permission to show debug overlay in dev builds.
-    if (!Settings.canDrawOverlays(context)) {
-      val intent = Intent(
-        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-        Uri.parse("package:" + context.packageName)
-      ).apply {
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK
-      }
-      FLog.w(
-        ReactConstants.TAG,
-        "Overlay permissions needs to be granted in order for React Native apps to run in development mode"
-      )
-      if (intent.resolveActivity(context.packageManager) != null) {
-        context.startActivity(intent)
-      }
-    }
-  }
-
   private fun togglePerformanceMonitor() {
     val currentActivity = Exponent.instance.currentActivity as? ReactNativeActivity ?: return run {
       FLog.e(
@@ -99,14 +76,10 @@ object VersionedUtils {
       )
     }
 
-    val devSettings = devSupportManager.devSettings
-    if (devSettings != null) {
-      if (!devSettings.isFpsDebugEnabled) {
-        // Request overlay permission if needed when "Show Perf Monitor" option is selected
-        requestOverlayPermission(currentActivity)
-      }
-      devSettings.isFpsDebugEnabled = !devSettings.isFpsDebugEnabled
-    }
+    val isShown = (devSupportManager as? CustomPerformanceMonitor)?.isPerformanceMonitorShown
+      ?: devSupportManager.devSettings?.isFpsDebugEnabled
+      ?: false
+    devSupportManager.setFpsDebugEnabled(!isShown)
   }
 
   fun createPackagerCommandHelpers(): Map<String, RequestHandler> {


### PR DESCRIPTION
# Why
Expo Go stored its monitor state in RN's isFpsDebugEnabled. DevSupportManagerBase.reload() shows RN's own FPS overlay whenever that flag is true, which is why the fork forces it hidden. This pr allows us to drop that from the fork.

# How

The manager keeps the state in its own preferences and implements CustomPerformanceMonitor for the dev menu. Init clears any stale flag persisted by older versions and carries the enabled state over, so RN's overlay can never show even for users who granted the overlay permission. The packager toggle routes through the manager and the permission request is gone.

# Test Plan
Expo go