### PR TITLE
[camera] Add normalizeOrientation option to takePictureAsync

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 - Added `CameraView.scanDocumentAsync` to scan multi-page documents on Android and iOS. ([#47362](https://github.com/expo/expo/pull/47362) by [@alanjhughes](https://github.com/alanjhughes))
-- Added a `normalizeOrientation` option to `takePictureAsync` that rotates the captured pixels upright so the returned image is always EXIF `Orientation` 1, for consumers that ignore the orientation tag. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@boojamya](https://github.com/boojamya))
+- Added a `normalizeOrientation` option to `takePictureAsync` that rotates the captured pixels upright so the returned image is always EXIF `Orientation` 1, for consumers that ignore the orientation tag. ([#49175](https://github.com/expo/expo/pull/49175) by [@boojamya](https://github.com/boojamya))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [Android] Add `PhotographicSensitivity` to returned EXIF metadata. ([#47222](https://github.com/expo/expo/pull/47222) by [@Wenszel](https://github.com/Wenszel))
 - Added `CameraView.scanDocumentAsync` to scan multi-page documents on Android and iOS. ([#47362](https://github.com/expo/expo/pull/47362) by [@alanjhughes](https://github.com/alanjhughes))
+- Added a `normalizeOrientation` option to `takePictureAsync` that rotates the captured pixels upright so the returned image is always EXIF `Orientation` 1, for consumers that ignore the orientation tag. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@boojamya](https://github.com/boojamya))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
@@ -13,6 +13,7 @@ data class PictureOptions(
   @Field val additionalExif: Map<String, Any>? = null,
   @Field val mirror: Boolean = false,
   @Field val skipProcessing: Boolean = false,
+  @Field val normalizeOrientation: Boolean = false,
   @Field val imageType: PictureFormat = PictureFormat.JPEG,
   @Field val fastMode: Boolean = false,
   @Field val id: Int? = null,

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/tasks/ResolveTakenPicture.kt
@@ -99,7 +99,11 @@ class ResolveTakenPicture(
           ExifInterface.TAG_ORIENTATION,
           ExifInterface.ORIENTATION_NORMAL
         )
-        if (mirror) {
+        if (options.normalizeOrientation) {
+          // Rotation (and mirroring) is baked into the pixels below, so the
+          // output must not carry a transform tag.
+          exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL.toString())
+        } else if (mirror) {
           exifInterface.setAttribute(ExifInterface.TAG_ORIENTATION, getMirroredOrientation(orientation).toString())
         }
 
@@ -125,6 +129,15 @@ class ResolveTakenPicture(
         if (bitmap == null) {
           promise.reject(OUT_OF_MEMORY_TAG, OUT_OF_MEMORY_EXCEPTION_MSG, lastError)
           return null
+        }
+
+        // Rotation is baked into the pixels, so the recorded dimensions have to
+        // describe the rotated bitmap rather than the sensor buffer.
+        if (options.normalizeOrientation) {
+          exifInterface.setAttribute(ExifInterface.TAG_PIXEL_X_DIMENSION, bitmap.width.toString())
+          exifInterface.setAttribute(ExifInterface.TAG_PIXEL_Y_DIMENSION, bitmap.height.toString())
+          exifInterface.setAttribute(ExifInterface.TAG_IMAGE_WIDTH, bitmap.width.toString())
+          exifInterface.setAttribute(ExifInterface.TAG_IMAGE_LENGTH, bitmap.height.toString())
         }
 
         // Write Exif data to the response if requested
@@ -240,8 +253,9 @@ class ResolveTakenPicture(
   }
 
   private fun decodeBitmap(imageData: ByteArray, orientation: Int, options: PictureOptions, bitmapOptions: BitmapFactory.Options): Bitmap {
-    // Rotate the bitmap to the proper orientation if needed
-    return if (!options.exif) {
+    // Rotate the bitmap to the proper orientation if needed. With `exif` the
+    // orientation is preserved as a tag instead, unless normalization is requested.
+    return if (!options.exif || options.normalizeOrientation) {
       decodeAndRotateBitmap(imageData, getImageRotation(orientation), bitmapOptions)
     } else {
       BitmapFactory.decodeByteArray(imageData, 0, imageData.size, bitmapOptions)

--- a/packages/expo-camera/ios/Common/CapturedPhotoProcessor.swift
+++ b/packages/expo-camera/ios/Common/CapturedPhotoProcessor.swift
@@ -46,6 +46,14 @@ struct CapturedPhotoProcessor {
     var updatedMetadata = sourceMetadata
     updatedMetadata[kCGImagePropertyOrientation as String] =
       ExpoCameraUtils.toExifOrientation(orientation: image.imageOrientation)
+    // Keep a nested TIFF orientation in sync with the top-level tag so a stale
+    // value can't survive into the serialized file.
+    if var tiffDict = updatedMetadata[kCGImagePropertyTIFFDictionary as String] as? [String: Any],
+      tiffDict[kCGImagePropertyTIFFOrientation as String] != nil {
+      tiffDict[kCGImagePropertyTIFFOrientation as String] =
+        ExpoCameraUtils.toExifOrientation(orientation: image.imageOrientation)
+      updatedMetadata[kCGImagePropertyTIFFDictionary as String] = tiffDict
+    }
 
     if let additionalExif = request.additionalExif {
       for (key, value) in additionalExif {

--- a/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
+++ b/packages/expo-camera/ios/Common/ExpoCameraUtils.swift
@@ -179,6 +179,85 @@ struct ExpoCameraUtils {
     return UIImage(cgImage: croppedCgImage, scale: image.scale, orientation: image.imageOrientation)
   }
 
+  /**
+   Redraws the image so its pixels are upright and `imageOrientation` is `.up` (EXIF orientation 1).
+   Draws through a raw `CGContext` in the source color space at scale 1 to preserve wide-gamut captures
+   (a `UIGraphicsImageRenderer` pass would flatten Display P3 to sRGB at screen scale). Returns the image
+   unchanged when it is already upright or when no bitmap context can be created for its pixel format.
+   */
+  static func bakeOrientation(image: UIImage) -> UIImage {
+    guard image.imageOrientation != .up, let cgImage = image.cgImage else {
+      return image
+    }
+
+    let sourceWidth = CGFloat(cgImage.width)
+    let sourceHeight = CGFloat(cgImage.height)
+    let swapsDimensions: Bool
+    switch image.imageOrientation {
+    case .left, .leftMirrored, .right, .rightMirrored:
+      swapsDimensions = true
+    default:
+      swapsDimensions = false
+    }
+    let outputWidth = swapsDimensions ? sourceHeight : sourceWidth
+    let outputHeight = swapsDimensions ? sourceWidth : sourceHeight
+
+    var transform = CGAffineTransform.identity
+    switch image.imageOrientation {
+    case .down, .downMirrored:
+      transform = transform.translatedBy(x: outputWidth, y: outputHeight).rotated(by: .pi)
+    case .left, .leftMirrored:
+      transform = transform.translatedBy(x: outputWidth, y: 0).rotated(by: .pi / 2)
+    case .right, .rightMirrored:
+      transform = transform.translatedBy(x: 0, y: outputHeight).rotated(by: -.pi / 2)
+    default:
+      break
+    }
+    switch image.imageOrientation {
+    case .upMirrored, .downMirrored:
+      transform = transform.translatedBy(x: outputWidth, y: 0).scaledBy(x: -1, y: 1)
+    case .leftMirrored, .rightMirrored:
+      transform = transform.translatedBy(x: outputHeight, y: 0).scaledBy(x: -1, y: 1)
+    default:
+      break
+    }
+
+    return autoreleasepool { () -> UIImage in
+      // Prefer the source pixel format; fall back to 8-bit RGBA in device RGB
+      // for formats that can't back a bitmap context.
+      guard let context = CGContext(
+        data: nil,
+        width: Int(outputWidth),
+        height: Int(outputHeight),
+        bitsPerComponent: cgImage.bitsPerComponent,
+        bytesPerRow: 0,
+        space: cgImage.colorSpace ?? CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: cgImage.bitmapInfo.rawValue
+      ) ?? CGContext(
+        data: nil,
+        width: Int(outputWidth),
+        height: Int(outputHeight),
+        bitsPerComponent: 8,
+        bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      ) else {
+        return image
+      }
+
+      // Exact quarter/half turns map pixels one-to-one; pin nearest-neighbor
+      // so no resampling path can soften the render.
+      context.interpolationQuality = .none
+      context.concatenate(transform)
+      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: sourceWidth, height: sourceHeight))
+
+      guard let uprightImage = context.makeImage() else {
+        return image
+      }
+      return UIImage(cgImage: uprightImage, scale: image.scale, orientation: .up)
+    }
+  }
+
   static func write(data: Data, to path: String) -> String? {
     let url = URL(fileURLWithPath: path)
     do {

--- a/packages/expo-camera/ios/Common/PictureOptions.swift
+++ b/packages/expo-camera/ios/Common/PictureOptions.swift
@@ -26,6 +26,9 @@ struct TakePictureOptions: Record {
   var additionalExif: [String: Any]?
 
   @Field
+  var normalizeOrientation: Bool = false
+
+  @Field
   var shutterSound: Bool? = true
 
   @Field

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -191,6 +191,10 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
 
     takenImage = ExpoCameraUtils.crop(image: takenImage, to: croppedSize)
 
+    if options.normalizeOrientation {
+      takenImage = ExpoCameraUtils.bakeOrientation(image: takenImage)
+    }
+
     let request = CaptureRequest(
       exif: options.exif,
       quality: options.quality,

--- a/packages/expo-camera/ios/Tests/CapturedPhotoProcessorTests.swift
+++ b/packages/expo-camera/ios/Tests/CapturedPhotoProcessorTests.swift
@@ -109,6 +109,31 @@ struct CapturedPhotoProcessorTests {
   }
 
   @Test
+  func `syncs a stale nested TIFF orientation with the top-level tag`() throws {
+    // An upright image (e.g. after `normalizeOrientation`) whose source
+    // metadata still carries the sensor's TIFF orientation.
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .up)
+    let request = CaptureRequest(exif: true, quality: 1, imageType: .jpg, additionalExif: nil)
+
+    let result = try CapturedPhotoProcessor().process(
+      image: image,
+      sourceMetadata: [
+        kCGImagePropertyExifDictionary as String: [String: Any](),
+        kCGImagePropertyTIFFDictionary as String: [kCGImagePropertyTIFFOrientation as String: 6]
+      ],
+      request: request
+    )
+
+    let source = try #require(CGImageSourceCreateWithData(result.data as CFData, nil))
+    let props = try #require(CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any])
+    #expect(props[kCGImagePropertyOrientation] as? Int == 1)
+    if let tiff = props[kCGImagePropertyTIFFDictionary] as? [CFString: Any],
+      let tiffOrientation = tiff[kCGImagePropertyTIFFOrientation] as? Int {
+      #expect(tiffOrientation == 1)
+    }
+  }
+
+  @Test
   func `additionalExif is reflected in the returned exif and encoded as GPS metadata`() throws {
     let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
     let additionalExif: [String: Any] = ["GPSLatitude": 37.33, "GPSLongitude": -122.03]

--- a/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
+++ b/packages/expo-camera/ios/Tests/ExpoCameraUtilsTests.swift
@@ -140,6 +140,65 @@ struct ExpoCameraUtilsTests {
     #expect(cropped.scale == 1)
   }
 
+  @Test(arguments: [
+    UIImage.Orientation.down,
+    .left,
+    .right,
+    .upMirrored,
+    .downMirrored,
+    .leftMirrored,
+    .rightMirrored
+  ] as [UIImage.Orientation])
+  func `bakeOrientation returns an upright image at display dimensions`(orientation: UIImage.Orientation) {
+    let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: orientation)
+
+    let baked = ExpoCameraUtils.bakeOrientation(image: image)
+
+    let swaps = [UIImage.Orientation.left, .leftMirrored, .right, .rightMirrored].contains(orientation)
+    #expect(baked.imageOrientation == .up)
+    #expect(baked.cgImage?.width == (swaps ? 300 : 400))
+    #expect(baked.cgImage?.height == (swaps ? 400 : 300))
+    // UIImage.size is display-oriented, so it must not change across the bake.
+    #expect(baked.size == image.size)
+  }
+
+  @Test
+  func `bakeOrientation returns the same instance when already upright`() {
+    let image = makeImage(bufferWidth: 100, bufferHeight: 80, orientation: .up)
+
+    #expect(ExpoCameraUtils.bakeOrientation(image: image) === image)
+  }
+
+  @Test
+  func `bakeOrientation rotates the pixels, not just the tag`() throws {
+    // Displayed via .right (EXIF 6), the buffer's white left half is at the
+    // top — so it must end up at the top of the baked pixels.
+    let image = makeHalfWhiteImage(orientation: .right)
+
+    let baked = try #require(ExpoCameraUtils.bakeOrientation(image: image).cgImage)
+
+    #expect(baked.width == 2)
+    #expect(baked.height == 4)
+    let pixels = try #require(rgba(of: baked))
+    #expect(pixels[0] == 255) // top-left is white
+    #expect(pixels[(baked.height - 1) * baked.width * 4] == 0) // bottom-left is black
+  }
+
+  @Test
+  func `bakeOrientation applies mirrored orientations`() throws {
+    // .upMirrored (EXIF 2) flips horizontally: the buffer's white left half
+    // displays on the right.
+    let image = makeHalfWhiteImage(orientation: .upMirrored)
+
+    let baked = try #require(ExpoCameraUtils.bakeOrientation(image: image).cgImage)
+
+    #expect(baked.width == 4)
+    #expect(baked.height == 2)
+    let pixels = try #require(rgba(of: baked))
+    #expect(pixels[0] == 0) // top-left is black
+    #expect(pixels[(baked.width - 1) * 4] == 255) // top-right is white
+  }
+
   @Test
   func `encodeForSave writes the capture orientation and returns display dimensions`() throws {
     let image = makeImage(bufferWidth: 400, bufferHeight: 300, orientation: .right)
@@ -177,5 +236,41 @@ struct ExpoCameraUtilsTests {
       context.fill(CGRect(x: 0, y: 0, width: bufferWidth, height: bufferHeight))
     }
     return UIImage(cgImage: base.cgImage!, scale: 1, orientation: orientation)
+  }
+
+  // A 4x2 buffer with the left half white and the right half black.
+  private func makeHalfWhiteImage(orientation: UIImage.Orientation) -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    let base = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 2), format: format).image { context in
+      UIColor.black.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 4, height: 2))
+      UIColor.white.setFill()
+      context.fill(CGRect(x: 0, y: 0, width: 2, height: 2))
+    }
+    return UIImage(cgImage: base.cgImage!, scale: 1, orientation: orientation)
+  }
+
+  // RGBA8 bytes of the image, rows top to bottom.
+  private func rgba(of cgImage: CGImage) -> [UInt8]? {
+    let width = cgImage.width
+    let height = cgImage.height
+    var data = [UInt8](repeating: 0, count: width * height * 4)
+    let drawn = data.withUnsafeMutableBytes { buffer -> Bool in
+      guard let context = CGContext(
+        data: buffer.baseAddress,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+      ) else {
+        return false
+      }
+      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+      return true
+    }
+    return drawn ? data : nil
   }
 }

--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -160,6 +160,22 @@ export type CameraPictureOptions = {
    */
   skipProcessing?: boolean;
   /**
+   * If set to `true`, the resulting image is normalized at capture: the pixels are rotated upright (and mirrored,
+   * when the `mirror` option is enabled) inside the existing processing pipeline, and the EXIF `Orientation` tag is
+   * always `1`. Use this when the image bytes are consumed by tooling that ignores EXIF orientation — server-side
+   * processing, hashing or signing, or `Image` components that don't apply the stored orientation. This is the
+   * counterpart to `skipProcessing`: where that option skips orientation adjustment entirely, this one applies it
+   * permanently to the pixel data. It is ignored when `skipProcessing` is enabled.
+   *
+   * Has no effect when the capture is already upright. On iOS, this temporarily allocates one additional
+   * full-resolution bitmap while the upright copy is drawn. On web, captures are always upright, so the option is
+   * a no-op there.
+   * @default false
+   * @platform android
+   * @platform ios
+   */
+  normalizeOrientation?: boolean;
+  /**
    * @platform web
    */
   scale?: number;


### PR DESCRIPTION
# Why

expo-camera deliberately stopped rotating captured pixels on iOS in #47824 and records the capture orientation in EXIF instead. That is the right default, but a large class of consumers ignores the EXIF tag — upload backends, hashing and signing pipelines (C2PA), and image components that don't apply stored orientation — and "photos come out sideways after upload" remains one of the most common camera complaints. The `skipProcessing` docs already acknowledge the orientation-uncertainty problem; this adds the missing other half: an explicit, opt-in way to get upright pixels.

Android is inconsistent today: with `exif: false` the pixels are rotated upright, but with `exif: true` they are left as captured and the orientation is preserved as a tag — the same model as iOS.

# How

New opt-in `CameraPictureOptions.normalizeOrientation` (default `false`; existing behavior untouched):

- **iOS** — after the existing preview-aspect crop, the image is redrawn upright by a new `ExpoCameraUtils.bakeOrientation`. The draw rides the existing decode → encode pipeline, so it adds no extra compression generation — one `CGContext` draw. The context uses the source color space at scale 1 to preserve Display P3 (a `UIGraphicsImageRenderer` pass would flatten to sRGB at screen scale), pins `interpolationQuality = .none` (exact quarter/half turns map pixels one-to-one), falls back to 8-bit RGBA in device RGB for pixel formats that can't back a bitmap context, and fails open (returns the image unchanged) rather than throwing. The work is wrapped in an autoreleasepool; peak cost is one extra full-resolution bitmap during the draw.
- **iOS** — `CapturedPhotoProcessor` now also keeps a nested `{TIFF}` orientation in sync with the top-level tag it writes, so a stale sensor value can't survive into the serialized file.
- **Android** — with `normalizeOrientation`, the `exif: true` path uses the same decode-and-rotate the `exif: false` path already uses (mirroring included), writes `ORIENTATION_NORMAL` to the output EXIF instead of copying the capture tag, and updates the pixel-dimension tags to describe the rotated bitmap (`addExifData` copies `PixelXDimension`/`ImageWidth` back from the capture, which would otherwise be transposed relative to the rotated pixels).
- **Web** — captures are already upright; documented as a no-op.
- Ignored when `skipProcessing` is enabled, since that skips the processing pipeline as a whole.

`photo.width`/`photo.height` are unchanged (already display-oriented). `photo.exif.Orientation` becomes `1`, and the pixel-dimension tags describe the upright buffer.

# Test Plan

**Unit tests** added to the existing `ios/Tests` suites: `bakeOrientation` maps all seven non-upright orientations to `.up` at display dimensions and leaves `UIImage.size` unchanged; pixel-level assertions that rotation and mirroring transform the pixels rather than just the tag; an already-upright image is returned as the same instance; and the `{TIFF}` orientation sync round-trips through an encoded JPEG. Note for reviewers: I wasn't able to run the iOS test target locally, so CI is their first execution.

**iOS device verification** (iPhone SE 2nd gen, iOS 26.5.2), four device orientations plus a front-camera capture, checked from the exported originals rather than the UI:

```
$ exiftool -s -ImageWidth -ImageHeight -Orientation -ProfileDescription *.JPG
ImageWidth: 3024   ImageHeight: 4032   Orientation: Horizontal (normal)   ProfileDescription: Display P3
ImageWidth: 4032   ImageHeight: 3024   Orientation: Horizontal (normal)   ProfileDescription: Display P3
ImageWidth: 4032   ImageHeight: 3024   Orientation: Horizontal (normal)   ProfileDescription: Display P3
ImageWidth: 3024   ImageHeight: 4032   Orientation: Horizontal (normal)   ProfileDescription: Display P3
```

Every capture is upright at full sensor resolution with the wide-gamut profile intact. With the option omitted, output matches the existing behavior.

**Android device verification** (Pixel 10), same four orientations, before and after the change:

```
before:  4000x3000  Orientation: Rotate 90 CW    ExifImageWidth: 4000  ExifImageHeight: 3000
         4000x3000  Orientation: Horizontal      ExifImageWidth: 4000  ExifImageHeight: 3000
         4000x3000  Orientation: Rotate 270 CW   ExifImageWidth: 4000  ExifImageHeight: 3000
         4000x3000  Orientation: Rotate 180      ExifImageWidth: 4000  ExifImageHeight: 3000

after:   3000x4000  Orientation: Horizontal      ExifImageWidth: 3000  ExifImageHeight: 4000
         4000x3000  Orientation: Horizontal      ExifImageWidth: 4000  ExifImageHeight: 3000
         3000x4000  Orientation: Horizontal      ExifImageWidth: 3000  ExifImageHeight: 4000
         4000x3000  Orientation: Horizontal      ExifImageWidth: 4000  ExifImageHeight: 3000
```

The quarter-turn holds are transposed to upright portrait, every tag is `1`, and the pixel-dimension tags follow the rotated bitmap.

Front-camera mirroring is covered by the unit tests rather than the device runs, since the app used for verification does not enable the `mirror` option.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
