### PR TITLE
[doctor] Don't report isolated store copies as duplicate dependencies

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - [Internal] Prevent `ncc` from removing dynamic requires where we need them ([#48887](https://github.com/expo/expo/pull/48887) by [@kitten](https://github.com/kitten))
 - Keep loaded `.env` values out of `expo install --check`. ([#48845](https://github.com/expo/expo/pull/48845) by [@ramonclaudio](https://github.com/ramonclaudio))
+- Don't report copies of one version in an isolated package manager store as duplicate dependencies ([#49177](https://github.com/expo/expo/pull/49177) by [@ajaysingh56656](https://github.com/ajaysingh56656))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
+++ b/packages/expo-doctor/src/checks/AutolinkingDependencyDuplicatesCheck.ts
@@ -55,14 +55,6 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
       }
     }
 
-    const issues: string[] = [];
-    if (packagesWithIssues.size) {
-      issues.unshift(
-        'Your project contains duplicate native module dependencies, which should be de-duplicated.\n' +
-          'Native builds may only contain one version of any given native module, and having multiple versions of a single Native module installed may lead to unexpected build errors.'
-      );
-    }
-
     function getDependencyVersion(dependency: BaseDependencyResolution): string | null {
       if (!dependency.version) {
         const pkgContents = fs.readFileSync(path.join(dependency.path, 'package.json'), 'utf8');
@@ -91,6 +83,37 @@ export class AutolinkingDependencyDuplicatesCheck implements DoctorCheck<DoctorC
       return version
         ? `${dependency.name}@${version} (at: ${relative})`
         : `${dependency.name} at: ${relative}`;
+    }
+
+    // NOTE(@ajaysingh56656): Isolated linkers (Bun and pnpm) keep one copy of a package in
+    // their store per unique peer dependency resolution, so several store entries of the same
+    // version are the expected layout rather than a broken install, and autolinking only ever
+    // links one of them. Requiring *every* copy to resolve inside the store keeps genuinely
+    // corrupted trees reported: a leftover copy from an earlier hoisted install resolves to a
+    // real directory outside of it.
+    function isIsolatedStoreLayout(dependency: DependencyResolution): boolean {
+      const versions = [dependency, ...(dependency.duplicates ?? [])];
+      if (!versions.every((version) => STORE_PATH.test(version.path))) {
+        return false;
+      }
+      const version = getDependencyVersion(dependency);
+      return (
+        version != null && versions.every((duplicate) => getDependencyVersion(duplicate) === version)
+      );
+    }
+
+    for (const [dependencyName, dependency] of packagesWithIssues) {
+      if (isIsolatedStoreLayout(dependency)) {
+        packagesWithIssues.delete(dependencyName);
+      }
+    }
+
+    const issues: string[] = [];
+    if (packagesWithIssues.size) {
+      issues.unshift(
+        'Your project contains duplicate native module dependencies, which should be de-duplicated.\n' +
+          'Native builds may only contain one version of any given native module, and having multiple versions of a single Native module installed may lead to unexpected build errors.'
+      );
     }
 
     const corruptedInstallations: BaseDependencyResolution[] = [];

--- a/packages/expo-doctor/src/checks/__tests__/AutolinkingDependencyDuplicatesCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/AutolinkingDependencyDuplicatesCheck.test.ts
@@ -162,4 +162,110 @@ describe('AutolinkingDependencyDuplicatesCheck', () => {
       ]
     `);
   });
+  const isolatedResolution = (
+    name: string,
+    entries: { version: string; path: string; originPath?: string }[]
+  ) =>
+    Promise.resolve(
+      new Map([
+        [
+          name,
+          {
+            source: 0 as any,
+            depth: 0,
+            name,
+            version: entries[0].version,
+            path: entries[0].path,
+            originPath: entries[0].originPath ?? entries[0].path,
+            duplicates: entries.slice(1).map((entry) => ({
+              name,
+              version: entry.version,
+              path: entry.path,
+              originPath: entry.originPath ?? entry.path,
+            })),
+          },
+        ],
+      ])
+    );
+
+  const projectProps = {
+    pkg: { name: 'test-project', version: '1.0.0', dependencies: { 'expo-constants': '*' } },
+    ...additionalProjectProps,
+  };
+
+  it('ignores same-version copies that all live in an isolated store', async () => {
+    const check = new AutolinkingDependencyDuplicatesCheck();
+    const result = await check.runAsync(projectProps, {
+      resolutions: isolatedResolution('expo-constants', [
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.bun/expo-constants@18.0.2+aaa/node_modules/expo-constants',
+          originPath: '/tmp/root/node_modules/expo-constants',
+        },
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.bun/expo@54.0.0+bbb/node_modules/expo-constants',
+        },
+      ]),
+    });
+
+    expect(result.isSuccessful).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(result.advice).toEqual([]);
+  });
+
+  it('ignores same-version copies in a pnpm store', async () => {
+    const check = new AutolinkingDependencyDuplicatesCheck();
+    const result = await check.runAsync(projectProps, {
+      resolutions: isolatedResolution('expo-constants', [
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.pnpm/expo-constants@18.0.2/node_modules/expo-constants',
+          originPath: '/tmp/root/node_modules/expo-constants',
+        },
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.pnpm/expo@54.0.0/node_modules/expo-constants',
+        },
+      ]),
+    });
+
+    expect(result.isSuccessful).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('still reports differing versions inside an isolated store', async () => {
+    const check = new AutolinkingDependencyDuplicatesCheck();
+    const result = await check.runAsync(projectProps, {
+      resolutions: isolatedResolution('expo-constants', [
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.bun/expo-constants@18.0.2+aaa/node_modules/expo-constants',
+        },
+        {
+          version: '17.0.0',
+          path: '/tmp/root/node_modules/.bun/expo-constants@17.0.0+bbb/node_modules/expo-constants',
+        },
+      ]),
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues.join('\n')).toContain('Found duplicates for expo-constants');
+  });
+
+  it('still reports a leftover copy resolving outside the store as corrupted', async () => {
+    const check = new AutolinkingDependencyDuplicatesCheck();
+    const result = await check.runAsync(projectProps, {
+      resolutions: isolatedResolution('expo-constants', [
+        { version: '18.0.2', path: '/tmp/root/node_modules/expo-constants' },
+        {
+          version: '18.0.2',
+          path: '/tmp/root/node_modules/.bun/expo@54.0.0+bbb/node_modules/expo-constants',
+        },
+      ]),
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.advice.join('\n')).toContain('Your node_modules folder may be corrupted');
+  });
 });


### PR DESCRIPTION
# Why

Bun 1.3 uses the **isolated linker by default** for workspaces. That linker keeps one copy of a package in `node_modules/.bun` per unique peer dependency resolution, so the same version legitimately resolves to several realpaths.

`AutolinkingDependencyDuplicatesCheck` counts every extra realpath as a duplicate, so a brand-new monorepo fails the check and is told its `node_modules` may be corrupted and to delete its lockfile — which changes nothing, because the layout is already correct.

**Reproduction** — a nine-line workspace, never hoisted, one `bun install`:

```jsonc
// package.json
{ "name": "repro-root", "private": true, "workspaces": ["apps/*"] }

// apps/mobile/package.json
{
  "name": "repro-mobile", "version": "1.0.0", "private": true,
  "dependencies": {
    "expo": "~57.0.15", "expo-router": "~57.0.15", "expo-constants": "~57.0.13",
    "expo-file-system": "~57.0.5", "expo-font": "~57.0.1", "expo-linking": "~57.0.7",
    "@expo/metro-runtime": "~57.0.12", "react": "19.2.3", "react-native": "0.86.2"
  }
}
```

```
bun install && cd apps/mobile && bunx expo-doctor

✖ Check that no duplicate dependencies are installed
Found duplicates for expo:
  ├─ expo@57.0.15 (at: node_modules/expo)
  │  └─ linked to: ../../node_modules/.bun/expo@57.0.15+cd8a5773cb6a9f42/node_modules/expo
  └─ expo@57.0.15 (at: ../../node_modules/.bun/expo-router@57.0.15+f2afb277c86d75b3/node_modules/expo)
     └─ linked to a different installation
...
Advice:
Your node_modules folder may be corrupted. Multiple copies of the same version exist for: expo, expo-constants, ...
- Try deleting your node_modules folders and reinstall your dependencies after.
- If this error persists, delete your node_modules as well as your lockfile and reinstall.
```

This is distinct from the corrupted-installation case that #40279 targets. There the store entries are redundant copies of one resolution; here they carry genuinely different dependency graphs:

```
$ diff <(links in expo@57.0.15+9d5bd225...) <(links in expo@57.0.15+ec175a6c...)
< cli        -> ../../../@expo+cli@57.0.17+2bf0b22276876b1f/node_modules/@expo/cli
> cli        -> ../../../@expo+cli@57.0.17+5e3426671a6e396f/node_modules/@expo/cli
< expo-asset -> ../../expo-asset@57.0.13+84e1ddfaa9f4e82f/node_modules/expo-asset
> expo-asset -> ../../expo-asset@57.0.13+676df777aada1a0b/node_modules/expo-asset
```

# How

Several store entries of one version are the expected shape for an isolated linker, and `mergeWithDuplicate` only ever links one of them, so the extra entries never reach a native build.

A copy left behind by an earlier hoisted install resolves to a real directory **outside** the store — which is what the existing corrupted-installation fixture looks like. So the discriminator is the realpath: if *every* copy resolves inside `.bun`/`.pnpm` **and** all versions are identical, the layout is the linker working as intended and is skipped. Anything else reports exactly as before.

`STORE_PATH` already existed for output formatting; this reuses it for the verdict.

# Test Plan

Four tests added to `AutolinkingDependencyDuplicatesCheck.test.ts`:

- same-version copies all inside a `.bun` store → no issues
- same-version copies all inside a `.pnpm` store → no issues
- **differing** versions inside a store → still reported
- one copy resolving outside the store → still reported, still advises corruption

The two existing tests are untouched and their output is byte-identical before and after the change.

Verified end to end by porting the change into a built `expo-doctor` and running it against real projects:

| project | before | after |
| --- | --- | --- |
| repro monorepo above | duplicates + corruption advice | check passes |
| repro with a leftover real copy at `node_modules/expo-constants` | reported | **still reported**, corruption advice intact |
| an SDK 57 / RN 0.86 monorepo app | 8 packages reported as corrupted | check passes |

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
