### PR TITLE
[docs] Add agent instructions covering the docs CI checks

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent instructions for docs
+
+These instructions apply to changes inside `docs/`.
+
+## Check what CI checks before pushing
+
+The `docs-pr` workflow (`.github/workflows/docs-pr.yml`) runs these from the `docs/` directory. Run them locally on every docs change:
+
+```sh
+pnpm test                     # docs unit tests
+pnpm test:worker              # Cloudflare worker and route tests
+NODE_ENV=production pnpm lint --max-warnings 0
+pnpm lint-prose               # Vale prose lint (same rules as CI)
+```
+
+All four must pass. CI fails the PR on any Vale error in added lines.
+
+## Vale prose rules to know
+
+- Config: `docs/.vale.ini`; rules: `docs/.vale/writing-styles/expo-docs/`.
+- Headings must be sentence case (`HeadingCase.yml`). Product and proper nouns are allowed only if listed in that file's exceptions. When a heading names a new product, add a `- '.*Product Name.*'` entry to the alphabetized exception list in `HeadingCase.yml` in the same PR.
+
+## Other conventions
+
+- New pages must be registered in `docs/constants/navigation.js` or they will not appear in the sidebar.
+- There is no Prettier config in this repo. Do not run `npx prettier` on docs files — it rewrites quote style across whole files. Match the existing formatting of the file you are editing (single quotes in JS and MDX imports).
+- Follow the structure of an existing sibling page when adding a page (for example, a new page in `pages/agents/` should mirror `pages/agents/codex.mdx`).

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent instructions for docs
 
-These instructions apply to changes inside `docs/`.
+These instructions apply to changes inside `docs/`. Always use `pnpm` as the package manager.
 
 ## Check what CI checks before pushing
 
@@ -11,9 +11,10 @@ pnpm test                     # docs unit tests
 pnpm test:worker              # Cloudflare worker and route tests
 NODE_ENV=production pnpm lint --max-warnings 0
 pnpm lint-prose               # Vale prose lint (same rules as CI)
+pnpm lint                          # Run tests
 ```
 
-All four must pass. CI fails the PR on any Vale error in added lines.
+All five must pass. CI fails the PR on any Vale error in added lines.
 
 ## Vale prose rules to know
 
@@ -23,5 +24,6 @@ All four must pass. CI fails the PR on any Vale error in added lines.
 ## Other conventions
 
 - New pages must be registered in `docs/constants/navigation.js` or they will not appear in the sidebar.
-- There is no Prettier config in this repo. Do not run `npx prettier` on docs files — it rewrites quote style across whole files. Match the existing formatting of the file you are editing (single quotes in JS and MDX imports).
+- There are Oxlint and Oxfmt rules and conventions. Match the existing formatting of the file you are editing (single quotes in JS and MDX imports).
 - Follow the structure of an existing sibling page when adding a page (for example, a new page in `pages/agents/` should mirror `pages/agents/codex.mdx`).
+- When snapshots test files are affected, run `pnpm test -u` to update the snapshot tests.

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -63,6 +63,8 @@ export default defineConfig([
     'pages/versions/latest',
     'types/global.d.ts',
     'README.md',
+    'AGENTS.md',
+    'CLAUDE.md',
     'next-env.d.ts',
   ]),
   universeWebConfig,


### PR DESCRIPTION
# Why

AI agents working in `docs/` keep discovering the CI requirements by failing them (example: expo/expo#49135 failed Vale's `HeadingCase` rule on a new product name). The repo had no agent context files, so agents have no way to know what `docs-pr` checks before pushing.

# How

Adds `docs/AGENTS.md` following the convention documented on https://docs.expo.dev/agents/ (AGENTS.md as the source of truth, `docs/CLAUDE.md` containing `@AGENTS.md` for Claude Code). It covers:

- The four checks `docs-pr` runs (`pnpm test`, `pnpm test:worker`, `NODE_ENV=production pnpm lint --max-warnings 0`, `pnpm lint-prose`), with the instruction to run them locally before pushing.
- The Vale `HeadingCase` proper-noun rule, and that new product names need an exception entry in the same PR.
- Registering new pages in `docs/constants/navigation.js`.
- Not running Prettier here (no config in the repo; it rewrites quote style across whole files) — match existing file formatting instead.
- Mirroring an existing sibling page when adding a page.

Split out of #49135 so it can be reviewed independently; it is not stacked on that branch.

# Test Plan

- `pnpm lint-prose` passes with the new files present.
- Files are documentation only; no build or runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)