### PR TITLE
[web][font] Match @font-face rules by their bare family name

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [web] Match `@font-face` rules by their bare family name, so `isLoaded()`, `unloadAsync()` and `getLoadedFonts()` work on Firefox and for family names containing a space. ([#49192](https://github.com/expo/expo/pull/49192) by [@dennytosp](https://github.com/dennytosp))
 - [android] Apply `fontWeight` and `fontStyle` to fonts loaded with `useFonts`, instancing a variable font's `wght` axis at each weight. Bold and italic text previously fell back to a system font. ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
 - [iOS] Fixed `renderToImageAsync` reporting the main screen's scale rather than the scale the image was rendered at. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -40,6 +40,40 @@ function getFontFaceRules(): RuleItem[] {
   return [];
 }
 
+const QUOTED_FONT_FAMILY_RE = /^(["'])([\s\S]*)\1$/;
+
+/**
+ * Returns the bare family name from a CSS `font-family` value.
+ *
+ * Rules written by this module always quote the family name (see `_createWebFontTemplate`), but
+ * engines disagree about how they serialize it back through `CSSFontFaceRule.style.fontFamily`:
+ * Firefox preserves the quotes for every rule, while Chromium and WebKit strip them only for names
+ * that are valid CSS identifiers — a name such as `DIN 2014` reads back quoted everywhere.
+ * Comparing the raw serialization against a caller's name therefore fails for every font on Firefox,
+ * and for quote-requiring names in every engine.
+ */
+export function _normalizeFontFamilyName(fontFamily: string): string {
+  const trimmed = fontFamily.trim();
+  const unquoted = trimmed.match(QUOTED_FONT_FAMILY_RE)?.[2];
+  if (unquoted === undefined) {
+    return trimmed;
+  }
+  return unquoted.replace(/\\([\s\S])/g, '$1');
+}
+
+/**
+ * Whether a rule's serialized `font-family` names the family a caller asked for.
+ *
+ * Only the rule's side is normalized. The two strings are not the same kind of value: the rule
+ * holds a CSS component value, which an engine may quote and escape, while `fontFamilyName` is the
+ * literal family name the caller loaded the font under. Normalizing the caller's name too would
+ * strip quotes and whitespace that are part of the name itself, so a family such as `"Weird"` or
+ * `  Padded  ` would stop matching the very rule this module wrote for it.
+ */
+export function _fontFamilyMatchesRule(ruleFontFamily: string, fontFamilyName: string): boolean {
+  return _normalizeFontFamilyName(ruleFontFamily) === fontFamilyName;
+}
+
 function getFontFaceRulesMatchingResource(
   fontFamilyName: string,
   options?: UnloadFontOptions
@@ -47,7 +81,7 @@ function getFontFaceRulesMatchingResource(
   const rules = getFontFaceRules();
   return rules.filter(({ rule }) => {
     return (
-      rule.style.fontFamily === fontFamilyName &&
+      _fontFamilyMatchesRule(rule.style.fontFamily, fontFamilyName) &&
       (options && options.display ? options.display === (rule.style as any).fontDisplay : true)
     );
   });
@@ -98,7 +132,7 @@ const ExpoFontLoader: Required<ExpoFontLoaderModule> = {
       return getLoadedServerFonts();
     }
     const rules = getFontFaceRules();
-    return rules.map(({ rule }) => rule.style.fontFamily);
+    return rules.map(({ rule }) => _normalizeFontFamilyName(rule.style.fontFamily));
   },
 
   isLoaded(fontFamilyName: string, resource: UnloadFontOptions = {}): boolean {

--- a/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
+++ b/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
@@ -1,0 +1,93 @@
+import {
+  _createWebFontTemplate,
+  _fontFamilyMatchesRule,
+  _normalizeFontFamilyName,
+} from '../ExpoFontLoader.web';
+
+// The family name this module writes into a `@font-face` rule and the family name it later reads
+// back off `CSSFontFaceRule.style.fontFamily` are not the same string. CSSOM serialization of
+// `font-family` is a gray area where engines disagree about quoting:
+//
+// - Firefox preserves the quotes from the declaration, so every rule this module writes reads back
+//   quoted, for any family name.
+// - Chromium and WebKit strip the quotes for identifier-safe names but keep them for names that
+//   need quoting, such as anything containing a space.
+//
+// Normalizing both sides before comparing is what keeps `isLoaded`, `unloadAsync` and
+// `getLoadedFonts` working across engines.
+describe('_normalizeFontFamilyName', () => {
+  it('strips the double quotes Firefox preserves for every rule', () => {
+    expect(_normalizeFontFamilyName('"MyFont"')).toBe('MyFont');
+  });
+
+  it('leaves an unquoted name as Chromium and WebKit serialize it', () => {
+    expect(_normalizeFontFamilyName('MyFont')).toBe('MyFont');
+  });
+
+  it('strips the quotes every engine keeps for a name containing a space', () => {
+    expect(_normalizeFontFamilyName('"DIN 2014"')).toBe('DIN 2014');
+  });
+
+  it('strips single quotes', () => {
+    expect(_normalizeFontFamilyName("'MyFont'")).toBe('MyFont');
+  });
+
+  it('unescapes a quote inside a quoted name', () => {
+    expect(_normalizeFontFamilyName('"My\\"Font"')).toBe('My"Font');
+  });
+
+  it('ignores surrounding whitespace', () => {
+    expect(_normalizeFontFamilyName('  "MyFont"  ')).toBe('MyFont');
+  });
+
+  it('leaves a bare name whose quotes are unbalanced alone', () => {
+    expect(_normalizeFontFamilyName('"MyFont')).toBe('"MyFont');
+  });
+});
+
+// The invariant that was broken: a family name written by this module must normalize back to the
+// name it was written with, whichever way the engine chose to serialize it.
+describe('round trip with _createWebFontTemplate', () => {
+  it.each(['MyFont', 'DIN 2014', "Ada's Font"])('round trips %p', (fontFamily) => {
+    const css = _createWebFontTemplate(fontFamily, { uri: 'font.ttf' });
+    const declared = css.match(/font-family:([^;]+);/)?.[1];
+
+    expect(declared).toBeDefined();
+    // As Firefox serializes it: the declaration is preserved verbatim.
+    expect(_normalizeFontFamilyName(declared!)).toBe(fontFamily);
+  });
+});
+
+// A rule's `font-family` is a CSS component value that an engine may quote and escape; the name a
+// caller loads a font under is a literal string. Only the rule's side may be normalized — a family
+// name is allowed to contain the very quotes and whitespace normalization strips.
+describe('_fontFamilyMatchesRule', () => {
+  const declaredValue = (fontFamily: string) => {
+    const css = _createWebFontTemplate(fontFamily, { uri: 'font.ttf', display: 'auto' } as any);
+    const declared = css.match(/font-family:([^;]+);/)?.[1];
+    expect(declared).toBeDefined();
+    return declared!;
+  };
+
+  it.each([
+    ['an identifier-safe name', 'MyFont'],
+    ['a name containing a space', 'DIN 2014'],
+    ['a name that is itself wrapped in quotes', '"Weird"'],
+    ['a name with significant surrounding whitespace', '  Padded  '],
+    ['a name containing a quote', 'He said "hi"'],
+  ])('matches the rule this module writes for %s', (_label, fontFamily) => {
+    expect(_fontFamilyMatchesRule(declaredValue(fontFamily), fontFamily)).toBe(true);
+  });
+
+  it('matches an unquoted serialization', () => {
+    expect(_fontFamilyMatchesRule('MyFont', 'MyFont')).toBe(true);
+  });
+
+  it('does not match a different family', () => {
+    expect(_fontFamilyMatchesRule('"MyFont"', 'OtherFont')).toBe(false);
+  });
+
+  it('does not conflate two families that differ only by surrounding whitespace', () => {
+    expect(_fontFamilyMatchesRule(declaredValue('  Padded  '), 'Padded')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Why

Fixes #49092.

`expo-font`'s web loader decides whether a family is already registered by comparing a caller's name against the CSSOM serialization of `CSSFontFaceRule.style.fontFamily`. But the rules it compares against are the ones it wrote itself, and `_createWebFontTemplate` always quotes the family name via `JSON.stringify`.

CSSOM serialization of `font-family` is a gray area where engines disagree about quoting:

- **Firefox** preserves the quotes from the declaration, so for every rule this module writes, `rule.style.fontFamily` reads back as `"MyFont"` — with literal quote characters — and the comparison never matches, for any font.
- **Chromium and WebKit** strip the quotes for identifier-safe names, but keep them for names that need quoting. A family such as `DIN 2014` fails in all three engines.

So `isLoaded()` is always `false` on Firefox, which breaks every consumer of the matcher:

1. `loadAsync` injects a duplicate `@font-face` rule on every call, because it never sees the existing one. The reporter's production expo-router site ends up with 19 rules inside `#expo-generated-fonts` on Firefox where Chromium and WebKit have 10.
2. With static rendering, `useFonts` seeds its state synchronously from `isLoaded` precisely so hydration matches the server pass. On Firefox that seed is `false` even though the inlined rules are present, so an app that gates render on `loaded` hydrates different markup — surfacing as React error #418 and a full client-side teardown, Firefox only.
3. `unloadAsync` silently removes nothing.
4. `getLoadedFonts()` returns names wrapped in literal quote characters, which never equal the names callers loaded with.

# How

Added `_normalizeFontFamilyName`, which returns the bare family name from a CSS `font-family` value: it strips one layer of matching quotes and unescapes the contents, leaving an unquoted value untouched.

`getFontFaceRulesMatchingResource` now normalizes the rule's side before comparing, and `getLoadedFonts` reports normalized names.

Normalizing the rule rather than, say, quoting the caller's name keeps the comparison correct no matter which way the engine chose to serialize, instead of trading Firefox's behaviour for Chromium's.

Only the rule's side is normalized, via `_fontFamilyMatchesRule`. The two strings are not the same kind of value: a rule holds a CSS component value, which an engine may quote and escape, while the caller's name is a literal string. Normalizing the caller's name too would strip quotes and whitespace that can be part of the name itself, so a family loaded as `"Weird"` or `  Padded  ` would stop matching the very rule this module wrote for it — the same `isLoaded`-returns-false failure this PR is fixing, just for rarer names.

# Test Plan

Added `ExpoFontLoader-test.web.ts`, covering each engine's serialization plus a round trip asserting the invariant that actually broke: a name written by `_createWebFontTemplate` normalizes back to the name it was written with.

The tests fail against the current code — 20 failures across both jest projects:

```
Test Suites: 2 failed, 2 total
Tests:       20 failed, 20 total
```

and pass with the fix:

```
PASS Node src/__tests__/ExpoFontLoader-test.web.ts
PASS Web  src/__tests__/ExpoFontLoader-test.web.ts
Test Suites: 2 passed, 2 total
Tests:       20 passed, 20 total
```

Full package suite is green, so no existing behaviour changed:

```
Test Suites: 19 passed, 19 total
Tests:       29 skipped, 102 passed, 131 total
```

`et check-packages expo-font`:

```
Tasks:    2 successful, 2 total
🏁 All checks passed.
```

The issue also has a no-tooling repro: save an `.html` file containing `<style>@font-face{font-family:"MyFont";src:url("data:font/woff2;base64,")}</style>`, open it in Firefox, and read `document.styleSheets[0].cssRules[0].style.fontFamily` — it comes back with the quotes.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
