### PR TITLE
[secure-store][iOS] apply keychainAccessible when updating an existing item

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed.
+- [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with.
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed.
-- [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with.
+- [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with. ([#49128](https://github.com/expo/expo/pull/49128) by [@JoRo-Code](https://github.com/JoRo-Code) and [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -109,12 +109,7 @@ public final class SecureStoreModule: Module {
         throw MissingPlistKeyException()
       }
 
-      var error: Unmanaged<CFError>? = nil
-      guard let accessOptions = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility, .biometryCurrentSet, &error) else {
-        let errorCode = error.map { CFErrorGetCode($0.takeRetainedValue()) }
-        throw SecAccessControlError(errorCode)
-      }
-      setItemQuery[kSecAttrAccessControl as String] = accessOptions
+      setItemQuery[kSecAttrAccessControl as String] = try accessControlWith(options: options)
     }
 
     let status = SecItemAdd(setItemQuery as CFDictionary, nil)
@@ -137,24 +132,23 @@ public final class SecureStoreModule: Module {
 
     let valueData = Data(value.utf8)
 
-    // An existing item keeps the accessibility it was created with unless the update
-    // names the attribute, so apply `keychainAccessible` when it was explicitly provided.
-    // Only the unauthenticated path applies it here, mirroring `set(value:with:options:)`,
-    // where an authenticated item carries its accessibility inside `kSecAttrAccessControl`.
-    let updateDictionary = if !options.requireAuthentication, options.keychainAccessible != nil {
-      [
-        kSecValueData: valueData,
-        kSecAttrAccessible: attributeWith(options: options)
-      ] as CFDictionary
-    } else {
-      [kSecValueData: valueData] as CFDictionary
+    var updateDictionary: [CFString: Any] = [kSecValueData: valueData]
+
+    // Keychain updates keep the existing access settings by default, so include the
+    // requested accessibility setting when one is provided.
+    if options.keychainAccessible != nil {
+      if options.requireAuthentication {
+        updateDictionary[kSecAttrAccessControl] = try accessControlWith(options: options)
+      } else {
+        updateDictionary[kSecAttrAccessible] = attributeWith(options: options)
+      }
     }
 
     if let authPrompt = options.authenticationPrompt {
       query[kSecUseOperationPrompt as String] = authPrompt
     }
 
-    let status = SecItemUpdate(query as CFDictionary, updateDictionary)
+    let status = SecItemUpdate(query as CFDictionary, updateDictionary as CFDictionary)
 
     if status == errSecSuccess {
       return true
@@ -228,6 +222,20 @@ public final class SecureStoreModule: Module {
     case .whenUnlockedThisDeviceOnly:
       return kSecAttrAccessibleWhenUnlockedThisDeviceOnly
     }
+  }
+
+  private func accessControlWith(options: SecureStoreOptions) throws -> SecAccessControl {
+    var error: Unmanaged<CFError>?
+    guard let accessControl = SecAccessControlCreateWithFlags(
+      kCFAllocatorDefault,
+      attributeWith(options: options),
+      .biometryCurrentSet,
+      &error
+    ) else {
+      let errorCode = error.map { CFErrorGetCode($0.takeRetainedValue()) }
+      throw SecAccessControlError(errorCode)
+    }
+    return accessControl
   }
 
   private func validate(for key: String) -> String? {

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -135,21 +135,26 @@ public final class SecureStoreModule: Module {
   private func update(value: String, with key: String, options: SecureStoreOptions) throws -> Bool {
     var query = query(with: key, options: options, requireAuthentication: options.requireAuthentication)
 
-    var updateDictionary: [String: Any] = [kSecValueData as String: Data(value.utf8)]
+    let valueData = Data(value.utf8)
 
     // An existing item keeps the accessibility it was created with unless the update
-    // names the attribute, so `keychainAccessible` was silently ignored on every write
-    // to a key that already existed. Mirrors `set(value:with:options:)`, where an
-    // authenticated item carries its accessibility in `kSecAttrAccessControl` instead.
-    if !options.requireAuthentication {
-      updateDictionary[kSecAttrAccessible as String] = attributeWith(options: options)
+    // names the attribute, so apply `keychainAccessible` when it was explicitly provided.
+    // Only the unauthenticated path applies it here, mirroring `set(value:with:options:)`,
+    // where an authenticated item carries its accessibility inside `kSecAttrAccessControl`.
+    let updateDictionary = if !options.requireAuthentication, options.keychainAccessible != nil {
+      [
+        kSecValueData: valueData,
+        kSecAttrAccessible: attributeWith(options: options)
+      ] as CFDictionary
+    } else {
+      [kSecValueData: valueData] as CFDictionary
     }
 
     if let authPrompt = options.authenticationPrompt {
       query[kSecUseOperationPrompt as String] = authPrompt
     }
 
-    let status = SecItemUpdate(query as CFDictionary, updateDictionary as CFDictionary)
+    let status = SecItemUpdate(query as CFDictionary, updateDictionary)
 
     if status == errSecSuccess {
       return true
@@ -207,7 +212,7 @@ public final class SecureStoreModule: Module {
   }
 
   private func attributeWith(options: SecureStoreOptions) -> CFString {
-    switch options.keychainAccessible {
+    switch options.keychainAccessible ?? .whenUnlocked {
     case .afterFirstUnlock:
       return kSecAttrAccessibleAfterFirstUnlock
     case .afterFirstUnlockThisDeviceOnly:

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -135,8 +135,15 @@ public final class SecureStoreModule: Module {
   private func update(value: String, with key: String, options: SecureStoreOptions) throws -> Bool {
     var query = query(with: key, options: options, requireAuthentication: options.requireAuthentication)
 
-    let valueData = value.data(using: .utf8)
-    let updateDictionary = [kSecValueData as String: valueData]
+    var updateDictionary: [String: Any] = [kSecValueData as String: Data(value.utf8)]
+
+    // An existing item keeps the accessibility it was created with unless the update
+    // names the attribute, so `keychainAccessible` was silently ignored on every write
+    // to a key that already existed. Mirrors `set(value:with:options:)`, where an
+    // authenticated item carries its accessibility in `kSecAttrAccessControl` instead.
+    if !options.requireAuthentication {
+      updateDictionary[kSecAttrAccessible as String] = attributeWith(options: options)
+    }
 
     if let authPrompt = options.authenticationPrompt {
       query[kSecUseOperationPrompt as String] = authPrompt

--- a/packages/expo-secure-store/ios/SecureStoreOptions.swift
+++ b/packages/expo-secure-store/ios/SecureStoreOptions.swift
@@ -5,7 +5,7 @@ internal struct SecureStoreOptions: Record {
   var authenticationPrompt: String?
 
   @Field
-  var keychainAccessible: SecureStoreAccessible = .whenUnlocked
+  var keychainAccessible: SecureStoreAccessible?
 
   @Field
   var keychainService: String?

--- a/packages/expo-secure-store/src/SecureStore.ts
+++ b/packages/expo-secure-store/src/SecureStore.ts
@@ -99,6 +99,8 @@ export type SecureStoreOptions = {
   authenticationPrompt?: string;
   /**
    * Specifies when the stored entry is accessible, using iOS's `kSecAttrAccessible` property.
+   * When an existing entry is overwritten, passing this option updates the entry's accessibility,
+   * and omitting it keeps the accessibility the entry was stored with.
    * @see Apple's documentation on [keychain item accessibility](https://developer.apple.com/documentation/security/ksecattraccessible/).
    * @default SecureStore.WHEN_UNLOCKED
    * @platform ios


### PR DESCRIPTION
# Why

On iOS, `keychainAccessible` is silently ignored on every write to a key that already exists. The item keeps the accessibility class it was first created with, for the life of the install.

Because the default is `kSecAttrAccessibleWhenUnlocked`, an app that later decides its data must survive a locked screen has no way to get there through the public API. Calling `setItem(key, value, { keychainAccessible: AFTER_FIRST_UNLOCK })` looks like it worked — it returns normally and the value really is updated — but reads behind a locked screen keep failing with `errSecInteractionNotAllowed` ("User interaction is not allowed."). There is no error and no warning to suggest the option did not take.

We hit this in an app that records audio in the background. With `UIBackgroundModes: ["audio"]` the JS thread keeps running while the phone is locked in someone's pocket, so a timer read the keychain, got `errSecInteractionNotAllowed`, and the throw took the app down mid-recording. Setting `keychainAccessible` was the obvious fix and it changed nothing, which took a while to explain.

Closed issue #23924 reports the same `User interaction is not allowed` symptom; I could not find an existing issue for this cause.

# How

`set(value:with:options:)` tries `SecItemAdd` first and puts `kSecAttrAccessible` in that dictionary, so a **new** key gets the requested class. An existing key returns `errSecDuplicateItem` and falls through to `update(value:with:options:)`, whose `SecItemUpdate` attributes dictionary contains `kSecValueData` and nothing else:

```swift
let updateDictionary = [kSecValueData as String: valueData]
```

`query(with:options:requireAuthentication:)` does not name `kSecAttrAccessible` either, so the item is found by service/account, the value is replaced, and the accessibility attribute is left exactly as it was.

This keeps `keychainAccessible` optional in the native options record so omission remains distinguishable from the default. New items still default to `kSecAttrAccessibleWhenUnlocked`; updates include the attribute only when the caller supplied it:

```swift
let updateDictionary = if !options.requireAuthentication, options.keychainAccessible != nil {
  [
    kSecValueData: valueData,
    kSecAttrAccessible: attributeWith(options: options)
  ] as CFDictionary
} else {
  [kSecValueData: valueData] as CFDictionary
}
```

Only the unauthenticated path applies it, mirroring `set`, where an authenticated item carries its accessibility inside `kSecAttrAccessControl` rather than `kSecAttrAccessible`. Updating that in place would mean rebuilding a `SecAccessControl` and has biometric-enrollment implications, so I left it alone — happy to follow up if you would like it covered too.

Behaviour is unchanged for new keys, for reads, and for any call that does not pass `keychainAccessible`: new items still receive the documented `kSecAttrAccessibleWhenUnlocked` default, while existing items retain the accessibility class with which they were stored.

# Test Plan

I want to be straightforward about what is and is not verified here: the diagnosis comes from reading `SecureStoreModule.swift`, and I have not yet run a build of this branch on a device. I am opening it because the cause looks unambiguous in the source and the reproduction is cheap for anyone with the module already set up. Happy to come back with device output before you merge — say the word and I will.

The reproduction, on a physical device (a simulator will not do — it needs a real lock screen):

```js
// create the item the default way, then try to upgrade it in place
await SecureStore.setItemAsync('probe', 'hello');
await SecureStore.setItemAsync('probe', 'hello', {
  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
});
```

Then read `probe` from something that keeps running once the phone is locked — an app with an active audio session and `UIBackgroundModes: ["audio"]` is the easiest, which is how we ran into it:

- **before this change** — `getValueWithKeySync` throws `KeyChainException: User interaction is not allowed.`, because the item is still `kSecAttrAccessibleWhenUnlocked` despite the second write.
- **after this change** — the read returns `hello`.

`deleteItemAsync` followed by a fresh `setItemAsync` with the same option succeeds on both builds, which is the workaround this is meant to make unnecessary, and is also the evidence that the class itself is applied correctly on an add.

Worth a reviewer's eye specifically: whether a plain `setItemAsync(key, value)` on an existing key is genuinely unaffected. It should be — the omitted option remains `nil`, so the update dictionary contains only `kSecValueData` and leaves the existing accessibility unchanged — but that is reasoning, not a measurement.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
