### PR TITLE
[docs] Explain Android lifecycle package autolinking

### DIFF
--- a/docs/pages/modules/android-lifecycle-listeners.mdx
+++ b/docs/pages/modules/android-lifecycle-listeners.mdx
@@ -16,9 +16,7 @@ First, you need to have created an Expo module or integrated the Expo modules AP
 
 Inside your module, create a concrete class that implements the [`Package`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Package.java) interface. For most cases, you only need to implement the `createReactActivityLifecycleListeners` or `createApplicationLifecycleListeners` methods.
 
-You do not need to register this class in **MainApplication.java** or **MainApplication.kt**. [Expo Autolinking](/modules/autolinking/) scans each linked module's Android sources for classes in files ending in **Package.java** or **Package.kt** that implement the `Package` interface. During the Android build, it adds those classes to the generated `ExpoModulesPackageList`, which Expo uses to create the lifecycle listeners. No additional entry in **expo-module.config.json** is required for the `Package` class itself, as long as the module is already configured for Android.
-
-If you add a `Package` class after the Android project has already been built and it is not detected, run `./gradlew clean` from the app's **android** directory and rebuild the app. This forces Gradle to regenerate the package list.
+You do not need to register this class in **MainApplication.java** or **MainApplication.kt**. [Expo Autolinking](/modules/autolinking/) scans each linked module's Android sources for classes in files ending in **Package.java** or **Package.kt** that implement the `Package` interface. During the Android build, it adds those classes to the generated `ExpoModulesPackageList`, which Expo uses to create the lifecycle listeners. If the module already supports Android, you also do not need to add the `Package` class to **expo-module.config.json**.
 
 ## `Activity` lifecycle listeners
 

--- a/docs/pages/modules/android-lifecycle-listeners.mdx
+++ b/docs/pages/modules/android-lifecycle-listeners.mdx
@@ -16,6 +16,10 @@ First, you need to have created an Expo module or integrated the Expo modules AP
 
 Inside your module, create a concrete class that implements the [`Package`](https://github.com/expo/expo/tree/main/packages/expo-modules-core/android/src/main/java/expo/modules/core/interfaces/Package.java) interface. For most cases, you only need to implement the `createReactActivityLifecycleListeners` or `createApplicationLifecycleListeners` methods.
 
+You do not need to register this class in **MainApplication.java** or **MainApplication.kt**. [Expo Autolinking](/modules/autolinking/) scans each linked module's Android sources for classes in files ending in **Package.java** or **Package.kt** that implement the `Package` interface. During the Android build, it adds those classes to the generated `ExpoModulesPackageList`, which Expo uses to create the lifecycle listeners. No additional entry in **expo-module.config.json** is required for the `Package` class itself, as long as the module is already configured for Android.
+
+If you add a `Package` class after the Android project has already been built and it is not detected, run `./gradlew clean` from the app's **android** directory and rebuild the app. This forces Gradle to regenerate the package list.
+
 ## `Activity` lifecycle listeners
 
 You can hook into the `Activity` lifecycle using `ReactActivityLifecycleListener`. `ReactActivityLifecycleListener` hooks into React Native's `ReactActivity` lifecycle using its `ReactActivityDelegate` and provides a similar experience to the Android `Activity` lifecycle.


### PR DESCRIPTION
## Why

The Android lifecycle listener guide explains how to implement `expo.modules.core.interfaces.Package`, but it does not explain how that class is registered. This leaves module authors unsure whether they need to edit `MainApplication` or `expo-module.config.json`.

## What changed

- clarify that Expo Autolinking discovers Android source files ending in `Package.java` or `Package.kt` that implement `Package`
- explain that the Android build adds them to the generated `ExpoModulesPackageList`
- document that no manual `MainApplication` or package config entry is needed
- add the Gradle clean/rebuild recovery step for a stale generated package list

## Test plan

- `cd docs && pnpm test` — 58 suites, 620 tests passed
- `cd docs && pnpm test:worker` — all worker and route checks passed
- `cd docs && NODE_ENV=production pnpm lint --max-warnings 0` — passed
- `cd docs && pnpm lint-prose` — 0 errors, warnings, or suggestions
- `cd docs && pnpm lint` — passed

Closes #28409.