### PR TITLE
[ios][expo-go] Toggle the performance monitor after the dev menu closes

### DIFF
--- a/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift
+++ b/apps/expo-go/ios/Exponent/DevMenu/SwiftUI/DevMenuViewModel.swift
@@ -112,8 +112,14 @@ class DevMenuViewModel: ObservableObject {
   }
 
   func togglePerformanceMonitor() {
-    manager.togglePerformanceMonitor()
-    manager.closeMenu()
+    // Close the menu first. RCTPerfMonitor attaches its overlay to the key window, which is still
+    // the menu's window until the sheet is dismissed.
+    let closed = manager.closeMenu {
+      self.manager.togglePerformanceMonitor()
+    }
+    if !closed {
+      manager.togglePerformanceMonitor()
+    }
   }
 
   func toggleElementInspector() {


### PR DESCRIPTION
# Why
RCTPerfMonitor attaches its overlay to the key window. Expo Go toggled it while the dev menu's window was still up, so the overlay landed in the menu's window and died with it, which the fork patched around by repointing the attach at the app delegate's window.

# How
Toggle from closeMenu's completion, so the app window is key again when the overlay attaches and upstream's code is correct as written. Also bumps react-native-lab, which drops the three patches this stack replaces

# Test Plan
Expo go on device with the new fork pointer. Perf monitor appears over the app, survives the menu closing, and toggles off.
