### PR TITLE
[docs] Fix llms.txt generator dropping pages in nested navigation groups

### DIFF
--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -133,20 +133,23 @@ function processPage(page) {
   return processPageData(page.href, page.name);
 }
 
-function processGroup(group) {
-  const items = (group.children ?? [])
-    .filter(child => child.type === 'page')
-    .map(processPage)
+function collectPages(node) {
+  return (node.children ?? [])
+    .flatMap(child => (child.type === 'page' ? processPage(child) : collectPages(child)))
     .filter(Boolean);
+}
+
+function processGroup(group) {
+  const items = collectPages(group);
 
   return items.length > 0 ? { title: group.name, items } : null;
 }
 
 function hasContent(section) {
-  return section?.items?.length ?? section?.groups?.length ?? section?.sections?.length;
+  return section?.items.length > 0 || section?.groups.length > 0 || section?.sections.length > 0;
 }
 
-const COLLAPSED_SECTIONS = new Set(['Expo UI']);
+export const COLLAPSED_SECTIONS = new Set(['Expo UI']);
 
 function collapseToOverviews(section) {
   if (!COLLAPSED_SECTIONS.has(section.title)) {
@@ -159,6 +162,10 @@ function collapseToOverviews(section) {
     .map(item => ({ ...item, overview: true }));
 
   return { ...section, items: [...section.items, ...overviews], groups: [], sections: [] };
+}
+
+function processNestedSection(node) {
+  return { title: node.name, items: collectPages(node), groups: [], sections: [] };
 }
 
 function processSection(node) {
@@ -190,7 +197,7 @@ function processSection(node) {
         break;
       }
       case 'section': {
-        const sectionData = processSection(child);
+        const sectionData = processNestedSection(child);
         if (hasContent(sectionData)) {
           section.sections.push(sectionData);
         }
@@ -202,21 +209,23 @@ function processSection(node) {
   return section;
 }
 
+export function generateLlmsTxtMarkdown(nodes) {
+  const sections = nodes.map(processSection).filter(Boolean).map(collapseToOverviews);
+
+  return generateFullMarkdown({
+    title: TITLE,
+    description: EXPO_DESCRIPTION,
+    sections,
+  });
+}
+
 export async function generateLlmsTxt() {
   try {
-    const allSections = Object.values({ home, general, learn, eas, reference: reference.latest })
-      .flat()
-      .map(processSection)
-      .filter(Boolean)
-      .map(collapseToOverviews);
+    const nodes = Object.values({ home, general, learn, eas, reference: reference.latest }).flat();
 
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_LLMS_TXT),
-      generateFullMarkdown({
-        title: TITLE,
-        description: EXPO_DESCRIPTION,
-        sections: allSections,
-      })
+      generateLlmsTxtMarkdown(nodes)
     );
 
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_LLMS_TXT}`);

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -149,7 +149,7 @@ function hasContent(section) {
   return section?.items.length > 0 || section?.groups.length > 0 || section?.sections.length > 0;
 }
 
-export const COLLAPSED_SECTIONS = new Set(['Expo UI']);
+const COLLAPSED_SECTIONS = new Set(['Expo UI']);
 
 function collapseToOverviews(section) {
   if (!COLLAPSED_SECTIONS.has(section.title)) {
@@ -209,23 +209,21 @@ function processSection(node) {
   return section;
 }
 
-export function generateLlmsTxtMarkdown(nodes) {
-  const sections = nodes.map(processSection).filter(Boolean).map(collapseToOverviews);
-
-  return generateFullMarkdown({
-    title: TITLE,
-    description: EXPO_DESCRIPTION,
-    sections,
-  });
-}
-
 export async function generateLlmsTxt() {
   try {
-    const nodes = Object.values({ home, general, learn, eas, reference: reference.latest }).flat();
+    const allSections = Object.values({ home, general, learn, eas, reference: reference.latest })
+      .flat()
+      .map(processSection)
+      .filter(Boolean)
+      .map(collapseToOverviews);
 
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_LLMS_TXT),
-      generateLlmsTxtMarkdown(nodes)
+      generateFullMarkdown({
+        title: TITLE,
+        description: EXPO_DESCRIPTION,
+        sections: allSections,
+      })
     );
 
     console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully generated ${OUTPUT_FILENAME_LLMS_TXT}`);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26094

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix llms.txt generator dropping pages in nested navigation groups in the `llms.txt` generation script.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See [preview](https://pr-49184.expo-docs.pages.dev/llms.txt) and search for `using-posthog` and there should be two pages:

<img width="1618" height="264" alt="CleanShot 2026-08-21 at 01 26 18@2x" src="https://github.com/user-attachments/assets/33ddf78a-3b27-444b-8aeb-ce0bfbe9d50c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
