### PR TITLE
[ui][ios] Yoga node holding old styles after props style update

### DIFF
--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -84,6 +84,7 @@ export function getTestModules() {
   }
 
   if (['android', 'ios'].includes(Platform.OS)) {
+    modules.push(optionalRequire(() => require('./tests/ExpoUIHostSize')));
     modules.push(require('./tests/AppMetrics'));
     modules.push(require('./tests/Blob'));
     modules.push(require('./tests/FileSystem'));

--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -84,7 +84,7 @@ export function getTestModules() {
   }
 
   if (['android', 'ios'].includes(Platform.OS)) {
-    modules.push(optionalRequire(() => require('./tests/ExpoUIHostSize')));
+    modules.push(require('./tests/ExpoUIHostSize'));
     modules.push(require('./tests/AppMetrics'));
     modules.push(require('./tests/Blob'));
     modules.push(require('./tests/FileSystem'));

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@expo/html-elements": "workspace:*",
     "@expo/styleguide-base": "^1.0.1",
+    "@expo/ui": "workspace:*",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-vector-icons/material-design-icons": "^13.1.2",
     "async-retry": "^1.1.4",

--- a/apps/test-suite/tests/ExpoUIHostSize.tsx
+++ b/apps/test-suite/tests/ExpoUIHostSize.tsx
@@ -2,6 +2,7 @@ import { Column, Host, Text as UIText } from '@expo/ui';
 import React from 'react';
 import { View } from 'react-native';
 
+import type { JasmineInterface, TestPortal } from '../types';
 import { mountAndWaitForWithTimeout } from './helpers';
 
 export const name = 'ExpoUI Host size';
@@ -64,8 +65,8 @@ function HostSizeProbe({
 }
 
 export async function test(
-  { it, describe, expect, afterEach }: any,
-  { setPortalChild, cleanupPortal }: any
+  { it, describe, expect, afterEach }: JasmineInterface,
+  { setPortalChild, cleanupPortal }: TestPortal
 ) {
   const measure = (matchContents: boolean | { vertical?: boolean; horizontal?: boolean }) =>
     mountAndWaitForWithTimeout<Measured>(

--- a/apps/test-suite/tests/ExpoUIHostSize.tsx
+++ b/apps/test-suite/tests/ExpoUIHostSize.tsx
@@ -7,17 +7,8 @@ import { mountAndWaitForWithTimeout } from './helpers';
 export const name = 'ExpoUI Host size';
 export const route = 'expo-ui-host-size';
 
-/**
- * A `matchContents` Host reports the size its native content measured, and that size has to reach
- * the Yoga node for the host to be laid out at it. So on every matched axis these must agree:
- *
- *   content - what SwiftUI or Compose measured, from `onLayoutContent`
- *   laid    - what Yoga laid the host out at, from `onLayout`
- *
- * This is the invariant that https://github.com/expo/expo/pull/48059 broke. Note that reproducing
- * that particular regression needs shadow tree commit contention, which this test does not create.
- */
-
+// Tests Host matchContents behavior on iOS and Android. Uses onLayoutContent and onLayout callback to
+// assert that the Host's size matches its content size when matchContents is true
 const SETTLE_MS = 250;
 const TIMEOUT_MS = 10000;
 // Anything under a point is rounding between the two measurement systems.

--- a/apps/test-suite/tests/ExpoUIHostSize.tsx
+++ b/apps/test-suite/tests/ExpoUIHostSize.tsx
@@ -14,9 +14,54 @@ const SETTLE_MS = 250;
 const TIMEOUT_MS = 10000;
 // Anything under a point is rounding between the two measurement systems.
 const TOLERANCE = 1;
+const TINTS = ['#ff0000', '#0000ff'];
 
 type Axes = { width: number; height: number };
 type Measured = { laid: Axes; content: Axes };
+type AcrossRerender = { before: Measured; after: Measured };
+
+/** Stable handlers, so re-rendering a probe leaves the Host's props unchanged. */
+function useSettledSize(onSettled: (measured: Measured) => void) {
+  const sizes = React.useRef<{ laid?: Axes; content?: Axes }>({});
+  const settle = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const onSettledRef = React.useRef(onSettled);
+
+  React.useEffect(() => {
+    onSettledRef.current = onSettled;
+  });
+
+  React.useEffect(() => () => clearTimeout(settle.current), []);
+
+  const scheduleReport = React.useCallback(() => {
+    clearTimeout(settle.current);
+    settle.current = setTimeout(() => {
+      const { laid, content } = sizes.current;
+      if (laid && content) {
+        onSettledRef.current({ laid, content });
+      }
+    }, SETTLE_MS);
+  }, []);
+
+  const onLayout = React.useCallback(
+    (event: { nativeEvent: { layout: Axes } }) => {
+      const { width, height } = event.nativeEvent.layout;
+      sizes.current.laid = { width, height };
+      scheduleReport();
+    },
+    [scheduleReport]
+  );
+
+  const onLayoutContent = React.useCallback(
+    (event: { nativeEvent: Axes }) => {
+      const { width, height } = event.nativeEvent;
+      sizes.current.content = { width, height };
+      scheduleReport();
+    },
+    [scheduleReport]
+  );
+
+  return { onLayout, onLayoutContent, scheduleReport };
+}
 
 /** Reports both sizes once layout has been quiet for `SETTLE_MS`. */
 function HostSizeProbe({
@@ -26,38 +71,50 @@ function HostSizeProbe({
   matchContents: boolean | { vertical?: boolean; horizontal?: boolean };
   onMeasured: (measured: Measured) => void;
 }) {
-  const sizes = React.useRef<{ laid?: Axes; content?: Axes }>({});
-  const settle = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
-  const scheduleReport = () => {
-    clearTimeout(settle.current);
-    settle.current = setTimeout(() => {
-      const { laid, content } = sizes.current;
-      if (laid && content) {
-        onMeasured({ laid, content });
-      }
-    }, SETTLE_MS);
-  };
-
-  React.useEffect(() => () => clearTimeout(settle.current), []);
+  const { onLayout, onLayoutContent } = useSettledSize(onMeasured);
 
   return (
     <View style={{ width: 300 }}>
-      <Host
-        matchContents={matchContents}
-        onLayout={(event) => {
-          const { width, height } = event.nativeEvent.layout;
-          sizes.current.laid = { width, height };
-          scheduleReport();
-        }}
-        onLayoutContent={(event) => {
-          const { width, height } = event.nativeEvent;
-          sizes.current.content = { width, height };
-          scheduleReport();
-        }}>
+      <Host matchContents={matchContents} onLayout={onLayout} onLayoutContent={onLayoutContent}>
         <Column spacing={4}>
           <UIText>First line</UIText>
           <UIText>Second line</UIText>
+        </Column>
+      </Host>
+    </View>
+  );
+}
+
+/**
+ * Recoloring re-renders the Host's children without touching its props, the case where the yoga
+ * node used to keep its old sizeless style. The content size doesn't change, so nothing repairs it.
+ */
+function HostRerenderProbe({ onMeasured }: { onMeasured: (measured: AcrossRerender) => void }) {
+  const [tint, setTint] = React.useState(0);
+  const before = React.useRef<Measured | undefined>(undefined);
+
+  const { onLayout, onLayoutContent, scheduleReport } = useSettledSize((measured) => {
+    if (!before.current) {
+      before.current = measured;
+      setTint(1);
+    } else if (tint > 0) {
+      onMeasured({ before: before.current, after: measured });
+    }
+  });
+
+  // No layout event fires when the size is right, so report on a timer.
+  React.useEffect(() => {
+    if (tint > 0) {
+      scheduleReport();
+    }
+  }, [tint, scheduleReport]);
+
+  return (
+    <View style={{ width: 300 }}>
+      <Host matchContents onLayout={onLayout} onLayoutContent={onLayoutContent}>
+        <Column spacing={4}>
+          <UIText textStyle={{ color: TINTS[tint] }}>First line</UIText>
+          <UIText textStyle={{ color: TINTS[tint] }}>Second line</UIText>
         </Column>
       </Host>
     </View>
@@ -102,6 +159,21 @@ export async function test(
 
       expect(content.height).toBeGreaterThan(0);
       expect(Math.abs(laid.height - content.height)).toBeLessThan(TOLERANCE);
+    });
+
+    it('keeps a matchContents Host at its content size after its children re-render', async () => {
+      const { before, after } = await mountAndWaitForWithTimeout<AcrossRerender>(
+        <HostRerenderProbe onMeasured={() => {}} />,
+        'onMeasured',
+        setPortalChild,
+        TIMEOUT_MS
+      );
+
+      expect(Math.abs(after.content.width - before.content.width)).toBeLessThan(TOLERANCE);
+      expect(Math.abs(after.content.height - before.content.height)).toBeLessThan(TOLERANCE);
+
+      expect(Math.abs(after.laid.width - after.content.width)).toBeLessThan(TOLERANCE);
+      expect(Math.abs(after.laid.height - after.content.height)).toBeLessThan(TOLERANCE);
     });
   });
 }

--- a/apps/test-suite/tests/ExpoUIHostSize.tsx
+++ b/apps/test-suite/tests/ExpoUIHostSize.tsx
@@ -1,0 +1,115 @@
+import { Column, Host, Text as UIText } from '@expo/ui';
+import React from 'react';
+import { View } from 'react-native';
+
+import { mountAndWaitForWithTimeout } from './helpers';
+
+export const name = 'ExpoUI Host size';
+export const route = 'expo-ui-host-size';
+
+/**
+ * A `matchContents` Host reports the size its native content measured, and that size has to reach
+ * the Yoga node for the host to be laid out at it. So on every matched axis these must agree:
+ *
+ *   content - what SwiftUI or Compose measured, from `onLayoutContent`
+ *   laid    - what Yoga laid the host out at, from `onLayout`
+ *
+ * This is the invariant that https://github.com/expo/expo/pull/48059 broke. Note that reproducing
+ * that particular regression needs shadow tree commit contention, which this test does not create.
+ */
+
+const SETTLE_MS = 250;
+const TIMEOUT_MS = 10000;
+// Anything under a point is rounding between the two measurement systems.
+const TOLERANCE = 1;
+
+type Axes = { width: number; height: number };
+type Measured = { laid: Axes; content: Axes };
+
+/** Reports both sizes once layout has been quiet for `SETTLE_MS`. */
+function HostSizeProbe({
+  matchContents,
+  onMeasured,
+}: {
+  matchContents: boolean | { vertical?: boolean; horizontal?: boolean };
+  onMeasured: (measured: Measured) => void;
+}) {
+  const sizes = React.useRef<{ laid?: Axes; content?: Axes }>({});
+  const settle = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const scheduleReport = () => {
+    clearTimeout(settle.current);
+    settle.current = setTimeout(() => {
+      const { laid, content } = sizes.current;
+      if (laid && content) {
+        onMeasured({ laid, content });
+      }
+    }, SETTLE_MS);
+  };
+
+  React.useEffect(() => () => clearTimeout(settle.current), []);
+
+  return (
+    <View style={{ width: 300 }}>
+      <Host
+        matchContents={matchContents}
+        onLayout={(event) => {
+          const { width, height } = event.nativeEvent.layout;
+          sizes.current.laid = { width, height };
+          scheduleReport();
+        }}
+        onLayoutContent={(event) => {
+          const { width, height } = event.nativeEvent;
+          sizes.current.content = { width, height };
+          scheduleReport();
+        }}>
+        <Column spacing={4}>
+          <UIText>First line</UIText>
+          <UIText>Second line</UIText>
+        </Column>
+      </Host>
+    </View>
+  );
+}
+
+export async function test(
+  { it, describe, expect, afterEach }: any,
+  { setPortalChild, cleanupPortal }: any
+) {
+  const measure = (matchContents: boolean | { vertical?: boolean; horizontal?: boolean }) =>
+    mountAndWaitForWithTimeout<Measured>(
+      <HostSizeProbe matchContents={matchContents} onMeasured={() => {}} />,
+      'onMeasured',
+      setPortalChild,
+      TIMEOUT_MS
+    );
+
+  describe(name, () => {
+    afterEach(async () => {
+      await cleanupPortal();
+    });
+
+    it('lays out a matchContents Host at its content size on both axes', async () => {
+      const { laid, content } = await measure(true);
+
+      expect(content.width).toBeGreaterThan(0);
+      expect(content.height).toBeGreaterThan(0);
+      expect(Math.abs(laid.width - content.width)).toBeLessThan(TOLERANCE);
+      expect(Math.abs(laid.height - content.height)).toBeLessThan(TOLERANCE);
+    });
+
+    it('lays out a horizontal matchContents Host at its content width', async () => {
+      const { laid, content } = await measure({ horizontal: true });
+
+      expect(content.width).toBeGreaterThan(0);
+      expect(Math.abs(laid.width - content.width)).toBeLessThan(TOLERANCE);
+    });
+
+    it('lays out a vertical matchContents Host at its content height', async () => {
+      const { laid, content } = await measure({ vertical: true });
+
+      expect(content.height).toBeGreaterThan(0);
+      expect(Math.abs(laid.height - content.height)).toBeLessThan(TOLERANCE);
+    });
+  });
+}

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `matchContents` hosts sometimes being laid out at a stale size. Regression from [#48059](https://github.com/expo/expo/pull/48059). ([#49211](https://github.com/expo/expo/pull/49211) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed an infinite main-thread layout loop (frozen UI, watchdog kill on backgrounding) when a SwiftUI host with `matchContents` and Yoga persistently disagree on the content size, e.g. with the Button Shapes accessibility setting enabled. Synchronous size commits are now budgeted per run-loop turn; over-budget updates are coalesced on the view and committed asynchronously on the next turn, and no-op size updates no longer dirty the layout. ([#48058](https://github.com/expo/expo/issues/48058), [#48059](https://github.com/expo/expo/pull/48059) by [@focux](https://github.com/focux))
 - [iOS] Fixed the `ExpoModulesProvider` lookup missing the generated class when the app `name` starts with a digit, which registered no native modules and left release builds on a blank screen. ([#48793](https://github.com/expo/expo/pull/48793) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Fixed the tap that closes a SwiftUI menu also pressing the React Native view underneath it. ([#48419](https://github.com/expo/expo/issues/48419) by [@bohdanstefaniuk](https://github.com/bohdanstefaniuk)) ([#48463](https://github.com/expo/expo/pull/48463) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
+++ b/packages/expo-modules-core/common/cpp/fabric/ExpoViewComponentDescriptor.h
@@ -67,29 +67,19 @@ public:
         snode->getProps());
 
       auto &style = const_cast<facebook::yoga::Style &>(props.yogaStyle);
-      bool changedStyle = false;
 
       if (!isnan(styleWidth)) {
-        auto expectedWidth = facebook::yoga::StyleSizeLength::points(styleWidth);
-        if (style.dimension(facebook::yoga::Dimension::Width) != expectedWidth) {
-          style.setDimension(facebook::yoga::Dimension::Width, expectedWidth);
-          changedStyle = true;
-        }
+        style.setDimension(facebook::yoga::Dimension::Width,
+                           facebook::yoga::StyleSizeLength::points(styleWidth));
       }
 
       if (!isnan(styleHeight)) {
-        auto expectedHeight = facebook::yoga::StyleSizeLength::points(styleHeight);
-        if (style.dimension(facebook::yoga::Dimension::Height) != expectedHeight) {
-          style.setDimension(facebook::yoga::Dimension::Height, expectedHeight);
-          changedStyle = true;
-        }
+        style.setDimension(facebook::yoga::Dimension::Height,
+                           facebook::yoga::StyleSizeLength::points(styleHeight));
       }
 
-      // Update yoga props and dirty layout if we changed the style
-      if (changedStyle) {
-        snode->updateYogaProps();
-        snode->dirtyLayout();
-      }
+      // Updates yoga style from props and sets the node dirty
+      snode->updateYogaProps();
     }
     facebook::react::ConcreteComponentDescriptor<ShadowNodeType>::adopt(shadowNode);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1573,6 +1573,9 @@ importers:
       '@expo/styleguide-base':
         specifier: ^1.0.1
         version: 1.0.1(react@19.2.3)
+      '@expo/ui':
+        specifier: workspace:*
+        version: link:../../packages/expo-ui
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/jest-preset@0.86.0(@babel/core@7.29.7)(react@19.2.3))(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))


### PR DESCRIPTION
# Why

Reported by @matinzd https://github.com/expo/expo/pull/48059#issuecomment-5368086472

In `adopt` function, the props style gets updated but yoga node's style can have stale value in some cases. e.g. failed commits. We need to call `updateYogaProps` to make sure props are always copied to yoga node's style which is used during the layout.



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Call `updateYogaProps` after prop style changes it also calls `setDirty` internally, so another call to `setDirty` is not needed.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Added testcases in NCL test suite which should catch such issues in future.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
