### PR TITLE
[ios] Anchor generated Pods paths on ${PODS_ROOT} instead of absolute paths

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Anchor generated Pods paths (macros plugin flag, precompiled core header search paths, generated script arguments) on `${PODS_ROOT}` instead of absolute paths, so a relocated `Pods` directory (CI cache, git worktree clone) resolves within its own checkout. ([#49251](https://github.com/expo/expo/pull/49251) by [@janicduplessis](https://github.com/janicduplessis))
 - [iOS] Re-anchor the project-level `REACT_NATIVE_PATH` build setting to `$(SRCROOT)` when React Native's ccache integration is enabled, so the `CC`/`LD` ccache wrapper paths resolve in targets not integrated with CocoaPods (e.g. custom share or widget extensions), which previously failed with `unable to spawn process '/../../node_modules/react-native/scripts/xcode/ccache-clang.sh'`. ([#47596](https://github.com/expo/expo/pull/47596) by [@AbbanMustafa](https://github.com/AbbanMustafa))
 - [iOS] Fix `HEADER_SEARCH_PATHS` corruption for pod targets whose existing build setting is an array: interpolating the array into a string rendered it as `["…", "…"]`, producing unresolvable include paths. Surfaced as `'React/RCTSurfaceTouchHandler.h' file not found` when building `@expo/ui` with `use_frameworks! :linkage => :dynamic`. ([#48665](https://github.com/expo/expo/pull/48665) by [@Lanchez](https://github.com/Lanchez))
 - [Android] Fix autolinking pure C++ React Native modules published without `includesGeneratedCode: true`. ([#48514](https://github.com/expo/expo/pull/48514) by [@satya164](https://github.com/satya164))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -1041,6 +1041,12 @@ module Expo
         header_search_paths = collect_xcframework_header_paths(expo_core_xcframework)
         return if header_search_paths.empty?
 
+        # Make the paths relative to PODS_ROOT so a relocated Pods directory keeps working.
+        sandbox_root = installer.sandbox.root.to_s
+        header_search_paths = header_search_paths.map do |path|
+          path.start_with?("#{sandbox_root}/") ? path.sub(sandbox_root, '${PODS_ROOT}') : path
+        end
+
         paths_string = header_search_paths.map { |p| "\"#{p}\"" }.join(' ')
 
         Pod::UI.info "#{'[Expo-precompiled] '.blue}Adding ExpoModulesJSI header search paths to all targets"
@@ -1519,7 +1525,14 @@ module Expo
           next nil unless @framework_owner_map[dep_name] == pod_name
           source_base = shared_spm_dep_source_base(dep_name, pod_info)
           next nil unless source_base
-          %(--shared "#{dep_name}:#{source_base.gsub(/[\\"$`]/) { |c| "\\#{c}" }}")
+          # Make the path relative to PODS_ROOT so a relocated Pods directory keeps working.
+          pods_root = Pod::Config.instance.project_pods_root.to_s
+          begin
+            source_base = "$PODS_ROOT/#{Pathname.new(source_base).relative_path_from(Pathname.new(pods_root))}"
+          rescue ArgumentError
+            source_base = source_base.gsub(/[\\"$`]/) { |c| "\\#{c}" }
+          end
+          %(--shared "#{dep_name}:#{source_base}")
         end
       end
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -143,6 +143,14 @@ module Expo
           core_src_root = Expo::PrecompiledModules.package_root_for('ExpoModulesCore') ||
             File.realpath(core_pod_target.sandbox.pod_dir(core_pod_target.root_spec.name).to_s)
           macros_plugin_dir = resolve_macros_plugin_dir(core_src_root)
+          # Make the path relative to PODS_ROOT so a relocated Pods directory keeps working.
+          pods_root = Pod::Config.instance.project_pods_root.to_s
+          begin
+            relative_dir = Pathname.new(macros_plugin_dir).relative_path_from(Pathname.new(pods_root)).to_s
+            macros_plugin_dir = "${PODS_ROOT}/#{relative_dir}"
+          rescue ArgumentError
+            # Different volume or drive: keep the absolute path.
+          end
           macro_flags = "-Xfrontend -load-plugin-executable -Xfrontend \"#{macros_plugin_dir}/ExpoModulesMacros-tool#ExpoModulesMacros\""
         end
 
@@ -311,9 +319,16 @@ module Expo
       args = autolinking_manager.base_command_args.map { |arg| "\"#{arg}\"" }
       platform = autolinking_manager.platform_name.downcase
       package_names = autolinking_manager.packages_to_generate.map { |package| "\"#{package.name}\"" }
-      entitlement_param = entitlement_path.nil? ? '' : "--entitlement \"#{entitlement_path}\""
+      # Make the paths relative to PODS_ROOT so a relocated Pods directory keeps working.
+      pods_root = Pod::Config.instance.project_pods_root.to_s
+      relocatable = ->(path) {
+        path.start_with?("#{pods_root}/") ? path.sub(pods_root, '${PODS_ROOT}') :
+          path.start_with?("#{File.dirname(pods_root)}/") ? path.sub(File.dirname(pods_root), '${PODS_ROOT}/..') : path
+      }
+      modules_provider_path = relocatable.call(modules_provider_path)
+      entitlement_param = entitlement_path.nil? ? '' : "--entitlement \"#{relocatable.call(entitlement_path)}\""
       app_root_param = autolinking_manager.custom_app_root.nil? ? '' : "--app-root \"#{autolinking_manager.custom_app_root}\""
-      podfile_properties_param = "--podfile-properties-file-path \"#{autolinking_manager.get_podfile_properties_path()}\""
+      podfile_properties_param = "--podfile-properties-file-path \"#{relocatable.call(autolinking_manager.get_podfile_properties_path())}\""
 
       <<~SUPPORT_SCRIPT
       #!/usr/bin/env bash


### PR DESCRIPTION
# Why

`pod install` bakes machine-absolute paths into four kinds of generated output:

- the `ExpoModulesMacros` `-load-plugin-executable` flag (every Expo pod's xcconfig)
- the precompiled `ExpoModulesCore` header search paths injected into all targets
- `expo-configure-project.sh`'s `--target` / `--entitlement` / `--podfile-properties-file-path` arguments
- the `--shared` SPM dependency arguments of the xcframework replace script phase

Everything else CocoaPods generates is anchored on `${PODS_ROOT}` (10,516 references vs these 623 in a bare SDK 57 app I counted), so these are the only entries that tie a Pods directory to the checkout that ran `pod install`. A relocated Pods dir — a CI cache restored into a fresh checkout, a cloned git worktree, a moved project — silently resolves the *old* machine's paths for as long as they exist, and then fails without naming the real cause once they don't.

I hit this via git-worktree-per-task tooling that clones `ios/Pods` with APFS clonefiles instead of re-running `pod install` (~6s instead of ~26s per worktree).

# How

Anchor the four sites on `${PODS_ROOT}`:

- compile flags use the xcconfig build setting, which Xcode expands before the compiler sees the value — `-load-plugin-executable` just opens the expanded path, so a relative segment like `${PODS_ROOT}/../../node_modules/...` is fine
- generated scripts use the `$PODS_ROOT` shell variable, which the build-phase environment already provides (the same scripts already use it for `.xcode.env` and the autolinking entry point)

Paths that cannot be expressed relative to the sandbox (e.g. a pnpm store on a different volume, where `Pathname#relative_path_from` raises) keep the absolute path, matching current behavior.

# Test Plan

On a bare SDK 57 app (RN 0.86.2, precompiled modules on):

- before: 623 absolute-path references across `Pods/Target Support Files` + `Pods.xcodeproj` + generated scripts; after: **0** (`grep -r '/Volumes' ...`)
- `pod install` succeeds; full `xcodebuild` of the app workspace succeeds
- cloned the repo into a git worktree (carrying `Pods/` via clonefile, no `pod install`), built with a fresh DerivedData: succeeds, and the expanded flags now point inside the worktree instead of the original checkout

Not covered: a pnpm-style layout where `node_modules` resolves outside the repo — the fallback keeps today's absolute-path behavior there, but I only exercised the classic layout.