### PR TITLE
[app-metrics][iOS] Preserve millisecond precision in log event timestamps.

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Preserve millisecond precision in log event timestamps.
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Preserve millisecond precision in log event timestamps.
+- [iOS] Preserve millisecond precision in log event timestamps. ([#49141](https://github.com/expo/expo/pull/49141) by [@Ubax](https://github.com/Ubax))
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))
 - [iOS] Fix a crash on FirebaseAuth's first token refresh. GTMSessionFetcher branches on the class of `session.delegate`, so our network-observing delegate proxy now answers class and protocol checks for the delegate it wraps. ([#48360](https://github.com/expo/expo/pull/48360) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/ios/LogEvents/LogRecord.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/LogRecord.swift
@@ -13,7 +13,7 @@ public struct LogRecord: Codable, Sendable {
   public let droppedAttributesCount: Int
   /// Severity of the event.
   public let severity: Severity
-  public var timestamp: String = Date.now.ISO8601Format()
+  public var timestamp: String = Date.now.ISO8601Format(.init(includingFractionalSeconds: true))
 
   init(
     name: String,
@@ -21,7 +21,7 @@ public struct LogRecord: Codable, Sendable {
     attributes: [String: Any]? = nil,
     droppedAttributesCount: Int = 0,
     severity: Severity = .info,
-    timestamp: String = Date.now.ISO8601Format()
+    timestamp: String = Date.now.ISO8601Format(.init(includingFractionalSeconds: true))
   ) {
     self.name = name
     self.body = body

--- a/packages/expo-app-metrics/ios/Tests/LogRecordTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/LogRecordTests.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("LogRecord")
+struct LogRecordTests {
+  @Test
+  func `default timestamp includes milliseconds`() throws {
+    let timestamp = LogRecord(name: "event").timestamp
+
+    #expect(timestamp.range(of: #"\.\d{3}Z$"#, options: .regularExpression) != nil)
+    _ = try Date.ISO8601FormatStyle().parse(timestamp)
+  }
+}


### PR DESCRIPTION
# Why

Similar to metrics, there is a problem with millisecond precision when converting events' timestamps

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>