### PR TITLE
[patch-project] Apply CNG patches relative to the project directory

### DIFF
--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Use development mode when loading Expo config and `.env` files. ([#48882](https://github.com/expo/expo/pull/48882) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Skip applying a CNG patch that is already applied to the native project, e.g. when running `npx expo prebuild --no-clean` more than once. ([#47605](https://github.com/expo/expo/issues/47605) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
-- Apply CNG patches relative to the project directory, so that patches are no longer silently skipped when the project lives in a monorepo subdirectory. ([#47574](https://github.com/expo/expo/issues/47574) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
+- Apply CNG patches relative to the project directory, so that patches are no longer silently skipped when the project lives in a monorepo subdirectory. ([#49138](https://github.com/expo/expo/pull/49138) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
 
 ### 💡 Others
 

--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Use development mode when loading Expo config and `.env` files. ([#48882](https://github.com/expo/expo/pull/48882) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Skip applying a CNG patch that is already applied to the native project, e.g. when running `npx expo prebuild --no-clean` more than once. ([#47605](https://github.com/expo/expo/issues/47605) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
-- Apply CNG patches relative to the project directory, so that patches are no longer silently skipped when the project lives in a monorepo subdirectory. ([#49138](https://github.com/expo/expo/pull/49138) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
+- Apply CNG patches relative to the project directory, so that patches are no longer silently skipped when the project lives in a monorepo subdirectory. A patch that was hand-edited to add the project directory to its paths must be regenerated. ([#49138](https://github.com/expo/expo/pull/49138) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
 
 ### 💡 Others
 

--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Use development mode when loading Expo config and `.env` files. ([#48882](https://github.com/expo/expo/pull/48882) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Skip applying a CNG patch that is already applied to the native project, e.g. when running `npx expo prebuild --no-clean` more than once. ([#47605](https://github.com/expo/expo/issues/47605) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
+- Apply CNG patches relative to the project directory, so that patches are no longer silently skipped when the project lives in a monorepo subdirectory. ([#47574](https://github.com/expo/expo/issues/47574) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
 
 ### 💡 Others
 

--- a/packages/patch-project/src/__tests__/gitPatch-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatch-test.ts
@@ -21,22 +21,85 @@ describe(applyPatchAsync, () => {
     mockedSpawnAsync.mockRejectedValue(new Error('git apply failed'));
     await expect(() => applyPatchAsync('/app', '/app/cng-patches/ios+.patch')).rejects.toThrow();
   });
+
+  it('should not scope the patch when the project is the repository root', async () => {
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
+    mockedSpawnAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
+    await applyPatchAsync('/app', '/app/cng-patches/ios+.patch');
+
+    expect(mockedSpawnAsync).toHaveBeenLastCalledWith(
+      'git',
+      ['apply', '--ignore-whitespace', '/app/cng-patches/ios+.patch'],
+      { cwd: '/app' }
+    );
+  });
+
+  it('should scope the patch to the project directory inside a monorepo', async () => {
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
+    mockedSpawnAsync.mockResolvedValue({ stdout: 'apps/mobile/', stderr: '' });
+
+    await applyPatchAsync('/repo/apps/mobile', '/repo/apps/mobile/cng-patches/ios+.patch');
+
+    expect(mockedSpawnAsync).toHaveBeenLastCalledWith(
+      'git',
+      [
+        'apply',
+        '--ignore-whitespace',
+        '--directory=apps/mobile/',
+        '/repo/apps/mobile/cng-patches/ios+.patch',
+      ],
+      { cwd: '/repo/apps/mobile' }
+    );
+  });
 });
 
 describe(isPatchAppliedAsync, () => {
   it('should return true when the patch reverse-applies cleanly', async () => {
-    // @ts-expect-error
-    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` then `git apply --reverse --check`
+    mockedSpawnAsync.mockResolvedValue({ stdout: '', stderr: '' });
+
     await expect(isPatchAppliedAsync('/app', '/app/cng-patches/ios+.patch')).resolves.toBe(true);
-    expect(mockedSpawnAsync).toHaveBeenCalledWith(
+
+    expect(mockedSpawnAsync).toHaveBeenLastCalledWith(
       'git',
       ['apply', '--reverse', '--check', '--ignore-whitespace', '/app/cng-patches/ios+.patch'],
       { cwd: '/app' }
     );
   });
 
+  it('should check the patch against the project directory inside a monorepo', async () => {
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
+    mockedSpawnAsync.mockResolvedValue({ stdout: 'apps/mobile/', stderr: '' });
+
+    await expect(
+      isPatchAppliedAsync('/repo/apps/mobile', '/repo/apps/mobile/cng-patches/ios+.patch')
+    ).resolves.toBe(true);
+
+    expect(mockedSpawnAsync).toHaveBeenLastCalledWith(
+      'git',
+      [
+        'apply',
+        '--reverse',
+        '--check',
+        '--ignore-whitespace',
+        '--directory=apps/mobile/',
+        '/repo/apps/mobile/cng-patches/ios+.patch',
+      ],
+      { cwd: '/repo/apps/mobile' }
+    );
+  });
+
   it('should return false when the patch is not applied', async () => {
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` succeeds, the reverse check does not
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     mockedSpawnAsync.mockRejectedValueOnce(new Error('error: patch does not apply'));
+
     await expect(isPatchAppliedAsync('/app', '/app/cng-patches/ios+.patch')).resolves.toBe(false);
   });
 

--- a/packages/patch-project/src/__tests__/gitPatch-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatch-test.ts
@@ -6,6 +6,10 @@ jest.mock('@expo/spawn-async');
 jest.mock('fs');
 const mockedSpawnAsync = spawnAsync as jest.MockedFunction<typeof spawnAsync>;
 
+beforeEach(() => {
+  mockedSpawnAsync.mockReset();
+});
+
 describe(applyPatchAsync, () => {
   it('should throw if git is not installed', async () => {
     const error = new Error('spawn git ENOENT');
@@ -23,7 +27,6 @@ describe(applyPatchAsync, () => {
   });
 
   it('should not scope the patch when the project is the repository root', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
     mockedSpawnAsync.mockResolvedValue({ stdout: '', stderr: '' });
 
@@ -37,7 +40,6 @@ describe(applyPatchAsync, () => {
   });
 
   it('should scope the patch to the project directory inside a monorepo', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
     mockedSpawnAsync.mockResolvedValue({ stdout: 'apps/mobile/', stderr: '' });
 
@@ -58,7 +60,6 @@ describe(applyPatchAsync, () => {
 
 describe(isPatchAppliedAsync, () => {
   it('should return true when the patch reverse-applies cleanly', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` then `git apply --reverse --check`
     mockedSpawnAsync.mockResolvedValue({ stdout: '', stderr: '' });
 
@@ -72,7 +73,6 @@ describe(isPatchAppliedAsync, () => {
   });
 
   it('should check the patch against the project directory inside a monorepo', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
     mockedSpawnAsync.mockResolvedValue({ stdout: 'apps/mobile/', stderr: '' });
 
@@ -95,7 +95,6 @@ describe(isPatchAppliedAsync, () => {
   });
 
   it('should return false when the patch is not applied', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` succeeds, the reverse check does not
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     mockedSpawnAsync.mockRejectedValueOnce(new Error('error: patch does not apply'));
@@ -119,7 +118,6 @@ describe(getPatchChangedLinesAsync, () => {
     const mockPatchContent = `\
 1\t1\tandroid/app/build.gradle
 1\t3\tandroid/app/src/main/java/com/helloworld/MainApplication.kt`;
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error
@@ -130,7 +128,6 @@ describe(getPatchChangedLinesAsync, () => {
 
   it('should support movement semantic', async () => {
     const mockPatchContent = `0\t0\tbabel.config.js => babel.config.cjs`;
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error
@@ -140,7 +137,6 @@ describe(getPatchChangedLinesAsync, () => {
   });
 
   it('should count changed lines from the project directory inside a monorepo', async () => {
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: 'apps/mobile/', stderr: '' });
     // @ts-expect-error
@@ -169,7 +165,6 @@ describe(getPatchChangedLinesAsync, () => {
 
   it('should support movement semantic with extra changes', async () => {
     const mockPatchContent = `2\t0\tbabel.config.js => babel.config.cjs`;
-    mockedSpawnAsync.mockReset();
     // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error

--- a/packages/patch-project/src/__tests__/gitPatch-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatch-test.ts
@@ -119,25 +119,62 @@ describe(getPatchChangedLinesAsync, () => {
     const mockPatchContent = `\
 1\t1\tandroid/app/build.gradle
 1\t3\tandroid/app/src/main/java/com/helloworld/MainApplication.kt`;
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: mockPatchContent, stderr: '' });
-    const changedLines = await getPatchChangedLinesAsync('/app/test.patch');
+    const changedLines = await getPatchChangedLinesAsync('/app', '/app/test.patch');
     expect(changedLines).toBe(6);
   });
 
   it('should support movement semantic', async () => {
     const mockPatchContent = `0\t0\tbabel.config.js => babel.config.cjs`;
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: mockPatchContent, stderr: '' });
-    const changedLines = await getPatchChangedLinesAsync('/app/test.patch');
+    const changedLines = await getPatchChangedLinesAsync('/app', '/app/test.patch');
     expect(changedLines).toBe(0);
+  });
+
+  it('should count changed lines from the project directory inside a monorepo', async () => {
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports the nested project path
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: 'apps/mobile/', stderr: '' });
+    // @ts-expect-error
+    mockedSpawnAsync.mockResolvedValueOnce({
+      stdout: '1\t0\tapps/mobile/ios/mobile/Info.plist',
+      stderr: '',
+    });
+
+    const changedLines = await getPatchChangedLinesAsync(
+      '/repo/apps/mobile',
+      '/repo/apps/mobile/cng-patches/ios+.patch'
+    );
+
+    expect(changedLines).toBe(1);
+    expect(mockedSpawnAsync).toHaveBeenLastCalledWith(
+      'git',
+      [
+        'apply',
+        '--numstat',
+        '--directory=apps/mobile/',
+        '/repo/apps/mobile/cng-patches/ios+.patch',
+      ],
+      { cwd: '/repo/apps/mobile' }
+    );
   });
 
   it('should support movement semantic with extra changes', async () => {
     const mockPatchContent = `2\t0\tbabel.config.js => babel.config.cjs`;
+    mockedSpawnAsync.mockReset();
+    // @ts-expect-error: `git rev-parse --show-prefix` reports no prefix
+    mockedSpawnAsync.mockResolvedValueOnce({ stdout: '', stderr: '' });
     // @ts-expect-error
     mockedSpawnAsync.mockResolvedValueOnce({ stdout: mockPatchContent, stderr: '' });
-    const changedLines = await getPatchChangedLinesAsync('/app/test.patch');
+    const changedLines = await getPatchChangedLinesAsync('/app', '/app/test.patch');
     expect(changedLines).toBe(2);
   });
 });

--- a/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
@@ -41,7 +41,10 @@ async function initRepositoryAsync(repoRoot: string): Promise<void> {
 }
 
 function readInfoPlistAsync(projectRoot: string): Promise<string> {
-  return fs.readFile(path.join(projectRoot, INFO_PLIST_PATH), 'utf8');
+  return fs
+    .readFile(path.join(projectRoot, INFO_PLIST_PATH), 'utf8')
+    // `git apply` writes CRLF when global `core.autocrlf` is true, the Git for Windows default.
+    .then((contents) => contents.replace(/\r\n/g, '\n'));
 }
 
 describe('gitPatch against real repositories', () => {

--- a/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
@@ -1,0 +1,107 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { applyPatchAsync, getPatchChangedLinesAsync, isPatchAppliedAsync } from '../gitPatch';
+
+// These tests run real `git` against real directories, so that they cover what the argv assertions
+// in `gitPatch-test.ts` cannot: whether a patch actually lands in the native project.
+
+const INFO_PLIST_PATH = path.join('ios', 'Info.plist');
+
+const ORIGINAL_CONTENTS = ['<plist>', '<dict>', '</plist>', ''].join('\n');
+const PATCHED_CONTENTS = ['<plist>', '<key>PatchedKey</key>', '<dict>', '</plist>', ''].join('\n');
+
+// A patch as `patchProjectAsync` generates it: paths are relative to the native project.
+const PATCH_CONTENTS = [
+  'diff --git a/ios/Info.plist b/ios/Info.plist',
+  '--- a/ios/Info.plist',
+  '+++ b/ios/Info.plist',
+  '@@ -1,3 +1,4 @@',
+  ' <plist>',
+  '+<key>PatchedKey</key>',
+  ' <dict>',
+  ' </plist>',
+  '',
+].join('\n');
+
+async function createProjectAsync(projectRoot: string): Promise<string> {
+  await fs.mkdir(path.join(projectRoot, 'ios'), { recursive: true });
+  await fs.writeFile(path.join(projectRoot, INFO_PLIST_PATH), ORIGINAL_CONTENTS, 'utf8');
+
+  const patchFilePath = path.join(projectRoot, 'cng-patches', 'ios+checksum.patch');
+  await fs.mkdir(path.dirname(patchFilePath), { recursive: true });
+  await fs.writeFile(patchFilePath, PATCH_CONTENTS, 'utf8');
+  return patchFilePath;
+}
+
+async function initRepositoryAsync(repoRoot: string): Promise<void> {
+  await spawnAsync('git', ['init'], { cwd: repoRoot });
+}
+
+function readInfoPlistAsync(projectRoot: string): Promise<string> {
+  return fs.readFile(path.join(projectRoot, INFO_PLIST_PATH), 'utf8');
+}
+
+describe('gitPatch against real repositories', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'patch-project-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should apply a patch to a project nested in a monorepo', async () => {
+    const projectRoot = path.join(tmpDir, 'apps', 'mobile');
+    const patchFilePath = await createProjectAsync(projectRoot);
+    // The repository root is the monorepo root, not the project.
+    await initRepositoryAsync(tmpDir);
+
+    await expect(isPatchAppliedAsync(projectRoot, patchFilePath)).resolves.toBe(false);
+    await expect(getPatchChangedLinesAsync(projectRoot, patchFilePath)).resolves.toBe(1);
+
+    await applyPatchAsync(projectRoot, patchFilePath);
+
+    await expect(readInfoPlistAsync(projectRoot)).resolves.toBe(PATCHED_CONTENTS);
+    await expect(isPatchAppliedAsync(projectRoot, patchFilePath)).resolves.toBe(true);
+  });
+
+  it('should apply a patch when the project is the repository root', async () => {
+    const patchFilePath = await createProjectAsync(tmpDir);
+    await initRepositoryAsync(tmpDir);
+
+    await expect(isPatchAppliedAsync(tmpDir, patchFilePath)).resolves.toBe(false);
+    await expect(getPatchChangedLinesAsync(tmpDir, patchFilePath)).resolves.toBe(1);
+
+    await applyPatchAsync(tmpDir, patchFilePath);
+
+    await expect(readInfoPlistAsync(tmpDir)).resolves.toBe(PATCHED_CONTENTS);
+    await expect(isPatchAppliedAsync(tmpDir, patchFilePath)).resolves.toBe(true);
+  });
+
+  it('should apply a patch when the project is not inside a repository', async () => {
+    const patchFilePath = await createProjectAsync(tmpDir);
+
+    await expect(isPatchAppliedAsync(tmpDir, patchFilePath)).resolves.toBe(false);
+    await expect(getPatchChangedLinesAsync(tmpDir, patchFilePath)).resolves.toBe(1);
+
+    await applyPatchAsync(tmpDir, patchFilePath);
+
+    await expect(readInfoPlistAsync(tmpDir)).resolves.toBe(PATCHED_CONTENTS);
+    await expect(isPatchAppliedAsync(tmpDir, patchFilePath)).resolves.toBe(true);
+  });
+
+  it('should leave the project untouched when the patch does not apply', async () => {
+    const projectRoot = path.join(tmpDir, 'apps', 'mobile');
+    const patchFilePath = await createProjectAsync(projectRoot);
+    await initRepositoryAsync(tmpDir);
+    await fs.writeFile(path.join(projectRoot, INFO_PLIST_PATH), '<plist>\n</plist>\n', 'utf8');
+
+    await expect(applyPatchAsync(projectRoot, patchFilePath)).rejects.toThrow();
+    await expect(readInfoPlistAsync(projectRoot)).resolves.toBe('<plist>\n</plist>\n');
+  });
+});

--- a/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
+++ b/packages/patch-project/src/__tests__/gitPatchIntegration-test.ts
@@ -40,11 +40,10 @@ async function initRepositoryAsync(repoRoot: string): Promise<void> {
   await spawnAsync('git', ['init'], { cwd: repoRoot });
 }
 
-function readInfoPlistAsync(projectRoot: string): Promise<string> {
-  return fs
-    .readFile(path.join(projectRoot, INFO_PLIST_PATH), 'utf8')
-    // `git apply` writes CRLF when global `core.autocrlf` is true, the Git for Windows default.
-    .then((contents) => contents.replace(/\r\n/g, '\n'));
+async function readInfoPlistAsync(projectRoot: string): Promise<string> {
+  const contents = await fs.readFile(path.join(projectRoot, INFO_PLIST_PATH), 'utf8');
+  // `git apply` writes CRLF when global `core.autocrlf` is true, the Git for Windows default.
+  return contents.replace(/\r\n/g, '\n');
 }
 
 describe('gitPatch against real repositories', () => {

--- a/packages/patch-project/src/gitPatch.ts
+++ b/packages/patch-project/src/gitPatch.ts
@@ -103,8 +103,14 @@ export async function isPatchAppliedAsync(
   }
 }
 
-export async function getPatchChangedLinesAsync(patchFilePath: string): Promise<number> {
-  const stdout = await runGitAsync(['apply', '--numstat', patchFilePath]);
+export async function getPatchChangedLinesAsync(
+  projectRoot: string,
+  patchFilePath: string
+): Promise<number> {
+  const pathArgs = await getPatchPathArgsAsync(projectRoot);
+  const stdout = await runGitAsync(['apply', '--numstat', ...pathArgs, patchFilePath], {
+    cwd: projectRoot,
+  });
   const lines = stdout.split(/\r?\n/);
   let changedLines = 0;
   for (const line of lines) {

--- a/packages/patch-project/src/gitPatch.ts
+++ b/packages/patch-project/src/gitPatch.ts
@@ -53,7 +53,35 @@ export async function diffAsync(
 }
 
 export async function applyPatchAsync(projectRoot: string, patchFilePath: string) {
-  return await runGitAsync(['apply', '--ignore-whitespace', patchFilePath], { cwd: projectRoot });
+  const pathArgs = await getPatchPathArgsAsync(projectRoot);
+  return await runGitAsync(['apply', '--ignore-whitespace', ...pathArgs, patchFilePath], {
+    cwd: projectRoot,
+  });
+}
+
+/**
+ * Returns the extra `git apply` arguments that make patch paths resolve relative to
+ * `projectRoot`.
+ *
+ * Patches are generated in a standalone repository whose root is the native project, so their
+ * paths are project relative. `git apply` however resolves paths from the root of the enclosing
+ * repository, and ignores paths that fall outside the current directory. In a monorepo where the
+ * project lives in a subdirectory, that combination makes every hunk target the wrong location and
+ * the patch is skipped without an error. `--directory` restores the missing prefix.
+ */
+async function getPatchPathArgsAsync(projectRoot: string): Promise<string[]> {
+  try {
+    // Empty when `projectRoot` is the repository root, `apps/mobile/` when it is nested.
+    const prefix = await runGitAsync(['rev-parse', '--show-prefix'], { cwd: projectRoot });
+    return prefix ? [`--directory=${prefix}`] : [];
+  } catch (e: any) {
+    if (e.code === 'ENOENT') {
+      throw e;
+    }
+    // Not inside a repository at all — `git apply` then resolves paths from the current
+    // directory, which is already `projectRoot`.
+    return [];
+  }
 }
 
 export async function isPatchAppliedAsync(
@@ -61,9 +89,11 @@ export async function isPatchAppliedAsync(
   patchFilePath: string
 ): Promise<boolean> {
   try {
-    await runGitAsync(['apply', '--reverse', '--check', '--ignore-whitespace', patchFilePath], {
-      cwd: projectRoot,
-    });
+    const pathArgs = await getPatchPathArgsAsync(projectRoot);
+    await runGitAsync(
+      ['apply', '--reverse', '--check', '--ignore-whitespace', ...pathArgs, patchFilePath],
+      { cwd: projectRoot }
+    );
     return true;
   } catch (e: any) {
     if (e.code === 'ENOENT') {

--- a/packages/patch-project/src/withPatchPlugin.ts
+++ b/packages/patch-project/src/withPatchPlugin.ts
@@ -54,7 +54,7 @@ const withPatchMod: ConfigPlugin<{ platform: ModPlatform; props: PatchPluginProp
           return config;
         }
 
-        const changedLines = await getPatchChangedLinesAsync(patchFilePath);
+        const changedLines = await getPatchChangedLinesAsync(projectRoot, patchFilePath);
         const changedLinesLimit = props?.changedLinesLimit ?? DEFAULT_CHANGED_LINES_LIMIT;
         if (changedLines > changedLinesLimit) {
           WarningAggregator.addWarningForPlatform(


### PR DESCRIPTION
# Why

Fixes #47574

In a monorepo, a CNG patch is silently ignored: `npx expo prebuild` reports no error, but none of the patched changes reach the generated native project. Editing the patch file to prefix every path with the project directory (`/ios` → `/apps/mobile/ios`) makes it work, as noted in the issue.

The cause is a mismatch between how patches are written and how they are read back:

- Patches are generated in a standalone repository whose root is the native project, so the paths they contain are project relative (`ios/...`).
- `git apply` resolves paths from the root of the *enclosing* repository, and it ignores paths that fall outside the current directory.

When the project is the repository root those two agree. When the project sits in a subdirectory of a monorepo, `ios/...` is looked up at the monorepo root, falls outside the project directory, and is skipped — without a non-zero exit code, which is why the failure is silent.

# How

Pass `--directory` to `git apply`, built from `git rev-parse --show-prefix`, so patch paths resolve against the project directory again. The prefix is empty when the project already is the repository root, so single-project setups keep the exact same arguments as before.

The same prefix is applied to the reverse check in `isPatchAppliedAsync`; without it, the already-applied detection would answer for the wrong paths in a monorepo and could skip a patch that was never applied.

Projects that are not inside a git repository at all keep working too — `git rev-parse` fails there, and `git apply` already resolves paths from the current directory, which is the project root.

# Test Plan

- Added monorepo cases to `src/__tests__/gitPatch-test.ts` for both `applyPatchAsync` and `isPatchAppliedAsync`, asserting that `--directory=apps/mobile/` is passed when `git rev-parse --show-prefix` reports a nested path, and that no `--directory` argument is added when it reports none.
- Adjusted the existing `isPatchAppliedAsync` tests, since the mocked `spawnAsync` now sees the `git rev-parse` call before `git apply`.
- I have not run the package's test suite locally, so I would appreciate CI confirming it — happy to adjust anything that needs it.
- A reproduction for the reported failure is available at https://github.com/Yash-Singh1/patch-project-monorepo-repro. I have not run it against a locally built package, and I am glad to verify it end to end before landing if maintainers prefer.

# Checklist

- [x] Documentation is up to date to reflect these changes — no documentation change needed; this makes patches behave as documented in a monorepo.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eas build)