### PR TITLE
[router] Move store values into context

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 ### 💡 Others
 
-- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
+- Move Expo Router store values into React context. ([#49218](https://github.com/expo/expo/pull/49218) by [@Ubax](https://github.com/Ubax))
 - Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,7 +50,6 @@
 
 ### 🐛 Bug fixes
 
-- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### 🐛 Bug fixes
 
+- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -50,7 +50,6 @@
 
 ### 🐛 Bug fixes
 
-- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))
 - Fixed `Tabs` and `TopTabs` (`expo-router/js-tabs`, `expo-router/js-top-tabs`) not being usable from RSC ([#48330](https://github.com/expo/expo/pull/48330) by [@Ubax](https://github.com/Ubax))
@@ -67,6 +66,7 @@
 
 ### 💡 Others
 
+- Keep linking route information in React scope. ([#49176](https://github.com/expo/expo/pull/49176) by [@Ubax](https://github.com/Ubax))
 - Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
 - Render only the focused tab route during the first render. ([#48618](https://github.com/expo/expo/pull/48618) by [@Ubax](https://github.com/Ubax))
 - Order JS Tabs, NativeTabs, headless tabs and Drawer by `routeNames` order ([#48374](https://github.com/expo/expo/pull/48374) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -8,12 +8,14 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './
 import { useDomComponentNavigation } from './domComponents/useDomComponentNavigation';
 import { NavigationContainer as UpstreamNavigationContainer } from './fork/NavigationContainer';
 import type { ExpoLinkingOptions } from './getLinkingConfig';
-import { store, useStore } from './global-state/router-store';
+import { useStore } from './global-state/router-store';
 import { RouterRegistryProvider } from './global-state/routerRegistry';
 import type { ServerContextType } from './global-state/serverLocationContext';
 import { ServerContext } from './global-state/serverLocationContext';
+import { maybeHideSplashScreen, store } from './global-state/store';
 import { StoreContext } from './global-state/storeContext';
 import { shouldAppendNotFound, shouldAppendSitemap } from './global-state/utils';
+import { useImperativeApiEmitter } from './imperative-api';
 import { LinkPreviewContextProvider } from './link/preview/LinkPreviewContext';
 import { handleNavigationOnReady } from './navigationEvents/navigation';
 import { Screen } from './primitives';
@@ -90,12 +92,12 @@ const initialUrl =
     ? new URL(window.location.href)
     : undefined;
 
-// TODO(@ubax): Refactor onReady logic and use listeners pattern
 function onNavigationReady() {
   handleNavigationOnReady();
-  store.onReady();
+  maybeHideSplashScreen();
 }
 
+// TODO(@ubax): Refactor onReady logic and use listeners pattern
 function ContextNavigator({
   context,
   location: initialLocation = initialUrl,
@@ -134,11 +136,18 @@ function ContextNavigator({
     ? `${serverContext.location.pathname}${serverContext.location.search}${serverContext.location.hash ?? ''}`
     : undefined;
 
-  const store = useStore(context, linking, serverUrl);
-
+  const storeValue = useStore(context, linking, serverUrl);
+  const {
+    navigationRef,
+    initialState,
+    rootComponent,
+    linking: linkingConfig,
+    routeNode,
+  } = storeValue;
   useDomComponentNavigation();
 
-  if (store.shouldShowTutorial()) {
+  // TODO(@ubax): Revisit onboarding once route creation is React-owned.
+  if (process.env.NODE_ENV === 'development' && !routeNode) {
     SplashScreen.hideAsync();
     if (process.env.NODE_ENV === 'development') {
       const Tutorial = require('./onboard/Tutorial').Tutorial;
@@ -154,19 +163,20 @@ function ContextNavigator({
   }
 
   return (
-    <StoreContext.Provider value={store}>
+    <StoreContext.Provider value={storeValue}>
       <RouterRegistryProvider>
         <UpstreamNavigationContainer
-          ref={store.navigationRef}
-          initialState={store.state}
-          linking={store.linking as LinkingOptions<any>}
+          ref={navigationRef}
+          initialState={initialState}
+          linking={linkingConfig as LinkingOptions<any>}
           onUnhandledAction={onUnhandledAction}
           onStateChange={store.onStateChange}
           documentTitle={documentTitle}
           onReady={onNavigationReady}>
+          <ImperativeApiEmitter />
           <ServerContext.Provider value={serverContext}>
             <WrapperComponent>
-              <Content />
+              <Content rootComponent={rootComponent} />
             </WrapperComponent>
           </ServerContext.Provider>
         </UpstreamNavigationContainer>
@@ -175,10 +185,13 @@ function ContextNavigator({
   );
 }
 
-function Content() {
-  const children = [
-    <Screen key="SLOT" name={INTERNAL_SLOT_NAME} component={store.rootComponent} />,
-  ];
+function ImperativeApiEmitter() {
+  useImperativeApiEmitter();
+  return null;
+}
+
+function Content({ rootComponent }: { rootComponent: ComponentType<any> }) {
+  const children = [<Screen key="SLOT" name={INTERNAL_SLOT_NAME} component={rootComponent} />];
   if (shouldAppendNotFound()) {
     children.push(<Screen key="NOT-FOUND" name={NOT_FOUND_ROUTE_NAME} component={RootUnmatched} />);
   }

--- a/packages/expo-router/src/__tests__/redirects.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/redirects.test.ios.tsx
@@ -1,14 +1,18 @@
 import { screen, act, fireEvent } from '@testing-library/react-native';
+import { use } from 'react';
 import { Text } from 'react-native';
 
 import type { RedirectConfig } from '../exports';
 import { router } from '../exports';
+import type { StoreRedirects } from '../global-state/router-store';
 import { store } from '../global-state/router-store';
+import { StoreContext } from '../global-state/storeContext';
 import Stack from '../layouts/Stack';
 import { Tabs } from '../layouts/Tabs';
 import { renderRouter } from '../testing-library';
 
 const mockRedirects = jest.fn(() => [] as RedirectConfig[]);
+const mockRewrites = jest.fn(() => [] as RedirectConfig[]);
 const mockOpenURL = jest.fn((url: string) => undefined);
 
 jest.mock('expo-constants', () => {
@@ -21,10 +25,18 @@ jest.mock('expo-constants', () => {
           get redirects() {
             return mockRedirects();
           },
+          get rewrites() {
+            return mockRewrites();
+          },
         },
       },
     },
   };
+});
+
+beforeEach(() => {
+  mockRedirects.mockReturnValue([]);
+  mockRewrites.mockReturnValue([]);
 });
 
 jest.mock('expo-linking', () => {
@@ -34,6 +46,33 @@ jest.mock('expo-linking', () => {
       return (url: string) => mockOpenURL(url);
     },
   };
+});
+
+it('exposes redirects and rewrites through the store context', () => {
+  const redirect = { source: '/foo', destination: '/bar' } as RedirectConfig;
+  const externalRedirect = { source: '/away', destination: '//example.com' } as RedirectConfig;
+  const rewrite = { source: '/old', destination: '/new' } as RedirectConfig;
+  mockRedirects.mockReturnValue([redirect, externalRedirect]);
+  mockRewrites.mockReturnValue([rewrite]);
+
+  let contextRedirects: StoreRedirects[] | undefined;
+
+  function Index() {
+    contextRedirects = use(StoreContext)!.redirects;
+    return null;
+  }
+
+  renderRouter({
+    index: Index,
+    bar: () => null,
+    new: () => null,
+  });
+
+  expect(contextRedirects).toEqual([
+    [expect.any(RegExp), redirect, false],
+    [expect.any(RegExp), externalRedirect, true],
+    [expect.any(RegExp), rewrite, false],
+  ]);
 });
 
 it('deep link to a redirect', () => {

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { I18nManager } from 'react-native';
 
-import { useImperativeApiEmitter } from '../imperative-api';
 import type {
   DocumentTitleOptions,
   LinkingOptions,
@@ -83,7 +82,6 @@ function NavigationContainerInner(
 
   useBackButton(refContainer);
   useDocumentTitle(refContainer, documentTitle);
-  useImperativeApiEmitter(refContainer);
 
   const [lastUnhandledLink, setLastUnhandledLink] = React.useState<string | undefined>();
 

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
@@ -1,6 +1,7 @@
 import { act, render, waitFor } from '@testing-library/react-native';
 
 import { RouterRegistryProvider } from '../../global-state/routerRegistry';
+import { store } from '../../global-state/store';
 import { Screen } from '../../react-navigation/core/Screen';
 import { createNavigationContainerRef } from '../../react-navigation/core/createNavigationContainerRef';
 import { useNavigationBuilder } from '../../react-navigation/core/useNavigationBuilder';
@@ -11,14 +12,6 @@ import { createMemoryHistory } from '../createMemoryHistory';
 jest.mock('../createMemoryHistory');
 
 let mockNavigationRef: ReturnType<typeof createNavigationContainerRef>;
-
-jest.mock('../../global-state/storeContext', () => ({
-  useExpoRouterStore: () => ({
-    get state() {
-      return mockNavigationRef.current?.getRootState();
-    },
-  }),
-}));
 
 const history = {
   index: 0,
@@ -37,6 +30,9 @@ function EmptyScreen() {
 
 beforeEach(() => {
   jest.mocked(createMemoryHistory).mockReturnValue(history);
+  jest
+    .spyOn(store, 'state', 'get')
+    .mockImplementation(() => mockNavigationRef.current?.getRootState());
   Object.defineProperty(globalThis, 'location', {
     configurable: true,
     value: { hash: '' },

--- a/packages/expo-router/src/fork/getInitialURLWithTimeout.ts
+++ b/packages/expo-router/src/fork/getInitialURLWithTimeout.ts
@@ -1,0 +1,21 @@
+import * as ExpoLinking from 'expo-linking';
+import { Linking, Platform } from 'react-native';
+
+export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
+  if (typeof window === 'undefined') {
+    return '';
+  } else if (Platform.OS === 'ios') {
+    // Use the new Expo API for iOS. This has better support for App Clips and handoff.
+    return ExpoLinking.getLinkingURL();
+  }
+
+  return Promise.race([
+    // TODO: Phase this out in favor of expo-linking on Android.
+    Linking.getInitialURL(),
+    new Promise<null>((resolve) =>
+      // Timeout in 150ms if `getInitialState` doesn't resolve
+      // Workaround for https://github.com/facebook/react-native/issues/25675
+      setTimeout(() => resolve(null), 150)
+    ),
+  ]);
+}

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -2,6 +2,7 @@ import * as ExpoLinking from 'expo-linking';
 import { type RefObject, useEffect, useCallback, useRef } from 'react';
 import { Linking, Platform } from 'react-native';
 
+import { useRouteInfo } from '../global-state/useRouteInfo';
 import {
   type LinkingOptions,
   getActionFromState as getActionFromStateDefault,
@@ -10,10 +11,13 @@ import {
   type ParamListBase,
 } from '../react-navigation/native';
 import { extractExpoPathFromURL } from './extractPathFromURL';
+import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
-type Options = LinkingOptions<ParamListBase>;
+type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
+  getStateFromPath?: typeof getExpoStateFromPath;
+};
 
 const linkingHandlers: symbol[] = [];
 
@@ -49,8 +53,11 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
+  const independent = useNavigationIndependentTree();
+  const { segments } = useRouteInfo();
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
       return undefined;
@@ -93,6 +100,10 @@ export function useLinking(
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
   const getActionFromStateRef = useRef(getActionFromState);
+  const segmentsRef = useRef(segments);
+
+  // Keep stable URL listeners in sync with the latest navigation state.
+  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -112,7 +123,9 @@ export function useLinking(
 
       const path = extractExpoPathFromURL(prefixesRef.current, url);
 
-      return path !== undefined ? getStateFromPathRef.current(path, configRef.current) : undefined;
+      return path !== undefined
+        ? getStateFromPathRef.current(path, configRef.current, segmentsRef.current)
+        : undefined;
     },
 
     []

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,7 +53,6 @@ export function useLinking(
     });
   const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
-  const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -15,9 +15,7 @@ import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
-type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
-  getStateFromPath?: typeof getExpoStateFromPath;
-};
+type Options = LinkingOptions<ParamListBase>;
 
 const linkingHandlers: symbol[] = [];
 
@@ -53,8 +51,7 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,8 +53,8 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
@@ -102,8 +102,7 @@ export function useLinking(
   const getActionFromStateRef = useRef(getActionFromState);
   const segmentsRef = useRef(segments);
 
-  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
-  // against the route that was current when the URL was received.
+  // Keep stable URL listeners in sync with the latest navigation state.
   segmentsRef.current = segments;
 
   useEffect(() => {

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -1,6 +1,5 @@
-import * as ExpoLinking from 'expo-linking';
-import { type RefObject, useEffect, useCallback, useRef } from 'react';
-import { Linking, Platform } from 'react-native';
+import { type RefObject, useEffect, useEffectEvent, useCallback, useRef } from 'react';
+import { Linking } from 'react-native';
 
 import { useRouteInfo } from '../global-state/useRouteInfo';
 import {
@@ -11,6 +10,7 @@ import {
   type ParamListBase,
 } from '../react-navigation/native';
 import { extractExpoPathFromURL } from './extractPathFromURL';
+import { getInitialURLWithTimeout } from './getInitialURLWithTimeout';
 import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
@@ -100,11 +100,6 @@ export function useLinking(
   const getInitialURLRef = useRef(getInitialURL);
   const getStateFromPathRef = useRef(getStateFromPath);
   const getActionFromStateRef = useRef(getActionFromState);
-  const segmentsRef = useRef(segments);
-
-  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
-  // against the route that was current when the URL was received.
-  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -125,12 +120,13 @@ export function useLinking(
       const path = extractExpoPathFromURL(prefixesRef.current, url);
 
       return path !== undefined
-        ? getStateFromPathRef.current(path, configRef.current, segmentsRef.current)
+        ? getStateFromPathRef.current(path, configRef.current, segments)
         : undefined;
     },
 
-    []
+    [segments]
   );
+  const getStateFromURLInEffect = useEffectEvent(getStateFromURL);
 
   const getInitialState = useCallback(() => {
     let state: ResultState | undefined;
@@ -177,7 +173,7 @@ export function useLinking(
       }
 
       const navigation = ref.current;
-      const state = navigation ? getStateFromURL(url) : undefined;
+      const state = navigation ? getStateFromURLInEffect(url) : undefined;
 
       if (navigation && state) {
         // If the link were handled, it gets cleared in NavigationContainer
@@ -208,28 +204,9 @@ export function useLinking(
     };
 
     return subscribe(listener);
-  }, [enabled, getStateFromURL, onUnhandledLinking, prefixes, ref, subscribe]);
+  }, [enabled, onUnhandledLinking, prefixes, ref, subscribe]);
 
   return {
     getInitialState,
   };
-}
-
-export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  if (typeof window === 'undefined') {
-    return '';
-  } else if (Platform.OS === 'ios') {
-    // Use the new Expo API for iOS. This has better support for App Clips and handoff.
-    return ExpoLinking.getLinkingURL();
-  }
-
-  return Promise.race([
-    // TODO: Phase this out in favor of expo-linking on Android.
-    Linking.getInitialURL(),
-    new Promise<null>((resolve) =>
-      // Timeout in 150ms if `getInitialState` doesn't resolve
-      // Workaround for https://github.com/facebook/react-native/issues/25675
-      setTimeout(() => resolve(null), 150)
-    ),
-  ]);
 }

--- a/packages/expo-router/src/fork/useLinking.native.ts
+++ b/packages/expo-router/src/fork/useLinking.native.ts
@@ -53,8 +53,8 @@ export function useLinking(
         }
       };
     });
-  const getStateFromPath = (options?.getStateFromPath ??
-    getStateFromPathDefault) as typeof getExpoStateFromPath;
+  const getStateFromPath: typeof getExpoStateFromPath =
+    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const independent = useNavigationIndependentTree();
   const { segments } = useRouteInfo();
@@ -102,7 +102,8 @@ export function useLinking(
   const getActionFromStateRef = useRef(getActionFromState);
   const segmentsRef = useRef(segments);
 
-  // Keep stable URL listeners in sync with the latest navigation state.
+  // Linking listeners stay subscribed across navigation updates, but relative URLs must be parsed
+  // against the route that was current when the URL was received.
   segmentsRef.current = segments;
 
   useEffect(() => {

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -1,5 +1,13 @@
 import isEqual from 'fast-deep-equal';
-import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'react';
+import {
+  type RefObject,
+  useEffect,
+  useEffectEvent,
+  useState,
+  useCallback,
+  useRef,
+  use,
+} from 'react';
 
 import { ServerContext } from '../global-state/serverLocationContext';
 import { useExpoRouterStore } from '../global-state/storeContext';
@@ -135,11 +143,6 @@ export function useLinking(
   const getStateFromPathRef = useRef(getStateFromPath);
   const getPathFromStateRef = useRef(getPathFromState);
   const getActionFromStateRef = useRef(getActionFromState);
-  const segmentsRef = useRef(segments);
-
-  // Segments are navigation state, so keep this ref current during render. The
-  // linking listeners intentionally remain stable across navigation updates.
-  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -148,6 +151,12 @@ export function useLinking(
     getPathFromStateRef.current = getPathFromState;
     getActionFromStateRef.current = getActionFromState;
   });
+
+  const getStateFromPathForCurrentSegments = useCallback(
+    (path: string) => getStateFromPathRef.current(path, configRef.current, segments),
+    [segments]
+  );
+  const getStateFromPathInEffect = useEffectEvent(getStateFromPathForCurrentSegments);
 
   const validateRoutesNotExistInRootState = useCallback(
     (state: ResultState) => {
@@ -182,7 +191,7 @@ export function useLinking(
         : undefined;
 
       if (path) {
-        value = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
+        value = getStateFromPathForCurrentSegments(path);
       }
 
       // If the link were handled, it gets cleared in NavigationContainer
@@ -200,7 +209,7 @@ export function useLinking(
 
     return thenable as PromiseLike<ResultState | undefined>;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [getStateFromPathForCurrentSegments, onUnhandledLinking, server]);
 
   const previousIndexRef = useRef<number | undefined>(undefined);
   const previousStateRef = useRef<NavigationState | undefined>(undefined);
@@ -236,7 +245,7 @@ export function useLinking(
         return;
       }
 
-      const state = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
+      const state = getStateFromPathInEffect(path);
 
       // We should only dispatch an action when going forward
       // Otherwise the action will likely add items to history, which would mess things up
@@ -314,11 +323,7 @@ export function useLinking(
       // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
       // This makes sure that we preserve the original URL for wildcard routes
       if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(
-          route.path,
-          configRef.current,
-          segmentsRef.current
-        );
+        const stateForPath = getStateFromPathInEffect(route.path);
 
         if (stateForPath) {
           const focusedRoute = findFocusedRoute(stateForPath);
@@ -485,8 +490,4 @@ export function useLinking(
   return {
     getInitialState,
   };
-}
-
-export function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  return typeof window === 'undefined' ? '' : window.location.href;
 }

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -86,8 +86,8 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath = (options?.getStateFromPath ??
-    getStateFromPathDefault) as typeof getExpoStateFromPath;
+  const getStateFromPath: typeof getExpoStateFromPath =
+    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -86,8 +86,8 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -83,9 +83,7 @@ export const series = (cb: () => Promise<void>) => {
 
 const linkingHandlers: symbol[] = [];
 
-type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
-  getStateFromPath?: typeof getExpoStateFromPath;
-};
+type Options = LinkingOptions<ParamListBase>;
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
@@ -94,8 +92,7 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath: typeof getExpoStateFromPath =
-    options?.getStateFromPath ?? ((path, options) => getStateFromPathDefault(path, options));
+  const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();
@@ -208,8 +205,9 @@ export function useLinking(
     };
 
     return thenable as PromiseLike<ResultState | undefined>;
+    // NavigationContainer consumes this callback only once through useThenable.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getStateFromPathForCurrentSegments, onUnhandledLinking, server]);
+  }, []);
 
   const previousIndexRef = useRef<number | undefined>(undefined);
   const previousStateRef = useRef<NavigationState | undefined>(undefined);

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -10,7 +10,7 @@ import {
 } from 'react';
 
 import { ServerContext } from '../global-state/serverLocationContext';
-import { useExpoRouterStore } from '../global-state/storeContext';
+import { store } from '../global-state/store';
 import { useRouteInfo } from '../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../global-state/utils';
 import {
@@ -95,7 +95,7 @@ export function useLinking(
   const getStateFromPath = options?.getStateFromPath ?? getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
-  const store = useExpoRouterStore();
+
   const { segments } = useRouteInfo();
 
   useEffect(() => {

--- a/packages/expo-router/src/fork/useLinking.ts
+++ b/packages/expo-router/src/fork/useLinking.ts
@@ -3,6 +3,7 @@ import { type RefObject, useEffect, useState, useCallback, useRef, use } from 'r
 
 import { ServerContext } from '../global-state/serverLocationContext';
 import { useExpoRouterStore } from '../global-state/storeContext';
+import { useRouteInfo } from '../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../global-state/utils';
 import {
   type LinkingOptions,
@@ -17,6 +18,7 @@ import {
 import { getHistoryLength } from '../utils/stack';
 import { createMemoryHistory } from './createMemoryHistory';
 import { appendBaseUrl } from './getPathFromState';
+import { getStateFromPath as getExpoStateFromPath } from './getStateFromPath';
 
 type ResultState = ReturnType<typeof getStateFromPathDefault>;
 
@@ -73,7 +75,9 @@ export const series = (cb: () => Promise<void>) => {
 
 const linkingHandlers: symbol[] = [];
 
-type Options = LinkingOptions<ParamListBase>;
+type Options = Omit<LinkingOptions<ParamListBase>, 'getStateFromPath'> & {
+  getStateFromPath?: typeof getExpoStateFromPath;
+};
 
 export function useLinking(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
@@ -82,10 +86,12 @@ export function useLinking(
 ) {
   const enabled = options !== undefined;
   const config = options?.config;
-  const getStateFromPath = options?.getStateFromPath ?? getStateFromPathDefault;
+  const getStateFromPath = (options?.getStateFromPath ??
+    getStateFromPathDefault) as typeof getExpoStateFromPath;
   const getPathFromState = options?.getPathFromState ?? getPathFromStateDefault;
   const getActionFromState = options?.getActionFromState ?? getActionFromStateDefault;
   const store = useExpoRouterStore();
+  const { segments } = useRouteInfo();
 
   useEffect(() => {
     if (process.env.NODE_ENV === 'production') {
@@ -129,6 +135,11 @@ export function useLinking(
   const getStateFromPathRef = useRef(getStateFromPath);
   const getPathFromStateRef = useRef(getPathFromState);
   const getActionFromStateRef = useRef(getActionFromState);
+  const segmentsRef = useRef(segments);
+
+  // Segments are navigation state, so keep this ref current during render. The
+  // linking listeners intentionally remain stable across navigation updates.
+  segmentsRef.current = segments;
 
   useEffect(() => {
     enabledRef.current = enabled;
@@ -171,7 +182,7 @@ export function useLinking(
         : undefined;
 
       if (path) {
-        value = getStateFromPathRef.current(path, configRef.current);
+        value = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
       }
 
       // If the link were handled, it gets cleared in NavigationContainer
@@ -225,7 +236,7 @@ export function useLinking(
         return;
       }
 
-      const state = getStateFromPathRef.current(path, configRef.current);
+      const state = getStateFromPathRef.current(path, configRef.current, segmentsRef.current);
 
       // We should only dispatch an action when going forward
       // Otherwise the action will likely add items to history, which would mess things up
@@ -303,7 +314,11 @@ export function useLinking(
       // If the `route` object contains a `path`, use that path as long as `route.name` and `params` still match
       // This makes sure that we preserve the original URL for wildcard routes
       if (route?.path) {
-        const stateForPath = getStateFromPathRef.current(route.path, configRef.current);
+        const stateForPath = getStateFromPathRef.current(
+          route.path,
+          configRef.current,
+          segmentsRef.current
+        );
 
         if (stateForPath) {
           const focusedRoute = findFocusedRoute(stateForPath);

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -2,7 +2,7 @@ import { Platform } from 'expo';
 
 import type { RouteNode } from './Route';
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './constants';
-import type { Options, State } from './fork/getPathFromState';
+import type { State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
 import type { StoreRedirects } from './global-state/router-store';
@@ -134,13 +134,7 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath: <ParamList extends object>(
-      path: string,
-      options?: Options<ParamList>,
-      previousSegments?: string[]
-    ) => {
-      return getStateFromPath(path, options, previousSegments);
-    },
+    getStateFromPath,
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (
         getPathFromState(state, {

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -6,7 +6,7 @@ import type { State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
 import type { StoreRedirects } from './global-state/router-store';
-import { getInitialURL, getPathFromState, getStateFromPath, subscribe } from './link/linking';
+import { getInitialURL, getPathFromState, subscribe } from './link/linking';
 import type { LinkingOptions } from './react-navigation/native';
 import { getActionFromState } from './react-navigation/native';
 import type { NativeIntent, RequireContext } from './types';
@@ -47,7 +47,6 @@ export function getNavigationConfig(
 
 export type ExpoLinkingOptions<T extends object = Record<string, unknown>> = LinkingOptions<T> & {
   getPathFromState: typeof getPathFromState;
-  getStateFromPath: typeof getStateFromPath;
 };
 
 export type LinkingConfigOptions = {
@@ -134,7 +133,6 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath,
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (
         getPathFromState(state, {

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -5,7 +5,6 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './
 import type { Options, State } from './fork/getPathFromState';
 import { getReactNavigationConfig } from './getReactNavigationConfig';
 import { applyRedirects } from './getRoutesRedirects';
-import type { UrlObject } from './global-state/getRouteInfoFromState';
 import type { StoreRedirects } from './global-state/router-store';
 import { getInitialURL, getPathFromState, getStateFromPath, subscribe } from './link/linking';
 import type { LinkingOptions } from './react-navigation/native';
@@ -67,7 +66,6 @@ interface RouterOptions {
 export function getLinkingConfig(
   routes: RouteNode,
   context: RequireContext,
-  getRouteInfo: () => UrlObject,
   {
     metaOnly = true,
     serverUrl,
@@ -113,13 +111,19 @@ export function getLinkingConfig(
           if (typeof initialUrl === 'string') {
             initialUrl = applyRedirects(initialUrl, redirects);
             if (initialUrl && typeof nativeLinking?.redirectSystemPath === 'function') {
-              initialUrl = nativeLinking.redirectSystemPath({ path: initialUrl, initial: true });
+              initialUrl = nativeLinking.redirectSystemPath({
+                path: initialUrl,
+                initial: true,
+              });
             }
           } else if (initialUrl) {
             initialUrl = initialUrl.then((url) => {
               url = applyRedirects(url, redirects);
               if (url && typeof nativeLinking?.redirectSystemPath === 'function') {
-                return nativeLinking.redirectSystemPath({ path: url, initial: true });
+                return nativeLinking.redirectSystemPath({
+                  path: url,
+                  initial: true,
+                });
               }
               return url;
             });
@@ -130,8 +134,12 @@ export function getLinkingConfig(
       return initialUrl;
     },
     subscribe: subscribe(nativeLinking, redirects),
-    getStateFromPath: <ParamList extends object>(path: string, options?: Options<ParamList>) => {
-      return getStateFromPath(path, options, getRouteInfo().segments);
+    getStateFromPath: <ParamList extends object>(
+      path: string,
+      options?: Options<ParamList>,
+      previousSegments?: string[]
+    ) => {
+      return getStateFromPath(path, options, previousSegments);
     },
     getPathFromState(state: State, options: Parameters<typeof getPathFromState>[1]) {
       return (

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -110,19 +110,13 @@ export function getLinkingConfig(
           if (typeof initialUrl === 'string') {
             initialUrl = applyRedirects(initialUrl, redirects);
             if (initialUrl && typeof nativeLinking?.redirectSystemPath === 'function') {
-              initialUrl = nativeLinking.redirectSystemPath({
-                path: initialUrl,
-                initial: true,
-              });
+              initialUrl = nativeLinking.redirectSystemPath({ path: initialUrl, initial: true });
             }
           } else if (initialUrl) {
             initialUrl = initialUrl.then((url) => {
               url = applyRedirects(url, redirects);
               if (url && typeof nativeLinking?.redirectSystemPath === 'function') {
-                return nativeLinking.redirectSystemPath({
-                  path: url,
-                  initial: true,
-                });
+                return nativeLinking.redirectSystemPath({ path: url, initial: true });
               }
               return url;
             });

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -175,6 +175,22 @@ describe(getNavigateAction, () => {
     );
   });
 
+  it('uses route information provided by the caller', () => {
+    const routeInfo = {
+      pathname: '/current',
+      pathnameWithParams: '/current',
+      segments: ['current'],
+      params: {},
+      searchParams: new URLSearchParams(),
+      unstable_globalHref: '',
+      isIndex: false,
+    };
+
+    getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
+
+    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
+  });
+
   it('preserves PUSH when target navigator is tab', () => {
     mockFindDivergentState.mockReturnValue({
       actionState: { routes: [{ name: 'tab1' }] },

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,32 +1,9 @@
 import { applyRedirects } from '../../getRoutesRedirects';
 import { getStateFromPath } from '../../link/linking';
-import type { SingularOptions } from '../../useScreens';
-import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
+import { getNavigateAction } from '../getNavigationAction';
 import { defaultRouteInfo } from '../getRouteInfoFromState';
-import type { UrlObject } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
-import type { LinkToOptions } from '../types';
-
-function getNavigateAction(
-  baseHref: string,
-  options: LinkToOptions,
-  type = 'NAVIGATE',
-  withAnchor?: boolean,
-  singular?: SingularOptions,
-  isPreviewNavigation?: boolean,
-  routeInfo: Pick<UrlObject, 'segments' | 'params'> = defaultRouteInfo
-) {
-  return getNavigateActionImplementation(
-    baseHref,
-    options,
-    routeInfo,
-    type,
-    withAnchor,
-    singular,
-    isPreviewNavigation
-  );
-}
 
 jest.mock('../store', () => ({
   store: {
@@ -121,14 +98,14 @@ describe(getNavigateAction, () => {
       throw new Error('Not ready');
     });
 
-    expect(() => getNavigateAction('/home', {})).toThrow('Not ready');
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow('Not ready');
   });
 
   it('throws when navigationRef.current is null', () => {
     const originalCurrent = store.navigationRef.current;
     (store.navigationRef as any).current = null;
 
-    expect(() => getNavigateAction('/home', {})).toThrow(
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       "Couldn't find a navigation object. Is your component inside NavigationContainer?"
     );
 
@@ -142,7 +119,7 @@ describe(getNavigateAction, () => {
       configurable: true,
     });
 
-    expect(() => getNavigateAction('/home', {})).toThrow(
+    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       'Attempted to link to route when no routes are present'
     );
 
@@ -155,7 +132,7 @@ describe(getNavigateAction, () => {
   it('returns undefined when applyRedirects returns undefined', () => {
     mockApplyRedirects.mockReturnValueOnce(undefined as any);
 
-    const result = getNavigateAction('/redirect', {});
+    const result = getNavigateAction('/redirect', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
   });
@@ -164,7 +141,7 @@ describe(getNavigateAction, () => {
     mockGetStateFromPath.mockReturnValueOnce(null as any);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = getNavigateAction('/bad-path', {});
+    const result = getNavigateAction('/bad-path', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
@@ -179,7 +156,7 @@ describe(getNavigateAction, () => {
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const result = getNavigateAction('/bad-path', {});
+    const result = getNavigateAction('/bad-path', {}, defaultRouteInfo);
 
     expect(result).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledWith(
@@ -189,7 +166,7 @@ describe(getNavigateAction, () => {
   });
 
   it('returns action with type NAVIGATE by default', () => {
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
@@ -215,7 +192,7 @@ describe(getNavigateAction, () => {
       isIndex: false,
     };
 
-    getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
+    getNavigateAction('/home', {}, routeInfo, 'NAVIGATE', undefined, undefined, false);
 
     expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
   });
@@ -235,7 +212,7 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/tab1', {}, 'PUSH');
+    const result = getNavigateAction('/tab1', {}, defaultRouteInfo, 'PUSH');
 
     expect(result!.type).toBe('PUSH');
   });
@@ -255,7 +232,7 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/screen1', {}, 'PUSH');
+    const result = getNavigateAction('/screen1', {}, defaultRouteInfo, 'PUSH');
 
     expect(result!.type).toBe('PUSH');
   });
@@ -275,13 +252,13 @@ describe(getNavigateAction, () => {
       navigationRoutes: [],
     });
 
-    const result = getNavigateAction('/screen1', {}, 'REPLACE');
+    const result = getNavigateAction('/screen1', {}, defaultRouteInfo, 'REPLACE');
 
     expect(result!.type).toBe('REPLACE');
   });
 
   it('sets target to navigationState.key', () => {
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(result!.target).toBe('nav-key');
   });
@@ -298,7 +275,7 @@ describe(getNavigateAction, () => {
       },
     });
 
-    const result = getNavigateAction('/home', {}, 'NAVIGATE', true);
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE', true);
 
     // withAnchor=true → initial should be set to false at every level (inverted logic)
     const params = result!.payload.params as Record<string, any>;
@@ -312,6 +289,7 @@ describe(getNavigateAction, () => {
     const result = getNavigateAction(
       '/home',
       {},
+      defaultRouteInfo,
       'NAVIGATE',
       false,
       undefined,
@@ -329,13 +307,13 @@ describe(getNavigateAction, () => {
   it('passes singular option through to payload', () => {
     const singular = true;
 
-    const result = getNavigateAction('/home', {}, 'NAVIGATE', false, singular);
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE', false, singular);
 
     expect(result!.payload.singular).toBe(true);
   });
 
   it('PRELOAD uses lookThroughAllTabs=true on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'PRELOAD');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'PRELOAD');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -345,7 +323,7 @@ describe(getNavigateAction, () => {
   });
 
   it('non-PRELOAD uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'NAVIGATE');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'NAVIGATE');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -355,7 +333,7 @@ describe(getNavigateAction, () => {
   });
 
   it('REPLACE on stack navigator stays as REPLACE', () => {
-    const result = getNavigateAction('/home', {}, 'REPLACE');
+    const result = getNavigateAction('/home', {}, defaultRouteInfo, 'REPLACE');
 
     expect(result!.type).toBe('REPLACE');
   });
@@ -379,14 +357,14 @@ describe(getNavigateAction, () => {
 
     mockGetPayload.mockReturnValue({ screen: undefined, params: {} });
 
-    const result = getNavigateAction('/home', {});
+    const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
     expect(mockGetPayload).toHaveBeenCalledWith({});
     expect(result).toBeDefined();
   });
 
   it('PUSH uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'PUSH');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'PUSH');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),
@@ -396,7 +374,7 @@ describe(getNavigateAction, () => {
   });
 
   it('REPLACE uses lookThroughAllTabs=false on findDivergentState', () => {
-    getNavigateAction('/home', {}, 'REPLACE');
+    getNavigateAction('/home', {}, defaultRouteInfo, 'REPLACE');
 
     expect(mockFindDivergentState).toHaveBeenCalledWith(
       expect.anything(),

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,7 +1,19 @@
 import { applyRedirects } from '../../getRoutesRedirects';
-import { getNavigateAction } from '../getNavigationAction';
+import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
+import { defaultRouteInfo } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
+
+const getNavigateAction = (...args: any[]) =>
+  getNavigateActionImplementation(
+    args[0],
+    args[1],
+    args[2] ?? 'NAVIGATE',
+    args[3],
+    args[4],
+    args[5],
+    args[6] ?? defaultRouteInfo
+  );
 
 jest.mock('../store', () => ({
   store: {

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,42 +1,65 @@
 import { applyRedirects } from '../../getRoutesRedirects';
 import { getStateFromPath } from '../../link/linking';
-import { getNavigateAction } from '../getNavigationAction';
-import { defaultRouteInfo } from '../getRouteInfoFromState';
+import type { SingularOptions } from '../../useScreens';
+import {
+  getNavigateAction as getNavigateActionImplementation,
+  type NavigationActionContext,
+} from '../getNavigationAction';
+import { defaultRouteInfo, type UrlObject } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
-import { store } from '../store';
+import type { LinkToOptions } from '../types';
 
-jest.mock('../store', () => ({
-  store: {
-    assertIsReady: jest.fn(),
-    navigationRef: {
-      isReady: jest.fn(() => true),
-      current: {
-        canGoBack: jest.fn(),
-        setParams: jest.fn(),
-        goBack: jest.fn(),
-        getRootState: jest.fn(() => ({
-          routes: [{ key: 'root-key', name: '__root' }],
-          index: 0,
-          key: 'root-nav',
-          type: 'stack',
-          routeNames: ['__root'],
-          stale: false,
-        })),
-        dispatch: jest.fn(),
-      },
-    },
-    state: undefined as any,
-    linking: {
-      config: {},
-    },
-    getRouteInfo: jest.fn(() => ({
-      pathname: '/',
-      segments: [],
-      params: {},
+const mockIsReady = jest.fn(() => true);
+const navigationRef = {
+  isReady: mockIsReady,
+  current: {
+    canGoBack: jest.fn(),
+    setParams: jest.fn(),
+    goBack: jest.fn(),
+    getRootState: jest.fn(() => ({
+      routes: [{ key: 'root-key', name: '__root' }],
+      index: 0,
+      key: 'root-nav',
+      type: 'stack',
+      routeNames: ['__root'],
+      stale: false,
     })),
-    redirects: [],
+    dispatch: jest.fn(),
   },
-}));
+} as unknown as NavigationActionContext['navigationRef']; // Only navigation APIs exercised by these tests are mocked.
+
+let linking: NavigationActionContext['linking'] = {
+  prefixes: [],
+  config: { screens: {} },
+  getPathFromState: jest.fn(),
+};
+
+let redirects: NavigationActionContext['redirects'] = [];
+
+function getNavigateAction(
+  baseHref: string,
+  options: LinkToOptions,
+  routeInfo: Pick<UrlObject, 'segments' | 'params'> = defaultRouteInfo,
+  type = 'NAVIGATE',
+  withAnchor?: boolean,
+  singular?: SingularOptions,
+  isPreviewNavigation?: boolean
+) {
+  return getNavigateActionImplementation(
+    baseHref,
+    options,
+    routeInfo,
+    {
+      navigationRef,
+      linking,
+      redirects,
+    },
+    type,
+    withAnchor,
+    singular,
+    isPreviewNavigation
+  );
+}
 
 jest.mock('../stateUtils', () => ({
   findDivergentState: jest.fn(),
@@ -89,44 +112,64 @@ function setupDefaultMocks() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockIsReady.mockReturnValue(true);
+  linking = {
+    prefixes: [],
+    config: { screens: {} },
+    getPathFromState: jest.fn(),
+  };
+  redirects = [];
   setupDefaultMocks();
 });
 
 describe(getNavigateAction, () => {
-  it('throws when navigation is not ready (assertIsReady throws)', () => {
-    (store.assertIsReady as jest.Mock).mockImplementationOnce(() => {
-      throw new Error('Not ready');
-    });
+  it('throws when navigation is not ready', () => {
+    mockIsReady.mockReturnValueOnce(false);
 
-    expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow('Not ready');
+    expect(() => getNavigateAction('/home', {})).toThrow(
+      'Attempted to navigate before mounting the Root Layout component'
+    );
   });
 
   it('throws when navigationRef.current is null', () => {
-    const originalCurrent = store.navigationRef.current;
-    (store.navigationRef as any).current = null;
+    const originalCurrent = navigationRef.current;
+    navigationRef.current = null;
 
     expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       "Couldn't find a navigation object. Is your component inside NavigationContainer?"
     );
 
-    (store.navigationRef as any).current = originalCurrent;
+    navigationRef.current = originalCurrent;
   });
 
-  it('throws when store.linking is falsy', () => {
-    const originalLinking = store.linking;
-    Object.defineProperty(store, 'linking', {
-      value: null,
-      configurable: true,
-    });
+  it('throws when linking is falsy', () => {
+    linking = undefined;
 
     expect(() => getNavigateAction('/home', {}, defaultRouteInfo)).toThrow(
       'Attempted to link to route when no routes are present'
     );
+  });
 
-    Object.defineProperty(store, 'linking', {
-      value: originalLinking,
-      configurable: true,
-    });
+  it('forwards the redirects from the context to applyRedirects', () => {
+    redirects = [
+      [
+        /^\/from$/,
+        { source: '/from', destination: '/to', destinationContextKey: './to.tsx' },
+        false,
+      ],
+    ];
+
+    getNavigateAction('/from', {}, defaultRouteInfo);
+
+    expect(mockApplyRedirects).toHaveBeenCalledWith('/from', redirects);
+  });
+
+  it('navigates to the href returned by applyRedirects', () => {
+    mockApplyRedirects.mockReturnValueOnce('/redirected');
+
+    getNavigateAction('/from', {}, defaultRouteInfo);
+
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/redirected', { screens: {} }, []);
   });
 
   it('returns undefined when applyRedirects returns undefined', () => {
@@ -168,7 +211,7 @@ describe(getNavigateAction, () => {
   it('returns action with type NAVIGATE by default', () => {
     const result = getNavigateAction('/home', {}, defaultRouteInfo);
 
-    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, []);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', { screens: {} }, []);
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -194,7 +237,7 @@ describe(getNavigateAction, () => {
 
     getNavigateAction('/home', {}, routeInfo, 'NAVIGATE', undefined, undefined, false);
 
-    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', { screens: {} }, ['current']);
   });
 
   it('preserves PUSH when target navigator is tab', () => {

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -1,19 +1,32 @@
 import { applyRedirects } from '../../getRoutesRedirects';
+import { getStateFromPath } from '../../link/linking';
+import type { SingularOptions } from '../../useScreens';
 import { getNavigateAction as getNavigateActionImplementation } from '../getNavigationAction';
 import { defaultRouteInfo } from '../getRouteInfoFromState';
+import type { UrlObject } from '../getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from '../stateUtils';
 import { store } from '../store';
+import type { LinkToOptions } from '../types';
 
-const getNavigateAction = (...args: any[]) =>
-  getNavigateActionImplementation(
-    args[0],
-    args[1],
-    args[2] ?? 'NAVIGATE',
-    args[3],
-    args[4],
-    args[5],
-    args[6] ?? defaultRouteInfo
+function getNavigateAction(
+  baseHref: string,
+  options: LinkToOptions,
+  type = 'NAVIGATE',
+  withAnchor?: boolean,
+  singular?: SingularOptions,
+  isPreviewNavigation?: boolean,
+  routeInfo: Pick<UrlObject, 'segments' | 'params'> = defaultRouteInfo
+) {
+  return getNavigateActionImplementation(
+    baseHref,
+    options,
+    type,
+    withAnchor,
+    singular,
+    isPreviewNavigation,
+    routeInfo
   );
+}
 
 jest.mock('../store', () => ({
   store: {
@@ -37,7 +50,6 @@ jest.mock('../store', () => ({
     },
     state: undefined as any,
     linking: {
-      getStateFromPath: jest.fn(),
       config: {},
     },
     getRouteInfo: jest.fn(() => ({
@@ -62,14 +74,19 @@ jest.mock('../../link/href', () => ({
   resolveHrefStringWithSegments: jest.fn((href: string) => href),
 }));
 
+jest.mock('../../link/linking', () => ({
+  getStateFromPath: jest.fn(),
+}));
+
 const mockFindDivergentState = findDivergentState as jest.MockedFunction<typeof findDivergentState>;
 const mockGetPayload = getPayloadFromStateRoute as jest.MockedFunction<
   typeof getPayloadFromStateRoute
 >;
 const mockApplyRedirects = applyRedirects as jest.MockedFunction<typeof applyRedirects>;
+const mockGetStateFromPath = getStateFromPath as jest.MockedFunction<typeof getStateFromPath>;
 
 function setupDefaultMocks() {
-  (store.linking!.getStateFromPath as jest.Mock).mockReturnValue({
+  mockGetStateFromPath.mockReturnValue({
     routes: [{ name: 'home' }],
   });
 
@@ -144,7 +161,7 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns null', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce(null);
+    mockGetStateFromPath.mockReturnValueOnce(null as any);
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = getNavigateAction('/bad-path', {});
@@ -157,7 +174,7 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns empty routes', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({
+    mockGetStateFromPath.mockReturnValueOnce({
       routes: [],
     });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -174,7 +191,7 @@ describe(getNavigateAction, () => {
   it('returns action with type NAVIGATE by default', () => {
     const result = getNavigateAction('/home', {});
 
-    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, []);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -200,7 +217,7 @@ describe(getNavigateAction, () => {
 
     getNavigateAction('/home', {}, 'NAVIGATE', undefined, undefined, false, routeInfo);
 
-    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
+    expect(mockGetStateFromPath).toHaveBeenCalledWith('/home', {}, ['current']);
   });
 
   it('preserves PUSH when target navigator is tab', () => {

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -108,13 +108,19 @@ describe(getNavigateAction, () => {
 
   it('throws when store.linking is falsy', () => {
     const originalLinking = store.linking;
-    Object.defineProperty(store, 'linking', { value: null, configurable: true });
+    Object.defineProperty(store, 'linking', {
+      value: null,
+      configurable: true,
+    });
 
     expect(() => getNavigateAction('/home', {})).toThrow(
       'Attempted to link to route when no routes are present'
     );
 
-    Object.defineProperty(store, 'linking', { value: originalLinking, configurable: true });
+    Object.defineProperty(store, 'linking', {
+      value: originalLinking,
+      configurable: true,
+    });
   });
 
   it('returns undefined when applyRedirects returns undefined', () => {
@@ -139,7 +145,9 @@ describe(getNavigateAction, () => {
   });
 
   it('logs error and returns undefined when getStateFromPath returns empty routes', () => {
-    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({ routes: [] });
+    (store.linking!.getStateFromPath as jest.Mock).mockReturnValueOnce({
+      routes: [],
+    });
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     const result = getNavigateAction('/bad-path', {});
@@ -153,6 +161,8 @@ describe(getNavigateAction, () => {
 
   it('returns action with type NAVIGATE by default', () => {
     const result = getNavigateAction('/home', {});
+
+    expect(store.linking!.getStateFromPath).toHaveBeenCalledWith('/home', {}, []);
 
     expect(result).toEqual(
       expect.objectContaining({

--- a/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/getNavigationAction.test.ios.ts
@@ -20,11 +20,11 @@ function getNavigateAction(
   return getNavigateActionImplementation(
     baseHref,
     options,
+    routeInfo,
     type,
     withAnchor,
     singular,
-    isPreviewNavigation,
-    routeInfo
+    isPreviewNavigation
   );
 }
 

--- a/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/router.test.ios.ts
@@ -339,10 +339,10 @@ describe('router action functions', () => {
     expect(mockAdd).toHaveBeenCalledWith({ type: 'POP_TO_TOP' });
   });
 
-  it('goBack calls store.assertIsReady and enqueues GO_BACK', () => {
+  it('goBack checks navigation readiness and enqueues GO_BACK', () => {
     goBack();
 
-    expect(store.assertIsReady).toHaveBeenCalled();
+    expect(store.navigationRef.isReady).toHaveBeenCalled();
     expect(mockAdd).toHaveBeenCalledWith({ type: 'GO_BACK' });
   });
 
@@ -363,10 +363,10 @@ describe('router action functions', () => {
     expect(store.navigationRef.current!.canGoBack).toHaveBeenCalled();
   });
 
-  it('setParams calls store.assertIsReady', () => {
+  it('setParams checks navigation readiness', () => {
     setParams({ name: 'test' });
 
-    expect(store.assertIsReady).toHaveBeenCalled();
+    expect(store.navigationRef.isReady).toHaveBeenCalled();
     expect(store.navigationRef.current!.setParams).toHaveBeenCalledWith({ name: 'test' });
   });
 });
@@ -397,6 +397,6 @@ describe('DOM short-circuit paths', () => {
 
     expect(mockEmitDomGoBack).toHaveBeenCalled();
     expect(mockAdd).not.toHaveBeenCalled();
-    expect(store.assertIsReady).not.toHaveBeenCalled();
+    expect(store.navigationRef.isReady).not.toHaveBeenCalled();
   });
 });

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -104,6 +104,15 @@ describe('routingQueue', () => {
 
   it('run() converts ROUTER_LINK actions via getNavigateAction then dispatches', () => {
     const ref = makeRef();
+    const routeInfo = {
+      pathname: '/current',
+      pathnameWithParams: '/current',
+      segments: ['current'],
+      params: {},
+      searchParams: new URLSearchParams(),
+      unstable_globalHref: '',
+      isIndex: false,
+    };
     const navigateAction = {
       type: 'NAVIGATE',
       payload: { name: 'home', params: {}, singular: false },
@@ -116,7 +125,7 @@ describe('routingQueue', () => {
       payload: { href: '/home', options: { event: 'NAVIGATE' } },
     });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, routeInfo);
 
     expect(mockGetNavigateAction).toHaveBeenCalledWith(
       '/home',
@@ -124,7 +133,8 @@ describe('routingQueue', () => {
       'NAVIGATE',
       undefined,
       undefined,
-      false
+      false,
+      routeInfo
     );
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -1,9 +1,14 @@
-import type { RefObject } from 'react';
-
-import type { NavigationContainerRef, ParamListBase } from '../../react-navigation/native';
-import { getNavigateAction } from '../getNavigationAction';
+import { getNavigateAction, type NavigationActionContext } from '../getNavigationAction';
 import { defaultRouteInfo } from '../getRouteInfoFromState';
 import { routingQueue } from '../routingQueue';
+
+const navigationActionContext = (
+  navigationRef: NavigationActionContext['navigationRef']
+): NavigationActionContext => ({
+  navigationRef,
+  linking: undefined,
+  redirects: [],
+});
 
 jest.mock('../getNavigationAction', () => ({
   getNavigateAction: jest.fn(),
@@ -12,30 +17,29 @@ jest.mock('../getNavigationAction', () => ({
 const mockGetNavigateAction = getNavigateAction as jest.MockedFunction<typeof getNavigateAction>;
 
 function makeRef(
-  overrides: Partial<NavigationContainerRef<ParamListBase>> = {}
-): RefObject<NavigationContainerRef<ParamListBase>> {
-  return {
-    current: {
-      dispatch: jest.fn(),
-      navigate: jest.fn(),
-      reset: jest.fn(),
-      goBack: jest.fn(),
-      isFocused: jest.fn(),
-      canGoBack: jest.fn(),
-      getState: jest.fn(),
-      getRootState: jest.fn(),
-      getParent: jest.fn(),
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-      isReady: jest.fn(() => true),
-      setParams: jest.fn(),
-      getCurrentRoute: jest.fn(),
-      getCurrentOptions: jest.fn(),
-      getId: jest.fn(),
-      resetRoot: jest.fn(),
-      ...overrides,
-    } as unknown as NavigationContainerRef<ParamListBase>,
-  };
+  overrides: Partial<NonNullable<NavigationActionContext['navigationRef']['current']>> = {}
+): NavigationActionContext['navigationRef'] {
+  const ref = {
+    dispatch: jest.fn(),
+    navigate: jest.fn(),
+    reset: jest.fn(),
+    goBack: jest.fn(),
+    isFocused: jest.fn(),
+    canGoBack: jest.fn(),
+    getState: jest.fn(),
+    getRootState: jest.fn(),
+    getParent: jest.fn(),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    isReady: jest.fn(() => true),
+    setParams: jest.fn(),
+    getCurrentRoute: jest.fn(),
+    getCurrentOptions: jest.fn(),
+    getId: jest.fn(),
+    resetRoot: jest.fn(),
+    ...overrides,
+  } as unknown as NonNullable<NavigationActionContext['navigationRef']['current']>; // Only navigation APIs exercised by these tests are mocked.
+  return { ...ref, current: ref };
 }
 
 beforeEach(() => {
@@ -49,9 +53,11 @@ describe('routingQueue', () => {
   it('add() pushes action to queue and notifies subscribers', () => {
     const callback = jest.fn();
     routingQueue.subscribe(callback);
+    const previousSnapshot = routingQueue.snapshot();
 
     routingQueue.add({ type: 'GO_BACK' });
 
+    expect(routingQueue.snapshot()).not.toBe(previousSnapshot);
     expect(routingQueue.queue).toHaveLength(1);
     expect(routingQueue.queue[0]).toEqual({ type: 'GO_BACK' });
     expect(callback).toHaveBeenCalledTimes(1);
@@ -88,7 +94,7 @@ describe('routingQueue', () => {
     routingQueue.add({ type: 'GO_BACK' });
     routingQueue.add({ type: 'POP_TO_TOP' });
 
-    routingQueue.run(ref, defaultRouteInfo);
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
 
     expect(routingQueue.queue).toHaveLength(0);
   });
@@ -98,7 +104,7 @@ describe('routingQueue', () => {
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref, defaultRouteInfo);
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
 
     expect(ref.current!.dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
   });
@@ -123,16 +129,17 @@ describe('routingQueue', () => {
 
     routingQueue.add({
       type: 'ROUTER_LINK',
-      payload: { href: '/home', options: { event: 'NAVIGATE' } },
+      payload: { href: '/home', options: {} },
     });
 
-    routingQueue.run(ref, routeInfo);
+    routingQueue.run(routeInfo, navigationActionContext(ref));
 
     expect(mockGetNavigateAction).toHaveBeenCalledWith(
       '/home',
-      { event: 'NAVIGATE' },
+      {},
       routeInfo,
-      'NAVIGATE',
+      navigationActionContext(ref),
+      undefined,
       undefined,
       undefined,
       false
@@ -149,20 +156,30 @@ describe('routingQueue', () => {
       payload: { href: '/redirect', options: { event: 'NAVIGATE' } },
     });
 
-    routingQueue.run(ref, defaultRouteInfo);
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
 
     expect(ref.current!.dispatch).not.toHaveBeenCalled();
   });
 
-  it('run() does nothing when ref.current is null', () => {
-    const ref = { current: null };
+  it('run() preserves the queue when ref.current is null', () => {
+    const ref = makeRef();
+    ref.current = null;
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref as any, defaultRouteInfo);
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
 
-    // Queue should still be drained (reset identity happens before dispatch loop)
-    expect(routingQueue.queue).toHaveLength(0);
+    expect(routingQueue.queue).toEqual([{ type: 'GO_BACK' }]);
+  });
+
+  it('run() preserves the queue until navigation is ready', () => {
+    const ref = makeRef({ isReady: jest.fn(() => false) });
+
+    routingQueue.add({ type: 'GO_BACK' });
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
+
+    expect(routingQueue.queue).toEqual([{ type: 'GO_BACK' }]);
+    expect(ref.current!.dispatch).not.toHaveBeenCalled();
   });
 
   it('run() resets queue identity so new actions during run go to a fresh array', () => {
@@ -172,7 +189,7 @@ describe('routingQueue', () => {
 
     const oldQueue = routingQueue.queue;
 
-    routingQueue.run(ref, defaultRouteInfo);
+    routingQueue.run(defaultRouteInfo, navigationActionContext(ref));
 
     // The queue should be a new array reference
     expect(routingQueue.queue).not.toBe(oldQueue);

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -131,11 +131,11 @@ describe('routingQueue', () => {
     expect(mockGetNavigateAction).toHaveBeenCalledWith(
       '/home',
       { event: 'NAVIGATE' },
+      routeInfo,
       'NAVIGATE',
       undefined,
       undefined,
-      false,
-      routeInfo
+      false
     );
     expect(ref.current!.dispatch).toHaveBeenCalledWith(navigateAction);
   });

--- a/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
+++ b/packages/expo-router/src/global-state/__tests__/routingQueue.test.ios.ts
@@ -2,6 +2,7 @@ import type { RefObject } from 'react';
 
 import type { NavigationContainerRef, ParamListBase } from '../../react-navigation/native';
 import { getNavigateAction } from '../getNavigationAction';
+import { defaultRouteInfo } from '../getRouteInfoFromState';
 import { routingQueue } from '../routingQueue';
 
 jest.mock('../getNavigationAction', () => ({
@@ -87,7 +88,7 @@ describe('routingQueue', () => {
     routingQueue.add({ type: 'GO_BACK' });
     routingQueue.add({ type: 'POP_TO_TOP' });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(routingQueue.queue).toHaveLength(0);
   });
@@ -97,7 +98,7 @@ describe('routingQueue', () => {
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(ref.current!.dispatch).toHaveBeenCalledWith({ type: 'GO_BACK' });
   });
@@ -148,7 +149,7 @@ describe('routingQueue', () => {
       payload: { href: '/redirect', options: { event: 'NAVIGATE' } },
     });
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     expect(ref.current!.dispatch).not.toHaveBeenCalled();
   });
@@ -158,7 +159,7 @@ describe('routingQueue', () => {
 
     routingQueue.add({ type: 'GO_BACK' });
 
-    routingQueue.run(ref as any);
+    routingQueue.run(ref as any, defaultRouteInfo);
 
     // Queue should still be drained (reset identity happens before dispatch loop)
     expect(routingQueue.queue).toHaveLength(0);
@@ -171,7 +172,7 @@ describe('routingQueue', () => {
 
     const oldQueue = routingQueue.queue;
 
-    routingQueue.run(ref);
+    routingQueue.run(ref, defaultRouteInfo);
 
     // The queue should be a new array reference
     expect(routingQueue.queue).not.toBe(oldQueue);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -7,6 +7,7 @@ import {
   type InternalExpoRouterParams,
 } from '../navigationParams';
 import type { SingularOptions } from '../useScreens';
+import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
 import { store } from './store';
 import type { LinkToOptions } from './types';
@@ -17,7 +18,8 @@ export function getNavigateAction(
   type = 'NAVIGATE',
   withAnchor?: boolean,
   singular?: SingularOptions,
-  isPreviewNavigation?: boolean
+  isPreviewNavigation?: boolean,
+  routeInfo: UrlObject = defaultRouteInfo
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();
@@ -33,8 +35,6 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
-  const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -10,41 +10,51 @@ import {
 import type { SingularOptions } from '../useScreens';
 import type { UrlObject } from './getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
-import { store } from './store';
+import type { StoreContextValue } from './storeContext';
 import type { LinkToOptions } from './types';
+
+export type NavigationActionContext = Pick<
+  StoreContextValue,
+  'navigationRef' | 'linking' | 'redirects'
+>;
 
 export function getNavigateAction(
   baseHref: string,
   options: LinkToOptions,
   { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>,
+  { navigationRef, linking, redirects }: NavigationActionContext,
   type = 'NAVIGATE',
   withAnchor?: boolean,
   singular?: SingularOptions,
   isPreviewNavigation?: boolean
 ) {
   let href: string | undefined = baseHref;
-  store.assertIsReady();
-  const navigationRef = store.navigationRef.current;
-
-  if (navigationRef == null) {
+  if (!navigationRef.isReady()) {
+    throw new Error(
+      'Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.'
+    );
+  }
+  // TODO(@ubax): Check whether callers can guarantee a navigation ref.
+  const ref = navigationRef.current;
+  if (ref == null) {
     throw new Error(
       "Couldn't find a navigation object. Is your component inside NavigationContainer?"
     );
   }
-  if (!store.linking) {
+  if (!linking) {
     throw new Error('Attempted to link to route when no routes are present');
   }
-  const rootState = navigationRef.getRootState();
+  const rootState = ref.getRootState();
 
   href = resolveHrefStringWithSegments(href, { segments, params: routeParams }, options);
-  href = applyRedirects(href, store.redirects) ?? undefined;
+  href = applyRedirects(href, redirects) ?? undefined;
 
   // If the href is undefined, it means that the redirect has already been handled by the navigation
   if (!href) {
     return;
   }
 
-  const state = getStateFromPath(href, store.linking.config, segments);
+  const state = getStateFromPath(href, linking.config, segments);
 
   if (!state || state.routes.length === 0) {
     console.error('Could not generate a valid navigation state for the given path: ' + href);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,7 +33,8 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  href = resolveHrefStringWithSegments(href, store.getRouteInfo(), options);
+  const routeInfo = store.getRouteInfo();
+  href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 
   // If the href is undefined, it means that the redirect has already been handled by the navigation
@@ -41,7 +42,7 @@ export function getNavigateAction(
     return;
   }
 
-  const state = store.linking.getStateFromPath!(href, store.linking.config);
+  const state = store.linking.getStateFromPath!(href, store.linking.config, routeInfo.segments);
 
   if (!state || state.routes.length === 0) {
     console.error('Could not generate a valid navigation state for the given path: ' + href);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,7 +33,6 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
   const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -7,7 +7,7 @@ import {
   type InternalExpoRouterParams,
 } from '../navigationParams';
 import type { SingularOptions } from '../useScreens';
-import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
+import type { UrlObject } from './getRouteInfoFromState';
 import { findDivergentState, getPayloadFromStateRoute } from './stateUtils';
 import { store } from './store';
 import type { LinkToOptions } from './types';
@@ -15,11 +15,11 @@ import type { LinkToOptions } from './types';
 export function getNavigateAction(
   baseHref: string,
   options: LinkToOptions,
-  type = 'NAVIGATE',
-  withAnchor?: boolean,
-  singular?: SingularOptions,
-  isPreviewNavigation?: boolean,
-  routeInfo: UrlObject = defaultRouteInfo
+  type: string,
+  withAnchor: boolean | undefined,
+  singular: SingularOptions | undefined,
+  isPreviewNavigation: boolean | undefined,
+  routeInfo: UrlObject
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -1,5 +1,6 @@
 import { applyRedirects } from '../getRoutesRedirects';
 import { resolveHrefStringWithSegments } from '../link/href';
+import { getStateFromPath } from '../link/linking';
 import {
   appendInternalExpoRouterParams,
   INTERNAL_EXPO_ROUTER_IS_PREVIEW_NAVIGATION_PARAM_NAME,
@@ -19,7 +20,7 @@ export function getNavigateAction(
   withAnchor: boolean | undefined,
   singular: SingularOptions | undefined,
   isPreviewNavigation: boolean | undefined,
-  routeInfo: UrlObject
+  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();
@@ -35,7 +36,7 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
-  href = resolveHrefStringWithSegments(href, routeInfo, options);
+  href = resolveHrefStringWithSegments(href, { segments, params: routeParams }, options);
   href = applyRedirects(href, store.redirects) ?? undefined;
 
   // If the href is undefined, it means that the redirect has already been handled by the navigation
@@ -43,7 +44,7 @@ export function getNavigateAction(
     return;
   }
 
-  const state = store.linking.getStateFromPath!(href, store.linking.config, routeInfo.segments);
+  const state = getStateFromPath(href, store.linking.config, segments);
 
   if (!state || state.routes.length === 0) {
     console.error('Could not generate a valid navigation state for the given path: ' + href);

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -16,11 +16,11 @@ import type { LinkToOptions } from './types';
 export function getNavigateAction(
   baseHref: string,
   options: LinkToOptions,
-  type: string,
-  withAnchor: boolean | undefined,
-  singular: SingularOptions | undefined,
-  isPreviewNavigation: boolean | undefined,
-  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>
+  { segments, params: routeParams }: Pick<UrlObject, 'segments' | 'params'>,
+  type = 'NAVIGATE',
+  withAnchor?: boolean,
+  singular?: SingularOptions,
+  isPreviewNavigation?: boolean
 ) {
   let href: string | undefined = baseHref;
   store.assertIsReady();

--- a/packages/expo-router/src/global-state/getNavigationAction.ts
+++ b/packages/expo-router/src/global-state/getNavigationAction.ts
@@ -33,6 +33,7 @@ export function getNavigateAction(
   }
   const rootState = navigationRef.getRootState();
 
+  // Resolve and parse with the same route snapshot so relative paths use consistent segments.
   const routeInfo = store.getRouteInfo();
   href = resolveHrefStringWithSegments(href, routeInfo, options);
   href = applyRedirects(href, store.redirects) ?? undefined;

--- a/packages/expo-router/src/global-state/router.ts
+++ b/packages/expo-router/src/global-state/router.ts
@@ -17,6 +17,14 @@ import { routingQueue } from './routingQueue';
 import { store } from './store';
 import type { LinkToOptions, NavigationOptions } from './types';
 
+function assertIsReady() {
+  if (!store.navigationRef.isReady()) {
+    throw new Error(
+      'Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.'
+    );
+  }
+}
+
 export function navigate(url: Href, options?: NavigationOptions) {
   return linkTo(resolveHref(url), { ...options, event: 'NAVIGATE' });
 }
@@ -61,7 +69,7 @@ export function goBack() {
   if (emitDomGoBack()) {
     return;
   }
-  store.assertIsReady();
+  assertIsReady();
   routingQueue.add({ type: 'GO_BACK' });
 }
 
@@ -111,7 +119,7 @@ export function setParams(
   if (emitDomSetParams(params)) {
     return;
   }
-  store.assertIsReady();
+  assertIsReady();
   return (store.navigationRef?.current?.setParams as any)(params);
 }
 
@@ -133,7 +141,7 @@ export function linkTo(originalHref: Href | string, options: LinkToOptions = {})
   }
 
   if (href === '..' || href === '../') {
-    store.assertIsReady();
+    assertIsReady();
     const navigationRef = store.navigationRef.current;
 
     if (navigationRef == null) {

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -35,7 +35,10 @@ export const routingQueue = {
       callback();
     }
   },
-  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>, routeInfo: UrlObject) {
+  run(
+    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
+    routeInfo: Pick<UrlObject, 'segments' | 'params'>
+  ) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -51,7 +54,7 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event ?? 'NAVIGATE',
+            options.event!,
             options.withAnchor,
             options.dangerouslySingular,
             !!options.__internal__PreviewKey,

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -6,7 +6,7 @@ import type {
   NavigationContainerRef,
 } from '../react-navigation/native';
 import { getNavigateAction } from './getNavigationAction';
-import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
+import type { UrlObject } from './getRouteInfoFromState';
 import type { LinkToOptions } from './types';
 
 export interface LinkAction {
@@ -35,10 +35,7 @@ export const routingQueue = {
       callback();
     }
   },
-  run(
-    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
-    routeInfo: UrlObject = defaultRouteInfo
-  ) {
+  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>, routeInfo: UrlObject) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -54,7 +51,7 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event,
+            options.event ?? 'NAVIGATE',
             options.withAnchor,
             options.dangerouslySingular,
             !!options.__internal__PreviewKey,

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -1,11 +1,6 @@
-import type { RefObject } from 'react';
-
-import type {
-  NavigationAction,
-  ParamListBase,
-  NavigationContainerRef,
-} from '../react-navigation/native';
+import type { NavigationAction } from '../react-navigation/native';
 import { getNavigateAction } from './getNavigationAction';
+import type { NavigationActionContext } from './getNavigationAction';
 import type { UrlObject } from './getRouteInfoFromState';
 import type { LinkToOptions } from './types';
 
@@ -30,43 +25,43 @@ export const routingQueue = {
     return routingQueue.queue;
   },
   add(action: NavigationAction | LinkAction) {
-    routingQueue.queue.push(action);
+    routingQueue.queue = [...routingQueue.queue, action];
     for (const callback of routingQueue.subscribers) {
       callback();
     }
   },
-  run(
-    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
-    routeInfo: Pick<UrlObject, 'segments' | 'params'>
-  ) {
+  run(routeInfo: Pick<UrlObject, 'segments' | 'params'>, context: NavigationActionContext) {
+    if (!context.navigationRef.isReady() || !context.navigationRef.current) {
+      return;
+    }
+    const ref = context.navigationRef.current;
+
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
     let action: NavigationAction | LinkAction | undefined;
     while ((action = events.shift())) {
-      // TODO: Consider warning when ref.current is null — actions are silently dropped
-      if (ref.current) {
-        if (action.type === 'ROUTER_LINK') {
-          const {
-            payload: { href, options },
-          } = action as LinkAction;
+      if (action.type === 'ROUTER_LINK') {
+        const {
+          payload: { href, options },
+        } = action as LinkAction;
 
-          action = getNavigateAction(
-            href,
-            options,
-            routeInfo,
-            options.event,
-            options.withAnchor,
-            options.dangerouslySingular,
-            !!options.__internal__PreviewKey
-          );
-          // TODO: Consider warning when getNavigateAction returns undefined
-          if (action) {
-            ref.current.dispatch(action);
-          }
-        } else {
-          ref.current.dispatch(action);
+        action = getNavigateAction(
+          href,
+          options,
+          routeInfo,
+          context,
+          options.event,
+          options.withAnchor,
+          options.dangerouslySingular,
+          !!options.__internal__PreviewKey
+        );
+        // TODO: Consider warning when getNavigateAction returns undefined
+        if (action) {
+          ref.dispatch(action);
         }
+      } else {
+        ref.dispatch(action);
       }
     }
   },

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -6,6 +6,7 @@ import type {
   NavigationContainerRef,
 } from '../react-navigation/native';
 import { getNavigateAction } from './getNavigationAction';
+import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import type { LinkToOptions } from './types';
 
 export interface LinkAction {
@@ -34,7 +35,10 @@ export const routingQueue = {
       callback();
     }
   },
-  run(ref: RefObject<NavigationContainerRef<ParamListBase> | null>) {
+  run(
+    ref: RefObject<NavigationContainerRef<ParamListBase> | null>,
+    routeInfo: UrlObject = defaultRouteInfo
+  ) {
     // Reset the identity of the queue.
     const events = routingQueue.queue;
     routingQueue.queue = [];
@@ -53,7 +57,8 @@ export const routingQueue = {
             options.event,
             options.withAnchor,
             options.dangerouslySingular,
-            !!options.__internal__PreviewKey
+            !!options.__internal__PreviewKey,
+            routeInfo
           );
           // TODO: Consider warning when getNavigateAction returns undefined
           if (action) {

--- a/packages/expo-router/src/global-state/routingQueue.ts
+++ b/packages/expo-router/src/global-state/routingQueue.ts
@@ -54,11 +54,11 @@ export const routingQueue = {
           action = getNavigateAction(
             href,
             options,
-            options.event!,
+            routeInfo,
+            options.event,
             options.withAnchor,
             options.dangerouslySingular,
-            !!options.__internal__PreviewKey,
-            routeInfo
+            !!options.__internal__PreviewKey
           );
           // TODO: Consider warning when getNavigateAction returns undefined
           if (action) {

--- a/packages/expo-router/src/global-state/store.ts
+++ b/packages/expo-router/src/global-state/store.ts
@@ -1,23 +1,19 @@
-import type { ComponentType } from 'react';
-
 import type { RouteNode } from '../Route';
 import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import type { NavigationContainerRefWithCurrent } from '../react-navigation/native';
 import * as SplashScreen from '../views/Splash';
 import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { getCachedRouteInfo, routeInfoSubscribers } from './routeInfoCache';
-import type { FocusedRouteState, ReactNavigationState, StoreRedirects } from './types';
+import type { FocusedRouteState, ReactNavigationState } from './types';
 
 export type RouterStore = typeof store;
 
 type StoreRef = {
   navigationRef: NavigationContainerRefWithCurrent<ReactNavigation.RootParamList>;
   routeNode: RouteNode | null;
-  rootComponent: ComponentType<any>;
   state?: ReactNavigationState;
   linking?: ExpoLinkingOptions;
   config: any;
-  redirects: StoreRedirects[];
   routeInfo?: UrlObject;
 };
 
@@ -40,10 +36,18 @@ export function setHasAttemptedToHideSplash(value: boolean) {
   hasAttemptedToHideSplash = value;
 }
 
+export function maybeHideSplashScreen() {
+  if (!hasAttemptedToHideSplash) {
+    setHasAttemptedToHideSplash(true);
+    setSplashScreenAnimationFrame(
+      requestAnimationFrame(() => {
+        SplashScreen._internal_maybeHideAsync?.();
+      })
+    );
+  }
+}
+
 export const store = {
-  shouldShowTutorial() {
-    return !storeRef.current.routeNode && process.env.NODE_ENV === 'development';
-  },
   get state() {
     return storeRef.current.state;
   },
@@ -56,30 +60,12 @@ export const store = {
   getRouteInfo(): UrlObject {
     return storeRef.current.routeInfo || defaultRouteInfo;
   },
-  get redirects() {
-    return storeRef.current.redirects || [];
-  },
-  get rootComponent() {
-    return storeRef.current.rootComponent;
-  },
   get linking() {
     return storeRef.current.linking;
   },
   setFocusedState(state: FocusedRouteState) {
     const routeInfo = getCachedRouteInfo(state);
     storeRef.current.routeInfo = routeInfo;
-  },
-  // TODO(@ubax): Refactor onReady logic as it probably should live somewhere else then store
-  onReady() {
-    if (!hasAttemptedToHideSplash) {
-      setHasAttemptedToHideSplash(true);
-      // NOTE(EvanBacon): `navigationRef.isReady` is sometimes not true when state is called initially.
-      setSplashScreenAnimationFrame(
-        requestAnimationFrame(() => {
-          SplashScreen._internal_maybeHideAsync?.();
-        })
-      );
-    }
   },
   onStateChange(newState: ReactNavigationState | undefined) {
     if (!newState) {
@@ -112,13 +98,6 @@ export const store = {
 
     for (const callback of routeInfoSubscribers) {
       callback();
-    }
-  },
-  assertIsReady() {
-    if (!storeRef.current.navigationRef.isReady()) {
-      throw new Error(
-        'Attempted to navigate before mounting the Root Layout component. Ensure the Root Layout component is rendering a Slot, or other navigator on the first render.'
-      );
     }
   },
 };

--- a/packages/expo-router/src/global-state/store.ts
+++ b/packages/expo-router/src/global-state/store.ts
@@ -2,18 +2,11 @@ import type { ComponentType } from 'react';
 
 import type { RouteNode } from '../Route';
 import type { ExpoLinkingOptions } from '../getLinkingConfig';
-import { resolveHref, resolveHrefStringWithSegments } from '../link/href';
 import type { NavigationContainerRefWithCurrent } from '../react-navigation/native';
-import type { Href } from '../types';
 import * as SplashScreen from '../views/Splash';
 import { defaultRouteInfo, type UrlObject } from './getRouteInfoFromState';
 import { getCachedRouteInfo, routeInfoSubscribers } from './routeInfoCache';
-import type {
-  FocusedRouteState,
-  LinkToOptions,
-  ReactNavigationState,
-  StoreRedirects,
-} from './types';
+import type { FocusedRouteState, ReactNavigationState, StoreRedirects } from './types';
 
 export type RouterStore = typeof store;
 
@@ -68,12 +61,6 @@ export const store = {
   },
   get rootComponent() {
     return storeRef.current.rootComponent;
-  },
-  getStateForHref(href: Href | string, options?: LinkToOptions) {
-    href = resolveHref(href);
-
-    href = resolveHrefStringWithSegments(href, store.getRouteInfo(), options);
-    return this.linking?.getStateFromPath!(href, this.linking.config);
   },
   get linking() {
     return storeRef.current.linking;

--- a/packages/expo-router/src/global-state/storeContext.ts
+++ b/packages/expo-router/src/global-state/storeContext.ts
@@ -1,8 +1,19 @@
 'use client';
-import { createContext, use } from 'react';
+import { createContext } from 'react';
+import type { ComponentType } from 'react';
 
-import type { RouterStore } from './store';
+import type { RouteNode } from '../Route';
+import type { ExpoLinkingOptions } from '../getLinkingConfig';
+import type { NavigationContainerRefWithCurrent } from '../react-navigation/native';
+import type { ReactNavigationState, StoreRedirects } from './types';
 
-export const StoreContext = createContext<RouterStore | null>(null);
+export type StoreContextValue = {
+  navigationRef: NavigationContainerRefWithCurrent<ReactNavigation.RootParamList>;
+  linking: ExpoLinkingOptions | undefined;
+  initialState: ReactNavigationState | undefined;
+  rootComponent: ComponentType<any>;
+  routeNode: RouteNode | null;
+  redirects: StoreRedirects[];
+};
 
-export const useExpoRouterStore = () => use(StoreContext)!;
+export const StoreContext = createContext<StoreContextValue | null>(null);

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -78,7 +78,7 @@ export function useStore(
       // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
       if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
 
-      initialState = linking.getStateFromPath(initialPath, linking.config);
+      initialState = linking.getStateFromPath(initialPath, linking.config, []);
       const initialRouteInfo = getRouteInfoFromState(initialState);
       setCachedRouteInfo(initialState as any, initialRouteInfo);
     }

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -2,7 +2,7 @@
 
 import Constants from 'expo-constants';
 import type { ComponentType } from 'react';
-import { Fragment, useEffect } from 'react';
+import { Fragment, useEffect, useMemo } from 'react';
 import { Platform } from 'react-native';
 
 import { extractExpoPathFromURL } from '../fork/extractPathFromURL';
@@ -18,93 +18,97 @@ import { getQualifiedRouteComponent } from '../useScreens';
 import { shouldLinkExternally } from '../utils/url';
 import { getRouteInfoFromState } from './getRouteInfoFromState';
 import { getCachedRouteInfo, setCachedRouteInfo } from './routeInfoCache';
-import {
-  store,
-  storeRef,
-  getSplashScreenAnimationFrame,
-  setSplashScreenAnimationFrame,
-} from './store';
+import { storeRef, getSplashScreenAnimationFrame, setSplashScreenAnimationFrame } from './store';
+import type { StoreContextValue } from './storeContext';
 import type { ReactNavigationState, StoreRedirects } from './types';
 
 export function useStore(
   context: RequireContext,
   linkingConfigOptions: LinkingConfigOptions,
   serverUrl?: string
-) {
+): StoreContextValue {
   const navigationRef = useNavigationContainerRef();
   const config = Constants.expoConfig?.extra?.router;
-
-  let linking: ExpoLinkingOptions | undefined;
-  let rootComponent: ComponentType<any> = Fragment;
-  let initialState: ReactNavigationState | undefined;
-
-  const routeNode = getRoutes(context, {
-    ...config,
-    skipGenerated: true,
-    ignoreEntryPoints: true,
-    platform: Platform.OS,
-    preserveRedirectAndRewrites: true,
-  });
-
-  const redirects: StoreRedirects[] = [config?.redirects, config?.rewrites]
-    .filter(Boolean)
-    .flat()
-    .map((route) => {
-      return [
-        routePatternToRegex(parseRouteSegments(route.source)),
-        route,
-        shouldLinkExternally(route.destination),
-      ];
+  const storeValue = useMemo(() => {
+    let linking: ExpoLinkingOptions | undefined;
+    let rootComponent: ComponentType<any> = Fragment;
+    let initialState: ReactNavigationState | undefined;
+    const routeNode = getRoutes(context, {
+      ...config,
+      skipGenerated: true,
+      ignoreEntryPoints: true,
+      platform: Platform.OS,
+      preserveRedirectAndRewrites: true,
     });
 
-  if (routeNode) {
-    // We have routes, so get the linking config and the root component
-    linking = getLinkingConfig(routeNode, context, {
-      metaOnly: linkingConfigOptions.metaOnly,
-      serverUrl,
+    const redirects: StoreRedirects[] = [config?.redirects, config?.rewrites]
+      .filter(Boolean)
+      .flat()
+      .map((route) => {
+        return [
+          routePatternToRegex(parseRouteSegments(route.source)),
+          route,
+          shouldLinkExternally(route.destination),
+        ];
+      });
+
+    if (routeNode) {
+      // We have routes, so get the linking config and the root component
+      linking = getLinkingConfig(routeNode, context, {
+        metaOnly: linkingConfigOptions.metaOnly,
+        serverUrl,
+        redirects,
+        skipGenerated: config?.skipGenerated ?? false,
+        sitemap: config?.sitemap ?? true,
+        notFound: config?.notFound ?? true,
+      });
+      rootComponent = getQualifiedRouteComponent(routeNode);
+
+      // By default React Navigation is async and does not render anything in the first pass as it waits for `getInitialURL`
+      // This will cause static rendering to fail, which once performs a single pass.
+      // If the initialURL is a string, we can prefetch the state and routeInfo, skipping React Navigation's async behavior.
+      const initialURL = linking?.getInitialURL?.();
+      if (typeof initialURL === 'string') {
+        let initialPath = extractExpoPathFromURL(linking.prefixes, initialURL);
+
+        // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
+        if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
+
+        initialState = getStateFromPath(initialPath, linking.config);
+        const initialRouteInfo = getRouteInfoFromState(initialState);
+        setCachedRouteInfo(initialState as any, initialRouteInfo);
+      }
+    } else {
+      // Only error in production, in development we will show the onboarding screen
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error('No routes found');
+      }
+
+      // In development, we will show the onboarding screen
+      rootComponent = Fragment;
+    }
+
+    return {
+      navigationRef,
+      linking,
+      initialState,
+      rootComponent,
       redirects,
-      skipGenerated: config?.skipGenerated ?? false,
-      sitemap: config?.sitemap ?? true,
-      notFound: config?.notFound ?? true,
-    });
-    rootComponent = getQualifiedRouteComponent(routeNode);
+      routeNode,
+    };
+  }, [config, context, linkingConfigOptions, navigationRef, serverUrl]);
 
-    // By default React Navigation is async and does not render anything in the first pass as it waits for `getInitialURL`
-    // This will cause static rendering to fail, which once performs a single pass.
-    // If the initialURL is a string, we can prefetch the state and routeInfo, skipping React Navigation's async behavior.
-    const initialURL = linking?.getInitialURL?.();
-    if (typeof initialURL === 'string') {
-      let initialPath = extractExpoPathFromURL(linking.prefixes, initialURL);
-
-      // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
-      if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
-
-      initialState = getStateFromPath(initialPath, linking.config, []);
-      const initialRouteInfo = getRouteInfoFromState(initialState);
-      setCachedRouteInfo(initialState as any, initialRouteInfo);
-    }
-  } else {
-    // Only error in production, in development we will show the onboarding screen
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error('No routes found');
-    }
-
-    // In development, we will show the onboarding screen
-    rootComponent = Fragment;
-  }
-
+  // TODO(@ubax): Check whether updating the store ref during every render is safe and needed.
   storeRef.current = {
     navigationRef,
-    routeNode,
+    routeNode: storeValue.routeNode,
     config,
-    rootComponent,
-    linking,
-    redirects,
-    state: initialState,
+    linking: storeValue.linking,
+    state: storeValue.initialState,
   };
 
-  if (initialState) {
-    storeRef.current.routeInfo = getCachedRouteInfo(initialState);
+  if (storeValue.initialState) {
+    storeRef.current.routeInfo = getCachedRouteInfo(storeValue.initialState);
   }
 
   useEffect(() => {
@@ -119,5 +123,5 @@ export function useStore(
     };
   });
 
-  return store;
+  return storeValue;
 }

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -58,7 +58,7 @@ export function useStore(
 
   if (routeNode) {
     // We have routes, so get the linking config and the root component
-    linking = getLinkingConfig(routeNode, context, () => store.getRouteInfo(), {
+    linking = getLinkingConfig(routeNode, context, {
       metaOnly: linkingConfigOptions.metaOnly,
       serverUrl,
       redirects,

--- a/packages/expo-router/src/global-state/useStore.ts
+++ b/packages/expo-router/src/global-state/useStore.ts
@@ -11,6 +11,7 @@ import type { ExpoLinkingOptions, LinkingConfigOptions } from '../getLinkingConf
 import { getLinkingConfig } from '../getLinkingConfig';
 import { parseRouteSegments } from '../getReactNavigationConfig';
 import { getRoutes } from '../getRoutes';
+import { getStateFromPath } from '../link/linking';
 import { useNavigationContainerRef } from '../react-navigation/native';
 import type { RequireContext } from '../types';
 import { getQualifiedRouteComponent } from '../useScreens';
@@ -78,7 +79,7 @@ export function useStore(
       // It does not matter if the path starts with a `/` or not, but this keeps the behavior consistent
       if (!initialPath.startsWith('/')) initialPath = '/' + initialPath;
 
-      initialState = linking.getStateFromPath(initialPath, linking.config, []);
+      initialState = getStateFromPath(initialPath, linking.config, []);
       const initialRouteInfo = getRouteInfoFromState(initialState);
       setCachedRouteInfo(initialState as any, initialRouteInfo);
     }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useSyncExternalStore } from 'react';
+import { type RefObject, useEffect, useEffectEvent, useSyncExternalStore } from 'react';
 
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
@@ -18,8 +18,10 @@ export function useImperativeApiEmitter(
     routingQueue.snapshot,
     routingQueue.snapshot
   );
+  const runQueue = useEffectEvent(() => routingQueue.run(ref, routeInfo));
+
   useEffect(() => {
-    routingQueue.run(ref, routeInfo);
-  }, [events, ref, routeInfo]);
+    runQueue();
+  }, [events, ref]);
   return null;
 }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -3,6 +3,7 @@ import { type RefObject, useEffect, useSyncExternalStore } from 'react';
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
 import { routingQueue } from './global-state/routing';
+import { useRouteInfo } from './global-state/useRouteInfo';
 import type { NavigationContainerRef, ParamListBase } from './react-navigation/native';
 
 export type { ImperativeRouter };
@@ -11,13 +12,14 @@ export { router };
 export function useImperativeApiEmitter(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>
 ) {
+  const routeInfo = useRouteInfo();
   const events = useSyncExternalStore(
     routingQueue.subscribe,
     routingQueue.snapshot,
     routingQueue.snapshot
   );
   useEffect(() => {
-    routingQueue.run(ref);
-  }, [events, ref]);
+    routingQueue.run(ref, routeInfo);
+  }, [events, ref, routeInfo]);
   return null;
 }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -1,25 +1,39 @@
-import { type RefObject, useEffect, useSyncExternalStore } from 'react';
+import { use, useEffect, useEffectEvent, useSyncExternalStore } from 'react';
 
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
 import { routingQueue } from './global-state/routing';
-import { store } from './global-state/store';
-import type { NavigationContainerRef, ParamListBase } from './react-navigation/native';
+import { StoreContext } from './global-state/storeContext';
+import { useRouteInfo } from './global-state/useRouteInfo';
 
 export type { ImperativeRouter };
 export { router };
 
-export function useImperativeApiEmitter(
-  ref: RefObject<NavigationContainerRef<ParamListBase> | null>
-) {
+export function useImperativeApiEmitter() {
+  const routeInfo = useRouteInfo();
+  const store = use(StoreContext);
+  if (!store) {
+    throw new Error('useImperativeApiEmitter must be rendered inside ExpoRoot.');
+  }
+  if (!store.linking) {
+    throw new Error('Attempted to link to route when no routes are present');
+  }
+  const linking = store.linking;
   const events = useSyncExternalStore(
     routingQueue.subscribe,
     routingQueue.snapshot,
     routingQueue.snapshot
   );
+  const runQueue = useEffectEvent(() => {
+    routingQueue.run(routeInfo, {
+      navigationRef: store.navigationRef,
+      linking,
+      redirects: store.redirects,
+    });
+  });
+  useEffect(() => store.navigationRef.addListener('ready', runQueue), [store.navigationRef]);
   useEffect(() => {
-    // TODO: Use useRouteInfo once it is computed from global state.
-    routingQueue.run(ref, store.getRouteInfo());
-  }, [events, ref]);
+    runQueue();
+  }, [events]);
   return null;
 }

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -18,6 +18,7 @@ export function useImperativeApiEmitter(
     routingQueue.snapshot
   );
   useEffect(() => {
+    // TODO: Use useRouteInfo once it is computed from global state.
     routingQueue.run(ref, store.getRouteInfo());
   }, [events, ref]);
   return null;

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -1,9 +1,9 @@
-import { type RefObject, useEffect, useEffectEvent, useSyncExternalStore } from 'react';
+import { type RefObject, useEffect, useSyncExternalStore } from 'react';
 
 import type { ImperativeRouter } from './global-state/router';
 import { router } from './global-state/router';
 import { routingQueue } from './global-state/routing';
-import { useRouteInfo } from './global-state/useRouteInfo';
+import { store } from './global-state/store';
 import type { NavigationContainerRef, ParamListBase } from './react-navigation/native';
 
 export type { ImperativeRouter };
@@ -12,16 +12,13 @@ export { router };
 export function useImperativeApiEmitter(
   ref: RefObject<NavigationContainerRef<ParamListBase> | null>
 ) {
-  const routeInfo = useRouteInfo();
   const events = useSyncExternalStore(
     routingQueue.subscribe,
     routingQueue.snapshot,
     routingQueue.snapshot
   );
-  const runQueue = useEffectEvent(() => routingQueue.run(ref, routeInfo));
-
   useEffect(() => {
-    runQueue();
+    routingQueue.run(ref, store.getRouteInfo());
   }, [events, ref]);
   return null;
 }

--- a/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.ios.tsx
@@ -12,7 +12,6 @@ import { Slot } from '../../views/Navigator';
 import { Pressable } from '../../views/Pressable';
 import { Link } from '../Link';
 import { HrefPreview } from '../preview/HrefPreview';
-import { LinkPreviewContextProvider } from '../preview/LinkPreviewContext';
 import {
   type NativeLinkPreviewActionProps,
   type NativeLinkPreviewContentProps,
@@ -714,13 +713,13 @@ describe('Preview', () => {
   });
   it('when Link.Preview is used without Link.Trigger then exception is thrown', () => {
     expect(() => {
-      render(
-        <LinkPreviewContextProvider>
+      renderRouter({
+        index: () => (
           <Link href="/foo">
             <Link.Preview />
           </Link>
-        </LinkPreviewContextProvider>
-      );
+        ),
+      });
     }).toThrow(
       'When you use Link.Preview, you must use Link.Trigger to specify the trigger element'
     );
@@ -930,8 +929,8 @@ describe('Preview', () => {
   });
 
   it('correctly passes props to child component with asChild, Preview and trigger', () => {
-    const { getByText, getByTestId } = render(
-      <LinkPreviewContextProvider>
+    const { getByText, getByTestId } = renderRouter({
+      index: () => (
         <Link asChild href="/foo">
           <Link.Preview />
           <Link.Trigger>
@@ -940,8 +939,8 @@ describe('Preview', () => {
             </View>
           </Link.Trigger>
         </Link>
-      </LinkPreviewContextProvider>
-    );
+      ),
+    });
     const node = getByText('Button');
     expect(node.props).toEqual({
       children: 'Button',

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -1,5 +1,5 @@
-import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import type { UrlObject } from '../global-state/getRouteInfoFromState';
+import { store } from '../global-state/router-store';
 import type { LinkToOptions } from '../global-state/types';
 import type { Href } from '../types';
 import { resolveHref, resolveHrefStringWithSegments } from './href';
@@ -7,10 +7,9 @@ import { resolveHref, resolveHrefStringWithSegments } from './href';
 export function getStateForHref(
   href: Href | string,
   routeInfo: UrlObject,
-  linking: ExpoLinkingOptions | undefined,
   options?: LinkToOptions
 ) {
   href = resolveHref(href);
   href = resolveHrefStringWithSegments(href, routeInfo, options);
-  return linking?.getStateFromPath!(href, linking.config, routeInfo.segments);
+  return store.linking?.getStateFromPath!(href, store.linking.config, routeInfo.segments);
 }

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -1,0 +1,16 @@
+import type { ExpoLinkingOptions } from '../getLinkingConfig';
+import type { UrlObject } from '../global-state/getRouteInfoFromState';
+import type { LinkToOptions } from '../global-state/types';
+import type { Href } from '../types';
+import { resolveHref, resolveHrefStringWithSegments } from './href';
+
+export function getStateForHref(
+  href: Href | string,
+  routeInfo: UrlObject,
+  linking: ExpoLinkingOptions | undefined,
+  options?: LinkToOptions
+) {
+  href = resolveHref(href);
+  href = resolveHrefStringWithSegments(href, routeInfo, options);
+  return linking?.getStateFromPath!(href, linking.config, routeInfo.segments);
+}

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -1,5 +1,5 @@
+import type { ExpoLinkingOptions } from '../getLinkingConfig';
 import type { UrlObject } from '../global-state/getRouteInfoFromState';
-import { store } from '../global-state/router-store';
 import type { LinkToOptions } from '../global-state/types';
 import type { Href } from '../types';
 import { resolveHref, resolveHrefStringWithSegments } from './href';
@@ -8,11 +8,10 @@ import { getStateFromPath } from './linking';
 export function getStateForHref(
   href: Href | string,
   routeInfo: Pick<UrlObject, 'segments'>,
+  linking: ExpoLinkingOptions | undefined,
   options?: LinkToOptions
 ) {
   href = resolveHref(href);
   href = resolveHrefStringWithSegments(href, routeInfo, options);
-  return store.linking
-    ? getStateFromPath(href, store.linking.config, routeInfo.segments)
-    : undefined;
+  return linking ? getStateFromPath(href, linking.config, routeInfo.segments) : undefined;
 }

--- a/packages/expo-router/src/link/getStateForHref.ts
+++ b/packages/expo-router/src/link/getStateForHref.ts
@@ -3,13 +3,16 @@ import { store } from '../global-state/router-store';
 import type { LinkToOptions } from '../global-state/types';
 import type { Href } from '../types';
 import { resolveHref, resolveHrefStringWithSegments } from './href';
+import { getStateFromPath } from './linking';
 
 export function getStateForHref(
   href: Href | string,
-  routeInfo: UrlObject,
+  routeInfo: Pick<UrlObject, 'segments'>,
   options?: LinkToOptions
 ) {
   href = resolveHref(href);
   href = resolveHrefStringWithSegments(href, routeInfo, options);
-  return store.linking?.getStateFromPath!(href, store.linking.config, routeInfo.segments);
+  return store.linking
+    ? getStateFromPath(href, store.linking.config, routeInfo.segments)
+    : undefined;
 }

--- a/packages/expo-router/src/link/linking.ts
+++ b/packages/expo-router/src/link/linking.ts
@@ -7,13 +7,16 @@ import {
 } from '../fork/extractPathFromURL';
 import { getPathFromState } from '../fork/getPathFromState';
 import { getStateFromPath } from '../fork/getStateFromPath';
-import { getInitialURLWithTimeout } from '../fork/useLinking';
 import { applyRedirects } from '../getRoutesRedirects';
 import type { StoreRedirects } from '../global-state/router-store';
 import type { LinkingOptions } from '../react-navigation/native';
 import type { NativeIntent } from '../types';
 
 const isExpoGo = typeof expo !== 'undefined' && globalThis.expo?.modules?.ExpoGo;
+
+function getInitialURLWithTimeout(): string | null | Promise<string | null> {
+  return typeof window === 'undefined' ? '' : window.location.href;
+}
 
 // A custom getInitialURL is used on native to ensure the app always starts at
 // the root path if it's launched from something other than a deep link.

--- a/packages/expo-router/src/link/linking.ts
+++ b/packages/expo-router/src/link/linking.ts
@@ -5,6 +5,7 @@ import {
   parsePathAndParamsFromExpoGoLink,
   parsePathFromExpoGoLink,
 } from '../fork/extractPathFromURL';
+import { getInitialURLWithTimeout } from '../fork/getInitialURLWithTimeout';
 import { getPathFromState } from '../fork/getPathFromState';
 import { getStateFromPath } from '../fork/getStateFromPath';
 import { applyRedirects } from '../getRoutesRedirects';
@@ -13,10 +14,6 @@ import type { LinkingOptions } from '../react-navigation/native';
 import type { NativeIntent } from '../types';
 
 const isExpoGo = typeof expo !== 'undefined' && globalThis.expo?.modules?.ExpoGo;
-
-function getInitialURLWithTimeout(): string | null | Promise<string | null> {
-  return typeof window === 'undefined' ? '' : window.location.href;
-}
 
 // A custom getInitialURL is used on native to ensure the app always starts at
 // the root path if it's launched from something other than a deep link.

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { use, useMemo } from 'react';
 import { Text, View } from 'react-native';
 
 import type { RouteNode } from '../../Route';
@@ -8,6 +8,7 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '..
 import type { ResultState } from '../../exports';
 import { CompositionContext } from '../../fork/native-stack/composition-options';
 import { store } from '../../global-state/router-store';
+import { StoreContext } from '../../global-state/storeContext';
 import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../../global-state/utils';
 import { usePathname } from '../../hooks';
@@ -24,10 +25,12 @@ import { getPathFromState } from '../linking';
 import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
+  // TODO(@ubax): Extract `linking` and `routeNode` into separate contexts to avoid unrelated rerenders.
   const { segments: routeSegments } = useRouteInfo();
+  const { linking, routeNode } = use(StoreContext) ?? {};
   const hrefState = useMemo(
-    () => getStateForHref(href, { segments: routeSegments }),
-    [href, routeSegments]
+    () => getStateForHref(href, { segments: routeSegments }, linking),
+    [href, routeSegments, linking]
   );
   const index = hrefState?.index ?? 0;
 
@@ -51,7 +54,9 @@ export function HrefPreview({ href }: { href: Href }) {
       rnState = rnState.routes[rnIndex]?.state;
     }
     if (!isProtected) {
-      return <PreviewForRootHrefState hrefState={hrefState} href={href} />;
+      return (
+        <PreviewForRootHrefState hrefState={hrefState} href={href} rootRouteNode={routeNode} />
+      );
     }
   }
 
@@ -70,9 +75,17 @@ export function HrefPreview({ href }: { href: Href }) {
   );
 }
 
-function PreviewForRootHrefState({ hrefState, href }: { hrefState: ResultState; href: Href }) {
+function PreviewForRootHrefState({
+  hrefState,
+  href,
+  rootRouteNode,
+}: {
+  hrefState: ResultState;
+  href: Href;
+  rootRouteNode: RouteNode | null | undefined;
+}) {
   const navigation = useNavigation();
-  const { routeNode, params, state } = getParamsAndNodeFromHref(hrefState);
+  const { routeNode, params, state } = getParamsAndNodeFromHref(hrefState, rootRouteNode);
 
   const path = state ? getPathFromState(state) : undefined;
 
@@ -122,12 +135,15 @@ function PreviewForInternalRoutes() {
   );
 }
 
-function getParamsAndNodeFromHref(hrefState: ResultState) {
+function getParamsAndNodeFromHref(
+  hrefState: ResultState,
+  rootRouteNode: RouteNode | null | undefined
+) {
   const index = hrefState?.index ?? 0;
   if (hrefState?.routes[index] && hrefState.routes[index].name !== INTERNAL_SLOT_NAME) {
     const name = hrefState.routes[index].name;
     if (name === SITEMAP_ROUTE_NAME || name === NOT_FOUND_ROUTE_NAME) {
-      console.log(store.routeNode);
+      console.log(rootRouteNode);
       console.log(hrefState);
     }
     const error = `Expo Router Error: Expected navigation state to begin with one of [${getRootStackRouteNames().join(', ')}] routes`;
@@ -139,7 +155,7 @@ function getParamsAndNodeFromHref(hrefState: ResultState) {
   }
   const initialState = hrefState?.routes[index]?.state;
   let state = initialState;
-  let routeNode: RouteNode | undefined | null = store.routeNode;
+  let routeNode = rootRouteNode;
 
   const params: UnknownOutputParams = {};
 

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -25,10 +25,7 @@ import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
   const routeInfo = useRouteInfo();
-  const hrefState = useMemo(
-    () => getStateForHref(href, routeInfo, store.linking),
-    [href, routeInfo]
-  );
+  const hrefState = useMemo(() => getStateForHref(href, routeInfo), [href, routeInfo]);
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -24,8 +24,11 @@ import { getPathFromState } from '../linking';
 import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
-  const routeInfo = useRouteInfo();
-  const hrefState = useMemo(() => getStateForHref(href, routeInfo), [href, routeInfo]);
+  const { segments: routeSegments } = useRouteInfo();
+  const hrefState = useMemo(
+    () => getStateForHref(href, { segments: routeSegments }),
+    [href, routeSegments]
+  );
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -8,6 +8,7 @@ import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from '..
 import type { ResultState } from '../../exports';
 import { CompositionContext } from '../../fork/native-stack/composition-options';
 import { store } from '../../global-state/router-store';
+import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../../global-state/utils';
 import { usePathname } from '../../hooks';
 import {
@@ -18,11 +19,16 @@ import {
 import type { Href, UnknownOutputParams } from '../../types';
 import { useNavigation } from '../../useNavigation';
 import { getQualifiedRouteComponent } from '../../useScreens';
+import { getStateForHref } from '../getStateForHref';
 import { getPathFromState } from '../linking';
 import { PreviewRouteContext } from './PreviewRouteContext';
 
 export function HrefPreview({ href }: { href: Href }) {
-  const hrefState = useMemo(() => getHrefState(href), [href]);
+  const routeInfo = useRouteInfo();
+  const hrefState = useMemo(
+    () => getStateForHref(href, routeInfo, store.linking),
+    [href, routeInfo]
+  );
   const index = hrefState?.index ?? 0;
 
   let isProtected = false;
@@ -114,11 +120,6 @@ function PreviewForInternalRoutes() {
       <Text style={{ fontWeight: '200', fontSize: 14 }}>{pathname}</Text>
     </View>
   );
-}
-
-function getHrefState(href: Href) {
-  const hrefState = store.getStateForHref(href as any);
-  return hrefState;
 }
 
 function getParamsAndNodeFromHref(hrefState: ResultState) {

--- a/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
+++ b/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
@@ -179,7 +179,8 @@ describe(getTabPathFromRootStateByHref, () => {
     const tabPath = getTabPathFromRootStateByHref(
       href,
       state as NavigationState,
-      store.getRouteInfo()
+      store.getRouteInfo(),
+      store.linking
     );
     expect(tabPath).toEqual([
       {
@@ -255,7 +256,8 @@ describe(getTabPathFromRootStateByHref, () => {
     const tabPath = getTabPathFromRootStateByHref(
       href,
       state as NavigationState,
-      store.getRouteInfo()
+      store.getRouteInfo(),
+      store.linking
     );
     expect(tabPath).toEqual([
       {
@@ -354,7 +356,8 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
     const preloadedRoute = getPreloadedRouteFromRootStateByHref(
       href,
       state as NavigationState,
-      store.getRouteInfo()
+      store.getRouteInfo(),
+      store.linking
     );
     expect(preloadedRoute).toEqual({
       key: '[face]-9rms2gdsibY9dVYUGCpZG',
@@ -431,7 +434,8 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
     const preloadedRoute = getPreloadedRouteFromRootStateByHref(
       href,
       state as NavigationState,
-      store.getRouteInfo()
+      store.getRouteInfo(),
+      store.linking
     );
     expect(preloadedRoute).toEqual({
       key: '[face]-MZ5nYkDCFxwNv1BcD5exf',

--- a/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
+++ b/packages/expo-router/src/link/preview/__tests__/utils.test.ios.tsx
@@ -1,3 +1,4 @@
+import { store } from '../../../global-state/router-store';
 import { Stack } from '../../../layouts/Stack';
 import { NativeTabs } from '../../../native-tabs/index';
 import type { NavigationState } from '../../../react-navigation/native';
@@ -175,7 +176,11 @@ describe(getTabPathFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const tabPath = getTabPathFromRootStateByHref(href, state as NavigationState);
+    const tabPath = getTabPathFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(tabPath).toEqual([
       {
         oldTabKey: 'faces-BlzNnnAhZ7c9t5bfSf4kR',
@@ -247,7 +252,11 @@ describe(getTabPathFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const tabPath = getTabPathFromRootStateByHref(href, state as NavigationState);
+    const tabPath = getTabPathFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(tabPath).toEqual([
       {
         oldTabKey: 'index-rYeU6j6cRmkJK1pXpEFHs',
@@ -342,7 +351,11 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const preloadedRoute = getPreloadedRouteFromRootStateByHref(href, state as NavigationState);
+    const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(preloadedRoute).toEqual({
       key: '[face]-9rms2gdsibY9dVYUGCpZG',
       name: '[face]',
@@ -415,7 +428,11 @@ describe(getPreloadedRouteFromRootStateByHref, () => {
       ],
     };
     const href = '/faces/1e3a8a';
-    const preloadedRoute = getPreloadedRouteFromRootStateByHref(href, state as NavigationState);
+    const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+      href,
+      state as NavigationState,
+      store.getRouteInfo()
+    );
     expect(preloadedRoute).toEqual({
       key: '[face]-MZ5nYkDCFxwNv1BcD5exf',
       name: '[face]',

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
+import { use, useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 
-import { store, type ReactNavigationState } from '../../global-state/router-store';
+import type { ReactNavigationState } from '../../global-state/router-store';
+import { StoreContext } from '../../global-state/storeContext';
 import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { useRouter } from '../../hooks';
 import type { Href } from '../../types';
@@ -14,6 +15,11 @@ export function useNextScreenId(): [
 ] {
   const router = useRouter();
   const routeInfo = useRouteInfo();
+  const store = use(StoreContext);
+  if (!store) {
+    throw new Error('useNextScreenId must be rendered inside ExpoRoot.');
+  }
+  const { navigationRef } = store;
   const { setOpenPreviewKey } = useLinkPreviewContext();
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
@@ -26,13 +32,15 @@ export function useNextScreenId(): [
         const preloadedRoute = getPreloadedRouteFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfo
+          routeInfo,
+          store.linking
         );
         const routeKey = preloadedRoute?.key;
         const tabPathFromRootState = getTabPathFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfo
+          routeInfo,
+          store.linking
         );
         // Without this timeout react-native does not have enough time to mount the new screen
         // and thus it will not be found on the native side
@@ -52,8 +60,8 @@ export function useNextScreenId(): [
 
   useEffect(() => {
     // When screen is prefetched, then the root state is updated with the preloaded route.
-    return store.navigationRef.addListener('state', onNavigationStateChange);
-  }, []);
+    return navigationRef.addListener('state', onNavigationStateChange);
+  }, [navigationRef]);
 
   const prefetch = useCallback(
     (href: Href): void => {

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -18,6 +18,7 @@ export function useNextScreenId(): [
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
   const routeInfoRef = useRef(routeInfo);
+  // The navigation listener is stable, so read the current route when prefetch updates its state.
   routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react';
 
-import { store } from '../../global-state/router-store';
+import { store, type ReactNavigationState } from '../../global-state/router-store';
 import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { useRouter } from '../../hooks';
 import type { Href } from '../../types';
@@ -17,26 +17,22 @@ export function useNextScreenId(): [
   const { setOpenPreviewKey } = useLinkPreviewContext();
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
-  const routeInfoRef = useRef(routeInfo);
-  // The navigation listener is stable, so read the current route when prefetch updates its state.
-  routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 
-  useEffect(() => {
-    // When screen is prefetched, then the root state is updated with the preloaded route.
-    return store.navigationRef.addListener('state', ({ data: { state } }) => {
+  const onNavigationStateChange = useEffectEvent(
+    ({ data: { state } }: { data: { state?: ReactNavigationState } }) => {
       // If we have the current href, it means that we prefetched the route
       if (currentHref.current && state) {
         const preloadedRoute = getPreloadedRouteFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfoRef.current
+          routeInfo
         );
         const routeKey = preloadedRoute?.key;
         const tabPathFromRootState = getTabPathFromRootStateByHref(
           currentHref.current,
           state,
-          routeInfoRef.current
+          routeInfo
         );
         // Without this timeout react-native does not have enough time to mount the new screen
         // and thus it will not be found on the native side
@@ -51,7 +47,12 @@ export function useNextScreenId(): [
         // to prevent unnecessary processing
         currentHref.current = undefined;
       }
-    });
+    }
+  );
+
+  useEffect(() => {
+    // When screen is prefetched, then the root state is updated with the preloaded route.
+    return store.navigationRef.addListener('state', onNavigationStateChange);
   }, []);
 
   const prefetch = useCallback(

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { store } from '../../global-state/router-store';
+import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { useRouter } from '../../hooks';
 import type { Href } from '../../types';
 import { useLinkPreviewContext } from './LinkPreviewContext';
@@ -12,9 +13,12 @@ export function useNextScreenId(): [
   (href: Href) => void,
 ] {
   const router = useRouter();
+  const routeInfo = useRouteInfo();
   const { setOpenPreviewKey } = useLinkPreviewContext();
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
+  const routeInfoRef = useRef(routeInfo);
+  routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 
   useEffect(() => {
@@ -22,9 +26,17 @@ export function useNextScreenId(): [
     return store.navigationRef.addListener('state', ({ data: { state } }) => {
       // If we have the current href, it means that we prefetched the route
       if (currentHref.current && state) {
-        const preloadedRoute = getPreloadedRouteFromRootStateByHref(currentHref.current, state);
+        const preloadedRoute = getPreloadedRouteFromRootStateByHref(
+          currentHref.current,
+          state,
+          routeInfoRef.current
+        );
         const routeKey = preloadedRoute?.key;
-        const tabPathFromRootState = getTabPathFromRootStateByHref(currentHref.current, state);
+        const tabPathFromRootState = getTabPathFromRootStateByHref(
+          currentHref.current,
+          state,
+          routeInfoRef.current
+        );
         // Without this timeout react-native does not have enough time to mount the new screen
         // and thus it will not be found on the native side
         if (routeKey || tabPathFromRootState.length) {

--- a/packages/expo-router/src/link/preview/useNextScreenId.ts
+++ b/packages/expo-router/src/link/preview/useNextScreenId.ts
@@ -18,7 +18,6 @@ export function useNextScreenId(): [
   const [internalNextScreenId, internalSetNextScreenId] = useState<string | undefined>();
   const currentHref = useRef<Href | undefined>(undefined);
   const routeInfoRef = useRef(routeInfo);
-  // The navigation listener is stable, so read the current route when prefetch updates its state.
   routeInfoRef.current = routeInfo;
   const [tabPath, setTabPath] = useState<TabPath[]>([]);
 

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -1,5 +1,5 @@
 import type { UrlObject } from '../../global-state/getRouteInfoFromState';
-import { store, type ReactNavigationState } from '../../global-state/router-store';
+import type { ReactNavigationState } from '../../global-state/router-store';
 import { findDivergentState, getPayloadFromStateRoute } from '../../global-state/routing';
 import { removeInternalExpoRouterParams } from '../../navigationParams';
 import type {
@@ -19,7 +19,7 @@ export function getTabPathFromRootStateByHref(
   rootState: ReactNavigationState,
   routeInfo: UrlObject
 ): TabPath[] {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return [];
@@ -55,7 +55,7 @@ export function getPreloadedRouteFromRootStateByHref(
   rootState: ReactNavigationState,
   routeInfo: UrlObject
 ): NavigationRoute<ParamListBase, string> | undefined {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return undefined;

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -17,7 +17,7 @@ import type { TabPath } from './native';
 export function getTabPathFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: UrlObject
+  routeInfo: Pick<UrlObject, 'segments'>
 ): TabPath[] {
   const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;
@@ -53,7 +53,7 @@ export function getTabPathFromRootStateByHref(
 export function getPreloadedRouteFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: UrlObject
+  routeInfo: Pick<UrlObject, 'segments'>
 ): NavigationRoute<ParamListBase, string> | undefined {
   const hrefState = getStateForHref(resolveHref(href), routeInfo);
   const state: ReactNavigationState | undefined = rootState;

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -1,3 +1,4 @@
+import type { UrlObject } from '../../global-state/getRouteInfoFromState';
 import { store, type ReactNavigationState } from '../../global-state/router-store';
 import { findDivergentState, getPayloadFromStateRoute } from '../../global-state/routing';
 import { removeInternalExpoRouterParams } from '../../navigationParams';
@@ -9,14 +10,16 @@ import type {
   TabNavigationState,
 } from '../../react-navigation/native';
 import type { Href } from '../../types';
+import { getStateForHref } from '../getStateForHref';
 import { resolveHref } from '../href';
 import type { TabPath } from './native';
 
 export function getTabPathFromRootStateByHref(
   href: Href,
-  rootState: ReactNavigationState
+  rootState: ReactNavigationState,
+  routeInfo: UrlObject
 ): TabPath[] {
-  const hrefState = store.getStateForHref(resolveHref(href));
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return [];
@@ -49,9 +52,10 @@ export function getTabPathFromRootStateByHref(
 
 export function getPreloadedRouteFromRootStateByHref(
   href: Href,
-  rootState: ReactNavigationState
+  rootState: ReactNavigationState,
+  routeInfo: UrlObject
 ): NavigationRoute<ParamListBase, string> | undefined {
-  const hrefState = store.getStateForHref(resolveHref(href));
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, store.linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return undefined;

--- a/packages/expo-router/src/link/preview/utils.ts
+++ b/packages/expo-router/src/link/preview/utils.ts
@@ -1,3 +1,4 @@
+import type { ExpoLinkingOptions } from '../../getLinkingConfig';
 import type { UrlObject } from '../../global-state/getRouteInfoFromState';
 import type { ReactNavigationState } from '../../global-state/router-store';
 import { findDivergentState, getPayloadFromStateRoute } from '../../global-state/routing';
@@ -17,9 +18,10 @@ import type { TabPath } from './native';
 export function getTabPathFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: Pick<UrlObject, 'segments'>
+  routeInfo: Pick<UrlObject, 'segments'>,
+  linking: ExpoLinkingOptions | undefined
 ): TabPath[] {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return [];
@@ -53,9 +55,10 @@ export function getTabPathFromRootStateByHref(
 export function getPreloadedRouteFromRootStateByHref(
   href: Href,
   rootState: ReactNavigationState,
-  routeInfo: Pick<UrlObject, 'segments'>
+  routeInfo: Pick<UrlObject, 'segments'>,
+  linking: ExpoLinkingOptions | undefined
 ): NavigationRoute<ParamListBase, string> | undefined {
-  const hrefState = getStateForHref(resolveHref(href), routeInfo);
+  const hrefState = getStateForHref(resolveHref(href), routeInfo, linking);
   const state: ReactNavigationState | undefined = rootState;
   if (!hrefState || !state) {
     return undefined;

--- a/packages/expo-router/src/react-navigation/native/types.tsx
+++ b/packages/expo-router/src/react-navigation/native/types.tsx
@@ -1,9 +1,9 @@
 import type { ColorValue } from 'react-native';
 
+import type { getStateFromPath as getExpoStateFromPath } from '../../fork/getStateFromPath';
 import type {
   getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
-  getStateFromPath as getStateFromPathDefault,
   PathConfigMap,
   Route,
 } from '../core';
@@ -161,7 +161,7 @@ export type LinkingOptions<ParamList extends object> = {
   /**
    * Custom function to parse the URL to a valid navigation state (advanced).
    */
-  getStateFromPath?: typeof getStateFromPathDefault;
+  getStateFromPath?: typeof getExpoStateFromPath;
   /**
    * Custom function to convert the state object to a valid URL (advanced).
    * Only applicable on Web.

--- a/packages/expo-router/src/react-navigation/native/types.tsx
+++ b/packages/expo-router/src/react-navigation/native/types.tsx
@@ -1,9 +1,9 @@
 import type { ColorValue } from 'react-native';
 
-import type { getStateFromPath as getExpoStateFromPath } from '../../fork/getStateFromPath';
 import type {
   getActionFromState as getActionFromStateDefault,
   getPathFromState as getPathFromStateDefault,
+  getStateFromPath as getStateFromPathDefault,
   PathConfigMap,
   Route,
 } from '../core';
@@ -161,7 +161,7 @@ export type LinkingOptions<ParamList extends object> = {
   /**
    * Custom function to parse the URL to a valid navigation state (advanced).
    */
-  getStateFromPath?: typeof getExpoStateFromPath;
+  getStateFromPath?: typeof getStateFromPathDefault;
   /**
    * Custom function to convert the state object to a valid URL (advanced).
    * Only applicable on Web.

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -89,7 +89,8 @@ export function useTriggersToScreens(
       { relativeToDirectory: true }
     );
 
-    let state = linking.getStateFromPath?.(resolvedHref, linking.config)?.routes[0];
+    let state = linking.getStateFromPath?.(resolvedHref, linking.config, routeInfo.segments)
+      ?.routes[0];
 
     if (!state) {
       // This shouldn't occur, as you should get the global +not-found

--- a/packages/expo-router/src/ui/common.tsx
+++ b/packages/expo-router/src/ui/common.tsx
@@ -2,6 +2,7 @@ import type { UrlObject } from '../LocationProvider';
 import type { RouteNode } from '../Route';
 import { NOT_FOUND_ROUTE_NAME } from '../constants';
 import { resolveHref, resolveHrefStringWithSegments } from '../link/href';
+import { getStateFromPath } from '../link/linking';
 import type {
   LinkingOptions,
   ParamListBase,
@@ -89,8 +90,7 @@ export function useTriggersToScreens(
       { relativeToDirectory: true }
     );
 
-    let state = linking.getStateFromPath?.(resolvedHref, linking.config, routeInfo.segments)
-      ?.routes[0];
+    let state = getStateFromPath(resolvedHref, linking.config, routeInfo.segments)?.routes[0];
 
     if (!state) {
       // This shouldn't occur, as you should get the global +not-found

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -11,7 +11,7 @@ import {
   sortRoutesWithInitial,
   useRouteNode,
 } from './Route';
-import { useExpoRouterStore } from './global-state/storeContext';
+import { store } from './global-state/store';
 import { useColorSchemeChangesIfNeeded } from './global-state/utils';
 // Direct import to prevent a require cycle
 import { useCurrentRouteInfo } from './hooks/useCurrentRouteInfo';
@@ -299,7 +299,6 @@ export function getQualifiedRouteComponent(value: RouteNode) {
   }) {
     const stateForPath = useStateForPath();
     const isFocused = navigation.isFocused();
-    const store = useExpoRouterStore();
     const InheritedSuspenseFallback = use(SuspenseFallbackContext);
     const redirectHref = useGuardRedirect(value.route);
     const isGuarded = redirectHref !== undefined;

--- a/packages/expo-router/src/views/useSitemap.tsx
+++ b/packages/expo-router/src/views/useSitemap.tsx
@@ -1,8 +1,8 @@
-import { useMemo } from 'react';
+import { use, useMemo } from 'react';
 
 import type { RouteNode } from '../Route';
 import { sortRoutes } from '../Route';
-import { store } from '../global-state/router-store';
+import { StoreContext } from '../global-state/storeContext';
 import { matchDynamicName } from '../matchers';
 import type { Href } from '../types';
 
@@ -62,9 +62,8 @@ const mapForRoute: (route: RouteNode, parents: string[]) => SitemapType = (route
 });
 
 export function useSitemap(): SitemapType | null {
-  const sitemap = useMemo(
-    () => (store.routeNode ? mapForRoute(store.routeNode, []) : null),
-    [store.routeNode]
-  );
+  // TODO(@ubax): Extract `routeNode` into a separate context to avoid unrelated rerenders.
+  const routeNode = use(StoreContext)?.routeNode;
+  const sitemap = useMemo(() => (routeNode ? mapForRoute(routeNode, []) : null), [routeNode]);
   return sitemap;
 }


### PR DESCRIPTION
# Why

Many of the imperative `store` usages can be moved into the react scope:
- `store.getRouteInfo` - in most places it can be replaced with `useRouteInfo`. Some imperative routing still needs them until we integrate global state
- `store.redirects`, `store.rootComponent`, `store.routeNode` - they are stable and used only in react scope
-  `store.linking` - this is the hardest to migrate. However it is stable apart for hot-module reloading, so it should not be a problem
- `store.assertIsReady`, `store.onReady`, `shouldShowTutorial` - they can be fully removed, as they are not tied to the store state

Having them in the react scope, makes them concurrent safe and easier to integrate with global state

# How

Use react hooks and context wherever possible.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
