### PR TITLE
[android][sqlite] Keep shared database alive when one instance is released

### DIFF
--- a/apps/test-suite/tests/SQLite.ts
+++ b/apps/test-suite/tests/SQLite.ts
@@ -16,6 +16,33 @@ interface UserEntity {
   j: number;
 }
 
+// Only some Hermes builds and browsers expose `globalThis.gc()`.
+const globalGC = (globalThis as unknown as { gc?: () => void }).gc;
+
+// Opens in a frame of its own and hands back only a weak reference.
+// Anything left in the caller, even the resolved promise in a dead register, pins the database and
+// stops it from ever being collected.
+async function openAndForgetAsync(databaseName: string): Promise<WeakRef<object>> {
+  const db = await SQLite.openDatabaseAsync(databaseName);
+  return new WeakRef(db.nativeDatabase);
+}
+
+// `deref()` keeps its target alive until the end of the current job, so it must never share a job
+// with the collection.
+// The database wrapper and the shared object it holds also die on separate passes, hence the loop.
+async function collectAsync(ref: WeakRef<object>): Promise<boolean> {
+  for (let i = 0; i < 20; i++) {
+    globalGC?.();
+    await delayAsync(0);
+    const collected = ref.deref() === undefined;
+    await delayAsync(0);
+    if (collected) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function test({
   describe,
   expect,
@@ -312,6 +339,34 @@ INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
       expect(results.length).toBe(1);
       await srcDb.closeAsync();
       await destDb.closeAsync();
+    });
+  });
+
+  describe('Shared connections', () => {
+    // Nothing other than GC can force a shared object release.
+    const gcIt = globalGC && process.env.EXPO_OS !== 'web' ? it : t.xit;
+
+    gcIt('should keep other instances usable after one is collected', async () => {
+      const db2 = await SQLite.openDatabaseAsync('sharedconn.db');
+      const dropped = await openAndForgetAsync('sharedconn.db');
+      expect(await collectAsync(dropped)).toBe(true);
+
+      await db2.execAsync(`
+DROP TABLE IF EXISTS users;
+CREATE TABLE IF NOT EXISTS users (user_id INTEGER PRIMARY KEY NOT NULL, name VARCHAR(64), k INT, j REAL);
+INSERT INTO users (name, k, j) VALUES ('Tim Duncan', 1, 23.4);
+`);
+      const results = await db2.getAllAsync<UserEntity>('SELECT * FROM users');
+      expect(results.length).toBe(1);
+    });
+
+    gcIt('should be able to reopen a database after its only instance is collected', async () => {
+      const dropped = await openAndForgetAsync('sharedconn2.db');
+      expect(await collectAsync(dropped)).toBe(true);
+
+      const db2 = await SQLite.openDatabaseAsync('sharedconn2.db');
+      const row = await db2.getFirstAsync<{ value: number }>('SELECT 1 as value');
+      expect(requireNotNull(row).value).toBe(1);
     });
   });
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [Android][iOS] Fix `deleteDatabaseAsync` and `deleteDatabaseSync` leaving `-journal`, `-wal` and `-shm` sidecar files behind. ([#49125](https://github.com/expo/expo/pull/49125) by [@sbaiahmed1](https://github.com/sbaiahmed1))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
+- [Android] Fixed a shared database being closed when one of its JavaScript objects was released, which broke later calls with a bare `NullPointerException`. ([#49152](https://github.com/expo/expo/pull/49152) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeDatabase.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class NativeDatabase(val databasePath: String, val openOptions: OpenDatabaseOptions) : SharedRef<NativeDatabaseBinding>(NativeDatabaseBinding()) {
+  @Volatile
   var isClosed = false
   private val refCount = AtomicInteger(1)
 
@@ -27,6 +28,9 @@ internal class NativeDatabase(val databasePath: String, val openOptions: OpenDat
 
   override fun sharedObjectDidRelease() {
     super.sharedObjectDidRelease()
-    this.ref.close()
+    // Reopening a database reuses this instance, so other JavaScript objects may still use it.
+    if (isClosed) {
+      this.ref.close()
+    }
   }
 }

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -498,10 +498,11 @@ class SQLiteModule : Module() {
   private fun closeDatabase(database: NativeDatabase) {
     maybeFinalizeAllStatements(database)
     val ret = database.ref.sqlite3_close()
+    // Mark it closed even when sqlite3_close() fails, the database is already out of the cache.
+    database.isClosed = true
     if (ret != NativeDatabaseBinding.SQLITE_OK) {
       throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
     }
-    database.isClosed = true
   }
 
   private fun deleteDatabase(databasePath: String) {


### PR DESCRIPTION
# Why

fixes #48999.

# How

prevent db with existing references being closed

# Test Plan

add an e2e test case as #48999

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)