### PR TITLE
[module-scripts] Remove the dangling `build-src` command

### DIFF
--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `prepublishOnly` wiping `build/` for packages that compile with `expo-build`, by rebuilding via the package's own `build` script instead of `tsc`. ([#47344](https://github.com/expo/expo/pull/47344) by [@zoontek](https://github.com/zoontek))
+- Remove the dangling `build-src` command, which `expo-module --help` advertised but which failed with a Commander `'expo-module-build-src' does not exist` error because no such executable has ever existed. ([#49195](https://github.com/expo/expo/pull/49195) by [@dennytosp](https://github.com/dennytosp))
 
 ### 💡 Others
 

--- a/packages/expo-module-scripts/bin/expo-module.js
+++ b/packages/expo-module-scripts/bin/expo-module.js
@@ -10,7 +10,6 @@ program.command(
   `Type check the source TypeScript without emitting JS and watch for file changes`
 );
 program.command('build', `Compile the source JS or TypeScript and watch for file changes`);
-program.command('build-src', `Transpile source with oxc-transform and emit declarations with tsc`);
 program.command('depscheck', `Check that source imports resolve to declared dependencies`);
 program.command('format', `Format source files`);
 program.command('test', `Run unit tests with an interactive watcher`);


### PR DESCRIPTION
# Why

`expo-module build-src` is advertised by `expo-module --help` but cannot run at all.

`bin/expo-module.js` declares it with a description string:

```js
program.command('build-src', `Transpile source with oxc-transform and emit declarations with tsc`);
```

Passing a description to `.command()` puts Commander in [stand-alone executable mode](https://github.com/tj/commander.js#stand-alone-executable-subcommands): instead of running an action handler, it spawns a sibling executable named `expo-module-build-src`. That file does not exist:

```
$ expo-module build-src
Error: 'expo-module-build-src' does not exist
 - if 'build-src' is not meant to be an executable command, remove description parameter from '.command()' and use '.description()' instead
 - searched for local subcommand relative to directory '.../expo-module-scripts/bin'
    at ChildProcess.<anonymous> (.../commander/lib/command.js:1225:15)
```

It never has existed — `packages/expo-module-scripts/bin/expo-module-build-src` has no commits against it in the repository's history. Nor is `oxc-transform`, the tool the description names, a dependency of this package or of anything else in the tree; the string is its only occurrence in the repository.

The declaration was added in #46801 along with the Turborepo migration and was never wired up. Every other declared command resolves to a real executable — `build-src` is the only one that doesn't.

# How

Removed the declaration.

Removing it rather than adding an implementation is the conservative reading: there is no `build-src` implementation to restore, no dependency to build it on, and no caller anywhere in the repository — `grep -rn build-src` over the whole tree (excluding `node_modules`, `build/`, `.turbo`, `dist`) matches only the declaration itself. Writing a new oxc-transform build pipeline to satisfy a dangling string would be inventing a feature, not fixing a bug. If `build-src` is still wanted, it should land as its own change with the executable alongside it.

# Test Plan

`expo-module-scripts` has no test runner (no `jest` config and no `test` script), so this is verified by running the CLI. Adding a test harness to the package for a one-line deletion seemed disproportionate; happy to add one if you'd prefer the regression covered.

Before — a Node stack trace, exit code 1:

```
$ node ./bin/expo-module.js build-src
.../commander/lib/command.js:1225
        throw new Error(executableMissing);
        ^
Error: 'expo-module-build-src' does not exist
```

After — Commander's own unknown-command handling, exit code 1:

```
$ node ./bin/expo-module.js build-src
error: unknown command 'build-src'
$ echo $?
1
```

`build-src` no longer appears in `expo-module --help`, and every command that remains resolves to an executable in `bin/`:

```
  OK      configure       OK      depscheck       OK      prepare
  OK      readme          OK      format          OK      prepublishOnly
  OK      typecheck       OK      test            OK      jest
  OK      build           OK      clean           OK      tsc
```

`et check-packages expo-module-scripts`:

```
Tasks:    2 successful, 2 total
🏁 All checks passed.
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
