### PR TITLE
[sdk-55] chore: Update to `@expo/metro@~55.1.2` (metro@0.83.8)

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/metro@55.1.2` and `metro@0.83.8` ([#49220](https://github.com/expo/expo/pull/49220) by [@kitten](https://github.com/kitten))
+
 ## 55.0.35 — 2026-08-17
 
 ### 🐛 Bug fixes

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -48,7 +48,7 @@
     "@expo/image-utils": "^0.8.16",
     "@expo/json-file": "^10.0.15",
     "@expo/log-box": "55.0.13",
-    "@expo/metro": "~55.1.1",
+    "@expo/metro": "~55.1.2",
     "@expo/metro-config": "~55.0.26",
     "@expo/osascript": "^2.4.4",
     "@expo/package-manager": "^1.10.6",

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/metro@55.1.2` and `metro@0.83.8` ([#49220](https://github.com/expo/expo/pull/49220) by [@kitten](https://github.com/kitten))
+
 ## 55.0.26 — 2026-08-17
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.20.0",
     "@babel/generator": "^7.20.5",
     "@expo/config": "~55.0.20",
-    "@expo/metro": "~55.1.1",
+    "@expo/metro": "~55.1.2",
     "@expo/env": "~2.1.3",
     "@expo/json-file": "~10.0.15",
     "@expo/spawn-async": "^1.7.2",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@types/babel__core": "^7.20.5",
-    "@expo/metro": "~55.1.1",
+    "@expo/metro": "~55.1.2",
     "expo-module-scripts": "^55.0.2",
     "jest": "^29.2.1",
     "react-refresh": "^0.14.2"

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -39,7 +39,7 @@
     "@expo/config": "~55.0.20",
     "@expo/env": "~2.1.3",
     "@expo/json-file": "~10.0.15",
-    "@expo/metro": "~55.1.1",
+    "@expo/metro": "~55.1.2",
     "@expo/schemer": "2.1.4",
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.8",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/metro@55.1.2` and `metro@0.83.8` ([#49220](https://github.com/expo/expo/pull/49220) by [@kitten](https://github.com/kitten))
+
 ## 55.0.29 — 2026-08-17
 
 ### 🐛 Bug fixes

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -84,7 +84,7 @@
     "@expo/fingerprint": "0.16.8",
     "@expo/local-build-cache-provider": "55.0.15",
     "@expo/log-box": "55.0.13",
-    "@expo/metro": "~55.1.1",
+    "@expo/metro": "~55.1.2",
     "@expo/metro-config": "55.0.26",
     "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,25 +1554,25 @@
     zod "^3.25.76"
     zod-to-json-schema "^3.24.6"
 
-"@expo/metro@~55.1.1":
-  version "55.1.1"
-  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-55.1.1.tgz#6d164d2c9dde03967c4480f72c7cbea39ac156c8"
-  integrity sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==
+"@expo/metro@~55.1.2":
+  version "55.1.2"
+  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-55.1.2.tgz#cfe53285fea50c43ef74227501b5f846da209848"
+  integrity sha512-EOBoqqX4jD7JvHBHKDoek8SmWyAFPuJePyDSqIAhIjOCPAM67fVxd4+pCXJ6SDK1P9so55v2iTFBwCoeCmEj4Q==
   dependencies:
-    metro "0.83.7"
-    metro-babel-transformer "0.83.7"
-    metro-cache "0.83.7"
-    metro-cache-key "0.83.7"
-    metro-config "0.83.7"
-    metro-core "0.83.7"
-    metro-file-map "0.83.7"
-    metro-minify-terser "0.83.7"
-    metro-resolver "0.83.7"
-    metro-runtime "0.83.7"
-    metro-source-map "0.83.7"
-    metro-symbolicate "0.83.7"
-    metro-transform-plugins "0.83.7"
-    metro-transform-worker "0.83.7"
+    metro "0.83.8"
+    metro-babel-transformer "0.83.8"
+    metro-cache "0.83.8"
+    metro-cache-key "0.83.8"
+    metro-config "0.83.8"
+    metro-core "0.83.8"
+    metro-file-map "0.83.8"
+    metro-minify-terser "0.83.8"
+    metro-resolver "0.83.8"
+    metro-runtime "0.83.8"
+    metro-source-map "0.83.8"
+    metro-symbolicate "0.83.8"
+    metro-transform-plugins "0.83.8"
+    metro-transform-worker "0.83.8"
 
 "@expo/mux@^1.0.7":
   version "1.0.7"
@@ -9483,13 +9483,6 @@ ignore@^7.0.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
   integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
-image-size@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
-  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
-  dependencies:
-    queue "6.0.2"
-
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
@@ -11476,61 +11469,61 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-transformer@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz#8448c7a550571de87d00e97c1a7139c6b6900e4a"
-  integrity sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==
+metro-babel-transformer@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.8.tgz#dfee95b8e68bee2ea4b2ca1ee8979e28023c01c2"
+  integrity sha512-tnn0J5wzgTgTx2OJy3Cwr1y79bJz4eNgFQd+2HENOs5Vz6QOMnt05z7J+BedIo9wIbpEa0iN9U1nerxyvMRE9g==
   dependencies:
     "@babel/core" "^7.25.2"
     flow-enums-runtime "^0.0.6"
     hermes-parser "0.35.0"
-    metro-cache-key "0.83.7"
+    metro-cache-key "0.83.8"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.7.tgz#59e647cf6dd6297e43d0bd7ab927db48c6ba80b5"
-  integrity sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==
+metro-cache-key@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.8.tgz#39813d833fe283dd9e18de346d4745596011245c"
+  integrity sha512-I38PtcjT4crS5HY9UQ8i6z8S7tJ2WewtPGr/OwS6FcLKfy5T/1hlTaFw+wozUZkEtNpR6Gc0oJuvuKCbSoSN5A==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-cache@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.7.tgz#73ab7857ba6267b78f6374396829d660a67deccf"
-  integrity sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==
+metro-cache@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.8.tgz#e8cc1dc6a980673437746917e3eb20760ae2264c"
+  integrity sha512-aogMG5WbKzW5000otNjYrS9hIoORzkCI1faPJK+vxQLaf2BorJKBBFe/jl2Tfsi1mZUglS2EBuBt8B3JB7MYDQ==
   dependencies:
     exponential-backoff "^3.1.1"
     flow-enums-runtime "^0.0.6"
     https-proxy-agent "^7.0.5"
-    metro-core "0.83.7"
+    metro-core "0.83.8"
 
-metro-config@0.83.7, metro-config@^0.83.6:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.7.tgz#fc88f4f75992744d6d64bf27c6a2f11b10e9fcfb"
-  integrity sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==
+metro-config@0.83.8, metro-config@^0.83.6:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.8.tgz#9df5795fe8462b300b2dbdec7daf6ff9893b0886"
+  integrity sha512-crNbNy+/B4tCne2+HjUshwvC57gNBQj+V9fFSy3lHH2RlKcLHib3Mil/SfTX8Pfh2fCY5pPuSu2OKa7YiadB+Q==
   dependencies:
     connect "^3.6.5"
     flow-enums-runtime "^0.0.6"
     jest-validate "^29.7.0"
-    metro "0.83.7"
-    metro-cache "0.83.7"
-    metro-core "0.83.7"
-    metro-runtime "0.83.7"
+    metro "0.83.8"
+    metro-cache "0.83.8"
+    metro-core "0.83.8"
+    metro-runtime "0.83.8"
     yaml "^2.6.1"
 
-metro-core@0.83.7, metro-core@^0.83.6:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.7.tgz#45cc9eebd979c75021015f190dbd023e833bdd16"
-  integrity sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==
+metro-core@0.83.8, metro-core@^0.83.6:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.8.tgz#ab823f44b873ad07092625b43f81b27cdb7bf952"
+  integrity sha512-NTyOUOQaQKvQgJG9VI2ymN6KTM7gHEqkVFhkPc9bK4BsHSTz/EaXuFBXtC+wtwINLeH9tbusL/jfsSmdEmuU7A==
   dependencies:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.83.7"
+    metro-resolver "0.83.8"
 
-metro-file-map@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.7.tgz#1d0d47db8a76631f0fed2112edad5fec462aec50"
-  integrity sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==
+metro-file-map@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.8.tgz#e3b4ed4b57655da15b9e551c37524e5d096f4fa0"
+  integrity sha512-+W++EUuzEXIfWQEFTWQMVThzhWbnJL4gRNJ9WSHzIAM5pT7gsprUxo9+2hrfirURm/TLvrKwhq37oCECJcDSyQ==
   dependencies:
     debug "^4.4.0"
     fb-watchman "^2.0.0"
@@ -11542,60 +11535,60 @@ metro-file-map@0.83.7:
     nullthrows "^1.1.1"
     walker "^1.0.7"
 
-metro-minify-terser@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz#2de0b70f8cd58e9383b014313a1d9e7babe8d878"
-  integrity sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==
+metro-minify-terser@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.8.tgz#e5c7045315a6ca3e9afaf56e14c9db6621d0387b"
+  integrity sha512-7tU0J5/c7LZaZJwTlOb1xq0NepTFvGzRxigDhZOq4jSE6g0BRHmBqe7XvLH3WcRiJNGy+eshcZr34RpMjb6mmg==
   dependencies:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.7.tgz#84b2e2749f0dba0e1c204764d01c21892157cf1c"
-  integrity sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==
+metro-resolver@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.8.tgz#8234abf33e55978293c54cd95946716c44731271"
+  integrity sha512-piU0NVTI9i37YztDVF5rtn9uxP3NebVT0xZM9NKJ9z0jbigrctUQksi3NoYIeJMvL6Wn2dgAehpcmmnfn+gUwA==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-runtime@0.83.7, metro-runtime@^0.83.6:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.7.tgz#3606a71c94a4ef862b7a0e43156b35f7a4e4cf17"
-  integrity sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==
+metro-runtime@0.83.8, metro-runtime@^0.83.6:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.8.tgz#30ae9aaa8438348bb8ac55a806986c967144c9b7"
+  integrity sha512-f7FfeM0pamq8vrvs8aO9KvIUabbUKe0WkHFpLt6Q9yIIIsORqNFwlgJeHGraOFPU7Cxqj5yLXkJu5bT1uwDXvw==
   dependencies:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
-metro-source-map@0.83.7, metro-source-map@^0.83.6:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.7.tgz#6208e72427c987e66a9ec23ebaee0b3cc76dd16c"
-  integrity sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==
+metro-source-map@0.83.8, metro-source-map@^0.83.6:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.8.tgz#13a1a3d653d5cce5d03059ceda59c225d46d22e7"
+  integrity sha512-60Uor7bM+KsVewLkLCcZfkPFCbqjPDdoSmeBuT3+ye+ac80BuLWbbR8DpyxWpUqQeZPdaAT5ZqFgDIs8BNEcVA==
   dependencies:
     "@babel/traverse" "^7.29.0"
     "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-symbolicate "0.83.7"
+    metro-symbolicate "0.83.8"
     nullthrows "^1.1.1"
-    ob1 "0.83.7"
+    ob1 "0.83.8"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz#ee10cfbafb5ed5ae5f04a565c496fd772afb3f5c"
-  integrity sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==
+metro-symbolicate@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.8.tgz#eeecfe8c200a39b73bb00a19e40475f0b026deb5"
+  integrity sha512-ZLrbqOqQ+m+Mpv7zo65XEXkNqVYvgUbY7tIsb9e1zSSmU/4C3D6DjaJvRHqcAdl0mkg8TI/csKooAEa5xcZNwg==
   dependencies:
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-source-map "0.83.7"
+    metro-source-map "0.83.8"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz#9fc9b4c209ca2fdc1e720a9fefde7c20f32ab5ad"
-  integrity sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==
+metro-transform-plugins@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.8.tgz#548ed1ebabbdd9fc8a1af4b8b9ec9762df1aac1a"
+  integrity sha512-9JRPkvi+m0QH2Y/w5RjCF9mHqOUNFpMFLDDLhKUjhcKESh8Wm3HKDdHXHVldTN1lTToCIabv81nF0zyJzKEJ5g==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.29.1"
@@ -11604,29 +11597,29 @@ metro-transform-plugins@0.83.7:
     flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz#1ba8980f660630f7dfbf52fcf2b7bd6e4ae4528b"
-  integrity sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==
+metro-transform-worker@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.8.tgz#29c84f8e2394f8ea2afbe50f8647fe7f42ff0e20"
+  integrity sha512-Pa2hOfhUmWpI/dmkhsLq8uGyFHK2opoEK7j/YCiRtqNSe0YzzxYguXTNgg8AMiuZfc9LPcB1AhGENS10O5wcIw==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.29.1"
     "@babel/parser" "^7.29.0"
     "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
-    metro "0.83.7"
-    metro-babel-transformer "0.83.7"
-    metro-cache "0.83.7"
-    metro-cache-key "0.83.7"
-    metro-minify-terser "0.83.7"
-    metro-source-map "0.83.7"
-    metro-transform-plugins "0.83.7"
+    metro "0.83.8"
+    metro-babel-transformer "0.83.8"
+    metro-cache "0.83.8"
+    metro-cache-key "0.83.8"
+    metro-minify-terser "0.83.8"
+    metro-source-map "0.83.8"
+    metro-transform-plugins "0.83.8"
     nullthrows "^1.1.1"
 
-metro@0.83.7, metro@^0.83.6:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.7.tgz#8357495dfea9e11d34ea15c0a1e2acd508ee5559"
-  integrity sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==
+metro@0.83.8, metro@^0.83.6:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.8.tgz#4d47a6067f8cefe74b6a7e5ec955a07b81615fca"
+  integrity sha512-ZbJDJCDlvv0O3QHVbhZkyP2/DtebfEoDZ3wVyYHgu6Uoy6DmmE/bis6lIDBYh+kWPuaueJDegyutPjkIBLtZDQ==
   dependencies:
     "@babel/code-frame" "^7.29.0"
     "@babel/core" "^7.25.2"
@@ -11643,23 +11636,22 @@ metro@0.83.7, metro@^0.83.6:
     flow-enums-runtime "^0.0.6"
     graceful-fs "^4.2.4"
     hermes-parser "0.35.0"
-    image-size "^1.0.2"
     invariant "^2.2.4"
     jest-worker "^29.7.0"
     jsc-safe-url "^0.2.2"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.83.7"
-    metro-cache "0.83.7"
-    metro-cache-key "0.83.7"
-    metro-config "0.83.7"
-    metro-core "0.83.7"
-    metro-file-map "0.83.7"
-    metro-resolver "0.83.7"
-    metro-runtime "0.83.7"
-    metro-source-map "0.83.7"
-    metro-symbolicate "0.83.7"
-    metro-transform-plugins "0.83.7"
-    metro-transform-worker "0.83.7"
+    metro-babel-transformer "0.83.8"
+    metro-cache "0.83.8"
+    metro-cache-key "0.83.8"
+    metro-config "0.83.8"
+    metro-core "0.83.8"
+    metro-file-map "0.83.8"
+    metro-resolver "0.83.8"
+    metro-runtime "0.83.8"
+    metro-source-map "0.83.8"
+    metro-symbolicate "0.83.8"
+    metro-transform-plugins "0.83.8"
+    metro-transform-worker "0.83.8"
     mime-types "^3.0.1"
     nullthrows "^1.1.1"
     serialize-error "^2.1.0"
@@ -12179,10 +12171,10 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-ob1@0.83.7:
-  version "0.83.7"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.7.tgz#0f9a9461ee3c3048eacd40893fee3385d42d8731"
-  integrity sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==
+ob1@0.83.8:
+  version "0.83.8"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.8.tgz#874242942c1818ba3f6ecdf97eb0bba468820696"
+  integrity sha512-pk7el+eTOzfSKMAY4QBiiwKzegXn633JQj13y+pW5E5IdS+yV2CfDJ9Hf20K/LKy8nCrP9dAmd7XOk52OJxifA==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
@@ -13133,13 +13125,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-queue@6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
-  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
-  dependencies:
-    inherits "~2.0.3"
 
 quick-lru@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
# Summary

Related to #49161

Upgrades to `metro@0.83.8` via `@expo/metro@~55.1.2`

> [!NOTE]
> This cannot be backported to `sdk-54`, despite it also being on the `0.83.x` line of Metro due to internal conflicting changes.
> The related changes for `sdk-55` are:
> - #45206
> - #44767
> - #44320
> 
> As can be seen in the two latter PRs, the later changes are larger. We could pick them, but this could cause other issues with third-party dependencies, if they also depend on these internals, so picking to `sdk-54` should be skipped.

# Test Plan

- CI is expected to pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
