### PR TITLE
fix(dev-launcher): [iOS] take the lightweight manifest path for a live dev server [retracted — do not merge]

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Take the lightweight manifest path for a live Expo dev server (`application/expo+json`) instead of the `expo-updates` fetch, which exists for published manifests. ([#49250](https://github.com/expo/expo/pull/49250) by [@saileshbro](https://github.com/saileshbro))
 - [Android] Fix SIGABRT when loading a development server URL that has no path (e.g. `http://192.168.1.2:8081`): Android's `URI.resolve` omits the path separator for an empty-path base, so the first segment of a relative `bundleUrl` was spliced onto the port and the resulting authority failed to parse. ([#48625](https://github.com/expo/expo/pull/48625) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -478,7 +478,9 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
       return;
     }
 
-    if ([self->_updatesInterface isValidUpdatesConfiguration:updatesConfiguration] != YES) {
+    // A live dev server takes the lightweight manifest path even when the app's updates
+    // configuration is valid — the `expo-updates` fetch below exists for published manifests.
+    if ([self->_updatesInterface isValidUpdatesConfiguration:updatesConfiguration] != YES || manifestParser.isDevServerContentType) {
       [manifestParser tryToParseManifest:^(EXManifestsManifest *manifest) {
         if (!manifest.isUsingDeveloperTool) {
           onError([NSError errorWithDomain:@"DevelopmentClient" code:1 userInfo:@{NSLocalizedDescriptionKey: @"expo-updates is not properly installed or integrated. In order to load published projects with this development client, follow all installation and setup instructions for both the expo-dev-client and expo-updates packages."}]);

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.h
@@ -10,6 +10,15 @@ typedef void (^OnManifestError)(NSError *error);
 
 @interface EXDevLauncherManifestParser : NSObject
 
+/**
+ * YES once `isManifestURLWithCompletion:` classified the response as a live Expo dev server
+ * (`Content-Type: application/expo+json`) rather than a published/EAS-Update manifest. The response
+ * is still a manifest — its body is the only reliable source of the bundle URL and the transform
+ * options — but the caller can use this to take the lightweight manifest path instead of the
+ * `expo-updates` one.
+ */
+@property (nonatomic, readonly) BOOL isDevServerContentType;
+
 - (instancetype)initWithURL:(NSURL *)url
              installationID:(NSString *)installationID
                     session:(NSURLSession *)session

--- a/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
+++ b/packages/expo-dev-launcher/ios/Manifest/EXDevLauncherManifestParser.m
@@ -59,6 +59,15 @@ typedef void (^CompletionHandler)(NSData *data, NSURLResponse *response);
     }
 
     NSString *contentType = headers[@"Content-Type"];
+    // Expo CLI's manifest middleware negotiates the response content type from the Accept header
+    // this probe sends, so a live `expo start` server answers `application/expo+json`. That is a
+    // manifest — keep classifying it as one — but flag it so the caller can skip the `expo-updates`
+    // fetch path, which exists for published/EAS-Update manifests.
+    if (contentType && [contentType containsString:@"expo+json"]) {
+      _isDevServerContentType = YES;
+      completion(YES);
+      return;
+    }
     if (contentType && ![contentType hasPrefix:@"text/html"] && ![contentType containsString:@"/javascript"]) {
       completion(YES);
       return;

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherManifestParserTests.m
@@ -79,10 +79,25 @@
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"text/javascript"}];
   }];
   [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/expo-json1"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/expo+json"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
+    return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/expo-json2"];
+  } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
+    return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"application/expo+json; charset=utf-8"}];
+  }];
+  [HTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest * _Nonnull request) {
     return [request.URL.host isEqualToString:@"ohhttpstubs"] && [request.URL.path isEqualToString:@"/html"];
   } withStubResponse:^HTTPStubsResponse * _Nonnull(NSURLRequest * _Nonnull request) {
     return [HTTPStubsResponse responseWithData:[NSData new] statusCode:200 headers:@{@"Content-Type": @"text/html"}];
   }];
+
+  [self _testIsManifestURLString:@"http://ohhttpstubs/expo-json1" expected:YES description:@"an expo+json content-type is a manifest URL"];
+  [self _testIsDevServerContentTypeForURLString:@"http://ohhttpstubs/expo-json1" expected:YES description:@"an expo+json content-type is flagged as a live dev server"];
+  [self _testIsDevServerContentTypeForURLString:@"http://ohhttpstubs/expo-json2" expected:YES description:@"an expo+json content-type with a charset is flagged as a live dev server"];
+  [self _testIsDevServerContentTypeForURLString:@"http://ohhttpstubs/json1" expected:NO description:@"a plain JSON content-type is not a dev server"];
 
   [self _testIsManifestURLString:@"http://ohhttpstubs/json1" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
   [self _testIsManifestURLString:@"http://ohhttpstubs/json2" expected:YES description:@"should assume a JSON content-type indicates a manifest URL"];
@@ -110,6 +125,28 @@
 
   [self _testIsManifestURLString:@"http://ohhttpstubs/no-expo-server" expected:NO description:@"should assume a response with no exponent-server header means not a manifest URL"];
   [self _testIsManifestURLString:@"http://ohhttpstubs/expo-server" expected:YES description:@"should detect exponent-server header from expo dev server"];
+}
+
+- (void)_testIsDevServerContentTypeForURLString:(NSString *)urlString expected:(BOOL)expected description:(NSString *)description
+{
+  NSURL *url = [NSURL URLWithString:urlString];
+  EXDevLauncherManifestParser *parser = [[EXDevLauncherManifestParser alloc]
+                                         initWithURL:url
+                                         installationID:nil
+                                         session:NSURLSession.sharedSession
+                                         requestTimeout:NSURLSessionConfiguration.defaultSessionConfiguration.timeoutIntervalForRequest];
+
+  XCTestExpectation *expectation = [self expectationWithDescription:description];
+
+  [parser isManifestURLWithCompletion:^(BOOL isManifestURL) {
+    XCTAssertEqual(expected, parser.isDevServerContentType);
+    [expectation fulfill];
+  } onError:^(NSError * _Nonnull error) {
+    XCTFail(@"Response should have been successful");
+    [expectation fulfill];
+  }];
+
+  [self waitForExpectationsWithTimeout:5 handler:nil];
 }
 
 - (void)_testIsManifestURLString:(NSString *)urlString expected:(BOOL)expectedIsManifestUrl description:(NSString *)description


### PR DESCRIPTION
# Why

Fixes #49249.

**This PR has been rewritten.** The original approach classified `application/expo+json` as "not a
manifest"; [@alanjhughes' `/verify` run](https://github.com/expo/expo/pull/49250#issuecomment-5397737713)
showed that breaks dev-client launches, and it's right — see the comment below for the full
correction. The manifest is a manifest; what a live dev server doesn't need is the `expo-updates`
fetch.

`expo-dev-launcher`'s manifest probe sends `Accept: application/expo+json,application/json`, and the
CLI negotiates from it, so a stock `expo start` server answers `content-type: application/expo+json`
(#22470 added both halves together). `loadApp:` then routes that response through the `expo-updates`
branch whenever the app has a valid updates configuration — a branch that exists for published /
EAS-Update manifests, not for a Metro server that just told us what it is.

# How

- `EXDevLauncherManifestParser` records `isDevServerContentType` when the response content type
  contains `expo+json`. Classification is unchanged: it is still a manifest URL, and the body is
  still parsed — that body is the only reliable source of the bundle URL and the transform options.
- `loadApp:` takes the lightweight `tryToParseManifest` path when that flag is set, regardless of the
  updates configuration.

iOS only. The previous revision's Android hunk is dropped — it had the same defect as the iOS one.

# Status: retracted — do not merge

Two verification runs found no measurable win and one real regression. Leaving the diff up as the
record; the details are in the thread.

- **No speed-up.** 770ms stock vs 738ms patched (warm, n=13, p≈0.10); cold, no difference. The
  `expo-updates` setup work moves between segments (HEAD→manifest 512→347ms, manifest→bundle
  1214→1381ms) rather than disappearing.
- **My own numbers below are an artifact.** I ran the two arms sequentially rather than interleaved,
  so drift over those minutes landed entirely on the first arm. The 1.57s → 1.20s median difference
  is ordering, not this patch. Left in place, struck through, rather than quietly deleted.
- **Regression.** A self-hosted expo-updates server that answers the launcher probe with
  `200 application/expo+json` is legitimate under the protocol spec (the `expo-runtime-version`
  requirement is on the client, which this probe doesn't send). This branch reclassifies it as a dev
  server, so those users get "expo-updates is not properly installed or integrated" where the stock
  build loads the update. Content type alone cannot carry the distinction.

# Test Plan

Stock SDK 57 app on an iOS 26.4 simulator, Metro on loopback, deep-link launch, timed from the
simulator's unified log — from the launch's first request to the bundle GET. 8 runs each, with
`expo-updates` configured (`updates.url` + `runtimeVersion`), which is what makes the branch
reachable:

| | runs | median |
| - | - | - |
| ~~stock `expo-dev-client@57.0.15`~~ | ~~1.800 1.469 1.952 1.669 1.835 1.160 1.261 1.268~~ | ~~1.57s~~ |
| ~~this PR~~ | ~~1.957 1.234 1.142 1.208 1.096 1.075 1.188 1.265~~ | ~~1.20s~~ |

**Retracted — sequential arms, not interleaved. See the status note above.**

Same app **without** `expo-updates`: 0.878 / 0.919 / 0.951s, and this change is a no-op there — the
branch is never entered. That's why the verification run's stock template measured ~0.25s and saw
nothing to win; the difference is app configuration, not method.

Being explicit about the size: this is ~0.35s at the median, not the "seconds" the original
description claimed. That claim was wrong and I've retracted it.

Also verified the app launches normally with the patch on the same setup (the failure mode of the
previous revision), and that the bundle URL and transform options still come from the manifest.

`EXDevLauncherManifestParserTests` is updated for the new expectations (`expo+json` → manifest URL,
`isDevServerContentType` YES; plain `application/json` → NO). **Not executed** — I have no test host
for the package's XCTest target; the behaviour above was verified on device instead.
