### PR TITLE
[cli][metro] Include resolved config in Metro's transform cache key

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 🐛 Bug fixes
 
-- Bust Metro's persistent transform cache when the resolved Expo config changes (e.g. `app.config.js` reading `process.env.APP_ENV`), so `expo export -p web` and `expo start` pick up the new value across separate process runs instead of requiring `--clear`. ([#39619](https://github.com/expo/expo/issues/39619))
+- Bust Metro's persistent transform cache when the resolved Expo config changes (e.g. `app.config.js` reading `process.env.APP_ENV`), so `expo export -p web` and `expo start` pick up the new value across separate process runs instead of requiring `--clear`. ([#49264](https://github.com/expo/expo/pull/49264) by [@rakshit-gen](https://github.com/rakshit-gen))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Bust Metro's persistent transform cache when the resolved Expo config changes (e.g. `app.config.js` reading `process.env.APP_ENV`), so `expo export -p web` and `expo start` pick up the new value across separate process runs instead of requiring `--clear`. ([#39619](https://github.com/expo/expo/issues/39619))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -26,6 +26,7 @@ import type { GetStreamingContentOptions } from '@expo/router-server/build/serve
 import type { GetStaticContentOptions } from '@expo/router-server/build/static/renderStaticContent';
 import assert from 'assert';
 import chalk from 'chalk';
+import crypto from 'crypto';
 import type { RouteNode } from 'expo-router/build/Route';
 import {
   type RouteInfo,
@@ -1290,6 +1291,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       reactCompiler,
       minify: options.minify,
       asyncRoutes,
+      // Bust Metro's persistent transform cache when the resolved config differs (e.g. an
+      // `app.config.js` reading `process.env.APP_ENV` across separate `expo export` runs),
+      // even though the source files that inline it haven't changed. See #39619.
+      manifestHash: crypto.createHash('sha1').update(JSON.stringify(exp)).digest('hex'),
       // Options that are changing between platforms like engine, platform, and environment aren't set here.
     };
     this.instanceMetroOptions = instanceMetroOptions;

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/metroOptions.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/metroOptions.test.ts
@@ -48,6 +48,23 @@ describe(getMetroDirectBundleOptions, () => {
       shallow: false,
     });
   });
+  it(`forwards manifestHash into customTransformOptions to bust Metro's persistent cache when the resolved config changes`, () => {
+    // https://github.com/expo/expo/issues/39619
+    expect(
+      getMetroDirectBundleOptions({
+        mainModuleName: '/index.js',
+        mode: 'production',
+        platform: 'web',
+        isExporting: true,
+        bytecode: false,
+        reactCompiler: false,
+        manifestHash: 'abc123',
+      }).customTransformOptions
+    ).toMatchObject({
+      manifestHash: 'abc123',
+    });
+  });
+
   it(`injects source url if serializer options are provided`, () => {
     expect(
       getMetroDirectBundleOptions({

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -62,6 +62,15 @@ export type ExpoMetroOptions = {
   liveBindings?: boolean;
   /** When true, indicates this bundle should contain only the loader export. */
   isLoaderBundle?: boolean;
+  /**
+   * Hash of the resolved Expo config, used to bust Metro's persistent transform cache when the
+   * config's env-dependent output changes (e.g. `app.config.js` reading `process.env.APP_ENV`)
+   * without any project file changing. Without this, a file whose own contents are unchanged
+   * (like the one inlining `process.env.APP_MANIFEST`) can keep resolving to a stale cached
+   * transform across separate `expo export`/`expo start` process runs.
+   * https://github.com/expo/expo/issues/39619
+   */
+  manifestHash?: string;
 };
 
 // See: @expo/metro-config/src/serializer/fork/baseJSBundle.ts `ExpoSerializerOptions`
@@ -184,6 +193,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     liveBindings,
     isLoaderBundle,
     excludeSource,
+    manifestHash,
   } = withDefaults(options);
 
   const dev = mode !== 'production';
@@ -221,6 +231,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     routerRoot,
     bytecode: bytecode ? '1' : undefined,
     reactCompiler: reactCompiler ? toBoolStr(reactCompiler) : undefined,
+    manifestHash,
     dom: domRoot,
     hosted: hosted ? '1' : undefined,
     useMd5Filename: useMd5Filename || undefined,


### PR DESCRIPTION
# Why

Fixes #39619.

`expo export -p web` doesn't pick up a dynamic config value that depends on an environment variable across separate process runs, unless `--clear` is passed:

```bash
$ npx expo export -p web && grep -r API_BASE_URL dist/
"{\"extra\":{\"API_BASE_URL\":\"http://localhost:3000\"}

$ APP_ENV=development npx expo export -p web && grep -r API_BASE_URL dist/
"{\"extra\":{\"API_BASE_URL\":\"http://localhost:3000\"}   # still the old value
```

`npx expo config` (which just calls `getConfig()` directly) always shows the correct, current value — the divergence is specific to what Metro bundles for `export`/`start`.

# How

`babel-preset-expo`'s `expo-inline-manifest-plugin` rewrites `process.env.APP_MANIFEST` to a string literal containing the resolved public config, for any file that references it (this is how `expo-constants`' web implementation — `ExponentConstants.web.ts` — gets `Constants.manifest` on web). It resolves the config itself, correctly, on every transform.

The problem is one layer down, in Metro's **persistent transform cache**. That cache is keyed by (roughly) a base hash of the transformer + `customTransformOptions` + `dev`/`platform`/etc + the source file's own content hash (`packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts#getCacheKey`, consumed in `Transformer.transform` from `@expo/metro`). None of those inputs include anything about the *resolved* config — only the raw file bytes on disk. Since the file that references `process.env.APP_MANIFEST` doesn't change between two `expo export` runs, and none of the existing cache-key inputs change either, Metro's on-disk cache returns the transform output from the *first* run, silently keeping whatever config value was baked in then. `--clear` "fixes" it only by nuking the whole persistent cache.

This isn't unique to `APP_MANIFEST` — it's a gap for any Babel transform whose output depends on the resolved Expo config rather than only the file's own text. The fix generalizes to the whole class: thread a hash of the resolved config through `customTransformOptions`, which Metro already includes in its per-file cache key (that's exactly how existing config-derived values like `baseUrl` and `reactCompiler` already participate in cache-busting today).

Concretely:
- `ExpoMetroOptions` (`packages/@expo/cli/src/start/server/middleware/metroOptions.ts`) gets a new optional `manifestHash` field, forwarded into `customTransformOptions` in `getMetroDirectBundleOptions`.
- `MetroBundlerDevServer#startImplementationAsync` computes it once per dev-server/export session — `sha1(JSON.stringify(exp))` — alongside where `baseUrl`/`reactCompiler`/`asyncRoutes` are already derived from the same resolved `exp`, and stores it on `instanceMetroOptions` (so, like those other values, it's fixed for the lifetime of one `expo start` session — consistent with the existing behavior that editing `app.config.js` while the dev server is running already requires a restart to take effect).

This is intentionally coarse: it busts the transform cache for *any* config change, not just the fields that end up in the public manifest. That trades a bit of caching efficiency (only when the config itself changes, not on ordinary file edits) for correctness, and avoids hand-picking which config fields matter — `app.config.js` can read arbitrary env vars in arbitrary ways, so there's no fixed field list to special-case.

# Test Plan

Added `metroOptions.test.ts` coverage confirming `manifestHash` is forwarded into `customTransformOptions` (`getMetroDirectBundleOptions`), and confirmed the existing exact-shape (`toEqual`) tests in the same file are unaffected (an unset `manifestHash` is stripped like every other `undefined` option already is).

Ran `et check-packages @expo/cli` — build, typecheck, depscheck, test, lint, and format all pass.

I traced the root cause down to the exact `getCacheKey` / `customTransformOptions` mechanism in Metro and confirmed via source that `customTransformOptions` is included in Metro's per-file `partialKey` (`@expo/metro`'s `DeltaBundler/Transformer.js`) — the same mechanism already used for `baseUrl`/`reactCompiler`. I did not additionally spin up two full separate `expo export -p web` processes end-to-end in this environment (that requires a real npm install of a fixture app plus two full production Metro bundling passes) — the unit-level test targets the exact plumbing this fix adds, and the fix follows the codebase's own established pattern for busting the cache on config-derived values.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
