### PR TITLE
[docs] document Observe js error reporting

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -636,6 +636,7 @@ export const eas = [
     makePage('eas/observe/eas-cli.mdx'),
     makePage('eas/observe/eas-update.mdx'),
     makePage('eas/observe/events.mdx'),
+    makePage('eas/observe/errors.mdx'),
     makePage('eas/observe/configuration.mdx'),
     makeGroup('Integrations', [
       makePage('eas/observe/integrations/expo-router.mdx'),

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -27,9 +27,9 @@ Filters control which events are included in the metrics below.
 - **Time range**: 1 hour, 12 hours, 1 day, 3 days, 7 days, 14 days, 21 days, 30 days, or 60 days. Defaults to **Last 14 Days**.
 - **Release**: filter to a specific app version, a specific native build, or a specific OTA update.
 
-## Tabs
+## Pages
 
-The dashboard groups data into five tabs:
+The dashboard groups data into five pages:
 
 - **App startup**: startup performance metrics (cold launch, warm launch, bundle load time, time to first render, time to interactive). See the [Metrics reference](/eas/observe/reference/metrics/) for full descriptions.
 - **EAS Update**: download time for OTA updates and a per-update table. See [EAS Update download performance](/eas/observe/eas-update/) for details.
@@ -46,7 +46,7 @@ Each metric appears as a card with a chart and statistical breakdowns. For every
 - **Min** and **Max**: the fastest and slowest recorded values.
 - **P90** and **P99**: values below which 90% or 99% of events fall, useful for identifying tail latency.
 
-On the App startup tab, switch between a list layout (one chart per row) and a grid layout. Use the **Show builds** and **Show updates** toggles to control whether release markers appear on charts.
+On the App startup page, switch between a list layout (one chart per row) and a grid layout. Use the **Show builds** and **Show updates** toggles to control whether release markers appear on charts.
 
 ## Release markers and comparison
 
@@ -58,7 +58,7 @@ Without a release filter, App startup cards also show the metric for the **lates
 
 ## Investigating sessions
 
-When something looks off, drill into individual sessions from the **Events** tab or from a release marker popover. A session timeline shows:
+When something looks off, drill into individual sessions from the **Events** page or from a release marker popover. A session timeline shows:
 
 - All events recorded during that session (startup, user-defined, and update download events).
 - Device metadata: platform, app version, build number, OS, and timestamps.

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -29,12 +29,13 @@ Filters control which events are included in the metrics below.
 
 ## Tabs
 
-The dashboard groups data into four tabs:
+The dashboard groups data into five tabs:
 
 - **App startup**: startup performance metrics (cold launch, warm launch, bundle load time, time to first render, time to interactive). See the [Metrics reference](/eas/observe/reference/metrics/) for full descriptions.
 - **EAS Update**: download time for OTA updates and a per-update table. See [EAS Update download performance](/eas/observe/eas-update/) for details.
 - **Events** (requires SDK 56 and later): user-defined events logged with [`Observe.logEvent`](/eas/observe/events/), with counts and links to drill into each event.
 - **Navigation** (requires SDK 56 and later): per-route navigation timings with cold vs warm time to first render and time to interactive. Requires [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/).
+- **Errors** (in preview, requires SDK 57 and later): JavaScript errors recorded by the app, with symbolicated stack traces. See [Error reporting](/eas/observe/errors/) for details.
 
 ## Metric cards
 

--- a/docs/pages/eas/observe/eas-update.mdx
+++ b/docs/pages/eas/observe/eas-update.mdx
@@ -9,21 +9,21 @@ import { Terminal } from '~/ui/components/Snippet';
 
 EAS Observe automatically tracks how long each OTA update takes to download on real user devices. You don't need to add any instrumentation: if your app uses [EAS Update](/eas-update/introduction/) and includes [`expo-observe`](/eas/observe/get-started/), EAS Observe collects download metrics for every update fetch.
 
-Update download times appear in the **EAS Update** tab of the EAS Observe dashboard and are queryable from the EAS CLI.
+Update download times appear in the **EAS Update** page of the EAS Observe dashboard and are queryable from the EAS CLI.
 
 ## View update downloads
 
 In the dashboard: open your project and navigate to [**Observe > EAS Update**](https://expo.dev/accounts/[account]/projects/[project]/observe?tab=eas-update). The tab has two sections: an aggregate chart and a per-update table.
 
 <ContentSpotlight
-  alt="The EAS Update tab in the EAS Observe dashboard showing update download time and recent updates."
+  alt="The EAS Update page in the EAS Observe dashboard showing update download time and recent updates."
   src="/static/images/expo-observe/observe-updates-light.webp"
   darkSrc="/static/images/expo-observe/observe-updates-dark.webp"
 />
 
 ### Update download time
 
-A single chart showing aggregate download time across all updates fetched in the selected time range. Statistical breakdowns mirror the App startup tab: **Median**, **Avg**, **Min**, **Max**, **P90**, and **P99**. Use these to spot regressions in update size or CDN latency.
+A single chart showing aggregate download time across all updates fetched in the selected time range. Statistical breakdowns mirror the App startup page: **Median**, **Avg**, **Min**, **Max**, **P90**, and **P99**. Use these to spot regressions in update size or CDN latency.
 
 Update markers on the chart indicate when each update first downloaded. Click a marker to see the update ID, version, and metrics at that point.
 

--- a/docs/pages/eas/observe/eas-update.mdx
+++ b/docs/pages/eas/observe/eas-update.mdx
@@ -13,7 +13,7 @@ Update download times appear in the **EAS Update** page of the EAS Observe dashb
 
 ## View update downloads
 
-In the dashboard: open your project and navigate to [**Observe > EAS Update**](https://expo.dev/accounts/[account]/projects/[project]/observe?tab=eas-update). The tab has two sections: an aggregate chart and a per-update table.
+In the dashboard: open your project and navigate to [**Observe > EAS Update**](https://expo.dev/accounts/[account]/projects/[project]/observe?tab=eas-update). The page has two sections: an aggregate chart and a per-update table.
 
 <ContentSpotlight
   alt="The EAS Update page in the EAS Observe dashboard showing update download time and recent updates."

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -83,9 +83,29 @@ Avoid Personally Identifiable Information (PII) in error messages. Everything yo
 
 ## Symbolicated stack traces
 
-Stack traces from production apps point at locations in the generated JavaScript bundle. To make them readable, EAS Build uploads your app's source map when the build is created. The dashboard uses the stored source map to show the original file, line, and column for each frame, and links the build the error came from next to the stack trace.
+In a production app, your JavaScript is bundled and minified. Stack traces point at line and column positions in the generated bundle, not in your source files. A source map translates those positions back. When a source map is stored for a build, the dashboard shows the original file, line, and column for each frame, and links the build the error came from next to the stack trace.
 
-Symbolication is applied when you view an error in the dashboard. If no source map is stored for the build, the dashboard shows the reported stack trace as-is.
+If no source map is stored for the build, the dashboard shows the reported stack trace as-is. Frames then reference positions in the minified bundle, such as `index.android.bundle:1:481231`, and are difficult to map back to your code.
+
+### Upload source maps with EAS Build
+
+To store a source map for each build, set `uploadSourceMaps` to `true` in the build profile in **eas.json**:
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "uploadSourceMaps": true
+    }
+  }
+}
+```
+
+With this setting, EAS Build uploads the source map produced when your app's JavaScript is bundled. Symbolication then works for every error reported from that build. No changes to your app code are required.
+
+> **Note**: Source map upload requires EAS CLI version 22.0.0 or later and only works for builds that run on EAS Build servers. Local builds created with `eas build --local` do not upload source maps.
+
+The source code embedded in the source map (`sourcesContent`) is removed before upload. Only file names and position mappings are stored. If the upload fails, the build still completes and shows a warning in the build logs.
 
 ## View errors
 

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -6,7 +6,7 @@ description: Record JavaScript errors from your app and investigate symbolicated
 
 > **important** Error reporting in EAS Observe is in [preview](/more/release-statuses/#preview) and requires SDK 57 or later. Source maps for EAS Update, iOS symbolication, and more are still to come.
 
-The `expo-observe` library records JavaScript errors from your app alongside its performance metrics. Errors are persisted on-device, batched, and dispatched on the next flush. They appear in the **Errors** tab of the EAS Observe dashboard.
+The `expo-observe` library records JavaScript errors from your app alongside its performance metrics. Errors are persisted on-device, batched, and dispatched on the next flush. They appear in the **Errors** page of the EAS Observe dashboard.
 
 Errors are captured through three paths: unhandled errors are recorded automatically, render errors are caught by `ObserveErrorBoundary`, and handled errors can be reported with `Observe.reportError`.
 
@@ -91,7 +91,7 @@ Symbolication is applied when you view an error in the dashboard. If no source m
 
 ## View errors
 
-Open your project and navigate to [**Observe > Errors**](https://expo.dev/accounts/[account]/projects/[project]/observe/errors). The tab lists the errors recorded in the selected time range. Click an error to see its stack trace and details.
+Open your project and navigate to [**Observe > Errors**](https://expo.dev/accounts/[account]/projects/[project]/observe/errors). The page lists the errors recorded in the selected time range. Click an error to see its stack trace and details.
 
 ## Still to come
 

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -28,7 +28,7 @@ This only affects unhandled errors. Errors caught by `ObserveErrorBoundary` or r
 
 ## Render errors
 
-Errors thrown while rendering never reach the global error handler. Wrap a subtree with `ObserveErrorBoundary` to record them together with the React component stack and show a fallback UI in place of the subtree that threw:
+Without an error boundary, an error thrown while rendering is recorded by the global error handler as an unhandled error. Wrap a subtree with `ObserveErrorBoundary` to record it together with the React component stack and show a fallback UI in place of the subtree that threw:
 
 ```tsx
 import { ObserveErrorBoundary } from 'expo-observe';

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -1,0 +1,104 @@
+---
+title: Error reporting
+sidebar_title: Errors
+description: Record JavaScript errors from your app and investigate symbolicated stack traces in the EAS Observe dashboard.
+---
+
+> **important** Error reporting in EAS Observe is in [preview](/more/release-statuses/#preview) and requires SDK 57 or later. Source maps for EAS Update, iOS symbolication, and more are still to come.
+
+The `expo-observe` library records JavaScript errors from your app alongside its performance metrics. Errors are persisted on-device, batched, and dispatched on the next flush. They appear in the **Errors** tab of the EAS Observe dashboard.
+
+Errors are captured through three paths: unhandled errors are recorded automatically, render errors are caught by `ObserveErrorBoundary`, and handled errors can be reported with `Observe.reportError`.
+
+## Unhandled errors
+
+Unhandled JavaScript errors are recorded automatically. The library installs a global error handler when it is first imported, so no setup is required. React Native's own behavior is unchanged: the red box still appears in development, and fatal errors still terminate the app in production.
+
+To turn off automatic recording, set `errorHandlingEnabled` to `false` via [`configure()`](/versions/latest/sdk/observe/#configureconfig):
+
+```tsx
+import { Observe } from 'expo-observe';
+
+Observe.configure({
+  errorHandlingEnabled: false,
+});
+```
+
+This only affects unhandled errors. Errors caught by `ObserveErrorBoundary` or reported with `Observe.reportError` are still recorded.
+
+## Render errors
+
+Errors thrown while rendering never reach the global error handler. Wrap a subtree with `ObserveErrorBoundary` to record them together with the React component stack and show a fallback UI in place of the subtree that threw:
+
+```tsx
+import { ObserveErrorBoundary } from 'expo-observe';
+
+export default function FeedScreen() {
+  return (
+    <ObserveErrorBoundary
+      fallback={({ error, resetError }) => (
+        <ErrorScreen error={error} onRetry={resetError} />
+      )}>
+      <Feed />
+    </ObserveErrorBoundary>
+  );
+}
+```
+
+The `fallback` prop accepts a React element, `null`, or a function that receives the thrown `error` and a `resetError` callback. Calling `resetError()` clears the caught error and re-mounts the children, so they restart from a clean state.
+
+To place a boundary around your whole app, pass `errorBoundaryFallback` to the `ObserveRoot` component instead of wrapping it manually:
+
+```tsx src/app/_layout.tsx
+import { ObserveRoot } from 'expo-observe';
+
+export default function RootLayout() {
+  return (
+    <ObserveRoot errorBoundaryFallback={<FallbackScreen />}>
+      <Stack />
+    </ObserveRoot>
+  );
+}
+```
+
+Render errors that no boundary catches are still recorded by the global error handler.
+
+## Handled errors
+
+Errors your code catches and recovers from reach neither the global handler nor an error boundary. Report them with `Observe.reportError`:
+
+```tsx
+import { Observe } from 'expo-observe';
+
+async function handleSync() {
+  try {
+    await syncCart();
+  } catch (error) {
+    Observe.reportError(error);
+  }
+}
+```
+
+`reportError` accepts any thrown value. An `Error` contributes its name, message, and stack trace. Any other value (a string, a plain object, a number) is stringified into the message without a stack trace.
+
+Avoid Personally Identifiable Information (PII) in error messages. Everything you report is visible in the dashboard and is dispatched off-device.
+
+## Symbolicated stack traces
+
+Stack traces from production apps point at locations in the generated JavaScript bundle. To make them readable, EAS Build uploads your app's source map when the build is created. The dashboard uses the stored source map to show the original file, line, and column for each frame, and links the build the error came from next to the stack trace.
+
+Symbolication is applied when you view an error in the dashboard. If no source map is stored for the build, the dashboard shows the reported stack trace as-is.
+
+## View errors
+
+Open your project and navigate to [**Observe > Errors**](https://expo.dev/accounts/[account]/projects/[project]/observe/errors). The tab lists the errors recorded in the selected time range. Click an error to see its stack trace and details.
+
+## Still to come
+
+Error reporting is in preview, and the following are not available yet:
+
+- **Source maps for EAS Update**: errors from an app running an OTA update show the unsymbolicated stack trace.
+- **iOS symbolication**
+- Native crash reporting, and more.
+
+For native crash reporting today, use a service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -36,9 +36,7 @@ import { ObserveErrorBoundary } from 'expo-observe';
 export default function FeedScreen() {
   return (
     <ObserveErrorBoundary
-      fallback={({ error, resetError }) => (
-        <ErrorScreen error={error} onRetry={resetError} />
-      )}>
+      fallback={({ error, resetError }) => <ErrorScreen error={error} onRetry={resetError} />}>
       <Feed />
     </ObserveErrorBoundary>
   );

--- a/docs/pages/eas/observe/errors.mdx
+++ b/docs/pages/eas/observe/errors.mdx
@@ -4,7 +4,7 @@ sidebar_title: Errors
 description: Record JavaScript errors from your app and investigate symbolicated stack traces in the EAS Observe dashboard.
 ---
 
-> **important** Error reporting in EAS Observe is in [preview](/more/release-statuses/#preview) and requires SDK 57 or later. Source maps for EAS Update, iOS symbolication, and more are still to come.
+> **important** Error reporting in EAS Observe is in [preview](/more/release-statuses/#preview) and requires SDK 57 or later. Source maps for EAS Update, native crash reporting, and more are still to come.
 
 The `expo-observe` library records JavaScript errors from your app alongside its performance metrics. Errors are persisted on-device, batched, and dispatched on the next flush. They appear in the **Errors** page of the EAS Observe dashboard.
 
@@ -98,7 +98,6 @@ Open your project and navigate to [**Observe > Errors**](https://expo.dev/accoun
 Error reporting is in preview, and the following are not available yet:
 
 - **Source maps for EAS Update**: errors from an app running an OTA update show the unsymbolicated stack trace.
-- **iOS symbolication**
-- Native crash reporting, and more.
+- **Native crash reporting**, including iOS symbolication, and more.
 
 For native crash reporting today, use a service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 User-defined events let you record arbitrary, named events from your app. Use them to track any signal specific to your app that the built-in performance metrics do not cover.
 
-Events are persisted on-device, batched, and dispatched on the next flush as OpenTelemetry log records. They appear in the **Events** tab of the EAS Observe dashboard and are queryable from the EAS CLI.
+Events are persisted on-device, batched, and dispatched on the next flush as OpenTelemetry log records. They appear in the **Events** page of the EAS Observe dashboard and are queryable from the EAS CLI.
 
 ## Log an event
 
@@ -96,7 +96,7 @@ Observe.logEvent('onboarding.completed', {
 In the dashboard: open your project and navigate to [**Observe > Events**](https://expo.dev/accounts/[account]/projects/[project]/observe/events). The default view lists distinct event names with their counts in the selected time range. Click an event name to see individual events with their timestamps, attributes, and the session they belong to.
 
 <ContentSpotlight
-  alt="The Events tab in the EAS Observe dashboard listing distinct event names and their counts."
+  alt="The Events page in the EAS Observe dashboard listing distinct event names and their counts."
   src="/static/images/expo-observe/observe-events-light.webp"
   darkSrc="/static/images/expo-observe/observe-events-dark.webp"
 />

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -137,7 +137,7 @@ Emitted at most once per screen instance within a session.
 
 ## View navigation metrics
 
-In the dashboard, open your project, navigate to [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe), and select the **Navigation** tab. It shows per-route navigation timings with cold and warm time to first render and time to interactive.
+In the dashboard, open your project, navigate to [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe), and select the **Navigation** page. It shows per-route navigation timings with cold and warm time to first render and time to interactive.
 
 In the CLI, you can run the following commands:
 

--- a/docs/pages/eas/observe/integrations/react-navigation.mdx
+++ b/docs/pages/eas/observe/integrations/react-navigation.mdx
@@ -200,7 +200,7 @@ Emitted at most once per screen instance within a session.
 
 ## View navigation metrics
 
-In the dashboard, open your project, navigate to [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe), and select the **Navigation** tab. It shows per-screen navigation timings with cold and warm time to first render and time to interactive.
+In the dashboard, open your project, navigate to [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe), and select the **Navigation** page. It shows per-screen navigation timings with cold and warm time to first render and time to interactive.
 
 In the CLI, you can run the following commands:
 

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -71,6 +71,7 @@ Traditional development-time profiling tools show how your app performs on your 
 - **Per-route navigation metrics**: Compare render and interactive timings by route with the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/) integration
 - **Session investigation**: Drill into individual user sessions to understand why certain devices or conditions lead to slower performance
 - **User-defined events**: Log custom signals from your app with `Observe.logEvent` and analyze them alongside performance data
+- **Error reporting** (in preview): Record JavaScript errors with [`ObserveErrorBoundary` and `Observe.reportError`](/eas/observe/errors/) and investigate symbolicated stack traces in the dashboard
 - **CLI and dashboard access**: Query metrics from the terminal with `eas observe:` commands or view them in the EAS dashboard
 
 ## When to use EAS Observe
@@ -84,12 +85,15 @@ Traditional development-time profiling tools show how your app performs on your 
 | Track EAS Update download times                     | <YesIcon />    |
 | Query performance metrics from the CLI              | <YesIcon />    |
 | Track user-defined events from your app             | <YesIcon />    |
+| Track JavaScript errors in production (in preview)  | <YesIcon />    |
 | Development-time profiling and debugging            | <NoIcon />     |
-| Crash reporting and error tracking                  | <NoIcon />     |
+| Native crash reporting                              | <NoIcon />     |
 
 **Development-time profiling and debugging**: Use [React Native DevTools](/debugging/tools/#debugging-with-react-native-devtools) for debugging and [Expo Atlas](/guides/analyzing-bundles/) for bundle inspection.
 
-**Crash reporting and error tracking**: On SDK 57 and later, the [`expo-observe`](/versions/latest/sdk/observe/) library can record JavaScript errors with `ObserveErrorBoundary` and `reportError`. However, the EAS Observe dashboard and the EAS CLI do not display these errors yet. Until they do, we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
+**JavaScript errors**: On SDK 57 and later, EAS Observe records JavaScript errors and shows them in the dashboard with symbolicated stack traces. This feature is in [preview](/more/release-statuses/#preview). See [Error reporting](/eas/observe/errors/) for setup and current limitations.
+
+**Native crash reporting**: EAS Observe does not capture native crashes yet. Until it does, we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
 
 ## Frequently asked questions (FAQ)
 
@@ -97,7 +101,7 @@ Traditional development-time profiling tools show how your app performs on your 
 
 <Collapsible summary="What metrics does EAS Observe track?">
 
-EAS Observe tracks startup metrics (cold launch time, warm launch time, time to first render, time to interactive, and bundle load time) and [EAS Update download time](/eas/observe/eas-update/). On SDK 56 and later, the [navigation integrations](/eas/observe/integrations/expo-router/) add per-route render and interactive timings. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric. You can also log your own signals as [user-defined events](/eas/observe/events/).
+EAS Observe tracks startup metrics (cold launch time, warm launch time, time to first render, time to interactive, and bundle load time) and [EAS Update download time](/eas/observe/eas-update/). On SDK 56 and later, the [navigation integrations](/eas/observe/integrations/expo-router/) add per-route render and interactive timings. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric. You can also log your own signals as [user-defined events](/eas/observe/events/) and record [JavaScript errors](/eas/observe/errors/) (in preview).
 
 </Collapsible>
 
@@ -159,6 +163,13 @@ Metric data is retained for a minimum of 60 days.
   title="User-defined events"
   description="Log named events from your app and view them in the dashboard or query them from the CLI."
   href="/eas/observe/events"
+  Icon={ActivityIcon}
+/>
+
+<BoxLink
+  title="Error reporting"
+  description="Record JavaScript errors and investigate symbolicated stack traces in the dashboard."
+  href="/eas/observe/errors"
   Icon={ActivityIcon}
 />
 

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -71,7 +71,7 @@ Traditional development-time profiling tools show how your app performs on your 
 - **Per-route navigation metrics**: Compare render and interactive timings by route with the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/) integration
 - **Session investigation**: Drill into individual user sessions to understand why certain devices or conditions lead to slower performance
 - **User-defined events**: Log custom signals from your app with `Observe.logEvent` and analyze them alongside performance data
-- **Error reporting** (in preview): Record JavaScript errors with [`ObserveErrorBoundary` and `Observe.reportError`](/eas/observe/errors/) and investigate symbolicated stack traces in the dashboard
+- **Error reporting** (in preview): [Record JavaScript errors](/eas/observe/errors/) and investigate symbolicated stack traces in the dashboard
 - **CLI and dashboard access**: Query metrics from the terminal with `eas observe:` commands or view them in the EAS dashboard
 
 ## When to use EAS Observe
@@ -93,7 +93,7 @@ Traditional development-time profiling tools show how your app performs on your 
 
 **JavaScript errors**: On SDK 57 and later, EAS Observe records JavaScript errors and shows them in the dashboard with symbolicated stack traces. This feature is in [preview](/more/release-statuses/#preview). See [Error reporting](/eas/observe/errors/) for setup and current limitations.
 
-**Native crash reporting**: EAS Observe does not capture native crashes yet. Until it does, we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
+**Native crash reporting**: EAS Observe does not capture native crashes yet. Until it does, use a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
 
 ## Frequently asked questions (FAQ)
 

--- a/docs/pages/versions/unversioned/sdk/observe.mdx
+++ b/docs/pages/versions/unversioned/sdk/observe.mdx
@@ -19,7 +19,7 @@ Beyond app startup metrics, the library can also:
 - Collect per-route navigation metrics with the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/) integration.
 - Log [user-defined events](/eas/observe/events/) with `Observe.logEvent`.
 - Track [EAS Update download times](/eas/observe/eas-update/) automatically.
-- Record JavaScript errors with `ObserveErrorBoundary` and `reportError`. The EAS Observe dashboard and the EAS CLI do not display these errors yet.
+- Record [JavaScript errors](/eas/observe/errors/) with `ObserveErrorBoundary` and `Observe.reportError`, and view them with symbolicated stack traces in the EAS Observe dashboard (in [preview](/more/release-statuses/#preview)).
 - Let third-party packages [register their own integrations](/eas/observe/integrations/third-party/) with `Observe.registerIntegration`.
 
 > **warning** `expo-observe` is not available in Expo Go. To use it, create a [development build](/develop/development-builds/introduction/).

--- a/docs/pages/versions/v57.0.0/sdk/observe.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/observe.mdx
@@ -19,7 +19,7 @@ Beyond app startup metrics, the library can also:
 - Collect per-route navigation metrics with the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/) integration.
 - Log [user-defined events](/eas/observe/events/) with `Observe.logEvent`.
 - Track [EAS Update download times](/eas/observe/eas-update/) automatically.
-- Record JavaScript errors with `ObserveErrorBoundary` and `reportError`. The EAS Observe dashboard and the EAS CLI do not display these errors yet.
+- Record [JavaScript errors](/eas/observe/errors/) with `ObserveErrorBoundary` and `Observe.reportError`, and view them with symbolicated stack traces in the EAS Observe dashboard (in [preview](/more/release-statuses/#preview)).
 - Let third-party packages [register their own integrations](/eas/observe/integrations/third-party/) with `Observe.registerIntegration`.
 
 > **warning** `expo-observe` is not available in Expo Go. To use it, create a [development build](/develop/development-builds/introduction/).

--- a/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
+++ b/docs/public/static/schemas/unversioned/eas-json-build-common-schema.js
@@ -90,6 +90,15 @@ export default [
     ],
   },
   {
+    name: 'uploadSourceMaps',
+    type: 'boolean',
+    description: [
+      'If set to `true`, the JavaScript source map generated during the build is uploaded to EAS. Stored source maps are used by [EAS Observe](/eas/observe/errors/#symbolicated-stack-traces) to symbolicate reported error stack traces. The source code embedded in the map is removed before upload. Defaults to `false`.',
+      '',
+      '**Note**: only available for builds that run on EAS Build servers. Local builds do not upload source maps.',
+    ],
+  },
+  {
     name: 'node',
     type: 'string',
     description: ['Version of Node.js used for build.'],


### PR DESCRIPTION
# Why

Resolves ENG-26083
Resolves ENG-25696

We want to publish what we can with error reporting.

> [!IMPORTANT]
> Do not merge until we've enabled the errors page on the dash FYI @entiendoNull 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Document setup instructions and mark the feature as "in preview".

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Review the docs.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
