### PR TITLE
[android][secure-store] Reject setItemAsync when the write did not reach disk

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Reject `setItemAsync` when the write never reached disk, instead of resolving as if the value was persisted. ([#49191](https://github.com/expo/expo/pull/49191) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Fix `deleteItemAsync` resolving when a retried delete left the value on disk. ([#49151](https://github.com/expo/expo/pull/49151) by [@vonovak](https://github.com/vonovak))
 - [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed. ([#49146](https://github.com/expo/expo/pull/49146) by [@vonovak](https://github.com/vonovak))
 - [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with. ([#49128](https://github.com/expo/expo/pull/49128) by [@JoRo-Code](https://github.com/JoRo-Code) and [@behenate](https://github.com/behenate))

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Reject `setItemAsync` when the write never reached disk, instead of resolving as if the value was persisted. ([#49191](https://github.com/expo/expo/pull/49191) by [@dennytosp](https://github.com/dennytosp))
+- [Android] Roll back the in-memory value when a `setItemAsync` write is rejected, so a subsequent `getItemAsync` returns the value that is actually persisted instead of the one that failed to reach disk. ([#49191](https://github.com/expo/expo/pull/49191) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Fix `deleteItemAsync` resolving when a retried delete left the value on disk. ([#49151](https://github.com/expo/expo/pull/49151) by [@vonovak](https://github.com/vonovak))
 - [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed. ([#49146](https://github.com/expo/expo/pull/49146) by [@vonovak](https://github.com/vonovak))
 - [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with. ([#49128](https://github.com/expo/expo/pull/49128) by [@JoRo-Code](https://github.com/JoRo-Code) and [@behenate](https://github.com/behenate))

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
@@ -229,22 +229,6 @@ open class SecureStoreModule : Module() {
     }
   }
 
-  private fun saveEncryptedItem(encryptedItem: JSONObject, prefs: SharedPreferences, key: String, requireAuthentication: Boolean, keychainService: String): Boolean {
-    // We need a way to recognize entries that have been saved under an alias created with getExtendedKeychain
-    encryptedItem.put(USES_KEYSTORE_SUFFIX_PROPERTY, true)
-    // In order to be able to have the same keys under different keychains
-    // we need a way to recognize what is the keychain of the item when we read it
-    encryptedItem.put(KEYSTORE_ALIAS_PROPERTY, keychainService)
-    encryptedItem.put(AuthenticationHelper.REQUIRE_AUTHENTICATION_PROPERTY, requireAuthentication)
-
-    val encryptedItemString = encryptedItem.toString()
-    if (encryptedItemString.isNullOrEmpty()) { // JSONObject#toString() may return null
-      throw WriteException("Could not JSON-encode the encrypted item for SecureStore - the string $encryptedItemString is null or empty", key, keychainService)
-    }
-
-    return prefs.edit().putString(key, encryptedItemString).commit()
-  }
-
   private fun deleteItemImpl(key: String, options: SecureStoreOptions) {
     val success = removeItem(
       getSharedPreferences(),
@@ -375,7 +359,7 @@ open class SecureStoreModule : Module() {
     private const val SHARED_PREFERENCES_NAME = "SecureStore"
     private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
     private const val SCHEME_PROPERTY = "scheme"
-    private const val KEYSTORE_ALIAS_PROPERTY = "keystoreAlias"
+    internal const val KEYSTORE_ALIAS_PROPERTY = "keystoreAlias"
     const val USES_KEYSTORE_SUFFIX_PROPERTY = "usesKeystoreSuffix"
     const val DEFAULT_KEYSTORE_ALIAS = "key_v1"
     const val AUTHENTICATED_KEYSTORE_SUFFIX = "keystoreAuthenticated"
@@ -392,4 +376,36 @@ internal fun removeItem(
   val removedFromPrefs = prefs.edit().remove(keychainAwareKey).remove(key).commit()
   val removedFromLegacyPrefs = legacyPrefs.edit().remove(key).commit()
   return removedFromPrefs && removedFromLegacyPrefs
+}
+
+/**
+ * Writes an encrypted item to shared preferences, throwing if it could not be persisted.
+ *
+ * [SharedPreferences.Editor.commit] returns `false` when the write never reached disk — AOSP takes
+ * that path when it can't rename the backing file, for instance. The in-memory map is still updated,
+ * so reads in the same process keep succeeding and the failure is invisible until the process dies.
+ * Reporting it as a [WriteException] keeps a resolved `setItemAsync` meaning "persisted".
+ */
+internal fun saveEncryptedItem(
+  encryptedItem: JSONObject,
+  prefs: SharedPreferences,
+  key: String,
+  requireAuthentication: Boolean,
+  keychainService: String
+) {
+  // We need a way to recognize entries that have been saved under an alias created with getExtendedKeychain
+  encryptedItem.put(SecureStoreModule.USES_KEYSTORE_SUFFIX_PROPERTY, true)
+  // In order to be able to have the same keys under different keychains
+  // we need a way to recognize what is the keychain of the item when we read it
+  encryptedItem.put(SecureStoreModule.KEYSTORE_ALIAS_PROPERTY, keychainService)
+  encryptedItem.put(AuthenticationHelper.REQUIRE_AUTHENTICATION_PROPERTY, requireAuthentication)
+
+  val encryptedItemString = encryptedItem.toString()
+  if (encryptedItemString.isNullOrEmpty()) { // JSONObject#toString() may return null
+    throw WriteException("Could not JSON-encode the encrypted item for SecureStore - the string $encryptedItemString is null or empty", key, keychainService)
+  }
+
+  if (!prefs.edit().putString(key, encryptedItemString).commit()) {
+    throw WriteException("Could not write the encrypted item to SecureStore", key, keychainService)
+  }
 }

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreModule.kt
@@ -385,6 +385,12 @@ internal fun removeItem(
  * that path when it can't rename the backing file, for instance. The in-memory map is still updated,
  * so reads in the same process keep succeeding and the failure is invisible until the process dies.
  * Reporting it as a [WriteException] keeps a resolved `setItemAsync` meaning "persisted".
+ *
+ * Throwing alone isn't enough: `SharedPreferencesImpl` mutates the in-memory map *before* it tries
+ * the disk write, so a rejected write would otherwise leave the new value readable for the rest of
+ * the process lifetime while the disk still holds the old one. We therefore roll the in-memory map
+ * back to what was there before rethrowing, so a read after a rejected write returns the value that
+ * is actually persisted.
  */
 internal fun saveEncryptedItem(
   encryptedItem: JSONObject,
@@ -405,7 +411,25 @@ internal fun saveEncryptedItem(
     throw WriteException("Could not JSON-encode the encrypted item for SecureStore - the string $encryptedItemString is null or empty", key, keychainService)
   }
 
+  // Read the currently persisted value first so we can put it back if the write is rejected.
+  // This is racy in the sense that another thread writing the same key between this read and the
+  // rollback below would have its value overwritten by the old one. Concurrent writes to the same
+  // key are already last-writer-wins here, and losing a write that itself never reached disk is
+  // preferable to leaving the in-memory map claiming a value that isn't persisted.
+  val previousItemString = prefs.getString(key, null)
+
   if (!prefs.edit().putString(key, encryptedItemString).commit()) {
+    // `commit()` already mutated the in-memory map, so restore the previous entry before throwing.
+    // This restoring commit reports `false` too — the disk is still broken — and that is fine and
+    // expected: we only need its in-memory effect, which is applied regardless of the disk write.
+    val rollback = prefs.edit()
+    if (previousItemString != null) {
+      rollback.putString(key, previousItemString)
+    } else {
+      rollback.remove(key)
+    }
+    rollback.commit()
+
     throw WriteException("Could not write the encrypted item to SecureStore", key, keychainService)
   }
 }

--- a/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SaveEncryptedItemTest.kt
+++ b/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SaveEncryptedItemTest.kt
@@ -1,0 +1,85 @@
+package expo.modules.securestore
+
+import android.content.Context
+import android.content.SharedPreferences
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+/**
+ * A [SharedPreferences] whose writes never reach disk. AOSP's `SharedPreferencesImpl` behaves this
+ * way when it can't rename the backing file (for example when the `shared_prefs` directory is not
+ * writable): the in-memory map is updated, but `commit()` reports failure.
+ */
+private class NonCommittingPreferences(
+  private val delegate: SharedPreferences
+) : SharedPreferences by delegate {
+  override fun edit(): SharedPreferences.Editor = NonCommittingEditor(delegate.edit())
+}
+
+/**
+ * Every builder method returns `this` rather than the delegate's editor, so a chained
+ * `edit().putString(...).commit()` still lands on this editor's [commit].
+ */
+private class NonCommittingEditor(
+  private val delegate: SharedPreferences.Editor
+) : SharedPreferences.Editor {
+  override fun putString(key: String?, value: String?) = apply { delegate.putString(key, value) }
+  override fun putStringSet(key: String?, values: MutableSet<String>?) = apply { delegate.putStringSet(key, values) }
+  override fun putInt(key: String?, value: Int) = apply { delegate.putInt(key, value) }
+  override fun putLong(key: String?, value: Long) = apply { delegate.putLong(key, value) }
+  override fun putFloat(key: String?, value: Float) = apply { delegate.putFloat(key, value) }
+  override fun putBoolean(key: String?, value: Boolean) = apply { delegate.putBoolean(key, value) }
+  override fun remove(key: String?) = apply { delegate.remove(key) }
+  override fun clear() = apply { delegate.clear() }
+
+  override fun commit(): Boolean = false
+  override fun apply() = Unit
+}
+
+@RunWith(RobolectricTestRunner::class)
+class SaveEncryptedItemTest {
+  private val context: Context
+    get() = RuntimeEnvironment.getApplication()
+
+  private fun preferences(): SharedPreferences =
+    context.getSharedPreferences("SecureStoreTest", Context.MODE_PRIVATE)
+
+  @Test
+  fun `writes the encrypted item under the given key`() {
+    val prefs = preferences()
+
+    saveEncryptedItem(
+      encryptedItem = JSONObject().put("ciphertext", "value"),
+      prefs = prefs,
+      key = "key",
+      requireAuthentication = false,
+      keychainService = "keychain"
+    )
+
+    val stored = JSONObject(prefs.getString("key", null)!!)
+    assertEquals("value", stored.getString("ciphertext"))
+    assertEquals("keychain", stored.getString(SecureStoreModule.KEYSTORE_ALIAS_PROPERTY))
+    assertTrue(stored.getBoolean(SecureStoreModule.USES_KEYSTORE_SUFFIX_PROPERTY))
+  }
+
+  @Test
+  fun `throws when the write does not reach disk`() {
+    val prefs = NonCommittingPreferences(preferences())
+
+    assertThrows(WriteException::class.java) {
+      saveEncryptedItem(
+        encryptedItem = JSONObject().put("ciphertext", "value"),
+        prefs = prefs,
+        key = "key",
+        requireAuthentication = false,
+        keychainService = "keychain"
+      )
+    }
+  }
+}

--- a/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SaveEncryptedItemTest.kt
+++ b/packages/expo-secure-store/android/src/test/java/expo/modules/securestore/SaveEncryptedItemTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,6 +27,11 @@ private class NonCommittingPreferences(
 /**
  * Every builder method returns `this` rather than the delegate's editor, so a chained
  * `edit().putString(...).commit()` still lands on this editor's [commit].
+ *
+ * [commit] applies the mutations to the delegate before reporting failure, mirroring
+ * `SharedPreferencesImpl`, which updates the in-memory map first and only then attempts the disk
+ * write. That ordering is what makes a rejected write observable to later reads, so the fake has to
+ * reproduce it for the rollback to be worth testing.
  */
 private class NonCommittingEditor(
   private val delegate: SharedPreferences.Editor
@@ -38,7 +45,11 @@ private class NonCommittingEditor(
   override fun remove(key: String?) = apply { delegate.remove(key) }
   override fun clear() = apply { delegate.clear() }
 
-  override fun commit(): Boolean = false
+  override fun commit(): Boolean {
+    delegate.commit()
+    return false
+  }
+
   override fun apply() = Unit
 }
 
@@ -81,5 +92,54 @@ class SaveEncryptedItemTest {
         keychainService = "keychain"
       )
     }
+  }
+
+  @Test
+  fun `keeps the previously stored value readable when the write does not reach disk`() {
+    val prefs = NonCommittingPreferences(preferences())
+
+    // The first write goes through the delegate, so "existing-key" starts out persisted.
+    saveEncryptedItem(
+      encryptedItem = JSONObject().put("ciphertext", "v1"),
+      prefs = preferences(),
+      key = "existing-key",
+      requireAuthentication = false,
+      keychainService = "keychain"
+    )
+    val persisted = preferences().getString("existing-key", null)
+
+    assertThrows(WriteException::class.java) {
+      saveEncryptedItem(
+        encryptedItem = JSONObject().put("ciphertext", "v2"),
+        prefs = prefs,
+        key = "existing-key",
+        requireAuthentication = false,
+        keychainService = "keychain"
+      )
+    }
+
+    // Without the rollback the rejected "v2" would stay in the in-memory map and be handed to every
+    // read for the rest of the process, even though only "v1" ever reached disk.
+    val readBack = prefs.getString("existing-key", null)
+    assertEquals(persisted, readBack)
+    assertEquals("v1", JSONObject(readBack!!).getString("ciphertext"))
+  }
+
+  @Test
+  fun `leaves a key that was never stored absent when the write does not reach disk`() {
+    val prefs = NonCommittingPreferences(preferences())
+
+    assertThrows(WriteException::class.java) {
+      saveEncryptedItem(
+        encryptedItem = JSONObject().put("ciphertext", "value"),
+        prefs = prefs,
+        key = "new-key",
+        requireAuthentication = false,
+        keychainService = "keychain"
+      )
+    }
+
+    assertFalse(prefs.contains("new-key"))
+    assertNull(prefs.getString("new-key", null))
   }
 }


### PR DESCRIPTION
# Why

Fixes #48988.

On Android, `SecureStore.setItemAsync` can resolve successfully while the value never reaches disk.

`saveEncryptedItem` returned the result of `SharedPreferences.Editor.commit()`, but `setItemImpl` called it as a bare statement and discarded that `Boolean`. Every other `commit()` in the same file has its result checked — the null-value path a few lines above throws `WriteException` on exactly this condition.

AOSP updates the in-memory map even when `commit()` fails, so reads in the same process keep returning the new value and nothing distinguishes a failed write from a successful one. The consequence is silent data loss: a caller that treats resolution as "persisted" — by then clearing its own copy, for example — loses the value when the process dies.

The reporter's log shows `setItemAsync` resolving 7 ms after AOSP logged that the write had failed, a same-process read returning the new value, and the old value coming back after a force-stop.

# How

Moved `saveEncryptedItem` out of `SecureStoreModule` into a top-level `internal` function that throws `WriteException` instead of returning a `Boolean`, and updated the call site accordingly.

Throwing is already this function's error contract — it throws `WriteException` when `JSONObject#toString()` returns null or empty. Returning a `Boolean` for one failure mode while throwing for another is what let the discarded result go unnoticed, so removing the `Boolean` return closes the whole class of bug rather than just this call site.

Making it top-level also gives it a test seam, matching how `buildAuthenticationPromptInfo` is already a top-level `internal` function covered by `AuthenticationPromptTest`. `KEYSTORE_ALIAS_PROPERTY` went from `private` to `internal` so the extracted function can still read it.

# Test Plan

Added `SaveEncryptedItemTest`, following the Robolectric setup the package already uses. The failing-write case wraps a real `SharedPreferences` in an editor whose `commit()` returns `false`, which is what AOSP does when it can't rename the backing file.

Verified the test fails against the old behaviour before fixing it — with `saveEncryptedItem` back to calling `commit()` without checking it:

```
> There were failing tests.
java.lang.AssertionError: expected expo.modules.securestore.WriteException to be thrown, but nothing was thrown
	at expo.modules.securestore.SaveEncryptedItemTest.throws when the write does not reach disk(SaveEncryptedItemTest.kt:61)

tests="2" skipped="0" failures="1" errors="0"
```

And passes with the fix in place — `et native-unit-tests -p android --packages expo-secure-store`:

```
BUILD SUCCESSFUL
Finished android unit tests successfully.

TEST-expo.modules.securestore.AuthenticationPromptTest.xml   tests="3" failures="0" errors="0"
TEST-expo.modules.securestore.SaveEncryptedItemTest.xml      tests="2" failures="0" errors="0"
TEST-expo.modules.securestore.SecureStoreOptionsTest.xml     tests="4" failures="0" errors="0"
```

`et check-packages expo-secure-store`:

```
Tasks:    2 successful, 2 total
🏁 All checks passed.
```

To reproduce the original bug end to end, the issue has a repro app: write a value, `adb shell run-as <pkg> chmod 500 shared_prefs`, write again (resolves today, rejects with this change), then force-stop and read back.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
