### PR TITLE
[observe][ios] Batch metrics and logs in dispatch and retry on 413

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 💡 Others
 
-- [iOS] Add an optional limit when reading pending metric and log rows.
+- [iOS] Add an optional limit when reading pending metric and log rows. ([#49121](https://github.com/expo/expo/pull/49121) by [@Ubax](https://github.com/Ubax))
 - [Android] Load only requested metric and log rows when preparing observability payloads. ([#49011](https://github.com/expo/expo/pull/49011) by [@Ubax](https://github.com/Ubax))
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 💡 Others
 
+- [iOS] Add an optional limit when reading pending metric and log rows.
 - [Android] Load only requested metric and log rows when preparing observability payloads. ([#49011](https://github.com/expo/expo/pull/49011) by [@Ubax](https://github.com/Ubax))
 - Rename the no-update `downloadComplete` state event to `downloadCompleteUnavailable`. ([#47902](https://github.com/expo/expo/pull/47902) by [@kudo](https://github.com/kudo))
 - [iOS] Measure the JS bundle load time against the app startup end marker to stay compatible with upcoming React Native versions. ([#47782](https://github.com/expo/expo/pull/47782) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -68,17 +68,17 @@ public struct AppMetrics {
 
   /// Returns metric rows whose `id` is greater than `cursor`, in ascending id order. Consumers persist
   /// the largest seen id and pass it back on subsequent calls to fetch only newer rows. Empty when the
-  /// database failed to open.
+  /// database failed to open. Pass `limit` to return at most that many of the oldest rows.
   @AppMetricsActor
-  public static func getMetrics(afterId cursor: Int64) throws -> [MetricRow] {
-    return try database?.getMetrics(afterId: cursor) ?? []
+  public static func getMetrics(afterId cursor: Int64, limit: Int? = nil) throws -> [MetricRow] {
+    return try database?.getMetrics(afterId: cursor, limit: limit) ?? []
   }
 
   /// Returns log rows whose `id` is greater than `cursor`, in ascending id order. Empty when the
-  /// database failed to open.
+  /// database failed to open. Pass `limit` to return at most that many of the oldest rows.
   @AppMetricsActor
-  public static func getLogs(afterId cursor: Int64) throws -> [LogRow] {
-    return try database?.getLogs(afterId: cursor) ?? []
+  public static func getLogs(afterId cursor: Int64, limit: Int? = nil) throws -> [LogRow] {
+    return try database?.getLogs(afterId: cursor, limit: limit) ?? []
   }
 
   /// Hydrates session rows for the given ids. Used to attach session metadata to a batch of metrics

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -332,14 +332,14 @@ final class MetricsDatabase: Sendable {
   /// Returns metric rows whose `id` is greater than `cursor`, in ascending id order. Dispatch uses
   /// this with the persisted "last dispatched metric id" cursor to fetch only new rows.
   @AppMetricsActor
-  func getMetrics(afterId cursor: Int64) throws -> [MetricRow] {
+  func getMetrics(afterId cursor: Int64, limit: Int? = nil) throws -> [MetricRow] {
     let statement = try database.prepare(
       """
       SELECT id, sessionId, timestamp, category, name, value, routeName, updateId, params
-      FROM metrics WHERE id > ?1 ORDER BY id ASC
+      FROM metrics WHERE id > ?1 ORDER BY id ASC LIMIT ?2
       """
     )
-    try statement.bindAll([cursor])
+    try statement.bindAll([cursor, limit ?? -1])
     var rows: [MetricRow] = []
     try statement.forEachRow { row in
       rows.append(MetricRow(row: row))
@@ -349,14 +349,14 @@ final class MetricsDatabase: Sendable {
 
   /// Returns log rows whose `id` is greater than `cursor`, in ascending id order.
   @AppMetricsActor
-  func getLogs(afterId cursor: Int64) throws -> [LogRow] {
+  func getLogs(afterId cursor: Int64, limit: Int? = nil) throws -> [LogRow] {
     let statement = try database.prepare(
       """
       SELECT id, sessionId, timestamp, severity, name, body, attributes, droppedAttributesCount
-      FROM logs WHERE id > ?1 ORDER BY id ASC
+      FROM logs WHERE id > ?1 ORDER BY id ASC LIMIT ?2
       """
     )
-    try statement.bindAll([cursor])
+    try statement.bindAll([cursor, limit ?? -1])
     var rows: [LogRow] = []
     try statement.forEachRow { row in
       rows.append(LogRow(row: row))

--- a/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
@@ -394,6 +394,21 @@ struct MetricsDatabaseTests {
     }
   }
 
+  @Test
+  func `getMetrics after id limits the oldest remaining rows`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let ids = try ["a", "b", "c", "d"].map {
+        try database.insert(metric: makeMetricRow(sessionId: "s", name: $0))
+      }
+
+      #expect(try database.getMetrics(afterId: ids[0], limit: 2).map(\.name) == ["b", "c"])
+      #expect(try database.getMetrics(afterId: ids[1], limit: 10).map(\.name) == ["c", "d"])
+      #expect(try database.getMetrics(afterId: ids[0], limit: nil).map(\.name) == ["b", "c", "d"])
+      #expect(try database.getMetrics(afterId: ids[0]).map(\.name) == ["b", "c", "d"])
+    }
+  }
+
   // MARK: - Logs
 
   @Test
@@ -476,6 +491,21 @@ struct MetricsDatabaseTests {
       try database.deleteSession(id: "s")
       let logs = try database.getLogs(sessionId: "s")
       #expect(logs.isEmpty)
+    }
+  }
+
+  @Test
+  func `getLogs after id limits the oldest remaining rows`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let ids = try ["a", "b", "c", "d"].map {
+        try database.insert(log: makeLogRow(sessionId: "s", name: $0))
+      }
+
+      #expect(try database.getLogs(afterId: ids[0], limit: 2).map(\.name) == ["b", "c"])
+      #expect(try database.getLogs(afterId: ids[1], limit: 10).map(\.name) == ["c", "d"])
+      #expect(try database.getLogs(afterId: ids[0], limit: nil).map(\.name) == ["b", "c", "d"])
+      #expect(try database.getLogs(afterId: ids[0]).map(\.name) == ["b", "c", "d"])
     }
   }
 

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- [iOS] Dispatch pending metrics and logs in chunks of 200 and retry HTTP 413 responses with smaller batches.
 - [Android] Retry a dispatch that gets HTTP 413 ([#49016](https://github.com/expo/expo/pull/49016) by [@Ubax](https://github.com/Ubax))
 - [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work. ([#49012](https://github.com/expo/expo/pull/49012) by [@Ubax](https://github.com/Ubax))
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/expo-observe/CHANGELOG.md
+++ b/packages/expo-observe/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [iOS] Dispatch pending metrics and logs in chunks of 200 and retry HTTP 413 responses with smaller batches.
+- [iOS] Dispatch pending metrics and logs in chunks of 200 and retry HTTP 413 responses with smaller batches. ([#49121](https://github.com/expo/expo/pull/49121) by [@Ubax](https://github.com/Ubax))
 - [Android] Retry a dispatch that gets HTTP 413 ([#49016](https://github.com/expo/expo/pull/49016) by [@Ubax](https://github.com/Ubax))
 - [Android] Dispatch pending metrics and logs in bounded, oldest-first chunks without replacing active background work. ([#49012](https://github.com/expo/expo/pull/49012) by [@Ubax](https://github.com/Ubax))
 - Mark the `AppMetrics` export as deprecated in favor of `Observe`. ([#48901](https://github.com/expo/expo/pull/48901) by [@kadikraman](https://github.com/kadikraman))

--- a/packages/expo-observe/ios/DispatchLoop.swift
+++ b/packages/expo-observe/ios/DispatchLoop.swift
@@ -1,0 +1,84 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import ExpoAppMetrics
+
+@AppMetricsActor
+internal enum DispatchLoop {
+  internal static let defaultChunkSize = 200
+
+  internal static func drain<Row>(
+    startCursor: Int64,
+    chunkSize: Int = defaultChunkSize,
+    fetchBatch: (_ afterId: Int64, _ limit: Int) throws -> [Row],
+    rowId: (Row) -> Int64?,
+    send: (_ rows: [Row]) async throws -> DispatchResult?,
+    onResult: (_ result: DispatchResult, _ batchCount: Int, _ highestId: Int64) -> Void,
+    persistCursor: (Int64) -> Void
+  ) async {
+    var cursor = startCursor
+
+    dispatchLoop: while !Task.isCancelled {
+      let fetchedRows: [Row]
+      do {
+        fetchedRows = try fetchBatch(cursor, chunkSize)
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to read pending rows: \(error.localizedDescription)")
+        return
+      }
+      guard !fetchedRows.isEmpty else {
+        return
+      }
+
+      var rows = fetchedRows
+      while !Task.isCancelled {
+        guard let lastRow = rows.last else {
+          return
+        }
+        // A missing id must never rewind the cursor, so fall back to the current one.
+        let highestId = rowId(lastRow) ?? cursor
+        let result: DispatchResult?
+        do {
+          result = try await send(rows)
+        } catch {
+          observeLogger.warn("[EAS Observe] Failed to assemble or send pending rows: \(error.localizedDescription)")
+          return
+        }
+
+        guard let result else {
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          persistCursor(cursor)
+          continue dispatchLoop
+        }
+        onResult(result, rows.count, highestId)
+
+        switch result {
+        case .success, .partialSuccess:
+          // Stop when the batch cannot advance the cursor — continuing would refetch and
+          // re-send the same rows forever.
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          persistCursor(cursor)
+          continue dispatchLoop
+        case .retryableFailure:
+          return
+        case .nonRetryableFailure:
+          persistCursor(highestId)
+          return
+        case .payloadTooLarge:
+          guard rows.count > 1 else {
+            persistCursor(highestId)
+            return
+          }
+          // Unlike Android's re-fetch, slicing can re-send rows deleted during this loop, and event
+          // payloads are rebuilt from the session snapshot available on each attempt.
+          rows = Array(rows.prefix(max(1, rows.count / 2)))
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-observe/ios/DispatchUtils.swift
+++ b/packages/expo-observe/ios/DispatchUtils.swift
@@ -2,7 +2,7 @@
 
 import ExpoModulesCore
 
-/// Outcome of a single dispatch attempt to the OTLP endpoint. Four cases, modeled after the
+/// Outcome of a single dispatch attempt to the OTLP endpoint, modeled after the
 /// OTLP retry guidance (see https://opentelemetry.io/docs/specs/otlp/#otlphttp-response):
 ///
 /// - `.success` — server accepted the batch without rejections.
@@ -13,6 +13,7 @@ import ExpoModulesCore
 ///   a drop.
 /// - `.retryableFailure` — transient failure (408/429/502/503/504 or transport error); retry the
 ///   same batch after `retryAfter` seconds or a client-computed backoff.
+/// - `.payloadTooLarge` — HTTP 413; retry a smaller batch.
 /// - `.nonRetryableFailure` — permanent failure (4xx/5xx outside the retryable set, encoding error);
 ///   drop the batch so it can't wedge the loop.
 ///
@@ -23,6 +24,7 @@ internal enum DispatchResult: Equatable, Sendable {
   case success
   case partialSuccess(OTPartialSuccess)
   case retryableFailure(retryAfter: TimeInterval?)
+  case payloadTooLarge
   case nonRetryableFailure(reason: String)
 }
 
@@ -117,6 +119,10 @@ internal enum DispatchUtils {
         "[EAS Observe] Server responded with \(urlResponse.statusCode) (retryable) and data: "
           + "\(String(data: responseData, encoding: .utf8) ?? "<unreadable>")"
       )
+    case .payloadTooLarge:
+      observeLogger.warn(
+        "[EAS Observe] Server responded with 413 (payload too large); retrying a smaller batch"
+      )
     case .nonRetryableFailure(let reason):
       observeLogger.warn(
         "[EAS Observe] Server responded with \(urlResponse.statusCode) (non-retryable, "
@@ -126,7 +132,7 @@ internal enum DispatchUtils {
     return result
   }
 
-  /// Pure classifier that maps an HTTP response into one of three retry outcomes. Extracted
+  /// Pure classifier that maps an HTTP response into a dispatch outcome. Extracted
   /// from `sendRequest` so the OTLP-spec rules can be unit-tested without a real network call.
   ///
   /// `bodyExcerpt` is invoked lazily, only when the result is `.nonRetryableFailure` and the reason
@@ -151,6 +157,10 @@ internal enum DispatchUtils {
         return .partialSuccess(partial)
       }
       return .success
+    }
+
+    if statusCode == 413 {
+      return .payloadTooLarge
     }
 
     // Retryable per OTLP.
@@ -226,8 +236,9 @@ internal enum DispatchUtils {
   ///   permanently, so retrying would just produce the same answer; advancing the cursor
   ///   drops the batch so it can't wedge subsequent rounds. This is the acceptance-criterion
   ///   behavior: a 400/403 must not be re-sent on the next cycle.
-  /// - `.retryableFailure` leaves the cursor at its current value so the next dispatch attempt picks
-  ///   the same rows up again.
+  /// - `.retryableFailure` and `.payloadTooLarge` leave the cursor at its current value so the same
+  ///   rows can be retried. The dispatch loop makes the one exception for a single-row 413, which it
+  ///   drops directly so that record cannot wedge subsequent dispatches.
   internal static func nextCursor(
     for result: DispatchResult,
     currentCursor: Int64,
@@ -236,7 +247,7 @@ internal enum DispatchUtils {
     switch result {
     case .success, .partialSuccess, .nonRetryableFailure:
       return highestId
-    case .retryableFailure:
+    case .retryableFailure, .payloadTooLarge:
       return currentCursor
     }
   }
@@ -286,8 +297,8 @@ internal enum DispatchUtils {
   ///   gate either already expired (we wouldn't have dispatched otherwise) or was never set
   ///   — either way, a server response that ACCEPTED the bytes (even if it rejected a subset
   ///   server-side) doesn't introduce a new pause.
-  /// - `.nonRetryableFailure` also resets the counter. A permanent drop isn't a sign that the
-  ///   server is unhealthy and shouldn't pause subsequent rounds.
+  /// - `.nonRetryableFailure` and `.payloadTooLarge` also reset the counter. Neither indicates a
+  ///   transient server failure that should pause subsequent rounds.
   /// - `.retryableFailure` increments the counter and sets the gate to `now + delay`, where `delay`
   ///   is the server-supplied `Retry-After` if present, otherwise `backoff(nextCount)`.
   ///
@@ -300,7 +311,7 @@ internal enum DispatchUtils {
     backoff: (Int) -> TimeInterval
   ) -> RetryGateState {
     switch result {
-    case .success, .partialSuccess, .nonRetryableFailure:
+    case .success, .partialSuccess, .nonRetryableFailure, .payloadTooLarge:
       return RetryGateState(
         dispatchAfterDate: currentState.dispatchAfterDate,
         consecutiveRetryableFailures: 0

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -23,10 +23,6 @@ internal struct ObservabilityManager {
   private static var metricsRetryGate: DispatchUtils.RetryGateState = .initial
   private static var logsRetryGate: DispatchUtils.RetryGateState = .initial
 
-  /// How many rows one dispatch request carries at most. Dispatch keeps fetching and sending
-  /// chunks of this size until the table is drained or a batch fails.
-  private static let dispatchChunkSize = 200
-
   internal static func dispatch() async {
     // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` rather than
     // here, so a backoff on one endpoint doesn't suppress the other's traffic.
@@ -74,7 +70,7 @@ internal struct ObservabilityManager {
 
     repairMetricCursorIfStale()
 
-    var cursor = ObserveUserDefaults.lastDispatchedMetricId
+    let cursor = ObserveUserDefaults.lastDispatchedMetricId
     if !shouldDispatch {
       do {
         if let highestId = try AppMetrics.getMaxMetricId() {
@@ -86,94 +82,53 @@ internal struct ObservabilityManager {
       return
     }
 
-    dispatchLoop: while !Task.isCancelled {
-      let fetchedMetrics: [MetricRow]
-      do {
-        fetchedMetrics = try AppMetrics.getMetrics(afterId: cursor, limit: dispatchChunkSize)
-      } catch {
-        observeLogger.warn("[EAS Observe] Failed to read pending metrics: \(error.localizedDescription)")
-        return
-      }
-      guard !fetchedMetrics.isEmpty else {
-        observeLogger.debug("[EAS Observe] No new metrics to dispatch")
-        return
-      }
-
-      var metrics = fetchedMetrics
-      while !Task.isCancelled {
-        guard let lastRow = metrics.last else {
-          return
+    await DispatchLoop.drain(
+      startCursor: cursor,
+      fetchBatch: { cursor, limit in
+        let metrics = try AppMetrics.getMetrics(afterId: cursor, limit: limit)
+        if metrics.isEmpty {
+          observeLogger.debug("[EAS Observe] No new metrics to dispatch")
         }
-        // A missing id must never rewind the cursor, so fall back to the current one.
-        let highestId = lastRow.id ?? cursor
-
-        let events: [Event]
-        do {
-          events = try buildEvents(forMetrics: metrics)
-        } catch {
-          observeLogger.warn("[EAS Observe] Failed to assemble metric events: \(error.localizedDescription)")
-          return
-        }
+        return metrics
+      },
+      rowId: { $0.id },
+      send: { metrics in
+        let events = try buildEvents(forMetrics: metrics)
         guard !events.isEmpty else {
-          // Stop when the batch cannot advance the cursor — continuing would refetch and
-          // re-send the same rows forever.
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedMetricId = cursor
-          continue dispatchLoop
+          return nil
         }
-
         let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
-        let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+        return await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+      },
+      onResult: { result, batchCount, highestId in
         applyRetryOutcome(result, to: &metricsRetryGate)
-
         switch result {
         case .success:
           ObserveUserDefaults.lastDispatchDate = Date.now
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedMetricId = cursor
-          continue dispatchLoop
         case .partialSuccess(let partial):
           ObserveUserDefaults.lastDispatchDate = Date.now
           observeLogger.warn(
-            "[EAS Observe] Partial success on batch of \(metrics.count) metric row(s) past "
+            "[EAS Observe] Partial success on batch of \(batchCount) metric row(s) past "
               + "id \(highestId): server rejected \(partial.rejectedCount) "
               + "(\(partial.errorMessage ?? "no error message"))"
           )
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedMetricId = cursor
-          continue dispatchLoop
         case .retryableFailure:
-          return
+          break
         case .nonRetryableFailure(let reason):
           observeLogger.warn(
-            "[EAS Observe] Dropping batch of \(metrics.count) metric row(s) past id "
+            "[EAS Observe] Dropping batch of \(batchCount) metric row(s) past id "
               + "\(highestId): \(reason)"
           )
-          ObserveUserDefaults.lastDispatchedMetricId = highestId
-          return
+        case .payloadTooLarge where batchCount == 1:
+          observeLogger.warn(
+            "[EAS Observe] Dropping metric row id \(highestId) because it exceeds the server payload limit"
+          )
         case .payloadTooLarge:
-          guard metrics.count > 1 else {
-            observeLogger.warn(
-              "[EAS Observe] Dropping metric row id \(highestId) because it exceeds the server payload limit"
-            )
-            ObserveUserDefaults.lastDispatchedMetricId = highestId
-            return
-          }
-          // Unlike Android's re-fetch, slicing can re-send rows deleted during this loop, and event
-          // payloads are rebuilt from the session snapshot available on each attempt.
-          metrics = Array(metrics.prefix(max(1, metrics.count / 2)))
+          break
         }
-      }
-    }
+      },
+      persistCursor: { ObserveUserDefaults.lastDispatchedMetricId = $0 }
+    )
   }
 
   private static func dispatchLogs(shouldDispatch: Bool) async {
@@ -186,7 +141,7 @@ internal struct ObservabilityManager {
 
     repairLogCursorIfStale()
 
-    var cursor = ObserveUserDefaults.lastDispatchedLogId
+    let cursor = ObserveUserDefaults.lastDispatchedLogId
     if !shouldDispatch {
       do {
         if let highestId = try AppMetrics.getMaxLogId() {
@@ -198,34 +153,18 @@ internal struct ObservabilityManager {
       return
     }
 
-    dispatchLoop: while !Task.isCancelled {
-      let fetchedLogs: [LogRow]
-      do {
-        fetchedLogs = try AppMetrics.getLogs(afterId: cursor, limit: dispatchChunkSize)
-      } catch {
-        observeLogger.warn("[EAS Observe] Failed to read pending logs: \(error.localizedDescription)")
-        return
-      }
-      guard !fetchedLogs.isEmpty else {
-        observeLogger.debug("[EAS Observe] No new logs to dispatch")
-        return
-      }
-
-      var logs = fetchedLogs
-      while !Task.isCancelled {
-        guard let lastRow = logs.last else {
-          return
+    await DispatchLoop.drain(
+      startCursor: cursor,
+      fetchBatch: { cursor, limit in
+        let logs = try AppMetrics.getLogs(afterId: cursor, limit: limit)
+        if logs.isEmpty {
+          observeLogger.debug("[EAS Observe] No new logs to dispatch")
         }
-        // A missing id must never rewind the cursor, so fall back to the current one.
-        let highestId = lastRow.id ?? cursor
-
-        let events: [Event]
-        do {
-          events = try buildEvents(forLogs: logs)
-        } catch {
-          observeLogger.warn("[EAS Observe] Failed to assemble log events: \(error.localizedDescription)")
-          return
-        }
+        return logs
+      },
+      rowId: { $0.id },
+      send: { logs in
+        let events = try buildEvents(forLogs: logs)
         let resourceLogs = events.compactMap { event -> OTResourceLogs? in
           guard !event.logs.isEmpty else {
             return nil
@@ -233,66 +172,38 @@ internal struct ObservabilityManager {
           return event.toOTResourceLogs(easClientId)
         }
         guard !resourceLogs.isEmpty else {
-          // Stop when the batch cannot advance the cursor — continuing would refetch and
-          // re-send the same rows forever.
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedLogId = cursor
-          continue dispatchLoop
+          return nil
         }
-
         let body = OTLogsRequestBody(resourceLogs: resourceLogs)
-        let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+        return await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+      },
+      onResult: { result, batchCount, highestId in
         applyRetryOutcome(result, to: &logsRetryGate)
-
         switch result {
-        case .success:
+        case .success, .retryableFailure:
           ObserveUserDefaults.lastDispatchDate = Date.now
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedLogId = cursor
-          continue dispatchLoop
         case .partialSuccess(let partial):
           ObserveUserDefaults.lastDispatchDate = Date.now
           observeLogger.warn(
-            "[EAS Observe] Partial success on batch of \(logs.count) log row(s) past "
+            "[EAS Observe] Partial success on batch of \(batchCount) log row(s) past "
               + "id \(highestId): server rejected \(partial.rejectedCount) "
               + "(\(partial.errorMessage ?? "no error message"))"
           )
-          guard highestId > cursor else {
-            return
-          }
-          cursor = highestId
-          ObserveUserDefaults.lastDispatchedLogId = cursor
-          continue dispatchLoop
-        case .retryableFailure:
-          ObserveUserDefaults.lastDispatchDate = Date.now
-          return
         case .nonRetryableFailure(let reason):
           observeLogger.warn(
-            "[EAS Observe] Dropping batch of \(logs.count) log row(s) past id "
+            "[EAS Observe] Dropping batch of \(batchCount) log row(s) past id "
               + "\(highestId): \(reason)"
           )
-          ObserveUserDefaults.lastDispatchedLogId = highestId
-          return
+        case .payloadTooLarge where batchCount == 1:
+          observeLogger.warn(
+            "[EAS Observe] Dropping log row id \(highestId) because it exceeds the server payload limit"
+          )
         case .payloadTooLarge:
-          guard logs.count > 1 else {
-            observeLogger.warn(
-              "[EAS Observe] Dropping log row id \(highestId) because it exceeds the server payload limit"
-            )
-            ObserveUserDefaults.lastDispatchedLogId = highestId
-            return
-          }
-          // Unlike Android's re-fetch, slicing can re-send rows deleted during this loop, and event
-          // payloads are rebuilt from the session snapshot available on each attempt.
-          logs = Array(logs.prefix(max(1, logs.count / 2)))
+          break
         }
-      }
-    }
+      },
+      persistCursor: { ObserveUserDefaults.lastDispatchedLogId = $0 }
+    )
   }
 
   /// Groups `metrics` by `sessionId`, hydrates the matching session rows, and emits one `Event` per

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -23,6 +23,10 @@ internal struct ObservabilityManager {
   private static var metricsRetryGate: DispatchUtils.RetryGateState = .initial
   private static var logsRetryGate: DispatchUtils.RetryGateState = .initial
 
+  /// How many rows one dispatch request carries at most. Dispatch keeps fetching and sending
+  /// chunks of this size until the table is drained or a batch fails.
+  private static let dispatchChunkSize = 200
+
   internal static func dispatch() async {
     // Per-signal gates are checked inside `dispatchMetrics` / `dispatchLogs` rather than
     // here, so a backoff on one endpoint doesn't suppress the other's traffic.
@@ -61,132 +65,233 @@ internal struct ObservabilityManager {
   }
 
   private static func dispatchMetrics(shouldDispatch: Bool) async {
+    guard let endpointUrl = metricsEndpointUrl else {
+      return
+    }
     if retryGateBlocks(metricsRetryGate, signal: "metrics") {
       return
     }
 
     repairMetricCursorIfStale()
 
-    let cursor = ObserveUserDefaults.lastDispatchedMetricId
-    let pendingMetrics: [MetricRow]
-    do {
-      pendingMetrics = try AppMetrics.getMetrics(afterId: cursor)
-    } catch {
-      observeLogger.warn("[EAS Observe] Failed to read pending metrics: \(error.localizedDescription)")
-      return
-    }
-    guard !pendingMetrics.isEmpty, let endpointUrl = metricsEndpointUrl else {
-      observeLogger.debug("[EAS Observe] No new metrics to dispatch")
-      return
-    }
-    let highestId = pendingMetrics.last?.id ?? cursor
+    var cursor = ObserveUserDefaults.lastDispatchedMetricId
     if !shouldDispatch {
-      ObserveUserDefaults.lastDispatchedMetricId = highestId
+      do {
+        if let highestId = try AppMetrics.getMaxMetricId() {
+          ObserveUserDefaults.lastDispatchedMetricId = highestId
+        }
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to read pending metrics: \(error.localizedDescription)")
+      }
       return
     }
-    let events: [Event]
-    do {
-      events = try buildEvents(forMetrics: pendingMetrics)
-    } catch {
-      observeLogger.warn("[EAS Observe] Failed to assemble metric events: \(error.localizedDescription)")
-      return
-    }
-    if events.isEmpty {
-      ObserveUserDefaults.lastDispatchedMetricId = highestId
-      return
-    }
-    let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
-    let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    applyRetryOutcome(result, to: &metricsRetryGate)
-    ObserveUserDefaults.lastDispatchedMetricId = DispatchUtils.nextCursor(
-      for: result,
-      currentCursor: cursor,
-      highestId: highestId
-    )
-    switch result {
-    case .success:
-      ObserveUserDefaults.lastDispatchDate = Date.now
-    case .partialSuccess(let partial):
-      ObserveUserDefaults.lastDispatchDate = Date.now
-      observeLogger.warn(
-        "[EAS Observe] Partial success on batch of \(events.count) metric event(s) past "
-          + "id \(highestId): server rejected \(partial.rejectedCount) "
-          + "(\(partial.errorMessage ?? "no error message"))"
-      )
-    case .retryableFailure:
-      break
-    case .nonRetryableFailure(let reason):
-      observeLogger.warn(
-        "[EAS Observe] Dropping batch of \(events.count) metric event(s) past id "
-          + "\(highestId): \(reason)"
-      )
+
+    dispatchLoop: while !Task.isCancelled {
+      let fetchedMetrics: [MetricRow]
+      do {
+        fetchedMetrics = try AppMetrics.getMetrics(afterId: cursor, limit: dispatchChunkSize)
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to read pending metrics: \(error.localizedDescription)")
+        return
+      }
+      guard !fetchedMetrics.isEmpty else {
+        observeLogger.debug("[EAS Observe] No new metrics to dispatch")
+        return
+      }
+
+      var metrics = fetchedMetrics
+      while !Task.isCancelled {
+        guard let lastRow = metrics.last else {
+          return
+        }
+        // A missing id must never rewind the cursor, so fall back to the current one.
+        let highestId = lastRow.id ?? cursor
+
+        let events: [Event]
+        do {
+          events = try buildEvents(forMetrics: metrics)
+        } catch {
+          observeLogger.warn("[EAS Observe] Failed to assemble metric events: \(error.localizedDescription)")
+          return
+        }
+        guard !events.isEmpty else {
+          // Stop when the batch cannot advance the cursor — continuing would refetch and
+          // re-send the same rows forever.
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedMetricId = cursor
+          continue dispatchLoop
+        }
+
+        let body = OTRequestBody(resourceMetrics: events.map { $0.toOTEvent(easClientId) })
+        let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+        applyRetryOutcome(result, to: &metricsRetryGate)
+
+        switch result {
+        case .success:
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedMetricId = cursor
+          continue dispatchLoop
+        case .partialSuccess(let partial):
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          observeLogger.warn(
+            "[EAS Observe] Partial success on batch of \(metrics.count) metric row(s) past "
+              + "id \(highestId): server rejected \(partial.rejectedCount) "
+              + "(\(partial.errorMessage ?? "no error message"))"
+          )
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedMetricId = cursor
+          continue dispatchLoop
+        case .retryableFailure:
+          return
+        case .nonRetryableFailure(let reason):
+          observeLogger.warn(
+            "[EAS Observe] Dropping batch of \(metrics.count) metric row(s) past id "
+              + "\(highestId): \(reason)"
+          )
+          ObserveUserDefaults.lastDispatchedMetricId = highestId
+          return
+        case .payloadTooLarge:
+          guard metrics.count > 1 else {
+            observeLogger.warn(
+              "[EAS Observe] Dropping metric row id \(highestId) because it exceeds the server payload limit"
+            )
+            ObserveUserDefaults.lastDispatchedMetricId = highestId
+            return
+          }
+          // Unlike Android's re-fetch, slicing can re-send rows deleted during this loop, and event
+          // payloads are rebuilt from the session snapshot available on each attempt.
+          metrics = Array(metrics.prefix(max(1, metrics.count / 2)))
+        }
+      }
     }
   }
 
   private static func dispatchLogs(shouldDispatch: Bool) async {
+    guard let endpointUrl = logsEndpointUrl else {
+      return
+    }
     if retryGateBlocks(logsRetryGate, signal: "logs") {
       return
     }
 
     repairLogCursorIfStale()
 
-    let cursor = ObserveUserDefaults.lastDispatchedLogId
-    let pendingLogs: [LogRow]
-    do {
-      pendingLogs = try AppMetrics.getLogs(afterId: cursor)
-    } catch {
-      observeLogger.warn("[EAS Observe] Failed to read pending logs: \(error.localizedDescription)")
-      return
-    }
-    guard !pendingLogs.isEmpty, let endpointUrl = logsEndpointUrl else {
-      observeLogger.debug("[EAS Observe] No new logs to dispatch")
-      return
-    }
-    let highestId = pendingLogs.last?.id ?? cursor
+    var cursor = ObserveUserDefaults.lastDispatchedLogId
     if !shouldDispatch {
-      ObserveUserDefaults.lastDispatchedLogId = highestId
-      return
-    }
-    let events: [Event]
-    do {
-      events = try buildEvents(forLogs: pendingLogs)
-    } catch {
-      observeLogger.warn("[EAS Observe] Failed to assemble log events: \(error.localizedDescription)")
-      return
-    }
-    let resourceLogs = events.compactMap { event -> OTResourceLogs? in
-      guard !event.logs.isEmpty else {
-        return nil
+      do {
+        if let highestId = try AppMetrics.getMaxLogId() {
+          ObserveUserDefaults.lastDispatchedLogId = highestId
+        }
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to read pending logs: \(error.localizedDescription)")
       }
-      return event.toOTResourceLogs(easClientId)
-    }
-    if resourceLogs.isEmpty {
-      ObserveUserDefaults.lastDispatchedLogId = highestId
       return
     }
-    let body = OTLogsRequestBody(resourceLogs: resourceLogs)
-    let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
-    applyRetryOutcome(result, to: &logsRetryGate)
-    ObserveUserDefaults.lastDispatchedLogId = DispatchUtils.nextCursor(
-      for: result,
-      currentCursor: cursor,
-      highestId: highestId
-    )
-    switch result {
-    case .success, .retryableFailure:
-      ObserveUserDefaults.lastDispatchDate = Date.now
-    case .partialSuccess(let partial):
-      ObserveUserDefaults.lastDispatchDate = Date.now
-      observeLogger.warn(
-        "[EAS Observe] Partial success on batch of \(resourceLogs.count) log event(s) past "
-          + "id \(highestId): server rejected \(partial.rejectedCount) "
-          + "(\(partial.errorMessage ?? "no error message"))"
-      )
-    case .nonRetryableFailure(let reason):
-      observeLogger.warn(
-        "[EAS Observe] Dropping batch of \(resourceLogs.count) log event(s) past id "
-          + "\(highestId): \(reason)"
-      )
+
+    dispatchLoop: while !Task.isCancelled {
+      let fetchedLogs: [LogRow]
+      do {
+        fetchedLogs = try AppMetrics.getLogs(afterId: cursor, limit: dispatchChunkSize)
+      } catch {
+        observeLogger.warn("[EAS Observe] Failed to read pending logs: \(error.localizedDescription)")
+        return
+      }
+      guard !fetchedLogs.isEmpty else {
+        observeLogger.debug("[EAS Observe] No new logs to dispatch")
+        return
+      }
+
+      var logs = fetchedLogs
+      while !Task.isCancelled {
+        guard let lastRow = logs.last else {
+          return
+        }
+        // A missing id must never rewind the cursor, so fall back to the current one.
+        let highestId = lastRow.id ?? cursor
+
+        let events: [Event]
+        do {
+          events = try buildEvents(forLogs: logs)
+        } catch {
+          observeLogger.warn("[EAS Observe] Failed to assemble log events: \(error.localizedDescription)")
+          return
+        }
+        let resourceLogs = events.compactMap { event -> OTResourceLogs? in
+          guard !event.logs.isEmpty else {
+            return nil
+          }
+          return event.toOTResourceLogs(easClientId)
+        }
+        guard !resourceLogs.isEmpty else {
+          // Stop when the batch cannot advance the cursor — continuing would refetch and
+          // re-send the same rows forever.
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedLogId = cursor
+          continue dispatchLoop
+        }
+
+        let body = OTLogsRequestBody(resourceLogs: resourceLogs)
+        let result = await DispatchUtils.sendRequest(to: endpointUrl, body: body)
+        applyRetryOutcome(result, to: &logsRetryGate)
+
+        switch result {
+        case .success:
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedLogId = cursor
+          continue dispatchLoop
+        case .partialSuccess(let partial):
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          observeLogger.warn(
+            "[EAS Observe] Partial success on batch of \(logs.count) log row(s) past "
+              + "id \(highestId): server rejected \(partial.rejectedCount) "
+              + "(\(partial.errorMessage ?? "no error message"))"
+          )
+          guard highestId > cursor else {
+            return
+          }
+          cursor = highestId
+          ObserveUserDefaults.lastDispatchedLogId = cursor
+          continue dispatchLoop
+        case .retryableFailure:
+          ObserveUserDefaults.lastDispatchDate = Date.now
+          return
+        case .nonRetryableFailure(let reason):
+          observeLogger.warn(
+            "[EAS Observe] Dropping batch of \(logs.count) log row(s) past id "
+              + "\(highestId): \(reason)"
+          )
+          ObserveUserDefaults.lastDispatchedLogId = highestId
+          return
+        case .payloadTooLarge:
+          guard logs.count > 1 else {
+            observeLogger.warn(
+              "[EAS Observe] Dropping log row id \(highestId) because it exceeds the server payload limit"
+            )
+            ObserveUserDefaults.lastDispatchedLogId = highestId
+            return
+          }
+          // Unlike Android's re-fetch, slicing can re-send rows deleted during this loop, and event
+          // payloads are rebuilt from the session snapshot available on each attempt.
+          logs = Array(logs.prefix(max(1, logs.count / 2)))
+        }
+      }
     }
   }
 

--- a/packages/expo-observe/ios/Tests/DispatchLoopTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchLoopTests.swift
@@ -1,0 +1,223 @@
+import ExpoAppMetrics
+import Testing
+
+@testable import ExpoObserve
+
+@AppMetricsActor
+@Suite("DispatchLoop")
+struct DispatchLoopTests {
+  private struct Row {
+    let id: Int64?
+  }
+
+  private enum TestError: Error {
+    case failed
+  }
+
+  @Test
+  func `single batch advances to its highest id`() async {
+    let state = State(rows: rows(1...3), results: [.success])
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, 2, 3]])
+    #expect(state.persistedCursors == [3])
+  }
+
+  @Test
+  func `drains multiple chunks with the configured fetch limit`() async {
+    let state = State(rows: rows(1...450), results: [.success, .success, .success])
+
+    await drain(state)
+
+    #expect(state.sentIds.map(\.count) == [200, 200, 50])
+    #expect(state.persistedCursors == [200, 400, 450])
+    #expect(state.fetchLimits == [200, 200, 200, 200])
+  }
+
+  @Test
+  func `partial success advances and continues`() async {
+    let partial = OTPartialSuccess(rejectedDataPoints: 1, rejectedLogRecords: nil, errorMessage: nil)
+    let state = State(rows: rows(1...3), results: [.partialSuccess(partial), .success], chunkSize: 2)
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, 2], [3]])
+    #expect(state.persistedCursors == [2, 3])
+  }
+
+  @Test
+  func `retryable failure on second batch keeps that cursor and stops`() async {
+    let state = State(
+      rows: rows(1...5),
+      results: [.success, .retryableFailure(retryAfter: nil)],
+      chunkSize: 2
+    )
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, 2], [3, 4]])
+    #expect(state.persistedCursors == [2])
+  }
+
+  @Test
+  func `non retryable failure drops the batch and stops`() async {
+    let state = State(rows: rows(1...3), results: [.nonRetryableFailure(reason: "bad")], chunkSize: 2)
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, 2]])
+    #expect(state.persistedCursors == [2])
+  }
+
+  @Test
+  func `empty fetch does not send or persist`() async {
+    let state = State(rows: [], results: [])
+
+    await drain(state)
+
+    #expect(state.sentIds.isEmpty)
+    #expect(state.persistedCursors.isEmpty)
+  }
+
+  @Test
+  func `fetch error keeps the cursor`() async {
+    let state = State(rows: rows(1...2), results: [.success])
+    state.fetchError = .failed
+
+    await drain(state)
+
+    #expect(state.sentIds.isEmpty)
+    #expect(state.persistedCursors.isEmpty)
+  }
+
+  @Test
+  func `send error keeps the cursor and skips onResult`() async {
+    let state = State(rows: rows(1...2), results: [.success])
+    state.sendError = .failed
+
+    await drain(state)
+
+    #expect(state.persistedCursors.isEmpty)
+    #expect(state.observedResults.isEmpty)
+  }
+
+  @Test
+  func `nil send advances and continues without onResult`() async {
+    let state = State(rows: rows(1...3), results: [nil, .success], chunkSize: 2)
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, 2], [3]])
+    #expect(state.persistedCursors == [2, 3])
+    #expect(state.observedResults.map(\.result) == [.success])
+  }
+
+  @Test
+  func `payload too large halves the batch then resumes full chunks`() async {
+    let state = State(
+      rows: rows(1...250),
+      results: [.payloadTooLarge, .success, .success],
+      chunkSize: 200
+    )
+
+    await drain(state)
+
+    #expect(state.sentIds.map(\.count) == [200, 100, 150])
+    #expect(state.persistedCursors == [100, 250])
+    #expect(state.fetchLimits == [200, 200, 200])
+  }
+
+  @Test
+  func `retryable after halving keeps the original cursor`() async {
+    let state = State(
+      rows: rows(1...200),
+      results: [.payloadTooLarge, .retryableFailure(retryAfter: nil)]
+    )
+
+    await drain(state)
+
+    #expect(state.sentIds.map(\.count) == [200, 100])
+    #expect(state.persistedCursors.isEmpty)
+  }
+
+  @Test
+  func `repeated payload too large drops exactly one row`() async {
+    let state = State(rows: rows(1...200), results: Array(repeating: .payloadTooLarge, count: 9))
+
+    await drain(state)
+
+    #expect(state.sentIds.map(\.count) == [200, 100, 50, 25, 12, 6, 3, 1])
+    #expect(state.persistedCursors == [1])
+    #expect(state.observedResults.last?.batchCount == 1)
+  }
+
+  @Test
+  func `nil last row id stops without moving the cursor`() async {
+    let state = State(rows: [Row(id: 1), Row(id: nil)], results: [.success])
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1, nil]])
+    #expect(state.persistedCursors.isEmpty)
+  }
+
+  @Test
+  func `single row payload too large drops and stops`() async {
+    let state = State(rows: rows(1...2), results: [.payloadTooLarge], chunkSize: 1)
+
+    await drain(state)
+
+    #expect(state.sentIds == [[1]])
+    #expect(state.persistedCursors == [1])
+    #expect(state.fetchLimits == [1])
+  }
+
+  private func drain(_ state: State) async {
+    await DispatchLoop.drain(
+      startCursor: 0,
+      chunkSize: state.chunkSize,
+      fetchBatch: { cursor, limit in
+        state.fetchLimits.append(limit)
+        if let error = state.fetchError {
+          throw error
+        }
+        return Array(state.rows.filter { ($0.id ?? .max) > cursor }.prefix(limit))
+      },
+      rowId: { $0.id },
+      send: { batch in
+        state.sentIds.append(batch.map(\.id))
+        if let error = state.sendError {
+          throw error
+        }
+        return state.results.removeFirst()
+      },
+      onResult: { result, batchCount, highestId in
+        state.observedResults.append((result, batchCount, highestId))
+      },
+      persistCursor: { state.persistedCursors.append($0) }
+    )
+  }
+
+  private func rows(_ ids: ClosedRange<Int>) -> [Row] {
+    return ids.map { Row(id: Int64($0)) }
+  }
+
+  private final class State {
+    let rows: [Row]
+    var results: [DispatchResult?]
+    let chunkSize: Int
+    var fetchError: TestError?
+    var sendError: TestError?
+    var fetchLimits: [Int] = []
+    var sentIds: [[Int64?]] = []
+    var persistedCursors: [Int64] = []
+    var observedResults: [(result: DispatchResult, batchCount: Int, highestId: Int64)] = []
+
+    init(rows: [Row], results: [DispatchResult?], chunkSize: Int = 200) {
+      self.rows = rows
+      self.results = results
+      self.chunkSize = chunkSize
+    }
+  }
+}

--- a/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsNextCursorTests.swift
@@ -42,6 +42,16 @@ struct DispatchUtilsNextCursorTests {
     #expect(next == 10)
   }
 
+  @Test
+  func `payloadTooLarge retains current cursor`() {
+    let next = DispatchUtils.nextCursor(
+      for: .payloadTooLarge,
+      currentCursor: 10,
+      highestId: 20
+    )
+    #expect(next == 10)
+  }
+
   /// `.partialSuccess` advances the cursor like `.success` does: the bytes landed on the
   /// server (a subset was rejected server-side, but the batch as a whole was accepted), so
   /// re-sending the same rows would just trip the same rejection.

--- a/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
+++ b/packages/expo-observe/ios/Tests/DispatchUtilsRetryGateTests.swift
@@ -70,6 +70,22 @@ struct DispatchUtilsRetryGateTests {
     #expect(next.dispatchAfterDate == state.dispatchAfterDate)
   }
 
+  @Test
+  func `payloadTooLarge resets the counter and leaves the gate alone`() {
+    let state = DispatchUtils.RetryGateState(
+      dispatchAfterDate: now.addingTimeInterval(60),
+      consecutiveRetryableFailures: 2
+    )
+    let next = DispatchUtils.nextRetryGateState(
+      result: .payloadTooLarge,
+      currentState: state,
+      now: now,
+      backoff: stubbedBackoff
+    )
+    #expect(next.consecutiveRetryableFailures == 0)
+    #expect(next.dispatchAfterDate == state.dispatchAfterDate)
+  }
+
   /// First retryable failure (from .initial): counter goes to 1, gate is now + backoff(1).
   /// `Retry-After` is `nil`, so we fall through to `computeBackoffDelay` (the stubbed value
   /// of 10 s here).

--- a/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
+++ b/packages/expo-observe/ios/Tests/ObservabilityClassifyResponseTests.swift
@@ -130,6 +130,16 @@ struct ObservabilityClassifyResponseTests {
   // MARK: - Non-retryable 4xx / other 5xx
 
   @Test
+  func `413 returns payloadTooLarge`() {
+    let result = DispatchUtils.classifyResponse(
+      statusCode: 413,
+      retryAfterHeader: nil,
+      partialSuccess: nil
+    )
+    #expect(result == .payloadTooLarge)
+  }
+
+  @Test
   func `400 returns nonRetryable`() {
     let result = DispatchUtils.classifyResponse(
       statusCode: 400,


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/expo/pull/49016 stack

# How

1. Batch events into 200 chunks
2. Retry the dispatch when 413 is received
3. Extract the dispatching logic into `DispatchLoop`

# Test Plan

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
