### PR TITLE
[precompiled] Bump iOS platform version to iOS 16.4

### DIFF
--- a/packages/expo-age-range/spm.config.json
+++ b/packages/expo-age-range/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoAgeRange",
       "podName": "ExpoAgeRange",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-app-integrity/spm.config.json
+++ b/packages/expo-app-integrity/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoAppIntegrity",
       "podName": "ExpoAppIntegrity",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-apple-authentication/spm.config.json
+++ b/packages/expo-apple-authentication/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoAppleAuthentication",
       "podName": "ExpoAppleAuthentication",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-application/spm.config.json
+++ b/packages/expo-application/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "EXApplication",
       "podName": "EXApplication",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-asset/spm.config.json
+++ b/packages/expo-asset/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoAsset",
       "podName": "ExpoAsset",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-audio/spm.config.json
+++ b/packages/expo-audio/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoAudio",
       "podName": "ExpoAudio",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-background-fetch/spm.config.json
+++ b/packages/expo-background-fetch/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBackgroundFetch",
       "podName": "ExpoBackgroundFetch",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-background-task/spm.config.json
+++ b/packages/expo-background-task/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBackgroundTask",
       "podName": "ExpoBackgroundTask",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-battery/spm.config.json
+++ b/packages/expo-battery/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBattery",
       "podName": "ExpoBattery",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-blob/spm.config.json
+++ b/packages/expo-blob/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBlob",
       "podName": "ExpoBlob",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-blur/spm.config.json
+++ b/packages/expo-blur/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBlur",
       "podName": "ExpoBlur",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-brightness/spm.config.json
+++ b/packages/expo-brightness/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBrightness",
       "podName": "ExpoBrightness",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-brownfield/spm.config.json
+++ b/packages/expo-brownfield/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoBrownfield",
       "podName": "ExpoBrownfield",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-calendar/spm.config.json
+++ b/packages/expo-calendar/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoCalendar",
       "podName": "ExpoCalendar",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-camera/spm.config.json
+++ b/packages/expo-camera/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoCamera",
       "podName": "ExpoCamera",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",
@@ -31,7 +31,7 @@
     {
       "name": "ExpoCameraBarcodeScanning",
       "podName": "ExpoCameraBarcodeScanning",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "autolinkWhen": {
         "podfileProperty": "expo.camera.barcode-scanner-enabled",
         "disabledValue": "false"

--- a/packages/expo-cellular/spm.config.json
+++ b/packages/expo-cellular/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoCellular",
       "podName": "ExpoCellular",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-clipboard/spm.config.json
+++ b/packages/expo-clipboard/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoClipboard",
       "podName": "ExpoClipboard",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-contacts/spm.config.json
+++ b/packages/expo-contacts/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoContacts",
       "podName": "ExpoContacts",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-crypto/spm.config.json
+++ b/packages/expo-crypto/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoCrypto",
       "podName": "ExpoCrypto",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-device/spm.config.json
+++ b/packages/expo-device/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoDevice",
       "podName": "ExpoDevice",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-document-picker/spm.config.json
+++ b/packages/expo-document-picker/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoDocumentPicker",
       "podName": "ExpoDocumentPicker",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-eas-client/spm.config.json
+++ b/packages/expo-eas-client/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "EASClient",
       "podName": "EASClient",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-file-system/spm.config.json
+++ b/packages/expo-file-system/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoFileSystem",
       "podName": "ExpoFileSystem",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-font/spm.config.json
+++ b/packages/expo-font/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoFont",
       "podName": "ExpoFont",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-glass-effect/spm.config.json
+++ b/packages/expo-glass-effect/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoGlassEffect",
       "podName": "ExpoGlassEffect",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-haptics/spm.config.json
+++ b/packages/expo-haptics/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoHaptics",
       "podName": "ExpoHaptics",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-image-manipulator/spm.config.json
+++ b/packages/expo-image-manipulator/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoImageManipulator",
       "podName": "ExpoImageManipulator",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-image-picker/spm.config.json
+++ b/packages/expo-image-picker/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoImagePicker",
       "podName": "ExpoImagePicker",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-image/spm.config.json
+++ b/packages/expo-image/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoImage",
       "podName": "ExpoImage",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-json-utils/spm.config.json
+++ b/packages/expo-json-utils/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXJSONUtils",
       "podName": "EXJSONUtils",
       "platforms": [
-        "iOS(.v16)"
+        "iOS(\"16.4\")"
       ],
       "externalDependencies": [],
       "targets": [

--- a/packages/expo-keep-awake/spm.config.json
+++ b/packages/expo-keep-awake/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoKeepAwake",
       "podName": "ExpoKeepAwake",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-linear-gradient/spm.config.json
+++ b/packages/expo-linear-gradient/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLinearGradient",
       "podName": "ExpoLinearGradient",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-linking/spm.config.json
+++ b/packages/expo-linking/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLinking",
       "podName": "ExpoLinking",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-live-photo/spm.config.json
+++ b/packages/expo-live-photo/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLivePhoto",
       "podName": "ExpoLivePhoto",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-local-authentication/spm.config.json
+++ b/packages/expo-local-authentication/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLocalAuthentication",
       "podName": "ExpoLocalAuthentication",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-localization/spm.config.json
+++ b/packages/expo-localization/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLocalization",
       "podName": "ExpoLocalization",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-location/spm.config.json
+++ b/packages/expo-location/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoLocation",
       "podName": "ExpoLocation",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-mail-composer/spm.config.json
+++ b/packages/expo-mail-composer/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoMailComposer",
       "podName": "ExpoMailComposer",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-manifests/spm.config.json
+++ b/packages/expo-manifests/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "EXManifests",
       "podName": "EXManifests",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-maps/spm.config.json
+++ b/packages/expo-maps/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoMaps",
       "podName": "ExpoMaps",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-media-library/spm.config.json
+++ b/packages/expo-media-library/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoMediaLibrary",
       "podName": "ExpoMediaLibrary",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-mesh-gradient/spm.config.json
+++ b/packages/expo-mesh-gradient/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoMeshGradient",
       "podName": "ExpoMeshGradient",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNCAsyncStorage",
             "codegenName": "rnasyncstorage",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
@@ -5,7 +5,7 @@
       "name": "RNSkia",
       "podName": "react-native-skia",
       "codegenName": "rnskia",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": ["ReactNativeDependencies", "React", "Hermes"],
       "targets": [
         {

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNReanimated",
             "codegenName": "rnreanimated",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "react-native-safe-area-context",
             "codegenName": "safeareacontext",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNScreens",
             "codegenName": "rnscreens",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNSVG",
             "codegenName": "rnsvg",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNWorklets",
             "codegenName": "rnworklets",
             "platforms": [
-                "iOS(.v16)"
+                "iOS(\"16.4\")"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoModulesCore",
       "podName": "ExpoModulesCore",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",
@@ -92,7 +92,7 @@
     {
       "name": "ExpoModulesWorklets",
       "podName": "ExpoModulesWorklets",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",
@@ -139,7 +139,7 @@
       "name": "ExpoModulesWorkletsAdapter",
       "podName": "ExpoModulesWorkletsAdapter",
       "sourceOnly": true,
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "autolinkWhen": {
         "podName": "RNWorklets"
       },

--- a/packages/expo-modules-jsi/spm.config.json
+++ b/packages/expo-modules-jsi/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoModulesJSI",
       "podName": "ExpoModulesJSI",
       "platforms": [
-        "iOS(.v16)"
+        "iOS(\"16.4\")"
       ],
       "externalDependencies": [
         "Hermes",

--- a/packages/expo-network/spm.config.json
+++ b/packages/expo-network/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoNetwork",
       "podName": "ExpoNetwork",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-notifications/spm.config.json
+++ b/packages/expo-notifications/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoNotifications",
       "podName": "ExpoNotifications",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-print/spm.config.json
+++ b/packages/expo-print/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoPrint",
       "podName": "ExpoPrint",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-screen-capture/spm.config.json
+++ b/packages/expo-screen-capture/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoScreenCapture",
       "podName": "ExpoScreenCapture",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-secure-store/spm.config.json
+++ b/packages/expo-secure-store/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSecureStore",
       "podName": "ExpoSecureStore",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-sensors/spm.config.json
+++ b/packages/expo-sensors/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSensors",
       "podName": "ExpoSensors",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-sharing/spm.config.json
+++ b/packages/expo-sharing/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSharing",
       "podName": "ExpoSharing",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-sms/spm.config.json
+++ b/packages/expo-sms/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSMS",
       "podName": "ExpoSMS",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-speech/spm.config.json
+++ b/packages/expo-speech/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSpeech",
       "podName": "ExpoSpeech",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-splash-screen/spm.config.json
+++ b/packages/expo-splash-screen/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSplashScreen",
       "podName": "ExpoSplashScreen",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-sqlite/spm.config.json
+++ b/packages/expo-sqlite/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSQLite",
       "podName": "ExpoSQLite",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-store-review/spm.config.json
+++ b/packages/expo-store-review/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoStoreReview",
       "podName": "ExpoStoreReview",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-structured-headers/spm.config.json
+++ b/packages/expo-structured-headers/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXStructuredHeaders",
       "podName": "EXStructuredHeaders",
       "platforms": [
-        "iOS(.v16)"
+        "iOS(\"16.4\")"
       ],
       "externalDependencies": [],
       "targets": [

--- a/packages/expo-symbols/spm.config.json
+++ b/packages/expo-symbols/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSymbols",
       "podName": "ExpoSymbols",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-system-ui/spm.config.json
+++ b/packages/expo-system-ui/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoSystemUI",
       "podName": "ExpoSystemUI",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-tracking-transparency/spm.config.json
+++ b/packages/expo-tracking-transparency/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoTrackingTransparency",
       "podName": "ExpoTrackingTransparency",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-ui/spm.config.json
+++ b/packages/expo-ui/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoUI",
       "podName": "ExpoUI",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-updates-interface/spm.config.json
+++ b/packages/expo-updates-interface/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXUpdatesInterface",
       "podName": "EXUpdatesInterface",
       "platforms": [
-        "iOS(.v16)"
+        "iOS(\"16.4\")"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-video-thumbnails/spm.config.json
+++ b/packages/expo-video-thumbnails/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoVideoThumbnails",
       "podName": "ExpoVideoThumbnails",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-video/spm.config.json
+++ b/packages/expo-video/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoVideo",
       "podName": "ExpoVideo",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-web-browser/spm.config.json
+++ b/packages/expo-web-browser/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoWebBrowser",
       "podName": "ExpoWebBrowser",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/expo-widgets/spm.config.json
+++ b/packages/expo-widgets/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "ExpoWidgets",
       "podName": "ExpoWidgets",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",

--- a/packages/precompile/README.md
+++ b/packages/precompile/README.md
@@ -411,7 +411,7 @@ et prebuild --local-react-native-tarball "/path/to/{flavor}/React.xcframework.ta
 | `name`                 | string | Product/XCFramework name (required)                                                             |
 | `podName`              | string | CocoaPods pod name from podspec (required)                                                      |
 | `codegenName`          | string | Codegen module name from `codegenConfig.name` in package.json (optional, for Fabric components) |
-| `platforms`            | array  | SPM platforms, e.g., `["iOS(.v15)"]`. Supported: `iOS(.v15)`, `macOS(.v11)`, `tvOS(.v15)`, `macCatalyst(.v15)`, `iOS(.v15_1)`, `tvOS(.v15_1)` |
+| `platforms`            | array  | SPM platforms, e.g., `["iOS(\"16.4\")"]`. Supported: `iOS(.v15)`, `iOS(.v16)`, `iOS("16.4")`, `macOS(.v11)`, `tvOS(.v15)`, `macCatalyst(.v15)` |
 | `externalDependencies` | array  | External package dependencies (React, Hermes, other expo packages)                              |
 | `spmPackages`          | array  | Third-party SPM package dependencies (see below)                                                |
 | `swiftLanguageVersions`| array  | Swift language versions supported                                                               |

--- a/packages/unimodules-app-loader/spm.config.json
+++ b/packages/unimodules-app-loader/spm.config.json
@@ -4,7 +4,7 @@
     {
       "name": "UMAppLoader",
       "podName": "UMAppLoader",
-      "platforms": ["iOS(.v16)"],
+      "platforms": ["iOS(\"16.4\")"],
       "externalDependencies": [],
       "targets": [
         {

--- a/tools/src/prebuilds/SPMBuild.test.ts
+++ b/tools/src/prebuilds/SPMBuild.test.ts
@@ -4,6 +4,7 @@
  *  - formatVersionRequirement
  *  - findFirstExisting
  *  - findXCFrameworkInDir
+ *  - getBuildPlatformsFromProductPlatform
  */
 import fs from 'fs-extra';
 import assert from 'node:assert/strict';
@@ -16,7 +17,18 @@ import {
   formatVersionRequirement,
   findFirstExisting,
   findXCFrameworkInDir,
+  getBuildPlatformsFromProductPlatform,
 } from './SPMBuild';
+
+// ---------------------------------------------------------------------------
+// getBuildPlatformsFromProductPlatform
+// ---------------------------------------------------------------------------
+
+describe('getBuildPlatformsFromProductPlatform', () => {
+  it('expands iOS 16.4 to device and simulator build platforms', () => {
+    assert.deepEqual(getBuildPlatformsFromProductPlatform('iOS("16.4")'), ['iOS', 'iOS Simulator']);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // derivePackageName

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -4,6 +4,8 @@ import { spawn } from 'child_process';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { getExpoRepositoryRootDir } from '../Directories';
+import logger from '../Logger';
 import type { SPMPackageSource } from './ExternalPackage';
 import { Frameworks } from './Frameworks';
 import { BuildFlavor } from './Prebuilder.types';
@@ -17,8 +19,6 @@ import { SPMGenerator } from './SPMGenerator';
 import { assertSafeSPMIdentifier } from './SPMIdentifier';
 import { createAsyncSpinner } from './Utils';
 import { spawnXcodeBuildWithSpinner } from './XCodeRunner';
-import { getExpoRepositoryRootDir } from '../Directories';
-import logger from '../Logger';
 
 export const SPMBuild = {
   /**
@@ -427,19 +427,19 @@ async function resolveSPMDependenciesAndPatch(packageDir: string): Promise<void>
 export const getBuildPlatformsFromProductPlatform = (
   platform: ProductPlatform
 ): BuildPlatform[] => {
-  switch (platform) {
-    case 'iOS(.v15)':
-    case 'iOS(.v16)':
-      return ['iOS', 'iOS Simulator'];
-    case 'macOS(.v11)':
-      return ['macOS'];
-    case 'tvOS(.v15)':
-      return ['tvOS', 'tvOS Simulator'];
-    case 'macCatalyst(.v15)':
-      return ['macOS,variant=Mac Catalyst'];
-    default:
-      return [];
+  if (platform.startsWith('iOS(')) {
+    return ['iOS', 'iOS Simulator'];
   }
+  if (platform.startsWith('macOS(')) {
+    return ['macOS'];
+  }
+  if (platform.startsWith('tvOS(')) {
+    return ['tvOS', 'tvOS Simulator'];
+  }
+  if (platform.startsWith('macCatalyst(')) {
+    return ['macOS,variant=Mac Catalyst'];
+  }
+  return [];
 };
 
 /**
@@ -807,7 +807,7 @@ let package = Package(
     name: "${dep.productName}-standalone",
 
     platforms: [
-        .iOS(.v16)
+        .iOS("16.4")
     ],
 
     products: [

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -199,6 +199,7 @@ export type BuildPlatform =
 export type ProductPlatform =
   | 'iOS(.v15)'
   | 'iOS(.v16)'
+  | 'iOS("16.4")'
   | 'macOS(.v11)'
   | 'tvOS(.v15)'
   | 'macCatalyst(.v15)';

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -94,11 +94,10 @@
             "enum": [
                 "iOS(.v15)",
                 "iOS(.v16)",
+                "iOS(\"16.4\")",
                 "macOS(.v11)",
                 "tvOS(.v15)",
-                "macCatalyst(.v15)",
-                "iOS(.v15_1)",
-                "tvOS(.v15_1)" ]
+                "macCatalyst(.v15)" ]
         },
         "product": {
             "type": "object",


### PR DESCRIPTION
# Why

Expo modules already require iOS 16.4, but SPM configurations declare iOS 16. It makes easy to miss the code that pass compile tests but fails during precompilation.

Related discussion: https://github.com/expo/expo/pull/44876/changes#r3101755826

# How

- Added support for `iOS("16.4")` to the SPM configuration type and schema.
- Updated all configs to `16.4`. 
- Refactored product-platform mapping to use platform prefixes instead of enumerating individual versions.
- Removed `iOS(.v15_1)` and `tvOS(.v15_1)` as it's invalid value and wouldn't work anyway. 

# Test Plan

`et prebuild-packages` and tests succeeds.