### PR TITLE
[templates][sdk-54] Bump react-native to 0.81.6

### DIFF
--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.37",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.6"
   }
 }

--- a/templates/expo-template-blank-typescript/package.json
+++ b/templates/expo-template-blank-typescript/package.json
@@ -14,7 +14,7 @@
     "expo": "~54.0.37",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.6"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/templates/expo-template-blank/package.json
+++ b/templates/expo-template-blank/package.json
@@ -14,6 +14,6 @@
     "expo": "~54.0.37",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
-    "react-native": "0.81.5"
+    "react-native": "0.81.6"
   }
 }

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -30,7 +30,7 @@
     "expo-web-browser": "~15.0.11",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.5",
+    "react-native": "0.81.6",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -23,7 +23,7 @@
     "expo-web-browser": "~15.0.11",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.5",
+    "react-native": "0.81.6",
     "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
# Why

Fixes #44314 (cc @Friskopp).

`RCTThirdPartyComponentsProvider.mm` is generated empty when `ios.useFrameworks: 'static'` is combined with native dependencies declared only in a pnpm workspace package, so third-party Fabric components fail to register and crash at runtime. Root cause on SDK 54 (react-native 0.81.5), and the proper fix landed in facebook/react-native#54066 released with 0.83 and was back ported into 081.6

Per @brentvatne's suggestion when closing #48383, I verified against current main (`expo@58.0.0-canary-20260812-27f94d4`, RN 0.86.2) and could not produce it, so no change is needed on main. SDK 54 is the only affected release.

# How

Bump the `react-native` pin from 0.81.5 to 0.81.6 in all five SDK 54 templates.

The SDK 54 `facebookReactNativeVersion` on the versions endpoint should also move to 0.81.6

# Test Plan

- [ ] RN 0.81.5 (as shipped): codegen logs `Could not find generated autolinking output at: <temp>/.../autolinking.json` and rewrites the provider to an empty dictionary, reproducing the report.
- [ ] RN 0.81.6 (this change): no autolinking miss; the provider keeps all workspace-only registrations (react-native-screens, react-native-gesture-handler, react-native-safe-area-context) after the simulated build phase.

> Note for existing SDK 54 apps: monorepos that pin react-native via `pnpm.overrides` (as the repro repo does) need to bump the override as well

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (verified via the prebuild-based test plan above)
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
