### PR TITLE
[cli][router] Cache evaluated API route module in dev server

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Cache the evaluated dev-server API route module between requests, instead of re-evaluating it on every request, so module-scope state (counters, long-lived connections, timers) persists across requests like it does in production instead of resetting each time. ([#33857](https://github.com/expo/expo/issues/33857))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 🐛 Bug fixes
 
-- Cache the evaluated dev-server API route module between requests, instead of re-evaluating it on every request, so module-scope state (counters, long-lived connections, timers) persists across requests like it does in production instead of resetting each time. ([#33857](https://github.com/expo/expo/issues/33857))
+- Cache the evaluated dev-server API route module between requests, instead of re-evaluating it on every request, so module-scope state (counters, long-lived connections, timers) persists across requests like it does in production instead of resetting each time. ([#49259](https://github.com/expo/expo/pull/49259) by [@rakshit-gen](https://github.com/rakshit-gen))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1809,48 +1809,72 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     return route;
   }
 
+  // Evaluated API route modules, keyed by file path. Unlike `pendingRouteOperations` (which
+  // only caches the bundled source), this keeps the module's live exports around between
+  // requests so module-scope state behaves like it does in production (`@expo/server`
+  // evaluates a route module once and reuses it), instead of resetting on every request.
+  // https://github.com/expo/expo/issues/33857
+  private evaluatedApiRoutes = new Map<
+    string,
+    Promise<null | Record<string, Function> | Response>
+  >();
+
   private async ssrImportApiRoute(
     filePath: string,
     { platform }: { platform: string }
   ): Promise<null | Record<string, Function> | Response> {
-    // TODO: Cache the evaluated function.
-    try {
-      const apiRoute = await this.bundleApiRoute(filePath, { platform });
+    if (this.evaluatedApiRoutes.has(filePath)) {
+      return this.evaluatedApiRoutes.get(filePath)!;
+    }
 
-      if (!apiRoute?.src) {
-        return null;
-      }
-      return evalMetroNoHandling(this.projectRoot, apiRoute.src, apiRoute.filename, apiRoute.map);
-    } catch (error) {
-      // Format any errors that were thrown in the global scope of the evaluation.
-      if (error instanceof Error) {
-        try {
-          const htmlServerError = await getErrorOverlayHtmlAsync({
-            error,
-            projectRoot: this.projectRoot,
-            routerRoot: this.instanceMetroOptions.routerRoot!,
-          });
+    const evalAsync = async (): Promise<null | Record<string, Function> | Response> => {
+      try {
+        const apiRoute = await this.bundleApiRoute(filePath, { platform });
 
-          return new Response(htmlServerError, {
-            status: 500,
-            headers: {
-              'Content-Type': 'text/html',
-            },
-          });
-        } catch (internalError) {
-          debugEvent('api_route_overlay_failed', {
-            error: debugEvent.error(internalError as Error),
-          });
+        if (!apiRoute?.src) {
+          return null;
+        }
+        return evalMetroNoHandling(this.projectRoot, apiRoute.src, apiRoute.filename, apiRoute.map);
+      } catch (error) {
+        // Format any errors that were thrown in the global scope of the evaluation.
+        if (error instanceof Error) {
+          try {
+            const htmlServerError = await getErrorOverlayHtmlAsync({
+              error,
+              projectRoot: this.projectRoot,
+              routerRoot: this.instanceMetroOptions.routerRoot!,
+            });
+
+            return new Response(htmlServerError, {
+              status: 500,
+              headers: {
+                'Content-Type': 'text/html',
+              },
+            });
+          } catch (internalError) {
+            debugEvent('api_route_overlay_failed', {
+              error: debugEvent.error(internalError as Error),
+            });
+            throw error;
+          }
+        } else {
           throw error;
         }
-      } else {
-        throw error;
       }
+    };
+
+    const evaluated = evalAsync();
+    // Re-check the cache after the (async) bundle step so concurrent first requests for the
+    // same route share a single evaluated module instance instead of racing to overwrite it.
+    if (!this.evaluatedApiRoutes.has(filePath)) {
+      this.evaluatedApiRoutes.set(filePath, evaluated);
     }
+    return this.evaluatedApiRoutes.get(filePath)!;
   }
 
   private invalidateApiRouteCache() {
     this.pendingRouteOperations.clear();
+    this.evaluatedApiRoutes.clear();
   }
 
   /**

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1813,11 +1813,11 @@ export class MetroBundlerDevServer extends BundlerDevServer {
   // only caches the bundled source), this keeps the module's live exports around between
   // requests so module-scope state behaves like it does in production (`@expo/server`
   // evaluates a route module once and reuses it), instead of resetting on every request.
+  // Only successfully evaluated modules are cached here: the `Response` returned on error is a
+  // one-shot object (its body stream can only be read once), so it's always rebuilt per-request,
+  // matching prior behavior and avoiding a "body stream already read" failure on a later request.
   // https://github.com/expo/expo/issues/33857
-  private evaluatedApiRoutes = new Map<
-    string,
-    Promise<null | Record<string, Function> | Response>
-  >();
+  private evaluatedApiRoutes = new Map<string, Promise<Record<string, Function>>>();
 
   private async ssrImportApiRoute(
     filePath: string,
@@ -1827,49 +1827,50 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       return this.evaluatedApiRoutes.get(filePath)!;
     }
 
-    const evalAsync = async (): Promise<null | Record<string, Function> | Response> => {
-      try {
-        const apiRoute = await this.bundleApiRoute(filePath, { platform });
+    try {
+      const apiRoute = await this.bundleApiRoute(filePath, { platform });
 
-        if (!apiRoute?.src) {
-          return null;
-        }
-        return evalMetroNoHandling(this.projectRoot, apiRoute.src, apiRoute.filename, apiRoute.map);
-      } catch (error) {
-        // Format any errors that were thrown in the global scope of the evaluation.
-        if (error instanceof Error) {
-          try {
-            const htmlServerError = await getErrorOverlayHtmlAsync({
-              error,
-              projectRoot: this.projectRoot,
-              routerRoot: this.instanceMetroOptions.routerRoot!,
-            });
+      if (!apiRoute?.src) {
+        return null;
+      }
 
-            return new Response(htmlServerError, {
-              status: 500,
-              headers: {
-                'Content-Type': 'text/html',
-              },
-            });
-          } catch (internalError) {
-            debugEvent('api_route_overlay_failed', {
-              error: debugEvent.error(internalError as Error),
-            });
-            throw error;
-          }
-        } else {
+      // Re-check the cache after the (async) bundle step so concurrent first requests for the
+      // same route share a single evaluated module instance instead of racing to overwrite it.
+      if (!this.evaluatedApiRoutes.has(filePath)) {
+        this.evaluatedApiRoutes.set(
+          filePath,
+          Promise.resolve(
+            evalMetroNoHandling(this.projectRoot, apiRoute.src, apiRoute.filename, apiRoute.map)
+          )
+        );
+      }
+      return this.evaluatedApiRoutes.get(filePath)!;
+    } catch (error) {
+      // Format any errors that were thrown in the global scope of the evaluation.
+      if (error instanceof Error) {
+        try {
+          const htmlServerError = await getErrorOverlayHtmlAsync({
+            error,
+            projectRoot: this.projectRoot,
+            routerRoot: this.instanceMetroOptions.routerRoot!,
+          });
+
+          return new Response(htmlServerError, {
+            status: 500,
+            headers: {
+              'Content-Type': 'text/html',
+            },
+          });
+        } catch (internalError) {
+          debugEvent('api_route_overlay_failed', {
+            error: debugEvent.error(internalError as Error),
+          });
           throw error;
         }
+      } else {
+        throw error;
       }
-    };
-
-    const evaluated = evalAsync();
-    // Re-check the cache after the (async) bundle step so concurrent first requests for the
-    // same route share a single evaluated module instance instead of racing to overwrite it.
-    if (!this.evaluatedApiRoutes.has(filePath)) {
-      this.evaluatedApiRoutes.set(filePath, evaluated);
     }
-    return this.evaluatedApiRoutes.get(filePath)!;
   }
 
   private invalidateApiRouteCache() {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -10,6 +10,7 @@ import { evalMetroNoHandling } from '../../getStaticRenderFunctions';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { instantiateMetroAsync } from '../instantiateMetro';
+import * as ErrorInterface from '../metroErrorInterface';
 import { warnInvalidWebOutput } from '../router';
 import { observeAnyFileChanges, observeFileChanges } from '../waitForMetroToObserveTypeScriptFile';
 
@@ -589,6 +590,28 @@ describe('ssrImportApiRoute', () => {
     await devServer['ssrImportApiRoute']('/app/bar+api.ts', { platform: 'web' });
 
     expect(evalMetroNoHandling).toHaveBeenCalledTimes(2);
+  });
+
+  it('rebuilds a fresh error Response on every request instead of reusing a consumed one', async () => {
+    // A cached error `Response` would have its one-shot body stream already read by the
+    // first request, so a second request reusing the same instance must still work.
+    const devServer = createDevServerForStaticPageTests();
+    devServer['ssrLoadModuleContents'] = jest.fn(async () => {
+      throw new Error('boom');
+    }) as any;
+    jest.spyOn(ErrorInterface, 'getErrorOverlayHtmlAsync').mockResolvedValue('<html>error</html>');
+
+    const first = await devServer['ssrImportApiRoute']('/app/broken+api.ts', { platform: 'web' });
+    const second = await devServer['ssrImportApiRoute']('/app/broken+api.ts', {
+      platform: 'web',
+    });
+
+    expect(first).toBeInstanceOf(Response);
+    expect(second).toBeInstanceOf(Response);
+    expect(first).not.toBe(second);
+    // Both response bodies must still be independently readable.
+    await expect((first as Response).text()).resolves.toBe('<html>error</html>');
+    await expect((second as Response).text()).resolves.toBe('<html>error</html>');
   });
 
   it('re-evaluates the module after the route cache is invalidated', async () => {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -6,6 +6,7 @@ import { vol } from 'memfs';
 import type { ExportAssetMap } from '../../../../export/saveAssets';
 import { getEnvFiles, reloadEnvFiles } from '../../../../utils/nodeEnv';
 import type { BundlerStartOptions } from '../../BundlerDevServer';
+import { evalMetroNoHandling } from '../../getStaticRenderFunctions';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { MetroBundlerDevServer } from '../MetroBundlerDevServer';
 import { instantiateMetroAsync } from '../instantiateMetro';
@@ -46,6 +47,10 @@ jest.mock('../instantiateMetro', () => ({
     middleware: { use: jest.fn() },
     server: { listen: jest.fn(), close: jest.fn() },
   })),
+}));
+jest.mock('../../getStaticRenderFunctions', () => ({
+  ...jest.requireActual('../../getStaticRenderFunctions'),
+  evalMetroNoHandling: jest.fn(),
 }));
 
 jest.mock('../../middleware/mutations');
@@ -545,5 +550,54 @@ describe('exportServerRouteAsync', () => {
       ].join('\n')
     );
     expect(files.has('_expo/server/render.js.map')).toBe(true);
+  });
+});
+
+describe('ssrImportApiRoute', () => {
+  // https://github.com/expo/expo/issues/33857
+  // In development, `ssrImportApiRoute` re-evaluated the API route module on every
+  // request, resetting any module-scope state (e.g. counters, long-lived connections)
+  // between requests, unlike the production `@expo/server` runtime which evaluates the
+  // module once and reuses it.
+  function setupApiRouteDevServer() {
+    const devServer = createDevServerForStaticPageTests();
+    devServer['ssrLoadModuleContents'] = jest.fn(async (filePath: string) => ({
+      src: `module.exports = { GET: () => {} };`,
+      filename: filePath,
+      map: '',
+    })) as any;
+    jest.mocked(evalMetroNoHandling).mockClear();
+    jest.mocked(evalMetroNoHandling).mockImplementation(() => ({ GET: jest.fn() }) as any);
+    return devServer;
+  }
+
+  it('evaluates the module once and reuses it across requests', async () => {
+    const devServer = setupApiRouteDevServer();
+
+    const first = await devServer['ssrImportApiRoute']('/app/foo+api.ts', { platform: 'web' });
+    const second = await devServer['ssrImportApiRoute']('/app/foo+api.ts', { platform: 'web' });
+
+    expect(evalMetroNoHandling).toHaveBeenCalledTimes(1);
+    expect(devServer['ssrLoadModuleContents']).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it('evaluates each API route file independently', async () => {
+    const devServer = setupApiRouteDevServer();
+
+    await devServer['ssrImportApiRoute']('/app/foo+api.ts', { platform: 'web' });
+    await devServer['ssrImportApiRoute']('/app/bar+api.ts', { platform: 'web' });
+
+    expect(evalMetroNoHandling).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-evaluates the module after the route cache is invalidated', async () => {
+    const devServer = setupApiRouteDevServer();
+
+    await devServer['ssrImportApiRoute']('/app/foo+api.ts', { platform: 'web' });
+    devServer['invalidateApiRouteCache']();
+    await devServer['ssrImportApiRoute']('/app/foo+api.ts', { platform: 'web' });
+
+    expect(evalMetroNoHandling).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
# Why

Fixes #33857.

In development, an Expo Router API route's module is re-evaluated on every request. `ssrImportApiRoute` calls `evalMetroNoHandling`, which always runs `evalModule(src, filename, { cache: false })`, giving the route a fresh CommonJS module scope on every request.

This means module-scope state doesn't survive between requests in dev:

```ts
let count = 0;

export async function GET() {
  return Response.json({ count: count++ });
}
```

always responds with `{ count: 0 }` in development. Module-scope side effects (timers, DB connections) also restart on every request without the old instance ever being disposed, so they pile up.

In production (`web.output: 'server'` via `@expo/server`), the built route module is required once by Node and its module cache keeps it, so state persists as expected. Dev and prod diverge in a way that's surprising and, for things like a route-scoped DB client, actively harmful.

# How

`ssrImportApiRoute` (`packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts`) already had a `// TODO: Cache the evaluated function.` marking the gap. The bundled *source* was already cached per file path in `bundleApiRoute` via `pendingRouteOperations`, invalidated on watched-file changes — but the *evaluated* module was not cached at all.

Added a second cache, `evaluatedApiRoutes: Map<string, Promise<...>>`, alongside `pendingRouteOperations`:

- `ssrImportApiRoute` returns the cached evaluated module if present.
- Otherwise it bundles + evaluates, then stores the promise, re-checking the cache after the async bundle step so concurrent first requests for the same route share one evaluated instance instead of racing.
- `invalidateApiRouteCache()` (already called on any watched-file change when API routes are present) now clears both maps, so editing a route file still re-evaluates it, matching the existing "aggressive invalidation" comment/behavior for the bundle cache.

# Test Plan

Added `describe('ssrImportApiRoute', ...)` in `MetroBundlerDevServer-test.ts`:

- module is evaluated once and the same instance is reused across repeated requests to the same route file
- different route files are evaluated independently
- the module is re-evaluated after `invalidateApiRouteCache()` runs (i.e. after a watched-file change)

Confirmed the first test fails without the fix (`evalMetroNoHandling` called twice instead of once) and passes with it.

Ran `et check-packages @expo/cli` — build, typecheck, depscheck, test, lint, and format all pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
