### PR TITLE
[expo] Don't emit DOM component props before the DOM side is ready

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Fix async imports (`import(...)`) via `asyncRequireModule` not a thenable instead of a full promise shape ([#48550](https://github.com/expo/expo/pull/48550) by [@kitten](https://github.com/kitten))
 - Fix `window.location` being called regardless of `@expo/metro-runtime` being present on native when an async chunk loads after Metro disconnects ([#48944](https://github.com/expo/expo/pull/48944) by [@expo-bot](https://github.com/expo-bot))
 - Fix DOM components dropping prop updates that are emitted while the WebView is still loading. ([#48813](https://github.com/expo/expo/pull/48813) by [@expo-bot](https://github.com/expo-bot))
-- [Android] Fix DOM components logging an uncaught `DomWebView.injectJavaScript` rejection on cold start by not emitting props before the DOM side is ready. ([#49173](https://github.com/expo/expo/issues/49173) by [@ahmdshrif](https://github.com/ahmdshrif))
+- [Android] Fix DOM components logging an uncaught `DomWebView.injectJavaScript` rejection on cold start by not emitting props before the DOM side is ready. ([#49257](https://github.com/expo/expo/pull/49257) by [@ahmdshrif](https://github.com/ahmdshrif))
 - Fix `import.meta.url` being `null` on web when `transform.inlineRequires` is enabled. ([#49045](https://github.com/expo/expo/pull/49045) by [@expo-bot](https://github.com/expo-bot))
 
 ### 💡 Others

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix async imports (`import(...)`) via `asyncRequireModule` not a thenable instead of a full promise shape ([#48550](https://github.com/expo/expo/pull/48550) by [@kitten](https://github.com/kitten))
 - Fix `window.location` being called regardless of `@expo/metro-runtime` being present on native when an async chunk loads after Metro disconnects ([#48944](https://github.com/expo/expo/pull/48944) by [@expo-bot](https://github.com/expo-bot))
 - Fix DOM components dropping prop updates that are emitted while the WebView is still loading. ([#48813](https://github.com/expo/expo/pull/48813) by [@expo-bot](https://github.com/expo-bot))
+- [Android] Fix DOM components logging an uncaught `DomWebView.injectJavaScript` rejection on cold start by not emitting props before the DOM side is ready. ([#49173](https://github.com/expo/expo/issues/49173) by [@ahmdshrif](https://github.com/ahmdshrif))
 - Fix `import.meta.url` being `null` on web when `transform.inlineRequires` is enabled. ([#49045](https://github.com/expo/expo/pull/49045) by [@expo-bot](https://github.com/expo-bot))
 
 ### 💡 Others

--- a/packages/expo/src/dom/__tests__/webview-props-emit-test.web.ts
+++ b/packages/expo/src/dom/__tests__/webview-props-emit-test.web.ts
@@ -67,8 +67,6 @@ describeWithDOM('$$props emit', () => {
 
     await render({ title: 'initial' });
 
-    // The DOM side has no `$$props` listener yet, and on the first commit the
-    // native view is not resolvable by tag, so this rejected instead.
     expect(injectJavaScript).not.toHaveBeenCalled();
   });
 

--- a/packages/expo/src/dom/__tests__/webview-props-emit-test.web.ts
+++ b/packages/expo/src/dom/__tests__/webview-props-emit-test.web.ts
@@ -1,0 +1,111 @@
+// `.web.ts` on purpose: mounting the wrapper for real (so its effects run) needs
+// `react-dom/client`, and the Web project is the only one with a DOM. The Node
+// project picks `.web` tests up as well, hence the guard below.
+import type { BridgeMessage } from '../dom.types';
+
+const describeWithDOM = typeof document !== 'undefined' ? describe : describe.skip;
+
+describeWithDOM('$$props emit', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.doMock('../../utils/getDevServer', () => ({
+      __esModule: true,
+      default: () => ({ url: 'http://localhost:8081' }),
+    }));
+  });
+
+  function mountRawWebView() {
+    // Mimics `@expo/dom-webview`, where `injectJavaScript` is a view `AsyncFunction`
+    // that rejects while the native view cannot be resolved by tag yet.
+    const injectJavaScript = jest.fn().mockImplementation(() => Promise.resolve());
+    let webViewProps: Record<string, any> = {};
+    jest.doMock('@expo/dom-webview', () => ({
+      WebView: (stubProps: any) => {
+        webViewProps = stubProps;
+        // `ref` arrives as a plain prop, and the wrapper injects scripts through it.
+        stubProps.ref.current = { injectJavaScript };
+        return null;
+      },
+    }));
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    const React = require('react');
+    const { act } = React;
+    const { createRoot } = require('react-dom/client');
+    const RawWebView = require('../webview-wrapper').default;
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    const render = async (props: Record<string, unknown>) => {
+      await act(async () => {
+        root.render(React.createElement(RawWebView, { filePath: 'index.tsx', ...props }));
+      });
+    };
+
+    const dispatchDOMReady = async () => {
+      await act(async () => {
+        webViewProps.onMessage({
+          nativeEvent: { data: JSON.stringify({ type: '$$dom_ready', data: null }) },
+        });
+      });
+    };
+
+    return { injectJavaScript, render, dispatchDOMReady };
+  }
+
+  function readInjectedEvent(script: string): BridgeMessage<any> {
+    const [, payload] = script.match(/new CustomEvent\("\$\$dom_event",([\s\S]*)\)\);/) ?? [];
+    if (payload == null) {
+      throw new Error(`Expected a script injecting a DOM event, got: ${script}`);
+    }
+    return JSON.parse(payload).detail;
+  }
+
+  it('should not inject anything before the DOM side is ready', async () => {
+    const { injectJavaScript, render } = mountRawWebView();
+
+    await render({ title: 'initial' });
+
+    // The DOM side has no `$$props` listener yet, and on the first commit the
+    // native view is not resolvable by tag, so this rejected instead.
+    expect(injectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('should not inject props that change before the DOM side is ready', async () => {
+    const { injectJavaScript, render } = mountRawWebView();
+
+    await render({ title: 'initial' });
+    await render({ title: 'updated-before-ready' });
+
+    expect(injectJavaScript).not.toHaveBeenCalled();
+  });
+
+  it('should answer `$$dom_ready` with the props as they are at that point', async () => {
+    const { injectJavaScript, render, dispatchDOMReady } = mountRawWebView();
+
+    await render({ title: 'initial' });
+    await render({ title: 'updated-before-ready' });
+    await dispatchDOMReady();
+
+    expect(injectJavaScript).toHaveBeenCalledTimes(1);
+    expect(readInjectedEvent(injectJavaScript.mock.calls[0][0])).toEqual({
+      type: '$$props',
+      data: { names: [], props: { title: 'updated-before-ready' } },
+    });
+  });
+
+  it('should emit prop updates once the DOM side is ready', async () => {
+    const { injectJavaScript, render, dispatchDOMReady } = mountRawWebView();
+
+    await render({ title: 'initial' });
+    await dispatchDOMReady();
+    await render({ title: 'updated-after-ready' });
+
+    expect(injectJavaScript).toHaveBeenCalledTimes(2);
+    expect(readInjectedEvent(injectJavaScript.mock.calls[1][0])).toEqual({
+      type: '$$props',
+      data: { names: [], props: { title: 'updated-after-ready' } },
+    });
+  });
+});

--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -74,7 +74,6 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
   const webView = resolveWebView(useExpoDOMWebView);
   const webviewRef = React.useRef<WebViewRef>(null);
   const domImperativeHandlePropsRef = React.useRef<string[]>([]);
-  // Whether the DOM side has registered its `$$props` listener, see `$$dom_ready` below.
   const isDOMReadyRef = React.useRef(false);
   const source = { uri: overrideUri ?? `${getBaseURL()}/${filePath}` };
   const [containerStyle, setContainerStyle] = React.useState<WebViewProps['containerStyle']>(null);
@@ -112,11 +111,7 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
 
   // When the `marshalProps` change, emit them to the webview.
   React.useEffect(() => {
-    // The DOM side only registers its `$$props` listener right before it posts
-    // `$$dom_ready`, so anything emitted earlier is dropped there anyway, and
-    // the `$$dom_ready` handler below answers with the current props. Emitting
-    // early is not just wasted: on the first commit after mount the native view
-    // is not resolvable by tag yet, and `injectJavaScript` rejects.
+    // Skip until `$$dom_ready`; earlier injects are dropped and reject on Android first commit.
     if (!isDOMReadyRef.current) {
       return;
     }

--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -74,6 +74,8 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
   const webView = resolveWebView(useExpoDOMWebView);
   const webviewRef = React.useRef<WebViewRef>(null);
   const domImperativeHandlePropsRef = React.useRef<string[]>([]);
+  // Whether the DOM side has registered its `$$props` listener, see `$$dom_ready` below.
+  const isDOMReadyRef = React.useRef(false);
   const source = { uri: overrideUri ?? `${getBaseURL()}/${filePath}` };
   const [containerStyle, setContainerStyle] = React.useState<WebViewProps['containerStyle']>(null);
 
@@ -110,6 +112,14 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
 
   // When the `marshalProps` change, emit them to the webview.
   React.useEffect(() => {
+    // The DOM side only registers its `$$props` listener right before it posts
+    // `$$dom_ready`, so anything emitted earlier is dropped there anyway, and
+    // the `$$dom_ready` handler below answers with the current props. Emitting
+    // early is not just wasted: on the first commit after mount the native view
+    // is not resolvable by tag yet, and `injectJavaScript` rejects.
+    if (!isDOMReadyRef.current) {
+      return;
+    }
     emit({ type: '$$props', data: smartActions });
   }, [emit, smartActions]);
 
@@ -179,6 +189,7 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
       }
 
       if (type === DOM_READY) {
+        isDOMReadyRef.current = true;
         // Re-send the props the DOM side missed while the WebView was loading.
         emit({ type: '$$props', data: smartActions });
         return;


### PR DESCRIPTION
# Why

Fixes #49173.

On Android, mounting a DOM component during app cold start logs an uncaught promise rejection:

```
Error: Call to function DomWebView.injectJavaScript has been rejected.
Caused by: Unable to find the class expo.modules.webview.DomWebView view with tag N
```

The app never calls `injectJavaScript` itself. It comes from the `$$props` emit effect in
[`packages/expo/src/dom/webview-wrapper.tsx`](https://github.com/expo/expo/blob/main/packages/expo/src/dom/webview-wrapper.tsx),
which runs on the **first commit after mount**: `smartActions` is rebuilt on every render, so the
effect fires immediately. With `@expo/dom-webview`, `injectJavaScript` is a view `AsyncFunction`
whose view argument is resolved by tag through `AppContext.findView`; at first-commit time the
Fabric view is not resolvable yet, so the call rejects. Nothing catches the returned promise, so it
surfaces as an uncaught rejection (LogBox in dev). iOS does not hit this race the same way.

The emit is also pointless at that moment. `dom-entry.tsx` registers the `$$props` listener and
only then posts `$$dom_ready` — with the comment *"Must stay after `addEventListener`: props
emitted before it existed were dropped."* So anything emitted before `$$dom_ready` is dropped on
the DOM side regardless, and #48813 already added the `$$dom_ready` handler that answers with the
current props.

Credit to @cameronapak for the report and the root-cause analysis, including the earlier #47469.

# How

Skip the `$$props` emit until the DOM side has signalled `$$dom_ready`. The rejecting call is no
longer made at all, rather than made and then ignored, and no error is swallowed:

- a `isDOMReadyRef` ref, set in the existing `DOM_READY` branch of `onMessage`;
- the props effect returns early while it is `false`.

Props that change before `$$dom_ready` are not lost: the `$$dom_ready` handler emits `smartActions`
from the current render, so it always answers with the latest values. This is the "ready handshake"
direction from the issue, without a buffer — the handshake added in #48813 already serves as one.

Deliberately **not** `.catch(() => {})` on `emit`: that would also silence delivery failures of
`$$native_action_result`, which are genuine errors, and would leave the useless pre-ready
`injectJavaScript` call in place.

Behaviour after `$$dom_ready` is unchanged, including WebView reloads: `dom-entry` remounts and
posts `$$dom_ready` again, and the handler answers as before.

The one way this could regress is a page that registers a `$$props` listener but never posts
`$$dom_ready`. That cannot happen for pages built by the DOM runtime — `dom-entry.tsx` does both in
the same effect, listener first — and a page that does neither (for example a custom `overrideUri`)
already dropped these emits.

# Test Plan

New `packages/expo/src/dom/__tests__/webview-props-emit-test.web.ts`, mounting `RawWebView` for real
so its effects run. `packages/expo` has no React Native renderer in its devDependencies, but
`react-dom` is already there and the Web project runs in jsdom, so the wrapper can be mounted with
`react-dom/client` and `act`. The file is `.web.ts` and guards on `document`, since the Node project
picks `.web` tests up too.

Four tests, run against `packages/expo`:

| | before | after |
| --- | --- | --- |
| `injectJavaScript` calls after mount | 1 | 0 |
| after a prop update before `$$dom_ready` | 2 | 0 |
| after `$$dom_ready` | 3 | 1, carrying `updated-before-ready` |
| after a prop update following `$$dom_ready` | 3 | 2, carrying `updated-after-ready` |

With only `webview-wrapper.tsx` reverted, all four fail; with the change, all four pass.

Package checks:

- `jest` (`packages/expo`): **68 suites / 576 passed, 8 skipped**, versus **66 suites / 572 passed,
  4 skipped** on a clean checkout of the same base — the delta is exactly the four new tests
  (passing in the Web project, skipped in the Node project). No churn elsewhere.
- `tsc -p tsconfig.json`: no new errors attributable to these files.
- `oxlint --config oxlint.config.mjs .`: clean.
- Formatting matches the surrounding file (the pre-existing trailing-comma differences in
  `webview-wrapper.tsx` are untouched).

Not verified on a device: I do not have the Android development build from the MRE
(`cameronapak/expo-use-dom-android-cold-start`) available here, so the disappearance of the LogBox
entry itself is argued from the mechanism — the rejecting call is no longer made — rather than
observed. Note also that jest's environment suppresses `process.on('unhandledRejection')`, so the
rejection cannot be asserted in-suite; the tests assert the call is not made, which is the cause.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin) — not relevant, JS-only change with no native or config surface.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — no docs changed.
