### PR TITLE
fix(metro-config): Seal worker chunks to prevent chunk-splitting from applying to them

### DIFF
--- a/apps/router-e2e/__e2e__/web-workers/app/index.tsx
+++ b/apps/router-e2e/__e2e__/web-workers/app/index.tsx
@@ -1,27 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Text } from 'react-native';
 
-const worker = new Worker(new URL('../worker-one', window.location.href));
-
 export default function Page() {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<number[]>([]);
+  const workerRef = useRef<Worker | null>(null);
 
   // Do not change this value, it is used in tests
   const input = 'ROUTE_VALUE';
 
   useEffect(() => {
-    worker.onmessage = (event) => {
-      setData((prev) => [...prev, event.data]);
-    };
+    let worker: Worker | undefined;
+    Promise.all([import('../worker-client'), import('../other')]).then(
+      ([{ createWorker }, { otherResult }]) => {
+        console.log('other result', otherResult);
+        worker = createWorker();
+        workerRef.current = worker;
+        worker.onmessage = (event: MessageEvent<number>) => {
+          setData((prev) => [...prev, event.data]);
+        };
+        worker.postMessage(5); // Send a number to the worker
+      }
+    );
 
-    worker.postMessage(5); // Send a number to the worker
+    return () => worker?.terminate();
   }, []);
 
   return (
     <>
       <Text
         onPress={() => {
-          worker.postMessage(10);
+          workerRef.current?.postMessage(10);
         }}
         testID="test-anchor">
         Test

--- a/apps/router-e2e/__e2e__/web-workers/math.ts
+++ b/apps/router-e2e/__e2e__/web-workers/math.ts
@@ -1,3 +1,6 @@
-export function multiply(a, b) {
+// NOTE(@kitten): This module is also async-imported by the app, and hence shared
+// in an async chunk. This module, however, must be duplicated in the web worker, since
+// web workers are self-sufficient bundles, and must not be common-chunk-split
+export function multiply(a: number, b: number) {
   return a * b;
 }

--- a/apps/router-e2e/__e2e__/web-workers/other.ts
+++ b/apps/router-e2e/__e2e__/web-workers/other.ts
@@ -1,0 +1,3 @@
+import { multiply } from './math';
+
+export const otherResult = multiply(3, 2);

--- a/apps/router-e2e/__e2e__/web-workers/worker-client.ts
+++ b/apps/router-e2e/__e2e__/web-workers/worker-client.ts
@@ -1,0 +1,3 @@
+export function createWorker() {
+  return new Worker(new URL('./worker-one', window.location.href));
+}

--- a/apps/router-e2e/__e2e__/web-workers/worker-one.ts
+++ b/apps/router-e2e/__e2e__/web-workers/worker-one.ts
@@ -1,7 +1,7 @@
 // Use an external module that should be bundled.
 import { multiply } from './math';
 
-self.onmessage = (event) => {
+self.onmessage = (event: MessageEvent<number>) => {
   const { data } = event;
   const result = multiply(data, 2);
   self.postMessage(result);

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
+- Seal web worker chunks to prevent common chunk splitting from applying to them ([#49227](https://github.com/expo/expo/pull/49227) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
@@ -147,6 +147,36 @@ it(`supports worker bundle`, async () => {
   expect(artifacts[1].source).toMatch('TEST_RUN_MODULE');
 });
 
+it('emits workers as standalone bundles when ordinary chunk splitting is disabled', async () => {
+  const [, artifacts] = await serializeShakingAsync(
+    {
+      'index.js': `
+        import('./async');
+        const worker = require.unstable_resolveWorker('./worker');
+        console.log(worker);
+      `,
+      'async.js': `
+        console.log('ordinary async module');
+      `,
+      'worker.js': `
+        console.log('worker module');
+      `,
+    },
+    {
+      splitChunks: false,
+      mockRuntime: true,
+    }
+  );
+  const serialAssets = artifacts as SerialAsset[];
+  const entryChunk = getChunkContaining(serialAssets, '/app/index.js');
+  const ordinaryAsyncChunk = getChunkContaining(serialAssets, '/app/async.js');
+  const workerChunk = getChunkContaining(serialAssets, '/app/worker.js');
+
+  expect(ordinaryAsyncChunk).toBe(entryChunk);
+  expect(workerChunk.metadata.modulePaths).toEqual(['/app/worker.js']);
+  expect(workerChunk).not.toBe(entryChunk);
+});
+
 it(`supports worker bundle with nested async chunk`, async () => {
   // TODO: Add actual support for eliminating code from async imports.
   const [[, , graph], artifacts] = await serializeShakingAsync(

--- a/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
@@ -1,6 +1,8 @@
 import type { ReadOnlyGraph } from '@expo/metro/metro/DeltaBundler/types';
+import vm from 'node:vm';
 
 import { serializeShakingAsync } from '../fork/__tests__/serializer-test-utils';
+import type { SerialAsset } from '../serializerAssets';
 
 jest.mock('../exportHermes', () => {
   return {
@@ -18,6 +20,84 @@ jest.mock('../../utils/findUpPackageJsonPath', () => ({
 function expectImports(graph: ReadOnlyGraph, name: string) {
   if (!graph.dependencies.has(name)) throw new Error(`Module not found: ${name}`);
   return expect([...graph.dependencies.get(name)!.dependencies.values()]);
+}
+
+const workerAsyncOverlapFiles = {
+  'index.js': `
+    import('./lib');
+    import('./other');
+  `,
+  'lib.js': `
+    const worker = require.unstable_resolveWorker('./worker');
+    console.log(worker);
+  `,
+  'worker.js': `
+    import { shared } from './shared';
+    self.workerResult = shared;
+  `,
+  'other.js': `
+    import { shared } from './shared';
+    console.log(shared);
+  `,
+  'shared.js': `
+    export const shared = 'shared-module-value';
+  `,
+};
+
+function getChunkContaining(artifacts: SerialAsset[], modulePath: string): SerialAsset {
+  const chunk = artifacts.find((artifact) => artifact.metadata.modulePaths?.includes(modulePath));
+  expect(chunk).toBeDefined();
+  return chunk!;
+}
+
+function runWorkerChunkInIsolatedContext(workerChunk: SerialAsset): unknown {
+  type ModuleRecord = {
+    dependencies: unknown[];
+    exports: Record<string, unknown>;
+    factory: (...args: any[]) => void;
+    initialized: boolean;
+  };
+
+  const modules = new Map<unknown, ModuleRecord>();
+  const context = vm.createContext({});
+  const metroRequire = (moduleId: unknown): Record<string, unknown> => {
+    const record = modules.get(moduleId);
+    if (!record) {
+      throw new Error(`Requiring unknown module "${String(moduleId)}".`);
+    }
+    if (!record.initialized) {
+      record.initialized = true;
+      const module = { exports: record.exports };
+      const importDefault = (id: unknown) => {
+        const exports = metroRequire(id);
+        return exports.__esModule ? exports.default : exports;
+      };
+      record.factory(
+        context,
+        metroRequire,
+        importDefault,
+        metroRequire,
+        module,
+        module.exports,
+        record.dependencies
+      );
+      record.exports = module.exports;
+    }
+    return record.exports;
+  };
+
+  Object.assign(context, {
+    __d(factory: ModuleRecord['factory'], moduleId: unknown, dependencies: unknown[]) {
+      modules.set(moduleId, { dependencies, exports: {}, factory, initialized: false });
+    },
+    TEST_RUN_MODULE: metroRequire,
+  });
+  context.global = context;
+  context.globalThis = context;
+  context.self = context;
+
+  vm.runInContext(workerChunk.source, context, { filename: workerChunk.filename });
+  return context.workerResult;
 }
 
 it(`supports worker bundle`, async () => {
@@ -187,4 +267,62 @@ it(`supports worker bundle with shared deps`, async () => {
   expect(artifacts[1].source).toMatch('runtime');
   expect(artifacts[1].source).toMatch('TEST_RUN_MODULE');
   expect(artifacts[1].source).toMatch('function add(a, b) {}');
+});
+
+describe('sealed worker chunks', () => {
+  it('keeps a dependency shared with a page async chunk inside the worker', async () => {
+    const [, artifacts] = await serializeShakingAsync(workerAsyncOverlapFiles, {
+      splitChunks: true,
+      mockRuntime: true,
+    });
+    const serialAssets = artifacts as SerialAsset[];
+    const workerChunk = getChunkContaining(serialAssets, '/app/worker.js');
+    const otherChunk = getChunkContaining(serialAssets, '/app/other.js');
+
+    expect(workerChunk.metadata.modulePaths).toEqual(['/app/worker.js', '/app/shared.js']);
+    expect(otherChunk.metadata.modulePaths).toEqual(['/app/other.js', '/app/shared.js']);
+    expect(serialAssets.map((artifact) => artifact.filename)).not.toContainEqual(
+      expect.stringContaining('__common-')
+    );
+  });
+
+  it('still extracts common dependencies shared by page async chunks', async () => {
+    const [, artifacts] = await serializeShakingAsync(
+      {
+        ...workerAsyncOverlapFiles,
+        'index.js': `
+          import('./lib');
+          import('./other');
+          import('./third');
+        `,
+        'third.js': `
+          import { shared } from './shared';
+          console.log(shared);
+        `,
+      },
+      {
+        splitChunks: true,
+        mockRuntime: true,
+      }
+    );
+    const serialAssets = artifacts as SerialAsset[];
+    const workerChunk = getChunkContaining(serialAssets, '/app/worker.js');
+    const otherChunk = getChunkContaining(serialAssets, '/app/other.js');
+    const thirdChunk = getChunkContaining(serialAssets, '/app/third.js');
+    const commonChunk = serialAssets.find((artifact) => artifact.filename.includes('__common-'));
+
+    expect(workerChunk.metadata.modulePaths).toEqual(['/app/worker.js', '/app/shared.js']);
+    expect(otherChunk.metadata.modulePaths).toEqual(['/app/other.js']);
+    expect(thirdChunk.metadata.modulePaths).toEqual(['/app/third.js']);
+    expect(commonChunk?.metadata.modulePaths).toEqual(['/app/shared.js']);
+  });
+
+  it('executes the emitted worker with an isolated module registry', async () => {
+    const [, artifacts] = await serializeShakingAsync(workerAsyncOverlapFiles, {
+      splitChunks: true,
+    });
+    const workerChunk = getChunkContaining(artifacts as SerialAsset[], '/app/worker.js');
+
+    expect(runWorkerChunkInIsolatedContext(workerChunk)).toBe('shared-module-value');
+  });
 });

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -867,10 +867,32 @@ function createRuntimeChunk(
 
 function makeChunkByPathLookupMap(chunks: Set<Chunk>): Map<string, Chunk> {
   const chunkByPath = new Map<string, Chunk>();
+  // First, we populate chunks with entry module paths
   for (const chunk of chunks) {
-    for (const module of chunk.deps) {
-      if (!chunkByPath.has(module.path)) {
-        chunkByPath.set(module.path, chunk);
+    for (const entry of chunk.entries) {
+      if (!chunkByPath.has(entry.path)) {
+        chunkByPath.set(entry.path, chunk);
+      }
+    }
+  }
+  // We then populate the chunks' module paths, excluding sealed chunks...
+  for (const chunk of chunks) {
+    if (!chunk.sealed) {
+      for (const module of chunk.deps) {
+        if (!chunkByPath.has(module.path)) {
+          chunkByPath.set(module.path, chunk);
+        }
+      }
+    }
+  }
+  // ...then populate with missing paths from sealed chunks.
+  // This gives precedence for modules from unsealed chunks after entry modules
+  for (const chunk of chunks) {
+    if (chunk.sealed) {
+      for (const module of chunk.deps) {
+        if (!chunkByPath.has(module.path)) {
+          chunkByPath.set(module.path, chunk);
+        }
       }
     }
   }

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -718,15 +718,17 @@ function gatherChunks(
   entryChunks.add(entryChunk);
 
   function includeModule(entryModule: Module<MixedOutput>) {
+    const splitChunks = entryChunk.options.serializerOptions?.splitChunks !== false;
     for (const dependency of entryModule.dependencies.values()) {
+      const asyncType = dependency.data.data.asyncType;
+      const isWorker = asyncType === 'worker';
       if (!isResolvedDependency(dependency)) {
         continue;
       } else if (
-        dependency.data.data.asyncType &&
-        // Support disabling multiple chunks.
-        entryChunk.options.serializerOptions?.splitChunks !== false
+        asyncType &&
+        // Workers require standalone bundles even when ordinary chunk splitting is disabled.
+        (isWorker || splitChunks)
       ) {
-        const isWorker = dependency.data.data.asyncType === 'worker';
         const asyncChunks = gatherChunks(
           runtimePremodules,
           chunks,

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -95,8 +95,7 @@ export async function graphToSerialAssetsAsync(
 
   // Create chunks for splitting.
   const chunks = new Set<Chunk>();
-
-  gatherChunks(
+  const entryChunks = gatherChunks(
     preModules,
     chunks,
     { test: pathToRegex(entryFile) },
@@ -107,8 +106,10 @@ export async function graphToSerialAssetsAsync(
     true
   );
 
-  const entryChunk = findEntryChunk(chunks, entryFile);
-
+  // TODO(@kitten): We know that the returned `entryChunks` should only have a single value
+  // with `!isAsync` and matching `.hasAbsolutePath(entryFile)` due to us only starting with
+  // an entry module. This is temporarily implicit and not enforced by an invariant
+  const entryChunk = entryChunks.values().next().value;
   if (entryChunk) {
     removeEntryDepsFromAsyncChunks(entryChunk, chunks);
 
@@ -762,10 +763,6 @@ function gatherChunks(
   }
 
   return entryChunks;
-}
-
-function findEntryChunk(chunks: Set<Chunk>, entryFile: string): Chunk | undefined {
-  return [...chunks.values()].find((chunk) => !chunk.isAsync && chunk.hasAbsolutePath(entryFile));
 }
 
 function removeEntryDepsFromAsyncChunks(entryChunk: Chunk, chunks: Set<Chunk>): void {

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -174,6 +174,14 @@ export class Chunk {
   // These are included in the HTML as <script> tags.
   public requiredChunks: Set<Chunk> = new Set();
 
+  /** Whether this chunk owns an isolated module registry and must retain all of its dependencies.
+   * @remarks
+   * When a chunk is sealed, its `deps` and `preModules` shouldn't be altered, and it doesn't qualify
+   * for bundle/chunk splitting. This is the case for web workers, which must form a "closed" and
+   * self-sufficient entry bundle.
+   */
+  public sealed = false;
+
   constructor(
     public name: string,
     public entries: Module<MixedOutput>[],
@@ -184,6 +192,10 @@ export class Chunk {
     public isEntry: boolean = false
   ) {
     this.deps = new Set(entries);
+  }
+
+  seal(): void {
+    this.sealed = true;
   }
 
   private getPlatform() {
@@ -658,16 +670,23 @@ function gatherChunks(
   isEntry: boolean = false
 ): Set<Chunk> {
   let entryModules = getEntryModulesForChunkSettings(graph, settings);
-
-  const existingChunks = [...chunks.values()];
-
-  entryModules = entryModules.filter((module) => {
-    return !existingChunks.find((chunk) => chunk.entries.includes(module));
-  });
-
-  // Prevent processing the same entry file twice.
+  const entryChunks = new Set<Chunk>();
   if (!entryModules.length) {
-    return chunks;
+    return entryChunks;
+  }
+
+  for (const chunk of chunks) {
+    entryModules = entryModules.filter((module) => {
+      if (chunk.entries.includes(module)) {
+        entryChunks.add(chunk);
+        return false;
+      }
+      return true;
+    });
+    // Prevent processing the same entry file twice.
+    if (!entryModules.length) {
+      return entryChunks;
+    }
   }
 
   const entryChunk = new Chunk(
@@ -689,6 +708,7 @@ function gatherChunks(
   }
 
   chunks.add(entryChunk);
+  entryChunks.add(entryChunk);
 
   function includeModule(entryModule: Module<MixedOutput>) {
     for (const dependency of entryModule.dependencies.values()) {
@@ -699,18 +719,25 @@ function gatherChunks(
         // Support disabling multiple chunks.
         entryChunk.options.serializerOptions?.splitChunks !== false
       ) {
-        const isEntry = dependency.data.data.asyncType === 'worker';
-
-        gatherChunks(
+        const isWorker = dependency.data.data.asyncType === 'worker';
+        const asyncChunks = gatherChunks(
           runtimePremodules,
           chunks,
           { test: pathToRegex(dependency.absolutePath) },
-          isEntry ? runtimePremodules : [],
+          isWorker ? runtimePremodules : [],
           graph,
           options,
           true,
-          isEntry
+          isWorker
         );
+
+        // Seal all chunks that are for web workers, as these must be self-sufficient chunks
+        if (isWorker) {
+          assert(asyncChunks.size, `Worker chunk not found for: ${dependency.absolutePath}`);
+          for (const chunk of asyncChunks) {
+            chunk.seal();
+          }
+        }
       } else {
         const module = graph.dependencies.get(dependency.absolutePath);
         if (module) {
@@ -728,7 +755,7 @@ function gatherChunks(
     includeModule(entryModule);
   }
 
-  return chunks;
+  return entryChunks;
 }
 
 function findEntryChunk(chunks: Set<Chunk>, entryFile: string): Chunk | undefined {

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -184,7 +184,7 @@ export class Chunk {
 
   constructor(
     public name: string,
-    public entries: Module<MixedOutput>[],
+    public entries: Set<Module<MixedOutput>>,
     public graph: ReadOnlyGraph<MixedOutput>,
     public options: ExpoSerializerOptions,
     public isAsync: boolean = false,
@@ -646,19 +646,26 @@ function collectOutputReferences(modules: Iterable<Module>, key: string): string
   ].filter((value): value is string => typeof value === 'string');
 }
 
-function getEntryModulesForChunkSettings(graph: ReadOnlyGraph, settings: ChunkSettings) {
-  return [...graph.dependencies.entries()]
-    .filter(([path]) => settings.test.test(path))
-    .map(([, module]) => module);
+function getEntryModulesForChunkSettings(
+  graph: ReadOnlyGraph,
+  settings: ChunkSettings
+): Set<Module<MixedOutput>> {
+  const modules = new Set<Module<MixedOutput>>();
+  for (const entry of graph.dependencies) {
+    if (settings.test.test(entry[0])) {
+      modules.add(entry[1]);
+    }
+  }
+  return modules;
 }
 
-function chunkIdForModules(modules: Module[]) {
-  return modules
-    .map((module) => module.path)
-    .sort()
-    .join('=>');
+function chunkIdForModules(modules: Iterable<Module>) {
+  const modPaths: string[] = [];
+  for (const mod of modules) modPaths.push(mod.path);
+  return modPaths.sort().join('=>');
 }
 
+// TODO(@kitten): The recursion is starting to hurt clarity here a bit
 function gatherChunks(
   runtimePremodules: readonly Module[],
   chunks: Set<Chunk>,
@@ -669,22 +676,21 @@ function gatherChunks(
   isAsync: boolean = false,
   isEntry: boolean = false
 ): Set<Chunk> {
-  let entryModules = getEntryModulesForChunkSettings(graph, settings);
+  const entryModules = getEntryModulesForChunkSettings(graph, settings);
   const entryChunks = new Set<Chunk>();
-  if (!entryModules.length) {
+  if (!entryModules.size) {
     return entryChunks;
   }
 
   for (const chunk of chunks) {
-    entryModules = entryModules.filter((module) => {
-      if (chunk.entries.includes(module)) {
+    for (const entry of chunk.entries) {
+      // Remove already processed entries
+      if (entryModules.delete(entry)) {
         entryChunks.add(chunk);
-        return false;
       }
-      return true;
-    });
+    }
     // Prevent processing the same entry file twice.
-    if (!entryModules.length) {
+    if (!entryModules.size) {
       return entryChunks;
     }
   }
@@ -782,28 +788,26 @@ function extractCommonChunk(
 ): Chunk | undefined {
   const toCompare = [...chunks.values()];
 
-  const commonDependencies = [];
+  const commonDependencies = new Set<Module<MixedOutput>>();
 
   while (toCompare.length) {
     const chunk = toCompare.shift()!;
     for (const chunk2 of toCompare) {
       if (chunk !== chunk2 && chunk.isAsync && chunk2.isAsync) {
-        const commonDeps = [...chunk.deps].filter((dep) => chunk2.deps.has(dep));
-
-        for (const dep of commonDeps) {
-          chunk.deps.delete(dep);
-          chunk2.deps.delete(dep);
+        for (const dep of chunk.deps) {
+          if (chunk2.deps.has(dep)) {
+            chunk.deps.delete(dep);
+            chunk2.deps.delete(dep);
+            commonDependencies.add(dep);
+          }
         }
-
-        commonDependencies.push(...commonDeps);
       }
     }
   }
 
   // If common dependencies were found, extract them to the shared chunk.
-  if (commonDependencies.length) {
-    const commonDependenciesUnique = [...new Set(commonDependencies)];
-    return new Chunk('/__common.js', commonDependenciesUnique, graph, options, false, true);
+  if (commonDependencies.size) {
+    return new Chunk('/__common.js', commonDependencies, graph, options, false, true);
   }
 
   return undefined;
@@ -816,7 +820,7 @@ function deduplicateAgainstKnownChunks(
 ): void {
   // TODO: Optimize this pass more.
   // Remove all dependencies from async chunks that are already in the common chunk.
-  for (const chunk of [...chunks.values()]) {
+  for (const chunk of chunks) {
     if (!chunk.isEntry && chunk !== commonChunk) {
       for (const dep of chunk.deps) {
         if (entryChunk.deps.has(dep) || commonChunk?.deps.has(dep)) {
@@ -828,7 +832,7 @@ function deduplicateAgainstKnownChunks(
 }
 
 function removeEmptyChunks(chunks: Set<Chunk>): void {
-  for (const chunk of [...chunks.values()]) {
+  for (const chunk of chunks) {
     if (!chunk.isEntry && chunk.deps.size === 0) {
       chunks.delete(chunk);
     }
@@ -841,7 +845,14 @@ function createRuntimeChunk(
   graph: ReadOnlyGraph,
   options: SerializerOptions
 ): void {
-  const runtimeChunk = new Chunk('/__expo-metro-runtime.js', [], graph, options, false, true);
+  const runtimeChunk = new Chunk(
+    '/__expo-metro-runtime.js',
+    new Set(),
+    graph,
+    options,
+    false,
+    true
+  );
 
   // All premodules (including metro-runtime) should load first
   for (const preModule of entryChunk.preModules) {

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -766,9 +766,9 @@ function gatherChunks(
 }
 
 function removeEntryDepsFromAsyncChunks(entryChunk: Chunk, chunks: Set<Chunk>): void {
-  for (const chunk of chunks.values()) {
-    if (!chunk.isEntry && chunk.isAsync) {
-      for (const dep of chunk.deps.values()) {
+  for (const chunk of chunks) {
+    if (!chunk.sealed && !chunk.isEntry && chunk.isAsync) {
+      for (const dep of chunk.deps) {
         if (entryChunk.deps.has(dep)) {
           // Remove the dependency from the async chunk since it will be loaded in the main chunk.
           chunk.deps.delete(dep);
@@ -783,8 +783,7 @@ function extractCommonChunk(
   graph: ReadOnlyGraph,
   options: SerializerOptions
 ): Chunk | undefined {
-  const toCompare = [...chunks.values()];
-
+  const toCompare = [...chunks.values()].filter((chunk) => !chunk.sealed);
   const commonDependencies = new Set<Module<MixedOutput>>();
 
   while (toCompare.length) {
@@ -818,7 +817,7 @@ function deduplicateAgainstKnownChunks(
   // TODO: Optimize this pass more.
   // Remove all dependencies from async chunks that are already in the common chunk.
   for (const chunk of chunks) {
-    if (!chunk.isEntry && chunk !== commonChunk) {
+    if (!chunk.sealed && !chunk.isEntry && chunk !== commonChunk) {
       for (const dep of chunk.deps) {
         if (entryChunk.deps.has(dep) || commonChunk?.deps.has(dep)) {
           chunk.deps.delete(dep);
@@ -830,7 +829,7 @@ function deduplicateAgainstKnownChunks(
 
 function removeEmptyChunks(chunks: Set<Chunk>): void {
   for (const chunk of chunks) {
-    if (!chunk.isEntry && chunk.deps.size === 0) {
+    if (!chunk.sealed && !chunk.isEntry && chunk.deps.size === 0) {
       chunks.delete(chunk);
     }
   }


### PR DESCRIPTION
# Why

Resolves #49032

Web worker bundles are treated as self-sufficient and contain runtime modules and all modules they may execute. They're essentially supposed to be "sealed" and not "sparsened" (no deps must be removed/extracted from them)

This invariant was hidden and not explicitly enforced, causing loading of web workers that share modules with another async chunk to fail, which breaks web worker bundles.

Supersedes #49067: While currently worker chunks can theoretically be identified as `isEntry && isAsync`, this is a coincidence, and not explicitly enforced. Instead, while we have the information that a given chunk is a worker chunk, we should mark it as _sealed_ and exclude it from (common) chunk-splitting or other modifications.

Explicitly capturing `seal()` as a flag/method should stop us from regressing on this again. However, while this could also pass a `type: 'worker'` flag to chunks, this currently conflicts with the `isAsync` and `isEntry` design a little, which is why this wasn't added (yet)

# How

- When creating a `Chunk` we call `Chunk#seal` on it if it's a (web) worker chunk
- When `Chunk#sealed` is set, we skip chunk splitting/modifications entirely

Unrelated changes have been made following up on #46003 to clean up redundant Set/Array conversions and iterations.

# Test Plan

- Unit test added to verify sealed behaviour
- E2E updated to share `math.ts` module with worker and an `import(...)` async chunk

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
