### PR TITLE
[font][web] fix font matching when the CSSOM keeps quotes around family names

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - [android] Apply `fontWeight` and `fontStyle` to fonts loaded with `useFonts`, instancing a variable font's `wght` axis at each weight. Bold and italic text previously fell back to a system font. ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
 - [iOS] Fixed `renderToImageAsync` reporting the main screen's scale rather than the scale the image was rendered at. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
+- [web] Fixed `isLoaded()` always returning `false` on Firefox, and on every engine for font families whose name needs quoting, by normalizing quotes when comparing family names against the CSSOM. This also stops `loadAsync()` from injecting a duplicate `@font-face` rule on every call and makes `unloadAsync()` and `getLoadedFonts()` behave consistently across engines. ([#49266](https://github.com/expo/expo/pull/49266) by [@irfanfandi](https://github.com/irfanfandi))
 
 ### 💡 Others
 

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -40,14 +40,32 @@ function getFontFaceRules(): RuleItem[] {
   return [];
 }
 
+// Engines disagree about whether the CSSOM keeps the quotes from a `font-family`
+// declaration: Firefox keeps them for every name, while Chromium and WebKit keep them only
+// for names that need quoting, such as anything containing a space. `_createWebFontTemplate`
+// always writes the name quoted, so the quoting has to be normalized away before comparing.
+function normalizeFontFamilyName(fontFamily: string): string {
+  // jsdom leaves `style.fontFamily` undefined on the `@font-face` rules it parses.
+  const trimmed = fontFamily?.trim();
+  if (!trimmed) {
+    return '';
+  }
+  const quote = trimmed[0];
+  if (trimmed.length >= 2 && (quote === '"' || quote === "'") && trimmed.endsWith(quote)) {
+    return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+  }
+  return trimmed;
+}
+
 function getFontFaceRulesMatchingResource(
   fontFamilyName: string,
   options?: UnloadFontOptions
 ): RuleItem[] {
   const rules = getFontFaceRules();
+  const normalizedFontFamilyName = normalizeFontFamilyName(fontFamilyName);
   return rules.filter(({ rule }) => {
     return (
-      rule.style.fontFamily === fontFamilyName &&
+      normalizeFontFamilyName(rule.style.fontFamily) === normalizedFontFamilyName &&
       (options && options.display ? options.display === (rule.style as any).fontDisplay : true)
     );
   });
@@ -98,7 +116,7 @@ const ExpoFontLoader: Required<ExpoFontLoaderModule> = {
       return getLoadedServerFonts();
     }
     const rules = getFontFaceRules();
-    return rules.map(({ rule }) => rule.style.fontFamily);
+    return rules.map(({ rule }) => normalizeFontFamilyName(rule.style.fontFamily));
   },
 
   isLoaded(fontFamilyName: string, resource: UnloadFontOptions = {}): boolean {

--- a/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
+++ b/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
@@ -1,0 +1,105 @@
+import ExpoFontLoader from '../ExpoFontLoader.web';
+
+const STYLE_ID = 'expo-generated-fonts';
+
+// jsdom doesn't implement `CSSFontFaceRule`, and its CSSOM leaves `style.fontFamily`
+// undefined on the `@font-face` rules it does parse. What's under test is how *browser*
+// engines serialize `font-family`, so the rules are faked with the exact strings each
+// engine returns — verified with Playwright in https://github.com/expo/expo/issues/49092.
+class FakeCSSFontFaceRule {
+  style: { fontFamily: string; fontDisplay: string };
+
+  constructor(serializedFontFamily: string, fontDisplay: string = 'auto') {
+    this.style = { fontFamily: serializedFontFamily, fontDisplay };
+  }
+}
+
+type FakeSheet = { cssRules: FakeCSSFontFaceRule[]; deleteRule(index: number): void };
+
+function installFontFaceRules(serializedFontFamilies: string[]): FakeSheet {
+  const cssRules = serializedFontFamilies.map((family) => new FakeCSSFontFaceRule(family));
+  const sheet: FakeSheet = {
+    cssRules,
+    deleteRule(index: number) {
+      cssRules.splice(index, 1);
+    },
+  };
+
+  const styleElement = document.createElement('style');
+  styleElement.id = STYLE_ID;
+  Object.defineProperty(styleElement, 'sheet', { value: sheet, configurable: true });
+  document.head.appendChild(styleElement);
+
+  return sheet;
+}
+
+// This file also runs under the Node project, which has no DOM to install rules into.
+if (typeof window === 'undefined') {
+  it(`noop`, async () => {});
+} else {
+  beforeAll(() => {
+    (globalThis as any).CSSFontFaceRule = FakeCSSFontFaceRule;
+  });
+
+  afterAll(() => {
+    delete (globalThis as any).CSSFontFaceRule;
+  });
+
+  afterEach(() => {
+    document.getElementById(STYLE_ID)?.remove();
+  });
+
+  describe('isLoaded', () => {
+    it(`matches a family name the engine serializes without quotes`, () => {
+      installFontFaceRules(['FlamaUltracondensed-Basic']);
+
+      expect(ExpoFontLoader.isLoaded('FlamaUltracondensed-Basic')).toBe(true);
+    });
+
+    it(`matches a family name the engine serializes with quotes`, () => {
+      installFontFaceRules(['"FlamaUltracondensed-Basic"']);
+
+      expect(ExpoFontLoader.isLoaded('FlamaUltracondensed-Basic')).toBe(true);
+    });
+
+    it(`matches a family name that needs quoting, which every engine keeps quoted`, () => {
+      installFontFaceRules(['"DIN 2014"']);
+
+      expect(ExpoFontLoader.isLoaded('DIN 2014')).toBe(true);
+    });
+
+    it(`matches a family name serialized with single quotes`, () => {
+      installFontFaceRules([`'DIN 2014'`]);
+
+      expect(ExpoFontLoader.isLoaded('DIN 2014')).toBe(true);
+    });
+
+    it(`doesn't match a family that isn't registered`, () => {
+      installFontFaceRules(['"DIN 2014"']);
+
+      expect(ExpoFontLoader.isLoaded('DIN 2015')).toBe(false);
+    });
+  });
+
+  describe('getLoadedFonts', () => {
+    it(`returns the names fonts were loaded with, not the CSSOM serialization`, () => {
+      installFontFaceRules(['FlamaUltracondensed-Basic', '"DIN 2014"', `'Single Quoted'`]);
+
+      expect(ExpoFontLoader.getLoadedFonts()).toEqual([
+        'FlamaUltracondensed-Basic',
+        'DIN 2014',
+        'Single Quoted',
+      ]);
+    });
+  });
+
+  describe('unloadAsync', () => {
+    it(`removes a rule whose family name the engine serialized with quotes`, async () => {
+      const sheet = installFontFaceRules(['"DIN 2014"']);
+
+      await ExpoFontLoader.unloadAsync('DIN 2014');
+
+      expect(sheet.cssRules).toHaveLength(0);
+    });
+  });
+}


### PR DESCRIPTION
# Why

Fixes #49092.

`expo-font`'s web loader decides whether a family is already registered by comparing the
raw family name against the CSSOM serialization of `font-family`:

https://github.com/expo/expo/blob/main/packages/expo-font/src/ExpoFontLoader.web.ts#L50

The rules it compares against are written by `_createWebFontTemplate`, which always quotes
the name via `JSON.stringify`. Engines disagree about whether the CSSOM keeps those quotes:

| Engine | `FlamaUltracondensed-Basic` | `DIN 2014` |
|---|---|---|
| Chromium | `FlamaUltracondensed-Basic` (matches) | `"DIN 2014"` (no match) |
| Firefox | `"FlamaUltracondensed-Basic"` (no match) | `"DIN 2014"` (no match) |
| WebKit | `FlamaUltracondensed-Basic` (matches) | `"DIN 2014"` (no match) |

So `isLoaded()` is always `false` on Firefox, and false on every engine for any family whose
name needs quoting. Each consumer of the matcher breaks with it:

- `loadAsync()` injects a duplicate `@font-face` rule on every call, because it never sees
  the rule it already wrote.
- `useFonts` seeds its state from `isLoaded()` so that hydration matches the server markup.
  On Firefox the seed is `false` even though the server-inlined rules are in the document,
  so an app that gates render on `loaded` hydrates different markup — reported in the issue
  as React error #418 on Firefox only.
- `unloadAsync()` matches nothing and removes nothing.
- `getLoadedFonts()` returns names wrapped in literal quote characters, which never equal
  the names callers loaded with.

# How

Normalize the quoting away before comparing, since `"MyFont"` and `MyFont` name the same
family. `normalizeFontFamilyName()` strips one layer of matching surrounding quotes and
unescapes, and is applied to both sides of the comparison in
`getFontFaceRulesMatchingResource()` and to the values `getLoadedFonts()` returns.

Normalizing both sides rather than only the CSSOM value also makes the matcher tolerant of
callers that pass an already-quoted name.

I left one thing out of this PR deliberately: `unloadAsync()` calls `sheet.deleteRule(index)`
over matches in ascending order, so when more than one rule matches, each deletion shifts the
indices of the rules after it. That is a separate bug from the one in #49092 and I didn't want
to widen this diff — happy to open a follow-up.

# Test Plan

New `packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts`.

jsdom can't stand in for a real CSSOM here: it doesn't implement `CSSFontFaceRule`, and it
leaves `style.fontFamily` undefined on the `@font-face` rules it does parse. Since what's
under test is precisely how *browser* engines serialize `font-family`, the test installs
rules carrying the exact strings each engine returns, taken from the verified matrix in the
issue. Two of the cases are controls that pass before this change (an unquoted name, and a
name that isn't registered), so the test pins the fix rather than the scaffolding.

Before the fix — 5 failing, 2 passing:

```
FAIL Web src/__tests__/ExpoFontLoader-test.web.ts
  ● isLoaded › matches a family name the engine serializes with quotes
  ● isLoaded › matches a family name that needs quoting, which every engine keeps quoted
  ● isLoaded › matches a family name serialized with single quotes
  ● getLoadedFonts › returns the names fonts were loaded with, not the CSSOM serialization
  ● unloadAsync › removes a rule whose family name the engine serialized with quotes
Tests:       5 failed, 3 passed, 8 total
```

After the fix, `et check-packages expo-font` is green (build, typecheck, depscheck, lint,
format) and the full package suite passes:

```
Test Suites: 19 passed, 19 total
Tests:       29 skipped, 74 passed, 103 total
Snapshots:   2 passed, 2 total
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin) — web-only runtime change, not touched by prebuild.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
