### PR TITLE
[ios][secure-store] Reject `deleteItemAsync` when the keychain delete fails

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed.
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-secure-store/ios/SecureStoreModule.swift
+++ b/packages/expo-secure-store/ios/SecureStoreModule.swift
@@ -45,9 +45,17 @@ public final class SecureStoreModule: Module {
       let authSearchDictionary = query(with: key, options: options, requireAuthentication: true)
       let legacySearchDictionary = query(with: key, options: options)
 
-      SecItemDelete(legacySearchDictionary as CFDictionary)
-      SecItemDelete(authSearchDictionary as CFDictionary)
-      SecItemDelete(noAuthSearchDictionary as CFDictionary)
+      // Delete all three aliases before reporting a failure, so that a failing alias
+      // cannot leave the remaining entries behind.
+      let statuses = [
+        SecItemDelete(legacySearchDictionary as CFDictionary),
+        SecItemDelete(authSearchDictionary as CFDictionary),
+        SecItemDelete(noAuthSearchDictionary as CFDictionary)
+      ]
+
+      if let failure = statuses.first(where: { $0 != errSecSuccess && $0 != errSecItemNotFound }) {
+        throw KeyChainException(failure)
+      }
     }
 
     Function("canUseBiometricAuthentication") {() -> Bool in


### PR DESCRIPTION


Verified by /verify for #49126. Run: https://github.com/expo/expo/actions/runs/32291050766

# Why

closes #49126

# How

check the return value and throw if it's not `errSecSuccess` or `errSecItemNotFound`


# Test Plan

this is a verified fix as indicated by screnshots from https://github.com/expo/expo/issues/49126#issuecomment-5347123827

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
