### PR TITLE
refactor(cli): Improve avd/adb reliability with bounded and cancellable operations

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
+- Make Android tooling (avd and adb) handling safer, more reliable, and cancellable ([#49258](https://github.com/expo/expo/pull/49258) by [@kitten](https://github.com/kitten))
 - Serve one virtual Metro asset registry to every consumer on React Native 0.87 — Metro's generated asset modules, `react-native/asset-registry` and legacy `@react-native/assets-registry` imports, and React Native core's internal registry imports — so Metro-registered assets and React Native's `<Image>` share one registry instance. ([#49444](https://github.com/expo/expo/pull/49444) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Depend on `@react-native/js-polyfills` directly for the web polyfills instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 

--- a/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
+++ b/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
@@ -6,14 +6,15 @@ import { assertSdkRoot } from './AndroidSdk';
 import {
   AdbProcessWaitError,
   runAdbDeviceMutationAsync,
-  runAdbDeviceQueryAsync,
   runAdbHostQueryAsync,
   runBoundedAdbDeviceQueryAsync,
+  runBoundedAdbDeviceMutationAsync,
   runBoundedAdbHostQueryAsync,
 } from './adbProcess';
 
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
 const PROPERTY_QUERY_WAIT_LIMIT_MS = 10_000;
+const DEVICE_QUERY_WAIT_LIMIT_MS = 10_000;
 
 export class ADBServer {
   /** Returns the command line reference to ADB. */
@@ -35,7 +36,8 @@ export class ADBServer {
   async runDeviceQueryAsync(
     args: string[],
     operation: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    waitLimitMs: number = DEVICE_QUERY_WAIT_LIMIT_MS
   ): Promise<string> {
     const adb = this.getAdbExecutablePath();
 
@@ -44,22 +46,27 @@ export class ADBServer {
 
     event('adb_server_run', { command: [adb, ...args].join(' ') });
     const result = await this.resolveAdbPromise(
-      runAdbDeviceQueryAsync(adb, args, operation, signal)
+      runBoundedAdbDeviceQueryAsync(adb, args, operation, waitLimitMs, signal)
     );
-    return [result.stdout, result.stderr].join('\n');
+    assertValidAdbUserOutput(result);
+    return result.stdout;
   }
 
   async runDeviceMutationAsync(
     args: string[],
     operation: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    waitLimitMs?: number
   ): Promise<string> {
     const adb = this.getAdbExecutablePath();
     event('adb_server_run', { command: [adb, ...args].join(' ') });
     const result = await this.resolveAdbPromise(
-      runAdbDeviceMutationAsync(adb, args, operation, signal)
+      waitLimitMs == null
+        ? runAdbDeviceMutationAsync(adb, args, operation, signal)
+        : runBoundedAdbDeviceMutationAsync(adb, args, operation, waitLimitMs, signal)
     );
-    return [result.stdout, result.stderr].join('\n');
+    assertValidAdbUserOutput(result);
+    return result.stdout;
   }
 
   async runHostQueryAsync(
@@ -94,6 +101,7 @@ export class ADBServer {
         signal
       )
     );
+    assertValidAdbUserOutput(result);
     event('adb_file_output', { output: result.stdout });
     return result.stdout;
   }
@@ -110,8 +118,9 @@ export class ADBServer {
       if (error.signal === 'SIGINT') {
         throw new AbortCommandError();
       }
-      if (error.status === 255 && error.stdout.includes('Bad user number')) {
-        const userNumber = error.stdout.match(/Bad user number: (.+)/)?.[1] ?? env.EXPO_ADB_USER;
+      const processOutput = [error.stdout, error.stderr].filter(Boolean).join('\n');
+      if (error.status === 255 && processOutput.includes('Bad user number')) {
+        const userNumber = processOutput.match(/Bad user number: (.+)/)?.[1] ?? env.EXPO_ADB_USER;
         throw new CommandError(
           'EXPO_ADB_USER',
           `Invalid ADB user number "${userNumber}" set with environment variable EXPO_ADB_USER. Run "adb shell pm list users" to see valid user numbers.`
@@ -126,5 +135,16 @@ export class ADBServer {
       error.message = errorMessage;
       throw error;
     }
+  }
+}
+
+function assertValidAdbUserOutput(result: { stdout: string; stderr: string }): void {
+  if (!env.EXPO_ADB_USER) return;
+  const output = [result.stdout, result.stderr].filter(Boolean).join('\n');
+  if (/Bad user number|(?:user .* does not exist|no user with id)/i.test(output)) {
+    throw new CommandError(
+      'EXPO_ADB_USER',
+      `Invalid ADB user number "${env.EXPO_ADB_USER}" set with environment variable EXPO_ADB_USER. Run "adb shell pm list users" to see valid user numbers.`
+    );
   }
 }

--- a/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
+++ b/packages/@expo/cli/src/start/platforms/android/ADBServer.ts
@@ -1,23 +1,21 @@
-import spawnAsync from '@expo/spawn-async';
-import { execFileSync } from 'child_process';
-
 import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { AbortCommandError, CommandError } from '../../../utils/errors';
-import { installExitHooks } from '../../../utils/exit';
 import { event } from '../events';
 import { assertSdkRoot } from './AndroidSdk';
+import {
+  AdbProcessWaitError,
+  runAdbDeviceMutationAsync,
+  runAdbDeviceQueryAsync,
+  runAdbHostQueryAsync,
+  runBoundedAdbDeviceQueryAsync,
+  runBoundedAdbHostQueryAsync,
+} from './adbProcess';
 
 const BEGINNING_OF_ADB_ERROR_MESSAGE = 'error: ';
-
-// This is a tricky class since it controls a system state (side-effects).
-// A more ideal solution would be to implement ADB in JS.
-// The main reason this is a class is to control the flow of testing.
+const PROPERTY_QUERY_WAIT_LIMIT_MS = 10_000;
 
 export class ADBServer {
-  isRunning: boolean = false;
-  removeExitHook: () => void = () => {};
-
   /** Returns the command line reference to ADB. */
   getAdbExecutablePath(): string {
     try {
@@ -33,69 +31,71 @@ export class ADBServer {
     return 'adb';
   }
 
-  /** Start the ADB server. */
-  async startAsync(): Promise<boolean> {
-    if (this.isRunning) {
-      return false;
-    }
-    // clean up
-    this.removeExitHook = installExitHooks(() => {
-      if (this.isRunning) {
-        this.stopAsync();
-      }
-    });
-    const adb = this.getAdbExecutablePath();
-    const result = await this.resolveAdbPromise(spawnAsync(adb, ['start-server']));
-    const lines = result.stderr.trim().split(/\r?\n/);
-    const isStarted = lines.includes('* daemon started successfully');
-    this.isRunning = isStarted;
-    return isStarted;
-  }
-
-  /** Kill the ADB server. */
-  async stopAsync(): Promise<boolean> {
-    if (!this.isRunning) {
-      return false;
-    }
-    this.removeExitHook();
-    try {
-      await this.runAsync(['kill-server']);
-      return true;
-    } catch (error: any) {
-      Log.error('Failed to stop ADB server: ' + error.message);
-      return false;
-    } finally {
-      this.isRunning = false;
-    }
-  }
-
   /** Execute an ADB command with given args. */
-  async runAsync(args: string[]): Promise<string> {
-    // TODO: Add a global package that installs adb to the path.
+  async runDeviceQueryAsync(
+    args: string[],
+    operation: string,
+    signal?: AbortSignal
+  ): Promise<string> {
     const adb = this.getAdbExecutablePath();
 
-    await this.startAsync();
+    // NOTE(@kitten): We removed start-server/stop-server calls,
+    // because each command already negotiates the server automatically
 
     event('adb_server_run', { command: [adb, ...args].join(' ') });
-    const result = await this.resolveAdbPromise(spawnAsync(adb, args));
-    return result.output.join('\n');
+    const result = await this.resolveAdbPromise(
+      runAdbDeviceQueryAsync(adb, args, operation, signal)
+    );
+    return [result.stdout, result.stderr].join('\n');
+  }
+
+  async runDeviceMutationAsync(
+    args: string[],
+    operation: string,
+    signal?: AbortSignal
+  ): Promise<string> {
+    const adb = this.getAdbExecutablePath();
+    event('adb_server_run', { command: [adb, ...args].join(' ') });
+    const result = await this.resolveAdbPromise(
+      runAdbDeviceMutationAsync(adb, args, operation, signal)
+    );
+    return [result.stdout, result.stderr].join('\n');
+  }
+
+  async runHostQueryAsync(
+    args: string[],
+    operation: string,
+    signal?: AbortSignal,
+    waitLimitMs?: number
+  ): Promise<string> {
+    const adb = this.getAdbExecutablePath();
+    const result = await this.resolveAdbPromise(
+      waitLimitMs == null
+        ? runAdbHostQueryAsync(adb, args, operation, signal)
+        : runBoundedAdbHostQueryAsync(adb, args, operation, waitLimitMs, signal)
+    );
+    return result.stdout;
   }
 
   /** Get ADB file output. Useful for reading device state/settings. */
-  async getFileOutputAsync(args: string[]): Promise<string> {
+  async getFileOutputAsync(
+    args: string[],
+    { signal, waitLimitMs }: { signal?: AbortSignal; waitLimitMs?: number } = {}
+  ): Promise<string> {
     // TODO: Add a global package that installs adb to the path.
     const adb = this.getAdbExecutablePath();
 
-    await this.startAsync();
-
-    const results = await this.resolveAdbPromise(
-      execFileSync(adb, args, {
-        encoding: 'latin1',
-        stdio: 'pipe',
-      })
+    const result = await this.resolveAdbPromise(
+      runBoundedAdbDeviceQueryAsync(
+        adb,
+        args,
+        'device property/boot query',
+        waitLimitMs ?? PROPERTY_QUERY_WAIT_LIMIT_MS,
+        signal
+      )
     );
-    event('adb_file_output', { output: results });
-    return results;
+    event('adb_file_output', { output: result.stdout });
+    return result.stdout;
   }
 
   /** Formats error info. */
@@ -103,6 +103,9 @@ export class ADBServer {
     try {
       return await promise;
     } catch (error: any) {
+      if (error instanceof AdbProcessWaitError) {
+        throw error;
+      }
       // User pressed ctrl+c to cancel the process...
       if (error.signal === 'SIGINT') {
         throw new AbortCommandError();

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -24,12 +24,22 @@ import { promptForDeviceAsync } from './promptAndroidDevice';
 const EXPO_GO_APPLICATION_IDENTIFIER = 'host.exp.exponent';
 
 export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Device> {
-  static async resolveFromNameAsync(name: string): Promise<AndroidDeviceManager> {
+  static async resolveFromNameAsync(query: string): Promise<AndroidDeviceManager> {
     const devices = await getDevicesAsync();
-    const device = devices.find((device) => device.name === name);
+    const device =
+      devices.find((device) => device.pid === query) ??
+      devices.find((device) => device.name === query);
 
     if (!device) {
-      throw new CommandError('Could not find device with name: ' + name);
+      const message = [
+        `No connected Android device or emulator matched "${query}" by serial or name.`,
+        'Available devices:',
+        ...devices.map(
+          (device) => `  ${device.name} (${device.pid ?? 'not attached'}, ${device.type})`
+        ),
+        'Pass a device serial from `adb devices` or a name from the list above to --device.',
+      ].join('\n');
+      throw new CommandError('BAD_ARGS', message);
     }
     return AndroidDeviceManager.resolveAsync({ device, shouldPrompt: false });
   }

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -112,6 +112,11 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   }
 
   private assertDeviceStateIsUsable(device: AndroidDebugBridge.Device): void {
+    // Exclude unauthorized states, which are checked separately
+    if (device.state === 'unauthorized') {
+      return;
+    }
+
     if (device.state && !isAdbDeviceStateUsable(device.state)) {
       throw this.createDeviceStateError(
         new Error(`Device ${device.pid ?? device.name} is in state ${device.state}.`),

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -78,7 +78,8 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   protected async attemptToStartAsync(): Promise<AndroidDebugBridge.Device | null> {
     // Only detached AVD inventory entries may enter the emulator launch path
     if (this.device.isLaunchable) {
-      this.device = await startDeviceAsync(this.device);
+      const attachedDevice = await AndroidDebugBridge.isDeviceBootedAsync(this.device);
+      this.device = attachedDevice ?? (await startDeviceAsync(this.device));
     } else {
       this.assertDeviceStateIsUsable(this.device);
       const attachedDevice = await AndroidDebugBridge.isDeviceBootedAsync(this.device);
@@ -105,7 +106,9 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
 
     if (this.device.isAuthorized === false) {
       AndroidDebugBridge.logUnauthorized(this.device);
-      return null;
+      throw this.createDeviceStateError(
+        new Error(`Device ${this.device.pid ?? this.device.name} is unauthorized.`)
+      );
     }
 
     return this.device;
@@ -133,6 +136,9 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   }
 
   private async mapDeviceOperationError(error: unknown): Promise<never> {
+    if (error instanceof CommandError) {
+      throw error;
+    }
     if (isAdbDeviceDisconnectedError(error)) {
       throw new CommandError('ADB_DEVICE_DISCONNECTED', formatAdbDeviceError(error, this.device));
     }
@@ -181,7 +187,6 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
         AndroidDebugBridge.uninstallAsync(this.device, { appId }, signal)
       );
     } catch (e) {
-      if (e instanceof CommandError && e.code.startsWith('ADB_')) throw e;
       Log.error(
         `Could not uninstall app "${appId}" from your device, please uninstall it manually and try again.`
       );
@@ -198,7 +203,11 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
         AndroidDebugBridge.launchActivityAsync(this.device, { launchActivity, url }, signal)
       );
     } catch (error: any) {
-      if (error instanceof CommandError && error.code.startsWith('ADB_')) {
+      if (
+        error instanceof CommandError &&
+        error.code.startsWith('ADB_') &&
+        error.code !== 'ADB_DEVICE_OPERATION'
+      ) {
         throw error;
       }
       let errorMessage = `Couldn't open Android app with activity "${launchActivity}" on device "${this.name}".`;

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -79,7 +79,12 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     // Only detached AVD inventory entries may enter the emulator launch path
     if (this.device.isLaunchable) {
       const attachedDevice = await AndroidDebugBridge.isDeviceBootedAsync(this.device);
-      this.device = attachedDevice ?? (await startDeviceAsync(this.device));
+      if (attachedDevice) {
+        this.assertDeviceStateIsUsable(attachedDevice);
+        this.device = attachedDevice;
+      } else {
+        this.device = await startDeviceAsync(this.device);
+      }
     } else {
       this.assertDeviceStateIsUsable(this.device);
       const attachedDevice = await AndroidDebugBridge.isDeviceBootedAsync(this.device);

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -3,12 +3,20 @@ import chalk from 'chalk';
 
 import * as Log from '../../../log';
 import { AbortCommandError, CommandError } from '../../../utils/errors';
+import { installExitHooks } from '../../../utils/exit';
 import { validateUrl } from '../../../utils/url';
 import { DeviceManager } from '../DeviceManager';
 import { ExpoGoInstaller } from '../ExpoGoInstaller';
 import type { BaseResolveDeviceProps } from '../PlatformManager';
 import { activateWindowAsync } from './activateWindow';
 import * as AndroidDebugBridge from './adb';
+import { isAdbDeviceStateUsable } from './adbDeviceList';
+import {
+  createAdbOperationErrorAsync,
+  formatAdbDeviceError,
+  isAdbDeviceDisconnectedError,
+} from './adbDiagnostics';
+import { AdbProcessError } from './adbProcess';
 import { startDeviceAsync } from './emulator';
 import { getDevicesAsync } from './getDevices';
 import { promptForDeviceAsync } from './promptAndroidDevice';
@@ -53,18 +61,46 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   }
 
   async getAppVersionAsync(applicationId: string): Promise<string | null> {
-    const info = await AndroidDebugBridge.getPackageInfoAsync(this.device, {
-      appId: applicationId,
-    });
+    const info = await this.runDeviceOperationAsync((signal) =>
+      AndroidDebugBridge.getPackageInfoAsync(
+        this.device,
+        {
+          appId: applicationId,
+        },
+        signal
+      )
+    );
 
     const regex = /versionName=([0-9.]+)/;
     return regex.exec(info)?.[1] ?? null;
   }
 
   protected async attemptToStartAsync(): Promise<AndroidDebugBridge.Device | null> {
-    // TODO: Add a light-weight method for checking since a device could disconnect.
-    if (!(await AndroidDebugBridge.isDeviceBootedAsync(this.device))) {
+    // Only detached AVD inventory entries may enter the emulator launch path
+    if (this.device.isLaunchable) {
       this.device = await startDeviceAsync(this.device);
+    } else {
+      this.assertDeviceStateIsUsable(this.device);
+      const attachedDevice = await AndroidDebugBridge.isDeviceBootedAsync(this.device);
+      if (!attachedDevice) {
+        throw this.createDeviceStateError(
+          new Error(`Device not found after discovery: ${this.device.pid ?? this.device.name}.`)
+        );
+      }
+      this.assertDeviceStateIsUsable(attachedDevice);
+      if (
+        this.device.transportId &&
+        attachedDevice.transportId &&
+        this.device.transportId !== attachedDevice.transportId
+      ) {
+        throw this.createDeviceStateError(
+          new Error(
+            `Device ${this.device.pid ?? this.device.name} was replaced after discovery (transport ${this.device.transportId} became ${attachedDevice.transportId})`
+          ),
+          attachedDevice
+        );
+      }
+      this.device = attachedDevice;
     }
 
     if (this.device.isAuthorized === false) {
@@ -75,6 +111,47 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     return this.device;
   }
 
+  private assertDeviceStateIsUsable(device: AndroidDebugBridge.Device): void {
+    if (device.state && !isAdbDeviceStateUsable(device.state)) {
+      throw this.createDeviceStateError(
+        new Error(`Device ${device.pid ?? device.name} is in state ${device.state}.`),
+        device
+      );
+    }
+  }
+
+  private createDeviceStateError(
+    error: Error,
+    device: AndroidDebugBridge.Device = this.device
+  ): CommandError {
+    return new CommandError('ADB_DEVICE_STATE', formatAdbDeviceError(error, device));
+  }
+
+  private async mapDeviceOperationError(error: unknown): Promise<never> {
+    if (isAdbDeviceDisconnectedError(error)) {
+      throw new CommandError('ADB_DEVICE_DISCONNECTED', formatAdbDeviceError(error, this.device));
+    }
+    if (error instanceof AdbProcessError) {
+      throw await createAdbOperationErrorAsync('ADB_DEVICE_OPERATION', error, this.device);
+    }
+    throw error;
+  }
+
+  private async runDeviceOperationAsync<T>(
+    operation: (signal: AbortSignal) => Promise<T>
+  ): Promise<T> {
+    // NOTE(@kitten): Do not retry device commands; side effects may already have started
+    const controller = new AbortController();
+    const removeExitHook = installExitHooks(() => controller.abort(new AbortCommandError()));
+    try {
+      return await operation(controller.signal);
+    } catch (error) {
+      return await this.mapDeviceOperationError(error);
+    } finally {
+      removeExitHook();
+    }
+  }
+
   async startAsync(): Promise<AndroidDebugBridge.Device> {
     const device = await this.attemptToStartAsync();
     assert(device, `Failed to boot emulator.`);
@@ -82,9 +159,9 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   }
 
   async installAppAsync(binaryPath: string) {
-    await AndroidDebugBridge.installAsync(this.device, {
-      filePath: binaryPath,
-    });
+    await this.runDeviceOperationAsync((signal) =>
+      AndroidDebugBridge.installAsync(this.device, { filePath: binaryPath }, signal)
+    );
   }
 
   async uninstallAppAsync(appId: string) {
@@ -95,10 +172,11 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     }
 
     try {
-      await AndroidDebugBridge.uninstallAsync(this.device, {
-        appId,
-      });
+      await this.runDeviceOperationAsync((signal) =>
+        AndroidDebugBridge.uninstallAsync(this.device, { appId }, signal)
+      );
     } catch (e) {
+      if (e instanceof CommandError && e.code.startsWith('ADB_')) throw e;
       Log.error(
         `Could not uninstall app "${appId}" from your device, please uninstall it manually and try again.`
       );
@@ -111,11 +189,13 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
    */
   async launchActivityAsync(launchActivity: string, url?: string): Promise<string> {
     try {
-      return await AndroidDebugBridge.launchActivityAsync(this.device, {
-        launchActivity,
-        url,
-      });
+      return await this.runDeviceOperationAsync((signal) =>
+        AndroidDebugBridge.launchActivityAsync(this.device, { launchActivity, url }, signal)
+      );
     } catch (error: any) {
+      if (error instanceof CommandError && error.code.startsWith('ADB_')) {
+        throw error;
+      }
       let errorMessage = `Couldn't open Android app with activity "${launchActivity}" on device "${this.name}".`;
       if (error instanceof CommandError && error.code === 'APP_NOT_INSTALLED') {
         errorMessage += `\nThe app might not be installed, try installing it with: ${chalk.bold(
@@ -129,7 +209,9 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
   }
 
   async isAppInstalledAndIfSoReturnContainerPathForIOSAsync(applicationId: string) {
-    return await AndroidDebugBridge.isPackageInstalledAsync(this.device, applicationId);
+    return await this.runDeviceOperationAsync((signal) =>
+      AndroidDebugBridge.isPackageInstalledAsync(this.device, applicationId, signal)
+    );
   }
 
   async openUrlAsync(url: string) {
@@ -142,15 +224,20 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
     const parsed = new URL(url);
 
     if (parsed.protocol === 'exp:') {
-      await AndroidDebugBridge.launchActivityAsync(
-        { pid: this.device.pid },
-        {
-          launchActivity: `${EXPO_GO_APPLICATION_IDENTIFIER}/.experience.HomeActivity`,
-        }
+      await this.runDeviceOperationAsync((signal) =>
+        AndroidDebugBridge.launchActivityAsync(
+          { pid: this.device.pid },
+          {
+            launchActivity: `${EXPO_GO_APPLICATION_IDENTIFIER}/.experience.HomeActivity`,
+          },
+          signal
+        )
       );
     }
 
-    await AndroidDebugBridge.openUrlAsync({ pid: this.device.pid }, { url });
+    await this.runDeviceOperationAsync((signal) =>
+      AndroidDebugBridge.openUrlAsync({ pid: this.device.pid }, { url }, signal)
+    );
   }
 
   async activateWindowAsync() {

--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -12,7 +12,7 @@ import { activateWindowAsync } from './activateWindow';
 import * as AndroidDebugBridge from './adb';
 import { isAdbDeviceStateUsable } from './adbDeviceList';
 import {
-  createAdbOperationErrorAsync,
+  createAdbOperationError,
   formatAdbDeviceError,
   isAdbDeviceDisconnectedError,
 } from './adbDiagnostics';
@@ -143,7 +143,7 @@ export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Devic
       throw new CommandError('ADB_DEVICE_DISCONNECTED', formatAdbDeviceError(error, this.device));
     }
     if (error instanceof AdbProcessError) {
-      throw await createAdbOperationErrorAsync('ADB_DEVICE_OPERATION', error, this.device);
+      throw createAdbOperationError('ADB_DEVICE_OPERATION', error, this.device);
     }
     throw error;
   }

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
@@ -107,7 +107,7 @@ describe('runDeviceQueryAsync', () => {
     server.resolveAdbPromise = jest.fn(server.resolveAdbPromise);
     server.getAdbExecutablePath = jest.fn(() => 'adb');
     await expect(server.runDeviceQueryAsync(['foo', 'bar'], 'test query')).resolves.toBe(
-      'did thing\n'
+      'did thing'
     );
     expect(server.getAdbExecutablePath).toHaveBeenCalledTimes(1);
     expect(server.resolveAdbPromise).toHaveBeenCalledTimes(1);
@@ -115,7 +115,7 @@ describe('runDeviceQueryAsync', () => {
     expect(spawnAsync).toHaveBeenCalledWith('adb', ['foo', 'bar']);
   });
 
-  it('preserves stdout-before-stderr combined output', async () => {
+  it('keeps diagnostic stderr out of parsed query output', async () => {
     jest.mocked(spawnAsync).mockResolvedValueOnce({
       stdout: 'machine-readable output',
       stderr: 'diagnostic output',
@@ -126,8 +126,25 @@ describe('runDeviceQueryAsync', () => {
     server.getAdbExecutablePath = jest.fn(() => 'adb');
 
     await expect(server.runDeviceQueryAsync(['devices', '-l'], 'device query')).resolves.toBe(
-      'machine-readable output\ndiagnostic output'
+      'machine-readable output'
     );
+  });
+
+  it('rejects a nonexistent ADB user reported with a successful exit', async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
+      stdout: '',
+      stderr: 'Error: user 99 does not exist',
+      status: 0,
+      signal: null,
+    } as any);
+    const server = new ADBServer();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+
+    await expect(
+      server.runDeviceQueryAsync(['shell', 'pm', 'list', 'packages'], 'query')
+    ).rejects.toMatchObject({
+      code: 'EXPO_ADB_USER',
+    });
   });
 });
 describe('getFileOutputAsync', () => {
@@ -163,6 +180,27 @@ describe('getFileOutputAsync', () => {
     );
   });
 
+  it('maps bad ADB users reported on stderr', async () => {
+    const server = new ADBServer();
+    await expect(
+      server.resolveAdbPromise(
+        Promise.reject({
+          status: 255,
+          stderr: 'java.lang.IllegalArgumentException: Bad user number: FUNKY',
+        })
+      )
+    ).rejects.toMatchObject({ code: 'EXPO_ADB_USER' });
+  });
+
+  it('formats status failures without stdout', async () => {
+    const server = new ADBServer();
+    const error = { status: 255, stderr: 'device rejected command' };
+
+    await expect(server.resolveAdbPromise(Promise.reject(error))).rejects.toMatchObject({
+      message: 'device rejected command',
+    });
+  });
+
   it('does not block scheduled JavaScript while a property query is pending', async () => {
     let resolveSpawn!: (result: any) => void;
     jest.mocked(spawnAsync).mockReturnValueOnce(
@@ -188,7 +226,7 @@ describe('getFileOutputAsync', () => {
   });
 });
 
-describe('unbounded commands', () => {
+describe('bounded commands', () => {
   jest.setTimeout(10_000);
 
   class FixtureADBServer extends ADBServer {
@@ -206,9 +244,9 @@ describe('unbounded commands', () => {
     jest.mocked(spawnAsync).mockImplementation(jest.requireActual('@expo/spawn-async'));
   });
 
-  it('allows a finite command to run without a default deadline', async () => {
+  it('allows a finite command to finish within the default deadline', async () => {
     await expect(new FixtureADBServer().runDeviceQueryAsync(['finite'], 'finite')).resolves.toBe(
-      'completed\n'
+      'completed'
     );
   });
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/ADBServer-test.ts
@@ -1,17 +1,15 @@
 import spawnAsync from '@expo/spawn-async';
-import { execFileSync } from 'child_process';
 import { vol } from 'memfs';
+import path from 'node:path';
 
 import * as Log from '../../../../log';
 import { AbortCommandError } from '../../../../utils/errors';
-import { installExitHooks } from '../../../../utils/exit';
 import { ADBServer } from '../ADBServer';
+import { AdbProcessWaitError } from '../adbProcess';
 
 jest.mock('fs', () => jest.requireActual('memfs').fs);
 jest.mock('../../../../log');
-jest.mock('../../../../utils/exit', () => ({
-  installExitHooks: jest.fn(),
-}));
+jest.unmock('child_process');
 
 const env = process.env;
 
@@ -78,89 +76,156 @@ describe('resolveAdbPromise', () => {
       /^Invalid ADB user number "FUNKY" set with environment variable EXPO_ADB_USER. Run "adb shell pm list users" to see valid user numbers.$/
     );
   });
+  it('preserves structured wait errors even when the terminated client produced output', async () => {
+    const server = new ADBServer();
+    const error = Object.assign(
+      new AdbProcessWaitError(
+        'Expo stopped waiting for discovery.',
+        'device discovery',
+        'host-request'
+      ),
+      {
+        stdout: 'partial output',
+        stderr: 'diagnostic output',
+        signal: 'SIGTERM',
+      }
+    );
+
+    await expect(server.resolveAdbPromise(Promise.reject(error))).rejects.toBe(error);
+  });
 });
 
-describe('startAsync', () => {
-  it(`starts the ADB server`, async () => {
-    jest.mocked(spawnAsync).mockResolvedValueOnce({
-      stderr: '* daemon started successfully',
-    } as any);
-    const server = new ADBServer();
-    await expect(server.startAsync()).resolves.toBe(true);
-    expect(server.isRunning).toBe(true);
-    expect(installExitHooks).toHaveBeenCalledTimes(1);
-    expect(spawnAsync).toHaveBeenCalledTimes(1);
-  });
-  it(`does not start if the server is already running`, async () => {
-    const server = new ADBServer();
-    server.isRunning = true;
-    await expect(server.startAsync()).resolves.toBe(false);
-    expect(server.isRunning).toBe(true);
-    expect(installExitHooks).toHaveBeenCalledTimes(0);
-    expect(spawnAsync).toHaveBeenCalledTimes(0);
-  });
-});
-describe('runAsync', () => {
+describe('runDeviceQueryAsync', () => {
   it(`runs an ADB command`, async () => {
     jest.mocked(spawnAsync).mockResolvedValueOnce({
-      output: ['did thing'],
-      stderr: 'did thing',
+      stdout: 'did thing',
+      stderr: '',
+      status: 0,
+      signal: null,
     } as any);
     const server = new ADBServer();
-    server.startAsync = jest.fn();
     server.resolveAdbPromise = jest.fn(server.resolveAdbPromise);
     server.getAdbExecutablePath = jest.fn(() => 'adb');
-    await expect(server.runAsync(['foo', 'bar'])).resolves.toBe('did thing');
+    await expect(server.runDeviceQueryAsync(['foo', 'bar'], 'test query')).resolves.toBe(
+      'did thing\n'
+    );
     expect(server.getAdbExecutablePath).toHaveBeenCalledTimes(1);
-    expect(server.startAsync).toHaveBeenCalledTimes(1);
     expect(server.resolveAdbPromise).toHaveBeenCalledTimes(1);
     expect(spawnAsync).toHaveBeenCalledTimes(1);
     expect(spawnAsync).toHaveBeenCalledWith('adb', ['foo', 'bar']);
   });
+
+  it('preserves stdout-before-stderr combined output', async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
+      stdout: 'machine-readable output',
+      stderr: 'diagnostic output',
+      status: 0,
+      signal: null,
+    } as any);
+    const server = new ADBServer();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+
+    await expect(server.runDeviceQueryAsync(['devices', '-l'], 'device query')).resolves.toBe(
+      'machine-readable output\ndiagnostic output'
+    );
+  });
 });
 describe('getFileOutputAsync', () => {
-  it(`returns file output from ADB`, async () => {
-    jest.mocked(execFileSync).mockReturnValueOnce('foobar');
+  it(`returns UTF-8 file output from ADB`, async () => {
+    const output = '日本語 🚀';
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
+      stdout: output,
+      stderr: '',
+      status: 0,
+      signal: null,
+    } as any);
     const server = new ADBServer();
-    server.startAsync = jest.fn();
     server.resolveAdbPromise = jest.fn(server.resolveAdbPromise);
     server.getAdbExecutablePath = jest.fn(() => 'adb');
-    await expect(server.getFileOutputAsync(['foo', 'bar'])).resolves.toBe('foobar');
+    await expect(server.getFileOutputAsync(['foo', 'bar'])).resolves.toBe(output);
     expect(server.getAdbExecutablePath).toHaveBeenCalledTimes(1);
-    expect(server.startAsync).toHaveBeenCalledTimes(1);
     expect(server.resolveAdbPromise).toHaveBeenCalledTimes(1);
-    expect(execFileSync).toHaveBeenCalledTimes(1);
-    expect(execFileSync).toHaveBeenCalledWith('adb', ['foo', 'bar'], {
-      encoding: 'latin1',
-      stdio: 'pipe',
-    });
-  });
-});
-describe('stopAsync', () => {
-  it(`stops the ADB server when running`, async () => {
-    jest.mocked(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
-    const server = new ADBServer();
-    server.isRunning = true;
-    await expect(server.stopAsync()).resolves.toBe(true);
-    expect(server.isRunning).toBe(false);
     expect(spawnAsync).toHaveBeenCalledTimes(1);
-  });
-  it(`stops the ADB server when not running`, async () => {
-    jest.mocked(spawnAsync).mockResolvedValueOnce({ output: [''] } as any);
-    const server = new ADBServer();
-    server.isRunning = false;
-    await expect(server.stopAsync()).resolves.toBe(false);
-    expect(spawnAsync).toHaveBeenCalledTimes(0);
+    expect(spawnAsync).toHaveBeenCalledWith('adb', ['foo', 'bar']);
   });
 
-  it(`considers the ADB server stopped if the process fails`, async () => {
-    const server = new ADBServer();
-    server.isRunning = true;
-    server.runAsync = jest.fn(() => {
-      throw new Error('foobar');
+  it('maps ADB errors from property queries', async () => {
+    jest.mocked(spawnAsync).mockRejectedValueOnce({
+      status: 255,
+      stdout: 'Error: java.lang.IllegalArgumentException: Bad user number: FUNKY\n',
+      stderr: '',
     });
-    await expect(server.stopAsync()).resolves.toBe(false);
-    expect(server.isRunning).toBe(false);
-    expect(Log.error).toHaveBeenCalled();
+    const server = new ADBServer();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+
+    await expect(server.getFileOutputAsync(['shell', 'getprop'])).rejects.toThrow(
+      'Invalid ADB user number "FUNKY"'
+    );
+  });
+
+  it('does not block scheduled JavaScript while a property query is pending', async () => {
+    let resolveSpawn!: (result: any) => void;
+    jest.mocked(spawnAsync).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSpawn = resolve;
+      }) as any
+    );
+    const server = new ADBServer();
+    server.getAdbExecutablePath = jest.fn(() => 'adb');
+    const scheduledTask = jest.fn();
+    const query = server.getFileOutputAsync(['shell', 'getprop']);
+
+    await new Promise<void>((resolve) =>
+      setTimeout(() => {
+        scheduledTask();
+        resolve();
+      }, 0)
+    );
+    expect(scheduledTask).toHaveBeenCalledTimes(1);
+
+    resolveSpawn({ stdout: 'value', stderr: '', status: 0, signal: null });
+    await expect(query).resolves.toBe('value');
+  });
+});
+
+describe('unbounded commands', () => {
+  jest.setTimeout(10_000);
+
+  class FixtureADBServer extends ADBServer {
+    override getAdbExecutablePath(): string {
+      return process.execPath;
+    }
+
+    override runDeviceQueryAsync(args: string[], operation: string, signal?: AbortSignal) {
+      const fixture = path.join(__dirname, 'fixtures', 'adb-long-command.js');
+      return super.runDeviceQueryAsync([fixture, ...args], operation, signal);
+    }
+  }
+
+  beforeEach(() => {
+    jest.mocked(spawnAsync).mockImplementation(jest.requireActual('@expo/spawn-async'));
+  });
+
+  it('allows a finite command to run without a default deadline', async () => {
+    await expect(new FixtureADBServer().runDeviceQueryAsync(['finite'], 'finite')).resolves.toBe(
+      'completed\n'
+    );
+  });
+
+  it('keeps a stream active until its caller cancels', async () => {
+    const controller = new AbortController();
+    const stream = new FixtureADBServer().runDeviceQueryAsync(
+      ['stream'],
+      'stream',
+      controller.signal
+    );
+    const reason = new Error('stop stream');
+    const cancellation = setTimeout(() => controller.abort(reason), 100);
+
+    try {
+      await expect(stream).rejects.toBe(reason);
+    } finally {
+      clearTimeout(cancellation);
+    }
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -10,6 +10,7 @@ import {
   openUrlAsync,
 } from '../adb';
 import { startDeviceAsync } from '../emulator';
+import { getDevicesAsync } from '../getDevices';
 import { shellDumpsysPackage } from './fixtures/adb-output';
 
 jest.mock('../adbReverse', () => ({
@@ -26,6 +27,7 @@ jest.mock('../adb', () => ({
   logUnauthorized: jest.fn(),
 }));
 jest.mock('../emulator', () => ({ startDeviceAsync: jest.fn() }));
+jest.mock('../getDevices', () => ({ getDevicesAsync: jest.fn() }));
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 
@@ -228,6 +230,87 @@ describe('device resolution', () => {
       /The device disconnected. Reconnect it and try again./
     );
     expect(installAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveFromNameAsync', () => {
+  it('resolves a physical device by serial', async () => {
+    const device = asDevice({
+      name: 'moto_g55_5G',
+      pid: 'ZY22KPLGQ9',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([device]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(device);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('ZY22KPLGQ9');
+    expect(manager.device.pid).toBe('ZY22KPLGQ9');
+  });
+
+  it('resolves a physical device by name', async () => {
+    const device = asDevice({
+      name: 'moto_g55_5G',
+      pid: 'ZY22KPLGQ9',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([device]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(device);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('moto_g55_5G');
+    expect(manager.device.pid).toBe('ZY22KPLGQ9');
+  });
+
+  it('prefers a serial match over a name match', async () => {
+    const deviceNamedX = asDevice({
+      name: 'X',
+      pid: 'other-serial',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    const deviceWithSerialX = asDevice({
+      name: 'other-name',
+      pid: 'X',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([deviceNamedX, deviceWithSerialX]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(deviceWithSerialX);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('X');
+    expect(manager.device.pid).toBe('X');
+    expect(manager.device.name).toBe('other-name');
+  });
+
+  it('rejects with an actionable error when no device matches', async () => {
+    const device = asDevice({
+      name: 'Pixel 5',
+      pid: '123',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValue([device]);
+
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /nonsense/s
+    );
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /Pixel 5.*123/s
+    );
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /--device/s
+    );
   });
 });
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -1,7 +1,14 @@
 import { CommandError } from '../../../../utils/errors';
 import { AndroidDeviceManager } from '../AndroidDeviceManager';
 import type { Device } from '../adb';
-import { getPackageInfoAsync, launchActivityAsync, openUrlAsync } from '../adb';
+import {
+  getPackageInfoAsync,
+  installAsync,
+  isDeviceBootedAsync,
+  launchActivityAsync,
+  openUrlAsync,
+} from '../adb';
+import { startDeviceAsync } from '../emulator';
 import { shellDumpsysPackage } from './fixtures/adb-output';
 
 jest.mock('../adbReverse', () => ({
@@ -12,13 +19,127 @@ jest.mock('../adb', () => ({
   launchActivityAsync: jest.fn(),
   openAppIdAsync: jest.fn(),
   openUrlAsync: jest.fn(),
+  installAsync: jest.fn(),
+  isPackageInstalledAsync: jest.fn(),
+  isDeviceBootedAsync: jest.fn(),
+  logUnauthorized: jest.fn(),
 }));
+jest.mock('../emulator', () => ({ startDeviceAsync: jest.fn() }));
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 
 function createDevice() {
   return new AndroidDeviceManager(asDevice({ name: 'Pixel 5', pid: '123' }));
 }
+
+describe('device resolution', () => {
+  it('launches only an explicit AVD inventory record', async () => {
+    const avd = asDevice({
+      name: 'Pixel_API_35',
+      type: 'emulator',
+      isLaunchable: true,
+      isBooted: false,
+      isAuthorized: true,
+    });
+    const attached = asDevice({
+      ...avd,
+      pid: 'emulator-5554',
+      state: 'device',
+      transportId: '4',
+      isLaunchable: false,
+      isBooted: true,
+    });
+    jest.mocked(startDeviceAsync).mockResolvedValueOnce(attached);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: avd })).resolves.toMatchObject({
+      device: attached,
+    });
+    expect(startDeviceAsync).toHaveBeenCalledWith(avd);
+    expect(isDeviceBootedAsync).not.toHaveBeenCalled();
+  });
+
+  it.each(['offline', 'unauthorized', 'future-state'])(
+    'rejects an attached %s transport without entering the AVD launch path',
+    async (state) => {
+      const physical = asDevice({
+        name: 'Device USB-1',
+        pid: 'USB-1',
+        type: 'device',
+        state,
+        isLaunchable: false,
+        isAuthorized: state !== 'unauthorized',
+      });
+
+      await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(state);
+      expect(startDeviceAsync).not.toHaveBeenCalled();
+      expect(isDeviceBootedAsync).not.toHaveBeenCalled();
+    }
+  );
+
+  it('reports disappearance after discovery without launching or replaying', async () => {
+    const physical = asDevice({
+      name: 'Pixel USB',
+      pid: 'USB-1',
+      type: 'device',
+      state: 'device',
+      transportId: '4',
+      isLaunchable: false,
+      isAuthorized: true,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(null);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(
+      /Device not found after discovery/
+    );
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+  });
+
+  it('uses a freshly rediscovered physical transport without launching an emulator', async () => {
+    const physical = asDevice({
+      name: 'Pixel USB',
+      pid: 'USB-1',
+      type: 'device',
+      state: 'device',
+      transportId: '4',
+      isLaunchable: false,
+      isAuthorized: true,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(physical);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: physical })).resolves.toMatchObject({
+      device: physical,
+    });
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+  });
+
+  it('reports transport replacement after discovery', async () => {
+    const physical = asDevice({
+      name: 'Pixel USB',
+      pid: 'USB-1',
+      type: 'device',
+      state: 'device',
+      transportId: '4',
+      isLaunchable: false,
+      isAuthorized: true,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce({ ...physical, transportId: '5' });
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(
+      /transport 4 became 5/
+    );
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+  });
+
+  it('maps a post-selection device-not-found error without replaying install', async () => {
+    const manager = createDevice();
+    jest.mocked(installAsync).mockRejectedValueOnce(new Error('error: device not found'));
+
+    await expect(manager.installAppAsync('/tmp/app.apk')).rejects.toThrow(
+      /The device disconnected. Reconnect it and try again./
+    );
+    expect(installAsync).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('getAppVersionAsync', () => {
   it(`gets the version from an installed app`, async () => {
@@ -65,7 +186,8 @@ describe('launchActivityAsync', () => {
       expect.objectContaining({
         launchActivity: 'dev.expo.test/.MainActivity',
         url: 'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
-      })
+      }),
+      expect.any(AbortSignal)
     );
   });
 });
@@ -76,15 +198,24 @@ describe('openUrlAsync', () => {
     await device.openUrlAsync('exp://foobar');
     expect(launchActivityAsync).toHaveBeenCalledWith(
       { pid: '123' },
-      { launchActivity: 'host.exp.exponent/.experience.HomeActivity' }
+      { launchActivity: 'host.exp.exponent/.experience.HomeActivity' },
+      expect.any(AbortSignal)
     );
-    expect(openUrlAsync).toHaveBeenCalledWith({ pid: '123' }, { url: 'exp://foobar' });
+    expect(openUrlAsync).toHaveBeenCalledWith(
+      { pid: '123' },
+      { url: 'exp://foobar' },
+      expect.any(AbortSignal)
+    );
   });
   it('opens a URL on a device', async () => {
     const device = createDevice();
     await device.openUrlAsync('http://foobar');
     expect(launchActivityAsync).not.toHaveBeenCalled();
-    expect(openUrlAsync).toHaveBeenCalledWith({ pid: '123' }, { url: 'http://foobar' });
+    expect(openUrlAsync).toHaveBeenCalledWith(
+      { pid: '123' },
+      { url: 'http://foobar' },
+      expect.any(AbortSignal)
+    );
   });
   it('launches nonstandard URL', async () => {
     const device = createDevice();

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -6,6 +6,7 @@ import {
   installAsync,
   isDeviceBootedAsync,
   launchActivityAsync,
+  logUnauthorized,
   openUrlAsync,
 } from '../adb';
 import { startDeviceAsync } from '../emulator';
@@ -58,7 +59,7 @@ describe('device resolution', () => {
     expect(isDeviceBootedAsync).not.toHaveBeenCalled();
   });
 
-  it.each(['offline', 'unauthorized', 'future-state'])(
+  it.each(['offline', 'future-state'])(
     'rejects an attached %s transport without entering the AVD launch path',
     async (state) => {
       const physical = asDevice({
@@ -67,7 +68,7 @@ describe('device resolution', () => {
         type: 'device',
         state,
         isLaunchable: false,
-        isAuthorized: state !== 'unauthorized',
+        isAuthorized: true,
       });
 
       await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(state);
@@ -75,6 +76,24 @@ describe('device resolution', () => {
       expect(isDeviceBootedAsync).not.toHaveBeenCalled();
     }
   );
+
+  it('preserves the dedicated authorization flow for an attached unauthorized device', async () => {
+    const physical = asDevice({
+      name: 'Device USB-1',
+      pid: 'USB-1',
+      type: 'device',
+      state: 'unauthorized',
+      isLaunchable: false,
+      isAuthorized: false,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(physical);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(
+      'Interactive prompt was cancelled.'
+    );
+    expect(logUnauthorized).toHaveBeenCalledWith(physical);
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+  });
 
   it('reports disappearance after discovery without launching or replaying', async () => {
     const physical = asDevice({

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -56,7 +56,30 @@ describe('device resolution', () => {
       device: attached,
     });
     expect(startDeviceAsync).toHaveBeenCalledWith(avd);
-    expect(isDeviceBootedAsync).not.toHaveBeenCalled();
+    expect(isDeviceBootedAsync).toHaveBeenCalledWith(avd);
+  });
+
+  it('does not relaunch an AVD that became attached after inventory', async () => {
+    const avd = asDevice({
+      name: 'Pixel_API_35',
+      type: 'emulator',
+      isLaunchable: true,
+      isBooted: false,
+      isAuthorized: true,
+    });
+    const attached = asDevice({
+      ...avd,
+      pid: 'emulator-5554',
+      state: 'device',
+      isLaunchable: false,
+      isBooted: true,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(attached);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: avd })).resolves.toMatchObject({
+      device: attached,
+    });
+    expect(startDeviceAsync).not.toHaveBeenCalled();
   });
 
   it.each(['offline', 'future-state'])(
@@ -89,7 +112,7 @@ describe('device resolution', () => {
     jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(physical);
 
     await expect(AndroidDeviceManager.resolveAsync({ device: physical })).rejects.toThrow(
-      'Interactive prompt was cancelled.'
+      /Device USB-1 is unauthorized.*Authorize this computer/s
     );
     expect(logUnauthorized).toHaveBeenCalledWith(physical);
     expect(startDeviceAsync).not.toHaveBeenCalled();

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -82,6 +82,54 @@ describe('device resolution', () => {
     expect(startDeviceAsync).not.toHaveBeenCalled();
   });
 
+  it('reports a booting AVD that became attached after inventory as unready', async () => {
+    const avd = asDevice({
+      name: 'Pixel_API_35',
+      type: 'emulator',
+      isLaunchable: true,
+      isBooted: false,
+      isAuthorized: true,
+    });
+    const booting = asDevice({
+      ...avd,
+      pid: 'emulator-5554',
+      state: 'offline',
+      isLaunchable: false,
+      isAuthorized: false,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(booting);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: avd })).rejects.toThrow(
+      /emulator-5554 is in state offline.*Wait until ADB reports the emulator as ready/s
+    );
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+    expect(logUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('keeps the authorization flow for an unauthorized AVD that became attached', async () => {
+    const avd = asDevice({
+      name: 'Pixel_API_35',
+      type: 'emulator',
+      isLaunchable: true,
+      isBooted: false,
+      isAuthorized: true,
+    });
+    const attached = asDevice({
+      ...avd,
+      pid: 'emulator-5554',
+      state: 'unauthorized',
+      isLaunchable: false,
+      isAuthorized: false,
+    });
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(attached);
+
+    await expect(AndroidDeviceManager.resolveAsync({ device: avd })).rejects.toThrow(
+      /emulator-5554 is unauthorized.*Authorize this computer/s
+    );
+    expect(logUnauthorized).toHaveBeenCalledWith(attached);
+    expect(startDeviceAsync).not.toHaveBeenCalled();
+  });
+
   it.each(['offline', 'future-state'])(
     'rejects an attached %s transport without entering the AVD launch path',
     async (state) => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -304,6 +304,53 @@ describe(isDeviceBootedAsync, () => {
 });
 
 describe(getAttachedDevicesAsync, () => {
+  it('retries transient empty discovery results', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockResolvedValueOnce(deviceListResult(''))
+      .mockResolvedValueOnce(deviceListResult(''))
+      .mockResolvedValueOnce(deviceListResult('USB-1 device usb:1 model:Pixel transport_id:4'));
+
+    await expect(getAttachedDevicesAsync()).resolves.toEqual([
+      expect.objectContaining({ pid: 'USB-1', name: 'Pixel' }),
+    ]);
+    expect(getServer().runHostQueryAsync).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses an AVD name for a booting offline emulator', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockResolvedValueOnce(deviceListResult('emulator-5554 offline transport_id:1'));
+    jest.mocked(getServer().runDeviceQueryAsync).mockResolvedValueOnce('Pixel_8a_big\nOK');
+
+    await expect(getAttachedDevicesAsync()).resolves.toEqual([
+      expect.objectContaining({
+        pid: 'emulator-5554',
+        name: 'Pixel_8a_big',
+        state: 'offline',
+        isBooted: false,
+      }),
+    ]);
+  });
+
+  it('keeps healthy devices when an emulator console name query fails', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockResolvedValueOnce(
+        deviceListResult(
+          'USB-1 device usb:1 model:Pixel transport_id:4\nemulator-5554 device transport_id:1'
+        )
+      );
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockRejectedValueOnce(new Error('could not connect to TCP port 5554: Connection refused'));
+
+    await expect(getAttachedDevicesAsync()).resolves.toEqual([
+      expect.objectContaining({ pid: 'USB-1', name: 'Pixel' }),
+      expect.objectContaining({ pid: 'emulator-5554', name: 'Device emulator-5554' }),
+    ]);
+  });
+
   it(`gets devices`, async () => {
     jest.mocked(getServer().runHostQueryAsync).mockResolvedValueOnce(
       deviceListResult(
@@ -448,10 +495,14 @@ describe(getAttachedDevicesAsync, () => {
 
   it('reports a silent remote endpoint without replacing its owner', async () => {
     process.env.ANDROID_ADB_SERVER_ADDRESS = '192.0.2.10';
-    jest.mocked(getServer().runHostQueryAsync).mockRejectedValueOnce(new Error('discovery failed'));
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockRejectedValue(
+        new AdbProcessWaitError('discovery timed out', 'device discovery', 'host-request')
+      );
     jest
       .spyOn(AdbEndpoint, 'probeAdbHostVersionAsync')
-      .mockResolvedValueOnce({ kind: 'connected-no-reply' });
+      .mockResolvedValue({ kind: 'connected-no-reply' });
 
     await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).rejects.toThrow(
       /ADB server at tcp:192\.0\.2\.10:5037.*is not responding/
@@ -464,8 +515,10 @@ describe(getAttachedDevicesAsync, () => {
 
   it('reports invalid protocol at the custom selected socket', async () => {
     process.env.ADB_SERVER_SOCKET = 'tcp:localhost:5041';
-    jest.mocked(getServer().runHostQueryAsync).mockRejectedValueOnce(new Error('protocol failure'));
-    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockRejectedValue(new Error('cannot connect: invalid protocol'));
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValue({
       kind: 'invalid-protocol',
     });
 
@@ -474,7 +527,7 @@ describe(getAttachedDevicesAsync, () => {
     );
   });
 
-  it('diagnoses a timeout while resolving an attached emulator name', async () => {
+  it('keeps an attached emulator when resolving its name times out', async () => {
     jest
       .mocked(getServer().runHostQueryAsync)
       .mockResolvedValueOnce('List of devices attached\nemulator-5554 device transport_id:1');
@@ -483,11 +536,9 @@ describe(getAttachedDevicesAsync, () => {
       .mockRejectedValueOnce(
         new AdbProcessWaitError('name lookup timed out', 'emulator name query', 'device-service')
       );
-    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({ kind: 'version' });
-
-    await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).rejects.toThrow(
-      /ADB server is responding, but emulator name query did not finish/
-    );
+    await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).resolves.toEqual([
+      expect.objectContaining({ pid: 'emulator-5554', name: 'Device emulator-5554' }),
+    ]);
   });
 
   it('does not probe after explicit caller cancellation', async () => {
@@ -551,14 +602,13 @@ describe(getPropertyDataForDeviceAsync, () => {
       .mockRejectedValueOnce(
         new AdbProcessWaitError('property wait expired', operation, 'device-service')
       );
-    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValue({
       kind: 'version',
     });
 
     const result = getPropertyDataForDeviceAsync(asDevice({ pid: '123' }));
-    await expect(result).rejects.toThrow(
-      /ADB server is responding, but device property\/boot query did not finish/
-    );
+    await expect(result).rejects.toThrow('property wait expired');
+    await expect(result).rejects.not.toThrow(/ADB server is responding/);
   });
 
   it(`returns parsed property data`, async () => {
@@ -647,7 +697,7 @@ describe('bounded discovery integration', () => {
           waitLimitMs: 100,
           probeWaitLimitMs: 500,
         })
-      ).rejects.toThrow(/ADB server is responding, but device discovery did not finish/);
+      ).rejects.toThrow(/Expo stopped waiting for the ADB device discovery operation to finish/);
     } finally {
       for (const socket of sockets) socket.destroy();
       await new Promise<void>((resolve, reject) =>

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -3,6 +3,7 @@ import net from 'node:net';
 import path from 'node:path';
 
 import { CommandError } from '../../../../utils/errors';
+import { ora } from '../../../../utils/ora';
 import type { ADBServer } from '../ADBServer';
 import type { Device } from '../adb';
 import {
@@ -310,6 +311,8 @@ describe(getAttachedDevicesAsync, () => {
       .mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
     const devices = await getAttachedDevicesAsync();
+
+    expect(ora).not.toHaveBeenCalled();
 
     expect(devices).toEqual([
       {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -258,6 +258,29 @@ describe(isDeviceBootedAsync, () => {
     });
   });
 
+  it('revalidates a selected device by serial when device names are duplicated', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockResolvedValueOnce(
+        deviceListResult(
+          [
+            'List of devices attached',
+            'serial-1 device product:walleye model:Pixel_2 device:walleye transport_id:1',
+            'serial-2 device product:walleye model:Pixel_2 device:walleye transport_id:2',
+            '',
+          ].join('\n')
+        )
+      );
+
+    await expect(
+      isDeviceBootedAsync(asDevice({ pid: 'serial-2', name: 'Pixel_2' }))
+    ).resolves.toMatchObject({
+      pid: 'serial-2',
+      name: 'Pixel_2',
+      transportId: '2',
+    });
+  });
+
   it(`returns null when the device is not booted`, async () => {
     jest.mocked(getServer().runHostQueryAsync).mockResolvedValueOnce(deviceListResult(''));
     expect(await isDeviceBootedAsync(device)).toBe(null);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -1,5 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
 import net from 'node:net';
+import os from 'node:os';
 import path from 'node:path';
 
 import { CommandError } from '../../../../utils/errors';
@@ -21,11 +23,7 @@ import {
   openUrlAsync,
 } from '../adb';
 import * as AdbEndpoint from '../adbEndpoint';
-import {
-  AdbProcessWaitError,
-  runAdbHostQueryAsync,
-  runBoundedAdbHostQueryAsync,
-} from '../adbProcess';
+import { AdbProcessWaitError } from '../adbProcess';
 
 jest.mock('../ADBServer', () => ({
   ADBServer: jest.fn(() => {
@@ -41,6 +39,10 @@ jest.mock('../../../../utils/ora', () => ({
   ora: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })),
 }));
 jest.unmock('child_process');
+jest.unmock('fs');
+jest.unmock('node:fs');
+jest.unmock('os');
+jest.unmock('node:os');
 
 const originalEndpointEnvironment = {
   ADB_SERVER_SOCKET: process.env.ADB_SERVER_SOCKET,
@@ -698,6 +700,43 @@ describe('bounded discovery integration', () => {
     ]);
   });
 
+  it('retries a cold start that fails before its daemon accepts connections', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-adb-cold-start-'));
+    const attemptFile = path.join(directory, 'attempts');
+
+    try {
+      await expect(
+        getAttachedDevicesAsync({
+          server: fixtureServer('adb-cold-start-failure.js', [attemptFile, '1']),
+          waitLimitMs: 5_000,
+        })
+      ).resolves.toEqual([
+        expect.objectContaining({ pid: 'USB-1', name: 'Pixel', transportId: '4' }),
+      ]);
+      expect(fs.readFileSync(attemptFile, 'utf8')).toBe('2');
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a cold start that keeps failing for the whole retry window', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-adb-cold-start-'));
+    const attemptFile = path.join(directory, 'attempts');
+
+    try {
+      await expect(
+        getAttachedDevicesAsync({
+          server: fixtureServer('adb-cold-start-failure.js', [attemptFile, '1000']),
+          waitLimitMs: 5_000,
+          probeWaitLimitMs: 5,
+        })
+      ).rejects.toThrow(/cannot connect to daemon at tcp:5037: Connection refused/);
+      expect(Number(fs.readFileSync(attemptFile, 'utf8'))).toBeGreaterThan(1);
+    } finally {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
   it('cleans up silent discovery before probing the selected host', async () => {
     const sockets = new Set<net.Socket>();
     const hostServer = net.createServer((socket) => {
@@ -730,28 +769,28 @@ describe('bounded discovery integration', () => {
   });
 });
 
-function fixtureServer(name: string): ADBServer {
-  return {
+function fixtureServer(name: string, fixtureArgs: string[] = []): ADBServer {
+  const { ADBServer: ActualADBServer } =
+    jest.requireActual<typeof import('../ADBServer')>('../ADBServer');
+  const fixtureArgv = [fixturePath(name), ...fixtureArgs];
+
+  class FixtureADBServer extends ActualADBServer {
+    getAdbExecutablePath(): string {
+      return process.execPath;
+    }
+
     runHostQueryAsync(
       args: string[],
       operation: string,
       signal?: AbortSignal,
       waitLimitMs?: number
-    ) {
+    ): Promise<string> {
       jest.mocked(spawnAsync).mockImplementationOnce(jest.requireActual('@expo/spawn-async'));
-      const result =
-        waitLimitMs == null
-          ? runAdbHostQueryAsync(process.execPath, [fixturePath(name), ...args], operation, signal)
-          : runBoundedAdbHostQueryAsync(
-              process.execPath,
-              [fixturePath(name), ...args],
-              operation,
-              waitLimitMs,
-              signal
-            );
-      return result.then((result) => result.stdout);
-    },
-  } as ADBServer;
+      return super.runHostQueryAsync([...fixtureArgv, ...args], operation, signal, waitLimitMs);
+    }
+  }
+
+  return new FixtureADBServer();
 }
 
 function fixturePath(name: string): string {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -164,6 +164,21 @@ describe(launchActivityAsync, () => {
       undefined
     );
   });
+  it('classifies a rejected missing activity as not installed', async () => {
+    jest.mocked(getServer().runDeviceMutationAsync).mockRejectedValueOnce(
+      Object.assign(new Error('ADB command failed'), {
+        status: 1,
+        stderr:
+          'Error type 3\nError: Activity class {com.does.not.exist/com.does.not.exist.MainActivity} does not exist.',
+      })
+    );
+
+    await expect(
+      launchActivityAsync(device, {
+        launchActivity: 'com.does.not.exist/.MainActivity',
+      })
+    ).rejects.toMatchObject({ code: 'APP_NOT_INSTALLED' });
+  });
 });
 
 describe(isPackageInstalledAsync, () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -17,6 +17,7 @@ import {
   isPackageInstalledAsync,
   launchActivityAsync,
   sanitizeAdbDeviceName,
+  waitForAttachedDevicesAsync,
   openUrlAsync,
 } from '../adb';
 import * as AdbEndpoint from '../adbEndpoint';
@@ -304,17 +305,19 @@ describe(isDeviceBootedAsync, () => {
 });
 
 describe(getAttachedDevicesAsync, () => {
-  it('retries transient empty discovery results', async () => {
+  it('retries transient empty discovery results beyond three rapid attempts', async () => {
     jest
       .mocked(getServer().runHostQueryAsync)
       .mockResolvedValueOnce(deviceListResult(''))
       .mockResolvedValueOnce(deviceListResult(''))
+      .mockResolvedValueOnce(deviceListResult(''))
+      .mockResolvedValueOnce(deviceListResult(''))
       .mockResolvedValueOnce(deviceListResult('USB-1 device usb:1 model:Pixel transport_id:4'));
 
-    await expect(getAttachedDevicesAsync()).resolves.toEqual([
+    await expect(waitForAttachedDevicesAsync()).resolves.toEqual([
       expect.objectContaining({ pid: 'USB-1', name: 'Pixel' }),
     ]);
-    expect(getServer().runHostQueryAsync).toHaveBeenCalledTimes(3);
+    expect(getServer().runHostQueryAsync).toHaveBeenCalledTimes(5);
   });
 
   it('uses an AVD name for a booting offline emulator', async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -322,6 +322,33 @@ describe(getAttachedDevicesAsync, () => {
     expect(getServer().runHostQueryAsync).toHaveBeenCalledTimes(5);
   });
 
+  it('reports the daemon failure that drove retries when discovery runs out of time', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockRejectedValueOnce(new Error('cannot connect to daemon at tcp:5037: Connection refused'))
+      .mockResolvedValueOnce(deviceListResult('emulator-5554 device transport_id:1'));
+    jest.mocked(getServer().runDeviceQueryAsync).mockImplementationOnce(
+      (_args, _operation, signal) =>
+        new Promise((_resolve, reject) => {
+          signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+        })
+    );
+
+    await expect(
+      getAttachedDevicesAsync({ waitLimitMs: 400, probeWaitLimitMs: 5 })
+    ).rejects.toThrow(/cannot connect to daemon at tcp:5037: Connection refused/);
+    expect(getServer().runHostQueryAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not report an earlier daemon failure once a later attempt lists no devices', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockRejectedValueOnce(new Error('cannot connect to daemon at tcp:5037: Connection refused'))
+      .mockResolvedValue(deviceListResult(''));
+
+    await expect(waitForAttachedDevicesAsync()).resolves.toEqual([]);
+  });
+
   it('uses an AVD name for a booting offline emulator', async () => {
     jest
       .mocked(getServer().runHostQueryAsync)

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -303,40 +303,6 @@ describe(getAttachedDevicesAsync, () => {
       },
     ]);
   });
-
-  it(`gets devices when ADB_TRACE is set`, async () => {
-    jest
-      .mocked(getServer().runAsync)
-      .mockResolvedValueOnce(
-        [
-          'List of devices attached',
-          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:393] adb_query: host:devices-l',
-          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:351] adb_connect: service: host:devices-l',
-          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:160] _adb_connect: host:devices-l',
-          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:194] _adb_connect: return fd 3',
-          'adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:369] adb_connect: return fd 3',
-          // Emulator
-          'emulator-5554          offline transport_id:1',
-          '',
-        ].join('\n')
-      )
-      .mockResolvedValueOnce(
-        // Return the emulator name
-        ['Pixel_4_XL_API_30', 'OK'].join('\n')
-      );
-
-    const devices = await getAttachedDevicesAsync();
-
-    expect(devices).toEqual([
-      {
-        isAuthorized: true,
-        isBooted: true,
-        name: 'Pixel_4_XL_API_30',
-        pid: 'emulator-5554',
-        type: 'emulator',
-      },
-    ]);
-  });
 });
 
 describe(isBootAnimationCompleteAsync, () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -1,11 +1,16 @@
+import spawnAsync from '@expo/spawn-async';
+import net from 'node:net';
+import path from 'node:path';
+
 import { CommandError } from '../../../../utils/errors';
+import type { ADBServer } from '../ADBServer';
 import type { Device } from '../adb';
 import {
   getAdbNameForDeviceIdAsync,
   getAttachedDevicesAsync,
   getDeviceABIsAsync,
   getPropertyDataForDeviceAsync,
-  getServer,
+  getServer as getServerBase,
   isBootAnimationCompleteAsync,
   isDeviceBootedAsync,
   isPackageInstalledAsync,
@@ -13,38 +18,80 @@ import {
   sanitizeAdbDeviceName,
   openUrlAsync,
 } from '../adb';
+import * as AdbEndpoint from '../adbEndpoint';
+import {
+  AdbProcessWaitError,
+  runAdbHostQueryAsync,
+  runBoundedAdbHostQueryAsync,
+} from '../adbProcess';
 
 jest.mock('../ADBServer', () => ({
-  ADBServer: jest.fn(() => ({
-    runAsync: jest.fn(async () => ''),
-    getFileOutputAsync: jest.fn(async () => ''),
-  })),
+  ADBServer: jest.fn(() => {
+    return {
+      runDeviceQueryAsync: jest.fn(async () => ''),
+      runDeviceMutationAsync: jest.fn(async () => ''),
+      runHostQueryAsync: jest.fn(async () => ''),
+      getFileOutputAsync: jest.fn(async () => ''),
+    };
+  }),
 }));
+jest.mock('../../../../utils/ora', () => ({
+  ora: jest.fn(() => ({ start: jest.fn(), stop: jest.fn() })),
+}));
+jest.unmock('child_process');
+
+const originalEndpointEnvironment = {
+  ADB_SERVER_SOCKET: process.env.ADB_SERVER_SOCKET,
+  ANDROID_ADB_SERVER_ADDRESS: process.env.ANDROID_ADB_SERVER_ADDRESS,
+  ANDROID_ADB_SERVER_PORT: process.env.ANDROID_ADB_SERVER_PORT,
+};
+
+beforeEach(() => {
+  delete process.env.ADB_SERVER_SOCKET;
+  delete process.env.ANDROID_ADB_SERVER_ADDRESS;
+  delete process.env.ANDROID_ADB_SERVER_PORT;
+});
+
+afterAll(() => {
+  for (const [key, value] of Object.entries(originalEndpointEnvironment)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
+const getServer = () => jest.mocked(getServerBase());
 
 const device = asDevice({ name: 'Pixel 5', pid: '123' });
+
+const deviceListResult = (stdout: string) => stdout;
 
 describe(openUrlAsync, () => {
   it(`quotes the url`, async () => {
     await openUrlAsync(device, { url: 'acme://foo?bar=1&baz=2' });
-    expect(getServer().runAsync).toHaveBeenCalledWith([
-      '-s',
-      '123',
-      'shell',
-      "'am'",
-      "'start'",
-      "'-a'",
-      "'android.intent.action.VIEW'",
-      "'-d'",
-      "'acme://foo?bar=1&baz=2'",
-    ]);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledWith(
+      [
+        '-s',
+        '123',
+        'shell',
+        "'am'",
+        "'start'",
+        "'-a'",
+        "'android.intent.action.VIEW'",
+        "'-d'",
+        "'acme://foo?bar=1&baz=2'",
+      ],
+      'URL launch',
+      undefined
+    );
   });
 
   it(`neutralizes shell-injection attempts in the url`, async () => {
     await openUrlAsync(device, { url: 'acme://x; reboot' });
-    expect(getServer().runAsync).toHaveBeenCalledWith(
-      expect.arrayContaining(["'acme://x; reboot'"])
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'acme://x; reboot'"]),
+      'URL launch',
+      undefined
     );
   });
 });
@@ -52,7 +99,7 @@ describe(openUrlAsync, () => {
 describe(launchActivityAsync, () => {
   it(`asserts that the launch activity does not exist`, async () => {
     jest
-      .mocked(getServer().runAsync)
+      .mocked(getServer().runDeviceMutationAsync)
       .mockResolvedValueOnce('Error: Activity class dev.bacon.app/.MainActivity does not exist.');
     await expect(
       launchActivityAsync(device, {
@@ -61,49 +108,59 @@ describe(launchActivityAsync, () => {
     ).rejects.toThrow(CommandError);
   });
   it(`launches activity`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
+    jest.mocked(getServer().runDeviceMutationAsync).mockResolvedValueOnce('...');
     await launchActivityAsync(device, {
       launchActivity: 'dev.bacon.app/.MainActivity',
     });
-    expect(getServer().runAsync).toHaveBeenCalledWith([
-      '-s',
-      '123',
-      'shell',
-      "'am'",
-      "'start'",
-      "'-f'",
-      "'0x20000000'",
-      "'-n'",
-      "'dev.bacon.app/.MainActivity'",
-    ]);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledWith(
+      [
+        '-s',
+        '123',
+        'shell',
+        "'am'",
+        "'start'",
+        "'-f'",
+        "'0x20000000'",
+        "'-n'",
+        "'dev.bacon.app/.MainActivity'",
+      ],
+      'activity launch',
+      undefined
+    );
   });
   it(`launches activity with url`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
+    jest.mocked(getServer().runDeviceMutationAsync).mockResolvedValueOnce('...');
     await launchActivityAsync(device, {
       launchActivity: 'dev.expo.custom.appid/dev.bacon.app.MainActivity',
       url: 'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
     });
-    expect(getServer().runAsync).toHaveBeenCalledWith([
-      '-s',
-      '123',
-      'shell',
-      "'am'",
-      "'start'",
-      "'-f'",
-      "'0x20000000'",
-      "'-n'",
-      "'dev.expo.custom.appid/dev.bacon.app.MainActivity'",
-      "'-d'",
-      "'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081'",
-    ]);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledWith(
+      [
+        '-s',
+        '123',
+        'shell',
+        "'am'",
+        "'start'",
+        "'-f'",
+        "'0x20000000'",
+        "'-n'",
+        "'dev.expo.custom.appid/dev.bacon.app.MainActivity'",
+        "'-d'",
+        "'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081'",
+      ],
+      'activity launch',
+      undefined
+    );
   });
   it(`neutralizes shell-injection attempts in the launch activity`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
+    jest.mocked(getServer().runDeviceMutationAsync).mockResolvedValueOnce('...');
     await launchActivityAsync(device, {
       launchActivity: 'dev.bacon.app/.MainActivity; reboot',
     });
-    expect(getServer().runAsync).toHaveBeenCalledWith(
-      expect.arrayContaining(["'dev.bacon.app/.MainActivity; reboot'"])
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'dev.bacon.app/.MainActivity; reboot'"]),
+      'activity launch',
+      undefined
     );
   });
 });
@@ -111,7 +168,7 @@ describe(launchActivityAsync, () => {
 describe(isPackageInstalledAsync, () => {
   it(`returns true when a package is installed`, async () => {
     jest
-      .mocked(getServer().runAsync)
+      .mocked(getServer().runDeviceQueryAsync)
       .mockResolvedValueOnce(
         [
           'package:com.google.android.networkstack.tethering',
@@ -120,34 +177,42 @@ describe(isPackageInstalledAsync, () => {
         ].join('\n')
       );
     expect(await isPackageInstalledAsync(device, 'com.google.android.youtube')).toBe(true);
-    expect(getServer().runAsync).toHaveBeenCalledWith([
-      '-s',
-      '123',
-      'shell',
-      "'pm'",
-      "'list'",
-      "'packages'",
-      "'--user'",
-      "'0'",
-      "'com.google.android.youtube'",
-    ]);
+    expect(getServer().runDeviceQueryAsync).toHaveBeenCalledWith(
+      [
+        '-s',
+        '123',
+        'shell',
+        "'pm'",
+        "'list'",
+        "'packages'",
+        "'--user'",
+        "'0'",
+        "'com.google.android.youtube'",
+      ],
+      'package query',
+      undefined
+    );
   });
   it(`returns false when a package is not isntalled`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
+    jest.mocked(getServer().runDeviceQueryAsync).mockResolvedValueOnce('');
     expect(await isPackageInstalledAsync(device, 'com.google.android.youtube')).toBe(false);
   });
   it(`neutralizes shell-injection attempts in the package name`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
+    jest.mocked(getServer().runDeviceQueryAsync).mockResolvedValueOnce('');
     await isPackageInstalledAsync(device, 'com.google.android.youtube; reboot');
-    expect(getServer().runAsync).toHaveBeenCalledWith(
-      expect.arrayContaining(["'com.google.android.youtube; reboot'"])
+    expect(getServer().runDeviceQueryAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'com.google.android.youtube; reboot'"]),
+      'package query',
+      undefined
     );
   });
 });
 
 describe(getAdbNameForDeviceIdAsync, () => {
   it(`returns a device name`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
     expect(await getAdbNameForDeviceIdAsync(asDevice({ pid: 'emulator-5554' }))).toBe(
       'Pixel_4_XL_API_30'
@@ -155,7 +220,7 @@ describe(getAdbNameForDeviceIdAsync, () => {
   });
   it(`asserts when a device is not found`, async () => {
     jest
-      .mocked(getServer().runAsync)
+      .mocked(getServer().runDeviceQueryAsync)
       .mockResolvedValueOnce('error: could not connect to TCP port 55534: Connection refused');
 
     await expect(getAdbNameForDeviceIdAsync(asDevice({ pid: 'emulator-5554' }))).rejects.toThrow(
@@ -167,39 +232,42 @@ describe(getAdbNameForDeviceIdAsync, () => {
 describe(isDeviceBootedAsync, () => {
   it(`returns a device when booted`, async () => {
     jest
-      .mocked(getServer().runAsync)
+      .mocked(getServer().runHostQueryAsync)
       .mockResolvedValueOnce(
-        [
-          'List of devices attached',
-          'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
-          '',
-        ].join('\n')
-      )
-      .mockResolvedValueOnce(
-        // Return the emulator name
-        ['Pixel_4_XL_API_30', 'OK'].join('\n')
+        deviceListResult(
+          [
+            'List of devices attached',
+            'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
+            '',
+          ].join('\n')
+        )
       );
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
-    expect(await isDeviceBootedAsync(asDevice({ name: 'Pixel_4_XL_API_30' }))).toStrictEqual({
+    expect(await isDeviceBootedAsync(asDevice({ name: 'Pixel_4_XL_API_30' }))).toMatchObject({
       isAuthorized: true,
       isBooted: true,
+      isLaunchable: false,
       name: 'Pixel_4_XL_API_30',
       pid: 'emulator-5554',
+      state: 'device',
+      transportId: '1',
       type: 'emulator',
     });
   });
 
   it(`returns null when the device is not booted`, async () => {
-    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
+    jest.mocked(getServer().runHostQueryAsync).mockResolvedValueOnce(deviceListResult(''));
     expect(await isDeviceBootedAsync(device)).toBe(null);
   });
 });
 
 describe(getAttachedDevicesAsync, () => {
   it(`gets devices`, async () => {
-    jest
-      .mocked(getServer().runAsync)
-      .mockResolvedValueOnce(
+    jest.mocked(getServer().runHostQueryAsync).mockResolvedValueOnce(
+      deviceListResult(
         [
           'List of devices attached',
           // unauthorized
@@ -208,64 +276,85 @@ describe(getAttachedDevicesAsync, () => {
           'FA8251A00720 device usb:338690048X product:walleye model:Pixel_2 device:walleye transport_id:4',
           // Emulator
           'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
+          // Physical device with "emulator" in its metadata
+          'FA8251A00721 device usb:338690048X model:emulator_phone transport_id:6',
           '',
         ].join('\n')
       )
-      .mockResolvedValueOnce(
-        // Return the emulator name
-        ['Pixel_4_XL_API_30', 'OK'].join('\n')
-      );
+    );
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
     const devices = await getAttachedDevicesAsync();
 
     expect(devices).toEqual([
       {
         isAuthorized: false,
-        isBooted: true,
+        isBooted: false,
+        isLaunchable: false,
         name: 'Device FA8251A00719',
         pid: 'FA8251A00719',
+        state: 'unauthorized',
+        transportId: '5',
         type: 'device',
         connectionType: 'USB',
       },
       {
         isAuthorized: true,
         isBooted: true,
+        isLaunchable: false,
         name: 'Pixel_2',
         pid: 'FA8251A00720',
+        state: 'device',
+        transportId: '4',
         type: 'device',
         connectionType: 'USB',
       },
       {
         isAuthorized: true,
         isBooted: true,
+        isLaunchable: false,
         name: 'Pixel_4_XL_API_30',
         pid: 'emulator-5554',
+        state: 'device',
+        transportId: '1',
         type: 'emulator',
+      },
+      {
+        connectionType: 'USB',
+        isAuthorized: true,
+        isBooted: true,
+        isLaunchable: false,
+        name: 'emulator_phone',
+        pid: 'FA8251A00721',
+        state: 'device',
+        transportId: '6',
+        type: 'device',
       },
     ]);
   });
 
   it(`gets network connected devices`, async () => {
-    jest
-      .mocked(getServer().runAsync)
-      .mockResolvedValueOnce(
+    jest.mocked(getServer().runHostQueryAsync).mockResolvedValueOnce(
+      deviceListResult(
         [
           'List of devices attached',
-          // unauthorized
+          // offline
           'adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp. offline transport_id:1',
           // authorized & online
           'adb-00000XXX000XXX-YzXxxx._adb-tls-connect._tcp. device product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
-          // authorized & offline
+          // offline with retained model metadata
           'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp. offline product:cheetah model:Pixel_7_Pro device:cheetah transport_id:2',
           // Emulator
           'emulator-5554          device product:sdk_gphone_x86_arm model:sdk_gphone_x86_arm device:generic_x86_arm transport_id:1',
           '',
         ].join('\n')
       )
-      .mockResolvedValueOnce(
-        // Return the emulator name
-        ['Pixel_4_XL_API_30', 'OK'].join('\n')
-      );
+    );
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockResolvedValueOnce(['Pixel_4_XL_API_30', 'OK'].join('\n'));
 
     const devices = await getAttachedDevicesAsync();
 
@@ -273,35 +362,104 @@ describe(getAttachedDevicesAsync, () => {
       {
         isAuthorized: false,
         isBooted: false,
+        isLaunchable: false,
         name: 'Device adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp.',
         pid: 'adb-00000XXX000XXX-YzYyyy._adb-tls-connect._tcp.',
+        state: 'offline',
+        transportId: '1',
         type: 'device',
         connectionType: 'Network',
       },
       {
         isAuthorized: true,
         isBooted: true,
+        isLaunchable: false,
         name: 'Pixel_7_Pro',
         pid: 'adb-00000XXX000XXX-YzXxxx._adb-tls-connect._tcp.',
+        state: 'device',
+        transportId: '2',
         type: 'device',
         connectionType: 'Network',
       },
       {
-        isAuthorized: true,
+        isAuthorized: false,
         isBooted: false,
-        name: 'Pixel_7_Pro',
+        isLaunchable: false,
+        name: 'Device adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp.',
         pid: 'adb-00000XXX000XXX-YzZzzz._adb-tls-connect._tcp.',
+        state: 'offline',
+        transportId: '2',
         type: 'device',
         connectionType: 'Network',
       },
       {
         isAuthorized: true,
         isBooted: true,
+        isLaunchable: false,
         name: 'Pixel_4_XL_API_30',
         pid: 'emulator-5554',
+        state: 'device',
+        transportId: '1',
         type: 'emulator',
       },
     ]);
+  });
+
+  it('reports a silent remote endpoint without replacing its owner', async () => {
+    process.env.ANDROID_ADB_SERVER_ADDRESS = '192.0.2.10';
+    jest.mocked(getServer().runHostQueryAsync).mockRejectedValueOnce(new Error('discovery failed'));
+    jest
+      .spyOn(AdbEndpoint, 'probeAdbHostVersionAsync')
+      .mockResolvedValueOnce({ kind: 'connected-no-reply' });
+
+    await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).rejects.toThrow(
+      /ADB server at tcp:192\.0\.2\.10:5037.*is not responding/
+    );
+    expect(AdbEndpoint.probeAdbHostVersionAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ host: '192.0.2.10', scope: 'remote' }),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('reports invalid protocol at the custom selected socket', async () => {
+    process.env.ADB_SERVER_SOCKET = 'tcp:localhost:5041';
+    jest.mocked(getServer().runHostQueryAsync).mockRejectedValueOnce(new Error('protocol failure'));
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({
+      kind: 'invalid-protocol',
+    });
+
+    await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).rejects.toThrow(
+      /endpoint at tcp:localhost:5041.*is not an ADB server/s
+    );
+  });
+
+  it('does not probe after explicit caller cancellation', async () => {
+    const cancellation = new Error('cancelled');
+    const controller = new AbortController();
+    controller.abort(cancellation);
+    jest.mocked(getServer().runHostQueryAsync).mockRejectedValueOnce(cancellation);
+    const probe = jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync');
+
+    await expect(getAttachedDevicesAsync({ signal: controller.signal })).rejects.toBe(cancellation);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('does not probe after a caller timeout', async () => {
+    const controller = new AbortController();
+    const reason = new DOMException('caller timed out', 'TimeoutError');
+    jest.mocked(getServer().runHostQueryAsync).mockImplementationOnce(
+      (_args, _operation, signal) =>
+        new Promise((_, reject) => {
+          signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+        })
+    );
+    const probe = jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync');
+
+    const result = getAttachedDevicesAsync({ signal: controller.signal });
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(probe).not.toHaveBeenCalled();
   });
 });
 
@@ -319,16 +477,33 @@ describe(isBootAnimationCompleteAsync, () => {
       .mockResolvedValueOnce(['[init.svc.bootanim]: [running]'].join('\n'));
     await expect(isBootAnimationCompleteAsync()).resolves.toBe(false);
   });
-  it(`returns false if the properties cannot be read`, async () => {
+  it(`preserves errors when boot properties cannot be read`, async () => {
     jest.mocked(getServer().getFileOutputAsync).mockImplementationOnce(() => {
       throw new Error('File not found');
     });
 
-    await expect(isBootAnimationCompleteAsync()).resolves.toBe(false);
+    await expect(isBootAnimationCompleteAsync()).rejects.toThrow('File not found');
   });
 });
 
 describe(getPropertyDataForDeviceAsync, () => {
+  it('reports host health after a property wait expires', async () => {
+    const operation = 'device property/boot query';
+    jest
+      .mocked(getServer().getFileOutputAsync)
+      .mockRejectedValueOnce(
+        new AdbProcessWaitError('property wait expired', operation, 'device-service')
+      );
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({
+      kind: 'version',
+    });
+
+    const result = getPropertyDataForDeviceAsync(asDevice({ pid: '123' }));
+    await expect(result).rejects.toThrow(
+      /ADB server is responding, but device property\/boot query did not finish/
+    );
+  });
+
   it(`returns parsed property data`, async () => {
     jest.mocked(getServer().getFileOutputAsync).mockResolvedValueOnce(
       [
@@ -374,3 +549,81 @@ describe(sanitizeAdbDeviceName, () => {
     expect(sanitizeAdbDeviceName(`Pixel_6_API_31\rOK`)).toBe('Pixel_6_API_31');
   });
 });
+
+describe('bounded discovery integration', () => {
+  jest.setTimeout(10_000);
+
+  it('keeps startup diagnostics on stderr out of the device parser', async () => {
+    await expect(
+      getAttachedDevicesAsync({
+        server: fixtureServer('adb-cold-start.js'),
+        waitLimitMs: 1_000,
+      })
+    ).resolves.toEqual([
+      expect.objectContaining({
+        pid: 'USB-1',
+        name: 'Pixel',
+        transportId: '4',
+      }),
+    ]);
+  });
+
+  it('cleans up silent discovery before probing the selected host', async () => {
+    const sockets = new Set<net.Socket>();
+    const hostServer = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      socket.end('OKAY00040029');
+    });
+    await new Promise<void>((resolve, reject) => {
+      hostServer.once('error', reject);
+      hostServer.listen(0, '127.0.0.1', resolve);
+    });
+    const address = hostServer.address();
+    if (!address || typeof address === 'string') throw new Error('Expected TCP server address.');
+    process.env.ADB_SERVER_SOCKET = `tcp:127.0.0.1:${address.port}`;
+
+    try {
+      await expect(
+        getAttachedDevicesAsync({
+          server: fixtureServer('adb-hang.js'),
+          waitLimitMs: 100,
+          probeWaitLimitMs: 500,
+        })
+      ).rejects.toThrow(/ADB server is responding, but device discovery did not finish/);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) =>
+        hostServer.close((error) => (error ? reject(error) : resolve()))
+      );
+    }
+  });
+});
+
+function fixtureServer(name: string): ADBServer {
+  return {
+    runHostQueryAsync(
+      args: string[],
+      operation: string,
+      signal?: AbortSignal,
+      waitLimitMs?: number
+    ) {
+      jest.mocked(spawnAsync).mockImplementationOnce(jest.requireActual('@expo/spawn-async'));
+      const result =
+        waitLimitMs == null
+          ? runAdbHostQueryAsync(process.execPath, [fixturePath(name), ...args], operation, signal)
+          : runBoundedAdbHostQueryAsync(
+              process.execPath,
+              [fixturePath(name), ...args],
+              operation,
+              waitLimitMs,
+              signal
+            );
+      return result.then((result) => result.stdout);
+    },
+  } as ADBServer;
+}
+
+function fixturePath(name: string): string {
+  return path.join(__dirname, 'fixtures', name);
+}

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -569,6 +569,28 @@ describe(getAttachedDevicesAsync, () => {
     await expect(result).rejects.toBe(reason);
     expect(probe).not.toHaveBeenCalled();
   });
+
+  it('preserves caller cancellation while the diagnostic probe is running', async () => {
+    const controller = new AbortController();
+    const reason = new Error('cancel diagnostics');
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockRejectedValueOnce(
+        new AdbProcessWaitError('discovery timed out', 'device discovery', 'host-request')
+      );
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockImplementationOnce(
+      (_endpoint, signal) =>
+        new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        })
+    );
+
+    const result = getAttachedDevicesAsync({ signal: controller.signal });
+    await Promise.resolve();
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+  });
 });
 
 describe(isBootAnimationCompleteAsync, () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -456,6 +456,22 @@ describe(getAttachedDevicesAsync, () => {
     );
   });
 
+  it('diagnoses a timeout while resolving an attached emulator name', async () => {
+    jest
+      .mocked(getServer().runHostQueryAsync)
+      .mockResolvedValueOnce('List of devices attached\nemulator-5554 device transport_id:1');
+    jest
+      .mocked(getServer().runDeviceQueryAsync)
+      .mockRejectedValueOnce(
+        new AdbProcessWaitError('name lookup timed out', 'emulator name query', 'device-service')
+      );
+    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValueOnce({ kind: 'version' });
+
+    await expect(getAttachedDevicesAsync({ probeWaitLimitMs: 5 })).rejects.toThrow(
+      /ADB server is responding, but emulator name query did not finish/
+    );
+  });
+
   it('does not probe after explicit caller cancellation', async () => {
     const cancellation = new Error('cancelled');
     const controller = new AbortController();

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -620,20 +620,18 @@ describe(isBootAnimationCompleteAsync, () => {
 });
 
 describe(getPropertyDataForDeviceAsync, () => {
-  it('reports host health after a property wait expires', async () => {
+  it('does not extend an expired property wait with a host probe', async () => {
     const operation = 'device property/boot query';
     jest
       .mocked(getServer().getFileOutputAsync)
       .mockRejectedValueOnce(
         new AdbProcessWaitError('property wait expired', operation, 'device-service')
       );
-    jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync').mockResolvedValue({
-      kind: 'version',
-    });
+    const probe = jest.spyOn(AdbEndpoint, 'probeAdbHostVersionAsync');
 
     const result = getPropertyDataForDeviceAsync(asDevice({ pid: '123' }));
     await expect(result).rejects.toThrow('property wait expired');
-    await expect(result).rejects.not.toThrow(/ADB server is responding/);
+    expect(probe).not.toHaveBeenCalled();
   });
 
   it(`returns parsed property data`, async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
@@ -1,0 +1,92 @@
+import { parseAdbDeviceList } from '../adbDeviceList';
+
+describe(parseAdbDeviceList, () => {
+  it.each([
+    ['tabs', 'emulator-5554\tdevice product:sdk model:Pixel transport_id:1'],
+    ['runs of whitespace', 'emulator-5554          offline transport_id:1'],
+    ['CRLF', 'emulator-5554\tdevice transport_id:1\r\n'],
+  ])('parses records separated with %s', (_, record) => {
+    expect(parseAdbDeviceList(`List of devices attached\r\n${record}`)).toEqual([
+      expect.objectContaining({
+        serial: 'emulator-5554',
+        transportId: '1',
+      }),
+    ]);
+  });
+
+  it('parses USB and network device metadata', () => {
+    expect(
+      parseAdbDeviceList(
+        [
+          'List of devices attached',
+          'FA8251A00720 device usb:338690048X product:walleye model:Pixel_2 transport_id:4',
+          '192.0.2.1:5555 device product:cheetah model:Pixel_7 transport_id:7',
+        ].join('\n')
+      )
+    ).toEqual([
+      {
+        serial: 'FA8251A00720',
+        state: 'device',
+        metadata: ['usb:338690048X', 'product:walleye', 'model:Pixel_2', 'transport_id:4'],
+        transportId: '4',
+      },
+      {
+        serial: '192.0.2.1:5555',
+        state: 'device',
+        metadata: ['product:cheetah', 'model:Pixel_7', 'transport_id:7'],
+        transportId: '7',
+      },
+    ]);
+  });
+
+  it.each(['offline', 'unauthorized', 'authorizing', 'connecting'])(
+    'retains the transitional state %s',
+    (state) => {
+      expect(parseAdbDeviceList(`List of devices attached\nserial-1 ${state}`)).toEqual([
+        { serial: 'serial-1', state, metadata: [] },
+      ]);
+    }
+  );
+
+  it('retains multi-word no permissions diagnostics', () => {
+    expect(
+      parseAdbDeviceList(
+        'List of devices attached\nserial-1 no permissions (user is in the plugdev group); see [http://developer.android.com/tools/device.html]'
+      )
+    ).toEqual([
+      {
+        serial: 'serial-1',
+        state: 'no permissions',
+        metadata: [
+          '(user',
+          'is',
+          'in',
+          'the',
+          'plugdev',
+          'group);',
+          'see',
+          '[http://developer.android.com/tools/device.html]',
+        ],
+      },
+    ]);
+  });
+
+  it('filters ADB trace lines', () => {
+    expect(
+      parseAdbDeviceList(
+        [
+          'List of devices attached',
+          'adb D 03-06 15:25:53 adb_client.cpp:393] adb_query: host:devices-l',
+          'emulator-5554 device transport_id:1',
+        ].join('\n')
+      )
+    ).toEqual([
+      {
+        serial: 'emulator-5554',
+        state: 'device',
+        metadata: ['transport_id:1'],
+        transportId: '1',
+      },
+    ]);
+  });
+});

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
@@ -70,6 +70,25 @@ describe(parseAdbDeviceList, () => {
       },
     ]);
   });
+
+  it('ignores ADB trace lines written alongside the device list', () => {
+    expect(
+      parseAdbDeviceList(
+        [
+          'List of devices attached',
+          'adb D adb_client.cpp:393] adb_query: host:devices-l',
+          'emulator-5554 device transport_id:1',
+        ].join('\n')
+      )
+    ).toEqual([
+      {
+        serial: 'emulator-5554',
+        state: 'device',
+        metadata: ['transport_id:1'],
+        transportId: '1',
+      },
+    ]);
+  });
 });
 
 describe('ADB device state predicates', () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDeviceList-test.ts
@@ -1,4 +1,4 @@
-import { parseAdbDeviceList } from '../adbDeviceList';
+import { isAdbDeviceStateUsable, parseAdbDeviceList } from '../adbDeviceList';
 
 describe(parseAdbDeviceList, () => {
   it.each([
@@ -70,23 +70,12 @@ describe(parseAdbDeviceList, () => {
       },
     ]);
   });
+});
 
-  it('filters ADB trace lines', () => {
-    expect(
-      parseAdbDeviceList(
-        [
-          'List of devices attached',
-          'adb D 03-06 15:25:53 adb_client.cpp:393] adb_query: host:devices-l',
-          'emulator-5554 device transport_id:1',
-        ].join('\n')
-      )
-    ).toEqual([
-      {
-        serial: 'emulator-5554',
-        state: 'device',
-        metadata: ['transport_id:1'],
-        transportId: '1',
-      },
-    ]);
+describe('ADB device state predicates', () => {
+  it('recognizes only the states Expo acts on without losing unknown values', () => {
+    expect(isAdbDeviceStateUsable('device')).toBe(true);
+    expect(isAdbDeviceStateUsable('authorizing')).toBe(false);
+    expect(isAdbDeviceStateUsable('future-adb-state')).toBe(false);
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
@@ -23,6 +23,16 @@ describe('ADB diagnostics', () => {
     expect(message).not.toContain('tcp:127.0.0.1:5037');
   });
 
+  it('does not infer a cause from a successful post-failure host probe', () => {
+    const message = formatAdbDiscoveryError(
+      new AdbProcessError('device discovery failed', 'device discovery', 'host-request'),
+      localEndpoint,
+      { kind: 'version' }
+    );
+
+    expect(message).toBe('device discovery failed');
+  });
+
   it('identifies remote, unsupported, device-state, and discovery/use-race contexts', () => {
     const message = formatAdbDeviceError(new Error('error: device not found'), {
       pid: 'serial-1',
@@ -43,6 +53,17 @@ describe('ADB diagnostics', () => {
         { kind: 'unsupported' }
       )
     ).toContain('Check ADB_SERVER_SOCKET and try again');
+  });
+
+  it('uses boot advice instead of USB reconnect advice for offline emulators', () => {
+    const message = formatAdbDeviceError(new Error('emulator is offline'), {
+      pid: 'emulator-5554',
+      state: 'offline',
+      type: 'emulator',
+    });
+
+    expect(message).toContain('Wait until ADB reports the emulator as ready');
+    expect(message).not.toContain('Reconnect device emulator-5554');
   });
 
   it.each([

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
@@ -1,0 +1,69 @@
+import { formatAdbDeviceError, formatAdbDiscoveryError } from '../adbDiagnostics';
+import type { AdbEndpoint } from '../adbEndpoint';
+import { AdbProcessError } from '../adbProcess';
+
+const localEndpoint: AdbEndpoint = {
+  type: 'tcp',
+  host: '127.0.0.1',
+  port: 5037,
+  scope: 'local',
+  source: 'default',
+};
+
+describe('ADB diagnostics', () => {
+  it('reports spawn failures with concise advice', () => {
+    const message = formatAdbDiscoveryError(
+      new AdbProcessError('spawn adb ENOENT', 'device discovery', 'host-request', undefined, true),
+      localEndpoint,
+      { kind: 'connection-refused' }
+    );
+
+    expect(message).toContain('spawn adb ENOENT');
+    expect(message).toContain('Android SDK Platform-Tools');
+    expect(message).not.toContain('tcp:127.0.0.1:5037');
+  });
+
+  it('identifies remote, unsupported, device-state, and discovery/use-race contexts', () => {
+    const message = formatAdbDeviceError(new Error('error: device not found'), {
+      pid: 'serial-1',
+      state: 'offline',
+    });
+    expect(message).toContain('Reconnect device serial-1 and try again.');
+    expect(message).not.toContain('disappeared after discovery');
+    expect(message).not.toMatch(/kill-server|USB|driver/i);
+
+    expect(
+      formatAdbDiscoveryError(
+        new Error('unsupported socket'),
+        {
+          type: 'unsupported',
+          specification: 'localabstract:adb',
+          source: 'ADB_SERVER_SOCKET',
+        },
+        { kind: 'unsupported' }
+      )
+    ).toContain('Check ADB_SERVER_SOCKET and try again');
+  });
+
+  it.each([
+    ['unauthorized', 'Authorize this computer on the device'],
+    ['authorizing', 'Wait until ADB reports the device as ready'],
+    ['future-state', 'Wait until ADB reports the device as ready'],
+  ])('preserves %s state in actionable diagnostics', (state, expected) => {
+    expect(formatAdbDeviceError(new Error('transport unavailable'), { state })).toContain(expected);
+  });
+
+  it('reports unknown remote completion for a cancelled side effect', () => {
+    const cancellation = Object.assign(new Error('cancelled'), { remoteCompletionUnknown: true });
+    const message = formatAdbDeviceError(cancellation, {});
+
+    expect(message).toContain('may have completed on the device');
+    expect(message).toContain('Check before trying again');
+  });
+
+  it('reports a device that is still authorizing as disconnected without a known state', () => {
+    const message = formatAdbDeviceError(new Error('error: device still authorizing'), {});
+
+    expect(message).toContain('The device disconnected. Reconnect it and try again.');
+  });
+});

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbDiagnostics-test.ts
@@ -46,7 +46,8 @@ describe('ADB diagnostics', () => {
   });
 
   it.each([
-    ['unauthorized', 'Authorize this computer on the device'],
+    ['unauthorized', 'https://expo.fyi/authorize-android-device'],
+    ['no permissions', 'configure the appropriate udev rules'],
     ['authorizing', 'Wait until ADB reports the device as ready'],
     ['future-state', 'Wait until ADB reports the device as ready'],
   ])('preserves %s state in actionable diagnostics', (state, expected) => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbEndpoint-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbEndpoint-test.ts
@@ -1,0 +1,272 @@
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+import { event } from '../../events';
+import {
+  ADB_HOST_PROBE_WAIT_LIMIT_MS,
+  formatAdbEndpoint,
+  parseAdbHostVersionResponse,
+  probeAdbHostVersionAsync,
+  resolveAdbEndpoint,
+} from '../adbEndpoint';
+
+jest.unmock('fs');
+jest.unmock('node:fs');
+jest.unmock('os');
+jest.unmock('node:os');
+jest.mock('../../events', () => ({ event: jest.fn() }));
+
+it('allows for the cold-start device scan before a host probe expires', () => {
+  expect(ADB_HOST_PROBE_WAIT_LIMIT_MS).toBe(4_000);
+});
+
+describe(resolveAdbEndpoint, () => {
+  it('uses ADB_SERVER_SOCKET before Android address and port variables', () => {
+    expect(
+      resolveAdbEndpoint({
+        ADB_SERVER_SOCKET: 'tcp:localhost:5041',
+        ANDROID_ADB_SERVER_ADDRESS: '192.0.2.10',
+        ANDROID_ADB_SERVER_PORT: '5042',
+      })
+    ).toEqual({
+      type: 'tcp',
+      host: 'localhost',
+      port: 5041,
+      scope: 'local',
+      source: 'ADB_SERVER_SOCKET',
+    });
+  });
+
+  it.each([
+    [{}, { type: 'tcp', host: '127.0.0.1', port: 5037, scope: 'local', source: 'default' }],
+    [
+      { ANDROID_ADB_SERVER_PORT: '5041' },
+      {
+        type: 'tcp',
+        host: '127.0.0.1',
+        port: 5041,
+        scope: 'local',
+        source: 'ANDROID_ADB_SERVER_PORT',
+      },
+    ],
+    [
+      { ANDROID_ADB_SERVER_ADDRESS: '192.0.2.10' },
+      {
+        type: 'tcp',
+        host: '192.0.2.10',
+        port: 5037,
+        scope: 'remote',
+        source: 'ANDROID_ADB_SERVER_ADDRESS',
+      },
+    ],
+    [
+      { ANDROID_ADB_SERVER_ADDRESS: '::1', ANDROID_ADB_SERVER_PORT: '5041' },
+      {
+        type: 'tcp',
+        host: '::1',
+        port: 5041,
+        scope: 'local',
+        source: 'ANDROID_ADB_SERVER_ADDRESS',
+      },
+    ],
+  ])('resolves Android address/port combination %#', (environment, endpoint) => {
+    expect(resolveAdbEndpoint(environment)).toEqual(endpoint);
+  });
+
+  it.each([
+    ['tcp:5041', { type: 'tcp', host: '127.0.0.1', port: 5041, scope: 'local' }],
+    ['tcp:localhost:5041', { type: 'tcp', host: 'localhost', port: 5041, scope: 'local' }],
+    ['tcp:[::1]:5041', { type: 'tcp', host: '::1', port: 5041, scope: 'local' }],
+    ['tcp:192.0.2.10:5041', { type: 'tcp', host: '192.0.2.10', port: 5041, scope: 'remote' }],
+  ])('parses the socket specification %s', (specification, endpoint) => {
+    expect(resolveAdbEndpoint({ ADB_SERVER_SOCKET: specification })).toEqual({
+      ...endpoint,
+      source: 'ADB_SERVER_SOCKET',
+    });
+  });
+
+  it('parses local filesystem sockets and preserves unsupported specifications', () => {
+    expect(resolveAdbEndpoint({ ADB_SERVER_SOCKET: 'localfilesystem:/tmp/adb.sock' })).toEqual({
+      type: 'local-filesystem',
+      path: '/tmp/adb.sock',
+      source: 'ADB_SERVER_SOCKET',
+    });
+    expect(resolveAdbEndpoint({ ADB_SERVER_SOCKET: 'localabstract:adb' })).toEqual({
+      type: 'unsupported',
+      specification: 'localabstract:adb',
+      source: 'ADB_SERVER_SOCKET',
+    });
+  });
+});
+
+describe(formatAdbEndpoint, () => {
+  it('brackets IPv6 addresses', () => {
+    expect(
+      formatAdbEndpoint({
+        type: 'tcp',
+        host: '::1',
+        port: 5037,
+        scope: 'local',
+        source: 'default',
+      })
+    ).toBe('tcp:[::1]:5037 (local, selected by default)');
+  });
+});
+
+describe('ADB smart-socket framing', () => {
+  it.each([
+    [Buffer.from('OKAY00040029'), { kind: 'version' }],
+    [Buffer.from('FAIL0004nope'), { kind: 'adb-failure', message: 'nope' }],
+    [Buffer.from('NOPE'), { kind: 'invalid-protocol' }],
+    [Buffer.from('OKAY00'), { kind: 'incomplete' }],
+    [Buffer.from('OKAY000400'), { kind: 'incomplete' }],
+  ])('parses response fixture %#', (response, result) => {
+    expect(parseAdbHostVersionResponse(response as Buffer)).toEqual(result);
+  });
+});
+
+describe(probeAdbHostVersionAsync, () => {
+  it('reads a complete host:version response across partial TCP packets', async () => {
+    const server = net.createServer((socket) => {
+      socket.once('data', () => {
+        socket.write('OKAY');
+        setTimeout(() => socket.end('00040029'), 5);
+      });
+    });
+    const endpoint = await listenTcpAsync(server);
+    try {
+      await expect(probeAdbHostVersionAsync(endpoint, AbortSignal.timeout(500))).resolves.toEqual({
+        kind: 'version',
+      });
+      expect(event).toHaveBeenCalledWith('adb_host_probe', {
+        endpoint: expect.stringContaining(`tcp:${endpoint.host}:${endpoint.port}`),
+        result: 'version',
+      });
+    } finally {
+      await closeServerAsync(server);
+    }
+  });
+
+  it('distinguishes an accepted connection with no complete reply', async () => {
+    const server = net.createServer(() => {});
+    const endpoint = await listenTcpAsync(server);
+    try {
+      await expect(probeAdbHostVersionAsync(endpoint, AbortSignal.timeout(50))).resolves.toEqual({
+        kind: 'connected-no-reply',
+      });
+    } finally {
+      await closeServerAsync(server);
+    }
+  });
+
+  it('reports a listener that returns invalid ADB status bytes', async () => {
+    const server = net.createServer((socket) => socket.end('NOPE'));
+    const endpoint = await listenTcpAsync(server);
+    try {
+      await expect(probeAdbHostVersionAsync(endpoint, AbortSignal.timeout(500))).resolves.toEqual({
+        kind: 'invalid-protocol',
+      });
+    } finally {
+      await closeServerAsync(server);
+    }
+  });
+
+  it('distinguishes refusal and retries a newly appearing local listener after startup grace', async () => {
+    const reservation = net.createServer();
+    const endpoint = await listenTcpAsync(reservation);
+    await closeServerAsync(reservation);
+
+    await expect(probeAdbHostVersionAsync(endpoint, AbortSignal.timeout(500))).resolves.toEqual({
+      kind: 'connection-refused',
+    });
+
+    const server = net.createServer((socket) => socket.end('OKAY00040029'));
+    trackServerConnections(server);
+    const startServer = setTimeout(() => server.listen(endpoint.port, endpoint.host), 20);
+    try {
+      await expect(probeAdbHostVersionAsync(endpoint, AbortSignal.timeout(500))).resolves.toEqual({
+        kind: 'version',
+      });
+    } finally {
+      clearTimeout(startServer);
+      await closeServerAsync(server);
+    }
+  });
+
+  it('propagates explicit caller cancellation while reading', async () => {
+    const server = net.createServer(() => {});
+    const endpoint = await listenTcpAsync(server);
+    const controller = new AbortController();
+    const reason = new Error('caller cancelled');
+    const cancellation = setTimeout(() => controller.abort(reason), 20);
+    try {
+      await expect(probeAdbHostVersionAsync(endpoint, controller.signal)).rejects.toBe(reason);
+    } finally {
+      clearTimeout(cancellation);
+      await closeServerAsync(server);
+    }
+  });
+
+  const filesystemTest = process.platform === 'win32' ? it.skip : it;
+  filesystemTest('probes a selected local-filesystem socket', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-adb-endpoint-'));
+    const socketPath = path.join(directory, 'adb.sock');
+    const server = net.createServer((socket) => socket.end('OKAY00040029'));
+    trackServerConnections(server);
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(socketPath, resolve);
+    });
+    try {
+      await expect(
+        probeAdbHostVersionAsync(
+          { type: 'local-filesystem', path: socketPath, source: 'ADB_SERVER_SOCKET' },
+          AbortSignal.timeout(500)
+        )
+      ).resolves.toEqual({ kind: 'version' });
+    } finally {
+      await closeServerAsync(server);
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function listenTcpAsync(server: net.Server) {
+  trackServerConnections(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Expected a TCP fixture server address.');
+  }
+  return {
+    type: 'tcp' as const,
+    host: address.address,
+    port: address.port,
+    scope: 'local' as const,
+    source: 'default' as const,
+  };
+}
+
+async function closeServerAsync(server: net.Server): Promise<void> {
+  if (!server.listening) return;
+  for (const socket of serverConnections.get(server) ?? []) socket.destroy();
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  );
+}
+
+const serverConnections = new WeakMap<net.Server, Set<net.Socket>>();
+
+function trackServerConnections(server: net.Server): void {
+  const sockets = new Set<net.Socket>();
+  serverConnections.set(server, sockets);
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+}

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
@@ -62,6 +62,18 @@ describe(runAdbDeviceQueryAsync, () => {
     });
   });
 
+  it('does not spawn a command when the caller signal is already aborted', async () => {
+    const controller = new AbortController();
+    const reason = new Error('already cancelled');
+    controller.abort(reason);
+
+    await expect(
+      runAdbDeviceMutationAsync('adb', ['install'], 'app install', controller.signal)
+    ).rejects.toBe(reason);
+    expect(spawnAsync).not.toHaveBeenCalled();
+    expect(event).not.toHaveBeenCalled();
+  });
+
   it('maps wait-policy expiry after observing graceful cleanup', async () => {
     const pending = createPendingSpawn();
     jest.mocked(spawnAsync).mockReturnValueOnce(pending);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
@@ -1,0 +1,182 @@
+import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { event } from '../../events';
+import {
+  AdbProcessWaitError,
+  runAdbDeviceMutationAsync,
+  runAdbDeviceQueryAsync,
+  runAdbHostQueryAsync,
+  runBoundedAdbHostQueryAsync,
+} from '../adbProcess';
+
+jest.mock('../../events', () => ({ event: jest.fn() }));
+jest.unmock('child_process');
+jest.unmock('fs');
+jest.unmock('node:fs');
+jest.unmock('os');
+jest.unmock('node:os');
+
+describe(runAdbDeviceQueryAsync, () => {
+  function createPendingSpawn({ ignoreTerm = false, ignoreKill = false } = {}) {
+    let reject!: (error: unknown) => void;
+    const promise = new Promise((_, rejectPromise) => {
+      reject = rejectPromise;
+    }) as any;
+    promise.child = {
+      kill: jest.fn((signal) => {
+        if ((signal === 'SIGKILL' && !ignoreKill) || (signal !== 'SIGKILL' && !ignoreTerm)) {
+          reject(
+            Object.assign(new Error(`killed with ${signal}`), {
+              signal,
+              status: null,
+            })
+          );
+        }
+        return true;
+      }),
+    };
+    return promise;
+  }
+
+  it('returns separate process output and exit data', async () => {
+    jest.mocked(spawnAsync).mockResolvedValueOnce({
+      stdout: 'stdout',
+      stderr: 'stderr',
+      status: 0,
+      signal: null,
+    } as any);
+
+    await expect(runAdbDeviceQueryAsync('adb', ['devices'], 'test command')).resolves.toMatchObject(
+      {
+        stdout: 'stdout',
+        stderr: 'stderr',
+      }
+    );
+    expect(event).toHaveBeenCalledWith('adb_operation_start', {
+      operation: 'test command',
+      phase: 'device-service',
+      waitLimitMs: undefined,
+    });
+  });
+
+  it('maps wait-policy expiry after observing graceful cleanup', async () => {
+    const pending = createPendingSpawn();
+    jest.mocked(spawnAsync).mockReturnValueOnce(pending);
+
+    const result = runBoundedAdbHostQueryAsync('adb', ['devices'], 'device discovery', 1);
+    await expect(result).rejects.toBeInstanceOf(AdbProcessWaitError);
+    expect(event).toHaveBeenCalledWith('adb_operation_cleanup', {
+      operation: 'device discovery',
+      phase: 'host-request',
+      reason: 'wait-limit',
+      status: 'terminated',
+    });
+  });
+
+  it('preserves a caller timeout when a longer wait policy is configured', async () => {
+    const pending = createPendingSpawn();
+    jest.mocked(spawnAsync).mockReturnValueOnce(pending);
+    const controller = new AbortController();
+    const reason = new DOMException('caller timed out', 'TimeoutError');
+
+    const result = runBoundedAdbHostQueryAsync(
+      'adb',
+      ['devices'],
+      'device discovery',
+      10_000,
+      controller.signal
+    );
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(event).toHaveBeenCalledWith('adb_operation_cleanup', {
+      operation: 'device discovery',
+      phase: 'host-request',
+      reason: 'cancelled',
+      status: 'terminated',
+    });
+  });
+
+  it('reports when cleanup cannot observe child exit', async () => {
+    const pending = createPendingSpawn({ ignoreTerm: true, ignoreKill: true });
+    jest.mocked(spawnAsync).mockReturnValueOnce(pending);
+    const controller = new AbortController();
+    const result = runAdbHostQueryAsync('adb', ['devices'], 'device discovery', controller.signal);
+
+    const reason = new Error('stop discovery');
+    controller.abort(reason);
+    await expect(result).rejects.toBe(reason);
+  });
+
+  it('marks cancelled side-effecting operations as having unknown remote completion', async () => {
+    const pending = createPendingSpawn();
+    jest.mocked(spawnAsync).mockReturnValueOnce(pending);
+    const controller = new AbortController();
+    const result = runAdbDeviceMutationAsync('adb', ['install'], 'app install', controller.signal);
+
+    const reason = new Error('stop install');
+    controller.abort(reason);
+    await expect(result).rejects.toBe(reason);
+    expect(reason).toMatchObject({ remoteCompletionUnknown: true });
+  });
+
+  it('distinguishes spawn and nonzero-exit failures', async () => {
+    jest.mocked(spawnAsync).mockRejectedValueOnce(
+      Object.assign(new Error('ENOENT'), {
+        status: null,
+        signal: null,
+      })
+    );
+    await expect(runAdbDeviceQueryAsync('adb', [], 'test command')).rejects.toMatchObject({
+      spawnFailed: true,
+    });
+
+    jest.mocked(spawnAsync).mockRejectedValueOnce(
+      Object.assign(new Error('exit 1'), {
+        stdout: '',
+        stderr: 'failed',
+        status: 1,
+        signal: null,
+      })
+    );
+    await expect(runAdbDeviceQueryAsync('adb', [], 'test command')).rejects.toMatchObject({
+      spawnFailed: undefined,
+    });
+  });
+});
+
+describe('subprocess cleanup integration', () => {
+  jest.setTimeout(10_000);
+
+  it('drains both pipes, escalates where supported, and reaps after cancellation', async () => {
+    const signal = AbortSignal.timeout(300);
+    const error = await runFixture(signal);
+
+    expect(error).toBe(signal.reason);
+  });
+});
+
+async function runFixture(signal: AbortSignal): Promise<unknown> {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'expo-adb-process-'));
+  const pidFile = path.join(directory, 'pid');
+  const fixture = path.join(__dirname, 'fixtures', 'adb-process-child.js');
+  try {
+    jest.mocked(spawnAsync).mockImplementationOnce(jest.requireActual('@expo/spawn-async'));
+    let error: unknown;
+    try {
+      await runAdbHostQueryAsync(process.execPath, [fixture, pidFile], 'fixture child', signal);
+    } catch (caught) {
+      error = caught;
+    }
+
+    const pid = Number(fs.readFileSync(pidFile, 'utf8'));
+    expect(Number.isInteger(pid)).toBe(true);
+    expect(() => process.kill(pid, 0)).toThrow();
+    return error;
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbProcess-test.ts
@@ -88,6 +88,18 @@ describe(runAdbDeviceQueryAsync, () => {
     });
   });
 
+  it('includes subprocess cleanup in the bounded wait policy', async () => {
+    const pending = createPendingSpawn({ ignoreTerm: true });
+    jest.mocked(spawnAsync).mockReturnValueOnce(pending);
+    const startedAt = Date.now();
+
+    await expect(
+      runBoundedAdbHostQueryAsync('adb', ['devices'], 'device discovery', 100)
+    ).rejects.toBeInstanceOf(AdbProcessWaitError);
+    expect(Date.now() - startedAt).toBeLessThan(200);
+    expect(pending.child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
   it('preserves a caller timeout when a longer wait policy is configured', async () => {
     const pending = createPendingSpawn();
     jest.mocked(spawnAsync).mockReturnValueOnce(pending);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
@@ -6,7 +6,7 @@ jest.mock('../../../../log');
 jest.mock('../adb', () => {
   const actual = jest.requireActual('../adb');
   const server = {
-    runAsync: jest.fn(async () => ''),
+    runDeviceMutationAsync: jest.fn(async () => ''),
   };
   return {
     ...actual,
@@ -38,14 +38,13 @@ describe(startAdbReverseAsync, () => {
     ]);
     await expect(startAdbReverseAsync([3000])).resolves.toBe(true);
 
-    expect(getServer().runAsync).toHaveBeenCalledTimes(2);
-    expect(getServer().runAsync).toHaveBeenNthCalledWith(1, [
-      '-s',
-      'FA8251A00720',
-      'reverse',
-      'tcp:3000',
-      'tcp:3000',
-    ]);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledTimes(2);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenNthCalledWith(
+      1,
+      ['-s', 'FA8251A00720', 'reverse', 'tcp:3000', 'tcp:3000'],
+      'reverse port',
+      undefined
+    );
   });
   it(`reverses multiple ports`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
@@ -59,14 +58,13 @@ describe(startAdbReverseAsync, () => {
     ]);
     await expect(startAdbReverseAsync([3000, 3001])).resolves.toBe(true);
 
-    expect(getServer().runAsync).toHaveBeenCalledTimes(2);
-    expect(getServer().runAsync).toHaveBeenNthCalledWith(1, [
-      '-s',
-      'emulator-5554',
-      'reverse',
-      'tcp:3000',
-      'tcp:3000',
-    ]);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledTimes(2);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenNthCalledWith(
+      1,
+      ['-s', 'emulator-5554', 'reverse', 'tcp:3000', 'tcp:3000'],
+      'reverse port',
+      undefined
+    );
   });
 
   it(`returns false when reversing a device that is unauthorized`, async () => {
@@ -80,7 +78,7 @@ describe(startAdbReverseAsync, () => {
       },
     ]);
     await expect(startAdbReverseAsync([3000])).resolves.toBe(false);
-    expect(getServer().runAsync).toHaveBeenCalledTimes(0);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledTimes(0);
     expect(Log.warn).toHaveBeenCalledTimes(1);
   });
 
@@ -94,10 +92,29 @@ describe(startAdbReverseAsync, () => {
         type: 'device',
       },
     ]);
-    jest.mocked(getServer().runAsync).mockRejectedValueOnce(new Error('test'));
+    jest.mocked(getServer().runDeviceMutationAsync).mockRejectedValueOnce(new Error('test'));
     await expect(startAdbReverseAsync([3000])).resolves.toBe(false);
-    expect(getServer().runAsync).toHaveBeenCalledTimes(1);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledTimes(1);
     expect(Log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves caller cancellation when reversing a port', async () => {
+    const reason = new Error('cancel reverse');
+    const controller = new AbortController();
+    controller.abort(reason);
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
+      {
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_2',
+        pid: 'FA8251A00720',
+        type: 'device',
+      },
+    ]);
+    jest.mocked(getServer().runDeviceMutationAsync).mockRejectedValueOnce(reason);
+
+    await expect(startAdbReverseAsync([3000], controller.signal)).rejects.toBe(reason);
+    expect(Log.warn).not.toHaveBeenCalled();
   });
 });
 
@@ -121,13 +138,30 @@ describe(stopAdbReverseAsync, () => {
       },
     ]);
     await stopAdbReverseAsync([3000]);
-    expect(getServer().runAsync).toHaveBeenCalledTimes(2);
-    expect(getServer().runAsync).toHaveBeenNthCalledWith(1, [
-      '-s',
-      'FA8251A00720',
-      'reverse',
-      '--remove',
-      'tcp:3000',
+    expect(getServer().runDeviceMutationAsync).toHaveBeenCalledTimes(2);
+    expect(getServer().runDeviceMutationAsync).toHaveBeenNthCalledWith(
+      1,
+      ['-s', 'FA8251A00720', 'reverse', '--remove', 'tcp:3000'],
+      'remove reverse port',
+      undefined
+    );
+  });
+
+  it('preserves caller cancellation when removing a reversed port', async () => {
+    const reason = new Error('cancel reverse cleanup');
+    const controller = new AbortController();
+    controller.abort(reason);
+    jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
+      {
+        isAuthorized: true,
+        isBooted: true,
+        name: 'Pixel_2',
+        pid: 'FA8251A00720',
+        type: 'device',
+      },
     ]);
+    jest.mocked(getServer().runDeviceMutationAsync).mockRejectedValueOnce(reason);
+
+    await expect(stopAdbReverseAsync([3000], controller.signal)).rejects.toBe(reason);
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
@@ -43,7 +43,8 @@ describe(startAdbReverseAsync, () => {
       1,
       ['-s', 'FA8251A00720', 'reverse', 'tcp:3000', 'tcp:3000'],
       'reverse port',
-      undefined
+      expect.any(AbortSignal),
+      2_000
     );
   });
   it(`reverses multiple ports`, async () => {
@@ -63,7 +64,8 @@ describe(startAdbReverseAsync, () => {
       1,
       ['-s', 'emulator-5554', 'reverse', 'tcp:3000', 'tcp:3000'],
       'reverse port',
-      undefined
+      expect.any(AbortSignal),
+      2_000
     );
   });
 
@@ -143,7 +145,8 @@ describe(stopAdbReverseAsync, () => {
       1,
       ['-s', 'FA8251A00720', 'reverse', '--remove', 'tcp:3000'],
       'remove reverse port',
-      undefined
+      undefined,
+      2_000
     );
   });
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adbReverse-test.ts
@@ -1,4 +1,5 @@
 import * as Log from '../../../../log';
+import { installExitHooks } from '../../../../utils/exit';
 import { getAttachedDevicesAsync, getServer } from '../adb';
 import { startAdbReverseAsync, stopAdbReverseAsync } from '../adbReverse';
 
@@ -19,6 +20,31 @@ jest.mock('../../../../utils/exit', () => ({
 }));
 
 describe(startAdbReverseAsync, () => {
+  it('awaits and bounds best-effort cleanup in the exit hook', async () => {
+    jest.useFakeTimers();
+    let exitHook: (() => void | Promise<void>) | undefined;
+    jest.mocked(installExitHooks).mockImplementationOnce((hook) => {
+      exitHook = () => hook('SIGINT');
+      return jest.fn();
+    });
+    jest
+      .mocked(getAttachedDevicesAsync)
+      .mockResolvedValueOnce([])
+      .mockImplementationOnce(
+        ({ signal } = {}) =>
+          new Promise((_, reject) => {
+            signal!.addEventListener('abort', () => reject(signal!.reason), { once: true });
+          })
+      );
+
+    await expect(startAdbReverseAsync([3000])).resolves.toBe(true);
+    const cleanup = exitHook!();
+    expect(cleanup).toBeInstanceOf(Promise);
+    await jest.advanceTimersByTimeAsync(2_000);
+    await expect(cleanup).resolves.toBeUndefined();
+    jest.useRealTimers();
+  });
+
   it(`reverses devices`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([
       {
@@ -145,7 +171,7 @@ describe(stopAdbReverseAsync, () => {
       1,
       ['-s', 'FA8251A00720', 'reverse', '--remove', 'tcp:3000'],
       'remove reverse port',
-      undefined,
+      expect.any(AbortSignal),
       2_000
     );
   });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -20,16 +20,31 @@ describe(listAvdsAsync, () => {
     } as any);
 
     await expect(listAvdsAsync()).resolves.toStrictEqual([
-      { isAuthorized: true, isBooted: false, name: 'avd1', type: 'emulator' },
-      { isAuthorized: true, isBooted: false, name: 'avd2', type: 'emulator' },
+      {
+        isAuthorized: true,
+        isBooted: false,
+        isLaunchable: true,
+        name: 'avd1',
+        type: 'emulator',
+      },
+      {
+        isAuthorized: true,
+        isBooted: false,
+        isLaunchable: true,
+        name: 'avd2',
+        type: 'emulator',
+      },
     ]);
   });
-  it(`returns an empty list when emulator fails`, async () => {
-    jest.mocked(spawnAsync).mockRejectedValueOnce({
-      stderr: 'err',
-    } as any);
+  it(`preserves emulator tool failures`, async () => {
+    jest
+      .mocked(spawnAsync)
+      .mockRejectedValueOnce(Object.assign(new Error('emulator failed'), { stderr: 'err' }));
 
-    await expect(listAvdsAsync()).resolves.toStrictEqual([]);
+    await expect(listAvdsAsync()).rejects.toMatchObject({
+      message: 'emulator failed',
+      stderr: 'err',
+    });
   });
 });
 
@@ -41,6 +56,7 @@ describe(startDeviceAsync, () => {
     jest.mocked(spawn).mockReturnValueOnce({
       unref: jest.fn(),
       on: jest.fn(),
+      off: jest.fn(),
     });
 
     await expect(startDeviceAsync({ name: 'foo' }, { timeout: 5 })).rejects.toThrow(
@@ -63,6 +79,7 @@ describe(startDeviceAsync, () => {
     jest.mocked(spawn).mockReturnValueOnce({
       unref: jest.fn(),
       on: jest.fn(),
+      off: jest.fn(),
     });
 
     await expect(
@@ -70,5 +87,82 @@ describe(startDeviceAsync, () => {
     ).resolves.toStrictEqual({
       name: 'foo',
     });
+  });
+
+  it('keeps boot checks single-flight while an earlier attempt is pending', async () => {
+    let resolveFirstCheck!: (devices: ADB.Device[]) => void;
+    jest
+      .mocked(ADB.getAttachedDevicesAsync)
+      .mockImplementationOnce(
+        () => new Promise<ADB.Device[]>((resolve) => (resolveFirstCheck = resolve))
+      )
+      .mockResolvedValue([]);
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce({
+      unref: jest.fn(),
+      on: jest.fn(),
+      off: jest.fn(),
+    });
+
+    const result = startDeviceAsync({ name: 'foo' }, { timeout: 50, interval: 5 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(ADB.getAttachedDevicesAsync).toHaveBeenCalledTimes(1);
+    expect(ADB.getAttachedDevicesAsync).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+
+    resolveFirstCheck([]);
+    await expect(result).rejects.toThrow(/It took too long/);
+  });
+
+  it('stops immediately on an underlying discovery failure', async () => {
+    const failure = new Error('ADB discovery failed');
+    jest.mocked(ADB.getAttachedDevicesAsync).mockRejectedValueOnce(failure);
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce({ unref: jest.fn(), on: jest.fn(), off: jest.fn() });
+
+    await expect(startDeviceAsync({ name: 'foo' })).rejects.toBe(failure);
+  });
+
+  it('threads explicit caller cancellation through a pending discovery check', async () => {
+    jest
+      .mocked(ADB.getAttachedDevicesAsync)
+      .mockImplementationOnce(
+        ({ signal } = {}) =>
+          new Promise((_, reject) =>
+            signal!.addEventListener('abort', () => reject(signal!.reason), { once: true })
+          )
+      );
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce({ unref: jest.fn(), on: jest.fn(), off: jest.fn() });
+    const controller = new AbortController();
+    const reason = new Error('caller cancelled');
+    const result = startDeviceAsync({ name: 'foo' }, { signal: controller.signal });
+
+    controller.abort(reason);
+    await expect(result).rejects.toBe(reason);
+  });
+
+  it('reports emulator process exit instead of a boot timeout and disposes listeners', async () => {
+    const handlers = new Map<string, () => void>();
+    const child = {
+      unref: jest.fn(),
+      on: jest.fn((event: string, handler: () => void) => handlers.set(event, handler)),
+      off: jest.fn(),
+    };
+    jest
+      .mocked(ADB.getAttachedDevicesAsync)
+      .mockImplementationOnce(
+        ({ signal } = {}) =>
+          new Promise((_, reject) =>
+            signal!.addEventListener('abort', () => reject(signal!.reason), { once: true })
+          )
+      );
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce(child);
+    const result = startDeviceAsync({ name: 'foo' });
+
+    handlers.get('exit')!();
+    await expect(result).rejects.toThrow('quit before it finished opening');
+    expect(child.off).toHaveBeenCalledWith('error', handlers.get('error'));
+    expect(child.off).toHaveBeenCalledWith('exit', handlers.get('exit'));
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -2,6 +2,7 @@ import spawnAsync from '@expo/spawn-async';
 import { spawn } from 'child_process';
 
 import * as ADB from '../adb';
+import { AdbProcessWaitError } from '../adbProcess';
 import { listAvdsAsync, startDeviceAsync } from '../emulator';
 
 jest.mock('../../../../log');
@@ -96,7 +97,13 @@ describe(startDeviceAsync, () => {
     ]);
     jest
       .mocked(ADB.isBootAnimationCompleteAsync)
-      .mockRejectedValueOnce(new Error('property query timed out'))
+      .mockRejectedValueOnce(
+        new AdbProcessWaitError(
+          'property query timed out',
+          'device property/boot query',
+          'device-service'
+        )
+      )
       .mockResolvedValueOnce(true);
     // @ts-expect-error
     jest.mocked(spawn).mockReturnValueOnce({ unref: jest.fn(), on: jest.fn(), off: jest.fn() });
@@ -105,6 +112,20 @@ describe(startDeviceAsync, () => {
       startDeviceAsync({ name: 'foo' }, { timeout: 500, interval: 1 })
     ).resolves.toMatchObject({ name: 'foo' });
     expect(ADB.isBootAnimationCompleteAsync).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves a permanent boot property failure', async () => {
+    const failure = new Error('getprop is unavailable');
+    jest.mocked(ADB.getAttachedDevicesAsync).mockResolvedValue([
+      // @ts-expect-error
+      { name: 'foo', pid: 'emulator-5554' },
+    ]);
+    jest.mocked(ADB.isBootAnimationCompleteAsync).mockRejectedValueOnce(failure);
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce({ unref: jest.fn(), on: jest.fn(), off: jest.fn() });
+
+    await expect(startDeviceAsync({ name: 'foo' })).rejects.toBe(failure);
+    expect(ADB.isBootAnimationCompleteAsync).toHaveBeenCalledTimes(1);
   });
 
   it('keeps boot checks single-flight while an earlier attempt is pending', async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -89,6 +89,24 @@ describe(startDeviceAsync, () => {
     });
   });
 
+  it('retries a transient boot property failure', async () => {
+    jest.mocked(ADB.getAttachedDevicesAsync).mockResolvedValue([
+      // @ts-expect-error
+      { name: 'foo', pid: 'emulator-5554' },
+    ]);
+    jest
+      .mocked(ADB.isBootAnimationCompleteAsync)
+      .mockRejectedValueOnce(new Error('property query timed out'))
+      .mockResolvedValueOnce(true);
+    // @ts-expect-error
+    jest.mocked(spawn).mockReturnValueOnce({ unref: jest.fn(), on: jest.fn(), off: jest.fn() });
+
+    await expect(
+      startDeviceAsync({ name: 'foo' }, { timeout: 500, interval: 1 })
+    ).resolves.toMatchObject({ name: 'foo' });
+    expect(ADB.isBootAnimationCompleteAsync).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps boot checks single-flight while an earlier attempt is pending', async () => {
     let resolveFirstCheck!: (devices: ADB.Device[]) => void;
     jest

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/emulator-test.ts
@@ -107,7 +107,10 @@ describe(startDeviceAsync, () => {
     const result = startDeviceAsync({ name: 'foo' }, { timeout: 50, interval: 5 });
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(ADB.getAttachedDevicesAsync).toHaveBeenCalledTimes(1);
-    expect(ADB.getAttachedDevicesAsync).toHaveBeenCalledWith({ signal: expect.any(AbortSignal) });
+    expect(ADB.getAttachedDevicesAsync).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal),
+      shouldShowWaitingMessage: false,
+    });
 
     resolveFirstCheck([]);
     await expect(result).rejects.toThrow(/It took too long/);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-cold-start-failure.js
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-cold-start-failure.js
@@ -1,0 +1,23 @@
+const fs = require('node:fs');
+
+const attemptFile = process.argv[2];
+const failingAttempts = Number(process.argv[3]);
+
+let attempt = 0;
+try {
+  attempt = Number(fs.readFileSync(attemptFile, 'utf8')) || 0;
+} catch {
+  attempt = 0;
+}
+fs.writeFileSync(attemptFile, String(++attempt));
+
+if (attempt <= failingAttempts) {
+  process.stderr.write(
+    '* daemon not running; starting now at tcp:5037\n' +
+      'adb: failed to check server version: cannot connect to daemon at tcp:5037: Connection refused\n'
+  );
+  process.exitCode = 1;
+} else {
+  process.stdout.write('List of devices attached\nUSB-1 device usb:1 model:Pixel transport_id:4\n');
+  process.stderr.write('* daemon started successfully\n');
+}

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-cold-start.js
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-cold-start.js
@@ -1,0 +1,6 @@
+process.stdout.write('List of devices attached\nUSB-1 device usb:1 model:Pixel transport_id:4\n');
+process.stderr.write(
+  '* daemon not running; starting now at tcp:5037\n' +
+    '* daemon started successfully\n' +
+    'adb D adb_client.cpp:393] adb_query: host:devices-l\n'
+);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-hang.js
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-hang.js
@@ -1,0 +1,2 @@
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1_000);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-long-command.js
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-long-command.js
@@ -1,0 +1,10 @@
+const mode = process.argv[2];
+
+if (mode === 'finite') {
+  setTimeout(() => process.stdout.write('completed'), 150);
+} else if (mode === 'stream') {
+  setInterval(() => process.stdout.write('tick\n'), 10);
+} else {
+  process.stderr.write(`unknown fixture mode: ${mode}`);
+  process.exitCode = 1;
+}

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-process-child.js
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/fixtures/adb-process-child.js
@@ -1,0 +1,17 @@
+const fs = require('node:fs');
+
+const pidFile = process.argv[2];
+fs.writeFileSync(pidFile, String(process.pid));
+
+process.on('SIGTERM', () => {
+  // Exercise the runner's escalation path on platforms with catchable SIGTERM.
+});
+
+const output = Buffer.alloc(64 * 1024, 'o');
+const errorOutput = Buffer.alloc(64 * 1024, 'e');
+for (let index = 0; index < 32; index++) {
+  process.stdout.write(output);
+  process.stderr.write(errorOutput);
+}
+
+setInterval(() => {}, 1_000);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -25,6 +25,20 @@ it('preserves AVD inventory tool failures', async () => {
   await expect(getDevicesAsync()).rejects.toThrow('emulator -list-avds failed');
 });
 
+it('preserves attached devices when AVD inventory is unavailable', async () => {
+  const device = {
+    name: 'Pixel USB',
+    pid: 'serial-1',
+    type: 'device' as const,
+    isBooted: true,
+    isAuthorized: true,
+  };
+  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([device]);
+  jest.mocked(listAvdsAsync).mockRejectedValueOnce(new Error('emulator -list-avds failed'));
+
+  await expect(getDevicesAsync()).resolves.toEqual([device]);
+});
+
 describe(mergeDevices, () => {
   const avd = (name: string) => ({
     name,

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -18,12 +18,20 @@ it(`asserts no devices are available`, async () => {
   expect(listAvdsAsync).toHaveBeenCalled();
 });
 
+it('preserves AVD inventory tool failures', async () => {
+  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
+  jest.mocked(listAvdsAsync).mockRejectedValueOnce(new Error('emulator -list-avds failed'));
+
+  await expect(getDevicesAsync()).rejects.toThrow('emulator -list-avds failed');
+});
+
 describe(mergeDevices, () => {
   const avd = (name: string) => ({
     name,
     type: 'emulator' as const,
     isBooted: false,
     isAuthorized: true,
+    isLaunchable: true,
   });
 
   it('preserves attached-device ordering and appends absent AVDs', () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -14,7 +14,7 @@ it(`asserts no devices are available`, async () => {
   jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
   jest.mocked(listAvdsAsync).mockResolvedValueOnce([]);
   await expect(getDevicesAsync()).rejects.toThrow(CommandError);
-  expect(getAttachedDevicesAsync).toHaveBeenCalled();
+  expect(getAttachedDevicesAsync).toHaveBeenCalledWith({ shouldShowWaitingMessage: true });
   expect(listAvdsAsync).toHaveBeenCalled();
 });
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -1,4 +1,3 @@
-import { CommandError } from '../../../../utils/errors';
 import { getAttachedDevicesAsync } from '../adb';
 import { listAvdsAsync } from '../emulator';
 import { getDevicesAsync, mergeDevices } from '../getDevices';
@@ -13,7 +12,9 @@ jest.mock('../emulator', () => ({
 it(`asserts no devices are available`, async () => {
   jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
   jest.mocked(listAvdsAsync).mockResolvedValueOnce([]);
-  await expect(getDevicesAsync()).rejects.toThrow(CommandError);
+  await expect(getDevicesAsync()).rejects.toMatchObject({
+    code: 'ANDROID_NO_DEVICES',
+  });
   expect(getAttachedDevicesAsync).toHaveBeenCalledWith({ shouldShowWaitingMessage: true });
   expect(listAvdsAsync).toHaveBeenCalled();
 });

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -18,11 +18,13 @@ it(`asserts no devices are available`, async () => {
   expect(listAvdsAsync).toHaveBeenCalled();
 });
 
-it('preserves AVD inventory tool failures', async () => {
+it('adds device setup guidance to AVD inventory tool failures', async () => {
   jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
   jest.mocked(listAvdsAsync).mockRejectedValueOnce(new Error('emulator -list-avds failed'));
 
-  await expect(getDevicesAsync()).rejects.toThrow('emulator -list-avds failed');
+  await expect(getDevicesAsync()).rejects.toThrow(
+    /No Android connected device found[\s\S]*emulator -list-avds failed[\s\S]*Connect a device or create an emulator/
+  );
 });
 
 it('preserves attached devices when AVD inventory is unavailable', async () => {

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -1,26 +1,26 @@
-import { getAttachedDevicesAsync } from '../adb';
+import { waitForAttachedDevicesAsync } from '../adb';
 import { listAvdsAsync } from '../emulator';
 import { getDevicesAsync, mergeDevices } from '../getDevices';
 
 jest.mock('../adb', () => ({
-  getAttachedDevicesAsync: jest.fn(),
+  waitForAttachedDevicesAsync: jest.fn(),
 }));
 jest.mock('../emulator', () => ({
   listAvdsAsync: jest.fn(),
 }));
 
 it(`asserts no devices are available`, async () => {
-  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
+  jest.mocked(waitForAttachedDevicesAsync).mockResolvedValueOnce([]);
   jest.mocked(listAvdsAsync).mockResolvedValueOnce([]);
   await expect(getDevicesAsync()).rejects.toMatchObject({
     code: 'ANDROID_NO_DEVICES',
   });
-  expect(getAttachedDevicesAsync).toHaveBeenCalledWith({ shouldShowWaitingMessage: true });
+  expect(waitForAttachedDevicesAsync).toHaveBeenCalled();
   expect(listAvdsAsync).toHaveBeenCalled();
 });
 
 it('adds device setup guidance to AVD inventory tool failures', async () => {
-  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([]);
+  jest.mocked(waitForAttachedDevicesAsync).mockResolvedValueOnce([]);
   jest.mocked(listAvdsAsync).mockRejectedValueOnce(new Error('emulator -list-avds failed'));
 
   await expect(getDevicesAsync()).rejects.toThrow(
@@ -36,7 +36,7 @@ it('preserves attached devices when AVD inventory is unavailable', async () => {
     isBooted: true,
     isAuthorized: true,
   };
-  jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([device]);
+  jest.mocked(waitForAttachedDevicesAsync).mockResolvedValueOnce([device]);
   jest.mocked(listAvdsAsync).mockRejectedValueOnce(new Error('emulator -list-avds failed'));
 
   await expect(getDevicesAsync()).resolves.toEqual([device]);

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/getDevices-test.ts
@@ -1,7 +1,7 @@
 import { CommandError } from '../../../../utils/errors';
 import { getAttachedDevicesAsync } from '../adb';
 import { listAvdsAsync } from '../emulator';
-import { getDevicesAsync } from '../getDevices';
+import { getDevicesAsync, mergeDevices } from '../getDevices';
 
 jest.mock('../adb', () => ({
   getAttachedDevicesAsync: jest.fn(),
@@ -16,4 +16,29 @@ it(`asserts no devices are available`, async () => {
   await expect(getDevicesAsync()).rejects.toThrow(CommandError);
   expect(getAttachedDevicesAsync).toHaveBeenCalled();
   expect(listAvdsAsync).toHaveBeenCalled();
+});
+
+describe(mergeDevices, () => {
+  const avd = (name: string) => ({
+    name,
+    type: 'emulator' as const,
+    isBooted: false,
+    isAuthorized: true,
+  });
+
+  it('preserves attached-device ordering and appends absent AVDs', () => {
+    const physical = {
+      name: 'Pixel USB',
+      pid: 'serial-1',
+      type: 'device' as const,
+      isBooted: true,
+      isAuthorized: true,
+      connectionType: 'USB' as const,
+    };
+    const attachedAvd = { ...avd('Pixel_API_35'), pid: 'emulator-5554', isBooted: true };
+
+    expect(
+      mergeDevices([physical, attachedAvd], [avd('Pixel_API_35'), avd('Tablet_API_35')])
+    ).toEqual([physical, attachedAvd, avd('Tablet_API_35')]);
+  });
 });

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -3,12 +3,17 @@ import chalk from 'chalk';
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
+import { isInteractive } from '../../../utils/interactive';
 import { learnMore } from '../../../utils/link';
 import { ora } from '../../../utils/ora';
 import { event } from '../events';
 import { ADBServer } from './ADBServer';
 import { isAdbDeviceStateUsable, parseAdbDeviceList } from './adbDeviceList';
-import { createAdbOperationErrorAsync, formatAdbDiscoveryError } from './adbDiagnostics';
+import {
+  createAdbOperationErrorAsync,
+  formatAdbDiscoveryError,
+  shouldProbeAdbHost,
+} from './adbDiagnostics';
 import {
   ADB_HOST_PROBE_WAIT_LIMIT_MS,
   AdbHostProbeResult,
@@ -68,6 +73,8 @@ const PROP_CPU_ABI_LIST_NAME = 'ro.product.cpu.abilist';
 // http://developer.android.com/ndk/guides/abis.html
 const PROP_BOOT_ANIMATION_STATE = 'init.svc.bootanim';
 const DEVICE_DISCOVERY_WAIT_LIMIT_MS = 10_000;
+const DEVICE_DISCOVERY_RETRY_DELAY_MS = 200;
+const DEVICE_DISCOVERY_MAX_ATTEMPTS = 3;
 
 let _server: ADBServer | null;
 
@@ -278,33 +285,58 @@ export async function getAttachedDevicesAsync({
   shouldShowWaitingMessage?: boolean;
 } = {}): Promise<Device[]> {
   const discoveryWaitLimitMs = waitLimitMs ?? DEVICE_DISCOVERY_WAIT_LIMIT_MS;
+  const discoveryDeadline = Date.now() + discoveryWaitLimitMs;
   const waitSignal = AbortSignal.timeout(discoveryWaitLimitMs);
   const operationSignal = signal ? AbortSignal.any([signal, waitSignal]) : waitSignal;
   const endpoint = resolveAdbEndpoint();
-  const spinner = shouldShowWaitingMessage ? ora('Waiting for ADB device discovery').start() : null;
+  const spinner =
+    shouldShowWaitingMessage && isInteractive()
+      ? ora('Waiting for ADB device discovery').start()
+      : null;
 
   try {
-    const output = await server.runHostQueryAsync(
-      ['devices', '-l'],
-      'device discovery',
-      signal,
-      discoveryWaitLimitMs
-    );
-    return await parseAttachedDevicesAsync(output, operationSignal);
+    let lastError: unknown;
+    for (let attempt = 0; attempt < DEVICE_DISCOVERY_MAX_ATTEMPTS; attempt++) {
+      try {
+        const output = await server.runHostQueryAsync(
+          ['devices', '-l'],
+          'device discovery',
+          signal,
+          Math.max(1, discoveryDeadline - Date.now())
+        );
+        const devices = await parseAttachedDevicesAsync(output, operationSignal);
+        if (devices.length || attempt === DEVICE_DISCOVERY_MAX_ATTEMPTS - 1) {
+          return devices;
+        }
+      } catch (error) {
+        if (operationSignal.aborted && error === operationSignal.reason) throw error;
+        lastError = error;
+        if (!shouldRetryAdbDiscovery(error) || attempt === DEVICE_DISCOVERY_MAX_ATTEMPTS - 1) {
+          throw error;
+        }
+      }
+      await waitForRetryAsync(DEVICE_DISCOVERY_RETRY_DELAY_MS, operationSignal);
+    }
+    throw lastError;
   } catch (error) {
     // Caller cancellation is not a discovery failure, so skip the diagnostic probe
     if (signal?.aborted && error === signal.reason) {
       throw error;
     }
 
-    let hostProbe: AdbHostProbeResult;
-    try {
-      const probeSignal = AbortSignal.timeout(probeWaitLimitMs);
-      hostProbe = await probeAdbHostVersionAsync(endpoint, probeSignal);
-    } catch {
-      hostProbe = {
-        kind: 'connection-failure',
-      };
+    let hostProbe: AdbHostProbeResult | undefined;
+    if (shouldProbeAdbHost(error) && !operationSignal.aborted) {
+      try {
+        const probeSignal = AbortSignal.any([
+          operationSignal,
+          AbortSignal.timeout(probeWaitLimitMs),
+        ]);
+        hostProbe = await probeAdbHostVersionAsync(endpoint, probeSignal);
+      } catch {
+        hostProbe = {
+          kind: 'connection-failure',
+        };
+      }
     }
     throw new CommandError('ADB_DISCOVERY', formatAdbDiscoveryError(error, endpoint, hostProbe));
   } finally {
@@ -339,11 +371,15 @@ async function parseAttachedDevicesAsync(output: string, signal: AbortSignal): P
           ? deviceInfo.find((field) => field.startsWith('model:'))?.slice('model:'.length)
           : undefined;
         name = model || `Device ${pid}`;
-      } else if (isUsable) {
-        // Given a usable emulator pid, get the AVD name for matching the attached transport.
-        name = (await getAdbNameForDeviceIdAsync({ pid }, signal)) ?? '';
       } else {
-        name = `Device ${pid}`;
+        // Resolve names in every emulator state so booting transports merge with AVD inventory.
+        // A broken emulator console must not discard otherwise healthy attached devices.
+        try {
+          name = (await getAdbNameForDeviceIdAsync({ pid }, signal)) || `Device ${pid}`;
+        } catch (error) {
+          if (signal.aborted && error === signal.reason) throw error;
+          name = `Device ${pid}`;
+        }
       }
 
       return {
@@ -359,6 +395,31 @@ async function parseAttachedDevicesAsync(output: string, signal: AbortSignal): P
       };
     })
   );
+}
+
+function shouldRetryAdbDiscovery(error: unknown): boolean {
+  return (
+    !(error instanceof Error && error.name === 'AbortError') &&
+    error instanceof Error &&
+    /(?:cannot connect|connection refused|server didn't ACK|daemon (?:not running|still not running)|smartsocket)/i.test(
+      error.message
+    )
+  );
+}
+
+function waitForRetryAsync(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener('abort', handleAbort);
+      resolve();
+    }, delayMs);
+    const handleAbort = () => {
+      clearTimeout(timeout);
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', handleAbort, { once: true });
+  });
 }
 
 /**

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -74,7 +74,7 @@ const PROP_CPU_ABI_LIST_NAME = 'ro.product.cpu.abilist';
 const PROP_BOOT_ANIMATION_STATE = 'init.svc.bootanim';
 const DEVICE_DISCOVERY_WAIT_LIMIT_MS = 10_000;
 const DEVICE_DISCOVERY_RETRY_DELAY_MS = 200;
-const DEVICE_DISCOVERY_MAX_ATTEMPTS = 3;
+const DEVICE_DISCOVERY_RETRY_WINDOW_MS = 2_000;
 
 let _server: ADBServer | null;
 
@@ -271,21 +271,37 @@ function shellQuote(value: string): string {
 }
 
 // TODO: This is very expensive for some operations.
-export async function getAttachedDevicesAsync({
-  server = getServer(),
-  signal,
-  waitLimitMs,
-  probeWaitLimitMs = ADB_HOST_PROBE_WAIT_LIMIT_MS,
-  shouldShowWaitingMessage = false,
-}: {
+type GetAttachedDevicesOptions = {
   server?: ADBServer;
   signal?: AbortSignal;
   waitLimitMs?: number;
   probeWaitLimitMs?: number;
   shouldShowWaitingMessage?: boolean;
-} = {}): Promise<Device[]> {
+};
+
+export async function getAttachedDevicesAsync(
+  options: GetAttachedDevicesOptions = {}
+): Promise<Device[]> {
+  return getAttachedDevicesWithOptionsAsync(options, false);
+}
+
+export async function waitForAttachedDevicesAsync(): Promise<Device[]> {
+  return getAttachedDevicesWithOptionsAsync({ shouldShowWaitingMessage: true }, true);
+}
+
+async function getAttachedDevicesWithOptionsAsync(
+  {
+    server = getServer(),
+    signal,
+    waitLimitMs,
+    probeWaitLimitMs = ADB_HOST_PROBE_WAIT_LIMIT_MS,
+    shouldShowWaitingMessage = false,
+  }: GetAttachedDevicesOptions,
+  shouldRetryEmptyResult: boolean
+): Promise<Device[]> {
   const discoveryWaitLimitMs = waitLimitMs ?? DEVICE_DISCOVERY_WAIT_LIMIT_MS;
   const discoveryDeadline = Date.now() + discoveryWaitLimitMs;
+  const retryDeadline = Math.min(discoveryDeadline, Date.now() + DEVICE_DISCOVERY_RETRY_WINDOW_MS);
   const waitSignal = AbortSignal.timeout(discoveryWaitLimitMs);
   const operationSignal = signal ? AbortSignal.any([signal, waitSignal]) : waitSignal;
   const endpoint = resolveAdbEndpoint();
@@ -295,8 +311,8 @@ export async function getAttachedDevicesAsync({
       : null;
 
   try {
-    let lastError: unknown;
-    for (let attempt = 0; attempt < DEVICE_DISCOVERY_MAX_ATTEMPTS; attempt++) {
+    while (true) {
+      let retryError: unknown;
       try {
         const output = await server.runHostQueryAsync(
           ['devices', '-l'],
@@ -305,19 +321,27 @@ export async function getAttachedDevicesAsync({
           Math.max(1, discoveryDeadline - Date.now())
         );
         const devices = await parseAttachedDevicesAsync(output, operationSignal);
-        if (devices.length || attempt === DEVICE_DISCOVERY_MAX_ATTEMPTS - 1) {
+        if (devices.length || !shouldRetryEmptyResult) {
           return devices;
         }
       } catch (error) {
         if (operationSignal.aborted && error === operationSignal.reason) throw error;
-        lastError = error;
-        if (!shouldRetryAdbDiscovery(error) || attempt === DEVICE_DISCOVERY_MAX_ATTEMPTS - 1) {
+        if (!shouldRetryAdbDiscovery(error)) {
           throw error;
         }
+        retryError = error;
       }
-      await waitForRetryAsync(DEVICE_DISCOVERY_RETRY_DELAY_MS, operationSignal);
+
+      const retryTimeRemaining = retryDeadline - Date.now();
+      if (retryTimeRemaining <= 0) {
+        if (retryError) throw retryError;
+        return [];
+      }
+      await waitForRetryAsync(
+        Math.min(DEVICE_DISCOVERY_RETRY_DELAY_MS, retryTimeRemaining),
+        operationSignal
+      );
     }
-    throw lastError;
   } catch (error) {
     // Caller cancellation is not a discovery failure, so skip the diagnostic probe
     if (signal?.aborted && error === signal.reason) {

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -255,14 +255,14 @@ export async function getAttachedDevicesAsync({
   const spinner = ora('Waiting for ADB device discovery');
   spinner.start();
 
-  let output: string;
   try {
-    output = await server.runHostQueryAsync(
+    const output = await server.runHostQueryAsync(
       ['devices', '-l'],
       'device discovery',
       signal,
       discoveryWaitLimitMs
     );
+    return await parseAttachedDevicesAsync(output, operationSignal);
   } catch (error) {
     // Caller cancellation is not a discovery failure, so skip the diagnostic probe
     if (signal?.aborted && error === signal.reason) {
@@ -282,7 +282,9 @@ export async function getAttachedDevicesAsync({
   } finally {
     spinner.stop();
   }
+}
 
+async function parseAttachedDevicesAsync(output: string, signal: AbortSignal): Promise<Device[]> {
   return Promise.all(
     parseAdbDeviceList(output).map(async (record): Promise<Device> => {
       // unauthorized: ['FA8251A00719', 'unauthorized', 'usb:338690048X', 'transport_id:5']
@@ -311,7 +313,7 @@ export async function getAttachedDevicesAsync({
         name = model || `Device ${pid}`;
       } else if (isUsable) {
         // Given a usable emulator pid, get the AVD name for matching the attached transport.
-        name = (await getAdbNameForDeviceIdAsync({ pid }, operationSignal)) ?? '';
+        name = (await getAdbNameForDeviceIdAsync({ pid }, signal)) ?? '';
       } else {
         name = `Device ${pid}`;
       }

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -4,9 +4,17 @@ import * as Log from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { learnMore } from '../../../utils/link';
+import { ora } from '../../../utils/ora';
 import { event } from '../events';
 import { ADBServer } from './ADBServer';
-import { parseAdbDeviceList } from './adbDeviceList';
+import { isAdbDeviceStateUsable, parseAdbDeviceList } from './adbDeviceList';
+import { createAdbOperationErrorAsync, formatAdbDiscoveryError } from './adbDiagnostics';
+import {
+  ADB_HOST_PROBE_WAIT_LIMIT_MS,
+  AdbHostProbeResult,
+  probeAdbHostVersionAsync,
+  resolveAdbEndpoint,
+} from './adbEndpoint';
 
 export enum DeviceABI {
   // The arch specific android target platforms are soft-deprecated.
@@ -38,6 +46,12 @@ export type Device = {
   isAuthorized: boolean;
   /** The connection type to ADB, only available when `type: device` */
   connectionType?: 'USB' | 'Network';
+  /** Raw state reported by ADB. Absent for an AVD that is not attached. */
+  state?: string;
+  /** Stable transport identity reported by `adb devices -l`, when available. */
+  transportId?: string;
+  /** Whether Expo may launch this inventory record with `emulator @name`. */
+  isLaunchable?: boolean;
 };
 
 type DeviceContext = Pick<Device, 'pid'>;
@@ -53,6 +67,7 @@ const PROP_CPU_ABI_LIST_NAME = 'ro.product.cpu.abilist';
 // Can sometimes be null
 // http://developer.android.com/ndk/guides/abis.html
 const PROP_BOOT_ANIMATION_STATE = 'init.svc.bootanim';
+const DEVICE_DISCOVERY_WAIT_LIMIT_MS = 10_000;
 
 let _server: ADBServer | null;
 
@@ -74,10 +89,13 @@ export function logUnauthorized(device: Device) {
 /** Returns true if the provided package name is installed on the provided Android device. */
 export async function isPackageInstalledAsync(
   device: DeviceContext,
-  androidPackage: string
+  androidPackage: string,
+  signal?: AbortSignal
 ): Promise<boolean> {
-  const packages = await getServer().runAsync(
-    adbShellArgs(device.pid, 'pm', 'list', 'packages', '--user', env.EXPO_ADB_USER, androidPackage)
+  const packages = await getServer().runDeviceQueryAsync(
+    adbShellArgs(device.pid, 'pm', 'list', 'packages', '--user', env.EXPO_ADB_USER, androidPackage),
+    'package query',
+    signal
   );
 
   const lines = packages.split(/\r?\n/);
@@ -103,7 +121,8 @@ export async function launchActivityAsync(
   }: {
     launchActivity: string;
     url?: string;
-  }
+  },
+  signal?: AbortSignal
 ) {
   const command: string[] = [
     'am',
@@ -120,7 +139,7 @@ export async function launchActivityAsync(
     command.push('-d', url);
   }
 
-  return openAsync(adbShellArgs(device.pid, ...command));
+  return openAsync(adbShellArgs(device.pid, ...command), 'activity launch', signal);
 }
 
 /**
@@ -133,16 +152,19 @@ export async function openUrlAsync(
     url,
   }: {
     url: string;
-  }
+  },
+  signal?: AbortSignal
 ) {
   return openAsync(
-    adbShellArgs(device.pid, 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url)
+    adbShellArgs(device.pid, 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url),
+    'URL launch',
+    signal
   );
 }
 
 /** Runs a generic command watches for common errors in order to throw with an expected code. */
-async function openAsync(args: string[]): Promise<string> {
-  const results = await getServer().runAsync(args);
+async function openAsync(args: string[], operation: string, signal?: AbortSignal): Promise<string> {
+  const results = await getServer().runDeviceMutationAsync(args, operation, signal);
   if (
     results.includes(CANT_START_ACTIVITY_ERROR) ||
     results.match(/Error: Activity class .* does not exist\./g)
@@ -155,26 +177,40 @@ async function openAsync(args: string[]): Promise<string> {
 /** Uninstall an app given its Android package name. */
 export async function uninstallAsync(
   device: DeviceContext,
-  { appId }: { appId: string }
+  { appId }: { appId: string },
+  signal?: AbortSignal
 ): Promise<string> {
-  return await getServer().runAsync(
-    adbArgs(device.pid, 'uninstall', '--user', env.EXPO_ADB_USER, appId)
+  return await getServer().runDeviceMutationAsync(
+    adbArgs(device.pid, 'uninstall', '--user', env.EXPO_ADB_USER, appId),
+    'app uninstall',
+    signal
   );
 }
 
 /** Get package info from an app based on its Android package name. */
 export async function getPackageInfoAsync(
   device: DeviceContext,
-  { appId }: { appId: string }
+  { appId }: { appId: string },
+  signal?: AbortSignal
 ): Promise<string> {
-  return await getServer().runAsync(adbShellArgs(device.pid, 'dumpsys', 'package', appId));
+  return await getServer().runDeviceQueryAsync(
+    adbShellArgs(device.pid, 'dumpsys', 'package', appId),
+    'package info query',
+    signal
+  );
 }
 
 /** Install an app on a connected device. */
-export async function installAsync(device: DeviceContext, { filePath }: { filePath: string }) {
+export async function installAsync(
+  device: DeviceContext,
+  { filePath }: { filePath: string },
+  signal?: AbortSignal
+) {
   // TODO: Handle the `INSTALL_FAILED_INSUFFICIENT_STORAGE` error.
-  return await getServer().runAsync(
-    adbArgs(device.pid, 'install', '-r', '-d', '--user', env.EXPO_ADB_USER, filePath)
+  return await getServer().runDeviceMutationAsync(
+    adbArgs(device.pid, 'install', '-r', '-d', '--user', env.EXPO_ADB_USER, filePath),
+    'app install',
+    signal
   );
 }
 
@@ -201,76 +237,98 @@ function shellQuote(value: string): string {
 }
 
 // TODO: This is very expensive for some operations.
-export async function getAttachedDevicesAsync(): Promise<Device[]> {
-  const output = await getServer().runAsync(['devices', '-l']);
+export async function getAttachedDevicesAsync({
+  server = getServer(),
+  signal,
+  waitLimitMs,
+  probeWaitLimitMs = ADB_HOST_PROBE_WAIT_LIMIT_MS,
+}: {
+  server?: ADBServer;
+  signal?: AbortSignal;
+  waitLimitMs?: number;
+  probeWaitLimitMs?: number;
+} = {}): Promise<Device[]> {
+  const discoveryWaitLimitMs = waitLimitMs ?? DEVICE_DISCOVERY_WAIT_LIMIT_MS;
+  const waitSignal = AbortSignal.timeout(discoveryWaitLimitMs);
+  const operationSignal = signal ? AbortSignal.any([signal, waitSignal]) : waitSignal;
+  const endpoint = resolveAdbEndpoint();
+  const spinner = ora('Waiting for ADB device discovery');
+  spinner.start();
 
-  const attachedDevices: {
-    props: string[];
-    type: Device['type'];
-    isAuthorized: Device['isAuthorized'];
-    isBooted: Device['isBooted'];
-    connectionType?: Device['connectionType'];
-  }[] = parseAdbDeviceList(output)
-    .map((record) => {
+  let output: string;
+  try {
+    output = await server.runHostQueryAsync(
+      ['devices', '-l'],
+      'device discovery',
+      signal,
+      discoveryWaitLimitMs
+    );
+  } catch (error) {
+    // Caller cancellation is not a discovery failure, so skip the diagnostic probe
+    if (signal?.aborted && error === signal.reason) {
+      throw error;
+    }
+
+    let hostProbe: AdbHostProbeResult;
+    try {
+      const probeSignal = AbortSignal.timeout(probeWaitLimitMs);
+      hostProbe = await probeAdbHostVersionAsync(endpoint, probeSignal);
+    } catch {
+      hostProbe = {
+        kind: 'connection-failure',
+      };
+    }
+    throw new CommandError('ADB_DISCOVERY', formatAdbDiscoveryError(error, endpoint, hostProbe));
+  } finally {
+    spinner.stop();
+  }
+
+  return Promise.all(
+    parseAdbDeviceList(output).map(async (record): Promise<Device> => {
       // unauthorized: ['FA8251A00719', 'unauthorized', 'usb:338690048X', 'transport_id:5']
       // authorized: ['FA8251A00719', 'device', 'usb:336592896X', 'product:walleye', 'model:Pixel_2', 'device:walleye', 'transport_id:4']
       // emulator: ['emulator-5554', 'offline', 'transport_id:1']
-      const props = [record.serial, record.state, ...record.metadata];
-      const line = props.join(' ');
-      const type: Device['type'] = line.includes('emulator') ? 'emulator' : 'device';
+      const type: Device['type'] = /^emulator-\d+$/.test(record.serial) ? 'emulator' : 'device';
 
-      let connectionType: Device['connectionType'];
-      if (type === 'device' && line.includes('usb:')) {
-        connectionType = 'USB';
-      } else if (type === 'device' && line.includes('_adb-tls-connect.')) {
-        connectionType = 'Network';
-      }
+      const connectionType: Device['connectionType'] =
+        type !== 'device'
+          ? undefined
+          : record.metadata.some((field) => field.startsWith('usb:'))
+            ? 'USB'
+            : record.serial.includes('_adb-tls-connect.')
+              ? 'Network'
+              : undefined;
 
-      const isBooted = type === 'emulator' || props[1] !== 'offline';
-      const isAuthorized =
-        connectionType === 'Network'
-          ? line.includes('model:') // Network connected devices show `model:<name>` when authorized
-          : props[1] !== 'unauthorized';
+      const { serial: pid, state, transportId, metadata: deviceInfo } = record;
+      const isUsable = isAdbDeviceStateUsable(state);
 
-      return { props, type, isAuthorized, isBooted, connectionType };
-    })
-    .filter(({ props: [pid] }) => !!pid);
-
-  const devicePromises = attachedDevices.map<Promise<Device>>(async (props) => {
-    const {
-      type,
-      props: [pid, ...deviceInfo],
-      isAuthorized,
-      isBooted,
-    } = props;
-
-    let name: string | null = null;
-
-    if (type === 'device') {
-      if (isAuthorized) {
-        // Possibly formatted like `model:Pixel_2`
-        // Transform to `Pixel_2`
-        const modelItem = deviceInfo.find((info) => info.includes('model:'));
-        if (modelItem) {
-          name = modelItem.replace('model:', '');
-        }
-      }
-      // unauthorized devices don't have a name available to read
-      if (!name) {
-        // Device FA8251A00719
+      let name: string;
+      if (type === 'device') {
+        // Unauthorized devices do not report model metadata.
+        const model = isUsable
+          ? deviceInfo.find((field) => field.startsWith('model:'))?.slice('model:'.length)
+          : undefined;
+        name = model || `Device ${pid}`;
+      } else if (isUsable) {
+        // Given a usable emulator pid, get the AVD name for matching the attached transport.
+        name = (await getAdbNameForDeviceIdAsync({ pid }, operationSignal)) ?? '';
+      } else {
         name = `Device ${pid}`;
       }
-    } else {
-      // Given an emulator pid, get the emulator name which can be used to start the emulator later.
-      name = (await getAdbNameForDeviceIdAsync({ pid })) ?? '';
-    }
 
-    return props.connectionType
-      ? { pid, name, type, isAuthorized, isBooted, connectionType: props.connectionType }
-      : { pid, name, type, isAuthorized, isBooted };
-  });
-
-  return Promise.all(devicePromises);
+      return {
+        pid,
+        name,
+        type,
+        isAuthorized: isUsable,
+        isBooted: isUsable,
+        isLaunchable: false,
+        state,
+        transportId,
+        connectionType,
+      };
+    })
+  );
 }
 
 /**
@@ -278,8 +336,15 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
  *
  * @param device.pid a value like `emulator-5554` from `abd devices`
  */
-export async function getAdbNameForDeviceIdAsync(device: DeviceContext): Promise<string | null> {
-  const results = await getServer().runAsync(adbArgs(device.pid, 'emu', 'avd', 'name'));
+export async function getAdbNameForDeviceIdAsync(
+  device: DeviceContext,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const results = await getServer().runDeviceQueryAsync(
+    adbArgs(device.pid, 'emu', 'avd', 'name'),
+    'emulator name query',
+    signal
+  );
 
   if (results.match(/could not connect to TCP port .*: Connection refused/)) {
     // Can also occur when the emulator does not exist.
@@ -307,13 +372,12 @@ export async function isDeviceBootedAsync({
  *
  * @param pid
  */
-export async function isBootAnimationCompleteAsync(pid?: string): Promise<boolean> {
-  try {
-    const props = await getPropertyDataForDeviceAsync({ pid }, PROP_BOOT_ANIMATION_STATE);
-    return !!props[PROP_BOOT_ANIMATION_STATE]?.match(/stopped/);
-  } catch {
-    return false;
-  }
+export async function isBootAnimationCompleteAsync(
+  pid?: string,
+  signal?: AbortSignal
+): Promise<boolean> {
+  const props = await getPropertyDataForDeviceAsync({ pid }, PROP_BOOT_ANIMATION_STATE, signal);
+  return !!props[PROP_BOOT_ANIMATION_STATE]?.match(/stopped/);
 }
 
 /** Get a list of ABIs for the provided device. */
@@ -336,20 +400,26 @@ export async function getDeviceABIsAsync(
 
 export async function getPropertyDataForDeviceAsync(
   device: DeviceContext,
-  prop?: string
+  prop?: string,
+  signal?: AbortSignal
 ): Promise<DeviceProperties> {
   const propCommand = prop
     ? adbShellArgs(device.pid, 'getprop', prop)
     : adbShellArgs(device.pid, 'getprop');
   try {
-    // Prevent reading as UTF8.
-    const results = await getServer().getFileOutputAsync(propCommand);
+    const results = await getServer().getFileOutputAsync(propCommand, {
+      signal,
+    });
     // Like:
     // [wifi.direct.interface]: [p2p-dev-wlan0]
     // [wifi.interface]: [wlan0]
 
     if (prop) {
-      event('adb_property_data', { devicePid: device.pid, prop, data: results });
+      event('adb_property_data', {
+        devicePid: device.pid,
+        prop,
+        data: results,
+      });
       return {
         [prop]: results,
       };
@@ -360,8 +430,7 @@ export async function getPropertyDataForDeviceAsync(
 
     return props;
   } catch (error: any) {
-    // TODO: Ensure error has message and not stderr
-    throw new CommandError(`Failed to get properties for device (${device.pid}): ${error.message}`);
+    throw await createAdbOperationErrorAsync('ADB_PROPERTY', error, device);
   }
 }
 

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -310,9 +310,9 @@ async function getAttachedDevicesWithOptionsAsync(
       ? ora('Waiting for ADB device discovery').start()
       : null;
 
+  let retryError: unknown;
   try {
     while (true) {
-      let retryError: unknown;
       try {
         const output = await server.runHostQueryAsync(
           ['devices', '-l'],
@@ -324,6 +324,7 @@ async function getAttachedDevicesWithOptionsAsync(
         if (devices.length || !shouldRetryEmptyResult) {
           return devices;
         }
+        retryError = undefined;
       } catch (error) {
         if (operationSignal.aborted && error === operationSignal.reason) throw error;
         if (!shouldRetryAdbDiscovery(error)) {
@@ -342,11 +343,16 @@ async function getAttachedDevicesWithOptionsAsync(
         operationSignal
       );
     }
-  } catch (error) {
+  } catch (caughtError) {
     // Caller cancellation is not a discovery failure, so skip the diagnostic probe
-    if (signal?.aborted && error === signal.reason) {
-      throw error;
+    if (signal?.aborted && caughtError === signal.reason) {
+      throw caughtError;
     }
+
+    const error =
+      retryError != null && operationSignal.aborted && caughtError === operationSignal.reason
+        ? retryError
+        : caughtError;
 
     let hostProbe: AdbHostProbeResult | undefined;
     if (shouldProbeAdbHost(error) && !operationSignal.aborted) {

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -242,18 +242,19 @@ export async function getAttachedDevicesAsync({
   signal,
   waitLimitMs,
   probeWaitLimitMs = ADB_HOST_PROBE_WAIT_LIMIT_MS,
+  shouldShowWaitingMessage = true,
 }: {
   server?: ADBServer;
   signal?: AbortSignal;
   waitLimitMs?: number;
   probeWaitLimitMs?: number;
+  shouldShowWaitingMessage?: boolean;
 } = {}): Promise<Device[]> {
   const discoveryWaitLimitMs = waitLimitMs ?? DEVICE_DISCOVERY_WAIT_LIMIT_MS;
   const waitSignal = AbortSignal.timeout(discoveryWaitLimitMs);
   const operationSignal = signal ? AbortSignal.any([signal, waitSignal]) : waitSignal;
   const endpoint = resolveAdbEndpoint();
-  const spinner = ora('Waiting for ADB device discovery');
-  spinner.start();
+  const spinner = shouldShowWaitingMessage ? ora('Waiting for ADB device discovery').start() : null;
 
   try {
     const output = await server.runHostQueryAsync(
@@ -280,7 +281,7 @@ export async function getAttachedDevicesAsync({
     }
     throw new CommandError('ADB_DISCOVERY', formatAdbDiscoveryError(error, endpoint, hostProbe));
   } finally {
-    spinner.stop();
+    spinner?.stop();
   }
 }
 

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import os from 'os';
 
 import * as Log from '../../../log';
 import { env } from '../../../utils/env';
@@ -7,6 +6,7 @@ import { CommandError } from '../../../utils/errors';
 import { learnMore } from '../../../utils/link';
 import { event } from '../events';
 import { ADBServer } from './ADBServer';
+import { parseAdbDeviceList } from './adbDeviceList';
 
 export enum DeviceABI {
   // The arch specific android target platforms are soft-deprecated.
@@ -204,34 +204,22 @@ function shellQuote(value: string): string {
 export async function getAttachedDevicesAsync(): Promise<Device[]> {
   const output = await getServer().runAsync(['devices', '-l']);
 
-  const splitItems = output
-    .trim()
-    .replace(/\n$/, '')
-    .split(os.EOL)
-    // Filter ADB trace logs from the output, e.g.
-    // adb D 03-06 15:25:53 63677 4018815 adb_client.cpp:393] adb_query: host:devices-l
-    // 03-04 12:29:44.557 16415 16415 D adb     : commandline.cpp:1646 Using server socket: tcp:172.27.192.1:5037
-    // 03-04 12:29:44.557 16415 16415 D adb     : adb_client.cpp:160 _adb_connect: host:version
-    .filter((line) => !line.match(/\.cpp:[0-9]+/));
-
-  // First line is `"List of devices attached"`, remove it
-  // @ts-ignore: todo
   const attachedDevices: {
     props: string[];
     type: Device['type'];
     isAuthorized: Device['isAuthorized'];
     isBooted: Device['isBooted'];
     connectionType?: Device['connectionType'];
-  }[] = splitItems
-    .slice(1, splitItems.length)
-    .map((line) => {
+  }[] = parseAdbDeviceList(output)
+    .map((record) => {
       // unauthorized: ['FA8251A00719', 'unauthorized', 'usb:338690048X', 'transport_id:5']
       // authorized: ['FA8251A00719', 'device', 'usb:336592896X', 'product:walleye', 'model:Pixel_2', 'device:walleye', 'transport_id:4']
       // emulator: ['emulator-5554', 'offline', 'transport_id:1']
-      const props = line.split(' ').filter(Boolean);
-      const type = line.includes('emulator') ? 'emulator' : 'device';
+      const props = [record.serial, record.state, ...record.metadata];
+      const line = props.join(' ');
+      const type: Device['type'] = line.includes('emulator') ? 'emulator' : 'device';
 
-      let connectionType;
+      let connectionType: Device['connectionType'];
       if (type === 'device' && line.includes('usb:')) {
         connectionType = 'USB';
       } else if (type === 'device' && line.includes('_adb-tls-connect.')) {

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -355,15 +355,14 @@ export async function getAdbNameForDeviceIdAsync(
 }
 
 export async function isDeviceBootedAsync({
+  pid,
   name,
-}: { name?: string } = {}): Promise<Device | null> {
+}: Partial<Pick<Device, 'pid' | 'name'>> = {}): Promise<Device | null> {
   const devices = await getAttachedDevicesAsync();
 
-  if (!name) {
-    return devices[0] ?? null;
-  }
-
-  return devices.find((device) => device.name === name) ?? null;
+  if (pid) return devices.find((device) => device.pid === pid) ?? null;
+  if (name) return devices.find((device) => device.name === name) ?? null;
+  return devices[0] ?? null;
 }
 
 /**

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -332,10 +332,14 @@ export async function getAttachedDevicesAsync({
           AbortSignal.timeout(probeWaitLimitMs),
         ]);
         hostProbe = await probeAdbHostVersionAsync(endpoint, probeSignal);
-      } catch {
-        hostProbe = {
-          kind: 'connection-failure',
-        };
+      } catch (probeError) {
+        if (signal?.aborted && probeError === signal.reason) {
+          throw probeError;
+        } else if (!operationSignal.aborted) {
+          hostProbe = {
+            kind: 'connection-failure',
+          };
+        }
       }
     }
     throw new CommandError('ADB_DISCOVERY', formatAdbDiscoveryError(error, endpoint, hostProbe));

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -164,14 +164,41 @@ export async function openUrlAsync(
 
 /** Runs a generic command watches for common errors in order to throw with an expected code. */
 async function openAsync(args: string[], operation: string, signal?: AbortSignal): Promise<string> {
-  const results = await getServer().runDeviceMutationAsync(args, operation, signal);
-  if (
-    results.includes(CANT_START_ACTIVITY_ERROR) ||
-    results.match(/Error: Activity class .* does not exist\./g)
-  ) {
-    throw new CommandError('APP_NOT_INSTALLED', results.substring(results.indexOf('Error: ')));
+  let results: string;
+  try {
+    results = await getServer().runDeviceMutationAsync(args, operation, signal);
+  } catch (error) {
+    const output =
+      error && typeof error === 'object'
+        ? [
+            'stdout' in error ? error.stdout : undefined,
+            'stderr' in error ? error.stderr : undefined,
+            error instanceof Error ? error.message : undefined,
+          ]
+            .filter((value): value is string => typeof value === 'string')
+            .join('\n')
+        : String(error);
+    if (isMissingActivityOutput(output)) {
+      throw new CommandError('APP_NOT_INSTALLED', extractActivityError(output));
+    }
+    throw error;
+  }
+  if (isMissingActivityOutput(results)) {
+    throw new CommandError('APP_NOT_INSTALLED', extractActivityError(results));
   }
   return results;
+}
+
+function isMissingActivityOutput(output: string): boolean {
+  return (
+    output.includes(CANT_START_ACTIVITY_ERROR) ||
+    /Error: Activity class .* does not exist\./.test(output)
+  );
+}
+
+function extractActivityError(output: string): string {
+  const errorIndex = output.indexOf('Error: ');
+  return errorIndex >= 0 ? output.substring(errorIndex) : output;
 }
 
 /** Uninstall an app given its Android package name. */

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -10,7 +10,7 @@ import { event } from '../events';
 import { ADBServer } from './ADBServer';
 import { isAdbDeviceStateUsable, parseAdbDeviceList } from './adbDeviceList';
 import {
-  createAdbOperationErrorAsync,
+  createAdbOperationError,
   formatAdbDiscoveryError,
   shouldProbeAdbHost,
 } from './adbDiagnostics';
@@ -548,7 +548,7 @@ export async function getPropertyDataForDeviceAsync(
 
     return props;
   } catch (error: any) {
-    throw await createAdbOperationErrorAsync('ADB_PROPERTY', error, device);
+    throw createAdbOperationError('ADB_PROPERTY', error, device);
   }
 }
 

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -242,7 +242,7 @@ export async function getAttachedDevicesAsync({
   signal,
   waitLimitMs,
   probeWaitLimitMs = ADB_HOST_PROBE_WAIT_LIMIT_MS,
-  shouldShowWaitingMessage = true,
+  shouldShowWaitingMessage = false,
 }: {
   server?: ADBServer;
   signal?: AbortSignal;

--- a/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
@@ -15,7 +15,7 @@ export function parseAdbDeviceList(output: string): AdbDeviceRecord[] {
   return output
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => line && line !== DEVICE_LIST_HEADER)
+    .filter((line) => line && line !== DEVICE_LIST_HEADER && !/\.cpp:[0-9]+/.test(line))
     .map(parseDeviceLine)
     .filter((record): record is AdbDeviceRecord => record != null);
 }

--- a/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
@@ -5,14 +5,17 @@ export interface AdbDeviceRecord {
   transportId: string | undefined;
 }
 
+export function isAdbDeviceStateUsable(state: string): boolean {
+  return state === 'device';
+}
+
 const DEVICE_LIST_HEADER = 'List of devices attached';
 
-/** Parse the machine-readable records produced by `adb devices -l`. */
 export function parseAdbDeviceList(output: string): AdbDeviceRecord[] {
   return output
     .split(/\r?\n/)
     .map((line) => line.trim())
-    .filter((line) => line && line !== DEVICE_LIST_HEADER && !line.match(/\.cpp:[0-9]+/))
+    .filter((line) => line && line !== DEVICE_LIST_HEADER)
     .map(parseDeviceLine)
     .filter((record): record is AdbDeviceRecord => record != null);
 }

--- a/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDeviceList.ts
@@ -1,0 +1,40 @@
+export interface AdbDeviceRecord {
+  serial: string;
+  state: string;
+  metadata: string[];
+  transportId: string | undefined;
+}
+
+const DEVICE_LIST_HEADER = 'List of devices attached';
+
+/** Parse the machine-readable records produced by `adb devices -l`. */
+export function parseAdbDeviceList(output: string): AdbDeviceRecord[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && line !== DEVICE_LIST_HEADER && !line.match(/\.cpp:[0-9]+/))
+    .map(parseDeviceLine)
+    .filter((record): record is AdbDeviceRecord => record != null);
+}
+
+function parseDeviceLine(line: string): AdbDeviceRecord | null {
+  const match = line.match(/^(\S+)\s+(.+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const [, serial, remainder] = match;
+  const fields = remainder!.split(/\s+/);
+  const state = fields[0] === 'no' && fields[1] === 'permissions' ? 'no permissions' : fields[0]!;
+  const metadata = fields.slice(state === 'no permissions' ? 2 : 1);
+  const transportId = metadata
+    .find((field) => field.startsWith('transport_id:'))
+    ?.slice('transport_id:'.length);
+
+  return {
+    serial: serial!,
+    state,
+    metadata,
+    transportId,
+  };
+}

--- a/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
@@ -101,7 +101,13 @@ function getAdvice(error: unknown, device?: AdbDeviceDiagnostic): string[] {
   if (device?.state === 'offline') {
     advice.push(`Reconnect ${device.pid ? `device ${device.pid}` : 'the device'} and try again.`);
   } else if (device?.state === 'unauthorized') {
-    advice.push('Authorize this computer on the device, then try again.');
+    advice.push(
+      'Authorize this computer on the device, then try again: https://expo.fyi/authorize-android-device'
+    );
+  } else if (device?.state === 'no permissions') {
+    advice.push(
+      'Set up permission to access the device, then reconnect it. On Linux, configure the appropriate udev rules; on Windows, install the appropriate USB driver: https://developer.android.com/studio/run/device.html'
+    );
   } else if (device?.state && device.state !== 'device') {
     advice.push('Wait until ADB reports the device as ready, then try again.');
   }

--- a/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
@@ -8,7 +8,7 @@ import {
 import type { AdbEndpoint, AdbHostProbeResult } from './adbEndpoint';
 import { AdbProcessError, AdbProcessWaitError } from './adbProcess';
 
-export type AdbDeviceDiagnostic = { pid?: string; state?: string };
+export type AdbDeviceDiagnostic = { pid?: string; state?: string; type?: 'emulator' | 'device' };
 
 function formatAdbError(
   error: unknown,
@@ -29,7 +29,10 @@ function formatAdbError(
   }
 
   if (hostProbe && !(error instanceof AdbProcessError && error.spawnFailed)) {
-    details.push(formatHostProbeAdvice(error, endpoint, hostProbe));
+    const hostProbeAdvice = formatHostProbeAdvice(endpoint, hostProbe);
+    if (hostProbeAdvice) {
+      details.push(hostProbeAdvice);
+    }
   }
 
   details.push(...getAdvice(error, device));
@@ -43,9 +46,19 @@ export function formatAdbDeviceError(error: unknown, device: AdbDeviceDiagnostic
 export function formatAdbDiscoveryError(
   error: unknown,
   endpoint: AdbEndpoint,
-  hostProbe: AdbHostProbeResult
+  hostProbe?: AdbHostProbeResult
 ): string {
   return formatAdbError(error, endpoint, hostProbe);
+}
+
+export function shouldProbeAdbHost(error: unknown): boolean {
+  return (
+    error instanceof AdbProcessWaitError ||
+    (error instanceof Error &&
+      /(?:cannot connect|connection refused|server didn't ACK|daemon (?:not running|still not running)|smartsocket)/i.test(
+        error.message
+      ))
+  );
 }
 
 export async function createAdbOperationErrorAsync(
@@ -71,14 +84,14 @@ export async function createAdbOperationErrorAsync(
 }
 
 function formatHostProbeAdvice(
-  error: unknown,
   endpoint: AdbEndpoint | undefined,
   result: AdbHostProbeResult
-): string {
+): string | null {
   const formattedEndpoint = endpoint ? formatAdbEndpoint(endpoint) : 'the configured endpoint';
   switch (result.kind) {
     case 'version':
-      return `The ADB server is responding, but ${error instanceof AdbProcessError ? error.operation : 'the command'} did not finish. Check the device connection and try again.`;
+      // A successful probe after an operation failed cannot explain the earlier failure.
+      return null;
     case 'connected-no-reply':
       return `The ADB server at ${formattedEndpoint} is not responding. Check or restart that server, then try again.`;
     case 'connection-refused':
@@ -98,7 +111,9 @@ function getAdvice(error: unknown, device?: AdbDeviceDiagnostic): string[] {
   if (error instanceof AdbProcessError && error.spawnFailed) {
     advice.push('Check that Android SDK Platform-Tools is installed and ADB is available.');
   }
-  if (device?.state === 'offline') {
+  if (device?.state === 'offline' && device.type === 'emulator') {
+    advice.push('Wait until ADB reports the emulator as ready, then try again.');
+  } else if (device?.state === 'offline') {
     advice.push(`Reconnect ${device.pid ? `device ${device.pid}` : 'the device'} and try again.`);
   } else if (device?.state === 'unauthorized') {
     advice.push(

--- a/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
@@ -80,7 +80,9 @@ export async function createAdbOperationErrorAsync(
       };
     }
   }
-  return new CommandError(code, formatAdbError(error, endpoint, hostProbe, device));
+  const commandError = new CommandError(code, formatAdbError(error, endpoint, hostProbe, device));
+  commandError.cause = error;
+  return commandError;
 }
 
 function formatHostProbeAdvice(

--- a/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
@@ -1,10 +1,5 @@
 import { CommandError } from '../../../utils/errors';
-import {
-  ADB_HOST_PROBE_WAIT_LIMIT_MS,
-  formatAdbEndpoint,
-  probeAdbHostVersionAsync,
-  resolveAdbEndpoint,
-} from './adbEndpoint';
+import { formatAdbEndpoint } from './adbEndpoint';
 import type { AdbEndpoint, AdbHostProbeResult } from './adbEndpoint';
 import { AdbProcessError, AdbProcessWaitError } from './adbProcess';
 
@@ -61,26 +56,12 @@ export function shouldProbeAdbHost(error: unknown): boolean {
   );
 }
 
-export async function createAdbOperationErrorAsync(
+export function createAdbOperationError(
   code: string,
   error: unknown,
   device?: AdbDeviceDiagnostic
-): Promise<CommandError> {
-  const endpoint = resolveAdbEndpoint();
-  let hostProbe: AdbHostProbeResult | undefined;
-  if (error instanceof AdbProcessWaitError && error.phase === 'device-service') {
-    try {
-      hostProbe = await probeAdbHostVersionAsync(
-        endpoint,
-        AbortSignal.timeout(ADB_HOST_PROBE_WAIT_LIMIT_MS)
-      );
-    } catch {
-      hostProbe = {
-        kind: 'connection-failure',
-      };
-    }
-  }
-  const commandError = new CommandError(code, formatAdbError(error, endpoint, hostProbe, device));
+): CommandError {
+  const commandError = new CommandError(code, formatAdbError(error, undefined, undefined, device));
   commandError.cause = error;
   return commandError;
 }

--- a/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbDiagnostics.ts
@@ -1,0 +1,121 @@
+import { CommandError } from '../../../utils/errors';
+import {
+  ADB_HOST_PROBE_WAIT_LIMIT_MS,
+  formatAdbEndpoint,
+  probeAdbHostVersionAsync,
+  resolveAdbEndpoint,
+} from './adbEndpoint';
+import type { AdbEndpoint, AdbHostProbeResult } from './adbEndpoint';
+import { AdbProcessError, AdbProcessWaitError } from './adbProcess';
+
+export type AdbDeviceDiagnostic = { pid?: string; state?: string };
+
+function formatAdbError(
+  error: unknown,
+  endpoint?: AdbEndpoint,
+  hostProbe?: AdbHostProbeResult,
+  device?: AdbDeviceDiagnostic
+): string {
+  const details: string[] = [error instanceof Error ? error.message : String(error)];
+
+  // NOTE(@kitten): Side-effect marker from `hasSideEffects` in ./adbProcess.ts
+  if (
+    typeof error === 'object' &&
+    error != null &&
+    'remoteCompletionUnknown' in error &&
+    error.remoteCompletionUnknown === true
+  ) {
+    details.push('The operation may have completed on the device. Check before trying again.');
+  }
+
+  if (hostProbe && !(error instanceof AdbProcessError && error.spawnFailed)) {
+    details.push(formatHostProbeAdvice(error, endpoint, hostProbe));
+  }
+
+  details.push(...getAdvice(error, device));
+  return details.join('\n');
+}
+
+export function formatAdbDeviceError(error: unknown, device: AdbDeviceDiagnostic): string {
+  return formatAdbError(error, undefined, undefined, device);
+}
+
+export function formatAdbDiscoveryError(
+  error: unknown,
+  endpoint: AdbEndpoint,
+  hostProbe: AdbHostProbeResult
+): string {
+  return formatAdbError(error, endpoint, hostProbe);
+}
+
+export async function createAdbOperationErrorAsync(
+  code: string,
+  error: unknown,
+  device?: AdbDeviceDiagnostic
+): Promise<CommandError> {
+  const endpoint = resolveAdbEndpoint();
+  let hostProbe: AdbHostProbeResult | undefined;
+  if (error instanceof AdbProcessWaitError && error.phase === 'device-service') {
+    try {
+      hostProbe = await probeAdbHostVersionAsync(
+        endpoint,
+        AbortSignal.timeout(ADB_HOST_PROBE_WAIT_LIMIT_MS)
+      );
+    } catch {
+      hostProbe = {
+        kind: 'connection-failure',
+      };
+    }
+  }
+  return new CommandError(code, formatAdbError(error, endpoint, hostProbe, device));
+}
+
+function formatHostProbeAdvice(
+  error: unknown,
+  endpoint: AdbEndpoint | undefined,
+  result: AdbHostProbeResult
+): string {
+  const formattedEndpoint = endpoint ? formatAdbEndpoint(endpoint) : 'the configured endpoint';
+  switch (result.kind) {
+    case 'version':
+      return `The ADB server is responding, but ${error instanceof AdbProcessError ? error.operation : 'the command'} did not finish. Check the device connection and try again.`;
+    case 'connected-no-reply':
+      return `The ADB server at ${formattedEndpoint} is not responding. Check or restart that server, then try again.`;
+    case 'connection-refused':
+    case 'connection-failure':
+      return `Could not connect to the ADB server at ${formattedEndpoint}. Check the server configuration and try again.`;
+    case 'adb-failure':
+      return `The ADB server rejected Expo's health check: ${result.message}. Check the server configuration and try again.`;
+    case 'invalid-protocol':
+      return `The configured endpoint at ${formattedEndpoint} is not an ADB server. Check ADB_SERVER_SOCKET and try again.`;
+    case 'unsupported':
+      return 'Expo could not check the configured ADB server. Check ADB_SERVER_SOCKET and try again.';
+  }
+}
+
+function getAdvice(error: unknown, device?: AdbDeviceDiagnostic): string[] {
+  const advice: string[] = [];
+  if (error instanceof AdbProcessError && error.spawnFailed) {
+    advice.push('Check that Android SDK Platform-Tools is installed and ADB is available.');
+  }
+  if (device?.state === 'offline') {
+    advice.push(`Reconnect ${device.pid ? `device ${device.pid}` : 'the device'} and try again.`);
+  } else if (device?.state === 'unauthorized') {
+    advice.push('Authorize this computer on the device, then try again.');
+  } else if (device?.state && device.state !== 'device') {
+    advice.push('Wait until ADB reports the device as ready, then try again.');
+  }
+  if ((!device?.state || device.state === 'device') && isAdbDeviceDisconnectedError(error)) {
+    advice.push('The device disconnected. Reconnect it and try again.');
+  }
+  return advice;
+}
+
+export function isAdbDeviceDisconnectedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    /device (?:not found|offline|still authorizing)|no devices\/emulators found|transport (?:is closed|error)/i.test(
+      error.message
+    )
+  );
+}

--- a/packages/@expo/cli/src/start/platforms/android/adbEndpoint.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbEndpoint.ts
@@ -1,0 +1,282 @@
+import net from 'node:net';
+import { setTimeout as delayAsync } from 'node:timers/promises';
+
+import { event } from '../events';
+import { isAdbTimeoutReason } from './adbProcess';
+
+export const ADB_HOST_PROBE_WAIT_LIMIT_MS = 4_000;
+
+type AdbEndpointSource =
+  | 'ADB_SERVER_SOCKET'
+  | 'ANDROID_ADB_SERVER_ADDRESS'
+  | 'ANDROID_ADB_SERVER_PORT'
+  | 'default';
+
+export type AdbEndpoint =
+  | {
+      type: 'tcp';
+      host: string;
+      port: number;
+      scope: 'local' | 'remote';
+      source: AdbEndpointSource;
+    }
+  | {
+      type: 'local-filesystem';
+      path: string;
+      source: 'ADB_SERVER_SOCKET';
+    }
+  | {
+      type: 'unsupported';
+      specification: string;
+      source: 'ADB_SERVER_SOCKET';
+    };
+
+export type AdbHostProbeResult =
+  | { kind: 'connection-refused' }
+  | { kind: 'connection-failure' }
+  | { kind: 'connected-no-reply' }
+  | { kind: 'adb-failure'; message: string }
+  | { kind: 'invalid-protocol' }
+  | { kind: 'version' }
+  | { kind: 'unsupported' };
+
+type AdbHostVersionFrame =
+  | Extract<AdbHostProbeResult, { kind: 'adb-failure' | 'invalid-protocol' | 'version' }>
+  | { kind: 'incomplete' };
+
+const DEFAULT_ADB_HOST = '127.0.0.1';
+const DEFAULT_ADB_PORT = 5037;
+const ADB_STARTUP_GRACE_MS = 250;
+
+export function formatAdbEndpoint(endpoint: AdbEndpoint): string {
+  switch (endpoint.type) {
+    case 'tcp': {
+      const host = net.isIP(endpoint.host) === 6 ? `[${endpoint.host}]` : endpoint.host;
+      return `tcp:${host}:${endpoint.port} (${endpoint.scope}, selected by ${endpoint.source})`;
+    }
+    case 'local-filesystem':
+      return `localfilesystem:${endpoint.path} (selected by ${endpoint.source})`;
+    case 'unsupported':
+      return `${endpoint.specification} (selected by ${endpoint.source}, direct probe unsupported)`;
+  }
+}
+
+export function resolveAdbEndpoint(
+  environment: Readonly<Record<string, string | undefined>> = process.env
+): AdbEndpoint {
+  const socket = environment.ADB_SERVER_SOCKET;
+  if (socket) {
+    return parseServerSocket(socket);
+  }
+
+  const address = environment.ANDROID_ADB_SERVER_ADDRESS;
+  const port = parsePort(environment.ANDROID_ADB_SERVER_PORT) ?? DEFAULT_ADB_PORT;
+  const host = address || DEFAULT_ADB_HOST;
+  const source: AdbEndpointSource = address
+    ? 'ANDROID_ADB_SERVER_ADDRESS'
+    : environment.ANDROID_ADB_SERVER_PORT
+      ? 'ANDROID_ADB_SERVER_PORT'
+      : 'default';
+  return tcpEndpoint(host, port, source);
+}
+
+function encodeAdbHostRequest(service: string): Buffer {
+  const payload = Buffer.from(service, 'utf8');
+  return Buffer.concat([Buffer.from(payload.length.toString(16).padStart(4, '0')), payload]);
+}
+
+export function parseAdbHostVersionResponse(response: Buffer): AdbHostVersionFrame {
+  if (response.length < 4) {
+    return { kind: 'incomplete' };
+  }
+
+  const status = response.subarray(0, 4).toString('ascii');
+  if (status !== 'OKAY' && status !== 'FAIL') {
+    return {
+      kind: 'invalid-protocol',
+    };
+  } else if (response.length < 8) {
+    return { kind: 'incomplete' };
+  }
+
+  const lengthText = response.subarray(4, 8).toString('ascii');
+  if (!/^[0-9a-fA-F]{4}$/.test(lengthText)) {
+    return {
+      kind: 'invalid-protocol',
+    };
+  }
+
+  const length = Number.parseInt(lengthText, 16);
+  if (response.length < 8 + length) {
+    return { kind: 'incomplete' };
+  }
+
+  const payload = response.subarray(8, 8 + length).toString('utf8');
+  if (status === 'FAIL') {
+    return { kind: 'adb-failure', message: payload };
+  } else if (!/^[0-9a-fA-F]+$/.test(payload)) {
+    return {
+      kind: 'invalid-protocol',
+    };
+  } else {
+    return { kind: 'version' };
+  }
+}
+
+export async function probeAdbHostVersionAsync(
+  endpoint: AdbEndpoint,
+  signal: AbortSignal
+): Promise<AdbHostProbeResult> {
+  function recordHostProbeResult(endpoint: AdbEndpoint, result: AdbHostProbeResult): void {
+    event('adb_host_probe', {
+      endpoint: formatAdbEndpoint(endpoint),
+      result: result.kind,
+    });
+  }
+
+  event('adb_operation_start', {
+    operation: 'host version probe',
+    phase: 'host-request',
+    waitLimitMs: ADB_HOST_PROBE_WAIT_LIMIT_MS,
+  });
+
+  if (endpoint.type === 'unsupported') {
+    const result = { kind: 'unsupported' } as const;
+    recordHostProbeResult(endpoint, result);
+    return result;
+  }
+
+  let result = await probeEndpointOnceAsync(endpoint, signal);
+  // A new local server may briefly refuse connections while starting.
+  if (
+    result.kind === 'connection-refused' &&
+    (endpoint.type === 'local-filesystem' || endpoint.scope === 'local') &&
+    !signal.aborted
+  ) {
+    await delayAsync(ADB_STARTUP_GRACE_MS, undefined, { signal });
+    result = await probeEndpointOnceAsync(endpoint, signal);
+  }
+
+  recordHostProbeResult(endpoint, result);
+  return result;
+}
+
+async function probeEndpointOnceAsync(
+  endpoint: Exclude<AdbEndpoint, { type: 'unsupported' }>,
+  signal: AbortSignal
+): Promise<AdbHostProbeResult> {
+  signal.throwIfAborted();
+  const socket =
+    endpoint.type === 'tcp'
+      ? net.createConnection({ host: endpoint.host, port: endpoint.port })
+      : net.createConnection(endpoint.path);
+  let connectionState: 'connecting' | 'connected' = 'connecting';
+  let response = Buffer.alloc(0);
+  let handleConnect = () => {};
+  let handleData = (_chunk: Buffer) => {};
+  let handleError = (_error: NodeJS.ErrnoException) => {};
+  let handleClose = () => {};
+  let handleAbort = () => {};
+
+  try {
+    return await new Promise<AdbHostProbeResult>((resolve, reject) => {
+      handleConnect = () => {
+        connectionState = 'connected';
+        socket.write(encodeAdbHostRequest('host:version'));
+      };
+      handleData = (chunk: Buffer) => {
+        response = Buffer.concat([response, chunk]);
+        const frame = parseAdbHostVersionResponse(response);
+        if (frame.kind !== 'incomplete') {
+          resolve(frame);
+        }
+      };
+      handleError = (error: NodeJS.ErrnoException) => {
+        resolve(
+          error.code === 'ECONNREFUSED'
+            ? { kind: 'connection-refused' }
+            : { kind: 'connection-failure' }
+        );
+      };
+      handleClose = () => {
+        resolve(
+          connectionState === 'connected'
+            ? { kind: 'connected-no-reply' }
+            : { kind: 'connection-failure' }
+        );
+      };
+      handleAbort = () => {
+        if (isAdbTimeoutReason(signal.reason) && connectionState === 'connected') {
+          resolve({ kind: 'connected-no-reply' });
+        } else {
+          reject(signal.reason);
+        }
+      };
+
+      socket.once('connect', handleConnect);
+      socket.on('data', handleData);
+      socket.once('error', handleError);
+      socket.once('close', handleClose);
+      signal.addEventListener('abort', handleAbort, { once: true });
+    });
+  } finally {
+    signal.removeEventListener('abort', handleAbort);
+    socket.removeListener('connect', handleConnect);
+    socket.removeListener('data', handleData);
+    socket.removeListener('error', handleError);
+    socket.removeListener('close', handleClose);
+    socket.destroy();
+  }
+}
+
+function parseServerSocket(specification: string): AdbEndpoint {
+  if (specification.startsWith('localfilesystem:')) {
+    const path = specification.slice('localfilesystem:'.length);
+    return path
+      ? { type: 'local-filesystem', path, source: 'ADB_SERVER_SOCKET' }
+      : { type: 'unsupported', specification, source: 'ADB_SERVER_SOCKET' };
+  }
+  if (specification.startsWith('tcp:')) {
+    const address = specification.slice('tcp:'.length);
+    const lastColon = address.lastIndexOf(':');
+    if (lastColon < 0) {
+      const port = parsePort(address);
+      if (port != null) {
+        return tcpEndpoint(DEFAULT_ADB_HOST, port, 'ADB_SERVER_SOCKET');
+      }
+    } else {
+      const host = stripIpv6Brackets(address.slice(0, lastColon));
+      const port = parsePort(address.slice(lastColon + 1));
+      if (host && port != null) {
+        return tcpEndpoint(host, port, 'ADB_SERVER_SOCKET');
+      }
+    }
+  }
+  return { type: 'unsupported', specification, source: 'ADB_SERVER_SOCKET' };
+}
+
+function tcpEndpoint(host: string, port: number, source: AdbEndpointSource): AdbEndpoint {
+  return {
+    type: 'tcp',
+    host,
+    port,
+    scope: isLocalhost(host) ? 'local' : 'remote',
+    source,
+  };
+}
+
+function isLocalhost(host: string): boolean {
+  return ['localhost', '127.0.0.1', '::1'].includes(stripIpv6Brackets(host).toLowerCase());
+}
+
+function stripIpv6Brackets(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
+function parsePort(value: string | undefined): number | null {
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+  const port = Number(value);
+  return port > 0 && port <= 65535 ? port : null;
+}

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -10,12 +10,16 @@ export class AdbProcessError extends Error {
     message: string,
     readonly operation: string,
     readonly phase: AdbProcessPhase,
-    readonly remoteCompletionUnknown?: true,
-    readonly spawnFailed?: true
+    remoteCompletionUnknown?: true,
+    spawnFailed?: true
   ) {
     super(message);
+    this.remoteCompletionUnknown = remoteCompletionUnknown;
+    this.spawnFailed = spawnFailed;
   }
 
+  remoteCompletionUnknown?: boolean;
+  spawnFailed?: boolean;
   stdout?: string;
   stderr?: string;
   status?: number;
@@ -157,7 +161,7 @@ async function runAdbProcessAsync(
       }
 
       if (params.hasSideEffects && error instanceof Error) {
-        Object.assign(error, { remoteCompletionUnknown: true });
+        (error as AdbProcessError).remoteCompletionUnknown = true;
       }
 
       throw error;

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -23,7 +23,7 @@ export class AdbProcessError extends Error {
   stdout?: string;
   stderr?: string;
   status?: number;
-  signal?: AbortSignal;
+  signal?: NodeJS.Signals | null;
 }
 
 export class AdbProcessWaitError extends AdbProcessError {}

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -124,6 +124,7 @@ async function runAdbProcessAsync(
   params: AdbProcessParams,
   signal?: AbortSignal
 ): Promise<spawnAsync.SpawnResult> {
+  signal?.throwIfAborted();
   event('adb_operation_start', {
     operation: params.operation,
     phase: params.phase,

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -1,0 +1,260 @@
+import spawnAsync from '@expo/spawn-async';
+
+import { event } from '../events';
+
+type AdbProcessPhase = 'host-request' | 'device-service';
+type AdbClientTermination = 'terminated' | 'killed' | 'exit-unobserved';
+
+export class AdbProcessError extends Error {
+  constructor(
+    message: string,
+    readonly operation: string,
+    readonly phase: AdbProcessPhase,
+    readonly remoteCompletionUnknown?: true,
+    readonly spawnFailed?: true
+  ) {
+    super(message);
+  }
+
+  stdout?: string;
+  stderr?: string;
+  status?: number;
+  signal?: AbortSignal;
+}
+
+export class AdbProcessWaitError extends AdbProcessError {}
+
+const ADB_SUBPROCESS_CLEANUP_WAIT_LIMIT_MS = 2_000;
+
+export const runAdbHostQueryAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'host-request', hasSideEffects: false },
+    signal
+  );
+
+export const runBoundedAdbHostQueryAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  waitLimitMs: number,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'host-request', hasSideEffects: false, waitLimitMs },
+    signal
+  );
+
+export const runAdbDeviceQueryAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'device-service', hasSideEffects: false },
+    signal
+  );
+
+export const runBoundedAdbDeviceQueryAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  waitLimitMs: number,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'device-service', hasSideEffects: false, waitLimitMs },
+    signal
+  );
+
+export const runAdbDeviceMutationAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'device-service', hasSideEffects: true },
+    signal
+  );
+
+interface AdbProcessParams {
+  operation: string;
+  phase: AdbProcessPhase;
+  hasSideEffects: boolean;
+  waitLimitMs?: number;
+}
+
+async function runAdbProcessAsync(
+  command: string,
+  args: string[],
+  params: AdbProcessParams,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> {
+  event('adb_operation_start', {
+    operation: params.operation,
+    phase: params.phase,
+    waitLimitMs: params.waitLimitMs,
+  });
+  let spawnPromise: spawnAsync.SpawnPromise<spawnAsync.SpawnResult>;
+  try {
+    // NOTE(@kitten): Passing signal to spawnAsync would bypass cleanup accounting.
+    spawnPromise = spawnAsync(command, args);
+  } catch (error) {
+    throw createProcessError(error, params.operation, params.phase);
+  }
+
+  let operationSignal = signal;
+  let waitLimitSignal: AbortSignal | undefined;
+  if (params.waitLimitMs != null) {
+    waitLimitSignal = AbortSignal.timeout(params.waitLimitMs);
+    operationSignal = operationSignal
+      ? AbortSignal.any([operationSignal, waitLimitSignal])
+      : waitLimitSignal;
+  }
+
+  try {
+    return operationSignal
+      ? await raceWithSignal(spawnPromise, operationSignal)
+      : await spawnPromise;
+  } catch (error) {
+    if (operationSignal?.aborted && error === operationSignal.reason) {
+      // NOTE(@kitten): Killing this client cannot retract a request already sent to the server
+      const clientTermination = await terminateAndObserveAsync(
+        spawnPromise,
+        ADB_SUBPROCESS_CLEANUP_WAIT_LIMIT_MS
+      );
+      const waitExpired = waitLimitSignal?.aborted && error === waitLimitSignal.reason;
+      event('adb_operation_cleanup', {
+        operation: params.operation,
+        phase: params.phase,
+        reason: waitExpired ? 'wait-limit' : 'cancelled',
+        status: clientTermination,
+      });
+
+      if (waitExpired) {
+        throw new AdbProcessWaitError(
+          `Expo stopped waiting for the ADB ${params.operation} operation to finish.`,
+          params.operation,
+          params.phase,
+          params.hasSideEffects ? true : undefined
+        );
+      }
+
+      if (params.hasSideEffects && error instanceof Error) {
+        Object.assign(error, { remoteCompletionUnknown: true });
+      }
+
+      throw error;
+    }
+    throw createProcessError(error, params.operation, params.phase);
+  }
+}
+
+async function terminateAndObserveAsync(
+  spawnPromise: spawnAsync.SpawnPromise<spawnAsync.SpawnResult>,
+  cleanupWaitLimitMs: number
+): Promise<AdbClientTermination> {
+  const observed = spawnPromise.then(
+    () => undefined,
+    () => undefined
+  );
+  // Cleanup needs a fresh timeout because the operation signal has already aborted
+  const cleanupSignal = AbortSignal.timeout(cleanupWaitLimitMs);
+
+  // Windows kill() is forced termination, not a graceful SIGTERM attempt.
+  if (process.platform === 'win32') {
+    spawnPromise.child.kill();
+    return observeProcessExitAsync(observed, cleanupSignal, 'killed');
+  }
+
+  const gracefulSignal = AbortSignal.any([
+    cleanupSignal,
+    AbortSignal.timeout(Math.floor(Math.min(500, Math.max(1, cleanupWaitLimitMs / 4)))),
+  ]);
+
+  spawnPromise.child.kill('SIGTERM');
+  const gracefulResult = await observeProcessExitAsync(observed, gracefulSignal, 'terminated');
+  if (gracefulResult === 'terminated') {
+    return gracefulResult;
+  } else {
+    spawnPromise.child.kill('SIGKILL');
+    return observeProcessExitAsync(observed, cleanupSignal, 'killed');
+  }
+}
+
+async function observeProcessExitAsync(
+  processResultPromise: Promise<unknown>,
+  signal: AbortSignal,
+  observedCleanup: 'terminated' | 'killed'
+): Promise<AdbClientTermination> {
+  try {
+    await raceWithSignal(processResultPromise, signal);
+    return observedCleanup;
+  } catch {
+    return 'exit-unobserved';
+  }
+}
+
+function raceWithSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const handleAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', handleAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener('abort', handleAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', handleAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+function createProcessError(
+  error: any,
+  operation: string,
+  phase: AdbProcessPhase
+): AdbProcessError {
+  const result = new AdbProcessError(
+    error?.message ?? 'Failed to run ADB.',
+    operation,
+    phase,
+    undefined,
+    error?.status == null && error?.signal == null ? true : undefined
+  );
+  result.stdout = error?.stdout;
+  result.stderr = error?.stderr;
+  result.status = error?.status;
+  result.signal = error?.signal;
+  return result;
+}
+
+export function isAdbTimeoutReason(reason: unknown): boolean {
+  return (
+    typeof reason === 'object' &&
+    reason != null &&
+    'name' in reason &&
+    reason.name === 'TimeoutError'
+  );
+}

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -97,6 +97,20 @@ export const runAdbDeviceMutationAsync = (
     signal
   );
 
+export const runBoundedAdbDeviceMutationAsync = (
+  command: string,
+  args: string[],
+  operation: string,
+  waitLimitMs: number,
+  signal?: AbortSignal
+): Promise<spawnAsync.SpawnResult> =>
+  runAdbProcessAsync(
+    command,
+    args,
+    { operation, phase: 'device-service', hasSideEffects: true, waitLimitMs },
+    signal
+  );
+
 interface AdbProcessParams {
   operation: string;
   phase: AdbProcessPhase;

--- a/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbProcess.ts
@@ -140,8 +140,14 @@ async function runAdbProcessAsync(
 
   let operationSignal = signal;
   let waitLimitSignal: AbortSignal | undefined;
+  let cleanupWaitLimitMs = ADB_SUBPROCESS_CLEANUP_WAIT_LIMIT_MS;
   if (params.waitLimitMs != null) {
-    waitLimitSignal = AbortSignal.timeout(params.waitLimitMs);
+    cleanupWaitLimitMs = Math.min(
+      ADB_SUBPROCESS_CLEANUP_WAIT_LIMIT_MS,
+      Math.max(1, Math.floor(params.waitLimitMs / 4))
+    );
+    // The public wait limit covers both command execution and reaping its child.
+    waitLimitSignal = AbortSignal.timeout(Math.max(1, params.waitLimitMs - cleanupWaitLimitMs));
     operationSignal = operationSignal
       ? AbortSignal.any([operationSignal, waitLimitSignal])
       : waitLimitSignal;
@@ -154,10 +160,7 @@ async function runAdbProcessAsync(
   } catch (error) {
     if (operationSignal?.aborted && error === operationSignal.reason) {
       // NOTE(@kitten): Killing this client cannot retract a request already sent to the server
-      const clientTermination = await terminateAndObserveAsync(
-        spawnPromise,
-        ADB_SUBPROCESS_CLEANUP_WAIT_LIMIT_MS
-      );
+      const clientTermination = await terminateAndObserveAsync(spawnPromise, cleanupWaitLimitMs);
       const waitExpired = waitLimitSignal?.aborted && error === waitLimitSignal.reason;
       event('adb_operation_cleanup', {
         operation: params.operation,

--- a/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
@@ -29,7 +29,7 @@ export async function startAdbReverseAsync(
   // Install cleanup automatically...
   removeExitHook = installExitHooks(() => {
     exitController.abort();
-    stopAdbReverseAsync(ports).catch(() => undefined);
+    return stopAdbReverseAsync(ports).catch(() => undefined);
   });
 
   const devices = await getAttachedDevicesAsync({ signal: operationSignal });
@@ -47,10 +47,12 @@ export async function startAdbReverseAsync(
 export async function stopAdbReverseAsync(ports: number[], signal?: AbortSignal): Promise<void> {
   removeExitHook?.();
 
-  const devices = await getAttachedDevicesAsync({ signal });
+  const cleanupSignal = AbortSignal.timeout(ADB_REVERSE_CLEANUP_WAIT_LIMIT_MS);
+  const operationSignal = signal ? AbortSignal.any([signal, cleanupSignal]) : cleanupSignal;
+  const devices = await getAttachedDevicesAsync({ signal: operationSignal });
   for (const device of devices) {
     for (const port of ports) {
-      await adbReverseRemoveAsync(device, port, signal);
+      await adbReverseRemoveAsync(device, port, operationSignal);
     }
   }
 }
@@ -99,11 +101,6 @@ async function adbReverseRemoveAsync(
     return true;
   } catch (error: any) {
     if (signal?.aborted && error === signal.reason) throw error;
-    // Don't send this to warn because we call this preemptively sometimes
-    event('adb_reverse_unforward_failed', {
-      port,
-      error: event.error(error as Error),
-    });
     return false;
   }
 }

--- a/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
@@ -16,16 +16,19 @@ export function hasAdbReverseAsync(): boolean {
   }
 }
 
-export async function startAdbReverseAsync(ports: number[]): Promise<boolean> {
+export async function startAdbReverseAsync(
+  ports: number[],
+  signal?: AbortSignal
+): Promise<boolean> {
   // Install cleanup automatically...
   removeExitHook = installExitHooks(() => {
     stopAdbReverseAsync(ports);
   });
 
-  const devices = await getAttachedDevicesAsync();
+  const devices = await getAttachedDevicesAsync({ signal });
   for (const device of devices) {
     for (const port of ports) {
-      if (!(await adbReverseAsync(device, port))) {
+      if (!(await adbReverseAsync(device, port, signal))) {
         event('adb_reverse_port_failed', { port, deviceName: device.name });
         return false;
       }
@@ -34,43 +37,64 @@ export async function startAdbReverseAsync(ports: number[]): Promise<boolean> {
   return true;
 }
 
-export async function stopAdbReverseAsync(ports: number[]): Promise<void> {
+export async function stopAdbReverseAsync(ports: number[], signal?: AbortSignal): Promise<void> {
   removeExitHook?.();
 
-  const devices = await getAttachedDevicesAsync();
+  const devices = await getAttachedDevicesAsync({ signal });
   for (const device of devices) {
     for (const port of ports) {
-      await adbReverseRemoveAsync(device, port);
+      await adbReverseRemoveAsync(device, port, signal);
     }
   }
 }
 
-async function adbReverseAsync(device: Device, port: number): Promise<boolean> {
+async function adbReverseAsync(
+  device: Device,
+  port: number,
+  signal?: AbortSignal
+): Promise<boolean> {
   if (!device.isAuthorized) {
     logUnauthorized(device);
     return false;
   }
 
   try {
-    await getServer().runAsync(adbArgs(device.pid, 'reverse', `tcp:${port}`, `tcp:${port}`));
+    await getServer().runDeviceMutationAsync(
+      adbArgs(device.pid, 'reverse', `tcp:${port}`, `tcp:${port}`),
+      'reverse port',
+      signal
+    );
     return true;
   } catch (error: any) {
+    if (signal?.aborted && error === signal.reason) throw error;
     Log.warn(`[ADB] Couldn't reverse port ${port}: ${error.message}`);
     return false;
   }
 }
 
-async function adbReverseRemoveAsync(device: Device, port: number): Promise<boolean> {
+async function adbReverseRemoveAsync(
+  device: Device,
+  port: number,
+  signal?: AbortSignal
+): Promise<boolean> {
   if (!device.isAuthorized) {
     return false;
   }
 
   try {
-    await getServer().runAsync(adbArgs(device.pid, 'reverse', '--remove', `tcp:${port}`));
+    await getServer().runDeviceMutationAsync(
+      adbArgs(device.pid, 'reverse', '--remove', `tcp:${port}`),
+      'remove reverse port',
+      signal
+    );
     return true;
   } catch (error: any) {
+    if (signal?.aborted && error === signal.reason) throw error;
     // Don't send this to warn because we call this preemptively sometimes
-    event('adb_reverse_unforward_failed', { port, error: event.error(error as Error) });
+    event('adb_reverse_unforward_failed', {
+      port,
+      error: event.error(error as Error),
+    });
     return false;
   }
 }

--- a/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adbReverse.ts
@@ -6,6 +6,8 @@ import type { Device } from './adb';
 import { adbArgs, getAttachedDevicesAsync, getServer, logUnauthorized } from './adb';
 
 let removeExitHook: (() => void) | null = null;
+const ADB_REVERSE_WAIT_LIMIT_MS = 2_000;
+const ADB_REVERSE_CLEANUP_WAIT_LIMIT_MS = 2_000;
 
 export function hasAdbReverseAsync(): boolean {
   try {
@@ -20,15 +22,20 @@ export async function startAdbReverseAsync(
   ports: number[],
   signal?: AbortSignal
 ): Promise<boolean> {
+  const exitController = new AbortController();
+  const operationSignal = signal
+    ? AbortSignal.any([signal, exitController.signal])
+    : exitController.signal;
   // Install cleanup automatically...
   removeExitHook = installExitHooks(() => {
-    stopAdbReverseAsync(ports);
+    exitController.abort();
+    stopAdbReverseAsync(ports).catch(() => undefined);
   });
 
-  const devices = await getAttachedDevicesAsync({ signal });
+  const devices = await getAttachedDevicesAsync({ signal: operationSignal });
   for (const device of devices) {
     for (const port of ports) {
-      if (!(await adbReverseAsync(device, port, signal))) {
+      if (!(await adbReverseAsync(device, port, operationSignal))) {
         event('adb_reverse_port_failed', { port, deviceName: device.name });
         return false;
       }
@@ -62,7 +69,8 @@ async function adbReverseAsync(
     await getServer().runDeviceMutationAsync(
       adbArgs(device.pid, 'reverse', `tcp:${port}`, `tcp:${port}`),
       'reverse port',
-      signal
+      signal,
+      ADB_REVERSE_WAIT_LIMIT_MS
     );
     return true;
   } catch (error: any) {
@@ -85,7 +93,8 @@ async function adbReverseRemoveAsync(
     await getServer().runDeviceMutationAsync(
       adbArgs(device.pid, 'reverse', '--remove', `tcp:${port}`),
       'remove reverse port',
-      signal
+      signal,
+      ADB_REVERSE_CLEANUP_WAIT_LIMIT_MS
     );
     return true;
   } catch (error: any) {

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -1,7 +1,7 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import { spawn } from 'child_process';
-import os from 'os';
+import { setTimeout as delayAsync } from 'node:timers/promises';
 
 import * as Log from '../../../log';
 import { AbortCommandError } from '../../../utils/errors';
@@ -22,28 +22,24 @@ export function whichEmulator(): string {
 
 /** Returns a list of emulator names. */
 export async function listAvdsAsync(): Promise<Device[]> {
-  try {
-    const { stdout } = await spawnAsync(whichEmulator(), ['-list-avds']);
-    return (
-      stdout
-        .split(os.EOL)
-        .filter(Boolean)
-        /**
-         * AVD IDs cannot contain spaces. This removes extra info lines from the output. e.g.
-         * "INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db
-         */
-        .filter((name) => !name.trim().includes(' '))
-        .map((name) => ({
-          name,
-          type: 'emulator',
-          // unsure from this
-          isBooted: false,
-          isAuthorized: true,
-        }))
-    );
-  } catch {
-    return [];
-  }
+  const { stdout } = await spawnAsync(whichEmulator(), ['-list-avds']);
+  return (
+    stdout
+      .split(/\r?\n/)
+      .filter(Boolean)
+      /**
+       * AVD IDs cannot contain spaces. This removes extra info lines from the output. e.g.
+       * "INFO    | Storing crashdata in: /tmp/android-brent/emu-crash-34.1.18.db
+       */
+      .filter((name) => !name.trim().includes(' '))
+      .map((name) => ({
+        name,
+        type: 'emulator',
+        isBooted: false,
+        isAuthorized: true,
+        isLaunchable: true,
+      }))
+  );
 }
 
 /** Start an Android device and wait until it is booted. */
@@ -52,12 +48,15 @@ export async function startDeviceAsync(
   {
     timeout = EMULATOR_MAX_WAIT_TIMEOUT,
     interval = 1000,
+    signal,
   }: {
     /** Time in milliseconds to wait before asserting a timeout error. */
     timeout?: number;
     interval?: number;
+    signal?: AbortSignal;
   } = {}
 ): Promise<Device> {
+  signal?.throwIfAborted();
   Log.log(`\u203A Opening emulator ${chalk.bold(device.name)}`);
 
   // Start a process to open an emulator
@@ -76,56 +75,52 @@ export async function startDeviceAsync(
 
   emulatorProcess.unref();
 
-  return new Promise<Device>((resolve, reject) => {
-    const waitTimer = setInterval(async () => {
-      try {
-        const bootedDevices = await getAttachedDevicesAsync();
-        const connected = bootedDevices.find(({ name }) => name === device.name);
-        if (connected) {
-          const isBooted = await isBootAnimationCompleteAsync(connected.pid);
-          if (isBooted) {
-            stopWaiting();
-            resolve(connected);
-          }
-        }
-      } catch (error) {
-        stopWaiting();
-        reject(error);
-      }
-    }, interval);
+  const controller = new AbortController();
+  const timeoutSignal = AbortSignal.timeout(timeout);
+  const operationSignal = signal
+    ? AbortSignal.any([signal, controller.signal, timeoutSignal])
+    : AbortSignal.any([controller.signal, timeoutSignal]);
+  const manualCommand = `${whichEmulator()} @${device.name}`;
+  const handleEmulatorError = (error: Error) => controller.abort(error);
+  const handleEmulatorExit = () =>
+    controller.abort(
+      new Error(
+        `The emulator (${device.name}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`
+      )
+    );
+  const removeExitHook = installExitHooks((exitSignal) => {
+    emulatorProcess.kill(exitSignal);
+    controller.abort(new AbortCommandError());
+  });
+  emulatorProcess.on('error', handleEmulatorError);
+  emulatorProcess.on('exit', handleEmulatorExit);
 
-    // Reject command after timeout
-    const maxTimer = setTimeout(() => {
-      const manualCommand = `${whichEmulator()} @${device.name}`;
-      stopWaitingAndReject(
+  try {
+    // Wait for each check before delaying so boot polls never overlap.
+    while (true) {
+      const connected = await checkEmulatorBootAsync(device.name, operationSignal);
+      if (connected) return connected;
+      await delayAsync(interval, undefined, { signal: operationSignal });
+    }
+  } catch (error) {
+    if (timeoutSignal.aborted && operationSignal.reason === timeoutSignal.reason) {
+      throw new Error(
         `It took too long to start the Android emulator: ${device.name}. You can try starting the emulator manually from the terminal with: ${manualCommand}`
       );
-    }, timeout);
+    }
+    throw operationSignal.aborted ? operationSignal.reason : error;
+  } finally {
+    removeExitHook();
+    emulatorProcess.off('error', handleEmulatorError);
+    emulatorProcess.off('exit', handleEmulatorExit);
+  }
+}
 
-    const stopWaiting = () => {
-      clearTimeout(maxTimer);
-      clearInterval(waitTimer);
-      removeExitHook();
-    };
-
-    const stopWaitingAndReject = (message: string) => {
-      stopWaiting();
-      reject(new Error(message));
-    };
-
-    const removeExitHook = installExitHooks((signal) => {
-      stopWaiting();
-      emulatorProcess.kill(signal);
-      reject(new AbortCommandError());
-    });
-
-    emulatorProcess.on('error', ({ message }) => stopWaitingAndReject(message));
-
-    emulatorProcess.on('exit', () => {
-      const manualCommand = `${whichEmulator()} @${device.name}`;
-      stopWaitingAndReject(
-        `The emulator (${device.name}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`
-      );
-    });
-  });
+async function checkEmulatorBootAsync(name: string, signal?: AbortSignal): Promise<Device | null> {
+  const bootedDevices = await getAttachedDevicesAsync({ signal });
+  const connected = bootedDevices.find((device) => device.name === name);
+  if (connected && (await isBootAnimationCompleteAsync(connected.pid, signal))) {
+    return connected;
+  }
+  return null;
 }

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -119,8 +119,16 @@ export async function startDeviceAsync(
 async function checkEmulatorBootAsync(name: string, signal?: AbortSignal): Promise<Device | null> {
   const bootedDevices = await getAttachedDevicesAsync({ signal, shouldShowWaitingMessage: false });
   const connected = bootedDevices.find((device) => device.name === name);
-  if (connected && (await isBootAnimationCompleteAsync(connected.pid, signal))) {
-    return connected;
+  if (connected) {
+    try {
+      if (await isBootAnimationCompleteAsync(connected.pid, signal)) {
+        return connected;
+      }
+    } catch {
+      if (signal?.aborted) throw signal.reason;
+      // NOTE(@kitten): If `isBootAnimationCompleteAsync` rejects, the device may not have been ready to reply.
+      // Assume we're still waiting for it, so the outer loop can continue checking
+    }
   }
   return null;
 }

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -4,10 +4,12 @@ import { spawn } from 'child_process';
 import { setTimeout as delayAsync } from 'node:timers/promises';
 
 import * as Log from '../../../log';
-import { AbortCommandError } from '../../../utils/errors';
+import { AbortCommandError, CommandError } from '../../../utils/errors';
 import { installExitHooks } from '../../../utils/exit';
 import type { Device } from './adb';
 import { getAttachedDevicesAsync, isBootAnimationCompleteAsync } from './adb';
+import { isAdbDeviceDisconnectedError } from './adbDiagnostics';
+import { AdbProcessWaitError } from './adbProcess';
 
 export const EMULATOR_MAX_WAIT_TIMEOUT = 60 * 1000 * 3;
 
@@ -124,11 +126,16 @@ async function checkEmulatorBootAsync(name: string, signal?: AbortSignal): Promi
       if (await isBootAnimationCompleteAsync(connected.pid, signal)) {
         return connected;
       }
-    } catch {
+    } catch (error) {
       if (signal?.aborted) throw signal.reason;
-      // NOTE(@kitten): If `isBootAnimationCompleteAsync` rejects, the device may not have been ready to reply.
-      // Assume we're still waiting for it, so the outer loop can continue checking
+      if (!isTransientBootPropertyError(error)) throw error;
     }
   }
   return null;
+}
+
+function isTransientBootPropertyError(error: unknown): boolean {
+  const cause =
+    error instanceof CommandError && error.code === 'ADB_PROPERTY' ? error.cause : error;
+  return cause instanceof AdbProcessWaitError || isAdbDeviceDisconnectedError(cause);
 }

--- a/packages/@expo/cli/src/start/platforms/android/emulator.ts
+++ b/packages/@expo/cli/src/start/platforms/android/emulator.ts
@@ -117,7 +117,7 @@ export async function startDeviceAsync(
 }
 
 async function checkEmulatorBootAsync(name: string, signal?: AbortSignal): Promise<Device | null> {
-  const bootedDevices = await getAttachedDevicesAsync({ signal });
+  const bootedDevices = await getAttachedDevicesAsync({ signal, shouldShowWaitingMessage: false });
   const connected = bootedDevices.find((device) => device.name === name);
   if (connected && (await isBootAnimationCompleteAsync(connected.pid, signal))) {
     return connected;

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -7,7 +7,16 @@ import { listAvdsAsync } from './emulator';
 export async function getDevicesAsync(): Promise<Device[]> {
   const bootedDevices = await getAttachedDevicesAsync();
 
-  const data = await listAvdsAsync();
+  // NOTE(@kitten): We don't assume AVD must succeed or be present, and still allow
+  // devices to be discovered and move on
+  let data: Device[];
+  try {
+    data = await listAvdsAsync();
+  } catch (error) {
+    if (!bootedDevices.length) throw error;
+    data = [];
+  }
+
   const allDevices = mergeDevices(bootedDevices, data);
 
   if (!allDevices.length) {

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -13,24 +13,34 @@ export async function getDevicesAsync(): Promise<Device[]> {
   try {
     data = await listAvdsAsync();
   } catch (error) {
-    if (!bootedDevices.length) throw error;
+    if (!bootedDevices.length) {
+      throw new CommandError(
+        'ANDROID_AVD_DISCOVERY',
+        formatNoDevicesMessage(error instanceof Error ? error.message : String(error))
+      );
+    }
     data = [];
   }
 
   const allDevices = mergeDevices(bootedDevices, data);
 
   if (!allDevices.length) {
-    throw new CommandError(
-      [
-        `No Android connected device found, and no emulators could be started automatically.`,
-        `Connect a device or create an emulator (https://docs.expo.dev/workflow/android-studio-emulator).`,
-        `Then follow the instructions here to enable USB debugging:`,
-        `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`,
-      ].join('\n')
-    );
+    throw new CommandError(formatNoDevicesMessage());
   }
 
   return allDevices;
+}
+
+function formatNoDevicesMessage(cause?: string): string {
+  return [
+    `No Android connected device found, and no emulators could be started automatically.`,
+    cause ? `Could not list Android emulators: ${cause}` : null,
+    `Connect a device or create an emulator (https://docs.expo.dev/workflow/android-studio-emulator).`,
+    `Then follow the instructions here to enable USB debugging:`,
+    `https://developer.android.com/studio/run/device.html#developer-device-options. If you are using Genymotion go to Settings -> ADB, select "Use custom Android SDK tools", and point it at your Android SDK directory.`,
+  ]
+    .filter((line): line is string => line != null)
+    .join('\n');
 }
 
 export function mergeDevices(attachedDevices: Device[], avds: Device[]): Device[] {

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -25,19 +25,6 @@ export async function getDevicesAsync(): Promise<Device[]> {
 }
 
 export function mergeDevices(attachedDevices: Device[], avds: Device[]): Device[] {
-  const connectedNames = attachedDevices.map(({ name }) => name);
-
-  const offlineEmulators = avds
-    .filter(({ name }) => !connectedNames.includes(name))
-    .map(({ name, type }) => {
-      return {
-        name,
-        type,
-        isBooted: false,
-        // TODO: Are emulators always authorized?
-        isAuthorized: true,
-      };
-    });
-
-  return attachedDevices.concat(offlineEmulators);
+  const connectedNames = new Set(attachedDevices.map(({ name }) => name));
+  return attachedDevices.concat(avds.filter(({ name }) => !connectedNames.has(name)));
 }

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -25,7 +25,7 @@ export async function getDevicesAsync(): Promise<Device[]> {
   const allDevices = mergeDevices(bootedDevices, data);
 
   if (!allDevices.length) {
-    throw new CommandError(formatNoDevicesMessage());
+    throw new CommandError('ANDROID_NO_DEVICES', formatNoDevicesMessage());
   }
 
   return allDevices;

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -5,7 +5,7 @@ import { listAvdsAsync } from './emulator';
 
 /** Get a list of all devices including offline emulators. Asserts if no devices are available. */
 export async function getDevicesAsync(): Promise<Device[]> {
-  const bootedDevices = await getAttachedDevicesAsync();
+  const bootedDevices = await getAttachedDevicesAsync({ shouldShowWaitingMessage: true });
 
   // NOTE(@kitten): We don't assume AVD must succeed or be present, and still allow
   // devices to be discovered and move on

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -8,21 +8,7 @@ export async function getDevicesAsync(): Promise<Device[]> {
   const bootedDevices = await getAttachedDevicesAsync();
 
   const data = await listAvdsAsync();
-  const connectedNames = bootedDevices.map(({ name }) => name);
-
-  const offlineEmulators = data
-    .filter(({ name }) => !connectedNames.includes(name))
-    .map(({ name, type }) => {
-      return {
-        name,
-        type,
-        isBooted: false,
-        // TODO: Are emulators always authorized?
-        isAuthorized: true,
-      };
-    });
-
-  const allDevices = bootedDevices.concat(offlineEmulators);
+  const allDevices = mergeDevices(bootedDevices, data);
 
   if (!allDevices.length) {
     throw new CommandError(
@@ -36,4 +22,22 @@ export async function getDevicesAsync(): Promise<Device[]> {
   }
 
   return allDevices;
+}
+
+export function mergeDevices(attachedDevices: Device[], avds: Device[]): Device[] {
+  const connectedNames = attachedDevices.map(({ name }) => name);
+
+  const offlineEmulators = avds
+    .filter(({ name }) => !connectedNames.includes(name))
+    .map(({ name, type }) => {
+      return {
+        name,
+        type,
+        isBooted: false,
+        // TODO: Are emulators always authorized?
+        isAuthorized: true,
+      };
+    });
+
+  return attachedDevices.concat(offlineEmulators);
 }

--- a/packages/@expo/cli/src/start/platforms/android/getDevices.ts
+++ b/packages/@expo/cli/src/start/platforms/android/getDevices.ts
@@ -1,11 +1,11 @@
 import { CommandError } from '../../../utils/errors';
 import type { Device } from './adb';
-import { getAttachedDevicesAsync } from './adb';
+import { waitForAttachedDevicesAsync } from './adb';
 import { listAvdsAsync } from './emulator';
 
 /** Get a list of all devices including offline emulators. Asserts if no devices are available. */
 export async function getDevicesAsync(): Promise<Device[]> {
-  const bootedDevices = await getAttachedDevicesAsync({ shouldShowWaitingMessage: true });
+  const bootedDevices = await waitForAttachedDevicesAsync();
 
   // NOTE(@kitten): We don't assume AVD must succeed or be present, and still allow
   // devices to be discovered and move on

--- a/packages/@expo/cli/src/start/platforms/events.ts
+++ b/packages/@expo/cli/src/start/platforms/events.ts
@@ -7,15 +7,34 @@ declare module '2g' {
     'platform:activate_window_lsof': { args: string };
     'platform:activate_window_pid': { pid: string };
     // android/adb.ts
-    'platform:adb_property_data': { devicePid: string | undefined; prop: string; data: string };
+    'platform:adb_property_data': {
+      devicePid: string | undefined;
+      prop: string;
+      data: string;
+    };
     'platform:adb_parsed_properties': { props: Record<string, string> };
     // android/adbReverse.ts
     'platform:adb_reverse_sdk_missing': { error: SerializedError };
     'platform:adb_reverse_port_failed': { port: number; deviceName: string };
-    'platform:adb_reverse_unforward_failed': { port: number; error: SerializedError };
+    'platform:adb_reverse_unforward_failed': {
+      port: number;
+      error: SerializedError;
+    };
     // android/ADBServer.ts
     'platform:adb_server_run': { command: string };
     'platform:adb_file_output': { output: string };
+    'platform:adb_operation_start': {
+      operation: string;
+      phase: 'host-request' | 'device-service';
+      waitLimitMs: number | undefined;
+    };
+    'platform:adb_operation_cleanup': {
+      operation: string;
+      phase: 'host-request' | 'device-service';
+      reason: 'wait-limit' | 'cancelled';
+      status: 'terminated' | 'killed' | 'exit-unobserved';
+    };
+    'platform:adb_host_probe': { endpoint: string; result: string };
     // android/gradle.ts
     'platform:gradle_spawn': { command: string };
     // ExpoGoInstaller.ts
@@ -51,14 +70,21 @@ declare module '2g' {
     };
     'platform:simctl_url_scheme_parse_error': { error: SerializedError };
     'platform:simctl_allowed_links': { plistData: Record<string, unknown> };
-    'platform:simctl_allow_deep_link': { key: string; appId: string | undefined };
+    'platform:simctl_allow_deep_link': {
+      key: string;
+      appId: string | undefined;
+    };
     // ios/xcrun.ts
     'platform:xcrun_run': { command: string };
     // PlatformManager.ts
     'platform:open_launch_url': { appId: string; redirectUrl: string };
     'platform:open_custom': { props: string };
     'platform:open_custom_url': { url: string | null; props: string };
-    'platform:open_async': { runtime: string; platform: string; shouldPrompt: boolean | undefined };
+    'platform:open_async': {
+      runtime: string;
+      platform: string;
+      shouldPrompt: boolean | undefined;
+    };
     // android/AndroidPlatformManager.ts
     'platform:android_open_custom_launch_activity': { launchActivity: string };
     // android/AndroidAppIdResolver.ts

--- a/packages/@expo/cli/src/start/server/DevServerManager.ts
+++ b/packages/@expo/cli/src/start/server/DevServerManager.ts
@@ -9,7 +9,6 @@ import { env } from '../../utils/env';
 import type { ProjectPrerequisite } from '../doctor/Prerequisite';
 import { TypeScriptProjectPrerequisite } from '../doctor/typescript/TypeScriptProjectPrerequisite';
 import { printItem } from '../interface/commandsTable';
-import * as AndroidDebugBridge from '../platforms/android/adb';
 import { resolveSchemeAsync } from '../resolveOptions';
 import type { BundlerDevServer, BundlerStartOptions } from './BundlerDevServer';
 import DevToolsPluginManager from './DevToolsPluginManager';
@@ -223,12 +222,10 @@ export class DevServerManager {
     await this.devServers.find((server) => server.name === 'metro')?.watchEnvironmentVariables();
   }
 
-  /** Stop all servers including ADB. */
+  /** Stop all development servers. */
   async stopAsync(): Promise<void> {
     await Promise.allSettled([
       this.notifier?.stopObserving(),
-      // Stop ADB
-      AndroidDebugBridge.getServer().stopAsync(),
       // Stop all dev servers
       ...this.devServers.map((server) =>
         server.stopAsync().catch((error) => {


### PR DESCRIPTION
# Why

Resolves #48744
Resolves #33301
Resolves #19864
Related #30401
Related #27421

Previously, `adb` discovery and subprocess handling was "unclean" and could lead to hanging `expo` processes, since some sub-tasks weren't bound. There's several conditions that can lead `adb` to hang or not respond properly. This is further complicated by us "pretending" to own the `start-server` / `kill-server` lifecycle.

Further, the `kill-server` invocation and lack of cancellation can lead to cases where we either fail our own adb server lifecycle assumption, or kill a server that's been used or adopted by another process (e.g. Android Studio)

# How

- Add cancellation signals from top to bottom to all `adb` operations
- Remove `start-server` and `kill-server` lifecycle calls
  - **Note:** This wasn't consistent and ignores that adb daemons should be shared. Stopping it again isn't necessary and there's no design in `adb` to facilitate this cleanly.
- Timeouts are scoped depending on the operation
- Allow devices to be parsed without AVD being available
- Improve emulator polling and name lookups
- Stop device being identified by `name` instead of `serial`, and use name only as a fallback
- Improve error handling and make messages more actionable
- Fix races and loops that ignore prior command hanging/overlapping

Exact cases of the lack of cancellation this should address are:
- `adb start-server` or `adb devices -l` could wait forever
- An already started adb server could be unhealthy, never answering requests, while we'd wait for responses forever
- Slow or stalled list/discovery requests could be invisible with no actionable error message

The `kill-server` lifecycle could previously cause:
- `adb start-server` may have been run with a server already being present
- CLI shutdown may call `adb kill-server` disrupting other processes, e.g. Android Studio
- Both can hang, causing stalls without timeouts

Timeouts on this branch are a bit tricky, since:
- some operations are shorter than others that may be long-living
- elapsed time alone isn't always indicative of failure (e.g. installs)
- a side-effect operation isn't universally retryable

Also, some operations were previously using `spawnSync` or blocking calls, which made the above refactors hard/impossible. Most of these were replaced with `@expo/spawn-async` to avoid duplicate wrapper code.

Lastly, with parsing and error handling:
- Some output handling mixed `stderr` into `stdout` before parsing, which could fail parsing unexpectedly
- Some error messages were generic and not helpful, although we had context on what went wrong (or could trivially track it)
- Device state parsing was lossy and throwing away valid information that we then either didn't have or re-derived later

Changes are validated and partially authored by LLMs, but reviewed/edited manually. For provenance/validation, the documents produced during this refactor (all iterated on as the branch evolved) are:
- [ADB_FINDINGS.md](https://github.com/user-attachments/files/31349033/ADB_FINDINGS.md)
- [ADB_PLAN.md](https://github.com/user-attachments/files/31349036/ADB_PLAN.md)
- [ADB_OUTCOME.md](https://github.com/user-attachments/files/31349046/ADB_OUTCOME.md)

# Test Plan

- [x] Check on macOS against an emulator (stopped or started)
- [x] Check on macOS against a real device
- [x] Check ctrl+c during discovery, install, or emulator startup
- [x] Check on Windows against a real device (run twice)
- [x] Check on Windows against a real device, disconnecting it during install from USB
- [x] Check a suspended/unresponsive ADB server on Windows

**Note:** We can confirm backporting this to previous SDK versions once the above is validated. We may merge before some of this has been tested, if the changes remain on `main` for now.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
