### PR TITLE
[expo-file-system][android] Resolve upload content length once instead of per 8 KiB segment

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fixed potential file offset races when asynchronous and synchronous `FileHandle` operations overlap on Android and iOS. ([#47945](https://github.com/expo/expo/pull/47945) by [@wh201906](https://github.com/wh201906))
 - Fixed `readAsStringAsync` to respect `position` and `length` when reading UTF-8 strings. ([#20291](https://github.com/expo/expo/issues/20291) by [@mvincentong](https://github.com/mvincentong)) ([#45714](https://github.com/expo/expo/pull/45714) by [@mvincentong](https://github.com/mvincentong))
 - [android] Fixed `rename()` storing an unencoded URI, so reading `.uri` afterwards threw for names containing a space. ([#48496](https://github.com/expo/expo/issues/48496) by [@yagiz2000](https://github.com/yagiz2000), [#48510](https://github.com/expo/expo/pull/48510) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
-- [android] Fixed slow uploads of SAF-backed `content://` files by resolving the request body's content length once, instead of querying it through `ContentResolver` for every 8 KiB written. (by [@gmaclennan](https://github.com/gmaclennan))
+- [android] Fixed slow uploads of SAF-backed `content://` files by resolving the request body's content length once, instead of querying it through `ContentResolver` for every 8 KiB written. ([#49206](https://github.com/expo/expo/pull/49206) by [@gmaclennan](https://github.com/gmaclennan))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed potential file offset races when asynchronous and synchronous `FileHandle` operations overlap on Android and iOS. ([#47945](https://github.com/expo/expo/pull/47945) by [@wh201906](https://github.com/wh201906))
 - Fixed `readAsStringAsync` to respect `position` and `length` when reading UTF-8 strings. ([#20291](https://github.com/expo/expo/issues/20291) by [@mvincentong](https://github.com/mvincentong)) ([#45714](https://github.com/expo/expo/pull/45714) by [@mvincentong](https://github.com/mvincentong))
 - [android] Fixed `rename()` storing an unencoded URI, so reading `.uri` afterwards threw for names containing a space. ([#48496](https://github.com/expo/expo/issues/48496) by [@yagiz2000](https://github.com/yagiz2000), [#48510](https://github.com/expo/expo/pull/48510) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [android] Fixed slow uploads of SAF-backed `content://` files by resolving the request body's content length once, instead of querying it through `ContentResolver` for every 8 KiB written. (by [@gmaclennan](https://github.com/gmaclennan))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
@@ -261,8 +261,9 @@ private class CountingSink(
 
 private fun UnifiedFileInterface.asRequestBody(contentType: String?): RequestBody {
   return object : RequestBody() {
-    // length() on a SAF document is a ContentResolver query, and it can fall back to
-    // reading the whole stream; resolve it once, and not before OkHttp asks for it.
+    // length() is a ContentResolver query for content:// files, and ContentProviderFile
+    // and AssetFile can fall back to reading the whole stream; resolve it once, and
+    // not before OkHttp asks for it.
     private val resolvedLength: Long by lazy { length() }
 
     override fun contentType() = contentType?.toMediaTypeOrNull()

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
@@ -260,9 +260,11 @@ private class CountingSink(
 }
 
 private fun UnifiedFileInterface.asRequestBody(contentType: String?): RequestBody {
-  // length() on a SAF document is a ContentResolver query; resolve it once.
-  val resolvedLength = length()
   return object : RequestBody() {
+    // length() on a SAF document is a ContentResolver query, and it can fall back to
+    // reading the whole stream; resolve it once, and not before OkHttp asks for it.
+    private val resolvedLength: Long by lazy { length() }
+
     override fun contentType() = contentType?.toMediaTypeOrNull()
     override fun contentLength() = resolvedLength
     override fun writeTo(sink: BufferedSink) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemUploadTask.kt
@@ -226,12 +226,16 @@ private class CountingRequestBody(
   private val requestBody: RequestBody,
   private val progressListener: (Long, Long) -> Unit
 ) : RequestBody() {
+  // Resolved once: contentLength() is a ContentResolver query for SAF-backed
+  // files, and the counting sink needs the total on every segment written.
+  private val cachedContentLength: Long by lazy { requestBody.contentLength() }
+
   override fun contentType() = requestBody.contentType()
 
-  override fun contentLength() = requestBody.contentLength()
+  override fun contentLength() = cachedContentLength
 
   override fun writeTo(sink: BufferedSink) {
-    val countingSink = CountingSink(sink, this, progressListener)
+    val countingSink = CountingSink(sink, cachedContentLength, progressListener)
     val bufferedSink = countingSink.buffer()
     requestBody.writeTo(bufferedSink)
     bufferedSink.flush()
@@ -243,7 +247,7 @@ private class CountingRequestBody(
  */
 private class CountingSink(
   sink: Sink,
-  private val requestBody: RequestBody,
+  private val totalBytes: Long,
   private val progressListener: (Long, Long) -> Unit
 ) : ForwardingSink(sink) {
   private var bytesWritten = 0L
@@ -251,14 +255,16 @@ private class CountingSink(
   override fun write(source: Buffer, byteCount: Long) {
     super.write(source, byteCount)
     bytesWritten += byteCount
-    progressListener(bytesWritten, requestBody.contentLength())
+    progressListener(bytesWritten, totalBytes)
   }
 }
 
 private fun UnifiedFileInterface.asRequestBody(contentType: String?): RequestBody {
+  // length() on a SAF document is a ContentResolver query; resolve it once.
+  val resolvedLength = length()
   return object : RequestBody() {
     override fun contentType() = contentType?.toMediaTypeOrNull()
-    override fun contentLength() = length()
+    override fun contentLength() = resolvedLength
     override fun writeTo(sink: BufferedSink) {
       inputStream().use { input ->
         val source = input.source()


### PR DESCRIPTION
# Why

On Android, uploading a file picked through the Storage Access Framework with `File.upload()` is around 100x slower than it should be.

`CountingSink.write` calls `requestBody.contentLength()` on every write to report progress, and okio hands it one 8 KiB segment at a time. For a `content://` URI the request body's `contentLength()` is `SAFDocumentFile.length()`, which is a `ContentResolver` query into the providing app. So the cost of an upload is dominated by one binder round trip per 8 KiB, not by the transfer itself.

Measured with `File.upload()` on a 294 MB document picked from the system picker, on an API 29 emulator: 94.4 s before, 0.86 s after (numbers and method below). `MULTIPART` was never affected — `MultipartBody` caches its own `contentLength()` — so this is `BINARY_CONTENT` only, which is the default.

iOS is unaffected: it uploads via `URLSession.uploadTask(fromFile:)`.

# How

`contentLength()` is constant for the lifetime of a `RequestBody`, so there is no reason to re-query it:

- `CountingRequestBody` resolves the delegate's length once into a `lazy` field, and passes that `Long` to `CountingSink` instead of passing the request body and letting the sink call back into it. `CountingSink` no longer holds a `RequestBody` at all, which makes its dependency on a constant length explicit rather than incidental.
- The `UnifiedFileInterface.asRequestBody` body resolves `length()` once, also into a `lazy` field, for the same reason — that call is the SAF query itself. Keeping it lazy rather than eager matters: `ContentProviderFile.length()` and `AssetFile.length()` can fall back to reading the whole stream, and this way that work still happens on the OkHttp thread when OkHttp asks for the header, not on the caller's queue while the request is being built.

No public API changes. Progress callbacks report the same values.

# Test Plan

Measured on device, on this branch versus its merge base, with the `expo-file-system` Android sources built from source so the Kotlin under test is the one in this diff.

**Correction to the original description:** the numbers in the first version of this PR were produced by `File.upload()`, not by `FileSystem.uploadAsync`. Thanks to @expo-bot for catching the wrong API name — the legacy call converts its URI to a `java.io.File` and never reaches this file, so it could not have exercised the change. Everything below is a fresh measurement through `File.upload()`.

**Setup.** Pixel 7a AVD, API 29, arm64. `apps/minimal-tester`, built with `npx expo run:android --variant release` on each arm. A 294 MB file (293,940,775 bytes) pushed to `/sdcard/Download` and picked with `File.pickFileAsync()`, which yields `content://com.android.providers.downloads.documents/document/msf%3A26` and so resolves to `SAFDocumentFile`. A Node HTTP sink on the host counts the bytes it receives and discards them, reached over `adb reverse tcp:8099 tcp:8099`. The app calls:

```ts
const result = await file.upload('http://127.0.0.1:8099/upload', {
  httpMethod: 'PUT',
  uploadType, // 0 = BINARY_CONTENT, 1 = MULTIPART
  headers: { 'Content-Type': 'application/octet-stream' },
  onProgress: ({ bytesSent, totalBytes }) => { /* count events, collect distinct totals */ },
});
```

**Results.** Each row is the wall clock of `file.upload()` measured in JS, three consecutive runs where three are given.

| source | upload type | before | after |
|---|---|---|---|
| SAF `content://` | `BINARY_CONTENT` | 91.8 / 94.4 / 105.5 s | 1.02 / 0.85 / 0.86 s |
| SAF `content://` | `MULTIPART` | 1.02 s | 0.64 s |
| `file://` (same file copied into the cache dir) | `BINARY_CONTENT` | 1.24 / 0.98 s | 1.04 / 0.78 s |

**Correctness, identical in both arms and in every run:** the sink received exactly 293,940,775 bytes and the request declared the same `Content-Length`; the last progress event was `(293940775, 293940775)`; and the progress stream carried exactly one distinct `totalBytes` value. The event *count* drops from ~900–1000 to ~10 only because `emitProgress` throttles to one event per 100 ms and the upload is now two orders of magnitude shorter.

**Cause, confirmed on device.** Eight `debuggerd -j` dumps taken about a second apart during a "before" upload caught the OkHttp thread in the same place 8 times out of 8, and never in a socket write:

```
at android.os.BinderProxy.transactNative(Native method)
at android.content.ContentProviderProxy.query(ContentProviderNative.java:421)
at android.content.ContentResolver.query(ContentResolver.java:944)
at androidx.documentfile.provider.DocumentsContractApi19.queryForLong(DocumentsContractApi19.java:181)
at androidx.documentfile.provider.SingleDocumentFile.length(SingleDocumentFile.java:83)
at expo.modules.filesystem.unifiedfile.SAFDocumentFile.length(SAFDocumentFile.kt:90)
at expo.modules.filesystem.FileSystemUploadTaskKt$asRequestBody$1.contentLength(FileSystemUploadTask.kt:261)
at expo.modules.filesystem.CountingRequestBody.contentLength(FileSystemUploadTask.kt:231)
at expo.modules.filesystem.CountingSink.write(FileSystemUploadTask.kt:254)
at okio.RealBufferedSink.emitCompleteSegments(RealBufferedSink.kt:256)
at okio.RealBufferedSink.writeAll(RealBufferedSink.kt:195)
at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:62)
```

After the change the same upload finishes in under a second, and a SAF-backed upload costs about the same as a `file://` one — which is what it should cost, since `JavaFile.length()` was only ever a `stat`.

This was first found in a production app (CoMapeo), where importing a custom offline map picked from the document picker ran at 1.8 MB/s and looked like a hang on low-end phones; the same import with this change lands in ~3 s.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
