### PR TITLE
[android][maps] Don't enable my-location without the location permission

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `isMyLocationEnabled` crashing the app with a `SecurityException` when the location permission has not been granted. The prop is now a request that is ignored without the permission, matching iOS. ([#49198](https://github.com/expo/expo/issues/49198), [#49235](https://github.com/expo/expo/pull/49235) by [@dennytosp](https://github.com/dennytosp))
 - [iOS] Stop `AppleMaps.View`'s `onMapClick` from firing when the tap landed on a marker, an annotation, or a drawn shape, as documented. ([#49193](https://github.com/expo/expo/pull/49193) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Return the `Promise` from `GoogleMaps.View`'s imperative `setCameraPosition` so callers can `await` it and catch the `Animation cancelled` rejection (matches iOS). ([#46421](https://github.com/expo/expo/pull/46421) by [@chownation](https://github.com/chownation))
 - [Android] Fixed Google Maps marker info windows reserving blank snippet space when `snippet` is omitted. ([#47271](https://github.com/expo/expo/pull/47271) by [@eliotgevers](https://github.com/eliotgevers))

--- a/packages/expo-maps/android/build.gradle
+++ b/packages/expo-maps/android/build.gradle
@@ -39,4 +39,6 @@ dependencies {
   implementation 'androidx.compose.material3:material3-android:1.3.2'
 
   implementation 'com.google.maps.android:maps-compose:6.10.0'
+
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -1,12 +1,15 @@
 package expo.modules.maps
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Point
 import android.graphics.drawable.Drawable
 import android.view.MotionEvent
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -111,7 +114,7 @@ class GoogleMapsView(context: Context, appContext: AppContext) :
       modifier = Modifier.fillMaxSize(),
       cameraPositionState = cameraState,
       uiSettings = props.uiSettings.value.toMapUiSettings(),
-      properties = props.properties.value.toMapProperties(),
+      properties = props.properties.value.toMapProperties(context.hasLocationPermission()),
       contentPadding = props.contentPadding.value.let {
         PaddingValues(start = it.start.dp, end = it.end.dp, top = it.top.dp, bottom = it.bottom.dp)
       },
@@ -457,3 +460,11 @@ private fun MapCircles(
     )
   }
 }
+
+/**
+ * Whether the app can show the user's location. The Maps SDK throws a `SecurityException` from
+ * `setMyLocationEnabled` unless one of these is granted.
+ */
+internal fun Context.hasLocationPermission(): Boolean =
+  ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
+    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
@@ -248,12 +248,14 @@ data class MapPropertiesRecord(
   @Field
   val minZoomPreference: Float = 3.0f
 ) : Record {
-  fun toMapProperties(): MapProperties {
+  fun toMapProperties(hasLocationPermission: Boolean): MapProperties {
     val mapStyleOptionsParsed = mapStyleOptions?.json?.let { MapStyleOptions(it) }
     return MapProperties(
       isBuildingEnabled = isBuildingEnabled,
       isIndoorEnabled = isIndoorEnabled,
-      isMyLocationEnabled = isMyLocationEnabled,
+      // The Maps SDK throws a SecurityException from setMyLocationEnabled when the app holds
+      // neither location permission, which crashes the app on the map's first composition.
+      isMyLocationEnabled = isMyLocationEnabled && hasLocationPermission,
       isTrafficEnabled = isTrafficEnabled,
       mapStyleOptions = mapStyleOptionsParsed,
       mapType = mapType.toMapType(),

--- a/packages/expo-maps/android/src/test/java/expo/modules/maps/MapPropertiesRecordTest.kt
+++ b/packages/expo-maps/android/src/test/java/expo/modules/maps/MapPropertiesRecordTest.kt
@@ -1,0 +1,49 @@
+package expo.modules.maps
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MapPropertiesRecordTest {
+  @Test
+  fun `my location stays disabled without the location permission`() {
+    val record = MapPropertiesRecord(isMyLocationEnabled = true)
+
+    val properties = record.toMapProperties(hasLocationPermission = false)
+
+    assertFalse(properties.isMyLocationEnabled)
+  }
+
+  @Test
+  fun `my location is enabled with the location permission`() {
+    val record = MapPropertiesRecord(isMyLocationEnabled = true)
+
+    val properties = record.toMapProperties(hasLocationPermission = true)
+
+    assertTrue(properties.isMyLocationEnabled)
+  }
+
+  @Test
+  fun `my location stays disabled when it was not requested`() {
+    val record = MapPropertiesRecord(isMyLocationEnabled = false)
+
+    val properties = record.toMapProperties(hasLocationPermission = true)
+
+    assertFalse(properties.isMyLocationEnabled)
+  }
+
+  @Test
+  fun `the other properties are unaffected by the location permission`() {
+    val record = MapPropertiesRecord(
+      isBuildingEnabled = true,
+      isIndoorEnabled = true,
+      isTrafficEnabled = true
+    )
+
+    val properties = record.toMapProperties(hasLocationPermission = false)
+
+    assertTrue(properties.isBuildingEnabled)
+    assertTrue(properties.isIndoorEnabled)
+    assertTrue(properties.isTrafficEnabled)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #49198.

`GoogleMaps.View` with `properties={{ isMyLocationEnabled: true }}` crashes the whole Android app when the location permission has not been granted:

```
java.lang.SecurityException: my location requires permission ACCESS_FINE_LOCATION or ACCESS_COARSE_LOCATION
  com.google.android.gms.maps.GoogleMap.setMyLocationEnabled(play-services-maps@@19.2.0:1)
  com.google.maps.android.compose.MapUpdaterKt$MapUpdater$1$2$8.invoke(MapUpdater.kt:133)
  ...
  androidx.compose.runtime.CompositionImpl.composeInitial(Composition.kt:732)
```

[`MapPropertiesRecord.toMapProperties`](https://github.com/expo/expo/blob/main/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt#L251) passed the flag through unconditionally, and nothing else in the Android module checked the permission. `maps-compose` then calls `GoogleMap.setMyLocationEnabled(true)` during composition, and the Maps SDK throws.

The `composeInitial` frame is the point: this happens on the map's first composition, so there is no JS boundary to catch it and the process dies. Any app that asks for the location permission on the same screen that renders the map hits this on a fresh install, because the map composes before the dialog is answered.

iOS treats the same prop as a request, not a command — it only decides whether to render `UserAnnotation()` ([`AppleMapsViewiOS17.swift:99`](https://github.com/expo/expo/blob/main/packages/expo-maps/ios/AppleMapsViewiOS17.swift#L99), [`AppleMapsViewiOS18.swift:154`](https://github.com/expo/expo/blob/main/packages/expo-maps/ios/AppleMapsViewiOS18.swift#L154)), which is a no-op without the permission. So the two platforms disagreed about what the prop means when the permission is missing.

# How

Android now treats it as a request too. `toMapProperties` takes the permission state and ands it in:

```kotlin
fun toMapProperties(hasLocationPermission: Boolean): MapProperties {
  ...
  isMyLocationEnabled = isMyLocationEnabled && hasLocationPermission,
```

`GoogleMapsView` supplies it from the view's context:

```kotlin
internal fun Context.hasLocationPermission(): Boolean =
  ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
    ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
```

The parameter is required rather than defaulted, so a future call site has to decide rather than silently inherit a default.

Either permission is accepted, matching what the Maps SDK itself requires — coarse location is enough for the blue dot.

Note on scope: the permission is read when the map composes. Granting the permission afterwards shows the dot on the next recomposition, which is what a normal permission flow produces since the app re-renders after the grant. Observing the permission live would need a lifecycle observer, which felt like more than this crash fix should carry — happy to add it if you would rather have it here.

# Test Plan

`packages/expo-maps/android/src/test/java/expo/modules/maps/MapPropertiesRecordTest.kt`, four cases, run with `et native-unit-tests -p android --packages expo-maps`.

```
MapPropertiesRecordTest  tests=4 failures=0 errors=0 skipped=0

  PASS my location stays disabled without the location permission
  PASS my location is enabled with the location permission
  PASS my location stays disabled when it was not requested
  PASS the other properties are unaffected by the location permission

BUILD SUCCESSFUL
Finished android unit tests successfully.
```

I also mutation-checked the tests: reverting the guard to `isMyLocationEnabled = isMyLocationEnabled` while keeping the new parameter makes them fail, so they are testing the guard rather than passing by construction.

```
> Task :expo-maps:testDebugUnitTest FAILED
MapPropertiesRecordTest > my location stays disabled without the location permission FAILED
4 tests completed, 1 failed
BUILD FAILED
```

`expo-maps` had no `src/test` directory, so this PR adds one plus a `testImplementation 'junit:junit:4.13.2'` line, matching how `expo-secure-store` wires its Android unit tests.

I did not run the reproduction app on a device — I do not have a Play-services emulator image set up here. The crash path is `setMyLocationEnabled(true)` throwing without the permission, and this change stops `true` from reaching it, which is what the reporter's stack trace points at.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Added unit tests.
- [x] Conforms to the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
