### PR TITLE
[router] Get linking route info from React scope instead of store.routeInfo

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,7 +50,6 @@
 
 ### 🐛 Bug fixes
 
-- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### 🐛 Bug fixes
 
+- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,7 +50,6 @@
 
 ### 🐛 Bug fixes
 
-- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
@@ -67,6 +66,7 @@
 
 ### 💡 Others
 
+- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/getInitialURLWithTimeout.ts
+++ b/packages/expo-router/src/fork/getInitialURLWithTimeout.ts
@@ -1,0 +1,21 @@
+import * as ExpoLinking from 'expo-linking';
+import { Linking, Platform } from 'react-native';
+
+export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
+  if (typeof window === 'undefined') {
+    return '';
+  } else if (Platform.OS === 'ios') {
+    // Use the new Expo API for iOS. This has better support for App Clips and handoff.
+    return ExpoLinking.getLinkingURL();
+  }
+
+  return Promise.race([
+    // TODO: Phase this out in favor of expo-linking on Android.
+    Linking.getInitialURL(),
+    new Promise<null>((resolve) =>
+      // Timeout in 150ms if `getInitialState` doesn't resolve
+      // Workaround for https://github.com/facebook/react-native/issues/25675
+      setTimeout(() => resolve(null), 150)
+    ),
+  ]);
+}

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -2,6 +2,7 @@ import * as ExpoLinking from 'expo-linking';
 import { type RefObject, useEffect, useCallback, useRef } from 'react';
 import { Linking, Platform } from 'react-native';
 
+import { useRouteInfo } from '../global-state/useRouteInfo';
 import {
   type LinkingOptions,
   getActionFromState as getActionFromStateDefault,
@@ -10,10 +11,13 @@ import {
   type ParamListBase,
 } from '../react-navigation/native';
 import { extractExpoPathFromURL } from './extractPathFromURL';
+import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
-type Options = LinkingOptions<ParamListBase>;
+type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
+  getStateFromPath?: typeof getExpoStateFromPath;
+};
 
 const linkingHandlers: symbol[] = [];
 
@@ -49,8 +53,11 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
+  const independent = useNavigationIndependentTree();
+  const { segments } = useRouteInfo();
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
       return undefined;
@@ -93,6 +100,10 @@ export function useLinking(
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
   const getActionFromStateRef = useRef(getActionFromState);
+  const segmentsRef = useRef(segments);
+
+  // Keep stable URL listeners in sync with the latest navigation state.
+  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -112,7 +123,9 @@ export function useLinking(
 
       const path = extractExpoPathFromURL(prefixesRef.current, url);
 
-      return path !== undefined ? getStateFromPathRef.current(path, configRef.current) : undefined;
+      return path !== undefined
+        ? getStateFromPathRef.current(path, configRef.current, segmentsRef.current)
+        : undefined;
     },
 
     []

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,7 +53,6 @@ export function useLinking(
     });
   const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
-  const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -15,9 +15,7 @@ import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
-type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
-  getStateFromPath?: typeof getExpoStateFromPath;
-};
+type Options = LinkingOptions<ParamListBase>;
 
 const linkingHandlers: symbol[] = [];
 
@@ -53,8 +51,7 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,8 +53,8 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
@@ -102,8 +102,7 @@ export function useLinking(
   const getActionFromStateRef = useRef(getActionFromState);
   const segmentsRef = useRef(segments);
 
-  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
-  // against the route that was current when the URL was received.
+  // Keep stable URL listeners in sync with the latest navigation state.
   segmentsRef.current = segments;
 
   useEffect(() => {

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -1,6 +1,5 @@
-import * as ExpoLinking from 'expo-linking';
-import { type RefObject, useEffect, useCallback, useRef } from 'react';
-import { Linking, Platform } from 'react-native';
+import { type RefObject, useEffect, useEffectEvent, useCallback, useRef } from 'react';
+import { Linking } from 'react-native';
 
 import { useRouteInfo } from '../global-state/useRouteInfo';
 import {
@@ -11,6 +10,7 @@ import {
   type ParamListBase,
 } from '../react-navigation/native';
 import { extractExpoPathFromURL } from './extractPathFromURL';
+import { getInitialURLWithTimeout } from './getInitialURLWithTimeout';
 import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
@@ -100,11 +100,6 @@ export function useLinking(
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
   const getActionFromStateRef = useRef(getActionFromState);
-  const segmentsRef = useRef(segments);
-
-  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
-  // against the route that was current when the URL was received.
-  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -125,12 +120,13 @@ export function useLinking(
       const path = extractExpoPathFromURL(prefixesRef.current, url);
 
       return path !== undefined
-        ? getStateFromPathRef.current(path, configRef.current, segmentsRef.current)
+        ? getStateFromPathRef.current(path, configRef.current, segments)
         : undefined;
     },
 
-    []
+    [segments]
   );
+  const getStateFromURLInEffect = useEffectEvent(getStateFromURL);
 
   const getInitialState = useCallback(() => {
     let state: ResultState | undefined;
@@ -177,7 +173,7 @@ export function useLinking(
       }
 
       const navigation = ref.current;
-      const state = navigation ? getStateFromURL(url) : undefined;
+      const state = navigation ? getStateFromURLInEffect(url) : undefined;
 
       if (navigation && state) {
         // If the link were handled, it gets cleared in NavigationContainer
@@ -208,28 +204,9 @@ export function useLinking(
     };
 
     return subscribe(listener);
-  }, [enabled, getStateFromURL, onUnhandledLinking, prefixes, ref, subscribe]);
+  }, [enabled, onUnhandledLinking, prefixes, ref, subscribe]);
 
   return {
     getInitialState,
   };
-}
-
-export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  if (typeof window === 'undefined') {
-    return '';
-  } else if (Platform.OS === 'ios') {
-    // Use the new Expo API for iOS. This has better support for App Clips and handoff.
-    return ExpoLinking.getLinkingURL();
-  }
-
-  return Promise.race([
-    // TODO: Phase this out in favor of expo-linking on Android.
-    Linking.getInitialURL(),
-    new Promise<null>((resolve) =>
-      // Timeout in 150ms if `getInitialState` doesn't resolve
-      // Workaround for https://github.com/facebook/react-native/issues/25675
-      setTimeout(() => resolve(null), 150)
-    ),
-  ]);
 }

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,8 +53,8 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath = (options?.getStateFromPath ??
-    getStateFromPathDefault) as typeof getExpoStateFromPath;
+  const getStateFromPath: typeof getExpoStateFromPath =
+    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
@@ -102,7 +102,8 @@ export function useLinking(
   const getActionFromStateRef = useRef(getActionFromState);
   const segmentsRef = useRef(segments);
 
-  // Keep stable URL listeners in sync with the latest navigation state.
+  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
+  // against the route that was current when the URL was received.
   segmentsRef.current = segments;
 
   useEffect(() => {

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -1,5 +1,13 @@
 import isEqual from 'fast-deep-equal';
-import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'react';
+import {
+  type RefObject,
+  useEffect,
+  useEffectEvent,
+  useState,
+  useCallback,
+  useRef,
+  use,
+} from 'react';
 
 import { ServerContext } from '../global-state/serverLocationContext';
 import { useExpoRouterStore } from '../global-state/storeContext';
@@ -135,11 +143,6 @@ export function useLinking(
   const getStateFromPathRef = useRef(getStateFromPath);
   const getPathFromStateRef = useRef(getPathFromState);
   const getActionFromStateRef = useRef(getActionFromState);
-  const segmentsRef = useRef(segments);
-
-  // Segments are navigation state, so keep this ref current during render. The
-  // linking listeners intentionally remain stable across navigation updates.
-  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -148,6 +151,12 @@ export function useLinking(
     getPathFromStateRef.current = getPathFromState;
     getActionFromStateRef.current = getActionFromState;
   });
+
+  const getStateFromPathForCurrentSegments = useCallback(
+    (path: string) => getStateFromPathRef.current(path, configRef.current, segments),
+    [segments]
+  );
+  const getStateFromPathInEffect = useEffectEvent(getStateFromPathForCurrentSegments);
 
   const validateRoutesNotExistInRootState = useCallback(
     (state: ResultState) => {
@@ -182,7 +191,7 @@ export function useLinking(
         : undefined;
 
       if (path) {
-        value = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
+        value = getStateFromPathForCurrentSegments(path);
       }
 
       // If the link were handled, it gets cleared in NavigationContainer
@@ -200,7 +209,7 @@ export function useLinking(
 
     return thenable as PromiseLike<ResultState | undefined>;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [getStateFromPathForCurrentSegments, onUnhandledLinking, server]);
 
   const previousIndexRef = useRef<number | undefined>(undefined);
   const previousStateRef = useRef<NavigationState | undefined>(undefined);
@@ -236,7 +245,7 @@ export function useLinking(
         return;
       }
 
-      const state = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
+      const state = getStateFromPathInEffect(path);
 
       // We should only dispatch an action when going forward
       // Otherwise the action will likely add items to history, which would mess things up
@@ -314,11 +323,7 @@ export function useLinking(
       // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
       // This makes sure that we preserve the original URL for wildcard routes
       if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(
-          route.path,
-          configRef.current,
-          segmentsRef.current
-        );
+        const stateForPath = getStateFromPathInEffect(route.path);
 
         if (stateForPath) {
           const focusedRoute = findFocusedRoute(stateForPath);
@@ -485,8 +490,4 @@ export function useLinking(
   return {
     getInitialState,
   };
-}
-
-export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  return typeof window === 'undefined' ? '' : window.location.href;
 }

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -86,8 +86,8 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath = (options?.getStateFromPath ??
-    getStateFromPathDefault) as typeof getExpoStateFromPath;
+  const getStateFromPath: typeof getExpoStateFromPath =
+    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -86,8 +86,8 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -83,9 +83,7 @@ export const series = (cb: () => Promise<void>) => {
 
 const linkingHandlers: symbol[] = [];
 
-type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
-  getStateFromPath?: typeof getExpoStateFromPath;
-};
+type Options = LinkingOptions<ParamListBase>;
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
@@ -94,8 +92,7 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();
@@ -208,8 +205,9 @@ export function useLinking(
     };
 
     return thenable as PromiseLike<ResultState | undefined>;
+    // NavigationContainer consumes this callback only once through useThenable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getStateFromPathForCurrentSegments, onUnhandledLinking, server]);
+  }, []);
 
   const previousIndexRef = useRef<number | undefined>(undefined);
   const previousStateRef = useRef<NavigationState | undefined>(undefined);

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -3,6 +3,7 @@ import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'r
 
 import { ServerContext } from '../global-state/serverLocationContext';
 import { useExpoRouterStore } from '../global-state/storeContext';
+import { useRouteInfo } from '../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../global-state/utils';
 import {
   type LinkingOptions,
@@ -17,6 +18,7 @@ import {
 import { getHistoryLength } from '../utils/stack';
 import { createMemoryHistory } from './createMemoryHistory';
 import { appendBaseUrl } from './getPathFromState';
+import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
@@ -73,7 +75,9 @@ export const series = (cb: () => Promise<void>) => {
 
 const linkingHandlers: symbol[] = [];
 
-type Options = LinkingOptions<ParamListBase>;
+type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
+  getStateFromPath?: typeof getExpoStateFromPath;
+};
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
@@ -82,10 +86,12 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();
+  const { segments } = useRouteInfo();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
@@ -129,6 +135,11 @@ export function useLinking(
   const getStateFromPathRef = useRef(getStateFromPath);
   const getPathFromStateRef = useRef(getPathFromState);
   const getActionFromStateRef = useRef(getActionFromState);
+  const segmentsRef = useRef(segments);
+
+  // Segments are navigation state, so keep this ref current during render. The
+  // linking listeners intentionally remain stable across navigation updates.
+  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -171,7 +182,7 @@ export function useLinking(
         : undefined;
 
       if (path) {
-        value = getStateFromPathRef.current(path, configRef.current);
+        value = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
       }
 
       // If the link were handled, it gets cleared in NavigationContainer
@@ -225,7 +236,7 @@ export function useLinking(
         return;
       }
 
-      const state = getStateFromPathRef.current(path, configRef.current);
+      const state = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
 
       // We should only dispatch an action when going forward
       // Otherwise the action will likely add items to history, which would mess things up
@@ -303,7 +314,11 @@ export function useLinking(
       // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
       // This makes sure that we preserve the original URL for wildcard routes
       if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(route.path, configRef.current);
+        const stateForPath = getStateFromPathRef.current(
+          route.path,
+          configRef.current,
+          segmentsRef.current
+        );
 
         if (stateForPath) {
           const focusedRoute = findFocusedRoute(stateForPath);

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -2,7 +2,7 @@ import { Platform } from 'expo';
 
 import type { RouteNode } from './Route';
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './constants';
-import type { Options, State } from './fork/getPathFromState';
+import type { State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
 import type { StoreRedirects } from './global-state/router-store';
@@ -134,13 +134,7 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath: <ParamList extends object>(
-      path: string,
-      options?: Options<ParamList>,
-      previousSegments?: string[]
-    ) => {
-      return getStateFromPath(path, options, previousSegments);
-    },
+    getStateFromPath,
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (
         getPathFromState(state, {

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -6,7 +6,7 @@ import type { State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
 import type { StoreRedirects } from './global-state/router-store';
-import { getInitialURL, getPathFromState, getStateFromPath, subscribe } from './link/linking';
+import { getInitialURL, getPathFromState, subscribe } from './link/linking';
 import type { LinkingOptions } from './react-navigation/native';
 import { getActionFromState } from './react-navigation/native';
 import type { NativeIntent, RequireContext } from './types';
@@ -47,7 +47,6 @@ export function getNavigationConfig(
 
 export type ExpoLinkingOptions<T extends object = Record<string, unknown>> = LinkingOptions<T> & {
   getPathFromState: typeof getPathFromState;
-  getStateFromPath: typeof getStateFromPath;
 };
 
 export type LinkingConfigOptions = {
@@ -134,7 +133,6 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath,
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (
         getPathFromState(state, {

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -5,7 +5,6 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './
 import type { Options, State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
-import type { UrlObject } from './global-state/getRouteInfoFromState';
 import type { StoreRedirects } from './global-state/router-store';
 import { getInitialURL, getPathFromState, getStateFromPath, subscribe } from './link/linking';
 import type { LinkingOptions } from './react-navigation/native';
@@ -67,7 +66,6 @@ interface RouterOptions {
 export function getLinkingConfig(
   routes: RouteNode,
   context: RequireContext,
-  getRouteInfo: () => UrlObject,
   {
     metaOnly = true,
     serverUrl,
@@ -113,13 +111,19 @@ export function getLinkingConfig(
           if (typeof initialUrl === 'string') {
             initialUrl = applyRedirects(initialUrl, redirects);
             if (initialUrl && typeof nativeLinking?.redirectSystemPath === 'function') {
-              initialUrl = nativeLinking.redirectSystemPath({ path: initialUrl, initial: true });
+              initialUrl = nativeLinking.redirectSystemPath({
+                path: initialUrl,
+                initial: true,
+              });
             }
           } else if (initialUrl) {
             initialUrl = initialUrl.then((url) => {
               url = applyRedirects(url, redirects);
               if (url && typeof nativeLinking?.redirectSystemPath === 'function') {
-                return nativeLinking.redirectSystemPath({ path: url, initial: true });
+                return nativeLinking.redirectSystemPath({
+                  path: url,
+                  initial: true,
+                });
               }
               return url;
             });
@@ -130,8 +134,12 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath: <ParamList extends object>(path: string, options?: Options<ParamList>) => {
-      return getStateFromPath(path, options, getRouteInfo().segments);
+    getStateFromPath: <ParamList extends object>(
+      path: string,
+      options?: Options<ParamList>,
+      previousSegments?: string[]
+    ) => {
+      return getStateFromPath(path, options, previousSegments);
     },
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -110,19 +110,13 @@ export function getLinkingConfig(
           if (typeof initialUrl === 'string') {
             initialUrl = applyRedirects(initialUrl, redirects);
             if (initialUrl && typeof nativeLinking?.redirectSystemPath === 'function') {
-              initialUrl = nativeLinking.redirectSystemPath({
-                path: initialUrl,
-                initial: true,
-              });
+              initialUrl = nativeLinking.redirectSystemPath({ path: initialUrl, initial: true });
             }
           } else if (initialUrl) {
             initialUrl = initialUrl.then((url) => {
               url = applyRedirects(url, redirects);
               if (url && typeof nativeLinking?.redirectSystemPath === 'function') {
-                return nativeLinking.redirectSystemPath({
-                  path: url,
-                  initial: true,
-                });
+                return nativeLinking.redirectSystemPath({ path: url, initial: true });
               }
               return url;
             });

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -175,6 +175,22 @@ describe(getNavigateAction, () => {
     );
   });
 
+  it('uses route information provided by the caller', () => {
+    const routeInfo = {
+      pathname: '/current',
+      pathnameWithParams: '/current',
+      segments: ['current'],
+      params: {},
+      searchParams: new URLSearchParams(),
+      unstable_globalHref: '',
+      isIndex: false,
+    };
+
+    getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
+
+    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
+  });
+
   it('preserves PUSH when target navigator is tab', () => {
     mockFindDivergentState.mockReturnValue({
       actionState: { routes: [{ name: 'tab1' }] },

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,32 +1,9 @@
 import { applyRedirects } from '../../getRoutesRedirects';
 import { getStateFromPath } from '../../link/linking';
-import type { SingularOptions } from '../../useScreens';
-import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
+import { getNavigateAction } from '../getNavigationAction';
 import { defaultRouteInfo } from '../getRouteInfoFromState';
-import type { UrlObject } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
-import type { LinkToOptions } from '../types';
-
-function getNavigateAction(
-  baseHref: string,
-  options: LinkToOptions,
-  type = 'NAVIGATE',
-  withAnchor?: boolean,
-  singular?: SingularOptions,
-  isPreviewNavigation?: boolean,
-  routeInfo: Pick<UrlObject, 'segments' | 'params'> = defaultRouteInfo
-) {
-  return getNavigateActionImplementation(
-    baseHref,
-    options,
-    routeInfo,
-    type,
-    withAnchor,
-    singular,
-    isPreviewNavigation
-  );
-}
 
 jest.mock('../store', () => ({
   store: {
@@ -121,14 +98,14 @@ describe(getNavigateAction, () => {
       throw new Error('Not ready');
     });
 
-    expect(() => getNavigateAction('/home', {})).toThrow('Not ready');
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow('Not ready');
   });
 
   it('throws when navigationRef.current is null', () => {
     const originalCurrent = store.navigationRef.current;
     (store.navigationRef as any).current = null;
 
-    expect(() => getNavigateAction('/home', {})).toThrow(
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       "Couldn't find a navigation object. Is your component inside NavigationContainer?"
     );
 
@@ -142,7 +119,7 @@ describe(getNavigateAction, () => {
       configurable: true,
     });
 
-    expect(() => getNavigateAction('/home', {})).toThrow(
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       'Attempted to link to route when no routes are present'
     );
 
@@ -155,7 +132,7 @@ describe(getNavigateAction, () => {
   it('returns undefined when applyRedirects returns undefined', () => {
     mockApplyRedirects.mockReturnValueOnce(undefined as any);
 
-    const result = getNavigateAction('/redirect', {});
+    const result = getNavigateAction('/redirect', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
   });
@@ -164,7 +141,7 @@ describe(getNavigateAction, () => {
     mockGetStateFromPath.mockReturnValueOnce(null as any);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = getNavigateAction('/bad-path', {});
+    const result = getNavigateAction('/bad-path', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
@@ -179,7 +156,7 @@ describe(getNavigateAction, () => {
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = getNavigateAction('/bad-path', {});
+    const result = getNavigateAction('/bad-path', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
@@ -189,7 +166,7 @@ describe(getNavigateAction, () => {
   });
 
   it('returns action with type NAVIGATE by default', () => {
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
@@ -215,7 +192,7 @@ describe(getNavigateAction, () => {
       isIndex: false,
     };
 
-    getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
+    getNavigateAction('/home', {}, routeInfo, 'NAVIGATE', undefined, undefined, false);
 
     expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
   });
@@ -235,7 +212,7 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/tab1', {}, 'PUSH');
+    const result = getNavigateAction('/tab1', {}, defaultRouteInfo, 'PUSH');
 
     expect(result!.type).toBe('PUSH');
   });
@@ -255,7 +232,7 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/screen1', {}, 'PUSH');
+    const result = getNavigateAction('/screen1', {}, defaultRouteInfo, 'PUSH');
 
     expect(result!.type).toBe('PUSH');
   });
@@ -275,13 +252,13 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/screen1', {}, 'REPLACE');
+    const result = getNavigateAction('/screen1', {}, defaultRouteInfo, 'REPLACE');
 
     expect(result!.type).toBe('REPLACE');
   });
 
   it('sets target to navigationState.key', () => {
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(result!.target).toBe('nav-key');
   });
@@ -298,7 +275,7 @@ describe(getNavigateAction, () => {
       },
     });
 
-    const result = getNavigateAction('/home', {}, 'NAVIGATE', true);
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE', true);
 
     // withAnchor=true → initial should be set to false at every level (inverted logic)
     const params = result!.payload.params as Record<string, any>;
@@ -312,6 +289,7 @@ describe(getNavigateAction, () => {
     const result = getNavigateAction(
       '/home',
       {},
+      defaultRouteInfo,
       'NAVIGATE',
       false,
       undefined,
@@ -329,13 +307,13 @@ describe(getNavigateAction, () => {
   it('passes singular option through to payload', () => {
     const singular = true;
 
-    const result = getNavigateAction('/home', {}, 'NAVIGATE', false, singular);
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE', false, singular);
 
     expect(result!.payload.singular).toBe(true);
   });
 
   it('PRELOAD uses lookThroughAllTabs=true on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'PRELOAD');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'PRELOAD');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -345,7 +323,7 @@ describe(getNavigateAction, () => {
   });
 
   it('non-PRELOAD uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'NAVIGATE');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -355,7 +333,7 @@ describe(getNavigateAction, () => {
   });
 
   it('REPLACE on stack navigator stays as REPLACE', () => {
-    const result = getNavigateAction('/home', {}, 'REPLACE');
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'REPLACE');
 
     expect(result!.type).toBe('REPLACE');
   });
@@ -379,14 +357,14 @@ describe(getNavigateAction, () => {
 
     mockGetPayload.mockReturnValue({ screen: undefined, params: {} });
 
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(mockGetPayload).toHaveBeenCalledWith({});
     expect(result).toBeDefined();
   });
 
   it('PUSH uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'PUSH');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'PUSH');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -396,7 +374,7 @@ describe(getNavigateAction, () => {
   });
 
   it('REPLACE uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'REPLACE');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'REPLACE');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,7 +1,19 @@
 import { applyRedirects } from '../../getRoutesRedirects';
-import { getNavigateAction } from '../getNavigationAction';
+import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
+import { defaultRouteInfo } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
+
+const getNavigateAction = (...args: any[]) =>
+  getNavigateActionImplementation(
+    args[0],
+    args[1],
+    args[2] ?? 'NAVIGATE',
+    args[3],
+    args[4],
+    args[5],
+    args[6] ?? defaultRouteInfo
+  );
 
 jest.mock('../store', () => ({
   store: {

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,19 +1,32 @@
 import { applyRedirects } from '../../getRoutesRedirects';
+import { getStateFromPath } from '../../link/linking';
+import type { SingularOptions } from '../../useScreens';
 import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
 import { defaultRouteInfo } from '../getRouteInfoFromState';
+import type { UrlObject } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
+import type { LinkToOptions } from '../types';
 
-const getNavigateAction = (...args: any[]) =>
-  getNavigateActionImplementation(
-    args[0],
-    args[1],
-    args[2] ?? 'NAVIGATE',
-    args[3],
-    args[4],
-    args[5],
-    args[6] ?? defaultRouteInfo
+function getNavigateAction(
+  baseHref: string,
+  options: LinkToOptions,
+  type = 'NAVIGATE',
+  withAnchor?: boolean,
+  singular?: SingularOptions,
+  isPreviewNavigation?: boolean,
+  routeInfo: Pick<UrlObject, 'segments' | 'params'> = defaultRouteInfo
+) {
+  return getNavigateActionImplementation(
+    baseHref,
+    options,
+    type,
+    withAnchor,
+    singular,
+    isPreviewNavigation,
+    routeInfo
   );
+}
 
 jest.mock('../store', () => ({
   store: {
@@ -37,7 +50,6 @@ jest.mock('../store', () => ({
     },
     state: undefined as any,
     linking: {
-      getStateFromPath: jest.fn(),
       config: {},
     },
     getRouteInfo: jest.fn(() => ({
@@ -62,14 +74,19 @@ jest.mock('../../link/href', () => ({
   resolveHrefStringWithSegments: jest.fn((href: string) => href),
 }));
 
+jest.mock('../../link/linking', () => ({
+  getStateFromPath: jest.fn(),
+}));
+
 const mockFindDivergentState = findDivergentState as jest.MockedFunction<typeof findDivergentState>;
 const mockGetPayload = getPayloadFromStateRoute as jest.MockedFunction<
   typeof getPayloadFromStateRoute
 >;
 const mockApplyRedirects = applyRedirects as jest.MockedFunction<typeof applyRedirects>;
+const mockGetStateFromPath = getStateFromPath as jest.MockedFunction<typeof getStateFromPath>;
 
 function setupDefaultMocks() {
-  (store.linking!.getStateFromPath as jest.Mock).mockReturnValue({
+  mockGetStateFromPath.mockReturnValue({
     routes: [{ name: 'home' }],
   });
 
@@ -144,7 +161,7 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns null', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce(null);
+    mockGetStateFromPath.mockReturnValueOnce(null as any);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = getNavigateAction('/bad-path', {});
@@ -157,7 +174,7 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns empty routes', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({
+    mockGetStateFromPath.mockReturnValueOnce({
       routes: [],
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -174,7 +191,7 @@ describe(getNavigateAction, () => {
   it('returns action with type NAVIGATE by default', () => {
     const result = getNavigateAction('/home', {});
 
-    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, []);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -200,7 +217,7 @@ describe(getNavigateAction, () => {
 
     getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
 
-    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
   });
 
   it('preserves PUSH when target navigator is tab', () => {

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -108,13 +108,19 @@ describe(getNavigateAction, () => {
 
   it('throws when store.linking is falsy', () => {
     const originalLinking = store.linking;
-    Object.defineProperty(store, 'linking', { value: null, configurable: true });
+    Object.defineProperty(store, 'linking', {
+      value: null,
+      configurable: true,
+    });
 
     expect(() => getNavigateAction('/home', {})).toThrow(
       'Attempted to link to route when no routes are present'
     );
 
-    Object.defineProperty(store, 'linking', { value: originalLinking, configurable: true });
+    Object.defineProperty(store, 'linking', {
+      value: originalLinking,
+      configurable: true,
+    });
   });
 
   it('returns undefined when applyRedirects returns undefined', () => {
@@ -139,7 +145,9 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns empty routes', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({ routes: [] });
+    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({
+      routes: [],
+    });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = getNavigateAction('/bad-path', {});
@@ -153,6 +161,8 @@ describe(getNavigateAction, () => {
 
   it('returns action with type NAVIGATE by default', () => {
     const result = getNavigateAction('/home', {});
+
+    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
     expect(result).toEqual(
       expect.objectContaining({

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -20,11 +20,11 @@ function getNavigateAction(
   return getNavigateActionImplementation(
     baseHref,
     options,
+    routeInfo,
     type,
     withAnchor,
     singular,
-    isPreviewNavigation,
-    routeInfo
+    isPreviewNavigation
   );
 }
 

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -104,6 +104,15 @@ describe('routingQueue', () => {
 
   it('run() converts ROUTER_LINK actions via getNavigateAction then dispatches', () => {
     const ref = makeRef();
+    const routeInfo = {
+      pathname: '/current',
+      pathnameWithParams: '/current',
+      segments: ['current'],
+      params: {},
+      searchParams: new URLSearchParams(),
+      unstable_globalHref: '',
+      isIndex: false,
+    };
     const navigateAction = {
       type: 'NAVIGATE',
       payload: { name: 'home', params: {}, singular: false },
@@ -116,7 +125,7 @@ describe('routingQueue', () => {
       payload: { href: '/home', options: { event: 'NAVIGATE' } },
     });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, routeInfo);
 
     expect(mockGetNavigateAction).toHaveBeenCalledWith(
       '/home',
@@ -124,7 +133,8 @@ describe('routingQueue', () => {
       'NAVIGATE',
       undefined,
       undefined,
-      false
+      false,
+      routeInfo
     );
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -131,11 +131,11 @@ describe('routingQueue', () => {
     expect(mockGetNavigateAction).toHaveBeenCalledWith(
       '/home',
       { event: 'NAVIGATE' },
+      routeInfo,
       'NAVIGATE',
       undefined,
       undefined,
-      false,
-      routeInfo
+      false
     );
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -2,6 +2,7 @@ import type { RefObject } from 'react';
 
 import type { NavigationContainerRef, ParamListBase } from '../../react-navigation/native';
 import { getNavigateAction } from '../getNavigationAction';
+import { defaultRouteInfo } from '../getRouteInfoFromState';
 import { routingQueue } from '../routingQueue';
 
 jest.mock('../getNavigationAction', () => ({
@@ -87,7 +88,7 @@ describe('routingQueue', () => {
     routingQueue.add({ type: 'GO_BACK' });
     routingQueue.add({ type: 'POP_TO_TOP' });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(routingQueue.queue).toHaveLength(0);
   });
@@ -97,7 +98,7 @@ describe('routingQueue', () => {
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(ref.current!.dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
   });
@@ -148,7 +149,7 @@ describe('routingQueue', () => {
       payload: { href: '/redirect', options: { event: 'NAVIGATE' } },
     });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(ref.current!.dispatch).not.toHaveBeenCalled();
   });
@@ -158,7 +159,7 @@ describe('routingQueue', () => {
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref as any);
+    routingQueue.run(ref as any, defaultRouteInfo);
 
     // Queue should still be drained (reset identity happens before dispatch loop)
     expect(routingQueue.queue).toHaveLength(0);
@@ -171,7 +172,7 @@ describe('routingQueue', () => {
 
     const oldQueue = routingQueue.queue;
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     // The queue should be a new array reference
     expect(routingQueue.queue).not.toBe(oldQueue);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -7,6 +7,7 @@ import {
   type InternalExpoRouterParams,
 } from '../navigationParams';
 import type { SingularOptions } from '../useScreens';
+import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
 import { store } from './store';
 import type { LinkToOptions } from './types';
@@ -17,7 +18,8 @@ export function getNavigateAction(
   type = 'NAVIGATE',
   withAnchor?: boolean,
   singular?: SingularOptions,
-  isPreviewNavigation?: boolean
+  isPreviewNavigation?: boolean,
+  routeInfo: UrlObject = defaultRouteInfo
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();
@@ -33,8 +35,6 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
-  const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,7 +33,8 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  href = resolveHrefStringWithSegments(href, store.getRouteInfo(), options);
+  const routeInfo = store.getRouteInfo();
+  href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 
   // If the href is undefined, it means that the redirect has already been handled by the navigation
@@ -41,7 +42,7 @@ export function getNavigateAction(
     return;
   }
 
-  const state = store.linking.getStateFromPath!(href, store.linking.config);
+  const state = store.linking.getStateFromPath!(href, store.linking.config, routeInfo.segments);
 
   if (!state || state.routes.length === 0) {
     console.error('Could not generate a valid navigation state for the given path: ' + href);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,7 +33,6 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
   const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -7,7 +7,7 @@ import {
   type InternalExpoRouterParams,
 } from '../navigationParams';
 import type { SingularOptions } from '../useScreens';
-import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
+import type { UrlObject } from './getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
 import { store } from './store';
 import type { LinkToOptions } from './types';
@@ -15,11 +15,11 @@ import type { LinkToOptions } from './types';
 export function getNavigateAction(
   baseHref: string,
   options: LinkToOptions,
-  type = 'NAVIGATE',
-  withAnchor?: boolean,
-  singular?: SingularOptions,
-  isPreviewNavigation?: boolean,
-  routeInfo: UrlObject = defaultRouteInfo
+  type: string,
+  withAnchor: boolean | undefined,
+  singular: SingularOptions | undefined,
+  isPreviewNavigation: boolean | undefined,
+  routeInfo: UrlObject
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -1,5 +1,6 @@
 import { applyRedirects } from '../getRoutesRedirects';
 import { resolveHrefStringWithSegments } from '../link/href';
+import { getStateFromPath } from '../link/linking';
 import {
   appendInternalExpoRouterParams,
   INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME,
@@ -19,7 +20,7 @@ export function getNavigateAction(
   withAnchor: boolean | undefined,
   singular: SingularOptions | undefined,
   isPreviewNavigation: boolean | undefined,
-  routeInfo: UrlObject
+  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();
@@ -35,7 +36,7 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  href = resolveHrefStringWithSegments(href, routeInfo, options);
+  href = resolveHrefStringWithSegments(href, { segments, params: routeParams }, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 
   // If the href is undefined, it means that the redirect has already been handled by the navigation
@@ -43,7 +44,7 @@ export function getNavigateAction(
     return;
   }
 
-  const state = store.linking.getStateFromPath!(href, store.linking.config, routeInfo.segments);
+  const state = getStateFromPath(href, store.linking.config, segments);
 
   if (!state || state.routes.length === 0) {
     console.error('Could not generate a valid navigation state for the given path: ' + href);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -16,11 +16,11 @@ import type { LinkToOptions } from './types';
 export function getNavigateAction(
   baseHref: string,
   options: LinkToOptions,
-  type: string,
-  withAnchor: boolean | undefined,
-  singular: SingularOptions | undefined,
-  isPreviewNavigation: boolean | undefined,
-  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>
+  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>,
+  type = 'NAVIGATE',
+  withAnchor?: boolean,
+  singular?: SingularOptions,
+  isPreviewNavigation?: boolean
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,6 +33,7 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
+  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
   const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -35,7 +35,10 @@ export const routingQueue = {
       callback();
     }
   },
-  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>, routeInfo: UrlObject) {
+  run(
+    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
+    routeInfo: Pick<UrlObject, 'segments' | 'params'>
+  ) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -51,7 +54,7 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event ?? 'NAVIGATE',
+            options.event!,
             options.withAnchor,
             options.dangerouslySingular,
             !!options.__internal__PreviewKey,

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -6,7 +6,7 @@ import type {
   NavigationContainerRef,
 } from '../react-navigation/native';
 import { getNavigateAction } from './getNavigationAction';
-import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
+import type { UrlObject } from './getRouteInfoFromState';
 import type { LinkToOptions } from './types';
 
 export interface LinkAction {
@@ -35,10 +35,7 @@ export const routingQueue = {
       callback();
     }
   },
-  run(
-    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
-    routeInfo: UrlObject = defaultRouteInfo
-  ) {
+  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>, routeInfo: UrlObject) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -54,7 +51,7 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event,
+            options.event ?? 'NAVIGATE',
             options.withAnchor,
             options.dangerouslySingular,
             !!options.__internal__PreviewKey,

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -6,6 +6,7 @@ import type {
   NavigationContainerRef,
 } from '../react-navigation/native';
 import { getNavigateAction } from './getNavigationAction';
+import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import type { LinkToOptions } from './types';
 
 export interface LinkAction {
@@ -34,7 +35,10 @@ export const routingQueue = {
       callback();
     }
   },
-  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>) {
+  run(
+    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
+    routeInfo: UrlObject = defaultRouteInfo
+  ) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -53,7 +57,8 @@ export const routingQueue = {
             options.event,
             options.withAnchor,
             options.dangerouslySingular,
-            !!options.__internal__PreviewKey
+            !!options.__internal__PreviewKey,
+            routeInfo
           );
           // TODO: Consider warning when getNavigateAction returns undefined
           if (action) {

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -54,11 +54,11 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event!,
+            routeInfo,
+            options.event,
             options.withAnchor,
             options.dangerouslySingular,
-            !!options.__internal__PreviewKey,
-            routeInfo
+            !!options.__internal__PreviewKey
           );
           // TODO: Consider warning when getNavigateAction returns undefined
           if (action) {

--- a/packages/expo-router/src/global-state/store.ts
+++ b/packages/expo-router/src/global-state/store.ts
@@ -2,18 +2,11 @@ import type { ComponentType } from 'react';
 
 import type { RouteNode } from '../Route';
 import type { ExpoLinkingOptions } from '../getLinkingConfig';
-import { resolveHref, resolveHrefStringWithSegments } from '../link/href';
 import type { NavigationContainerRefWithCurrent } from '../react-navigation/native';
-import type { Href } from '../types';
 import * as SplashScreen from '../views/Splash';
 import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { getCachedRouteInfo, routeInfoSubscribers } from './routeInfoCache';
-import type {
-  FocusedRouteState,
-  LinkToOptions,
-  ReactNavigationState,
-  StoreRedirects,
-} from './types';
+import type { FocusedRouteState, ReactNavigationState, StoreRedirects } from './types';
 
 export type RouterStore = typeof store;
 
@@ -68,12 +61,6 @@ export const store = {
   },
   get rootComponent() {
     return storeRef.current.rootComponent;
-  },
-  getStateForHref(href: Href | string, options?: LinkToOptions) {
-    href = resolveHref(href);
-
-    href = resolveHrefStringWithSegments(href, store.getRouteInfo(), options);
-    return this.linking?.getStateFromPath!(href, this.linking.config);
   },
   get linking() {
     return storeRef.current.linking;

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -78,7 +78,7 @@ export function useStore(
       // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
       if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
 
-      initialState = linking.getStateFromPath(initialPath, linking.config);
+      initialState = linking.getStateFromPath(initialPath, linking.config, []);
       const initialRouteInfo = getRouteInfoFromState(initialState);
       setCachedRouteInfo(initialState as any, initialRouteInfo);
     }

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -58,7 +58,7 @@ export function useStore(
 
   if (routeNode) {
     // We have routes, so get the linking config and the root component
-    linking = getLinkingConfig(routeNode, context, () => store.getRouteInfo(), {
+    linking = getLinkingConfig(routeNode, context, {
       metaOnly: linkingConfigOptions.metaOnly,
       serverUrl,
       redirects,

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -11,6 +11,7 @@ import type { ExpoLinkingOptions, LinkingConfigOptions } from '../getLinkingConf
 import { getLinkingConfig } from '../getLinkingConfig';
 import { parseRouteSegments } from '../getReactNavigationConfig';
 import { getRoutes } from '../getRoutes';
+import { getStateFromPath } from '../link/linking';
 import { useNavigationContainerRef } from '../react-navigation/native';
 import type { RequireContext } from '../types';
 import { getQualifiedRouteComponent } from '../useScreens';
@@ -78,7 +79,7 @@ export function useStore(
       // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
       if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
 
-      initialState = linking.getStateFromPath(initialPath, linking.config, []);
+      initialState = getStateFromPath(initialPath, linking.config, []);
       const initialRouteInfo = getRouteInfoFromState(initialState);
       setCachedRouteInfo(initialState as any, initialRouteInfo);
     }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useSyncExternalStore } from 'react';
+import { type RefObject, useEffect, useEffectEvent, useSyncExternalStore } from 'react';
 
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
@@ -18,8 +18,10 @@ export function useImperativeApiEmitter(
     routingQueue.snapshot,
     routingQueue.snapshot
   );
+  const runQueue = useEffectEvent(() => routingQueue.run(ref, routeInfo));
+
   useEffect(() => {
-    routingQueue.run(ref, routeInfo);
-  }, [events, ref, routeInfo]);
+    runQueue();
+  }, [events, ref]);
   return null;
 }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -3,6 +3,7 @@ import { type RefObject, useEffect, useSyncExternalStore } from 'react';
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
 import { routingQueue } from './global-state/routing';
+import { useRouteInfo } from './global-state/useRouteInfo';
 import type { NavigationContainerRef, ParamListBase } from './react-navigation/native';
 
 export type { ImperativeRouter };
@@ -11,13 +12,14 @@ export { router };
 export function useImperativeApiEmitter(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>
 ) {
+  const routeInfo = useRouteInfo();
   const events = useSyncExternalStore(
     routingQueue.subscribe,
     routingQueue.snapshot,
     routingQueue.snapshot
   );
   useEffect(() => {
-    routingQueue.run(ref);
-  }, [events, ref]);
+    routingQueue.run(ref, routeInfo);
+  }, [events, ref, routeInfo]);
   return null;
 }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -18,6 +18,7 @@ export function useImperativeApiEmitter(
     routingQueue.snapshot
   );
   useEffect(() => {
+    // TODO: Use useRouteInfo once it is computed from global state.
     routingQueue.run(ref, store.getRouteInfo());
   }, [events, ref]);
   return null;

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -1,9 +1,9 @@
-import { type RefObject, useEffect, useEffectEvent, useSyncExternalStore } from 'react';
+import { type RefObject, useEffect, useSyncExternalStore } from 'react';
 
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
 import { routingQueue } from './global-state/routing';
-import { useRouteInfo } from './global-state/useRouteInfo';
+import { store } from './global-state/store';
 import type { NavigationContainerRef, ParamListBase } from './react-navigation/native';
 
 export type { ImperativeRouter };
@@ -12,16 +12,13 @@ export { router };
 export function useImperativeApiEmitter(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>
 ) {
-  const routeInfo = useRouteInfo();
   const events = useSyncExternalStore(
     routingQueue.subscribe,
     routingQueue.snapshot,
     routingQueue.snapshot
   );
-  const runQueue = useEffectEvent(() => routingQueue.run(ref, routeInfo));
-
   useEffect(() => {
-    runQueue();
+    routingQueue.run(ref, store.getRouteInfo());
   }, [events, ref]);
   return null;
 }

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -1,5 +1,5 @@
-import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import type { UrlObject } from '../global-state/getRouteInfoFromState';
+import { store } from '../global-state/router-store';
 import type { LinkToOptions } from '../global-state/types';
 import type { Href } from '../types';
 import { resolveHref, resolveHrefStringWithSegments } from './href';
@@ -7,10 +7,9 @@ import { resolveHref, resolveHrefStringWithSegments } from './href';
 export function getStateForHref(
   href: Href | string,
   routeInfo: UrlObject,
-  linking: ExpoLinkingOptions | undefined,
   options?: LinkToOptions
 ) {
   href = resolveHref(href);
   href = resolveHrefStringWithSegments(href, routeInfo, options);
-  return linking?.getStateFromPath!(href, linking.config, routeInfo.segments);
+  return store.linking?.getStateFromPath!(href, store.linking.config, routeInfo.segments);
 }

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -1,0 +1,16 @@
+import type { ExpoLinkingOptions } from '../getLinkingConfig';
+import type { UrlObject } from '../global-state/getRouteInfoFromState';
+import type { LinkToOptions } from '../global-state/types';
+import type { Href } from '../types';
+import { resolveHref, resolveHrefStringWithSegments } from './href';
+
+export function getStateForHref(
+  href: Href | string,
+  routeInfo: UrlObject,
+  linking: ExpoLinkingOptions | undefined,
+  options?: LinkToOptions
+) {
+  href = resolveHref(href);
+  href = resolveHrefStringWithSegments(href, routeInfo, options);
+  return linking?.getStateFromPath!(href, linking.config, routeInfo.segments);
+}

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -3,13 +3,16 @@ import { store } from '../global-state/router-store';
 import type { LinkToOptions } from '../global-state/types';
 import type { Href } from '../types';
 import { resolveHref, resolveHrefStringWithSegments } from './href';
+import { getStateFromPath } from './linking';
 
 export function getStateForHref(
   href: Href | string,
-  routeInfo: UrlObject,
+  routeInfo: Pick<UrlObject, 'segments'>,
   options?: LinkToOptions
 ) {
   href = resolveHref(href);
   href = resolveHrefStringWithSegments(href, routeInfo, options);
-  return store.linking?.getStateFromPath!(href, store.linking.config, routeInfo.segments);
+  return store.linking
+    ? getStateFromPath(href, store.linking.config, routeInfo.segments)
+    : undefined;
 }

--- a/packages/expo-router/src/link/linking.ts
+++ b/packages/expo-router/src/link/linking.ts
@@ -7,13 +7,16 @@ import {
 } from '../fork/extractPathFromURL';
 import { getPathFromState } from '../fork/getPathFromState';
 import { getStateFromPath } from '../fork/getStateFromPath';
-import { getInitialURLWithTimeout } from '../fork/useLinking';
 import { applyRedirects } from '../getRoutesRedirects';
 import type { StoreRedirects } from '../global-state/router-store';
 import type { LinkingOptions } from '../react-navigation/native';
 import type { NativeIntent } from '../types';
 
 const isExpoGo = typeof expo !== 'undefined' && globalThis.expo?.modules?.ExpoGo;
+
+function getInitialURLWithTimeout(): string | null | Promise<string | null> {
+  return typeof window === 'undefined' ? '' : window.location.href;
+}
 
 // A custom getInitialURL is used on native to ensure the app always starts at
 // the root path if it's launched from something other than a deep link.

--- a/packages/expo-router/src/link/linking.ts
+++ b/packages/expo-router/src/link/linking.ts
@@ -5,6 +5,7 @@ import {
   parsePathAndParamsFromExpoGoLink,
   parsePathFromExpoGoLink,
 } from '../fork/extractPathFromURL';
+import { getInitialURLWithTimeout } from '../fork/getInitialURLWithTimeout';
 import { getPathFromState } from '../fork/getPathFromState';
 import { getStateFromPath } from '../fork/getStateFromPath';
 import { applyRedirects } from '../getRoutesRedirects';
@@ -13,10 +14,6 @@ import type { LinkingOptions } from '../react-navigation/native';
 import type { NativeIntent } from '../types';
 
 const isExpoGo = typeof expo !== 'undefined' && globalThis.expo?.modules?.ExpoGo;
-
-function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  return typeof window === 'undefined' ? '' : window.location.href;
-}
 
 // A custom getInitialURL is used on native to ensure the app always starts at
 // the root path if it's launched from something other than a deep link.

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -25,10 +25,7 @@ import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
   const routeInfo = useRouteInfo();
-  const hrefState = useMemo(
-    () => getStateForHref(href, routeInfo, store.linking),
-    [href, routeInfo]
-  );
+  const hrefState = useMemo(() => getStateForHref(href, routeInfo), [href, routeInfo]);
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -24,8 +24,11 @@ import { getPathFromState } from '../linking';
 import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
-  const routeInfo = useRouteInfo();
-  const hrefState = useMemo(() => getStateForHref(href, routeInfo), [href, routeInfo]);
+  const { segments: routeSegments } = useRouteInfo();
+  const hrefState = useMemo(
+    () => getStateForHref(href, { segments: routeSegments }),
+    [href, routeSegments]
+  );
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -8,6 +8,7 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '..
 import type { ResultState } from '../../exports';
 import { CompositionContext } from '../../fork/native-stack/composition-options';
 import { store } from '../../global-state/router-store';
+import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../../global-state/utils';
 import { usePathname } from '../../hooks';
 import {
@@ -18,11 +19,16 @@ import {
 import type { Href, UnknownOutputParams } from '../../types';
 import { useNavigation } from '../../useNavigation';
 import { getQualifiedRouteComponent } from '../../useScreens';
+import { getStateForHref } from '../getStateForHref';
 import { getPathFromState } from '../linking';
 import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
-  const hrefState = useMemo(() => getHrefState(href), [href]);
+  const routeInfo = useRouteInfo();
+  const hrefState = useMemo(
+    () => getStateForHref(href, routeInfo, store.linking),
+    [href, routeInfo]
+  );
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;
@@ -114,11 +120,6 @@ function PreviewForInternalRoutes() {
       <Text style={{ fontWeight: '200', fontSize: 14 }}>{pathname}</Text>
     </View>
   );
-}
-
-function getHrefState(href: Href) {
-  const hrefState = store.getStateForHref(href as any);
-  return hrefState;
 }
 
 function getParamsAndNodeFromHref(hrefState: ResultState) {

--- a/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
+++ b/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
@@ -1,3 +1,4 @@
+import { store } from '../../../global-state/router-store';
 import { Stack } from '../../../layouts/Stack';
 import { NativeTabs } from '../../../native-tabs/index';
 import type { NavigationState } from '../../../react-navigation/native';
@@ -175,7 +176,11 @@ describe(getTabPathFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const tabPath = getTabPathFromRootStateByHref(href, state as NavigationState);
+    const tabPath = getTabPathFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(tabPath).toEqual([
       {
         oldTabKey: 'faces-BlzNnnAhZ7c9t5bfSf4kR',
@@ -247,7 +252,11 @@ describe(getTabPathFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const tabPath = getTabPathFromRootStateByHref(href, state as NavigationState);
+    const tabPath = getTabPathFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(tabPath).toEqual([
       {
         oldTabKey: 'index-rYeU6j6cRmkJK1pXpEFHs',
@@ -342,7 +351,11 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const preloadedRoute = getPreloadedRouteFromRootStateByHref(href, state as NavigationState);
+    const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(preloadedRoute).toEqual({
       key: '[face]-9rms2gdsibY9dVYUGCpZG',
       name: '[face]',
@@ -415,7 +428,11 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const preloadedRoute = getPreloadedRouteFromRootStateByHref(href, state as NavigationState);
+    const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(preloadedRoute).toEqual({
       key: '[face]-MZ5nYkDCFxwNv1BcD5exf',
       name: '[face]',

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -18,6 +18,7 @@ export function useNextScreenId(): [
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
   const routeInfoRef = useRef(routeInfo);
+  // The navigation listener is stable, so read the current route when prefetch updates its state.
   routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 
-import { store } from '../../global-state/router-store';
+import { store, type ReactNavigationState } from '../../global-state/router-store';
 import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { useRouter } from '../../hooks';
 import type { Href } from '../../types';
@@ -17,26 +17,22 @@ export function useNextScreenId(): [
   const { setOpenPreviewKey } = useLinkPreviewContext();
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
-  const routeInfoRef = useRef(routeInfo);
-  // The navigation listener is stable, so read the current route when prefetch updates its state.
-  routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 
-  useEffect(() => {
-    // When screen is prefetched, then the root state is updated with the preloaded route.
-    return store.navigationRef.addListener('state', ({ data: { state } }) => {
+  const onNavigationStateChange = useEffectEvent(
+    ({ data: { state } }: { data: { state?: ReactNavigationState } }) => {
       // If we have the current href, it means that we prefetched the route
       if (currentHref.current && state) {
         const preloadedRoute = getPreloadedRouteFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfoRef.current
+          routeInfo
         );
         const routeKey = preloadedRoute?.key;
         const tabPathFromRootState = getTabPathFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfoRef.current
+          routeInfo
         );
         // Without this timeout react-native does not have enough time to mount the new screen
         // and thus it will not be found on the native side
@@ -51,7 +47,12 @@ export function useNextScreenId(): [
         // to prevent unnecessary processing
         currentHref.current = undefined;
       }
-    });
+    }
+  );
+
+  useEffect(() => {
+    // When screen is prefetched, then the root state is updated with the preloaded route.
+    return store.navigationRef.addListener('state', onNavigationStateChange);
   }, []);
 
   const prefetch = useCallback(

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { store } from '../../global-state/router-store';
+import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { useRouter } from '../../hooks';
 import type { Href } from '../../types';
 import { useLinkPreviewContext } from './LinkPreviewContext';
@@ -12,9 +13,12 @@ export function useNextScreenId(): [
   (href: Href) => void,
 ] {
   const router = useRouter();
+  const routeInfo = useRouteInfo();
   const { setOpenPreviewKey } = useLinkPreviewContext();
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
+  const routeInfoRef = useRef(routeInfo);
+  routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 
   useEffect(() => {
@@ -22,9 +26,17 @@ export function useNextScreenId(): [
     return store.navigationRef.addListener('state', ({ data: { state } }) => {
       // If we have the current href, it means that we prefetched the route
       if (currentHref.current && state) {
-        const preloadedRoute = getPreloadedRouteFromRootStateByHref(currentHref.current, state);
+        const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+          currentHref.current,
+          state,
+          routeInfoRef.current
+        );
         const routeKey = preloadedRoute?.key;
-        const tabPathFromRootState = getTabPathFromRootStateByHref(currentHref.current, state);
+        const tabPathFromRootState = getTabPathFromRootStateByHref(
+          currentHref.current,
+          state,
+          routeInfoRef.current
+        );
         // Without this timeout react-native does not have enough time to mount the new screen
         // and thus it will not be found on the native side
         if (routeKey || tabPathFromRootState.length) {

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -18,7 +18,6 @@ export function useNextScreenId(): [
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
   const routeInfoRef = useRef(routeInfo);
-  // The navigation listener is stable, so read the current route when prefetch updates its state.
   routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -1,5 +1,5 @@
 import type { UrlObject } from '../../global-state/getRouteInfoFromState';
-import { store, type ReactNavigationState } from '../../global-state/router-store';
+import type { ReactNavigationState } from '../../global-state/router-store';
 import { findDivergentState, getPayloadFromStateRoute } from '../../global-state/routing';
 import { removeInternalExpoRouterParams } from '../../navigationParams';
 import type {
@@ -19,7 +19,7 @@ export function getTabPathFromRootStateByHref(
   rootState: ReactNavigationState,
   routeInfo: UrlObject
 ): TabPath[] {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return [];
@@ -55,7 +55,7 @@ export function getPreloadedRouteFromRootStateByHref(
   rootState: ReactNavigationState,
   routeInfo: UrlObject
 ): NavigationRoute<ParamListBase, string> | undefined {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return undefined;

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -17,7 +17,7 @@ import type { TabPath } from './native';
 export function getTabPathFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: UrlObject
+  routeInfo: Pick<UrlObject, 'segments'>
 ): TabPath[] {
   const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
@@ -53,7 +53,7 @@ export function getTabPathFromRootStateByHref(
 export function getPreloadedRouteFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: UrlObject
+  routeInfo: Pick<UrlObject, 'segments'>
 ): NavigationRoute<ParamListBase, string> | undefined {
   const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -1,3 +1,4 @@
+import type { UrlObject } from '../../global-state/getRouteInfoFromState';
 import { store, type ReactNavigationState } from '../../global-state/router-store';
 import { findDivergentState, getPayloadFromStateRoute } from '../../global-state/routing';
 import { removeInternalExpoRouterParams } from '../../navigationParams';
@@ -9,14 +10,16 @@ import type {
   TabNavigationState,
 } from '../../react-navigation/native';
 import type { Href } from '../../types';
+import { getStateForHref } from '../getStateForHref';
 import { resolveHref } from '../href';
 import type { TabPath } from './native';
 
 export function getTabPathFromRootStateByHref(
   href: Href,
-  rootState: ReactNavigationState
+  rootState: ReactNavigationState,
+  routeInfo: UrlObject
 ): TabPath[] {
-  const hrefState = store.getStateForHref(resolveHref(href));
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return [];
@@ -49,9 +52,10 @@ export function getTabPathFromRootStateByHref(
 
 export function getPreloadedRouteFromRootStateByHref(
   href: Href,
-  rootState: ReactNavigationState
+  rootState: ReactNavigationState,
+  routeInfo: UrlObject
 ): NavigationRoute<ParamListBase, string> | undefined {
-  const hrefState = store.getStateForHref(resolveHref(href));
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return undefined;

--- a/packages/expo-router/src/react-navigation/native/types.tsx
+++ b/packages/expo-router/src/react-navigation/native/types.tsx
@@ -1,9 +1,9 @@
 import type { ColorValue } from 'react-native';
 
+import type { getStateFromPath as getExpoStateFromPath } from '../../fork/getStateFromPath';
 import type {
   getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
-  getStateFromPath as getStateFromPathDefault,
   PathConfigMap,
   Route,
 } from '../core';
@@ -161,7 +161,7 @@ export type LinkingOptions<ParamList extends object> = {
   /**
    * Custom function to parse the URL to a valid navigation state (advanced).
    */
-  getStateFromPath?: typeof getStateFromPathDefault;
+  getStateFromPath?: typeof getExpoStateFromPath;
   /**
    * Custom function to convert the state object to a valid URL (advanced).
    * Only applicable on Web.

--- a/packages/expo-router/src/react-navigation/native/types.tsx
+++ b/packages/expo-router/src/react-navigation/native/types.tsx
@@ -1,9 +1,9 @@
 import type { ColorValue } from 'react-native';
 
-import type { getStateFromPath as getExpoStateFromPath } from '../../fork/getStateFromPath';
 import type {
   getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
+  getStateFromPath as getStateFromPathDefault,
   PathConfigMap,
   Route,
 } from '../core';
@@ -161,7 +161,7 @@ export type LinkingOptions<ParamList extends object> = {
   /**
    * Custom function to parse the URL to a valid navigation state (advanced).
    */
-  getStateFromPath?: typeof getExpoStateFromPath;
+  getStateFromPath?: typeof getStateFromPathDefault;
   /**
    * Custom function to convert the state object to a valid URL (advanced).
    * Only applicable on Web.

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -89,7 +89,8 @@ export function useTriggersToScreens(
       { relativeToDirectory: true }
     );
 
-    let state = linking.getStateFromPath?.(resolvedHref, linking.config)?.routes[0];
+    let state = linking.getStateFromPath?.(resolvedHref, linking.config, routeInfo.segments)
+      ?.routes[0];
 
     if (!state) {
       // This shouldn't occur, as you should get the global +not-found

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -2,6 +2,7 @@ import type { UrlObject } from '../LocationProvider';
 import type { RouteNode } from '../Route';
 import { NOT_FOUND_ROUTE_NAME } from '../constants';
 import { resolveHref, resolveHrefStringWithSegments } from '../link/href';
+import { getStateFromPath } from '../link/linking';
 import type {
   LinkingOptions,
   ParamListBase,
@@ -89,8 +90,7 @@ export function useTriggersToScreens(
       { relativeToDirectory: true }
     );
 
-    let state = linking.getStateFromPath?.(resolvedHref, linking.config, routeInfo.segments)
-      ?.routes[0];
+    let state = getStateFromPath(resolvedHref, linking.config, routeInfo.segments)?.routes[0];
 
     if (!state) {
       // This shouldn't occur, as you should get the global +not-found


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
