### PR TITLE
[ios][maps] Don't fire onMapClick when the tap hit a marker or a shape

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -449,6 +449,8 @@ PODS:
     - ExpoModulesCore
   - ExpoMaps (57.0.1):
     - ExpoModulesCore
+  - ExpoMaps/Tests (57.0.1):
+    - ExpoModulesCore
   - ExpoMediaLibrary (57.0.3):
     - ExpoModulesCore
     - React-Core
@@ -3399,6 +3401,7 @@ DEPENDENCIES:
   - "ExpoLogBox (from `../../../packages/@expo/log-box`)"
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
   - ExpoMaps (from `../../../packages/expo-maps/ios`)
+  - ExpoMaps/Tests (from `../../../packages/expo-maps/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
   - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
   - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
@@ -4074,7 +4077,7 @@ SPEC CHECKSUMS:
   ExpoLocation: ad64144374a840dd365274b309dbbbb253a1e44e
   ExpoLogBox: 6bb73c341aca22e699bd4da6cc61afc844e1a648
   ExpoMailComposer: 101933dc6bdb4d7a46495d1dd87420365325adb9
-  ExpoMaps: 8762d166c08c4db08277c68561cdfab5bda0a2f4
+  ExpoMaps: dc3ea592f1b936bab4b5f545f21bd495945fe12e
   ExpoMediaLibrary: e0829ae4fe90dc8bcd5ec13250ba6503aebbbc94
   ExpoMeshGradient: ade33604a92081a2deda41c6107e7d080493012d
   ExpoModulesCore: c74426df582d7c3f7bfbaf20306c9c526c14e75d

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Stop `AppleMaps.View`'s `onMapClick` from firing when the tap landed on a marker, an annotation, or a drawn shape, as documented. ([#49193](https://github.com/expo/expo/pull/49193) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Return the `Promise` from `GoogleMaps.View`'s imperative `setCameraPosition` so callers can `await` it and catch the `Animation cancelled` rejection (matches iOS). ([#46421](https://github.com/expo/expo/pull/46421) by [@chownation](https://github.com/chownation))
 - [Android] Fixed Google Maps marker info windows reserving blank snippet space when `snippet` is omitted. ([#47271](https://github.com/expo/expo/pull/47271) by [@eliotgevers](https://github.com/eliotgevers))
 

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -26,6 +26,36 @@ extension MKMapPoint {
   }
 }
 
+/// Screen-space size of a MapKit `Marker` balloon. MapKit doesn't expose the balloon's bounds, so
+/// this approximates the default balloon drawn by `Marker(_:systemImage:coordinate:)`.
+private let markerHitSize = CGSize(width: 40, height: 44)
+
+/// Screen-space size of an annotation, matching the frame its icon is rendered with.
+private let annotationHitSize = CGSize(width: 50, height: 50)
+
+/// The rect a feature of `size` covers when its coordinate projects to `origin`.
+///
+/// `verticalAnchor` says where along the rect the coordinate itself sits: `1` puts it on the bottom
+/// edge, the way a balloon hangs above its tip, and `0.5` centres the rect on it.
+func featureHitRect(at origin: CGPoint, size: CGSize, verticalAnchor: CGFloat) -> CGRect {
+  CGRect(
+    x: origin.x - size.width / 2,
+    y: origin.y - size.height * verticalAnchor,
+    width: size.width,
+    height: size.height
+  )
+}
+
+/// A marker balloon hangs above the coordinate, which sits at its tip.
+func markerHitRect(at origin: CGPoint) -> CGRect {
+  featureHitRect(at: origin, size: markerHitSize, verticalAnchor: 1)
+}
+
+/// An annotation is centred on its coordinate.
+func annotationHitRect(at origin: CGPoint) -> CGRect {
+  featureHitRect(at: origin, size: annotationHitSize, verticalAnchor: 0.5)
+}
+
 @available(iOS 18.0, *)
 struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
   @EnvironmentObject var props: AppleMapsViewProps
@@ -160,67 +190,83 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
       // https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-26-release-notes#Maps
       .simultaneousGesture(SpatialTapGesture()
           .onEnded { event in
-            if let coordinate = reader.convert(event.location, from: .local) {
-              // check if we hit a polygon and send an event
-              if let hit = props.polygons.first(where: { polygon in
-                isTapInsidePolygon(tapCoordinate: coordinate, polygonCoordinates: polygon.clLocationCoordinates2D)
-              }) {
-                let coords = hit.coordinates.map {
-                  [
-                    "latitude": $0.latitude,
-                    "longitude": $0.longitude
-                  ]
-                }
-                props.onPolygonClick([
-                  "id": hit.id,
-                  "color": hit.color,
-                  "lineColor": hit.lineColor,
-                  "lineWidth": hit.lineWidth,
-                  "coordinates": coords
-                ])
-              } else if let hit = props.circles.first(where: { circle in
-                isTapInsideCircle(
-                  tapCoordinate: coordinate,
-                  circleCenter: circle.clLocationCoordinate2D,
-                  radius: circle.radius
-                )}) {
-                  props.onCircleClick([
-                    "id": hit.id,
-                    "color": hit.color,
-                    "lineColor": hit.lineColor,
-                    "lineWidth": hit.lineWidth,
-                    "radius": hit.radius,
-                    "coordinates": [
-                      "latitude": hit.center.latitude,
-                      "longitude": hit.center.longitude
-                    ]
-                  ])
-                }
-              // Then check if we hit a polyline and send an event
-              else if let hit = polyline(at: coordinate) {
-                let coords = hit.coordinates.map {
-                  [
-                    "latitude": $0.latitude,
-                    "longitude": $0.longitude
-                  ]
-                }
-                props.onPolylineClick([
-                  "id": hit.id,
-                  "color": hit.color,
-                  "width": hit.width,
-                  "contourStyle": hit.contourStyle.rawValue,
-                  "coordinates": coords
-                ])
-              }
+            guard let coordinate = reader.convert(event.location, from: .local) else {
+              return
+            }
 
-              // Send an event of map click regardless
-              props.onMapClick([
+            // `onMapClick` is documented as not being invoked when the tap lands on a marker or a
+            // POI. This gesture is attached with `simultaneousGesture`, so it also recognizes taps
+            // the map has already routed to a marker or an annotation through its selection
+            // binding — those are reported by `onMarkerClick` from `handleSelectionChange`, and
+            // must not be reported here as well.
+            if isTapOnMarker(at: event.location, reader: reader) {
+              return
+            }
+
+            // A tap that lands on a drawn shape belongs to that shape, so it is reported through
+            // the shape's own event instead of as a map click.
+            if let hit = props.polygons.first(where: { polygon in
+              isTapInsidePolygon(tapCoordinate: coordinate, polygonCoordinates: polygon.clLocationCoordinates2D)
+            }) {
+              let coords = hit.coordinates.map {
+                [
+                  "latitude": $0.latitude,
+                  "longitude": $0.longitude
+                ]
+              }
+              props.onPolygonClick([
+                "id": hit.id,
+                "color": hit.color,
+                "lineColor": hit.lineColor,
+                "lineWidth": hit.lineWidth,
+                "coordinates": coords
+              ])
+              return
+            }
+
+            if let hit = props.circles.first(where: { circle in
+              isTapInsideCircle(
+                tapCoordinate: coordinate,
+                circleCenter: circle.clLocationCoordinate2D,
+                radius: circle.radius
+              )}) {
+              props.onCircleClick([
+                "id": hit.id,
+                "color": hit.color,
+                "lineColor": hit.lineColor,
+                "lineWidth": hit.lineWidth,
+                "radius": hit.radius,
                 "coordinates": [
-                  "latitude": coordinate.latitude,
-                  "longitude": coordinate.longitude
+                  "latitude": hit.center.latitude,
+                  "longitude": hit.center.longitude
                 ]
               ])
+              return
             }
+
+            if let hit = polyline(at: coordinate) {
+              let coords = hit.coordinates.map {
+                [
+                  "latitude": $0.latitude,
+                  "longitude": $0.longitude
+                ]
+              }
+              props.onPolylineClick([
+                "id": hit.id,
+                "color": hit.color,
+                "width": hit.width,
+                "contourStyle": hit.contourStyle.rawValue,
+                "coordinates": coords
+              ])
+              return
+            }
+
+            props.onMapClick([
+              "coordinates": [
+                "latitude": coordinate.latitude,
+                "longitude": coordinate.longitude
+              ]
+            ])
           }
       )
       .mapControls {
@@ -319,6 +365,31 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
         ]
       ])
       return
+    }
+  }
+
+  /// Whether a tap landed on one of the markers or annotations drawn on the map.
+  ///
+  /// Markers and annotations are views drawn at a fixed size in screen space, so the tap is matched
+  /// against where they are rendered rather than against the coordinate it converts to: the span of
+  /// coordinates one covers changes with every zoom level.
+  private func isTapOnMarker(at location: CGPoint, reader: MapProxy) -> Bool {
+    let hitMarker = props.markers.contains { marker in
+      guard let origin = reader.convert(marker.clLocationCoordinate2D, to: .local) else {
+        return false
+      }
+      return markerHitRect(at: origin).contains(location)
+    }
+
+    if hitMarker {
+      return true
+    }
+
+    return props.annotations.contains { annotation in
+      guard let origin = reader.convert(annotation.clLocationCoordinate2D, to: .local) else {
+        return false
+      }
+      return annotationHitRect(at: origin).contains(location)
     }
   }
 

--- a/packages/expo-maps/ios/ExpoMaps.podspec
+++ b/packages/expo-maps/ios/ExpoMaps.podspec
@@ -16,8 +16,17 @@ Pod::Spec.new do |s|
   s.source         = { git: 'https://github.com/expo/expo.git' }
   s.static_framework = true
   s.source_files   = '**/*.{h,m,swift}'
+  s.exclude_files  = 'Tests'
   s.preserve_paths = '**/*.{h,m,swift}'
   s.requires_arc   = true
 
   s.dependency 'ExpoModulesCore'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests'
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
+  end
 end

--- a/packages/expo-maps/ios/Tests/FeatureHitTestingTests.swift
+++ b/packages/expo-maps/ios/Tests/FeatureHitTestingTests.swift
@@ -1,0 +1,67 @@
+import CoreGraphics
+import Testing
+
+@testable import ExpoMaps
+
+// A tap that lands on a marker or an annotation belongs to that feature, and `onMapClick` documents
+// that it is not invoked in that case. Markers and annotations are drawn at a fixed size in screen
+// space, so recognizing such a tap means matching it against where the feature is rendered rather
+// than against the coordinate the tap converts to.
+@Suite("Feature hit testing")
+struct FeatureHitTestingTests {
+  @Test
+  func `a balloon hangs above the coordinate at its tip`() {
+    let rect = markerHitRect(at: CGPoint(x: 100, y: 200))
+
+    #expect(rect.maxY == 200)
+    #expect(rect.midX == 100)
+    #expect(rect.minY < 200)
+  }
+
+  @Test
+  func `a tap on the balloon body is on the marker`() {
+    let rect = markerHitRect(at: CGPoint(x: 100, y: 200))
+
+    #expect(rect.contains(CGPoint(x: 100, y: 190)))
+  }
+
+  @Test
+  func `a tap below the balloon tip is not on the marker`() {
+    let rect = markerHitRect(at: CGPoint(x: 100, y: 200))
+
+    #expect(rect.contains(CGPoint(x: 100, y: 210)) == false)
+  }
+
+  @Test
+  func `a tap beside the balloon is not on the marker`() {
+    let rect = markerHitRect(at: CGPoint(x: 100, y: 200))
+
+    #expect(rect.contains(CGPoint(x: 400, y: 190)) == false)
+  }
+
+  @Test
+  func `an annotation is centred on its coordinate`() {
+    let rect = annotationHitRect(at: CGPoint(x: 100, y: 200))
+
+    #expect(rect.midX == 100)
+    #expect(rect.midY == 200)
+  }
+
+  @Test
+  func `a tap just above an annotation coordinate is on the annotation`() {
+    let rect = annotationHitRect(at: CGPoint(x: 100, y: 200))
+
+    // A balloon-shaped hit rect would miss this point, an annotation's centred one does not.
+    #expect(rect.contains(CGPoint(x: 100, y: 210)))
+  }
+
+  @Test
+  func `verticalAnchor places the coordinate along the rect`() {
+    let size = CGSize(width: 10, height: 20)
+    let origin = CGPoint(x: 0, y: 0)
+
+    #expect(featureHitRect(at: origin, size: size, verticalAnchor: 0).minY == 0)
+    #expect(featureHitRect(at: origin, size: size, verticalAnchor: 0.5).midY == 0)
+    #expect(featureHitRect(at: origin, size: size, verticalAnchor: 1).maxY == 0)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #41820.

`onMapClick` is documented as *"Lambda invoked when the user clicks on the map. It won't be invoked if the user clicks on POI or a marker."* On `AppleMaps.View` it fires for every tap regardless — tapping a marker logs both `onMarkerClick` and `onMapClick`, and tapping a polygon, circle, or polyline logs both that shape's event and `onMapClick`.

The tap handler in `AppleMapsViewiOS18` hit-tested the drawn shapes, dispatched their events, and then fell through to `onMapClick` under a comment that says as much:

```swift
// Send an event of map click regardless
props.onMapClick([...])
```

Markers are a second path to the same symptom. The gesture is attached with `simultaneousGesture` — a workaround for `onTapGesture` being broken on iOS 26 — so it also recognizes taps the map has already routed to a marker or an annotation through its selection binding. Those are reported by `onMarkerClick` from `handleSelectionChange`, and were being reported as a map click as well. The reporter notes `onMarkerClick` arrives noticeably later than `onMapClick`, which is consistent with the two paths being independent.

# How

Turned the hit-test chain into early returns, so `onMapClick` only fires when the tap hit nothing else. This is the whole fix for the shapes.

For markers and annotations, added `isTapOnMarker(at:reader:)`, which projects each feature's coordinate back into screen space with `MapProxy.convert(_:to:)` and checks whether the tap landed within the feature's rendered bounds. The test has to be in screen space: markers and annotations are drawn at a fixed point size, so the span of coordinates one covers changes with every zoom level, and a coordinate-distance threshold would be wrong at all but one zoom.

The two anchor a rect differently, so they get one function each over a shared `featureHitRect`:

- a `Marker` balloon hangs *above* the coordinate, which sits at its tip
- an `Annotation` is *centred* on its coordinate

`annotationHitSize` matches the `.frame(width: 50, height: 50)` the annotation icon is rendered with in the same file. `markerHitSize` approximates MapKit's default balloon, which doesn't expose its bounds — that constant is the one number here worth a second opinion, and it is easy to tune in isolation now that the geometry is a free function.

Left `AppleMapsViewiOS17` alone: it uses `onTapGesture` rather than `simultaneousGesture` and does no shape hit-testing, so it doesn't have this bug.

# Test Plan

`expo-maps` had no iOS test target, so this adds one, following the `test_spec` setup `expo-video` already uses (including `s.exclude_files = 'Tests'`, without which the test sources are compiled into the library target).

`FeatureHitTestingTests` covers the hit rects: that a balloon hangs above its tip and an annotation is centred, that a tap on the balloon body hits while one below the tip or off to the side does not, and that `verticalAnchor` places the coordinate along the rect as documented.

A first pass at the `test_spec` copied the minimal form `expo-video` uses, and the test bundle failed to link against `ExpoMaps`:

```
Undefined symbol: ___cxa_guard_acquire
Undefined symbol: ___gxx_personality_v0
...
Ld .../ExpoMaps-Unit-Tests.xctest/ExpoMaps-Unit-Tests
** TEST FAILED **
```

`ExpoMaps` pulls in C++ through `ExpoModulesCore`, so the test target needs `-lc++` the way `expo-camera`, `expo-audio` and `expo-image-picker` already declare it. With that added, `et native-unit-tests -p ios --packages expo-maps`:

```
Test case 'FeatureHitTestingTests/`a balloon hangs above the coordinate at its tip`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.002 seconds)
Test case 'FeatureHitTestingTests/`a tap on the balloon body is on the marker`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.002 seconds)
Test case 'FeatureHitTestingTests/`a tap below the balloon tip is not on the marker`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.001 seconds)
Test case 'FeatureHitTestingTests/`a tap beside the balloon is not on the marker`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.001 seconds)
Test case 'FeatureHitTestingTests/`an annotation is centred on its coordinate`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.002 seconds)
Test case 'FeatureHitTestingTests/`a tap just above an annotation coordinate is on the annotation`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.002 seconds)
Test case 'FeatureHitTestingTests/`verticalAnchor places the coordinate along the rect`()' passed on 'Clone 1 of iPhone 17 Pro - xctest (41481)' (0.002 seconds)
** TEST SUCCEEDED **
✅ All unit tests passed for the following packages: expo-maps
```

`et check-packages expo-maps`:

```
Tasks:    2 successful, 2 total
🏁 All checks passed.
```

The early-return restructuring of the tap handler itself is not covered by these tests — it needs the map on a device, so please see the manual reproduction below.

Manual reproduction, using the repro app from the issue (https://github.com/lenzi-e/expo-maps-repro): tap a marker in Los Angeles and only `onMarkerClick` logs; tap a polygon, circle, or polyline and only that shape's event logs; tap bare map and only `onMapClick` logs.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
