### PR TITLE
[iOS][precompile] Add SPM prebuild config for RNGH

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add an SPM prebuild config for `react-native-gesture-handler`, so it can ship as a prebuilt XCFramework instead of always building from source.
+- [iOS] Add an SPM prebuild config for `react-native-gesture-handler`, so it can ship as a prebuilt XCFramework instead of always building from source. ([#49171](https://github.com/expo/expo/pull/49171) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Detect React Native versions that ship self-contained XCFrameworks (no VFS overlay) during precompile and pod install, falling back to the legacy VFS overlay integration on pre-0.87 versions. ([#47256](https://github.com/expo/expo/pull/47256) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
 - [Android] Support linking published Gradle plugins. ([#48334](https://github.com/expo/expo/pull/48334) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS] Add an SPM prebuild config for `react-native-gesture-handler`, so it can ship as a prebuilt XCFramework instead of always building from source.
 - [iOS] Detect React Native versions that ship self-contained XCFrameworks (no VFS overlay) during precompile and pod install, falling back to the legacy VFS overlay integration on pre-0.87 versions. ([#47256](https://github.com/expo/expo/pull/47256) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Set `CMAKE_OBJECT_PATH_MAX=1024` by default for the app and all library subprojects that build native code with CMake, so long object file paths (for example in pnpm monorepos on Windows) no longer fail the build. Configurable with the `expo.android.cmakeObjectPathMax` Gradle property. ([#47791](https://github.com/expo/expo/pull/47791) by [@ide](https://github.com/ide))
 - [Android] Support linking published Gradle plugins. ([#48334](https://github.com/expo/expo/pull/48334) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-gesture-handler/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-gesture-handler/spm.config.json
@@ -1,0 +1,153 @@
+{
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "products": [
+        {
+            "name": "RNGestureHandler",
+            "podName": "RNGestureHandler",
+            "codegenName": "rngesturehandler_codegen",
+            "platforms": [
+                "iOS(.v15)"
+            ],
+            "externalDependencies": [
+                "ReactNativeDependencies",
+                "React",
+                "Hermes",
+                "RNWorklets"
+            ],
+            "targets": [
+                {
+                    "type": "cpp",
+                    "name": "RNGestureHandler_codegen_components",
+                    "moduleName": "rngesturehandler_codegen",
+                    "path": ".build/codegen/build/generated/ios/ReactCodegen/react/renderer/components/rngesturehandler_codegen",
+                    "pattern": "**/*.cpp",
+                    "headerPattern": "**/*.h",
+                    "dependencies": [
+                        "React",
+                        "ReactNativeDependencies"
+                    ],
+                    "includeDirectories": [
+                        "../../../.."
+                    ],
+                    "fileMapping": [
+                        {
+                            "from": "rngesturehandler_codegen",
+                            "to": "react/renderer/components/rngesturehandler_codegen",
+                            "type": "symlink"
+                        }
+                    ]
+                },
+                {
+                    "type": "objc",
+                    "name": "RNGestureHandler_codegen_modules",
+                    "moduleName": "rngesturehandler_codegen",
+                    "path": ".build/codegen/build/generated/ios/ReactCodegen/rngesturehandler_codegen",
+                    "pattern": "**/*.mm",
+                    "headerPattern": "**/*.h",
+                    "dependencies": [
+                        "React",
+                        "ReactNativeDependencies"
+                    ],
+                    "includeDirectories": [
+                        ".."
+                    ]
+                },
+                {
+                    "type": "cpp",
+                    "name": "RNGestureHandler_runtime",
+                    "path": "shared/runtime",
+                    "pattern": "**/*.cpp",
+                    "headerPattern": "**/*.h",
+                    "dependencies": [
+                        "React",
+                        "ReactNativeDependencies",
+                        "Hermes",
+                        "RNWorklets",
+                        "RNGestureHandler_codegen_components"
+                    ],
+                    "includeDirectories": [
+                        ".",
+                        "../../.build/codegen/build/generated/ios/ReactCodegen"
+                    ],
+                    "compilerFlags": [
+                        "-DRNGH_USE_WORKLETS=1",
+                        "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"
+                    ]
+                },
+                {
+                    "type": "cpp",
+                    "name": "RNGestureHandler_shadow_nodes",
+                    "moduleName": "rngesturehandler_codegen",
+                    "path": "shared/shadowNodes/react/renderer/components/rngesturehandler_codegen",
+                    "pattern": "**/*.cpp",
+                    "headerPattern": "**/*.h",
+                    "exclude": [
+                        "ComponentDescriptors.h"
+                    ],
+                    "dependencies": [
+                        "React",
+                        "ReactNativeDependencies",
+                        "RNGestureHandler_codegen_components"
+                    ],
+                    "includeDirectories": [
+                        "."
+                    ],
+                    "fileMapping": [
+                        {
+                            "from": "rngesturehandler_codegen",
+                            "to": "react/renderer/components/rngesturehandler_codegen",
+                            "type": "symlink"
+                        }
+                    ]
+                },
+                {
+                    "type": "objc",
+                    "name": "RNGestureHandler",
+                    "path": "apple",
+                    "pattern": "**/*.{m,mm}",
+                    "headerPattern": "**/*.h",
+                    "exclude": [
+                        "RNGestureHandler.xcodeproj/**"
+                    ],
+                    "dependencies": [
+                        "Hermes",
+                        "React",
+                        "ReactNativeDependencies",
+                        "RNWorklets",
+                        "RNGestureHandler_codegen_components",
+                        "RNGestureHandler_codegen_modules",
+                        "RNGestureHandler_runtime",
+                        "RNGestureHandler_shadow_nodes"
+                    ],
+                    "includeDirectories": [
+                        ".",
+                        "../shared/runtime",
+                        "../.build/codegen/build/generated/ios/ReactCodegen",
+                        "../.build/generated/RNGestureHandler/RNGestureHandler_codegen_components/include/rngesturehandler_codegen",
+                        "../.build/generated/RNGestureHandler/RNGestureHandler_shadow_nodes/include/rngesturehandler_codegen"
+                    ],
+                    "linkedFrameworks": [
+                        "Foundation",
+                        "UIKit",
+                        "QuartzCore"
+                    ],
+                    "compilerFlags": [
+                        "-include",
+                        "Foundation/Foundation.h",
+                        "-include",
+                        "UIKit/UIKit.h",
+                        "-DRNGH_USE_WORKLETS=1",
+                        "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}"
+                    ],
+                    "fileMapping": [
+                        {
+                            "from": "Handlers/*.h",
+                            "to": "RNGestureHandler/Handlers/{filename}",
+                            "type": "header"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
# Why

RNGH compiles c++ code (although it is not a huge offender in build-times), so it will benefit from being prebuilt. 

It also depends on RNWorklets - which has an issue in newer version causing compiling it against the precompiled from a source-built package (RNGH -> RNWorklets) fails with the following error:

```bash
❌  (node_modules/react-native-gesture-handler/shared/runtime/RNGHRuntimeDecorator.cpp:11:10)

   9 |
  10 | #if RNGH_USE_WORKLETS
> 11 | #include <worklets/Compat/StableApi.h>
     |          ^ 'worklets/Compat/StableApi.h' file not found
  12 | #endif
  13 |
  14 | namespace gesturehandler {
```

# How

Add build config to prebuild RNGH and push it to our GCloud bucket for EAS build to consume.

# Test Plan

Build application with RNGH and RNWorklets on EAS build.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
