### PR TITLE
fix(eas-client): make deterministicUniformValue actually uniform over [0, 1)

### DIFF
--- a/packages/expo-eas-client/CHANGELOG.md
+++ b/packages/expo-eas-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `deterministicUniformValue` to return a uniformly distributed value over `[0, 1)`. ([#49182](https://github.com/expo/expo/pull/49182) by [@bjjeong](https://github.com/bjjeong))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-eas-client/android/src/androidTest/java/expo/modules/easclient/EASClientIDTest.kt
+++ b/packages/expo-eas-client/android/src/androidTest/java/expo/modules/easclient/EASClientIDTest.kt
@@ -3,7 +3,8 @@ package expo.modules.easclient
 import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeInRange
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeLessThan
 import org.amshove.kluent.shouldNotBe
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,15 +26,16 @@ class EASClientIDTest {
   fun testDeterministicUniformValueKnownValue() {
     val uuid = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
     val value = EASClientID.deterministicUniformValue(uuid)
-    // leastSignificantBits (unsigned) = 0xABCDEF1234567890 / ULong.MAX
-    org.junit.Assert.assertEquals(0.6711110515064663, value, 1e-15)
+    // splitmix64(mostSignificantBits xor leastSignificantBits), scaled by 2^53.
+    org.junit.Assert.assertEquals(0.5075081783308123, value, 1e-15)
   }
 
   @Test
   fun testDeterministicUniformValueRange() {
     val context = getInstrumentation().targetContext
     val value = EASClientID.deterministicUniformValue(EASClientID(context).uuid)
-    value shouldBeInRange 0.0..1.0
+    value shouldBeGreaterOrEqualTo 0.0
+    value shouldBeLessThan 1.0
   }
 
   @Test
@@ -42,11 +44,57 @@ class EASClientIDTest {
     EASClientID.deterministicUniformValue(uuid) shouldBeEqualTo EASClientID.deterministicUniformValue(uuid)
   }
 
+  /**
+   * A known-value test passes for any biased formula, so occupying the whole range is the
+   * property that actually matters to callers comparing `value < threshold`.
+   */
+  @Test
+  fun testDeterministicUniformValueIsUniformlyDistributed() {
+    val occupiedDeciles =
+      (0 until 2000)
+        .map { seed ->
+          val value = EASClientID.deterministicUniformValue(makeV4Uuid(seed.toLong()))
+
+          value shouldBeGreaterOrEqualTo 0.0
+          value shouldBeLessThan 1.0
+
+          (value * 10).toInt()
+        }
+        .toSet()
+
+    occupiedDeciles shouldBeEqualTo (0 until 10).toSet()
+  }
+
   @Test
   fun testUuidIsV4() {
     val context = getInstrumentation().targetContext
     val uuid = EASClientID(context).uuid
     uuid.version() shouldBeEqualTo 4
     uuid.variant() shouldBeEqualTo 2
+  }
+
+  /**
+   * Builds RFC 4122 v4-shaped UUIDs from a seeded LCG so the distribution assertions are
+   * reproducible rather than relying on random input.
+   */
+  private fun makeV4Uuid(seed: Long): UUID {
+    var state = seed
+    val bytes = ByteArray(16)
+    for (index in bytes.indices) {
+      state = state * 6364136223846793005L + 1442695040888963407L
+      bytes[index] = (state ushr 33).toByte()
+    }
+    bytes[6] = ((bytes[6].toInt() and 0x0F) or 0x40).toByte() // version 4
+    bytes[8] = ((bytes[8].toInt() and 0x3F) or 0x80).toByte() // variant 10
+
+    var mostSignificantBits = 0L
+    var leastSignificantBits = 0L
+    for (index in 0 until 8) {
+      mostSignificantBits = (mostSignificantBits shl 8) or (bytes[index].toLong() and 0xFF)
+    }
+    for (index in 8 until 16) {
+      leastSignificantBits = (leastSignificantBits shl 8) or (bytes[index].toLong() and 0xFF)
+    }
+    return UUID(mostSignificantBits, leastSignificantBits)
   }
 }

--- a/packages/expo-eas-client/android/src/main/java/expo/modules/easclient/EASClientID.kt
+++ b/packages/expo-eas-client/android/src/main/java/expo/modules/easclient/EASClientID.kt
@@ -9,11 +9,17 @@ private const val EAS_CLIENT_ID_SHARED_PREFERENCES_KEY = "eas-client-id"
 class EASClientID(private val context: Context) {
   companion object {
     /**
-     * Converts a UUID to a deterministic value in [0, 1] using the least significant
-     * 64 bits interpreted as an unsigned integer fraction of ULong.MAX_VALUE.
+     * Converts a UUID to a deterministic value in [0, 1).
      */
     fun deterministicUniformValue(uuid: UUID): Double {
-      return uuid.leastSignificantBits.toULong().toDouble() / ULong.MAX_VALUE.toDouble()
+      // Byte 8 is the RFC 4122 variant octet, pinned to `10`, and it is the high byte of
+      // leastSignificantBits, so that half alone only spans [0.5, 0.75]. splitmix64 over both
+      // halves moves the fixed bits off the high end; 2^53 is the widest exact Double range.
+      var z = (uuid.mostSignificantBits xor uuid.leastSignificantBits).toULong()
+      z = (z xor (z shr 30)) * 0xbf58476d1ce4e5b9UL
+      z = (z xor (z shr 27)) * 0x94d049bb133111ebUL
+      z = z xor (z shr 31)
+      return (z shr 11).toDouble() / (1L shl 53).toDouble()
     }
   }
 

--- a/packages/expo-eas-client/ios/EASClient/EASClientID.swift
+++ b/packages/expo-eas-client/ios/EASClient/EASClientID.swift
@@ -12,13 +12,22 @@ public class EASClientID : NSObject {
     })!
   }
 
-  /// Converts a UUID to a deterministic value in [0, 1] using the least significant
-  /// 64 bits (bytes 8–15) interpreted as an unsigned integer fraction of UInt64.max.
+  /// Converts a UUID to a deterministic value in [0, 1).
   public static func deterministicUniformValue(_ uuid: UUID) -> Double {
-    let value = withUnsafeBytes(of: uuid.uuid) {
-      $0.load(fromByteOffset: 8, as: UInt64.self).bigEndian
+    // Byte 8 is the RFC 4122 variant octet, pinned to `10`, and it is the high byte of the low
+    // half, so that half alone only spans [0.5, 0.75]. splitmix64 over both halves moves the
+    // fixed bits off the high end; 2^53 is the widest exact Double range.
+    let (high, low) = withUnsafeBytes(of: uuid.uuid) {
+      (
+        $0.load(fromByteOffset: 0, as: UInt64.self).bigEndian,
+        $0.load(fromByteOffset: 8, as: UInt64.self).bigEndian
+      )
     }
-    return Double(value) / Double(UInt64.max)
+    var z = high ^ low
+    z = (z ^ (z >> 30)) &* 0xbf58_476d_1ce4_e5b9
+    z = (z ^ (z >> 27)) &* 0x94d0_49bb_1331_11eb
+    z = z ^ (z >> 31)
+    return Double(z >> 11) / Double(1 << 53)
   }
 }
 

--- a/packages/expo-eas-client/ios/Tests/EASClientIDTest.swift
+++ b/packages/expo-eas-client/ios/Tests/EASClientIDTest.swift
@@ -16,13 +16,14 @@ class EASClientIdTests : XCTestCase {
   func testDeterministicUniformValueKnownValue() {
     let uuid = UUID(uuidString: "A1B2C3D4-E5F6-7890-ABCD-EF1234567890")!
     let value = EASClientID.deterministicUniformValue(uuid)
-    XCTAssertEqual(value, 0.6711110515064663, accuracy: 1e-15)
+    // splitmix64(mostSignificantBits ^ leastSignificantBits), scaled by 2^53.
+    XCTAssertEqual(value, 0.5075081783308123, accuracy: 1e-15)
   }
 
   func testDeterministicUniformValueRange() {
     let value = EASClientID.deterministicUniformValue(EASClientID.uuid())
     XCTAssertGreaterThanOrEqual(value, 0.0)
-    XCTAssertLessThanOrEqual(value, 1.0)
+    XCTAssertLessThan(value, 1.0)
   }
 
   func testDeterministicUniformValueDeterministic() {
@@ -32,6 +33,23 @@ class EASClientIdTests : XCTestCase {
     XCTAssertEqual(a, b)
   }
 
+  /// A known-value test passes for any biased formula, so occupying the whole range is the
+  /// property that actually matters to callers comparing `value < threshold`.
+  func testDeterministicUniformValueIsUniformlyDistributed() {
+    let occupiedDeciles = Set(
+      (0..<2000).map { seed -> Int in
+        let value = EASClientID.deterministicUniformValue(Self.makeV4UUID(seed: UInt64(seed)))
+
+        XCTAssertGreaterThanOrEqual(value, 0.0)
+        XCTAssertLessThan(value, 1.0)
+
+        return Int(value * 10)
+      }
+    )
+
+    XCTAssertEqual(occupiedDeciles, Set(0..<10))
+  }
+
   func testUuidIsV4() {
     let uuid = EASClientID.uuid()
     let bytes = uuid.uuid
@@ -39,5 +57,25 @@ class EASClientIdTests : XCTestCase {
     XCTAssertEqual((bytes.6 >> 4) & 0x0F, 4)
     // Variant: high 2 bits of byte 8 must be 10
     XCTAssertEqual((bytes.8 >> 6) & 0x03, 2)
+  }
+
+  /// Builds RFC 4122 v4-shaped UUIDs from a seeded LCG so the distribution assertions are
+  /// reproducible rather than relying on random input.
+  private static func makeV4UUID(seed: UInt64) -> UUID {
+    var state = seed
+    func nextByte() -> UInt8 {
+      state = state &* 6364136223846793005 &+ 1442695040888963407
+      return UInt8(truncatingIfNeeded: state >> 33)
+    }
+
+    var b = [UInt8](repeating: 0, count: 16)
+    for index in 0..<16 {
+      b[index] = nextByte()
+    }
+    b[6] = (b[6] & 0x0F) | 0x40  // version 4
+    b[8] = (b[8] & 0x3F) | 0x80  // variant 10
+
+    return UUID(uuid: (b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7],
+                       b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]))
   }
 }

--- a/packages/expo-eas-client/src/index.ts
+++ b/packages/expo-eas-client/src/index.ts
@@ -2,7 +2,7 @@ import EASClient from './EASClient';
 
 export const clientID = EASClient.clientID;
 /**
- * A deterministic uniform value in [0, 1] derived from clientId.
+ * A deterministic uniform value in [0, 1) derived from clientId.
  * Stable across app launches for the same installation,
  * but unique per app instance.
  */


### PR DESCRIPTION
# Why

Fixes #49181.

`EASClientID.deterministicUniformValue` is documented as returning "a deterministic value in [0, 1]", but it returns a value confined to **[0.5, 0.75)**.

`expo-observe` is the only consumer, and it gates dispatch on `deterministicUniformValue(...) < sampleRate` (`Observability.swift:276`, `ObservabilityManager.kt:325`). So **any `sampleRate` at or below 0.5 selects exactly zero clients** — telemetry silently drops to nothing rather than being reduced. We hit this in production: shipping `sampleRate: 0.03` took fleet-wide startup and navigation telemetry to zero on both platforms.

Both implementations read bytes 8–15 of the UUID:

```swift
$0.load(fromByteOffset: 8, as: UInt64.self).bigEndian / UInt64.max
```
```kotlin
uuid.leastSignificantBits.toULong().toDouble() / ULong.MAX_VALUE.toDouble()
```

Byte 8 of an RFC 4122 UUID is `clock_seq_hi_and_reserved`, whose two most significant bits are pinned to `10` for the IETF variant. Because it is *also* the most significant byte of that 64-bit window, the quotient can never leave `[0.5, 0.75)`. `java.util.UUID.getLeastSignificantBits()` is exactly those same bytes, so Android carries the identical defect.

# How

Fold both halves (`high ^ low`) through a splitmix64 finalizer, which moves the reserved version/variant bits out of the high end of the result, then scale by `2^53` so the output stays in `[0, 1)` and can never be exactly `1.0`.

The two platforms produce **bit-identical** output for the same UUID, so a client's in/out-of-sample decision does not change if its platform implementation is ever swapped.

# Test Plan

Ran verbatim copies of the before and after implementations over freshly minted UUIDs — Swift 6 with `Foundation.UUID`, and Java with `java.util.UUID` (the Kotlin path).

**Before**

| platform | min | max | rate 0.03 | rate 0.50 | rate 0.75 |
|---|---|---|---|---|---|
| Swift | 0.5000032 | 0.7499994 | **0%** | **0%** | 100% |
| Java | 0.5000033 | 0.7499993 | **0%** | **0%** | 100% |

**After** (500k samples each)

| platform | min | max | rate 0.03 | rate 0.50 | decile histogram (per-mille) |
|---|---|---|---|---|---|
| Swift | 6.1e-07 | 0.9999988 | **3.037%** | **50.04%** | `100 99 100 100 100 99 100 100 99 99` |
| Java | 2.7e-06 | 0.9999997 | **2.954%** | **49.93%** | `99 98 99 100 101 99 99 100 100 100` |

Cross-platform agreement on fixed UUIDs (identical to the last digit):

| UUID | value |
|---|---|
| `00000000-0000-4000-8000-000000000000` | `0.6739966708523056` |
| `ffffffff-ffff-4fff-bfff-ffffffffffff` | `0.7311409341971677` |
| `3f2504e0-4f89-41d3-9a0c-0305e82c3301` | `0.7672797462886537` |
| `a1b2c3d4-e5f6-4789-abcd-ef0123456789` | `0.20976227781883072` |

Determinism (same UUID → same value across repeated calls) verified.

A standalone runnable reproduction for both platforms is linked from #49181.

# Notes

- **This changes which clients are in-sample.** The decision is keyed on the persisted client UUID, so a client's bucket will shift once — unavoidable when correcting the distribution, and harmless for the percentage-based sampling this feeds. Note `deterministicUniformValue` is also a public JS export of `expo-eas-client`, so apps reading it directly re-bucket as well.
- A regression test asserting approximate *uniformity* (e.g. decile occupancy) rather than mere `[0, 1]` membership would prevent a recurrence; the previous behaviour satisfies an "is within range" check while being badly non-uniform. Added as `testDeterministicUniformValueIsUniformlyDistributed` on both platforms.
- `jest-expo`'s mock for this constant (`0.694392985627176`, in `preset/moduleMocks/expoModules.js`) happens to sit inside the old biased range. It is still a valid value post-fix, so I have left it alone — flagging in case you would rather it be representative.

