### PR TITLE
[ios][expo-go] Disable RN's dev menu on shake and keyboard shortcuts

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -140,12 +140,26 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
                                                                                  initialProperties:[self initialPropertiesForRootView]
                                                                                      launchOptions:nil
                                                                                bundleConfiguration:[EXBundleConfiguration configurationWithBundleURL:[self bundleUrl]]
-                                                                              devMenuConfiguration:[RCTDevMenuConfiguration defaultConfiguration]];
+                                                                              devMenuConfiguration:[self _devMenuConfiguration]];
     }
 
     [self setupWebSocketControls];
     [_delegate reactAppManagerIsReadyForLoad:self];
   }
+}
+
+- (RCTDevMenuConfiguration *)_devMenuConfiguration
+{
+#if RCT_DEV_MENU
+  // Expo Go presents its own dev menu, and expo-dev-menu owns the shake gesture and keyboard
+  // shortcuts. RN's dev menu stays constructed so it can be opened programmatically, but must not
+  // respond to those gestures itself.
+  return [[RCTDevMenuConfiguration alloc] initWithDevMenuEnabled:YES
+                                            shakeGestureEnabled:NO
+                                       keyboardShortcutsEnabled:NO];
+#else
+  return [RCTDevMenuConfiguration defaultConfiguration];
+#endif
 }
 
 - (void)_createAppInstance


### PR DESCRIPTION
# Why
Let's us drop 40afeca484e from the fork

# How
Pass a scoped configuration with shakeGestureEnabled:NO and keyboardShortcutsEnabled:NO. devMenuEnabled stays on because Expo Go opens the module programmatically.

# Test Plan
Expo go. Shake shows one dev menu, and the menu still opens by gesture, button, and programmatically
