### PR TITLE
[docs] Clarify server-verified biometric sign-in

### DIFF
--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -268,9 +268,11 @@ Once you have a working authentication system in place, you can improve the user
 
 <Collapsible summary="Biometrics">
 
-Biometrics like Face ID and Touch ID can be used to unlock the app or confirm identity after a valid session is established. These are not authentication methods on their own, but act as a local gate that makes re-authentication faster and more secure.
+Biometrics like Face ID and Touch ID can unlock an app or confirm identity after a valid session is established. A biometric prompt alone does not authenticate with your server. It acts as a local gate that protects access to content or credentials on the device.
 
 React Native provides access to biometric APIs through libraries like [`expo-local-authentication`](/versions/latest/sdk/local-authentication) or [`react-native-biometrics`](https://github.com/SelfLender/react-native-biometrics).
+
+An authentication provider can combine the system biometric prompt with a device-bound credential to authenticate with its server and create a new session. For example, [Clerk biometric sign-in](https://clerk.com/docs/expo/guides/development/custom-flows/authentication/biometric-sign-in) enrolls an app installation as a trusted device. After the user approves the biometric prompt, the device signs a one-time challenge while the private key remains on the device. Unlike a passkey, this credential is scoped to the app installation and does not use [WebAuthn](https://www.w3.org/TR/webauthn-2/).
 
 </Collapsible>
 


### PR DESCRIPTION
# Why

The authentication guide currently describes biometric prompts as a local gate. That is accurate for a biometric prompt by itself, but an authentication provider can pair the prompt with a device-bound credential to authenticate with a server and establish a new session.

Clerk recently added this trusted-device flow for Expo, iOS, and Android. Documenting the distinction helps readers understand the difference between local biometric checks, server-verified trusted-device sign-in, and passkeys.

Related documentation:

- https://clerk.com/changelog/2026-08-17-biometric-sign-in-mobile-sdks
- https://clerk.com/docs/expo/guides/development/custom-flows/authentication/biometric-sign-in

# How

- Clarify that a biometric prompt alone does not authenticate with a server.
- Explain how an authentication provider can combine the prompt with a device-bound credential to create a session.
- Use Clerk biometric sign-in as a concrete example.
- Distinguish app-installation-scoped trusted-device credentials from WebAuthn passkeys.

# Test Plan

- Ran `npx -y oxfmt@0.47.0 --check docs/pages/develop/authentication.mdx`.
- Ran `git diff --check`.
- Confirmed the Clerk biometric sign-in and W3C WebAuthn links return HTTP 200.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
