### PR TITLE
[task-manager][iOS] Fix data races in EXTaskService and EXTaskExecutionRequest

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
+- [iOS] Fix data races in `EXTaskService` and `EXTaskExecutionRequest`: synchronize shared-collection access (entered concurrently from the main thread, the JS thread and the app-loader callback) and make the execution request's one-shot completion atomic. ([#49160](https://github.com/expo/expo/pull/49160) by [@nickcernera](https://github.com/nickcernera))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.m
@@ -25,24 +25,41 @@
 
 - (void)addTask:(nonnull id<EXTaskInterface>)task
 {
-  [_tasks addObject:task];
+  // `_tasks` is mutated from whichever thread registers tasks and read from the
+  // threads that complete them (main, JS, app loader), so every access must be
+  // synchronized. `@synchronized` is reentrant per-thread, which keeps the
+  // consumer call-out paths that re-enter this class safe.
+  @synchronized (self) {
+    [_tasks addObject:task];
+  }
 }
 
 - (void)task:(nonnull id<EXTaskInterface>)task didFinishWithResult:(id)result
 {
-  [_tasks removeObject:task];
-  [_results addObject:result];
+  @synchronized (self) {
+    [_tasks removeObject:task];
+    [_results addObject:result];
+  }
+  // Evaluate outside the lock — `maybeEvaluate` may invoke the completion
+  // callback, which calls back into EXTaskService and must not run under
+  // this request's lock.
   [self maybeEvaluate];
 }
 
 - (BOOL)isIncludingTask:(nullable id<EXTaskInterface>)task
 {
-  return task && [_tasks containsObject:task];
+  @synchronized (self) {
+    return task && [_tasks containsObject:task];
+  }
 }
 
 - (void)maybeEvaluate
 {
-  if ([_tasks count] == 0) {
+  BOOL shouldExecute;
+  @synchronized (self) {
+    shouldExecute = [_tasks count] == 0;
+  }
+  if (shouldExecute) {
     [self _maybeExecuteCallback];
   }
 }
@@ -51,24 +68,36 @@
 
 - (void)_maybeExecuteCallback
 {
-  if (_callback) {
-    // Make a strong pointer to self before executing a callback as the request may be deallocated there,
-    // due to this fact `_callback = nil;` was crashing on older versions of iOS (below 12.0).
-    __strong EXTaskExecutionRequest *strongSelf = self;
+  // Make a strong pointer to self before executing a callback as the request may be deallocated there,
+  // due to this fact `_callback = nil;` was crashing on older versions of iOS (below 12.0).
+  __strong EXTaskExecutionRequest *strongSelf = self;
 
-    // Capture the callback and results, then clear the request state before invoking. The callback is a
-    // one-shot completion that unregisters this request and breaks the retain cycle keeping its captured
-    // state alive, so a re-entrant or duplicated evaluation (e.g. a task finishing during a foreground
-    // transition) must not pass the `_callback` guard again and fire against freed memory.
-    void (^callback)(NSArray *) = _callback;
-    NSArray *results = _results;
-    _callback = nil;
-    _tasks = nil;
-    _results = nil;
+  // Capture the callback and results, then clear the request state before invoking. The callback is a
+  // one-shot completion that unregisters this request and breaks the retain cycle keeping its captured
+  // state alive, so a re-entrant or duplicated evaluation (e.g. a task finishing during a foreground
+  // transition) must not pass the `_callback` guard again and fire against freed memory.
+  //
+  // The capture-and-clear must be atomic: two threads passing the count check in `maybeEvaluate`
+  // concurrently would otherwise both capture `_callback` before either clears it, and the completion
+  // would fire twice against state the first invocation already tore down.
+  void (^callback)(NSArray *) = nil;
+  NSArray *results = nil;
 
-    callback(results);
-    strongSelf = nil;
+  @synchronized (self) {
+    if (_callback != nil) {
+      callback = _callback;
+      results = _results;
+      _callback = nil;
+      _tasks = nil;
+      _results = nil;
+    }
   }
+
+  // Invoke outside the lock — the callback calls back into EXTaskService.
+  if (callback != nil) {
+    callback(results);
+  }
+  strongSelf = nil;
 }
 
 @end

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -134,14 +134,16 @@
     @throw [NSException exceptionWithName:@"E_INVALID_TASK_CONSUMER" reason:reason userInfo:errorInfo];
   }
   
-  NSMutableDictionary *appTasks = [[self _getTasksForAppId:appId] mutableCopy];
-  
-  [appTasks removeObjectForKey:taskName];
-  
-  if (appTasks.count == 0) {
-    [_tasks removeObjectForKey:appId];
-  } else {
-    [_tasks setObject:appTasks forKey:appId];
+  @synchronized (self) {
+    NSMutableDictionary *appTasks = [[self _getTasksForAppId:appId] mutableCopy];
+
+    [appTasks removeObjectForKey:taskName];
+
+    if (appTasks.count == 0) {
+      [_tasks removeObjectForKey:appId];
+    } else {
+      [_tasks setObject:appTasks forKey:appId];
+    }
   }
   
   if ([task.consumer respondsToSelector:@selector(didUnregister)]) {
@@ -155,18 +157,27 @@
  */
 - (void)unregisterAllTasksForAppId:(NSString *)appId
 {
-  NSDictionary *appTasks = _tasks[appId];
-  
-  if (appTasks) {
+  // This is called from the app loader's failure callback (arbitrary queue) —
+  // detach the app's tasks under the lock, then run consumer call-outs outside it.
+  NSArray<EXTask *> *tasksToUnregister = nil;
+
+  @synchronized (self) {
+    NSDictionary *appTasks = _tasks[appId];
+
+    if (appTasks) {
+      tasksToUnregister = [appTasks allValues];
+      [_tasks removeObjectForKey:appId];
+    }
+  }
+
+  if (tasksToUnregister) {
     // Call `didUnregister` on task consumers
-    for (EXTask *task in [appTasks allValues]) {
+    for (EXTask *task in tasksToUnregister) {
       if ([task.consumer respondsToSelector:@selector(didUnregister)]) {
         [task.consumer didUnregister];
       }
     }
-    
-    [_tasks removeObjectForKey:appId];
-    
+
     // Remove the app from the config in user defaults.
     [self _removeFromConfigAppWithId:appId];
   }
@@ -214,37 +225,54 @@
   id<EXTaskInterface> task = [self _getTaskWithName:taskName forAppId:appId];
   NSString *eventId = response[@"eventId"];
   id result = response[@"result"];
-  
+
   if ([task.consumer respondsToSelector:@selector(normalizeTaskResult:)]) {
     result = @([task.consumer normalizeTaskResult:result]);
   }
   if ([task.consumer respondsToSelector:@selector(didFinish)]) {
     [task.consumer didFinish];
   }
-  
-  // Inform requests about finished tasks
-  for (EXTaskExecutionRequest *request in [_requests copy]) {
+
+  // Inform requests about finished tasks.
+  // Snapshot `_requests` under the lock — it is mutated by the launch path
+  // (`_runTasksSupportingLaunchReason:`) on other threads.
+  NSArray<EXTaskExecutionRequest *> *requests;
+  @synchronized (self) {
+    requests = [_requests copy];
+  }
+  for (EXTaskExecutionRequest *request in requests) {
     if ([request isIncludingTask:task]) {
       [request task:task didFinishWithResult:result];
     }
   }
-  
-  // Remove event and maybe invalidate related app record
-  NSMutableArray *appEvents = _events[appId];
-  
-  if (appEvents) {
-    [appEvents removeObject:eventId];
-    
-    if (appEvents.count == 0) {
-      [self->_events removeObjectForKey:appId];
-      
-      // Invalidate app record but after 1 second delay so we can still take batched events.
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+
+  // Remove event and maybe invalidate related app record.
+  // `_events` arrays are appended to by `executeTask:` on the thread that
+  // executes the task (e.g. main for location consumers) while this method
+  // runs on the JS thread — all access must happen under the lock.
+  BOOL appEventsEmptied = NO;
+  @synchronized (self) {
+    NSMutableArray *appEvents = _events[appId];
+
+    if (appEvents) {
+      [appEvents removeObject:eventId];
+
+      if (appEvents.count == 0) {
+        [self->_events removeObjectForKey:appId];
+        appEventsEmptied = YES;
+      }
+    }
+  }
+
+  if (appEventsEmptied) {
+    // Invalidate app record but after 1 second delay so we can still take batched events.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+      @synchronized (self) {
         if (!self->_events[appId]) {
           [self _invalidateAppWithId:appId];
         }
-      });
-    }
+      }
+    });
   }
 }
 
@@ -256,23 +284,27 @@
   // Having two tables for them is to prevent race condition problems,
   // when both foreground and background apps are launching at the same time.
   BOOL isHeadless = [taskManager isRunningInHeadlessMode];
-  NSMapTable *taskManagersTable = isHeadless ? _headlessTaskManagers : _taskManagers;
-  
-  // Set task manager in appropriate table.
-  [taskManagersTable setObject:taskManager forKey:appId];
-  
-  // Execute events waiting for the task manager.
-  NSMutableArray *appEventQueue = _eventsQueues[appId];
-  
+  NSMutableArray *appEventQueue;
+
+  @synchronized (self) {
+    NSMapTable *taskManagersTable = isHeadless ? _headlessTaskManagers : _taskManagers;
+
+    // Set task manager in appropriate table.
+    [taskManagersTable setObject:taskManager forKey:appId];
+
+    // Detach the events queue for that app — once removed from `_eventsQueues`
+    // nothing else references it, so it can be drained outside the lock.
+    appEventQueue = _eventsQueues[appId];
+    [_eventsQueues removeObjectForKey:appId];
+  }
+
+  // Execute events that were waiting for the task manager.
   if (appEventQueue) {
     for (NSDictionary *body in appEventQueue) {
       [taskManager executeWithBody:body];
     }
   }
-  
-  // Remove events queue for that app.
-  [_eventsQueues removeObjectForKey:appId];
-  
+
   if (!isHeadless) {
     // Maybe update app url in user defaults. It might change only in non-headless mode.
     [self _maybeUpdateAppUrl:appUrl forAppId:appId];
@@ -285,38 +317,49 @@
            withData:(nullable NSDictionary *)data
           withError:(nullable NSError *)error
 {
-  id<EXTaskManagerInterface> taskManager = [self _taskManagerForAppId:task.appId];
   NSDictionary *executionInfo = [self _executionInfoForTask:task];
   NSDictionary *body = @{
     @"executionInfo": executionInfo,
     @"data": data ?: @{},
     @"error": EXNullIfNil([self _exportError:error]),
   };
-  
+
   NSLog(@"EXTaskService: Executing task '%@' for app '%@'.", task.name, task.appId);
-  
-  // Save an event so we can keep tracking events for this app
-  NSMutableArray *appEvents = _events[task.appId] ?: [NSMutableArray new];
-  [appEvents addObject:executionInfo[@"eventId"]];
-  [_events setObject:appEvents forKey:task.appId];
-  
+
+  id<EXTaskManagerInterface> taskManager;
+
+  // This method is entered from whichever thread the task consumer fires on
+  // (e.g. main for location updates) while `notifyTaskWithName:` empties the
+  // same `_events` arrays from the JS thread. `addObject:` on NSMutableArray
+  // computes its insertion index from a count another thread can invalidate,
+  // so all bookkeeping happens under the lock; only the task manager
+  // call-out below stays outside it.
+  @synchronized (self) {
+    taskManager = [self _taskManagerForAppId:task.appId];
+
+    // Save an event so we can keep tracking events for this app
+    NSMutableArray *appEvents = _events[task.appId] ?: [NSMutableArray new];
+    [appEvents addObject:executionInfo[@"eventId"]];
+    [_events setObject:appEvents forKey:task.appId];
+
+    if (taskManager == nil) {
+      if (_appRecords[task.appId] == nil) {
+        // No app record yet - let's spin it up!
+        [self _loadAppWithId:task.appId appUrl:task.appUrl];
+      }
+
+      // App record for that app exists, but it's not fully loaded as its task manager is not there yet.
+      // We need to add event's body to the queue from which events will be executed once the task manager is ready.
+      NSMutableArray *appEventsQueue = _eventsQueues[task.appId] ?: [NSMutableArray new];
+      [appEventsQueue addObject:body];
+      [_eventsQueues setObject:appEventsQueue forKey:task.appId];
+    }
+  }
+
   if (taskManager != nil) {
     // Task manager is initialized and can execute events
     [taskManager executeWithBody:body];
-    return;
   }
-  
-  if (_appRecords[task.appId] == nil) {
-    // No app record yet - let's spin it up!
-    [self _loadAppWithId:task.appId appUrl:task.appUrl];
-  }
-  
-  // App record for that app exists, but it's not fully loaded as its task manager is not there yet.
-  // We need to add event's body to the queue from which events will be executed once the task manager is ready.
-  NSMutableArray *appEventsQueue = _eventsQueues[task.appId] ?: [NSMutableArray new];
-  [appEventsQueue addObject:body];
-  [_eventsQueues setObject:appEventsQueue forKey:task.appId];
-  return;
 }
 
 # pragma mark - statics
@@ -382,7 +425,12 @@
  */
 - (NSDictionary<NSString *, EXTask *> *)_getTasksForAppId:(NSString *)appId
 {
-  return _tasks[appId];
+  // The per-app dictionaries are replaced wholesale (copy-on-write) by the
+  // register/unregister paths, so callers may safely enumerate the returned
+  // snapshot; only the lookup itself needs the lock.
+  @synchronized (self) {
+    return _tasks[appId];
+  }
 }
 
 /**
@@ -394,16 +442,21 @@
                             consumerClass:(Class)consumerClass
                                   options:(nullable NSDictionary *)options
 {
-  NSMutableDictionary *appTasks = [[self _getTasksForAppId:appId] mutableCopy] ?: [NSMutableDictionary new];
   EXTask *task = [[EXTask alloc] initWithName:taskName
                                         appId:appId
                                        appUrl:appUrl
                                 consumerClass:consumerClass
                                       options:options
                                      delegate:self];
-  
-  [appTasks setObject:task forKey:task.name];
-  [_tasks setObject:appTasks forKey:appId];
+
+  @synchronized (self) {
+    NSMutableDictionary *appTasks = [[self _getTasksForAppId:appId] mutableCopy] ?: [NSMutableDictionary new];
+    [appTasks setObject:task forKey:task.name];
+    [_tasks setObject:appTasks forKey:appId];
+  }
+
+  // Inform the consumer outside the lock — consumer call-outs may re-enter
+  // the service (e.g. immediately executing a task).
   [task.consumer didRegisterTask:task];
   return task;
 }
@@ -413,18 +466,22 @@
  */
 - (void)_addTaskToConfig:(nonnull id<EXTaskInterface>)task
 {
-  NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy] ?: [NSMutableDictionary new];
-  NSMutableDictionary *appDict = [dict[task.appId] mutableCopy] ?: [NSMutableDictionary new];
-  NSMutableDictionary *tasks = [appDict[@"tasks"] mutableCopy] ?: [NSMutableDictionary new];
-  NSDictionary *taskDict = [self _dictionaryFromTask:task];
-  
-  [tasks setObject:taskDict forKey:task.name];
-  [appDict setObject:tasks forKey:@"tasks"];
-  if (task.appUrl) {
-    [appDict setObject:task.appUrl forKey:@"appUrl"];
+  // The config read-modify-write below races other config writers on other
+  // threads; hold the lock across it so no update is lost.
+  @synchronized (self) {
+    NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy] ?: [NSMutableDictionary new];
+    NSMutableDictionary *appDict = [dict[task.appId] mutableCopy] ?: [NSMutableDictionary new];
+    NSMutableDictionary *tasks = [appDict[@"tasks"] mutableCopy] ?: [NSMutableDictionary new];
+    NSDictionary *taskDict = [self _dictionaryFromTask:task];
+
+    [tasks setObject:taskDict forKey:task.name];
+    [appDict setObject:tasks forKey:@"tasks"];
+    if (task.appUrl) {
+      [appDict setObject:task.appUrl forKey:@"appUrl"];
+    }
+    [dict setObject:appDict forKey:task.appId];
+    [self _saveConfigWithDictionary:dict];
   }
-  [dict setObject:appDict forKey:task.appId];
-  [self _saveConfigWithDictionary:dict];
 }
 
 /**
@@ -432,30 +489,34 @@
  */
 - (void)_removeTaskFromConfig:(NSString *)taskName appId:(NSString *)appId
 {
-  NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
-  NSMutableDictionary *appDict = [dict[appId] mutableCopy];
-  NSMutableDictionary *tasks = [appDict[@"tasks"] mutableCopy];
-  
-  if (tasks != nil) {
-    [tasks removeObjectForKey:taskName];
-    
-    if ([tasks count] > 0) {
-      [appDict setObject:tasks forKey:@"tasks"];
-      [dict setObject:appDict forKey:appId];
-    } else {
-      [dict removeObjectForKey:appId];
+  @synchronized (self) {
+    NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
+    NSMutableDictionary *appDict = [dict[appId] mutableCopy];
+    NSMutableDictionary *tasks = [appDict[@"tasks"] mutableCopy];
+
+    if (tasks != nil) {
+      [tasks removeObjectForKey:taskName];
+
+      if ([tasks count] > 0) {
+        [appDict setObject:tasks forKey:@"tasks"];
+        [dict setObject:appDict forKey:appId];
+      } else {
+        [dict removeObjectForKey:appId];
+      }
+      [self _saveConfigWithDictionary:dict];
     }
-    [self _saveConfigWithDictionary:dict];
   }
 }
 
 - (void)_removeFromConfigAppWithId:(nonnull NSString *)appId
 {
-  NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
-  
-  if (dict[appId]) {
-    [dict removeObjectForKey:appId];
-    [self _saveConfigWithDictionary:dict];
+  @synchronized (self) {
+    NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
+
+    if (dict[appId]) {
+      [dict removeObjectForKey:appId];
+      [self _saveConfigWithDictionary:dict];
+    }
   }
 }
 
@@ -472,13 +533,28 @@
 
 - (void)_iterateTasksUsingBlock:(void(^)(id<EXTaskInterface> task))block
 {
-  for (NSString *appId in _tasks) {
-    NSDictionary *appTasks = [self _getTasksForAppId:appId];
-    
-    for (NSString *taskName in appTasks) {
-      id<EXTaskInterface> task = [self _getTaskWithName:taskName forAppId:appId];
-      block(task);
+  // Snapshot the tasks under the lock, then call out to the block outside it —
+  // `_tasks` is mutated by the register/unregister paths on other threads (the
+  // app loader's failure callback among them), and fast enumeration over a
+  // mutating dictionary throws.
+  NSMutableArray<id<EXTaskInterface>> *tasksSnapshot = [NSMutableArray new];
+
+  @synchronized (self) {
+    for (NSString *appId in _tasks) {
+      NSDictionary *appTasks = _tasks[appId];
+
+      for (NSString *taskName in appTasks) {
+        id<EXTaskInterface> task = appTasks[taskName];
+
+        if (task != nil) {
+          [tasksSnapshot addObject:task];
+        }
+      }
     }
+  }
+
+  for (id<EXTaskInterface> task in tasksSnapshot) {
+    block(task);
   }
 }
 
@@ -522,18 +598,22 @@
                                callback:(void(^)(NSArray * _Nonnull results))callback
 {
   __block EXTaskExecutionRequest *request;
-  
+
   request = [[EXTaskExecutionRequest alloc] initWithCallback:^(NSArray * _Nonnull results) {
     if (callback != nil) {
       callback(results);
     }
-    
-    [self->_requests removeObject:request];
+
+    @synchronized (self) {
+      [self->_requests removeObject:request];
+    }
     request = nil;
   }];
-  
-  [_requests addObject:request];
-  
+
+  @synchronized (self) {
+    [_requests addObject:request];
+  }
+
   [self _iterateTasksUsingBlock:^(id<EXTaskInterface> task) {
     if ([task.consumer.class respondsToSelector:@selector(supportsLaunchReason:)] && [task.consumer.class supportsLaunchReason:launchReason]) {
       [self _addTask:task toRequest:request withInfo:userInfo];
@@ -557,16 +637,20 @@
     appRecord = [appLoader loadAppWithUrl:appUrl options:nil callback:^(BOOL success, NSError *error) {
       if (!success) {
         NSLog(@"EXTaskService: Loading app '%@' from url '%@' failed. Error description: %@", appId, appUrl, error.description);
-        [self->_events removeObjectForKey:appId];
-        [self->_eventsQueues removeObjectForKey:appId];
-        [self->_appRecords removeObjectForKey:appId];
-        
+        @synchronized (self) {
+          [self->_events removeObjectForKey:appId];
+          [self->_eventsQueues removeObjectForKey:appId];
+          [self->_appRecords removeObjectForKey:appId];
+        }
+
         // Host unreachable? Unregister all tasks for that app.
         [self unregisterAllTasksForAppId:appId];
       }
     }];
-    
-    [_appRecords setObject:appRecord forKey:appId];
+
+    @synchronized (self) {
+      [_appRecords setObject:appRecord forKey:appId];
+    }
   }
 }
 
@@ -575,8 +659,10 @@
  */
 - (id<EXTaskManagerInterface>)_taskManagerForAppId:(NSString *)appId
 {
-  id<EXTaskManagerInterface> taskManager = [_taskManagers objectForKey:appId];
-  return taskManager ?: [_headlessTaskManagers objectForKey:appId];
+  @synchronized (self) {
+    id<EXTaskManagerInterface> taskManager = [_taskManagers objectForKey:appId];
+    return taskManager ?: [_headlessTaskManagers objectForKey:appId];
+  }
 }
 
 /**
@@ -586,13 +672,15 @@
 - (void)_maybeUpdateAppUrl:(NSString *)appUrl
                   forAppId:(NSString *)appId
 {
-  NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
-  NSMutableDictionary *appDict = [dict[appId] mutableCopy];
-  
-  if (appDict != nil && ![appDict[@"appUrl"] isEqualToString:appUrl]) {
-    appDict[@"appUrl"] = appUrl;
-    dict[appId] = appDict;
-    [self _saveConfigWithDictionary:dict];
+  @synchronized (self) {
+    NSMutableDictionary *dict = [[self _dictionaryWithRegisteredTasks] mutableCopy];
+    NSMutableDictionary *appDict = [dict[appId] mutableCopy];
+
+    if (appDict != nil && ![appDict[@"appUrl"] isEqualToString:appUrl]) {
+      appDict[@"appUrl"] = appUrl;
+      dict[appId] = appDict;
+      [self _saveConfigWithDictionary:dict];
+    }
   }
 }
 
@@ -667,13 +755,19 @@
 
 - (void)_invalidateAppWithId:(NSString *)appId
 {
-  id<UMAppRecordInterface> appRecord = _appRecords[appId];
-  
-  if (appRecord) {
-    [appRecord invalidate];
-    [_appRecords removeObjectForKey:appId];
-    [_headlessTaskManagers removeObjectForKey:appId];
+  id<UMAppRecordInterface> appRecord;
+
+  @synchronized (self) {
+    appRecord = _appRecords[appId];
+
+    if (appRecord) {
+      [_appRecords removeObjectForKey:appId];
+      [_headlessTaskManagers removeObjectForKey:appId];
+    }
   }
+
+  // Invalidate outside the lock — it tears down the headless app record.
+  [appRecord invalidate];
 }
 
 - (nullable NSDictionary *)_exportError:(nullable NSError *)error

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.m
@@ -250,7 +250,6 @@
   // `_events` arrays are appended to by `executeTask:` on the thread that
   // executes the task (e.g. main for location consumers) while this method
   // runs on the JS thread — all access must happen under the lock.
-  BOOL appEventsEmptied = NO;
   @synchronized (self) {
     NSMutableArray *appEvents = _events[appId];
 
@@ -259,20 +258,23 @@
 
       if (appEvents.count == 0) {
         [self->_events removeObjectForKey:appId];
-        appEventsEmptied = YES;
+
+        // Invalidate app record but after 1 second delay so we can still take batched events.
+        // `dispatch_after` only enqueues the block, so scheduling it under the lock is safe.
+        // The block re-checks under the lock but invalidates OUTSIDE it — `@synchronized` is
+        // reentrant, so wrapping the `_invalidateAppWithId` call would run the app-record
+        // teardown with the service lock held despite that method's own outside-the-lock split.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+          BOOL shouldInvalidate;
+          @synchronized (self) {
+            shouldInvalidate = self->_events[appId] == nil;
+          }
+          if (shouldInvalidate) {
+            [self _invalidateAppWithId:appId];
+          }
+        });
       }
     }
-  }
-
-  if (appEventsEmptied) {
-    // Invalidate app record but after 1 second delay so we can still take batched events.
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-      @synchronized (self) {
-        if (!self->_events[appId]) {
-          [self _invalidateAppWithId:appId];
-        }
-      }
-    });
   }
 }
 
@@ -332,8 +334,10 @@
   // (e.g. main for location updates) while `notifyTaskWithName:` empties the
   // same `_events` arrays from the JS thread. `addObject:` on NSMutableArray
   // computes its insertion index from a count another thread can invalidate,
-  // so all bookkeeping happens under the lock; only the task manager
-  // call-out below stays outside it.
+  // so all bookkeeping happens under the lock; the call-outs below (task
+  // manager, app loader) stay outside it.
+  BOOL shouldLoadApp = NO;
+
   @synchronized (self) {
     taskManager = [self _taskManagerForAppId:task.appId];
 
@@ -343,12 +347,9 @@
     [_events setObject:appEvents forKey:task.appId];
 
     if (taskManager == nil) {
-      if (_appRecords[task.appId] == nil) {
-        // No app record yet - let's spin it up!
-        [self _loadAppWithId:task.appId appUrl:task.appUrl];
-      }
+      shouldLoadApp = _appRecords[task.appId] == nil;
 
-      // App record for that app exists, but it's not fully loaded as its task manager is not there yet.
+      // App record for that app may exist but not be fully loaded, as its task manager is not there yet.
       // We need to add event's body to the queue from which events will be executed once the task manager is ready.
       NSMutableArray *appEventsQueue = _eventsQueues[task.appId] ?: [NSMutableArray new];
       [appEventsQueue addObject:body];
@@ -359,6 +360,11 @@
   if (taskManager != nil) {
     // Task manager is initialized and can execute events
     [taskManager executeWithBody:body];
+  } else if (shouldLoadApp) {
+    // No app record yet - let's spin it up!
+    // The app loader is an external call-out and must not run under the lock;
+    // `_loadAppWithId:` guards its own `_appRecords` mutation.
+    [self _loadAppWithId:task.appId appUrl:task.appUrl];
   }
 }
 

--- a/packages/expo-task-manager/ios/TaskManagerModule.swift
+++ b/packages/expo-task-manager/ios/TaskManagerModule.swift
@@ -11,6 +11,11 @@ public final class TaskManagerModule: Module, EXTaskManagerInterface {
   let appId: AppId = "mainApplication"
   var eventsQueue: [[String: Any]]? = []
 
+  // `eventsQueue` is appended to by `execute(withBody:)` on whichever thread the
+  // task consumer fires on (e.g. main for location updates) and drained/nil'd by
+  // `OnStartObserving` on the module queue — all access must hold this lock.
+  private let eventsQueueLock = NSLock()
+
   public func definition() -> ModuleDefinition {
     Name("ExpoTaskManager")
 
@@ -27,13 +32,18 @@ public final class TaskManagerModule: Module, EXTaskManagerInterface {
     OnStartObserving(EXECUTE_TASK_EVENT_NAME) {
       // When `OnStartObserving` is called, the app is ready to execute new tasks.
       // It sends all events that were queued before this call.
-      if let eventsQueue {
-        for eventBody in eventsQueue {
+      // Detach the queue atomically (we will not need it anymore), then send the
+      // drained events outside the lock.
+      eventsQueueLock.lock()
+      let queuedEvents = eventsQueue
+      eventsQueue = nil
+      eventsQueueLock.unlock()
+
+      if let queuedEvents {
+        for eventBody in queuedEvents {
           sendEvent(EXECUTE_TASK_EVENT_NAME, eventBody)
         }
       }
-      // We will not need the queue anymore.
-      eventsQueue = nil
     }
 
     AsyncFunction("isAvailableAsync") {
@@ -91,11 +101,14 @@ public final class TaskManagerModule: Module, EXTaskManagerInterface {
   }
 
   public func execute(withBody body: [String: Any]) {
+    eventsQueueLock.lock()
     if eventsQueue != nil {
       // The module was created, but JS is not listening for events yet.
       // In that case we need to queue them up.
       eventsQueue?.append(body)
+      eventsQueueLock.unlock()
     } else {
+      eventsQueueLock.unlock()
       // JS is already listening to the event, we can emit it straight away.
       sendEvent(EXECUTE_TASK_EVENT_NAME, body)
     }


### PR DESCRIPTION
# Why

Fixes the remaining thread-safety defects in `EXTaskService` / `EXTaskExecutionRequest` (iOS). These classes keep their bookkeeping in plain `NSMutable*` collections with no synchronization, but are entered concurrently from the **main thread** (task consumers such as `EXLocationTaskConsumer`, and `BGTaskScheduler` launch handlers), the **React JS thread** (task completions via `notifyTaskWithName:`), and the **app-loader failure callback** (arbitrary queue).

Full analysis in #49159 (auto-closed by the MRE bot — a scheduler-dependent data race has no deterministic repro by construction, so this PR carries the fix instead). We collected four distinct fatal production crash groups from this file pair over 90 days. The clearest signature: `NSRangeException: *** -[__NSArrayM insertObject:atIndex:]: index 1 beyond bounds for empty array` inside `executeTask:withData:withError:` — `[appEvents addObject:]` (main thread, deferred locations) racing `[appEvents removeObject:]` in `notifyTaskWithName:` (JS thread) on the same `_events` array. `addObject:` computes its insertion index from a count another thread invalidates mid-flight.

Precedent: #47572 → #47594 fixed one shape of this class (the completion-path double-fire) in these same files; this completes the job.

# How

Serialize all shared-state access with `@synchronized`, with every call-out kept **outside** the locks:

- **`EXTaskService`**: `_tasks`, `_requests`, `_events`, `_eventsQueues`, `_appRecords`, and the task-manager map tables are only touched under `@synchronized (self)`. Call-outs — consumer `didRegisterTask:` / `didUnregister` / `didBecomeReadyToExecuteWithData:`, task manager `executeWithBody:`, `appRecord invalidate`, and the execution request's completion — run outside the lock (snapshot under lock, call out after). `_iterateTasksUsingBlock:` snapshots tasks before invoking the block, since fast enumeration over a concurrently-mutated dictionary throws. The `NSUserDefaults` config read-modify-write helpers are serialized so concurrent writers cannot lose updates.
- **`EXTaskExecutionRequest`**: `_tasks` / `_results` access is synchronized, and the one-shot completion in `_maybeExecuteCallback` performs its capture-and-clear of `_callback` / `_results` atomically, invoking the captured callback outside the lock. This closes the double-fire window that #47594's reordering narrowed but did not close: two threads can both pass the `_callback != nil` check before either clears it.

`@synchronized` is reentrant per thread, so consumer call-outs that synchronously re-enter the service remain safe. Lock ordering is acyclic (service → request only; the request's completion takes the service lock only after the request lock has been released). No public API changes and no behavior changes beyond synchronization, with one incidental hardening: in `setTaskManager:forAppId:withUrl:` the map-table insert and events-queue detach are now atomic, so a concurrent `executeTask:` can no longer append an event to a queue that has already been drained and detached (it sees the registered task manager instead and executes directly).

# Test Plan

- The race analysis is line-level (#49159) and the diff was reviewed specifically for lock-ordering cycles and call-outs made under a lock.
- We carry this exact diff as a `patch-package` patch in our app (production step-tracking app using background fetch + background location); it ships in our next release build, with the four crash groups in our crash reporting as the post-release signal.
- No new unit tests: the package has no iOS test target covering these classes, and the change is synchronization-only — existing behavior is preserved.

# Checklist

- [x] I added a changelog entry (`packages/expo-task-manager/CHANGELOG.md`)
- [x] No documentation changes needed (no API changes)
- [x] Conforms to the ObjC style of the surrounding code
