### PR TITLE
[web][crypto] Respect the bounds of typed-array views in the AES module

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Respect the bounds of typed-array views in `Crypto.AES`, so sealed data passed as a `Uint8Array` that views part of a larger buffer no longer reads the wrong bytes and fails to decrypt. ([#49196](https://github.com/expo/expo/pull/49196) by [@dennytosp](https://github.com/dennytosp))
+- [Web] Reject sealed data that is too short to hold its IV and authentication tag in `AESSealedData.fromCombined()`, matching iOS and Android. ([#49196](https://github.com/expo/expo/pull/49196) by [@dennytosp](https://github.com/dennytosp))
 - Fix `AESSealedData.fromCombined()` throwing on Android when given a base64-encoded string. ([#47317](https://github.com/expo/expo/pull/47317) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/expo-crypto/src/aes/ExpoCryptoAES.web.ts
+++ b/packages/expo-crypto/src/aes/ExpoCryptoAES.web.ts
@@ -1,4 +1,4 @@
-import { registerWebModule, NativeModule } from 'expo';
+import { registerWebModule, NativeModule, CodedError } from 'expo';
 
 import type {
   AESDecryptOptions,
@@ -75,17 +75,27 @@ class EncryptionKey {
 }
 
 class SealedData {
-  private buffer: ArrayBuffer;
+  private bytes: Uint8Array;
   private config: AESSealedDataConfig;
 
-  private constructor(buffer: ArrayBuffer, config: AESSealedDataConfig) {
-    this.buffer = buffer;
+  private constructor(bytes: Uint8Array, config: AESSealedDataConfig) {
+    this.bytes = bytes;
     this.config = config;
   }
 
   static fromCombined(combined: BinaryInput, config?: AESSealedDataConfig): SealedData {
-    const buffer = binaryInputBytes(combined).buffer as ArrayBuffer;
-    return new SealedData(buffer, config ?? defaultConfig);
+    const bytes = binaryInputBytes(combined);
+    const sealedConfig = config ?? defaultConfig;
+    const minimumLength = sealedConfig.ivLength + sealedConfig.tagLength;
+
+    if (bytes.byteLength < minimumLength) {
+      throw new CodedError(
+        'ERR_INVALID_SEALED_DATA_CONFIG',
+        `Sealed data is ${bytes.byteLength} bytes, which is too short to hold a ${sealedConfig.ivLength}-byte IV and a ${sealedConfig.tagLength}-byte authentication tag. Pass the whole combined output of encryptAsync, or set ivLength and tagLength in the config to match how the data was sealed.`
+      );
+    }
+
+    return new SealedData(bytes, sealedConfig);
   }
 
   static fromParts(
@@ -111,7 +121,7 @@ class SealedData {
         ivLength,
         tagLength: tag,
       };
-      return new SealedData(combined.buffer, config);
+      return new SealedData(combined, config);
     }
 
     const tagBytes = binaryInputBytes(tag);
@@ -123,7 +133,7 @@ class SealedData {
     combined.set(ciphertextBytes, ivLength);
     combined.set(tagBytes, totalLength - tagLength);
 
-    return new SealedData(combined.buffer, { ivLength, tagLength });
+    return new SealedData(combined, { ivLength, tagLength });
   }
 
   get ivSize(): number {
@@ -133,23 +143,23 @@ class SealedData {
     return this.config.tagLength;
   }
   get combinedSize(): number {
-    return this.buffer.byteLength;
+    return this.bytes.byteLength;
   }
 
   async iv(encoding?: 'bytes' | 'base64'): Promise<Uint8Array | string> {
     const useBase64 = encoding === 'base64';
-    const bytes = new Uint8Array(this.buffer, 0, this.ivSize);
+    const bytes = this.bytes.subarray(0, this.ivSize);
     return useBase64 ? uint8ArrayToBase64(bytes) : bytes;
   }
   async tag(encoding?: 'bytes' | 'base64'): Promise<Uint8Array | string> {
     const useBase64 = encoding === 'base64';
     const offset = this.combinedSize - this.tagSize;
-    const bytes = new Uint8Array(this.buffer, offset, this.tagSize);
+    const bytes = this.bytes.subarray(offset, offset + this.tagSize);
     return useBase64 ? uint8ArrayToBase64(bytes) : bytes;
   }
   async combined(encoding?: 'bytes' | 'base64'): Promise<Uint8Array | string> {
     const useBase64 = encoding === 'base64';
-    const bytes = new Uint8Array(this.buffer);
+    const bytes = this.bytes.subarray();
     return useBase64 ? uint8ArrayToBase64(bytes) : bytes;
   }
   async ciphertext(options?: {
@@ -164,7 +174,7 @@ class SealedData {
       ? taggedCiphertextLength
       : taggedCiphertextLength - this.tagSize;
 
-    const bytes = new Uint8Array(this.buffer, this.ivSize, ciphertextLength);
+    const bytes = this.bytes.subarray(this.ivSize, this.ivSize + ciphertextLength);
     return useBase64 ? uint8ArrayToBase64(bytes) : bytes;
   }
 }

--- a/packages/expo-crypto/src/aes/__tests__/SealedData-test.web.ts
+++ b/packages/expo-crypto/src/aes/__tests__/SealedData-test.web.ts
@@ -1,0 +1,48 @@
+import AesCryptoModule from '../ExpoCryptoAES.web';
+
+// `registerWebModule` returns an instance of the module class, so the default
+// export carries the instance members even though it is typed as the class.
+const { SealedData } = AesCryptoModule as unknown as InstanceType<typeof AesCryptoModule>;
+
+const IV = new Uint8Array(12).fill(0xaa);
+const CIPHERTEXT = new Uint8Array(20).fill(0xbb);
+const TAG = new Uint8Array(16).fill(0xcc);
+const SEALED = new Uint8Array([...IV, ...CIPHERTEXT, ...TAG]);
+
+describe('SealedData.fromCombined', () => {
+  it('reads a standalone Uint8Array', async () => {
+    const sealed = SealedData.fromCombined(SEALED);
+
+    expect(sealed.combinedSize).toBe(SEALED.byteLength);
+    expect(Array.from((await sealed.iv()) as Uint8Array)).toEqual(Array.from(IV));
+    expect(Array.from((await sealed.tag()) as Uint8Array)).toEqual(Array.from(TAG));
+  });
+
+  it('reads a Uint8Array that views part of a larger buffer', async () => {
+    const backing = new Uint8Array(200);
+    backing.set(SEALED, 64);
+    const view = backing.subarray(64, 64 + SEALED.byteLength);
+
+    const sealed = SealedData.fromCombined(view);
+
+    expect(sealed.combinedSize).toBe(SEALED.byteLength);
+    expect(Array.from((await sealed.iv()) as Uint8Array)).toEqual(Array.from(IV));
+    expect(Array.from((await sealed.tag()) as Uint8Array)).toEqual(Array.from(TAG));
+    expect(Array.from((await sealed.ciphertext()) as Uint8Array)).toEqual(Array.from(CIPHERTEXT));
+  });
+
+  it('rejects data too short to hold an IV and a tag', () => {
+    expect(() => SealedData.fromCombined(new Uint8Array(10))).toThrow(
+      /too short to hold a 12-byte IV and a 16-byte authentication tag/
+    );
+  });
+
+  it('rejects data too short for a custom config', () => {
+    const combined = new Uint8Array(20);
+
+    expect(() => SealedData.fromCombined(combined, { ivLength: 16, tagLength: 16 })).toThrow(
+      /too short to hold a 16-byte IV and a 16-byte authentication tag/
+    );
+    expect(() => SealedData.fromCombined(combined, { ivLength: 4, tagLength: 16 })).not.toThrow();
+  });
+});

--- a/packages/expo-crypto/src/aes/__tests__/web-utils-test.web.ts
+++ b/packages/expo-crypto/src/aes/__tests__/web-utils-test.web.ts
@@ -1,0 +1,45 @@
+import { binaryInputBytes } from '../web-utils';
+
+describe('binaryInputBytes', () => {
+  it('returns a Uint8Array unchanged', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    expect(binaryInputBytes(bytes)).toBe(bytes);
+  });
+
+  it('wraps an ArrayBuffer', () => {
+    const buffer = new Uint8Array([1, 2, 3]).buffer;
+    expect(Array.from(binaryInputBytes(buffer))).toEqual([1, 2, 3]);
+  });
+
+  it('decodes a base64 string', () => {
+    expect(Array.from(binaryInputBytes('AQID'))).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the region of a Uint8Array that views part of a larger buffer', () => {
+    const backing = new Uint8Array(64);
+    backing.set([1, 2, 3], 16);
+    const view = backing.subarray(16, 19);
+
+    expect(Array.from(binaryInputBytes(view))).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the region of a DataView', () => {
+    const backing = new Uint8Array(64);
+    backing.set([1, 2, 3], 16);
+    const view = new DataView(backing.buffer, 16, 3);
+
+    const bytes = binaryInputBytes(view as unknown as ArrayBuffer);
+    expect(bytes.byteLength).toBe(3);
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the region of a non-Uint8Array typed view', () => {
+    const backing = new Uint8Array(64);
+    backing.set([1, 2, 3], 16);
+    const view = new Int8Array(backing.buffer, 16, 3);
+
+    const bytes = binaryInputBytes(view as unknown as ArrayBuffer);
+    expect(bytes.byteLength).toBe(3);
+    expect(Array.from(bytes)).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/expo-crypto/src/aes/web-utils.ts
+++ b/packages/expo-crypto/src/aes/web-utils.ts
@@ -47,7 +47,7 @@ export function binaryInputBytes(input: BinaryInput): Uint8Array {
   }
 
   if (ArrayBuffer.isView(input)) {
-    return new Uint8Array(input.buffer);
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
   }
 
   if (typeof input === 'string') {


### PR DESCRIPTION
# Why

On web, `Crypto.AES` reads the wrong bytes whenever a caller passes a `Uint8Array` that is a window onto a larger buffer.

Two places reach past a view to its backing buffer and drop `byteOffset` / `byteLength`:

```ts
// SealedData.fromCombined
const buffer = binaryInputBytes(combined).buffer as ArrayBuffer;

// binaryInputBytes
if (ArrayBuffer.isView(input)) {
  return new Uint8Array(input.buffer);
}
```

`BinaryInput` is `string | Uint8Array | ArrayBuffer`, and a `Uint8Array` is very often a window onto something bigger — `subarray()` of a read buffer, a slice of a pooled allocation, a record framed inside a larger payload. Reading `.buffer` off one of those yields the whole allocation, not the 48 bytes the caller meant.

The result is a `SealedData` describing the wrong region entirely. With a 42-byte sealed blob sitting at offset 100 of a 512-byte buffer:

```
combinedSize=512 (expected 42)
decrypt FAILED -> DOMException: The operation failed for an operation-specific reason
```

`combinedSize` reports the backing length, so `iv()` reads offset 0 of the backing buffer instead of the blob's IV, and `tag()` — which is positioned as `combinedSize - tagSize` — lands at the end of the backing buffer. Decryption fails with `OperationError`.

This is silent and input-dependent: the same sealed bytes work when they happen to own their buffer and fail when they are a view, which makes it look like data corruption rather than a library bug.

# How

Keep the view rather than its buffer.

`SealedData` now holds the `Uint8Array` and slices it with `subarray`, so every offset is relative to the sealed data instead of to whatever allocation happens to be underneath. `binaryInputBytes` passes `byteOffset` and `byteLength` through when it wraps a view.

Storing the view rather than normalizing with a copy in `fromCombined` keeps the existing zero-copy behaviour and fixes the getters as a class, instead of patching the one call site that happened to reach `.buffer`.

Data built by `fromParts` and `encryptAsync` is unaffected — both allocate exact-size arrays, where the view and its buffer coincide — so the only behaviour that changes is the cases that were reading the wrong bytes.

`subarray` clamps where `new Uint8Array(buffer, offset, length)` threw, so on its own this change would have made truncated input fail later and less clearly — `decryptAsync` would report a generic AES-GCM `OperationError`, and `tag()` would hand back a short slice instead of raising. `fromCombined` therefore now rejects data that cannot hold its own IV and tag.

That check is not new behaviour for the API, it is the behaviour the other platforms already have. Android throws `InvalidSealedDataConfigException` from [`SealedData`'s `init`](https://github.com/expo/expo/blob/main/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/objects/SealedData.kt), and iOS throws out of `AES.GCM.SealedBox(combined:)`. Web was the only platform that accepted a too-short blob, and it failed later with a raw `RangeError: Invalid typed array length: -18`. It now fails at the same point as the other two, with the code Android uses:

```
CodedError [ERR_INVALID_SEALED_DATA_CONFIG]: Sealed data is 10 bytes, which is too short to
hold a 12-byte IV and a 16-byte authentication tag. Pass the whole combined output of
encryptAsync, or set ivLength and tagLength in the config to match how the data was sealed.
```

The `ArrayBuffer.isView` branch is only reachable for views outside the declared `BinaryInput` union (`DataView`, `Int8Array`, …), since `Uint8Array` returns earlier. It is fixed for the same reason: the branch exists precisely to accept those, and it was mishandling every one of them.

# Test Plan

Added `src/aes/__tests__/`, which had no coverage before. Every test below fails on `main` and passes with this change.

`web-utils-test.web.ts` covers `binaryInputBytes` (6 tests), `SealedData-test.web.ts` covers `fromCombined` (4 tests).

Before — 5 distinct assertions fail, reported as 10 because each `.web.ts` file is picked up by both the Node and the Web jest project:

```
● binaryInputBytes › keeps the region of a DataView
    Expected: 3
    Received: 64
● binaryInputBytes › keeps the region of a non-Uint8Array typed view
    Expected: 3
    Received: 64
● SealedData.fromCombined › reads a Uint8Array that views part of a larger buffer
    Expected: 48
    Received: 200
● SealedData.fromCombined › rejects data too short to hold an IV and a tag
● SealedData.fromCombined › rejects data too short for a custom config

Test Suites: 4 failed, 4 total
Tests:       10 failed, 10 passed, 20 total
```

After, with the pre-existing 28 tests still green:

```
Test Suites: 10 passed, 10 total
Tests:       48 passed, 48 total
```

The unit tests stop at the `SealedData` boundary because `crypto.subtle` is present in the Node jest project but not in the jsdom one, so a round trip cannot run in both. To confirm the user-visible effect I ran one directly against Node's WebCrypto, encrypting, framing the sealed bytes at offset 100 of a 512-byte buffer, and decrypting through `fromCombined(view)`:

```
──────── BEFORE the fix ────────
MODE=old  combinedSize=512 (expected 42)
  decrypt FAILED -> DOMException: The operation failed for an operation-specific reason
──────── AFTER the fix ────────
MODE=fixed  combinedSize=42 (expected 42)
  decrypt OK -> "attack at dawn"
```

`et check-packages expo-crypto`:

```
Tasks:    2 successful, 2 total
🏁 All checks passed.
```

`tsc -p tsconfig.json --noEmit` exits 0.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
