### PR TITLE
[router] remove freezeOnBlur prop

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove freezeOnBlur prop ([#49163](https://github.com/expo/expo/pull/49163) by [@Ubax](https://github.com/Ubax))
 - Remove the experimental web modal implementation. See the [web modals guide](https://docs.expo.dev/router/advanced/web-modals/). ([#49204](https://github.com/expo/expo/pull/49204) by [@Ubax](https://github.com/Ubax))
 - Remove `NavigationIndependentTree` and `useNavigationIndependentTree` from `expo-router/react-navigation`. To embed an isolated navigation tree in a screen, use `@react-navigation/native`. ([#49172](https://github.com/expo/expo/pull/49172) by [@Ubax](https://github.com/Ubax))
 - Remove the deprecated `Link` and `useLinkProps` exports from `expo-router/react-navigation`. Use `Link` from `expo-router` with an `href` instead. ([#48895](https://github.com/expo/expo/pull/48895) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Remove freezeOnBlur prop ([#49163](https://github.com/expo/expo/pull/49163) by [@Ubax](https://github.com/Ubax))
+- The `freezeOnBlur` screen option is disabled and screens are never frozen when blurred. ([#49163](https://github.com/expo/expo/pull/49163) by [@Ubax](https://github.com/Ubax))
 - Remove the experimental web modal implementation. See the [web modals guide](https://docs.expo.dev/router/advanced/web-modals/). ([#49204](https://github.com/expo/expo/pull/49204) by [@Ubax](https://github.com/Ubax))
 - Remove `NavigationIndependentTree` and `useNavigationIndependentTree` from `expo-router/react-navigation`. To embed an isolated navigation tree in a screen, use `@react-navigation/native`. ([#49172](https://github.com/expo/expo/pull/49172) by [@Ubax](https://github.com/Ubax))
 - Remove the deprecated `Link` and `useLinkProps` exports from `expo-router/react-navigation`. Use `Link` from `expo-router` with an `href` instead. ([#48895](https://github.com/expo/expo/pull/48895) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/types.tsx
@@ -290,12 +290,9 @@ export type BottomTabNavigationOptions = HeaderOptions & {
    */
   popToTopOnBlur?: boolean;
 
+  // TODO(@ubax): Remove this prop
   /**
-   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
-   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
-   * Requires `react-native-screens` version >=3.16.0.
-   *
-   * Only supported on iOS and Android.
+   * @deprecated This option has no effect in Expo Router.
    */
   freezeOnBlur?: boolean;
 

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -77,15 +77,6 @@ export function BottomTabView(props: Props) {
 
   const focusedRouteKey = state.routes[state.index]!.key;
 
-  // Keys of tabs that have been focused during this mount. Only blurred tabs from this list are
-  // frozen, so a tab is never frozen before it has rendered once.
-  const [loaded, setLoaded] = React.useState([focusedRouteKey]);
-
-  if (!loaded.includes(focusedRouteKey)) {
-    // Set the current tab to be loaded if it was not loaded before
-    setLoaded([...loaded, focusedRouteKey]);
-  }
-
   const previousRouteKeyRef = React.useRef(focusedRouteKey);
   const tabAnims = useAnimatedHashMap(state);
 
@@ -232,7 +223,6 @@ export function BottomTabView(props: Props) {
           }
 
           const {
-            freezeOnBlur,
             header = ({ layout, options }: BottomTabHeaderProps) => (
               <Header {...options} layout={layout} title={getHeaderTitle(options, route.name)} />
             ),
@@ -269,10 +259,7 @@ export function BottomTabView(props: Props) {
               key={route.key}
               style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
               active={activityState}
-              enabled={detachInactiveScreens}
-              freezeOnBlur={freezeOnBlur}
-              // TODO: A visited blurred tab re-preloaded with new params stays frozen until focused.
-              shouldFreeze={activityState === STATE_INACTIVE && loaded.includes(route.key)}>
+              enabled={detachInactiveScreens}>
               <BottomTabBarHeightContext.Provider
                 value={tabBarPosition === 'bottom' ? tabBarHeight : 0}>
                 <Screen

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/ScreenFallback.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/ScreenFallback.tsx
@@ -5,8 +5,6 @@ type Props = {
   enabled: boolean;
   active: 0 | 1 | 2 | Animated.AnimatedInterpolation<0 | 1>;
   children: ReactNode;
-  freezeOnBlur?: boolean;
-  shouldFreeze: boolean;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -35,7 +33,9 @@ export const MaybeScreenContainer = ({
 
 export function MaybeScreen({ enabled, active, ...rest }: ViewProps & Props) {
   if (Screens?.screensEnabled?.()) {
-    return <Screens.Screen enabled={enabled} activityState={active} {...rest} />;
+    return (
+      <Screens.Screen {...rest} enabled={enabled} activityState={active} freezeOnBlur={false} />
+    );
   }
 
   return <View {...rest} />;

--- a/packages/expo-router/src/react-navigation/drawer/types.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/types.tsx
@@ -208,12 +208,9 @@ export type DrawerNavigationOptions = HeaderOptions & {
    */
   popToTopOnBlur?: boolean;
 
+  // TODO(@ubax): Remove this prop
   /**
-   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
-   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
-   * Requires `react-native-screens` version >=3.16.0.
-   *
-   * Only supported on iOS and Android.
+   * @deprecated This option has no effect in Expo Router.
    */
   freezeOnBlur?: boolean;
 };

--- a/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/DrawerView.tsx
@@ -77,14 +77,6 @@ function DrawerViewBase({
     overlayAccessibilityLabel,
   } = descriptors[focusedRouteKey]!.options;
 
-  // Keys of routes that have been focused during this mount. Only blurred routes from this list are
-  // frozen, so a route is never frozen before it has rendered once.
-  const [loaded, setLoaded] = React.useState([focusedRouteKey]);
-
-  if (!loaded.includes(focusedRouteKey)) {
-    setLoaded([...loaded, focusedRouteKey]);
-  }
-
   const previousRouteKeyRef = React.useRef(focusedRouteKey);
 
   React.useEffect(() => {
@@ -217,7 +209,6 @@ function DrawerViewBase({
           }
 
           const {
-            freezeOnBlur,
             header = ({ layout, options }: DrawerHeaderProps) => (
               <Header
                 {...options}
@@ -246,10 +237,7 @@ function DrawerViewBase({
               key={route.key}
               style={[StyleSheet.absoluteFill, { zIndex: isFocused ? 0 : -1 }]}
               visible={isFocused}
-              enabled={detachInactiveScreens}
-              freezeOnBlur={freezeOnBlur}
-              // TODO: A visited blurred route re-preloaded with new params stays frozen until focused.
-              shouldFreeze={!isFocused && loaded.includes(route.key)}>
+              enabled={detachInactiveScreens}>
               <Screen
                 focused={isFocused}
                 route={route}

--- a/packages/expo-router/src/react-navigation/drawer/views/ScreenFallback.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/views/ScreenFallback.tsx
@@ -7,8 +7,6 @@ type Props = {
   visible: boolean;
   children: React.ReactNode;
   enabled: boolean;
-  freezeOnBlur?: boolean;
-  shouldFreeze: boolean;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -38,7 +36,7 @@ export const MaybeScreenContainer = ({
 export function MaybeScreen({ visible, children, ...rest }: Props) {
   if (Screens?.screensEnabled?.()) {
     return (
-      <Screens.Screen activityState={visible ? 2 : 0} {...rest}>
+      <Screens.Screen {...rest} activityState={visible ? 2 : 0} freezeOnBlur={false}>
         {children}
       </Screens.Screen>
     );

--- a/packages/expo-router/src/react-navigation/native-stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/types.tsx
@@ -815,12 +815,9 @@ export type NativeStackNavigationOptions = {
    * Only supported on iOS and Android.
    */
   orientation?: ScreenProps['screenOrientation'];
+  // TODO(@ubax): Remove this prop
   /**
-   * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
-   * Defaults to `true` when `enableFreeze()` is run at the top of the application.
-   * Requires `react-native-screens` version >=3.16.0.
-   *
-   * Only supported on iOS and Android.
+   * @deprecated This option has no effect in Expo Router.
    */
   freezeOnBlur?: boolean;
   /**

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -37,14 +37,9 @@ import { useHeaderConfigProps } from './useHeaderConfigProps';
 
 const ANDROID_DEFAULT_HEADER_HEIGHT = 56;
 
-function isFabric() {
-  return 'nativeFabricUIManager' in global;
-}
-
 type SceneViewProps = {
   index: number;
   focused: boolean;
-  shouldFreeze: boolean;
   route: Route<string>;
   descriptor: NativeStackDescriptor;
   previousDescriptor?: NativeStackDescriptor;
@@ -67,7 +62,6 @@ const useNativeDriver = Platform.OS !== 'web';
 const SceneView = ({
   index,
   focused,
-  shouldFreeze,
   route,
   descriptor,
   previousDescriptor,
@@ -127,7 +121,6 @@ const SceneView = ({
     statusBarBackgroundColor,
     unstable_sheetFooter,
     scrollEdgeEffects,
-    freezeOnBlur,
     contentStyle,
     unstable_nativeProps,
   } = options;
@@ -339,7 +332,6 @@ const SceneView = ({
         customAnimationOnSwipe={animationMatchesGesture}
         fullScreenSwipeEnabled={fullScreenGestureEnabled}
         fullScreenSwipeShadowEnabled={fullScreenGestureShadowEnabled}
-        freezeOnBlur={freezeOnBlur}
         gestureEnabled={
           Platform.OS === 'android'
             ? // This prop enables handling of system back gestures on Android
@@ -400,11 +392,8 @@ const SceneView = ({
         ]}
         unstable_sheetFooter={unstable_sheetFooter}
         {...screenNativeProps}
-        headerConfig={headerConfig}
-        // When ts-expect-error is added, it affects all the props below it
-        // So we keep any props that need it at the end
-        // Otherwise invalid props may not be caught by TypeScript
-        shouldFreeze={shouldFreeze}>
+        freezeOnBlur={false}
+        headerConfig={headerConfig}>
         <ScreenPresentationContext.Provider value={presentation}>
           <AnimatedHeaderHeightContext.Provider value={animatedHeaderHeight}>
             <HeaderHeightContext.Provider
@@ -488,7 +477,6 @@ export function NativeStackView({ state, descriptors, emit, pop, unstable_native
         {state.routes.map((route, index) => {
           const descriptor = descriptors[route.key]!;
           const isFocused = state.index === index;
-          const isBelowFocused = state.index - 1 === index;
           const isPreloaded = index > state.index;
           const previousKey = activeRoutes[index - 1]?.key;
           const nextKey = activeRoutes[index + 1]?.key;
@@ -496,20 +484,12 @@ export function NativeStackView({ state, descriptors, emit, pop, unstable_native
           const nextDescriptor = nextKey ? descriptors[nextKey] : undefined;
 
           const isModal = modalRouteKeys.includes(route.key);
-          const isModalOnIos = isModal && Platform.OS === 'ios';
-
-          // On Fabric, when screen is frozen, animated and reanimated values are not updated
-          // due to component being unmounted. To avoid this, we don't freeze the previous screen there
-          const shouldFreeze = isFabric()
-            ? !isPreloaded && !isFocused && !isBelowFocused && !isModalOnIos
-            : !isPreloaded && !isFocused && !isModalOnIos;
 
           return (
             <SceneView
               key={route.key}
               index={index}
               focused={isFocused}
-              shouldFreeze={shouldFreeze}
               route={route}
               descriptor={descriptor}
               previousDescriptor={previousDescriptor}

--- a/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/NativeStackView.native.tsx
@@ -391,8 +391,8 @@ const SceneView = ({
           contentStyle,
         ]}
         unstable_sheetFooter={unstable_sheetFooter}
-        {...screenNativeProps}
         freezeOnBlur={false}
+        {...screenNativeProps}
         headerConfig={headerConfig}>
         <ScreenPresentationContext.Provider value={presentation}>
           <AnimatedHeaderHeightContext.Provider value={animatedHeaderHeight}>

--- a/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.unstable-native-props.test.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.unstable-native-props.test.native.tsx
@@ -58,10 +58,14 @@ describe('unstable_nativeProps', () => {
     expect(props.gestureEnabled).toBe(false);
   });
 
-  it('disables screen freezing', () => {
-    const props = renderStack({ freezeOnBlur: true });
+  it('lets raw screen props re-enable screen freezing', () => {
+    const props = renderStack({
+      unstable_nativeProps: {
+        freezeOnBlur: true,
+      },
+    });
 
-    expect(props.freezeOnBlur).toBe(false);
+    expect(props.freezeOnBlur).toBe(true);
   });
 
   it('forwards raw stack host props from Stack', () => {
@@ -151,6 +155,14 @@ describe('unstable_nativeProps', () => {
 
     expect(props.headerConfig?.title).toBe('index');
   });
+});
+
+it('ignores the deprecated freezeOnBlur screen option', () => {
+  ScreenStackItem.mockClear();
+
+  const props = renderStack({ freezeOnBlur: true });
+
+  expect(props.freezeOnBlur).toBe(false);
 });
 
 it('sets preventNativeDismiss from usePreventRemove', () => {

--- a/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.unstable-native-props.test.native.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/__tests__/NativeStackView.unstable-native-props.test.native.tsx
@@ -58,6 +58,12 @@ describe('unstable_nativeProps', () => {
     expect(props.gestureEnabled).toBe(false);
   });
 
+  it('disables screen freezing', () => {
+    const props = renderStack({ freezeOnBlur: true });
+
+    expect(props.freezeOnBlur).toBe(false);
+  });
+
   it('forwards raw stack host props from Stack', () => {
     const onFinishTransitioning = jest.fn();
     const nativeContainerStyle = { backgroundColor: 'red' } as const;

--- a/packages/expo-router/src/react-navigation/stack/types.tsx
+++ b/packages/expo-router/src/react-navigation/stack/types.tsx
@@ -403,12 +403,9 @@ export type StackNavigationOptions = StackHeaderOptions &
      * Defaults to `true`.
      */
     keyboardHandlingEnabled?: boolean;
+    // TODO(@ubax): Remove this prop
     /**
-     * Whether inactive screens should be suspended from re-rendering. Defaults to `false`.
-     * Defaults to `true` when `enableFreeze()` is run at the top of the application.
-     * Requires `react-native-screens` version >=3.16.0.
-     *
-     * Only supported on iOS and Android.
+     * @deprecated This option has no effect in Expo Router.
      */
     freezeOnBlur?: boolean;
     /**

--- a/packages/expo-router/src/react-navigation/stack/views/Screens.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Screens.tsx
@@ -31,12 +31,12 @@ export const MaybeScreen = ({
   enabled: boolean;
   active: 0 | 1 | Animated.AnimatedInterpolation<0 | 1>;
   children: ReactNode;
-  freezeOnBlur?: boolean;
-  shouldFreeze: boolean;
   homeIndicatorHidden?: boolean;
 }) => {
   if (Screens != null) {
-    return <Screens.Screen enabled={enabled} activityState={active} {...rest} />;
+    return (
+      <Screens.Screen {...rest} enabled={enabled} activityState={active} freezeOnBlur={false} />
+    );
   }
 
   return <View {...rest} />;

--- a/packages/expo-router/src/react-navigation/stack/views/Stack/CardStack.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Stack/CardStack.tsx
@@ -647,7 +647,6 @@ export class CardStack extends React.Component<Props, State> {
             const {
               headerShown = true,
               headerTransparent,
-              freezeOnBlur,
               autoHideHomeIndicator,
             } = scene.descriptor.options;
 
@@ -677,8 +676,6 @@ export class CardStack extends React.Component<Props, State> {
                 style={[styles.boxNone, StyleSheet.absoluteFill]}
                 enabled={detachInactiveScreens}
                 active={activityState}
-                freezeOnBlur={freezeOnBlur}
-                shouldFreeze={activityState === STATE_INACTIVE && !isPreloaded}
                 homeIndicatorHidden={autoHideHomeIndicator}>
                 <CardContainer
                   index={index}

--- a/packages/expo-router/src/ui/TabContext.tsx
+++ b/packages/expo-router/src/ui/TabContext.tsx
@@ -18,6 +18,10 @@ export type ExpoTabsProps = ExpoTabsNavigatorOptions;
 export type ExpoTabsNavigatorScreenOptions = {
   detachInactiveScreens?: boolean;
   unmountOnBlur?: boolean;
+  // TODO(@ubax): Remove this prop
+  /**
+   * @deprecated This option has no effect in Expo Router.
+   */
   freezeOnBlur?: boolean;
   lazy?: boolean;
 };

--- a/packages/expo-router/src/ui/TabSlot.tsx
+++ b/packages/expo-router/src/ui/TabSlot.tsx
@@ -117,7 +117,7 @@ export function defaultTabsSlotRender(
   descriptor: TabsDescriptor,
   { isFocused, loaded, detachInactiveScreens }: TabsSlotRenderOptions
 ) {
-  const { lazy = true, unmountOnBlur, freezeOnBlur } = descriptor.options;
+  const { lazy = true, unmountOnBlur } = descriptor.options;
 
   if (unmountOnBlur && !isFocused) {
     return null;
@@ -133,7 +133,7 @@ export function defaultTabsSlotRender(
       key={descriptor.route.key}
       enabled={detachInactiveScreens}
       activityState={isFocused ? 2 : 0}
-      freezeOnBlur={freezeOnBlur}
+      freezeOnBlur={false}
       style={[styles.screen, isFocused ? styles.focused : styles.unfocused]}>
       {descriptor.render()}
     </Screen>


### PR DESCRIPTION
# Why

We plan to replace `react-freeze` with `Activity`, so we need to remove the `freezeOnBlur` prop to keep only one behavior for freezing screens.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>