### PR TITLE
[ios][audio] Guard the remaining crash paths when mic permission is missing

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4113,7 +4113,7 @@ SPEC CHECKSUMS:
   EXUpdates: e8c071fa483afb3d9d1de09e8f4f9427278af0a1
   EXUpdatesInterface: 92d2aa5194b6fb93ca8ab749db75665cb28b2e60
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: dd9a9191125ffe9f57c224173db85afb0210cd23
+  hermes-engine: 4c998771d5218e20701b63d8358199a520a54447
   JestMockSchema: 96b4cfec246644f6323d1c30693b6a02044be1e6
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [iOS] Activate the audio session once and keep it active instead of toggling. ([#48588](https://github.com/expo/expo/pull/48588) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `createAudioPlayer`/`useAudioPlayer` throwing "Received 5 arguments, but 4 was expected" due to the native `AudioPlayer` constructor missing the iOS-only `allowsExternalPlayback` parameter. ([#48655](https://github.com/expo/expo/pull/48655) by [@RasmusKard](https://github.com/RasmusKard))
 - [iOS] Report `denied` instead of crashing the app when `NSMicrophoneUsageDescription` is missing. ([#48840](https://github.com/expo/expo/pull/48840) by [@ahmadaccino](https://github.com/ahmadaccino))
+- [iOS] Resolve permission requests with `denied` and reject recording calls instead of letting the OS terminate the app when `NSMicrophoneUsageDescription` is missing.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -27,7 +27,7 @@
 - [iOS] Activate the audio session once and keep it active instead of toggling. ([#48588](https://github.com/expo/expo/pull/48588) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Fix `createAudioPlayer`/`useAudioPlayer` throwing "Received 5 arguments, but 4 was expected" due to the native `AudioPlayer` constructor missing the iOS-only `allowsExternalPlayback` parameter. ([#48655](https://github.com/expo/expo/pull/48655) by [@RasmusKard](https://github.com/RasmusKard))
 - [iOS] Report `denied` instead of crashing the app when `NSMicrophoneUsageDescription` is missing. ([#48840](https://github.com/expo/expo/pull/48840) by [@ahmadaccino](https://github.com/ahmadaccino))
-- [iOS] Resolve permission requests with `denied` and reject recording calls instead of letting the OS terminate the app when `NSMicrophoneUsageDescription` is missing.
+- [iOS] Resolve permission requests with `denied` and reject recording calls instead of letting the OS terminate the app when `NSMicrophoneUsageDescription` is missing. ([#49162](https://github.com/expo/expo/pull/49162) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioExceptions.swift
+++ b/packages/expo-audio/ios/AudioExceptions.swift
@@ -18,6 +18,12 @@ internal final class AudioPermissionsException: Exception {
   }
 }
 
+internal final class MicrophoneUsageDescriptionException: Exception {
+  override var reason: String {
+    "Cannot record audio because NSMicrophoneUsageDescription is missing from the app's Info.plist"
+  }
+}
+
 internal final class InvalidAudioModeException: GenericException<String> {
   override var reason: String {
     "Impossible audio mode: \(param)"

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -485,6 +485,7 @@ public class AudioModule: Module {
       }
 
       AsyncFunction("prepareToRecordAsync") { (recorder, options: RecordingOptions?) in
+        try AudioRecordingRequester.requireUsageDescription()
         let deactivateSessionOnFailure = sessionQueue.sync {
           !sessionIsActive && audioSessionActivityKeepers.isEmpty
         }
@@ -1020,6 +1021,8 @@ public class AudioModule: Module {
 
   private func checkPermissions() throws {
     #if os(iOS)
+    try AudioRecordingRequester.requireUsageDescription()
+
     if #available(iOS 17.0, *) {
       switch AVAudioApplication.shared.recordPermission {
       case .denied, .undetermined:

--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -7,10 +7,14 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     return "audioRecording"
   }
 
+  static var microphoneUsageDescription: Any? {
+    Bundle.main.infoDictionary?["NSMicrophoneUsageDescription"]
+  }
+
   public func getPermissions() -> [AnyHashable: Any] {
     return Self.permissions(
       systemStatus: AVAudioSession.sharedInstance().recordPermission,
-      usageDescription: Bundle.main.object(forInfoDictionaryKey: "NSMicrophoneUsageDescription")
+      usageDescription: Self.microphoneUsageDescription
     )
   }
 
@@ -45,7 +49,26 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     ]
   }
 
+  static func requireUsageDescription() throws {
+    try requireUsageDescription(microphoneUsageDescription)
+  }
+
+  static func requireUsageDescription(_ usageDescription: Any?) throws {
+    guard usageDescription != nil else {
+      throw MicrophoneUsageDescriptionException()
+    }
+  }
+
   public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
+     requestPermissions(usageDescription: Self.microphoneUsageDescription, resolver: resolve, rejecter: reject)
+  }
+
+  func requestPermissions(usageDescription: Any?, resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
+    guard usageDescription != nil else {
+      resolve(Self.permissions(systemStatus: AVAudioSession.sharedInstance().recordPermission, usageDescription: nil))
+      return
+    }
+
     typealias PermissionRequestFunction = @convention(c) (AnyObject, Selector, @escaping (Bool) -> Void) -> Void
     let recordPermissionSelector = NSSelectorFromString(selector.joined())
 

--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -49,18 +49,14 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     ]
   }
 
-  static func requireUsageDescription() throws {
-    try requireUsageDescription(microphoneUsageDescription)
-  }
-
-  static func requireUsageDescription(_ usageDescription: Any?) throws {
+  static func requireUsageDescription(_ usageDescription: Any? = AudioRecordingRequester.microphoneUsageDescription) throws {
     guard usageDescription != nil else {
       throw MicrophoneUsageDescriptionException()
     }
   }
 
   public func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
-     requestPermissions(usageDescription: Self.microphoneUsageDescription, resolver: resolve, rejecter: reject)
+    requestPermissions(usageDescription: Self.microphoneUsageDescription, resolver: resolve, rejecter: reject)
   }
 
   func requestPermissions(usageDescription: Any?, resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {

--- a/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
@@ -30,5 +30,31 @@ struct AudioRecordingRequesterTests {
 
     #expect(permissions["status"] as? UInt32 == expected.rawValue)
   }
+
+  @Test
+  func `resolves denied without a system request when the usage description is missing`() {
+    let requester = AudioRecordingRequester()
+    var resolved: [AnyHashable: Any]?
+
+    requester.requestPermissions(usageDescription: nil) { result in
+      resolved = result as? [AnyHashable: Any]
+    } rejecter: { _, _, _ in
+      Issue.record("requestPermissions rejected instead of resolving")
+    }
+
+    #expect(resolved?["status"] as? UInt32 == EXPermissionStatusDenied.rawValue)
+  }
+
+  @Test
+  func `requireUsageDescription throws when the usage description is missing`() {
+    #expect(throws: MicrophoneUsageDescriptionException.self) {
+      try AudioRecordingRequester.requireUsageDescription(nil)
+    }
+  }
+
+  @Test
+  func `requireUsageDescription accepts a present usage description`() throws {
+    try AudioRecordingRequester.requireUsageDescription("Allow $(PRODUCT_NAME) to access your microphone")
+  }
 }
 #endif


### PR DESCRIPTION
# Why
Closes ENG-25995

#48840 stopped getRecordingPermissionsAsync from crashing when NSMicrophoneUsageDescription is missing, but it only covered the read path. The app can still be killed by the OS/

# How

- Added a usage description guard to AudioRecordingRequester.requestPermissions.
- Added MicrophoneUsageDescriptionException and a requireUsageDescription helper.
- prepareToRecordAsync gets only the usage description check, not the full permission check, so preparing before the permission is granted still works.
- Deduplicated the Info.plist lookup behind a single microphoneUsageDescription property.

# Test Plan
Bare expo

