### PR TITLE
[iOS][JSI] Fix xcframework prebuild failing under Xcode 27

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Fixed `JavaScriptPropNameID(_:string:)` and the array's string-keyed subscript truncating non-ASCII property keys: they passed `String.count` (the grapheme-cluster count) as the UTF-8 byte length to `PropNameID::forUtf8`, so keys like `"café"` or `"🎉"` were built from mangled bytes and no longer matched the intended property. ([#48329](https://github.com/expo/expo/pull/48329) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed a use-after-free when a non-owning `JavaScriptRuntime` wrapper outlives its runtime (e.g. it is captured by a task abandoned on reload): its cached `jsi::PropNameID`s were destroyed against the freed runtime when the wrapper deallocated. The teardown sweep now flushes the cache on the JavaScript thread while the runtime is still valid. ([#47927](https://github.com/expo/expo/pull/47927) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptPromise` no longer traps when a resolve or reject call throws, which can realistically only happen against a runtime that is being torn down: a failed resolver call rejects the promise instead and a failed rejecter call is dropped. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed the xcframework prebuild failing under Xcode 27 due to new foreign reference ownership warnings emitted for `RuntimeScheduler` constructors. ([#49120](https://github.com/expo/expo/pull/49120) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
@@ -50,7 +50,7 @@ public:
    `scheduleTask` dispatches through `fn`, which the host implements against
    the real react::RuntimeScheduler.
    */
-  RuntimeScheduler(void *scheduler, ScheduleFn fn) noexcept
+  SWIFT_RETURNS_RETAINED RuntimeScheduler(void *scheduler, ScheduleFn fn) noexcept
       : nativeScheduler(scheduler), scheduleFn(fn) {}
 
   /**
@@ -58,7 +58,7 @@ public:
    caller's thread — intended for standalone runtimes (e.g. tests) that have
    no React scheduler.
    */
-  RuntimeScheduler() {}
+  SWIFT_RETURNS_RETAINED RuntimeScheduler() {}
 
   RuntimeScheduler(const RuntimeScheduler &) = delete;
 


### PR DESCRIPTION
# Why

Xcode 27's Swift compiler added a warning for constructors of `SWIFT_SHARED_REFERENCE` types that don't declare ownership:

```
JavaScriptRuntime.swift:65:27: warning: cannot infer ownership of foreign reference value returned by 'init()' [#ForeignReferenceType]
 65 |     self.scheduler = expo.RuntimeScheduler()
    |                           `- warning: cannot infer ownership of foreign reference value returned by 'init()'

RuntimeScheduler.h:61:3: note: annotate 'init()' with either SWIFT_RETURNS_RETAINED or SWIFT_RETURNS_UNRETAINED
```

When the prebuild script actually recompiles a slice, the nested build system also prints spurious "error: the following command failed with exit code 0 but produced no further output" lines for the SwiftCompile tasks that emitted those warnings. The outer Xcode then fails the script phase on that "error:" text even though the script exits 0 and the xcframework builds fine. It only reproduces on a slice cache miss, which is why the failure looked intermittent.

# How

Annotated both `RuntimeScheduler` constructors with `SWIFT_RETURNS_RETAINED`, silencing the warning at its source. Retained is the correct ownership here: `refCount` starts at 1, so a new object hands Swift an owned reference that ARC balances with `releaseRuntimeScheduler`. This codifies the existing behavior rather than changing it.

# Test Plan

Rebuilt the simulator slice from a clean `.DerivedData` with Xcode 27.0 (27A5228h) via `build-xcframework.sh`: the ownership warnings and the spurious error lines are gone and the build succeeds. Also still builds cleanly with stable Xcode.
