### PR TITLE
[cli] Resolve the run:ios dev client scheme from the built binary

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve the dev client URL scheme from the built binary in `run:ios`, so projects with several iOS application targets no longer open the scheme of the first target in the pbxproj. (by [@Shywim](https://github.com/Shywim))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/run/ios/runIosAsync.ts
+++ b/packages/@expo/cli/src/run/ios/runIosAsync.ts
@@ -13,7 +13,7 @@ import { CommandError } from '../../utils/errors';
 import { loadEnvFiles } from '../../utils/nodeEnv';
 import { ensurePortAvailabilityAsync } from '../../utils/port';
 import { profile } from '../../utils/profile';
-import { getSchemesForIosAsync } from '../../utils/scheme';
+import { getSchemesForIosAsync, resolveExpoOrLongestScheme } from '../../utils/scheme';
 import { ensureNativeProjectAsync } from '../ensureNativeProject';
 import { event, debugEvent } from '../events';
 import { logProjectLogsLocation } from '../hints';
@@ -206,19 +206,22 @@ export async function runIosAsync(projectRoot: string, options: Options) {
     }
   }
 
+  // Prefer the schemes declared by the target being launched.
+  let scheme = resolveExpoOrLongestScheme(launchInfo.schemes)[0];
+  if (!scheme && !isCustomBinary) {
+    // Fallback to the Info.plist of the first application target in
+    // the pbxproj, which may be wrong if multiple targets exists in
+    // the project, only if not launching a custom binary.
+    scheme = (await getSchemesForIosAsync(projectRoot))[0];
+  }
+
   // Start the dev server which creates all of the required info for
   // launching the app on a simulator.
   const manager = await startBundlerAsync(projectRoot, {
     port: props.port,
     mode,
     headless: !props.shouldStartBundler,
-    // If a scheme is specified then use that instead of the package name.
-
-    scheme: isCustomBinary
-      ? // If launching a custom binary, use the schemes in the Info.plist.
-        launchInfo.schemes[0]
-      : // If a scheme is specified then use that instead of the package name.
-        (await getSchemesForIosAsync(projectRoot))?.[0],
+    scheme,
   });
 
   // Install and launch the app binary on a device.

--- a/packages/@expo/cli/src/utils/scheme.ts
+++ b/packages/@expo/cli/src/utils/scheme.ts
@@ -25,7 +25,7 @@ function sortLongest(obj: string[]): string[] {
  *   - filter on known Expo schemes, starting with `exp+`, avoiding 3rd party schemes.
  *   - filter on longest to ensure uniqueness.
  */
-function resolveExpoOrLongestScheme(schemes: string[]): string[] {
+export function resolveExpoOrLongestScheme(schemes: string[]): string[] {
   const expoOnlySchemes = schemes.filter((scheme) => scheme.startsWith('exp+'));
   return expoOnlySchemes.length > 0 ? sortLongest(expoOnlySchemes) : sortLongest(schemes);
 }


### PR DESCRIPTION
# Why

- When having multiple targets in the iOS project, the expo cli fails to launch the built target because it only look for the **first scheme** in the **first Info.plist** listed in the pbxproj.

# How

- This reuse utils to get the exp scheme from the **built** target we want to launch.

# Test Plan

- Create a second iOS target declaring a different scheme in its Info.plist
- Launch the second iOS target using `expo run:ios --scheme <Target name>`
  - Before: the build is successful, but the launch is failing (we can see it tries to launch with another scheme)
  - After: the app is launched successfully

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
