### PR TITLE
[secure-store] Add missing changelog credits

### DIFF
--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -6,11 +6,11 @@
 
 ### 🎉 New features
 
-- Add an Android-only `requireConfirmation` option for authenticated reads and writes.
+- Add an Android-only `requireConfirmation` option for authenticated reads and writes. ([#48556](https://github.com/expo/expo/pull/48556) by [@skylarbarrera](https://github.com/skylarbarrera))
 
 ### 🐛 Bug fixes
 
-- [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed.
+- [iOS] Reject `deleteItemAsync` when the keychain refuses the delete, instead of resolving as if the item was removed. ([#49146](https://github.com/expo/expo/pull/49146) by [@vonovak](https://github.com/vonovak))
 - [iOS] Apply `keychainAccessible` when overwriting an existing item, instead of silently keeping the accessibility it was first stored with. ([#49128](https://github.com/expo/expo/pull/49128) by [@JoRo-Code](https://github.com/JoRo-Code) and [@behenate](https://github.com/behenate))
 
 ### 💡 Others


### PR DESCRIPTION
# Why

Two recent merged PRs were missing the credit in changelog

# How

Add missing credits