### PR TITLE
[web-browser] Fix Android `toolbarColor` being applied as the secondary color

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed `toolbarColor` being applied as the secondary toolbar color, and being discarded entirely when `secondaryToolbarColor` was also set. ([#48900](https://github.com/expo/expo/issues/48900) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-21

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserModule.kt
@@ -104,18 +104,14 @@ class WebBrowserModule : Module() {
   private fun createCustomTabsIntent(options: OpenBrowserOptions): CustomTabsIntent {
     val builder = CustomTabsIntent.Builder()
 
-    val color = options.toolbarColor
-    if (color != null) {
+    val toolbarColor = options.toolbarColor
+    val secondaryToolbarColor = options.secondaryToolbarColor
+    if (toolbarColor != null || secondaryToolbarColor != null) {
       val params = CustomTabColorSchemeParams.Builder()
-        .setSecondaryToolbarColor(color)
-        .build()
-      builder.setDefaultColorSchemeParams(params)
-    }
-
-    val secondaryColor = options.secondaryToolbarColor
-    if (secondaryColor != null) {
-      val params = CustomTabColorSchemeParams.Builder()
-        .setSecondaryToolbarColor(secondaryColor)
+        .apply {
+          toolbarColor?.let { setToolbarColor(it) }
+          secondaryToolbarColor?.let { setSecondaryToolbarColor(it) }
+        }
         .build()
       builder.setDefaultColorSchemeParams(params)
     }

--- a/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
+++ b/packages/expo-web-browser/android/src/test/java/expo/modules/webbrowser/WebBrowserModuleTest.kt
@@ -141,6 +141,33 @@ internal class WebBrowserModuleTest {
   }
 
   @Test
+  fun testToolbarColorsCorrectlyPassedToIntent() = withWebBrowserMock {
+    // given
+    val toolbarColor = 0xFF361030.toInt()
+    val secondaryToolbarColor = 0xFF1B5E20.toInt()
+    val intentSlot = slot<CustomTabsIntent>()
+    val mock = mockkCustomTabsActivitiesHelper(defaultCanResolveIntent = true, startIntentSlot = intentSlot)
+    initialize(moduleSpy, customTabsActivitiesHelper = mock)
+
+    // when
+    module.openBrowserAsync(
+      "http://expo.io",
+      OpenBrowserOptions(
+        toolbarColor = toolbarColor,
+        secondaryToolbarColor = secondaryToolbarColor
+      )
+    )
+
+    // then
+    val colorSchemeParams = CustomTabsIntent.getColorSchemeParams(
+      intentSlot.captured.intent,
+      CustomTabsIntent.COLOR_SCHEME_LIGHT
+    )
+    assertEquals(toolbarColor, colorSchemeParams.toolbarColor)
+    assertEquals(secondaryToolbarColor, colorSchemeParams.secondaryToolbarColor)
+  }
+
+  @Test
   fun testActivitiesAndServicesReturnedForValidKeys() = withWebBrowserMock {
     // given
     val services = arrayListOf("service1", "service2")


### PR DESCRIPTION
# Why

Fixes #48900

`WebBrowser.openBrowserAsync(url, { toolbarColor })` has no visible effect on the Custom Tabs toolbar on Android. In `createCustomTabsIntent`, `toolbarColor` is passed to `setSecondaryToolbarColor`, so the primary toolbar color never reaches the intent.

There is a second problem on top of that. When `secondaryToolbarColor` is also provided, the following block builds a fresh `CustomTabColorSchemeParams` and calls `setDefaultColorSchemeParams` again, which replaces the params object built from `toolbarColor`. So the primary color is not merely placed in the wrong slot — it is dropped entirely whenever both options are set.

# How

Build a single `CustomTabColorSchemeParams` and assign each option to its matching slot:

- `toolbarColor` → `setToolbarColor`
- `secondaryToolbarColor` → `setSecondaryToolbarColor`

`setDefaultColorSchemeParams` is now called once, so the two colors no longer overwrite one another. Passing only one of them behaves as before, and passing neither leaves the intent untouched.

# Test Plan

- Added `testToolbarColorsCorrectlyPassedToIntent` to `WebBrowserModuleTest.kt`. It opens a browser with both colors set and reads them back through `CustomTabsIntent.getColorSchemeParams(intent, COLOR_SCHEME_LIGHT)`, asserting each color lands in its own slot.
- The existing `testArgumentsCorrectlyPassedToIntent` already passes `toolbarColor = 0`, but only asserts on the browser package, which is why this went unnoticed.
- I have not run the Android unit tests locally, so the new test has not been executed on my side — I would appreciate CI confirming it, and I am happy to adjust the assertions if they need anything.

# Checklist

- [x] Documentation is up to date to reflect these changes — no documentation change needed; this restores the already-documented behavior of `toolbarColor`.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)