### PR TITLE
[router] Add key router facts to Agents.md

### DIFF
--- a/packages/expo-router/AGENTS.md
+++ b/packages/expo-router/AGENTS.md
@@ -231,6 +231,13 @@ const screenProps = MockedComponent.mock.calls[1][0];
 
 ## Key Concepts
 
+### Expo Router Semantics
+
+- Evaluate all features exclusively from the Expo Router perspective. If a behavior is unavailable through Expo Router, React Navigation support for that behavior is irrelevant.
+- `expo-router/react-navigation` is only a compatibility layer. Do not treat its capabilities as Expo Router features unless Expo Router exposes them.
+- Protected routes are implemented as redirects and do not depend on `routeNames`.
+- `routeNames` are stable in Expo Router except during HMR.
+
 ### File-Based Routing Conventions
 
 - `page/index.tsx` → `/page`


### PR DESCRIPTION
# Why

After changing how protected routes work, I often see agents claiming that they still work based of `routeNames`. I face similar problem regarding the `routeNames`, where agents claim users can change them by hand - which they can't do in expo-router anymore.

# How

Update AGENTS.md file

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
