### PR TITLE
[speech][Android] Settle queued promises when the TTS engine fails to initialize

### DIFF
--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Resolve queued `getVoices`/`speak` calls when the TTS engine fails to initialize, instead of leaving their promises pending forever. ([#49228](https://github.com/expo/expo/pull/49228) by [@henryj](https://github.com/henryj))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
@@ -21,6 +21,7 @@ const val speakingErrorEvent = "Exponent.speakingError"
 class SpeechModule : Module() {
   private val delayedUtterances: Queue<Utterance> = ArrayDeque()
   private val delayedGetVoices: Queue<Promise> = ArrayDeque()
+  private var ttsState = TtsState.PENDING
 
   override fun definition() = ModuleDefinition {
     Name("ExpoSpeech")
@@ -46,17 +47,15 @@ class SpeechModule : Module() {
     }
 
     AsyncFunction("getVoices") { promise: Promise ->
-      if (isTextToSpeechReady) {
-        promise.resolve(getVoices())
-      } else if (ttsFailed) {
-        // The engine already failed to initialize once; it will never become
-        // ready, so answer immediately instead of queueing forever.
-        promise.resolve(emptyList<VoiceRecord>())
-      } else {
-        delayedGetVoices.add(promise)
+      when (ttsState) {
+        TtsState.READY -> promise.resolve(getVoices())
+        TtsState.FAILED -> promise.resolve(emptyList<VoiceRecord>())
+        TtsState.PENDING -> {
+          delayedGetVoices.add(promise)
 
-        // Init TTS, the promise will be fulfilled after onInit
-        textToSpeech
+          // Init TTS, the promise will be fulfilled after onInit
+          textToSpeech
+        }
       }
     }
 
@@ -69,16 +68,15 @@ class SpeechModule : Module() {
         throw SpeechInputIsToLongException()
       }
 
-      if (isTextToSpeechReady) {
-        speakOut(id, text, options)
-      } else if (ttsFailed) {
-        // The engine can never become ready; fail the utterance loudly.
-        sendEvent(speakingErrorEvent, idToMap(id))
-      } else {
-        delayedUtterances.add(Utterance(id, text, options))
+      when (ttsState) {
+        TtsState.READY -> speakOut(id, text, options)
+        TtsState.FAILED -> sendEvent(speakingErrorEvent, idToMap(id))
+        TtsState.PENDING -> {
+          delayedUtterances.add(Utterance(id, text, options))
 
-        // init TTS, speaking will be available only after onInit
-        textToSpeech
+          // init TTS, speaking will be available only after onInit
+          textToSpeech
+        }
       }
       Unit
     }
@@ -152,18 +150,12 @@ class SpeechModule : Module() {
 
   // TextToSpeech object related code
 
-  private val isTextToSpeechReady
-    get() = _ttsReady
-
-  private val ttsFailed
-    get() = _ttsFailed
-
   private val textToSpeech: TextToSpeech by lazy {
     val newTtsInstance = TextToSpeech(appContext.reactContext) { status: Int ->
       if (status == TextToSpeech.SUCCESS) {
         // synchronize because in some cases this runs on another thread and _textToSpeech is null
         synchronized(this@SpeechModule) {
-          _ttsReady = true
+          ttsState = TtsState.READY
           _textToSpeech!!.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
 
             override fun onStart(utteranceId: String) {
@@ -199,20 +191,10 @@ class SpeechModule : Module() {
           }
         }
       } else {
-        // The TTS engine failed to initialize (e.g. no engine is installed on
-        // the device). Settle every queued promise so callers get "no voices"
-        // instead of an await that never returns, and fail queued utterances
-        // through the error event instead of dropping them silently.
         synchronized(this@SpeechModule) {
-          _ttsFailed = true
-          while (true) {
-            val promise = delayedGetVoices.poll() ?: break
-            promise.resolve(emptyList<VoiceRecord>())
-          }
-          while (true) {
-            val utterance = delayedUtterances.poll() ?: break
-            sendEvent(speakingErrorEvent, idToMap(utterance.id))
-          }
+          ttsState = TtsState.FAILED
+          delayedGetVoices.forEach { it.resolve(emptyList<VoiceRecord>()) }
+          delayedUtterances.forEach { sendEvent(speakingErrorEvent, idToMap(it.id)) }
         }
       }
     }
@@ -231,8 +213,12 @@ class SpeechModule : Module() {
     val options: SpeechOptions
   )
 
-  // do not refer to these - they're only needed when initializing `textToSpeech`
+  private enum class TtsState {
+    PENDING,
+    READY,
+    FAILED
+  }
+
+  // do not refer to this - it's only needed when initializing `textToSpeech`
   private var _textToSpeech: TextToSpeech? = null
-  private var _ttsReady = false
-  private var _ttsFailed = false
 }

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechModule.kt
@@ -48,6 +48,10 @@ class SpeechModule : Module() {
     AsyncFunction("getVoices") { promise: Promise ->
       if (isTextToSpeechReady) {
         promise.resolve(getVoices())
+      } else if (ttsFailed) {
+        // The engine already failed to initialize once; it will never become
+        // ready, so answer immediately instead of queueing forever.
+        promise.resolve(emptyList<VoiceRecord>())
       } else {
         delayedGetVoices.add(promise)
 
@@ -67,6 +71,9 @@ class SpeechModule : Module() {
 
       if (isTextToSpeechReady) {
         speakOut(id, text, options)
+      } else if (ttsFailed) {
+        // The engine can never become ready; fail the utterance loudly.
+        sendEvent(speakingErrorEvent, idToMap(id))
       } else {
         delayedUtterances.add(Utterance(id, text, options))
 
@@ -148,6 +155,9 @@ class SpeechModule : Module() {
   private val isTextToSpeechReady
     get() = _ttsReady
 
+  private val ttsFailed
+    get() = _ttsFailed
+
   private val textToSpeech: TextToSpeech by lazy {
     val newTtsInstance = TextToSpeech(appContext.reactContext) { status: Int ->
       if (status == TextToSpeech.SUCCESS) {
@@ -188,6 +198,22 @@ class SpeechModule : Module() {
             promise.resolve(getVoices())
           }
         }
+      } else {
+        // The TTS engine failed to initialize (e.g. no engine is installed on
+        // the device). Settle every queued promise so callers get "no voices"
+        // instead of an await that never returns, and fail queued utterances
+        // through the error event instead of dropping them silently.
+        synchronized(this@SpeechModule) {
+          _ttsFailed = true
+          while (true) {
+            val promise = delayedGetVoices.poll() ?: break
+            promise.resolve(emptyList<VoiceRecord>())
+          }
+          while (true) {
+            val utterance = delayedUtterances.poll() ?: break
+            sendEvent(speakingErrorEvent, idToMap(utterance.id))
+          }
+        }
       }
     }
     _textToSpeech = newTtsInstance
@@ -208,4 +234,5 @@ class SpeechModule : Module() {
   // do not refer to these - they're only needed when initializing `textToSpeech`
   private var _textToSpeech: TextToSpeech? = null
   private var _ttsReady = false
+  private var _ttsFailed = false
 }


### PR DESCRIPTION
# Why

On Android, `getVoices` and `speak` calls made before the TTS engine is ready are queued and replayed from the `TextToSpeech` init callback (added in #36664). That callback only handles `TextToSpeech.SUCCESS`. When initialization fails — for example on devices with no TTS engine installed or enabled, which is common on Chinese-market phones shipping without Google services — the queued `getVoices` promises are never resolved and queued utterances are dropped silently.

The practical effect: any app that does `await Speech.getAvailableVoicesAsync()` on such a device hangs at that line forever, with no error to catch. We hit this in production; the repro chain is in the test plan.

# How

Add the missing failure branch to the init callback:

- resolve every queued `getVoices` promise with an empty list (the same shape callers get from a ready engine with no voices),
- fail every queued utterance through the existing `Events.SPEAKING_ERROR` event instead of dropping it,
- record the failure in a single `ttsState` enum (`PENDING`/`READY`/`FAILED`), so `getVoices`/`speak` calls made after the failed init answer immediately instead of re-queueing onto a queue that no future callback will drain (the lazy `TextToSpeech` property only initializes once, so a second callback never comes).

No behavior change when initialization succeeds.

# Test Plan

Verified on an Android 16 (API 36) emulator with this module compiled from source into a React Native app:

1. `adb shell pm disable-user --user 0 com.google.android.tts` (the emulator's only TTS engine), launch the app.
2. Before this change: `await Speech.getAvailableVoicesAsync()` never settles — no resolution, no rejection, nothing in logcat. In our app this froze a whole import pipeline at its voice-selection step.
3. With this change: the same call resolves with `[]` about a second after launch, and a `speak` call fires the speaking-error event.
4. Re-enabling the engine (`pm enable com.google.android.tts`) restores the normal voice list, confirming the success path is untouched.
