### PR TITLE
[secure store] fix `deleteItemAsync` resolving when a retried delete left the value on disk

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `deleteItemAsync` resolving when a retried delete left the value on disk. ([#49151](https://github.com/expo/expo/pull/49151) by [@vonovak](https://github.com/vonovak))
 - [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed. ([#49146](https://github.com/expo/expo/pull/49146) by [@vonovak](https://github.com/vonovak))
 - [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with. ([#49128](https://github.com/expo/expo/pull/49128) by [@JoRo-Code](https://github.com/JoRo-Code) and [@behenate](https://github.com/behenate))
 

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
@@ -246,22 +246,12 @@ open class SecureStoreModule : Module() {
   }
 
   private fun deleteItemImpl(key: String, options: SecureStoreOptions) {
-    var success = true
-    val prefs = getSharedPreferences()
-    val keychainAwareKey = createKeychainAwareKey(key, options.keychainService)
-    val legacyPrefs = PreferenceManager.getDefaultSharedPreferences(reactContext)
-
-    if (prefs.contains(keychainAwareKey)) {
-      success = prefs.edit().remove(keychainAwareKey).commit()
-    }
-
-    if (prefs.contains(key)) {
-      success = prefs.edit().remove(key).commit() && success
-    }
-
-    if (legacyPrefs.contains(key)) {
-      success = legacyPrefs.edit().remove(key).commit() && success
-    }
+    val success = removeItem(
+      getSharedPreferences(),
+      PreferenceManager.getDefaultSharedPreferences(reactContext),
+      key,
+      createKeychainAwareKey(key, options.keychainService)
+    )
 
     if (!success) {
       throw DeleteException("Could not delete the item from SecureStore", key, options.keychainService)
@@ -391,4 +381,15 @@ open class SecureStoreModule : Module() {
     const val AUTHENTICATED_KEYSTORE_SUFFIX = "keystoreAuthenticated"
     const val UNAUTHENTICATED_KEYSTORE_SUFFIX = "keystoreUnauthenticated"
   }
+}
+
+internal fun removeItem(
+  prefs: SharedPreferences,
+  legacyPrefs: SharedPreferences,
+  key: String,
+  keychainAwareKey: String
+): Boolean {
+  val removedFromPrefs = prefs.edit().remove(keychainAwareKey).remove(key).commit()
+  val removedFromLegacyPrefs = legacyPrefs.edit().remove(key).commit()
+  return removedFromPrefs && removedFromLegacyPrefs
 }

--- a/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SecureStoreDeleteTest.kt
+++ b/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SecureStoreDeleteTest.kt
@@ -1,0 +1,57 @@
+package expo.modules.securestore
+
+import android.content.Context
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class SecureStoreDeleteTest {
+  private val context: Context
+    get() = RuntimeEnvironment.getApplication()
+
+  private val sharedPreferencesDir: File
+    get() = File(context.applicationInfo.dataDir, "shared_prefs")
+
+  private val prefs
+    get() = context.getSharedPreferences("SecureStore", Context.MODE_PRIVATE)
+
+  private val legacyPrefs
+    get() = context.getSharedPreferences("legacy", Context.MODE_PRIVATE)
+
+  @Test
+  fun `removes both the current and the legacy key format`() {
+    prefs.edit().putString("keychain-key", "current").putString("key", "legacy").commit()
+    legacyPrefs.edit().putString("key", "oldest").commit()
+
+    assertTrue(removeItem(prefs, legacyPrefs, "key", "keychain-key"))
+
+    assertNull(prefs.getString("keychain-key", null))
+    assertNull(prefs.getString("key", null))
+    assertNull(legacyPrefs.getString("key", null))
+  }
+
+  @Test
+  fun `reports failure when a delete is retried after a failed commit`() {
+    prefs.edit().putString("keychain-key", "ciphertext").commit()
+    // Create the file up front so that only the SecureStore file can fail the write below.
+    legacyPrefs.edit().putString("unrelated", "value").commit()
+
+    // Without write permission on the directory `SharedPreferencesImpl` cannot rename the file to
+    // its backup, so `commit` returns false and leaves the entry on the disk. It still removes the
+    // key from its in-memory map, which is what defeats a `contains` check on the retry.
+    assertTrue(sharedPreferencesDir.setWritable(false))
+    try {
+      assertFalse(removeItem(prefs, legacyPrefs, "key", "keychain-key"))
+      assertFalse(removeItem(prefs, legacyPrefs, "key", "keychain-key"))
+      assertTrue(File(sharedPreferencesDir, "SecureStore.xml").readText().contains("ciphertext"))
+    } finally {
+      sharedPreferencesDir.setWritable(true)
+    }
+  }
+}

--- a/packages/expo-secure-store/android/src/test/resources/robolectric.properties
+++ b/packages/expo-secure-store/android/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# The delete-retry test needs API 26+, where a failed commit is retried. Default here is API 23.
+sdk=35


### PR DESCRIPTION
# Why

closes #48989 - a somewhat rare, but legit issue

# How

delete items unconditionally, without `prefs.contains` check, making it more robust

# Test Plan

- green CI, added a test that would be red in previous configuration

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
