### PR TITLE
[expo-audio] Preserve the record(forDuration:) limit across an audio session interruption

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Paused time is now excluded from the `AudioRecorder` duration limit. ([#49239](https://github.com/expo/expo/pull/49239) by [@stvrmrz](https://github.com/stvrmrz) and [@behenate](https://github.com/behenate))
 - [Android] Aligned the default audio focus request on Android 7.0–7.1 with newer versions by using transient exclusive focus when no interruption mode has been configured. ([#49101](https://github.com/expo/expo/pull/49101) by [@behenate](https://github.com/behenate))
 
 ### 🎉 New features
@@ -17,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Preserve recorder duration limits across pauses, consistently exclude paused time on Android, iOS, and Web. ([#49239](https://github.com/expo/expo/pull/49239) by [@stvrmrz](https://github.com/stvrmrz) and [@behenate](https://github.com/behenate))
 - [Android] Pause audio players and playlists when headphones or Bluetooth audio devices disconnect. ([#48151](https://github.com/expo/expo/pull/48151) by [@vivekjm](https://github.com/vivekjm))
 - [Android] Give the lock-screen `MediaSession` instances a unique ID so concurrent active players (and the basic session) no longer collide on the empty default. ([#47101](https://github.com/expo/expo/issues/47101) by [@tsushanth](https://github.com/tsushanth))
 - [Android] Fix stale lock screen artwork when updating metadata without an `artworkUrl`. ([#45738](https://github.com/expo/expo/pull/45738) by [@behenate](https://github.com/behenate))

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecorder.kt
@@ -47,6 +47,7 @@ class AudioRecorder(
   var isRecording = false
   var isPaused = false
   private var recordingTimerJob: Job? = null
+  private var durationLimitMillis: Long? = null
   var useForegroundService = false
 
   val serviceConnection = AudioRecordingServiceConnection(WeakReference(this), appContext)
@@ -118,6 +119,11 @@ class AudioRecorder(
       }
     }
 
+    if (isPaused && durationLimitMillis?.let { durationAlreadyRecorded >= it } == true) {
+      stopRecording()
+      return
+    }
+
     if (isPaused) {
       recorder?.resume()
     } else {
@@ -126,26 +132,23 @@ class AudioRecorder(
     startTime = System.currentTimeMillis()
     isRecording = true
     isPaused = false
+    scheduleRecordingStop()
   }
 
   fun recordWithOptions(atTimeSeconds: Double? = null, forDurationSeconds: Double? = null) {
     recordingTimerJob?.cancel()
+    recordingTimerJob = null
 
     // Note: atTime is not supported on Android (no native equivalent), so we ignore it entirely
     // Only forDuration is implemented using coroutines
+    if (forDurationSeconds != null) {
+      durationLimitMillis = (forDurationSeconds * 1000).toLong()
+    } else if (!isPaused || atTimeSeconds != null) {
+      // A bare record() resumes the current capture and keeps its limit.
+      durationLimitMillis = null
+    }
 
-    forDurationSeconds?.let {
-      record()
-      recordingTimerJob = appContext?.mainQueue?.launch {
-        delay((it * 1000).toLong())
-        // Stop recording regardless of current state
-        // This matches the iOS behaviour where the timer continues regardless of if
-        // the recording was paused.
-        if (isRecording || isPaused) {
-          stopRecording()
-        }
-      }
-    } ?: record()
+    record()
   }
 
   // Keep backward compatibility methods
@@ -158,10 +161,24 @@ class AudioRecorder(
   }
 
   fun pauseRecording() {
+    recordingTimerJob?.cancel()
+    recordingTimerJob = null
     recorder?.pause()
     durationAlreadyRecorded = getAudioRecorderDurationMillis()
     isRecording = false
     isPaused = true
+  }
+
+  private fun scheduleRecordingStop() {
+    recordingTimerJob?.cancel()
+    recordingTimerJob = durationLimitMillis?.let { limit ->
+      appContext?.mainQueue?.launch {
+        delay((limit - getAudioRecorderDurationMillis()).coerceAtLeast(0))
+        if (isRecording) {
+          stopRecording()
+        }
+      }
+    }
   }
 
   fun stopRecording(): Bundle {
@@ -220,6 +237,7 @@ class AudioRecorder(
     isRecording = false
     isPaused = false
     durationAlreadyRecorded = 0
+    durationLimitMillis = null
     startTime = 0L
     isPrepared = false
   }

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -483,8 +483,7 @@ public class AudioModule: Module {
         case let (atTime?, forDuration?):
           // Convert relative delay to absolute device time
           let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
-          recorder.ref.record(atTime: absoluteTime, forDuration: TimeInterval(forDuration))
-          recorder.updateStateForDirectRecording()
+          recorder.recordForDuration(TimeInterval(forDuration), atTime: absoluteTime)
           return recorder.getRecordingStatus()
         case let (atTime?, nil):
           // Convert relative delay to absolute device time
@@ -493,8 +492,7 @@ public class AudioModule: Module {
           recorder.updateStateForDirectRecording()
           return recorder.getRecordingStatus()
         case let (nil, forDuration?):
-          recorder.ref.record(forDuration: TimeInterval(forDuration))
-          recorder.updateStateForDirectRecording()
+          recorder.recordForDuration(TimeInterval(forDuration))
           return recorder.getRecordingStatus()
         case (nil, nil):
           return try recorder.startRecording()
@@ -522,7 +520,7 @@ public class AudioModule: Module {
 
       Function("recordForDuration") { (recorder, seconds: Double) in
         try checkPermissions()
-        recorder.ref.record(forDuration: TimeInterval(seconds))
+        recorder.recordForDuration(TimeInterval(seconds))
       }
 
       Function("getAvailableInputs") {

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -488,8 +488,7 @@ public class AudioModule: Module {
         case let (atTime?, nil):
           // Convert relative delay to absolute device time
           let absoluteTime = recorder.ref.deviceCurrentTime + TimeInterval(atTime)
-          recorder.ref.record(atTime: absoluteTime)
-          recorder.updateStateForDirectRecording()
+          recorder.record(atTime: absoluteTime)
           return recorder.getRecordingStatus()
         case let (nil, forDuration?):
           recorder.recordForDuration(TimeInterval(forDuration))
@@ -515,7 +514,7 @@ public class AudioModule: Module {
 
       Function("startRecordingAtTime") { (recorder, seconds: Double) in
         try checkPermissions()
-        recorder.ref.record(atTime: TimeInterval(seconds))
+        recorder.record(atTime: TimeInterval(seconds))
       }
 
       Function("recordForDuration") { (recorder, seconds: Double) in

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -23,8 +23,6 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   private var mediaServicesDidReset = false
   private var currentOptions: RecordingOptions?
   private var currentSessionOptions: AVAudioSession.CategoryOptions = []
-  // The duration a recording was armed with via `record({ forDuration })`.
-  // Remembered so an interruption resume can re-apply it — see `startRecording()`.
   private var durationLimitSeconds: TimeInterval?
 
   private var isPrepared: Bool {
@@ -132,9 +130,12 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     // boundaries instead.
   }
 
-  /// Arms `record(forDuration:)` and remembers the limit so it survives a
-  /// pause/resume. Callers should use this rather than driving `ref` directly.
   func recordForDuration(_ seconds: TimeInterval, atTime absoluteTime: TimeInterval? = nil) {
+    if currentState == .paused && ref.currentTime >= seconds {
+      stopRecording()
+      return
+    }
+
     if let absoluteTime {
       ref.record(atTime: absoluteTime, forDuration: seconds)
     } else {
@@ -142,6 +143,12 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     }
     updateStateForDirectRecording()
     durationLimitSeconds = seconds
+  }
+
+  func record(atTime absoluteTime: TimeInterval) {
+    ref.record(atTime: absoluteTime)
+    updateStateForDirectRecording()
+    durationLimitSeconds = nil
   }
 
   func startRecording() throws -> [String: Any] {
@@ -157,13 +164,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       resetDurationTracking()
     }
 
-    // If the recording was armed with a duration, re-apply it. A bare
-    // `ref.record()` carries no duration, so resuming after an interruption
-    // silently dropped the limit and the recording would continue indefinitely.
-    //
-    // `forDuration` is absolute rather than incremental — the recorder stops
-    // when its own `currentTime` reaches the value — so the ORIGINAL limit is
-    // re-applied, not a remaining-time calculation.
+    // If the recording was armed with a duration, re-apply it.
     if let limit = durationLimitSeconds {
       if ref.currentTime >= limit {
         // The allowance is already spent; stop rather than resume.

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -23,6 +23,9 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   private var mediaServicesDidReset = false
   private var currentOptions: RecordingOptions?
   private var currentSessionOptions: AVAudioSession.CategoryOptions = []
+  // The duration a recording was armed with via `record({ forDuration })`.
+  // Remembered so an interruption resume can re-apply it — see `startRecording()`.
+  private var durationLimitSeconds: TimeInterval?
 
   private var isPrepared: Bool {
     currentState == .prepared || currentState == .recording || currentState == .paused
@@ -81,6 +84,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       ref.stop()
     }
     resetDurationTracking()
+    durationLimitSeconds = nil
     mediaServicesDidReset = false
 
     let session = AVAudioSession.sharedInstance()
@@ -121,6 +125,23 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   private func resetDurationTracking() {
     startTimestamp = 0
     totalRecordedDuration = 0
+    // `durationLimitSeconds` is deliberately NOT cleared here. This helper runs
+    // from `updateStateForDirectRecording()`, which is called *after* a
+    // `record(forDuration:)` has already armed the limit, so clearing it here
+    // would discard the limit the caller just set. It is cleared at capture
+    // boundaries instead.
+  }
+
+  /// Arms `record(forDuration:)` and remembers the limit so it survives a
+  /// pause/resume. Callers should use this rather than driving `ref` directly.
+  func recordForDuration(_ seconds: TimeInterval, atTime absoluteTime: TimeInterval? = nil) {
+    if let absoluteTime {
+      ref.record(atTime: absoluteTime, forDuration: seconds)
+    } else {
+      ref.record(forDuration: seconds)
+    }
+    updateStateForDirectRecording()
+    durationLimitSeconds = seconds
   }
 
   func startRecording() throws -> [String: Any] {
@@ -136,7 +157,23 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
       resetDurationTracking()
     }
 
-    ref.record()
+    // If the recording was armed with a duration, re-apply it. A bare
+    // `ref.record()` carries no duration, so resuming after an interruption
+    // silently dropped the limit and the recording would continue indefinitely.
+    //
+    // `forDuration` is absolute rather than incremental — the recorder stops
+    // when its own `currentTime` reaches the value — so the ORIGINAL limit is
+    // re-applied, not a remaining-time calculation.
+    if let limit = durationLimitSeconds {
+      if ref.currentTime >= limit {
+        // The allowance is already spent; stop rather than resume.
+        stopRecording()
+        return getRecordingStatus()
+      }
+      ref.record(forDuration: limit)
+    } else {
+      ref.record()
+    }
 
     startTimestamp = deviceCurrentTime
     currentState = .recording
@@ -160,6 +197,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     ref.stop()
     currentState = .stopped
     resetDurationTracking()
+    durationLimitSeconds = nil
   }
 
   func pauseRecording() {
@@ -194,6 +232,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
   func handleMediaServicesReset() {
     mediaServicesDidReset = true
     resetDurationTracking()
+    durationLimitSeconds = nil
 
     if let options = currentOptions {
       do {
@@ -225,6 +264,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     // Update internal state when recording finishes automatically (e.g., from recordForDuration)
     currentState = .stopped
     resetDurationTracking()
+    durationLimitSeconds = nil
 
     emit(event: recordingStatus, payload: [
       "id": id,
@@ -239,6 +279,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     // Update internal state on error
     currentState = .error
     resetDurationTracking()
+    durationLimitSeconds = nil
 
     emit(event: recordingStatus, payload: [
       "id": id,

--- a/packages/expo-audio/src/Audio.types.ts
+++ b/packages/expo-audio/src/Audio.types.ts
@@ -367,8 +367,9 @@ export type BitRateStrategy = 'constant' | 'longTermAverage' | 'variableConstrai
  */
 export type RecordingStartOptions = {
   /**
-   * The duration in seconds after which recording should automatically stop.
-   * If not provided, recording continues until manually stopped.
+   * The maximum duration of recorded audio, in seconds. Time spent paused does not count
+   * toward the limit. A limited recording keeps the same limit when resumed without options.
+   * If not provided when starting a new recording, recording continues until manually stopped.
    *
    * @platform ios
    * @platform android

--- a/packages/expo-audio/src/AudioRecorder.web.ts
+++ b/packages/expo-audio/src/AudioRecorder.web.ts
@@ -20,6 +20,8 @@ export class AudioRecorderWeb
   }
 
   async setup() {
+    this.clearTimeouts();
+    this.durationLimitMillis = null;
     this.mediaRecorder = await this.createMediaRecorder(this.options);
   }
 
@@ -32,6 +34,7 @@ export class AudioRecorderWeb
   private mediaRecorderUptimeOfLastStartResume = 0;
   private mediaRecorderIsRecording = false;
   private timeoutIds: ReturnType<typeof setTimeout>[] = [];
+  private durationLimitMillis: number | null = null;
   private cachedInputs: RecordingInput[] = [];
   private selectedDeviceId: string | null = null;
   private stream: MediaStream | null = null;
@@ -53,22 +56,31 @@ export class AudioRecorderWeb
       );
     }
 
-    // Clear any existing timeouts
+    const wasPaused = this.mediaRecorder.state === 'paused';
     this.clearTimeouts();
 
     // Note: atTime is not supported on Web (no native equivalent), so we ignore it entirely
     // Only forDuration is implemented using setTimeout
-    const { forDuration } = options || {};
+    const { atTime, forDuration } = options || {};
+    if (forDuration !== undefined) {
+      this.durationLimitMillis = forDuration * 1000;
+    } else if (!wasPaused || atTime !== undefined) {
+      // A bare record() resumes the current capture and keeps its limit. Starting a
+      // new capture without forDuration, including record({ atTime }), clears it.
+      this.durationLimitMillis = null;
+    }
+
+    if (
+      wasPaused &&
+      this.durationLimitMillis !== null &&
+      this.getAudioRecorderDurationMillis() >= this.durationLimitMillis
+    ) {
+      this.stop();
+      return;
+    }
 
     this.startActualRecording();
-
-    if (forDuration !== undefined) {
-      this.timeoutIds.push(
-        setTimeout(() => {
-          this.stop();
-        }, forDuration * 1000)
-      );
-    }
+    this.scheduleRecordingStop();
   }
 
   private startActualRecording(): void {
@@ -126,7 +138,8 @@ export class AudioRecorderWeb
       );
     }
 
-    this.mediaRecorder?.pause();
+    this.clearTimeouts();
+    this.mediaRecorder.pause();
   }
 
   recordForDuration(seconds: number): void {
@@ -151,6 +164,9 @@ export class AudioRecorderWeb
       );
     }
 
+    this.clearTimeouts();
+    this.durationLimitMillis = null;
+
     const dataPromise = new Promise<Blob>((resolve) =>
       this.mediaRecorder?.addEventListener('dataavailable', (e) => resolve(e.data))
     );
@@ -174,6 +190,23 @@ export class AudioRecorderWeb
 
   clearTimeouts() {
     this.timeoutIds.forEach((id) => clearTimeout(id));
+    this.timeoutIds = [];
+  }
+
+  private scheduleRecordingStop() {
+    if (this.durationLimitMillis === null) {
+      return;
+    }
+
+    const remainingDuration = Math.max(
+      0,
+      this.durationLimitMillis - this.getAudioRecorderDurationMillis()
+    );
+    this.timeoutIds.push(
+      setTimeout(() => {
+        this.stop();
+      }, remainingDuration)
+    );
   }
 
   private async createMediaRecorder(
@@ -252,6 +285,8 @@ export class AudioRecorderWeb
     });
 
     mediaRecorder?.addEventListener('stop', () => {
+      this.clearTimeouts();
+      this.durationLimitMillis = null;
       this.currentTime = 0;
       this.mediaRecorderIsRecording = false;
       this.stream = null;

--- a/packages/expo-audio/src/__tests__/AudioRecorderWeb-test.ts
+++ b/packages/expo-audio/src/__tests__/AudioRecorderWeb-test.ts
@@ -87,3 +87,82 @@ describe('AudioRecorderWeb fileSize', () => {
     expect(recorder.getStatus().fileSize).toBe(0);
   });
 });
+
+describe('AudioRecorderWeb duration limit', () => {
+  beforeEach(() => {
+    mockMediaDevices();
+    jest.useFakeTimers();
+    jest.setSystemTime(1000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('counts recorded time and preserves the limit across a bare resume', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    const stopSpy = jest.spyOn(recorder, 'stop').mockResolvedValue(undefined);
+
+    recorder.record({ forDuration: 10 });
+    jest.advanceTimersByTime(3000);
+    recorder.pause();
+
+    jest.advanceTimersByTime(20000);
+    expect(recorder.getStatus().durationMillis).toBe(3000);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    recorder.record();
+    jest.advanceTimersByTime(6999);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a new forDuration value as an absolute recording limit', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    const stopSpy = jest.spyOn(recorder, 'stop').mockResolvedValue(undefined);
+
+    recorder.record({ forDuration: 10 });
+    jest.advanceTimersByTime(3000);
+    recorder.pause();
+    recorder.record({ forDuration: 5 });
+
+    jest.advanceTimersByTime(1999);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a previous limit when arming without a duration', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    const stopSpy = jest.spyOn(recorder, 'stop').mockResolvedValue(undefined);
+
+    recorder.record({ forDuration: 10 });
+    jest.advanceTimersByTime(3000);
+    recorder.pause();
+    recorder.record({ atTime: 1 });
+    jest.advanceTimersByTime(20000);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops instead of resuming when a replacement limit is already spent', async () => {
+    const recorder = new AudioRecorderWeb({});
+    await recorder.prepareToRecordAsync();
+    const stopSpy = jest.spyOn(recorder, 'stop').mockResolvedValue(undefined);
+
+    recorder.record({ forDuration: 10 });
+    jest.advanceTimersByTime(3000);
+    recorder.pause();
+    recorder.record({ forDuration: 2 });
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(recorder.isRecording).toBe(false);
+  });
+});


### PR DESCRIPTION
# Why

On iOS, a recording armed with `record({ forDuration })` loses its duration limit if an audio session interruption occurs. `handleInterruptionBegan` pauses the recorder, and the `.shouldResume` path reaches `startRecording()`, which resumes with a **bare `ref.record()`** — carrying no duration. The recording then continues indefinitely.

An incoming call, an alarm, or Siri is enough to trigger it, and nothing in the app is called, so there is no opportunity to re-arm from JS.

Measured on a physical iPhone 17 Pro Max (iOS 26.5), `expo-audio@57.0.3`: a recorder armed `forDuration: 6.0`, paused, then resumed via the bare call captured **14.06 s and was still going**.

# What this changes

`AudioRecorder` remembers the duration a recording was armed with, and `startRecording()` re-applies it instead of resuming unbounded.

Two details that matter:

**The limit is re-applied absolutely, not as a remainder.** `record(forDuration:)` stops when the recorder's own `currentTime` *reaches* the value, and `currentTime` is cumulative across pause/resume — so the original limit is correct. Re-arming with a computed remainder was measured to end the recording early: 3.98 s against a 6.0 s arm.

**`resetDurationTracking()` deliberately does not clear the limit.** `updateStateForDirectRecording()` calls that helper *after* `record(forDuration:)` has armed the limit, so clearing it there would discard the value the caller just set — and the first interruption would resume unbounded again. The limit is cleared at capture boundaries instead: `prepare`, `stopRecording`, `didFinish`, `encodeErrorDidOccur`, and `handleMediaServicesReset`.

If the allowance is already spent when the resume arrives, the recorder stops rather than resuming, which routes through the existing `didFinish` path and emits `isFinished` as usual.

All three arming paths (`record({ forDuration })`, `record({ atTime, forDuration })`, and the deprecated `recordForDuration`) now go through one method, so none of them can bypass the limit.

# Test Plan

Verified on a physical device against `expo-audio@57.0.3` with the equivalent change applied:

- armed 6.0 s, paused, resumed bare → **before:** 14.06 s and climbing; **after:** stops at 6.000 s
- a real Clock-alarm interruption during a 120 s-capped recording → resumes and ends at **exactly 120.0000 s** of audio, verified by parsing the CAF `data` chunk, across 4 trials
- one canonical file throughout; the recorder's `didFinish` fires normally at the limit

I could not run the repo's own iOS test suite for `expo-audio`; the verification above is device-level against the published package.
