### PR TITLE
[docs] explain publishing while a rollout is in progress

### DIFF
--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -31,15 +31,42 @@ You will be guided through the process of selecting the update to edit and asked
 
 ### Ending
 
-When ending an update-based rollout, you have two options:
+When ending an update-based rollout, you have three options:
 
 - **Roll out fully**: To accomplish this end state, progress the rollout as detailed above and set the percentage to 100.
 - **Revert back to previous state**: To accomplish this, run `eas update:revert-update-rollout` which will guide you through reverting back to the previous state.
+- **Supersede it with a new update**: To accomplish this, publish over the rollout as described in [Publishing while a rollout is in progress](#publishing-while-a-rollout-is-in-progress).
+
+### Publishing while a rollout is in progress
+
+Sometimes you need to ship a change before a rollout finishes. A crash report arrives, or the rollout itself turns out to be the problem.
+
+While a rollout is in progress, EAS Update rejects a new update for the same runtime version. This protects the rollout from ending by accident. Pick the option that matches your intent:
+
+| Your intent                                   | What to do                                |
+| --------------------------------------------- | ----------------------------------------- |
+| You trust the update you are rolling out      | Progress it to 100%                       |
+| You want everyone back on the previous update | Run `eas update:revert-update-rollout`    |
+| You need to ship something else now           | Publish with `--force-end-active-rollout` |
+
+Reverting deletes the rollout update group, so links to that update stop working. Publishing over the rollout leaves it in place. Prefer the flag when you reference update URLs in release notes or incident reports.
+
+<Terminal cmd={['$ eas update:roll-back-to-embedded --force-end-active-rollout']} />
+
+The flag works with `eas update`, `eas update:republish`, `eas update:roll-back-to-embedded`, and `eas update:rollback`.
+
+Without the flag, each command names the rollout in progress and asks you to confirm. In non-interactive mode, the command fails and tells you to pass the flag.
+
+The rollout ends once clients can receive your new update. For an update that uses code signing, this happens when you attach the signature, so the rollout continues until then.
+
+After the rollout ends, your update is the latest, so every user receives it. The update that was rolling out stops being served.
+
+You cannot use `--rollout-percentage` at the same time. Rolling out a new update over one already in progress would make the update being rolled out the control update, so it would reach more users rather than fewer. Finish or revert the rollout in progress first.
 
 ### Additional notes
 
 - Only one update can be rolled out on a branch at one time.
-- When a rollout is in progress, it must be ended using one of the options above before a new update (with the same runtime version) can be published. This prevents accidentally clobbering the rollout.
+- When a rollout is in progress, a new update for the same runtime version needs one of the options above. See [Publishing while a rollout is in progress](#publishing-while-a-rollout-is-in-progress).
 - To see the state of the rollout, use the `eas update:list` or `eas update:view` commands.
 - Reverting a rollout that is created on a branch with an existing update will republish the control update. This ensures that all clients are reverted back to the previous state.
 - A rollout can be started on a branch with no current update, in which case the first update will be rolled out to the specified percentage of users. When reverted, a rollback-to-embedded update will be created, which will revert the clients to their previous state (embedded update).

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -33,15 +33,15 @@ You will be guided through the process of selecting the update to edit and asked
 
 When ending an update-based rollout, you have three options:
 
-- **Roll out fully**: To accomplish this end state, progress the rollout as detailed above and set the percentage to 100.
-- **Revert back to previous state**: To accomplish this, run `eas update:revert-update-rollout` which will guide you through reverting back to the previous state.
-- **Supersede it with a new update**: To accomplish this, publish over the rollout as described in [Publishing while a rollout is in progress](#publishing-while-a-rollout-is-in-progress).
+- **Finish the rollout:** Use `eas update:edit` to increase the rollout percentage to 100.
+- **Revert the rollout:** Use `eas update:revert-update-rollout` to restore the control update.
+- **Replace the rollout:** Publish a new update or roll back to the update embedded in the build. See [Replace an active rollout](#replace-an-active-rollout).
 
-### Publishing while a rollout is in progress
+### Replace an active rollout
 
-If you need to publish a fix or roll back before a rollout finishes, you can replace it with a new update. EAS CLI asks you to confirm before ending a rollout for the same branch, platform, and runtime version.
+You can replace an active rollout if you need to publish a fix or roll back before the rollout finishes. When you publish to the same branch, platform, and runtime version, EAS CLI warns you that the new update will end the rollout and asks you to confirm.
 
-Use `--force-end-active-rollout` to confirm this in advance. The flag is required in non-interactive mode when a rollout is in progress. For example, to publish a fix:
+Add `--force-end-active-rollout` to skip the confirmation prompt. The flag is required in non-interactive mode. For example, use the following command to publish a fix:
 
 <Terminal
   cmd={[
@@ -53,15 +53,15 @@ To roll back to the update embedded in the build instead:
 
 <Terminal cmd={['$ eas update:roll-back-to-embedded --force-end-active-rollout']} />
 
-The flag works with `eas update`, `eas update:republish`, `eas update:roll-back-to-embedded`, and `eas update:rollback`.
+You can use the flag with `eas update`, `eas update:republish`, `eas update:roll-back-to-embedded`, and `eas update:rollback`.
 
-The rollout ends when the replacement is available to clients. For signed updates, EAS CLI must finish signing the replacement first. Until then, the existing rollout continues.
+The active rollout continues until the new update is ready. If you use code signing, EAS CLI signs the new update before ending the rollout.
 
-The replacement becomes available to all users on that branch with the matching platform and runtime version, regardless of whether they received the rollout update. Clients receive it according to their app's update checking and loading behavior. A rollback to embedded directs clients to use the update embedded in their build.
+When the rollout ends, the new update becomes available to all users on the matching branch, platform, and runtime version. Each app downloads and launches it according to the app's update behavior. If you publish a rollback to embedded, each app returns to the update embedded in its build instead.
 
-Replacing a rollout preserves the previous update group and its dashboard links. In contrast, `eas update:revert-update-rollout` deletes the rollout update group and republishes the control update, or creates a rollback to embedded if there is no control update.
+Replacing a rollout keeps the rollout update group and its dashboard links. The `eas update:revert-update-rollout` command works differently: it deletes the rollout update group and restores the control update. If the rollout has no control update, the command publishes a rollback to embedded.
 
-You cannot start another rollout for the same branch, platform, and runtime version while one is in progress, even with `--force-end-active-rollout`. To publish with `--rollout-percentage`, first finish the existing rollout with `eas update:edit` or revert it with `eas update:revert-update-rollout`.
+You cannot replace an active rollout with another rollout. To publish a new update with `--rollout-percentage`, first finish the active rollout with `eas update:edit` or revert it with `eas update:revert-update-rollout`.
 
 ### Additional notes
 

--- a/docs/pages/eas-update/rollouts.mdx
+++ b/docs/pages/eas-update/rollouts.mdx
@@ -39,34 +39,33 @@ When ending an update-based rollout, you have three options:
 
 ### Publishing while a rollout is in progress
 
-Sometimes you need to ship a change before a rollout finishes. A crash report arrives, or the rollout itself turns out to be the problem.
+If you need to publish a fix or roll back before a rollout finishes, you can replace it with a new update. EAS CLI asks you to confirm before ending a rollout for the same branch, platform, and runtime version.
 
-While a rollout is in progress, EAS Update rejects a new update for the same runtime version. This protects the rollout from ending by accident. Pick the option that matches your intent:
+Use `--force-end-active-rollout` to confirm this in advance. The flag is required in non-interactive mode when a rollout is in progress. For example, to publish a fix:
 
-| Your intent                                   | What to do                                |
-| --------------------------------------------- | ----------------------------------------- |
-| You trust the update you are rolling out      | Progress it to 100%                       |
-| You want everyone back on the previous update | Run `eas update:revert-update-rollout`    |
-| You need to ship something else now           | Publish with `--force-end-active-rollout` |
+<Terminal
+  cmd={[
+    '$ eas update --branch production --environment production --message "Fix a crash" --force-end-active-rollout',
+  ]}
+/>
 
-Reverting deletes the rollout update group, so links to that update stop working. Publishing over the rollout leaves it in place. Prefer the flag when you reference update URLs in release notes or incident reports.
+To roll back to the update embedded in the build instead:
 
 <Terminal cmd={['$ eas update:roll-back-to-embedded --force-end-active-rollout']} />
 
 The flag works with `eas update`, `eas update:republish`, `eas update:roll-back-to-embedded`, and `eas update:rollback`.
 
-Without the flag, each command names the rollout in progress and asks you to confirm. In non-interactive mode, the command fails and tells you to pass the flag.
+The rollout ends when the replacement is available to clients. For signed updates, EAS CLI must finish signing the replacement first. Until then, the existing rollout continues.
 
-The rollout ends once clients can receive your new update. For an update that uses code signing, this happens when you attach the signature, so the rollout continues until then.
+The replacement becomes available to all users on that branch with the matching platform and runtime version, regardless of whether they received the rollout update. Clients receive it according to their app's update checking and loading behavior. A rollback to embedded directs clients to use the update embedded in their build.
 
-After the rollout ends, your update is the latest, so every user receives it. The update that was rolling out stops being served.
+Replacing a rollout preserves the previous update group and its dashboard links. In contrast, `eas update:revert-update-rollout` deletes the rollout update group and republishes the control update, or creates a rollback to embedded if there is no control update.
 
-You cannot use `--rollout-percentage` at the same time. Rolling out a new update over one already in progress would make the update being rolled out the control update, so it would reach more users rather than fewer. Finish or revert the rollout in progress first.
+You cannot start another rollout for the same branch, platform, and runtime version while one is in progress, even with `--force-end-active-rollout`. To publish with `--rollout-percentage`, first finish the existing rollout with `eas update:edit` or revert it with `eas update:revert-update-rollout`.
 
 ### Additional notes
 
-- Only one update can be rolled out on a branch at one time.
-- When a rollout is in progress, a new update for the same runtime version needs one of the options above. See [Publishing while a rollout is in progress](#publishing-while-a-rollout-is-in-progress).
+- Only one rollout can be in progress for a given branch, platform, and runtime version.
 - To see the state of the rollout, use the `eas update:list` or `eas update:view` commands.
 - Reverting a rollout that is created on a branch with an existing update will republish the control update. This ensures that all clients are reverted back to the previous state.
 - A rollout can be started on a branch with no current update, in which case the first update will be rolled out to the specified percentage of users. When reverted, a rollback-to-embedded update will be created, which will revert the clients to their previous state (embedded update).


### PR DESCRIPTION
## Why

Explain how to publish a fix or roll back while an update rollout is in progress.

ENG-25976

## How

Document `--force-end-active-rollout`, confirmation, code signing, and how replacing a rollout preserves its update history. Add publish and rollback examples.

Keep this draft until https://github.com/expo/eas-cli/pull/4233 is merged and released.

## Test Plan

Docs tests (620 passed), worker tests, lint/type checks, and prose checks passed locally. Checked the instructions against the CLI and server implementation.
