### PR TITLE
[file-system] Fix BYOB stream reads into a view with a non-zero offset

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `File.readableStream()` returning zeroed bytes and writing past the requested region when a BYOB read targets a view that starts at a non-zero offset. ([#49234](https://github.com/expo/expo/pull/49234) by [@dennytosp](https://github.com/dennytosp))
 - [Android][iOS] Fix `File.size` returning `null` for a missing or unreadable file. ([#49086](https://github.com/expo/expo/pull/49086)) by [@ACHP](https://github.com/ACHP))
 - [iOS] Fix wrong permissions for text() and bytes(). ([#42422](https://github.com/expo/expo/pull/42422)) by [@simoneldevig](https://github.com/simoneldevig))
 - Fixed `copyAsync` on iOS copying the unedited original when a `ph://` asset has edits applied in Photos. ([#48248](https://github.com/expo/expo/pull/48248) by [@CoffeeFlux](https://github.com/CoffeeFlux))

--- a/packages/expo-file-system/src/internal/__tests__/streams-test.ts
+++ b/packages/expo-file-system/src/internal/__tests__/streams-test.ts
@@ -1,0 +1,106 @@
+import type { FileHandle } from '../../File.types';
+import { FileSystemReadableStreamSource } from '../streams';
+
+const CONTENTS = new Uint8Array(64).map((_, index) => index + 1);
+
+/** A handle over an in-memory buffer, reading sequentially like a real file handle. */
+function createHandle(contents: Uint8Array = CONTENTS) {
+  let position = 0;
+  const requestedLengths: number[] = [];
+  const handle = {
+    readBytes: async (length: number) => {
+      requestedLengths.push(length);
+      const slice = contents.subarray(position, position + length);
+      position += slice.length;
+      return new Uint8Array(slice);
+    },
+    close: () => {},
+  };
+  return { handle: handle as unknown as FileHandle, requestedLengths };
+}
+
+/**
+ * A `ReadableByteStreamController` stand-in. `byobRequest.view` covers the region of the
+ * caller's buffer the stream still has to fill, which is what the spec hands to `pull`.
+ * jsdom has no `ReadableStream`, so the source is driven directly.
+ */
+function createController(view: ArrayBufferView) {
+  const responded: number[] = [];
+  const controller = {
+    byobRequest: { view, respond: (bytesWritten: number) => responded.push(bytesWritten) },
+    close: () => {},
+    enqueue: () => {},
+  };
+  return { controller: controller as unknown as ReadableByteStreamController, responded };
+}
+
+describe(FileSystemReadableStreamSource, () => {
+  it('fills a BYOB view that starts at a non-zero offset in its buffer', async () => {
+    const { handle } = createHandle();
+    const view = new Uint8Array(new ArrayBuffer(32), 8, 16);
+    const { controller, responded } = createController(view);
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    expect(responded).toEqual([16]);
+    expect(Array.from(view)).toEqual(Array.from(CONTENTS.subarray(0, 16)));
+  });
+
+  it('requests as many bytes as the BYOB view can hold', async () => {
+    const { handle, requestedLengths } = createHandle();
+    const view = new Uint8Array(new ArrayBuffer(32), 8, 16);
+    const { controller } = createController(view);
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    expect(requestedLengths).toEqual([16]);
+  });
+
+  it('does not write outside the BYOB view', async () => {
+    const { handle } = createHandle();
+    const buffer = new ArrayBuffer(32);
+    const view = new Uint8Array(buffer, 8, 16);
+    const { controller } = createController(view);
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    const whole = new Uint8Array(buffer);
+    expect(Array.from(whole.subarray(0, 8))).toEqual(new Array(8).fill(0));
+    expect(Array.from(whole.subarray(24))).toEqual(new Array(8).fill(0));
+  });
+
+  it('fills a BYOB view that starts at offset zero', async () => {
+    const { handle } = createHandle();
+    const view = new Uint8Array(new ArrayBuffer(16));
+    const { controller, responded } = createController(view);
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    expect(responded).toEqual([16]);
+    expect(Array.from(view)).toEqual(Array.from(CONTENTS.subarray(0, 16)));
+  });
+
+  it('fills a BYOB view that is not a Uint8Array', async () => {
+    const { handle } = createHandle();
+    const buffer = new ArrayBuffer(32);
+    const view = new Uint16Array(buffer, 8, 8);
+    const { controller, responded } = createController(view);
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    expect(responded).toEqual([16]);
+    expect(Array.from(new Uint8Array(buffer, 8, 16))).toEqual(Array.from(CONTENTS.subarray(0, 16)));
+  });
+
+  it('closes the stream when the handle is exhausted', async () => {
+    const { handle } = createHandle(new Uint8Array(0));
+    const view = new Uint8Array(new ArrayBuffer(32), 8, 16);
+    const { controller, responded } = createController(view);
+    const close = jest.spyOn(controller, 'close');
+
+    await new FileSystemReadableStreamSource(handle).pull(controller);
+
+    expect(close).toHaveBeenCalled();
+    expect(responded).toEqual([0]);
+  });
+});

--- a/packages/expo-file-system/src/internal/streams.ts
+++ b/packages/expo-file-system/src/internal/streams.ts
@@ -26,20 +26,15 @@ export class FileSystemReadableStreamSource implements UnderlyingByteSource {
     }
 
     // TODO: Optimize by adding a native method that can write into a TypedArray at a given offset.
-    const bytes = await this.handle.readBytes(theView.byteLength - theView.byteOffset);
+    // `byteLength` is already the size of the region to fill, so `byteOffset` must not be
+    // subtracted from it, and `set` takes an offset relative to the view it is called on.
+    const bytes = await this.handle.readBytes(theView.byteLength);
     if (bytes.length === 0) {
       controller.close();
       controller.byobRequest.respond(0);
       return;
     }
-    if (theView instanceof Uint8Array) {
-      theView.set(bytes, theView.byteOffset);
-    } else {
-      const array = new Uint8Array(theView.buffer);
-      for (let i = 0; i < bytes.length; i++) {
-        array[i + (theView.byteOffset ?? 0)] = bytes[i]!;
-      }
-    }
+    new Uint8Array(theView.buffer, theView.byteOffset, theView.byteLength).set(bytes);
     controller.byobRequest.respond(bytes.length);
   }
 }


### PR DESCRIPTION
# Why

`File.readableStream()` returns zeroed bytes, and silently corrupts the caller's buffer, when it is read with a BYOB reader whose view starts at a non-zero offset.

`byobRequest.view` covers the region of the caller's buffer that the stream still has to fill. `byteLength` is already that region's size, and `byteOffset` is where it begins in the buffer. [`FileSystemReadableStreamSource.pull`](https://github.com/expo/expo/blob/main/packages/expo-file-system/src/internal/streams.ts#L28-L41) treated both as if they were measured from the start of the buffer:

```ts
const bytes = await this.handle.readBytes(theView.byteLength - theView.byteOffset);
...
if (theView instanceof Uint8Array) {
  theView.set(bytes, theView.byteOffset);
} else {
  const array = new Uint8Array(theView.buffer);
  for (let i = 0; i < bytes.length; i++) {
    array[i + (theView.byteOffset ?? 0)] = bytes[i]!;
  }
}
```

Two defects:

1. `readBytes(byteLength - byteOffset)` under-reads by `byteOffset`, and asks for a non-positive length once `byteOffset >= byteLength`.
2. `theView.set(bytes, theView.byteOffset)` — `set` takes an offset **relative to the view**, and the view already starts at `byteOffset`, so the offset is applied twice.

The two branches of that `if` disagree with each other. The `else` branch indexes a whole-buffer `Uint8Array` by `i + byteOffset`, which is correct. Only the `Uint8Array` branch double-applies.

`byobRequest.view` has a non-zero `byteOffset` whenever the caller passes an offset view, and also on any continuation of a partially-filled BYOB read, since the spec builds the view as `(buffer, byteOffset + bytesFilled, byteLength - bytesFilled)`.

# How

`byteLength` is the amount to read, and the write goes through a `Uint8Array` bounded to the view's region:

```ts
const bytes = await this.handle.readBytes(theView.byteLength);
...
new Uint8Array(theView.buffer, theView.byteOffset, theView.byteLength).set(bytes);
```

That is correct for every view type, so the `instanceof` branch goes away. The `TODO` above it still stands — a native method writing straight into the view at an offset would avoid this copy.

Partial reads are unaffected: a short `bytes` writes only what it has, and `respond(bytes.length)` is unchanged.

# Test Plan

New unit tests in `src/internal/__tests__/streams-test.ts`. They drive `pull()` with a `byobRequest` stand-in, because jsdom has no `ReadableStream` and the Web jest project would otherwise fail with `ReferenceError: ReadableStream is not defined`.

Before, on `main`:

```
Tests:       12 failed, 12 passed, 24 total
Test Suites: 4 failed, 4 total
```

The three failing cases, in all four projects:

```
✕ fills a BYOB view that starts at a non-zero offset in its buffer
✕ requests as many bytes as the BYOB view can hold
✕ fills a BYOB view that is not a Uint8Array
```

After:

```
PASS Node | PASS Web | PASS Android | PASS iOS
Tests:       24 passed, 24 total
```

I also checked this end to end against Node's real `ReadableStream`, reading a file of `1..64` through a BYOB reader with `new Uint8Array(new ArrayBuffer(32), 8, 16)`.

`main`:

```
value bytes    : [0,0,0,0,0,0,0,0]
expected       : [1,2,3,4,5,6,7,8]
whole buffer   : [0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0, 1,2,3,4,5,6,7,8, 0,0,0,0,0,0,0,0]
```

The caller gets eight zero bytes, and the file data is written at offset 16 — past the range `respond()` reported as filled, so it also clobbers whatever the caller had after the view.

This PR:

```
value bytes    : [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
expected       : [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
whole buffer   : [0,0,0,0,0,0,0,0, 1,2,...,16, 0,0,0,0,0,0,0,0]
```

`et check-packages expo-file-system` -> `🏁 All checks passed`.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Added tests that fail on `main` and pass here.
- [x] Conforms to the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
