### PR TITLE
[android][ios][sqlite] Delete journal, WAL and SHM sidecar files when deleting a database

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -633,6 +633,8 @@ PODS:
     - ExpoModulesCore
   - ExpoSQLite (57.0.1):
     - ExpoModulesCore
+  - ExpoSQLite/Tests (57.0.1):
+    - ExpoModulesCore
   - ExpoStoreReview (57.0.1):
     - ExpoModulesCore
   - ExpoSymbols (57.0.1):
@@ -3425,6 +3427,7 @@ DEPENDENCIES:
   - ExpoSpeech (from `../../../packages/expo-speech/ios`)
   - ExpoSplashScreen (from `../../../packages/expo-splash-screen/ios`)
   - ExpoSQLite (from `../../../packages/expo-sqlite/ios`)
+  - ExpoSQLite/Tests (from `../../../packages/expo-sqlite/ios`)
   - ExpoStoreReview (from `../../../packages/expo-store-review/ios`)
   - ExpoSymbols (from `../../../packages/expo-symbols/ios`)
   - ExpoSystemUI (from `../../../packages/expo-system-ui/ios`)
@@ -4092,7 +4095,7 @@ SPEC CHECKSUMS:
   ExpoSMS: ac35f6c85b72ee5b18a7c6bb06550fbd4a683775
   ExpoSpeech: 0e90904e2af5d6f166d4d2ffbdab535686597938
   ExpoSplashScreen: 247464c0fe484f766892db0d66c3fe54f92a624e
-  ExpoSQLite: 7ea4f5b0ebd0b6f15927c2349db7624a5abf6beb
+  ExpoSQLite: 73ec3c3dd0c5e8c6592c341edf00efa6271c51a8
   ExpoStoreReview: 2a0f6b8e04112aea2f6e3e1cb84109d78f4d041f
   ExpoSymbols: 7c7c7bd3c52f0b6dcbba6e8af4088b0dc1ea7d29
   ExpoSystemUI: ff3142b323ae7b4d11dc0b1dc4acfa30d92be7dc

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android][iOS] Fix `deleteDatabaseAsync` and `deleteDatabaseSync` leaving `-journal`, `-wal` and `-shm` sidecar files behind. ([#49125](https://github.com/expo/expo/pull/49125) by [@sbaiahmed1](https://github.com/sbaiahmed1))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 

--- a/packages/expo-sqlite/android/build.gradle
+++ b/packages/expo-sqlite/android/build.gradle
@@ -95,4 +95,6 @@ dependencies {
     compileOnly 'io.github.ronickg:openssl:3.3.2-1'
   }
   compileOnly 'com.facebook.fbjni:fbjni:0.3.0'
+
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteHelpers.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteHelpers.kt
@@ -3,6 +3,26 @@ package expo.modules.sqlite
 import java.io.File
 import java.io.IOException
 
+/**
+ * Deletes the database file together with its `-journal`, `-wal` and `-shm` sidecar files,
+ * mirroring the behavior of Android's `SQLiteDatabase.deleteDatabase()`.
+ */
+@Throws(DatabaseNotFoundException::class, DeleteDatabaseFileException::class)
+internal fun deleteDatabaseFiles(dbFile: File, databaseName: String) {
+  if (!dbFile.exists()) {
+    throw DatabaseNotFoundException(databaseName)
+  }
+  if (!dbFile.delete()) {
+    throw DeleteDatabaseFileException(databaseName)
+  }
+  for (suffix in listOf("-journal", "-wal", "-shm")) {
+    val sidecarFile = File(dbFile.path + suffix)
+    if (sidecarFile.exists()) {
+      sidecarFile.delete()
+    }
+  }
+}
+
 @Throws(IOException::class)
 internal fun ensureDirExists(dir: File): File {
   if (!dir.isDirectory) {

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -512,13 +512,7 @@ class SQLiteModule : Module() {
     if (databasePath == MEMORY_DB_NAME) {
       return
     }
-    val dbFile = File(ensureDatabasePathExists(databasePath))
-    if (!dbFile.exists()) {
-      throw DatabaseNotFoundException(databasePath)
-    }
-    if (!dbFile.delete()) {
-      throw DeleteDatabaseFileException(databasePath)
-    }
+    deleteDatabaseFiles(File(ensureDatabasePathExists(databasePath)), databasePath)
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)

--- a/packages/expo-sqlite/android/src/test/java/expo/modules/sqlite/SQLiteHelpersTest.kt
+++ b/packages/expo-sqlite/android/src/test/java/expo/modules/sqlite/SQLiteHelpersTest.kt
@@ -1,0 +1,62 @@
+package expo.modules.sqlite
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class SQLiteHelpersTest {
+  @get:Rule
+  val tempFolder = TemporaryFolder()
+
+  private fun createFile(name: String): File = tempFolder.newFile(name).apply { writeText("data") }
+
+  @Test
+  fun `deletes the main database file`() {
+    val dbFile = createFile("test.db")
+
+    deleteDatabaseFiles(dbFile, "test.db")
+
+    assertFalse(dbFile.exists())
+  }
+
+  @Test
+  fun `deletes journal, wal and shm sidecar files along with the database`() {
+    val dbFile = createFile("test.db")
+    val journalFile = createFile("test.db-journal")
+    val walFile = createFile("test.db-wal")
+    val shmFile = createFile("test.db-shm")
+
+    deleteDatabaseFiles(dbFile, "test.db")
+
+    assertFalse(dbFile.exists())
+    assertFalse(journalFile.exists())
+    assertFalse(walFile.exists())
+    assertFalse(shmFile.exists())
+  }
+
+  @Test
+  fun `keeps unrelated files intact`() {
+    val dbFile = createFile("test.db")
+    val otherDbFile = createFile("test2.db")
+    val otherWalFile = createFile("test2.db-wal")
+
+    deleteDatabaseFiles(dbFile, "test.db")
+
+    assertFalse(dbFile.exists())
+    assertTrue(otherDbFile.exists())
+    assertTrue(otherWalFile.exists())
+  }
+
+  @Test
+  fun `throws when the main database file does not exist`() {
+    val dbFile = File(tempFolder.root, "missing.db")
+
+    assertThrows(DatabaseNotFoundException::class.java) {
+      deleteDatabaseFiles(dbFile, "missing.db")
+    }
+  }
+}

--- a/packages/expo-sqlite/ios/DatabaseFileUtils.swift
+++ b/packages/expo-sqlite/ios/DatabaseFileUtils.swift
@@ -1,0 +1,29 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Foundation
+
+internal enum DatabaseFileUtils {
+  /**
+   Deletes the database file at the given path together with its `-journal`, `-wal` and `-shm`
+   sidecar files, mirroring the behavior of Android's `SQLiteDatabase.deleteDatabase()`.
+   */
+  static func deleteDatabaseFiles(atPath path: String) throws {
+    let fileManager = FileManager.default
+    if !fileManager.fileExists(atPath: path) {
+      throw DatabaseNotFoundException(path)
+    }
+
+    do {
+      try fileManager.removeItem(atPath: path)
+    } catch {
+      throw DeleteDatabaseFileException(path)
+    }
+
+    for suffix in ["-journal", "-wal", "-shm"] {
+      let sidecarPath = path + suffix
+      if fileManager.fileExists(atPath: sidecarPath) {
+        try? fileManager.removeItem(atPath: sidecarPath)
+      }
+    }
+  }
+}

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -75,6 +75,7 @@ Pod::Spec.new do |s|
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests'
     test_spec.pod_target_xcconfig = {
+      # The test bundle links the static ExpoModulesCore dependency chain, which contains C++.
       'OTHER_LDFLAGS' => '-lc++'
     }
   end

--- a/packages/expo-sqlite/ios/ExpoSQLite.podspec
+++ b/packages/expo-sqlite/ios/ExpoSQLite.podspec
@@ -70,6 +70,14 @@ Pod::Spec.new do |s|
     'OTHER_SWIFT_FLAGS' => '$(inherited) ' + swift_flags,
   }
   s.source_files = "**/*.{c,h,m,swift}"
+  s.exclude_files = 'Tests'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests'
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '-lc++'
+    }
+  end
 
   vendored_frameworks = []
   if podfile_properties['expo.sqlite.withSQLiteVecExtension'] == 'true'

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -516,16 +516,7 @@ public final class SQLiteModule: Module {
       return
     }
     let path = try ensureDatabasePathExists(path: databasePath).toFilePath()
-
-    if !FileManager.default.fileExists(atPath: path) {
-      throw DatabaseNotFoundException(path)
-    }
-
-    do {
-      try FileManager.default.removeItem(atPath: path)
-    } catch {
-      throw DeleteDatabaseFileException(path)
-    }
+    try DatabaseFileUtils.deleteDatabaseFiles(atPath: path)
   }
 
   private func backupDatabase(destDatabase: NativeDatabase, destDatabaseName: String, sourceDatabase: NativeDatabase, sourceDatabaseName: String) throws {

--- a/packages/expo-sqlite/ios/Tests/DatabaseFileUtilsTests.swift
+++ b/packages/expo-sqlite/ios/Tests/DatabaseFileUtilsTests.swift
@@ -1,18 +1,19 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
-import XCTest
+import Testing
 
 @testable import ExpoSQLite
 
-class DatabaseFileUtilsTests: XCTestCase {
-  private var tempDir: URL!
+@Suite("DatabaseFileUtils")
+final class DatabaseFileUtilsTests {
+  private let tempDir: URL
 
-  override func setUpWithError() throws {
+  init() throws {
     tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
   }
 
-  override func tearDownWithError() throws {
+  deinit {
     try? FileManager.default.removeItem(at: tempDir)
   }
 
@@ -22,15 +23,17 @@ class DatabaseFileUtilsTests: XCTestCase {
     return path
   }
 
-  func testDeletesTheMainDatabaseFile() throws {
+  @Test
+  func `deletes the main database file`() throws {
     let dbPath = createFile("test.db")
 
     try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
 
-    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
+    #expect(!FileManager.default.fileExists(atPath: dbPath))
   }
 
-  func testDeletesJournalWalAndShmSidecarFilesAlongWithTheDatabase() throws {
+  @Test
+  func `deletes journal wal and shm sidecar files along with the database`() throws {
     let dbPath = createFile("test.db")
     let journalPath = createFile("test.db-journal")
     let walPath = createFile("test.db-wal")
@@ -38,29 +41,31 @@ class DatabaseFileUtilsTests: XCTestCase {
 
     try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
 
-    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
-    XCTAssertFalse(FileManager.default.fileExists(atPath: journalPath))
-    XCTAssertFalse(FileManager.default.fileExists(atPath: walPath))
-    XCTAssertFalse(FileManager.default.fileExists(atPath: shmPath))
+    #expect(!FileManager.default.fileExists(atPath: dbPath))
+    #expect(!FileManager.default.fileExists(atPath: journalPath))
+    #expect(!FileManager.default.fileExists(atPath: walPath))
+    #expect(!FileManager.default.fileExists(atPath: shmPath))
   }
 
-  func testKeepsUnrelatedFilesIntact() throws {
+  @Test
+  func `keeps unrelated files intact`() throws {
     let dbPath = createFile("test.db")
     let otherDbPath = createFile("test2.db")
     let otherWalPath = createFile("test2.db-wal")
 
     try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
 
-    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
-    XCTAssertTrue(FileManager.default.fileExists(atPath: otherDbPath))
-    XCTAssertTrue(FileManager.default.fileExists(atPath: otherWalPath))
+    #expect(!FileManager.default.fileExists(atPath: dbPath))
+    #expect(FileManager.default.fileExists(atPath: otherDbPath))
+    #expect(FileManager.default.fileExists(atPath: otherWalPath))
   }
 
-  func testThrowsWhenTheMainDatabaseFileDoesNotExist() {
+  @Test
+  func `throws when the main database file does not exist`() {
     let dbPath = tempDir.appendingPathComponent("missing.db").path
 
-    XCTAssertThrowsError(try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)) { error in
-      XCTAssertTrue(error is DatabaseNotFoundException)
+    #expect(throws: DatabaseNotFoundException.self) {
+      try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
     }
   }
 }

--- a/packages/expo-sqlite/ios/Tests/DatabaseFileUtilsTests.swift
+++ b/packages/expo-sqlite/ios/Tests/DatabaseFileUtilsTests.swift
@@ -1,0 +1,66 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+
+@testable import ExpoSQLite
+
+class DatabaseFileUtilsTests: XCTestCase {
+  private var tempDir: URL!
+
+  override func setUpWithError() throws {
+    tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+  }
+
+  override func tearDownWithError() throws {
+    try? FileManager.default.removeItem(at: tempDir)
+  }
+
+  private func createFile(_ name: String) -> String {
+    let path = tempDir.appendingPathComponent(name).path
+    FileManager.default.createFile(atPath: path, contents: Data("data".utf8))
+    return path
+  }
+
+  func testDeletesTheMainDatabaseFile() throws {
+    let dbPath = createFile("test.db")
+
+    try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
+  }
+
+  func testDeletesJournalWalAndShmSidecarFilesAlongWithTheDatabase() throws {
+    let dbPath = createFile("test.db")
+    let journalPath = createFile("test.db-journal")
+    let walPath = createFile("test.db-wal")
+    let shmPath = createFile("test.db-shm")
+
+    try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: journalPath))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: walPath))
+    XCTAssertFalse(FileManager.default.fileExists(atPath: shmPath))
+  }
+
+  func testKeepsUnrelatedFilesIntact() throws {
+    let dbPath = createFile("test.db")
+    let otherDbPath = createFile("test2.db")
+    let otherWalPath = createFile("test2.db-wal")
+
+    try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)
+
+    XCTAssertFalse(FileManager.default.fileExists(atPath: dbPath))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: otherDbPath))
+    XCTAssertTrue(FileManager.default.fileExists(atPath: otherWalPath))
+  }
+
+  func testThrowsWhenTheMainDatabaseFileDoesNotExist() {
+    let dbPath = tempDir.appendingPathComponent("missing.db").path
+
+    XCTAssertThrowsError(try DatabaseFileUtils.deleteDatabaseFiles(atPath: dbPath)) { error in
+      XCTAssertTrue(error is DatabaseNotFoundException)
+    }
+  }
+}


### PR DESCRIPTION
# Why

Closes #43441.

`deleteDatabaseAsync` / `deleteDatabaseSync` only remove the main database file. When SQLite runs in WAL mode, the `<database>-wal` and `<database>-shm` sidecar files are left on disk (and `-journal` in rollback mode after a crash). Stale sidecars waste storage and can cause stale WAL replay if a new database is later created with the same name.

Android's own [`SQLiteDatabase.deleteDatabase()`](https://developer.android.com/reference/android/database/sqlite/SQLiteDatabase#deleteDatabase(java.io.File)) explicitly removes the `-journal`, `-wal` and `-shm` files, and the issue's minimal repro demonstrates the divergence.

# How

- Extracted the file-deletion logic into shared, unit-testable helpers: `deleteDatabaseFiles()` in `SQLiteHelpers.kt` (Android) and a new `DatabaseFileUtils.swift` (iOS/macOS/tvOS).
- After deleting the main database file, the helpers best-effort delete the `-journal`, `-wal` and `-shm` sidecars, mirroring `SQLiteDatabase.deleteDatabase()` semantics. Error contracts are unchanged: missing main file still throws `DatabaseNotFoundException`, failed main-file deletion still throws `DeleteDatabaseFileException`.
- Added the package's first native unit tests on both platforms, including a new iOS `test_spec` for `ExpoSQLite` (with `-lc++` in `OTHER_LDFLAGS`, required to link the static test bundle).

# Test Plan

- Android: `et native-unit-tests -p android -t local --packages expo-sqlite` — new `SQLiteHelpersTest` written red-first: the sidecar test failed against the original logic and passes with the fix (4/4 green).
- iOS: `et native-unit-tests -p ios --packages expo-sqlite` — new `DatabaseFileUtilsTests`, 4/4 green on the iPhone 17 Pro simulator.
- `et check-packages expo-sqlite` passes (build, typecheck, test, lint, format).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
