### PR TITLE
[haptics][android] run performHapticsAsync on the main queue

### DIFF
--- a/packages/expo-haptics/CHANGELOG.md
+++ b/packages/expo-haptics/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix `performAndroidHapticsAsync` doing nothing by running it on the main queue. ([#49263](https://github.com/expo/expo/pull/49263) by [@KAMRONBEK](https://github.com/KAMRONBEK))
+
 ### 💡 Others
 
 ## 57.0.1 - 2026-07-15

--- a/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
+++ b/packages/expo-haptics/android/src/main/java/expo/modules/haptics/HapticsModule.kt
@@ -11,6 +11,7 @@ import expo.modules.haptics.arguments.HapticsNotificationType
 import expo.modules.haptics.arguments.HapticsSelectionType
 import expo.modules.haptics.arguments.HapticsVibrationType
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
@@ -40,10 +41,14 @@ class HapticsModule : Module() {
       vibrate(HapticsImpactType.fromString(style))
     }
 
+    // `View.performHapticFeedback` is main-thread affine, and an `AsyncFunction`
+    // without a queue runs on the modules dispatcher, where the call is a
+    // silent no-op. The other functions here use `Vibrator`, which is thread
+    // safe, so only this one needs the main queue.
     AsyncFunction("performHapticsAsync") { type: HapticType ->
       val view = appContext.currentActivity?.findViewById<View>(android.R.id.content)
       view?.performHapticFeedback(type.toHapticFeedbackType())
-    }
+    }.runOnQueue(Queues.MAIN)
   }
 
   private fun vibrate(type: HapticsVibrationType) {


### PR DESCRIPTION
# Why

Fixes #49262.

`performAndroidHapticsAsync()` produces no haptic at all on Android. `View.performHapticFeedback` only works from the main thread, and an `AsyncFunction` without `.runOnQueue` runs on the modules dispatcher (`Queues.DEFAULT` resolves to `appContext.modulesQueue`), where the call silently no-ops. The other functions in the module go through `Vibrator`, which is thread safe, so only this one is affected.

The docs recommend `performAndroidHapticsAsync` over the impact/notification functions on Android, so the recommended API is the one that doesn't work.

# How

`.runOnQueue(Queues.MAIN)` on the function, the same treatment expo-camera, expo-image and expo-video already give their main-thread-affine functions. Plus a short comment so it doesn't get simplified away later.

# Test Plan

Repro app: https://github.com/KAMRONBEK/expo-haptics-android-repro (runs in Expo Go on a physical Android device, includes working Vibrator-based controls on the same screen for comparison).

Before: the three `performAndroidHapticsAsync` buttons do nothing while `impactAsync`/`selectionAsync` buzz. After (we've been running this exact change as a patch-package patch in a production chat app since SDK 56): all buttons produce haptics. Verified on physical devices, API 34 and 35.

# Checklist

- [x] Documentation is up to date to reflect these changes — no API change, behavior now matches what the docs already promise.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).