### PR TITLE
[ios][updates] Fix dev-client detection treating an absent package as installed

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `expo-dev-client` being detected as installed when it is absent, which enabled `USE_DEV_CLIENT` and printed a `MODULE_NOT_FOUND` trace during `pod install`. ([#49233](https://github.com/expo/expo/pull/49233) by [@dennytosp](https://github.com/dennytosp))
 - [iOS] Set `always_out_of_date` on the `Generate updates resources for expo-updates` script_phase to silence the Xcode "run script phase will run on every build" dependency-analysis warning. ([#47622](https://github.com/expo/expo/pull/47622) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 - [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -19,7 +19,10 @@ begin
   if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
     project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
     dev_client_package = podfile_properties['expo.updates.devClientPackage'] || 'expo-dev-client'
-    use_dev_client = File.dirname(`node --print "require.resolve('#{dev_client_package}/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`).length > 0
+    # `node --print` exits nonzero and prints a MODULE_NOT_FOUND trace when the package is
+    # absent, which is expected here, so discard stderr and test the resolved path instead.
+    dev_client_package_json_path = `node --print "require.resolve('#{dev_client_package}/package.json', { paths: ['#{__dir__}', '#{project_root}'] })" 2>/dev/null`.strip
+    use_dev_client = !dev_client_package_json_path.empty?
   end
 rescue
   use_dev_client = false

--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -19,8 +19,6 @@ begin
   if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
     project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
     dev_client_package = podfile_properties['expo.updates.devClientPackage'] || 'expo-dev-client'
-    # `node --print` exits nonzero and prints a MODULE_NOT_FOUND trace when the package is
-    # absent, which is expected here, so discard stderr and test the resolved path instead.
     dev_client_package_json_path = `node --print "require.resolve('#{dev_client_package}/package.json', { paths: ['#{__dir__}', '#{project_root}'] })" 2>/dev/null`.strip
     use_dev_client = !dev_client_package_json_path.empty?
   end


### PR DESCRIPTION
# Why

Fixes #48739.

`EXUpdates.podspec` decides whether the dev client is installed with a length check on `File.dirname`:

```ruby
use_dev_client = File.dirname(`node --print "require.resolve('#{dev_client_package}/package.json', ...)"`).length > 0
```

When `expo-dev-client` is **not** installed, `node --print` exits nonzero and writes nothing to stdout. Ruby backticks return `""`, and `File.dirname("")` is `"."`, whose length is `1`. So `use_dev_client` becomes `true` for every project that does not have the dev client. The surrounding `begin/rescue` cannot catch this, because a nonzero child process raises no Ruby exception.

Two consequences:

1. A Debug build compiles with `-DUSE_DEV_CLIENT`, so [`AppController.initializeWithoutStarting`](https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/AppController.swift#L218) installs a `DevLauncherController` instead of the `DisabledAppController` that branch is meant to select.
2. The expected resolution failure prints a full `MODULE_NOT_FOUND` stack trace into the `pod install` log, where it reads as a CocoaPods error even though installation continues.

Android does not have this bug — [`build.gradle`](https://github.com/expo/expo/blob/main/packages/expo-updates/android/build.gradle#L81) uses `findProject(":expo-dev-client") != null`, a real presence check. iOS was the outlier.

# How

Test the resolved path instead of `File.dirname` of it, and discard the expected stderr:

```ruby
dev_client_package_json_path = `node --print "require.resolve('#{dev_client_package}/package.json', ...)" 2>/dev/null`.strip
use_dev_client = !dev_client_package_json_path.empty?
```

This is the same shape [`ExpoModulesWorkletsAdapter.podspec`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/ExpoModulesWorkletsAdapter.podspec#L14) already uses to resolve an optional package (`2>/dev/null` + `.strip` + empty check), so the two optional-dependency probes in the repo now agree.

`$?.success?` would be redundant here: the only way stdout is non-empty is a successful `require.resolve`.

I checked every other `File.dirname(\`node --print ...\`)` in the repo. All of them feed the result straight into `require File.join(...)`, which fails loudly on a bad path rather than silently reporting presence. Line 22 was the only one used as a boolean.

# Test Plan

There is no Ruby test harness in the repo, so I evaluated the real podspec through CocoaPods (`Pod::Specification.from_file`) and read `OTHER_SWIFT_FLAGS[config=*Debug*]` back off the spec.

To get a tree where `expo-dev-client` is genuinely unresolvable, I rsynced `packages/expo-updates` outside the monorepo and linked only `react-native` and `react-native-worklets`. Confirmed first that `require.resolve('expo-dev-client/package.json')` from that tree is `MODULE_NOT_FOUND`.

Same tree, same command, only the podspec varies:

| Podspec | stderr | `USE_DEV_CLIENT` |
| --- | --- | --- |
| `main` | `MODULE_NOT_FOUND` stack trace | **`true`** — wrong |
| this PR | clean | **`false`** — correct |

`main`:

```
debug swift flags = $(inherited) -DUSE_DEV_CLIENT
USE_DEV_CLIENT    = true
```

this PR:

```
debug swift flags = $(inherited)
USE_DEV_CLIENT    = false
```

The positive case is unchanged. Evaluating this PR's podspec from `apps/bare-expo/ios`, where `expo-dev-client` is a workspace dependency:

```
debug swift flags = $(inherited) -DUSE_DEV_CLIENT
USE_DEV_CLIENT    = true
```

Also `ruby -c packages/expo-updates/ios/EXUpdates.podspec` -> `Syntax OK`, and the isolated `pod install` log no longer contains a Node stack trace.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Conforms to the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [x] This is an iOS podspec change with no JS surface; `et check-packages expo-updates` is green.
