### PR TITLE
[router] Add NavigationAwareActivity

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/index.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/index.tsx
@@ -35,6 +35,7 @@ const HomeIndex = () => {
       <CaseLink href="/js-tabs" text="JS Tabs" />
       <CaseLink href="/top-tabs" text="JS Top Tabs" />
       <CaseLink href="/experimental-stack" text="Experimental Stack" />
+      <CaseLink href="/navigation-aware-activity" text="Navigation Aware Activity" />
       <CaseLink href="/drawer" text="Drawer" />
       <CaseLink href="/drawer-open" text="Drawer (default open)" />
       <Pressable

--- a/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/_layout.tsx
@@ -1,0 +1,11 @@
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return (
+    <Stack screenOptions={{ headerShown: true }}>
+      <Stack.Screen name="index" options={{ title: 'Activity Home' }} />
+      <Stack.Screen name="a" options={{ title: 'Screen A' }} />
+      <Stack.Screen name="b" options={{ title: 'Screen B' }} />
+    </Stack>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/a.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/a.tsx
@@ -1,0 +1,19 @@
+import { Link, usePathname } from 'expo-router';
+import { Pressable, Text, View } from 'react-native';
+
+export default function ScreenA() {
+  const pathname = usePathname();
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <Text testID="e2e-screen">Screen A</Text>
+      <Text testID="e2e-pathname">{pathname}</Text>
+      <Text>The home screen is still visible at this depth.</Text>
+      <Link testID="e2e-goto-b" href="/navigation-aware-activity/b" asChild>
+        <Pressable style={{ backgroundColor: 'rgb(11, 103, 175)', padding: 16, borderRadius: 8 }}>
+          <Text style={{ color: '#fff' }}>Go to Screen B</Text>
+        </Pressable>
+      </Link>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/b.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/b.tsx
@@ -1,0 +1,14 @@
+import { usePathname } from 'expo-router';
+import { Text, View } from 'react-native';
+
+export default function ScreenB() {
+  const pathname = usePathname();
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', gap: 16 }}>
+      <Text testID="e2e-screen">Screen B</Text>
+      <Text testID="e2e-pathname">{pathname}</Text>
+      <Text>The home screen is hidden at this depth. Go back to check its state.</Text>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/index.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/navigation-aware-activity/index.tsx
@@ -1,0 +1,109 @@
+import { Link, NavigationAwareActivity, usePathname } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function ActivityHome() {
+  return (
+    <NavigationAwareActivity>
+      <ActivityHomeContents />
+    </NavigationAwareActivity>
+  );
+}
+
+function ActivityHomeContents() {
+  const pathname = usePathname();
+  const [count, setCount] = useState(0);
+  const [effectRuns, setEffectRuns] = useState(0);
+  const [cleanupRuns, setCleanupRuns] = useState(0);
+
+  useEffect(() => {
+    setEffectRuns((runs) => runs + 1);
+    return () => setCleanupRuns((runs) => runs + 1);
+  }, []);
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.contentContainer}>
+      <Text style={styles.title} testID="e2e-screen">
+        Navigation Aware Activity
+      </Text>
+      <Text testID="e2e-pathname">{pathname}</Text>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>State</Text>
+        <Text testID="e2e-counter">Counter: {count}</Text>
+        <Pressable
+          testID="e2e-increment"
+          style={styles.button}
+          onPress={() => setCount((value) => value + 1)}>
+          <Text style={styles.buttonText}>Increment</Text>
+        </Pressable>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Effects</Text>
+        <Text testID="e2e-effect-runs">Effect runs: {effectRuns}</Text>
+        <Text testID="e2e-cleanup-runs">Cleanup runs: {cleanupRuns}</Text>
+      </View>
+
+      <Link testID="e2e-goto-a" href="/navigation-aware-activity/a" asChild>
+        <Pressable style={styles.button}>
+          <Text style={styles.buttonText}>Go to Screen A</Text>
+        </Pressable>
+      </Link>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Instructions</Text>
+        <Text style={styles.instruction}>1. Increment the counter a few times.</Text>
+        <Text style={styles.instruction}>
+          2. Push Screen A, then Screen B. This screen now has two screens above it, so the activity
+          hides and the effect cleanup runs.
+        </Text>
+        <Text style={styles.instruction}>
+          3. Go back twice. The counter keeps its value, cleanup runs is 1, and effect runs is 2.
+        </Text>
+        <Text style={styles.instruction}>
+          4. Push only Screen A and go back. One screen above is below the default threshold of 2,
+          so both counts stay unchanged.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  contentContainer: {
+    padding: 16,
+    gap: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  section: {
+    padding: 16,
+    gap: 8,
+    backgroundColor: '#f5f5f5',
+    borderRadius: 8,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  instruction: {
+    fontSize: 14,
+    color: '#666',
+  },
+  button: {
+    backgroundColor: 'rgb(11, 103, 175)',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#fff',
+  },
+});

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### 🎉 New features
 
+- Add unstable `NavigationAwareActivity` component. ([#49145](https://github.com/expo/expo/pull/49145) by [@Ubax](https://github.com/Ubax))
 - Add screen error boundaries ([#49174](https://github.com/expo/expo/pull/49174) by [@Ubax](https://github.com/Ubax))
 - Export `NativeStackView` for custom navigator implementations on web. ([#49204](https://github.com/expo/expo/pull/49204) by [@Ubax](https://github.com/Ubax))
 - Add global registry for routers. ([#48707](https://github.com/expo/expo/pull/48707) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### 🎉 New features
 
-- Add unstable `NavigationAwareActivity` component. ([#49145](https://github.com/expo/expo/pull/49145) by [@Ubax](https://github.com/Ubax))
+- Add unstable `NavigationAwareActivity` component. ([#49164](https://github.com/expo/expo/pull/49164) by [@Ubax](https://github.com/Ubax))
 - Add screen error boundaries ([#49174](https://github.com/expo/expo/pull/49174) by [@Ubax](https://github.com/Ubax))
 - Export `NativeStackView` for custom navigator implementations on web. ([#49204](https://github.com/expo/expo/pull/49204) by [@Ubax](https://github.com/Ubax))
 - Add global registry for routers. ([#48707](https://github.com/expo/expo/pull/48707) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -28,6 +28,7 @@ export { useSitemap, type SitemapType } from './views/useSitemap';
 export type { ErrorBoundaryProps } from './views/Try';
 export { ErrorBoundary } from './views/ErrorBoundary';
 export { SuspenseFallback, type SuspenseFallbackProps } from './views/SuspenseFallback';
+export { NavigationAwareActivity } from './views/NavigationAwareActivity';
 export type { ScreenProps } from './useScreens';
 
 // Platform

--- a/packages/expo-router/src/views/ActivityContents.tsx
+++ b/packages/expo-router/src/views/ActivityContents.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { Activity, type ActivityProps } from 'react';
+import { NativeComponentRegistry, type ViewProps } from 'react-native';
+
+const NativeActivityContents = NativeComponentRegistry.get<ViewProps>(
+  'ExpoRouterActivityContents',
+  () => ({
+    uiViewClassName: 'RCTView',
+    validAttributes: {
+      style: {
+        // @ts-expect-error: React Native's index signature rejects its special nested style config.
+        display: {
+          process: () => 'contents',
+        },
+      },
+    },
+  })
+);
+
+export function ActivityContents({ mode, children }: ActivityProps) {
+  return (
+    <Activity mode={mode}>
+      <NativeActivityContents style={{ display: 'contents' }}>{children}</NativeActivityContents>
+    </Activity>
+  );
+}

--- a/packages/expo-router/src/views/ActivityContents.web.tsx
+++ b/packages/expo-router/src/views/ActivityContents.web.tsx
@@ -1,32 +1,31 @@
 'use client';
 import { Activity, type ActivityProps } from 'react';
 
-export function ActivityContents({ mode, children }: ActivityProps) {
-  const observeActivity = (element: HTMLDivElement | null) => {
-    if (element === null) {
-      return;
+function observeActivity(element: HTMLDivElement | null) {
+  if (element === null) {
+    return;
+  }
+
+  const activityChild = element.firstElementChild;
+  if (!(activityChild instanceof HTMLElement)) {
+    return;
+  }
+
+  const restoreDisplay = () => {
+    if (activityChild.style.display === 'none') {
+      activityChild.style.display = 'contents';
     }
-
-    const restoreDisplay = () => {
-      for (const child of element.children) {
-        if (child instanceof HTMLElement && child.style.display === 'none') {
-          child.style.display = 'contents';
-        }
-      }
-    };
-    const observer = new MutationObserver(restoreDisplay);
-    observer.observe(element, {
-      attributes: true,
-      attributeFilter: ['style'],
-      childList: true,
-      subtree: true,
-    });
-    restoreDisplay();
-
-    return () => observer.disconnect();
   };
+  const observer = new MutationObserver(restoreDisplay);
+  observer.observe(activityChild, { attributes: true, attributeFilter: ['style'] });
+  restoreDisplay();
 
+  return () => observer.disconnect();
+}
+
+export function ActivityContents({ mode, children }: ActivityProps) {
   return (
+    // React detaches refs inside a hidden Activity, so observe it from an outer wrapper.
     <div ref={observeActivity} style={{ display: 'contents' }}>
       <Activity mode={mode}>
         <div style={{ display: 'contents' }}>{children}</div>

--- a/packages/expo-router/src/views/ActivityContents.web.tsx
+++ b/packages/expo-router/src/views/ActivityContents.web.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { Activity, type ActivityProps } from 'react';
+
+export function ActivityContents({ mode, children }: ActivityProps) {
+  const observeActivity = (element: HTMLDivElement | null) => {
+    if (element === null) {
+      return;
+    }
+
+    const restoreDisplay = () => {
+      for (const child of element.children) {
+        if (child instanceof HTMLElement && child.style.display === 'none') {
+          child.style.display = 'contents';
+        }
+      }
+    };
+    const observer = new MutationObserver(restoreDisplay);
+    observer.observe(element, {
+      attributes: true,
+      attributeFilter: ['style'],
+      childList: true,
+      subtree: true,
+    });
+    restoreDisplay();
+
+    return () => observer.disconnect();
+  };
+
+  return (
+    <div ref={observeActivity} style={{ display: 'contents' }}>
+      <Activity mode={mode}>
+        <div style={{ display: 'contents' }}>{children}</div>
+      </Activity>
+    </div>
+  );
+}

--- a/packages/expo-router/src/views/NavigationAwareActivity.tsx
+++ b/packages/expo-router/src/views/NavigationAwareActivity.tsx
@@ -1,0 +1,64 @@
+'use client';
+import type { ReactNode } from 'react';
+
+import { useRouteNode } from '../Route';
+import { useIsFocused, useNavigationState, useRoute } from '../react-navigation/native';
+import { ActivityContents } from './ActivityContents';
+
+export type ActivityMode = 'visible' | 'hidden';
+
+/**
+ * @internal
+ */
+export function useActivityMode(hideWhenNestedAtLevel = 2): ActivityMode {
+  const route = useRoute();
+  const isFocused = useIsFocused();
+  const screensAbove = useNavigationState((state) => {
+    if (state.type !== 'stack') {
+      return 0;
+    }
+
+    const ownIndex = state.routes.findIndex(({ key }) => key === route.key);
+    return ownIndex < 0 ? 0 : Math.max(0, state.index - ownIndex);
+  });
+
+  return hideWhenNestedAtLevel <= 1
+    ? isFocused
+      ? 'visible'
+      : 'hidden'
+    : screensAbove >= hideWhenNestedAtLevel
+      ? 'hidden'
+      : 'visible';
+}
+
+export function NavigationAwareActivity({
+  hideWhenNestedAtLevel = 2,
+  children,
+}: {
+  hideWhenNestedAtLevel?: number;
+  children: ReactNode;
+}) {
+  const routeNode = useRouteNode();
+
+  if (routeNode?.type !== 'route') {
+    throw new Error('NavigationAwareActivity must be rendered inside a screen component.');
+  }
+
+  return (
+    <NavigationAwareScreenActivity hideWhenNestedAtLevel={hideWhenNestedAtLevel}>
+      {children}
+    </NavigationAwareScreenActivity>
+  );
+}
+
+function NavigationAwareScreenActivity({
+  hideWhenNestedAtLevel,
+  children,
+}: {
+  hideWhenNestedAtLevel: number;
+  children: ReactNode;
+}) {
+  const mode = useActivityMode(hideWhenNestedAtLevel);
+
+  return <ActivityContents mode={mode}>{children}</ActivityContents>;
+}

--- a/packages/expo-router/src/views/NavigationAwareActivity.tsx
+++ b/packages/expo-router/src/views/NavigationAwareActivity.tsx
@@ -31,6 +31,18 @@ export function useActivityMode(hideWhenNestedAtLevel = 2): ActivityMode {
       : 'visible';
 }
 
+/**
+ * Wraps the screen contents in a React `Activity` that hides once the screen is buried deep enough
+ * in the stack. Hiding runs effect cleanups and releases resources, but keeps React state, so the
+ * screen looks unchanged when the user navigates back to it.
+ *
+ * Must be rendered inside a screen component.
+ *
+ * @param hideWhenNestedAtLevel How many screens must sit above this one before it hides. `1` hides
+ * the screen as soon as it loses focus, which also works in tabs and drawers. Defaults to `2`.
+ *
+ * > **Note:** This API is unstable and may change or be removed in any release.
+ */
 export function NavigationAwareActivity({
   hideWhenNestedAtLevel = 2,
   children,

--- a/packages/expo-router/src/views/__tests__/ActivityContents.test.ios.tsx
+++ b/packages/expo-router/src/views/__tests__/ActivityContents.test.ios.tsx
@@ -1,0 +1,19 @@
+import { NativeComponentRegistry, View } from 'react-native';
+
+test('keeps Activity content displayed without affecting layout', () => {
+  const get = jest
+    .spyOn(NativeComponentRegistry, 'get')
+    // The test substitutes a regular host view for the registry's host component.
+    .mockImplementation(() => View as ReturnType<typeof NativeComponentRegistry.get>);
+
+  require('../ActivityContents');
+
+  expect(get).toHaveBeenCalledTimes(1);
+  expect(get.mock.calls[0]![0]).toBe('ExpoRouterActivityContents');
+
+  const config = get.mock.calls[0]![1]();
+  expect(config.uiViewClassName).toBe('RCTView');
+  const display = config.validAttributes?.style?.display;
+  expect(typeof display === 'object' && display?.process?.('none')).toBe('contents');
+  expect(typeof display === 'object' && display?.process?.('flex')).toBe('contents');
+});

--- a/packages/expo-router/src/views/__tests__/ActivityContents.test.web.tsx
+++ b/packages/expo-router/src/views/__tests__/ActivityContents.test.web.tsx
@@ -1,0 +1,27 @@
+/** @jest-environment jsdom */
+import { render, waitFor } from '@testing-library/react';
+
+import { ActivityContents } from '../ActivityContents';
+
+test('restores Activity display changes and disconnects its observer', async () => {
+  const disconnect = jest.spyOn(MutationObserver.prototype, 'disconnect');
+  const result = render(
+    <ActivityContents mode="visible">
+      <span>content</span>
+    </ActivityContents>
+  );
+  const outer = result.container.querySelector<HTMLDivElement>('div')!;
+  const activityChild = outer.querySelector<HTMLDivElement>('div')!;
+
+  expect(outer.style.display).toBe('contents');
+  expect(activityChild.style.display).toBe('contents');
+
+  activityChild.style.display = 'none';
+
+  await waitFor(() => expect(activityChild.style.display).toBe('contents'));
+
+  const disconnectCount = disconnect.mock.calls.length;
+  result.unmount();
+  expect(disconnect).toHaveBeenCalledTimes(disconnectCount + 1);
+  disconnect.mockRestore();
+});

--- a/packages/expo-router/src/views/__tests__/ActivityContents.test.web.tsx
+++ b/packages/expo-router/src/views/__tests__/ActivityContents.test.web.tsx
@@ -3,6 +3,27 @@ import { render, waitFor } from '@testing-library/react';
 
 import { ActivityContents } from '../ActivityContents';
 
+test('restores the child hidden by Activity with display: none !important', async () => {
+  const result = render(
+    <ActivityContents mode="visible">
+      <span>content</span>
+    </ActivityContents>
+  );
+  const outer = result.container.querySelector<HTMLDivElement>('div')!;
+  const activityChild = outer.querySelector<HTMLDivElement>('div')!;
+
+  result.rerender(
+    <ActivityContents mode="hidden">
+      <span>content</span>
+    </ActivityContents>
+  );
+
+  // React hides the Activity subtree with `display: none !important`. The
+  // observer must clear it, including the `important` priority.
+  await waitFor(() => expect(activityChild.style.display).toBe('contents'));
+  expect(activityChild.style.getPropertyPriority('display')).toBe('');
+});
+
 test('restores Activity display changes and disconnects its observer', async () => {
   const disconnect = jest.spyOn(MutationObserver.prototype, 'disconnect');
   const result = render(

--- a/packages/expo-router/src/views/__tests__/NavigationAwareActivity.test.ios.tsx
+++ b/packages/expo-router/src/views/__tests__/NavigationAwareActivity.test.ios.tsx
@@ -1,0 +1,273 @@
+import { act, render } from '@testing-library/react-native';
+import * as React from 'react';
+
+import { router } from '../../imperative-api';
+import JSStack from '../../layouts/JSStack';
+import Stack from '../../layouts/Stack';
+import Tabs from '../../layouts/Tabs';
+import {
+  CommonActions,
+  useIsFocused,
+  useNavigation,
+  useRoute,
+} from '../../react-navigation/native';
+import { createStackNavigator, type StackScreenProps } from '../../react-navigation/stack';
+import { renderRouter } from '../../testing-library';
+import {
+  NavigationAwareActivity,
+  useActivityMode,
+  type ActivityMode,
+} from '../NavigationAwareActivity';
+
+jest.mock('../ActivityContents', () => ({
+  ActivityContents: ({ children, mode }: React.ActivityProps) => {
+    const React = require('react') as typeof import('react');
+    return <React.Activity mode={mode}>{children}</React.Activity>;
+  },
+}));
+
+function EmptyScreen() {
+  return null;
+}
+
+function renderModes({ tabs = false, threshold }: { tabs?: boolean; threshold?: number } = {}) {
+  const modes: Record<string, ActivityMode> = {};
+
+  function ModeReporter() {
+    const route = useRoute();
+    modes[route.name] = useActivityMode(threshold);
+    return null;
+  }
+
+  renderRouter({
+    _layout: () =>
+      tabs ? (
+        <Tabs>
+          <Tabs.Screen name="index" />
+          <Tabs.Screen name="b" />
+          <Tabs.Screen name="c" />
+          <Tabs.Screen name="d" />
+          <Tabs.Screen name="e" />
+        </Tabs>
+      ) : (
+        <Stack />
+      ),
+    index: ModeReporter,
+    b: ModeReporter,
+    c: ModeReporter,
+    d: ModeReporter,
+    e: ModeReporter,
+  });
+
+  return modes;
+}
+
+test('hides stack screens at the default depth', () => {
+  const modes = renderModes();
+
+  act(() => router.push('/b'));
+  act(() => router.push('/c'));
+  act(() => router.push('/d'));
+  act(() => router.push('/e'));
+
+  expect(modes).toEqual({
+    index: 'hidden',
+    b: 'hidden',
+    c: 'hidden',
+    d: 'visible',
+    e: 'visible',
+  });
+
+  act(() => router.back());
+
+  expect(modes).toEqual({
+    index: 'hidden',
+    b: 'hidden',
+    c: 'visible',
+    d: 'visible',
+    e: 'visible',
+  });
+});
+
+test.each([
+  {
+    threshold: 1,
+    navigate: () => {
+      router.push('/b');
+      router.push('/c');
+    },
+    expected: { index: 'hidden', b: 'hidden', c: 'visible' },
+  },
+  {
+    threshold: 3,
+    navigate: () => {
+      router.push('/b');
+      router.push('/c');
+      router.push('/d');
+    },
+    expected: { index: 'hidden', b: 'visible', c: 'visible', d: 'visible' },
+  },
+] as const)('supports stack depth $threshold', ({ threshold, navigate, expected }) => {
+  const modes = renderModes({ threshold });
+
+  act(navigate);
+
+  expect(modes).toEqual(expected);
+});
+
+test.each([
+  {
+    threshold: 1,
+    expected: {
+      index: 'hidden',
+      b: 'hidden',
+      c: 'hidden',
+      d: 'hidden',
+      e: 'visible',
+    },
+  },
+  {
+    threshold: 2,
+    expected: {
+      index: 'visible',
+      b: 'visible',
+      c: 'visible',
+      d: 'visible',
+      e: 'visible',
+    },
+  },
+] as const)('uses depth $threshold for tabs', ({ threshold, expected }) => {
+  const modes = renderModes({ tabs: true, threshold });
+
+  act(() => router.navigate('/b'));
+  act(() => router.navigate('/c'));
+  act(() => router.navigate('/d'));
+  act(() => router.navigate('/e'));
+
+  expect(modes).toEqual(expected);
+
+  if (threshold === 1) {
+    act(() => router.navigate('/b'));
+    expect(modes.index).toBe('hidden');
+    expect(modes.b).toBe('visible');
+  }
+});
+
+test('keeps preloaded stack routes visible', () => {
+  const modes: Record<string, ActivityMode> = {};
+  let preload = () => {};
+
+  function ModeReporter() {
+    const navigation = useNavigation();
+    const route = useRoute();
+    modes[route.name] = useActivityMode();
+
+    if (route.name === 'index') {
+      preload = () => navigation.dispatch(CommonActions.preload('b'));
+    }
+
+    return null;
+  }
+
+  renderRouter({ _layout: () => <JSStack />, index: ModeReporter, b: ModeReporter });
+
+  act(preload);
+
+  expect(modes.b).toBe('visible');
+});
+
+test('cleans up effects while preserving local state', async () => {
+  const effect = jest.fn();
+  const cleanup = jest.fn();
+  const renderedValues: number[] = [];
+  let setValue: React.Dispatch<React.SetStateAction<number>> = () => {};
+
+  function StatefulScreen() {
+    const [value, updateValue] = React.useState(0);
+    setValue = updateValue;
+    renderedValues.push(value);
+
+    React.useEffect(() => {
+      effect();
+      return cleanup;
+    }, []);
+
+    return null;
+  }
+
+  renderRouter({
+    _layout: () => <JSStack />,
+    index: () => (
+      <NavigationAwareActivity>
+        <StatefulScreen />
+      </NavigationAwareActivity>
+    ),
+    b: EmptyScreen,
+    c: EmptyScreen,
+  });
+
+  act(() => setValue(1));
+  act(() => router.push('/b'));
+  act(() => router.push('/c'));
+
+  expect(cleanup).toHaveBeenCalledTimes(1);
+
+  await act(async () => router.back());
+
+  expect(effect).toHaveBeenCalledTimes(2);
+  expect(renderedValues.at(-1)).toBe(1);
+});
+
+test('retains nested navigator state while hidden', () => {
+  type NestedParamList = { one: undefined; two: undefined };
+  const NestedStack = createStackNavigator<NestedParamList>();
+  let focusedNestedRoute: keyof NestedParamList | undefined;
+  let navigateNested = () => {};
+
+  function NestedRoute({ navigation, route }: StackScreenProps<NestedParamList>) {
+    navigateNested = () => navigation.navigate('two');
+    if (useIsFocused()) {
+      focusedNestedRoute = route.name;
+    }
+    return null;
+  }
+
+  renderRouter({
+    _layout: () => <JSStack />,
+    index: () => (
+      <NavigationAwareActivity hideWhenNestedAtLevel={1}>
+        <NestedStack.Navigator>
+          <NestedStack.Screen name="one" component={NestedRoute} />
+          <NestedStack.Screen name="two" component={NestedRoute} />
+        </NestedStack.Navigator>
+      </NavigationAwareActivity>
+    ),
+    b: EmptyScreen,
+  });
+
+  act(navigateNested);
+  expect(focusedNestedRoute).toBe('two');
+  act(() => router.push('/b'));
+  act(() => router.back());
+
+  expect(focusedNestedRoute).toBe('two');
+});
+
+test('throws outside a screen', () => {
+  expect(() => render(<NavigationAwareActivity>content</NavigationAwareActivity>)).toThrow(
+    'NavigationAwareActivity must be rendered inside a screen component.'
+  );
+});
+
+test('throws in a layout', () => {
+  expect(() =>
+    renderRouter({
+      _layout: () => (
+        <NavigationAwareActivity>
+          <Stack />
+        </NavigationAwareActivity>
+      ),
+      index: EmptyScreen,
+    })
+  ).toThrow('NavigationAwareActivity must be rendered inside a screen component.');
+});


### PR DESCRIPTION
# Why

Add `NavigationAwareActivity` which can be used to hide content when it's nested deep inside the stack or in hidden tab. 

# How

1. Wrap React `Activity` with state aware wrapper
2. Use hints from https://www.callstack.com/blog/keeping-screens-visible-with-activity-mode-hidden to keep the content visible
3. Expose `hideWhenNestedAtLevel` prop which allows users to customize the depth at which screens should be frozen

# Test Plan

1. CI
2. Router e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>