### PR TITLE
[maps] export missing Circle type from GoogleMaps namespace

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `Circle` type to the `GoogleMaps` namespace. ([#49124](https://github.com/expo/expo/pull/49124) by [@CatLover01](https://github.com/CatLover01))
+
 ### 🐛 Bug fixes
 
 - [Android] Return the `Promise` from `GoogleMaps.View`'s imperative `setCameraPosition` so callers can `await` it and catch the `Animation cancelled` rejection (matches iOS). ([#46421](https://github.com/expo/expo/pull/46421) by [@chownation](https://github.com/chownation))

--- a/packages/expo-maps/src/index.ts
+++ b/packages/expo-maps/src/index.ts
@@ -28,6 +28,8 @@ export namespace GoogleMaps {
   export type MapView = GoogleTypes.GoogleMapsViewType;
 
   export type StreetViewProps = GoogleTypes.GoogleStreetViewProps;
+
+  export type Circle = GoogleTypes.GoogleMapsCircle;
 }
 
 /**


### PR DESCRIPTION
# Why

The `AppleMaps` namespace already exports a `Circle` type, but `GoogleMaps` was missing it, forcing users to import `GoogleMapsCircle` from internal built types. Add the missing `Circle` type to the `GoogleMaps` namespace for parity.


# How

Add `export type Circle = GoogleTypes.GoogleMapsCircle;` to the `GoogleMaps` namespace in `packages/expo-maps/src/index.ts`.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
