### PR TITLE
[ios][screen-orientation] Fix lockAsync rejecting upside-down masks on iPad

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed `lockAsync` throwing `UnsupportedOrientationLockException` for orientation masks containing upside-down portrait on iPad. ([#49267](https://github.com/expo/expo/pull/49267) by [@JavanPoirier](https://github.com/JavanPoirier))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationUtilities.swift
@@ -6,11 +6,21 @@ internal func isPad() -> Bool {
 
 // https://medium.com/@cafielo/how-to-detect-notch-screen-in-swift-56271827625d
 internal var doesDeviceHaveNotch = {
-  var bottomSafeAreaInsetIsPositive = false
+  var deviceHasNotch = false
   EXUtilities.performSynchronously {
-    bottomSafeAreaInsetIsPositive = (UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0.0) > 0.0
+    // The UIKit reads here have to happen on the main thread, and this closure
+    // is not guaranteed to run there: it runs wherever `doesDeviceHaveNotch` is
+    // first touched, which for a lock is `lockAsync`'s `AsyncFunction` body.
+    //
+    // No iPad has ever had a notch, but every iPad since 2018 has a home
+    // indicator and so a positive bottom safe area inset. Without this guard
+    // the check below reports a notch on every modern iPad.
+    guard !isPad() else {
+      return
+    }
+    deviceHasNotch = (UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0.0) > 0.0
   }
-  return bottomSafeAreaInsetIsPositive
+  return deviceHasNotch
 }()
 
 extension UIInterfaceOrientationMask {


### PR DESCRIPTION
# Why

`doesDeviceHaveNotch` in `ScreenOrientationUtilities.swift` is named for a notch but tests for a **positive bottom safe area inset**, which is a *home indicator* test:

```swift
bottomSafeAreaInsetIsPositive = (UIApplication.shared.delegate?.window??.safeAreaInsets.bottom ?? 0.0) > 0.0
```

Every iPad since 2018 has a home indicator (iPad Pro 2018+, iPad Air 4+, iPad mini 6, iPad 10th gen), and no iPad has ever had a notch. So the flag is `true` on all of them.

`isSupportedByDevice()` uses that flag to reject any mask containing `.portraitUpsideDown`:

```swift
internal func isSupportedByDevice() -> Bool {
  // Devices with a notch don't support upside down orientation mask.
  return !self.contains(.portraitUpsideDown) || !doesDeviceHaveNotch
}
```

`OrientationLock.ALL` maps to `.all`, which contains `.portraitUpsideDown`. So on every modern iPad:

```
FunctionCallException: Calling the 'lockAsync' function has failed
  (at ExpoModulesCore/AsyncFunctionDefinition.swift:123)
→ Caused by: UnsupportedOrientationLockException: This device does not
  support the requested orientation: all
  (at ExpoScreenOrientation/ScreenOrientationModule.swift:21)
```

iPad supports all four interface orientations, so this rejection is simply wrong. The throw happens *before* `screenOrientationRegistry.setMask`, so the lock never registers at all — `requiredOrientationMask()` keeps returning `[]` and the app silently falls back to the `UISupportedInterfaceOrientations~ipad` launch mask. It looks fine on device right up until an app depends on a lock actually being installed, and an app that locks to something narrower can never widen back to `ALL`.

iPhone is unaffected: `.portrait` and `.landscape` masks don't contain `.portraitUpsideDown`, so they pass the check regardless.

### Production evidence

From a shipping app that calls `lockAsync(OrientationLock.ALL)` on tablets:

| device | events |
|---|---|
| iPad Pro (12.9-inch) 5th gen | 9 |
| iPad Air 11-inch (M3) | 4 |
| iPad Air (5th generation) | 1 |
| any iPhone | **0** |

14/14 on iPad, 0 on iPhone. OS versions span 18.7.8 through 26.6.1, so this is not an iPadOS 26 behaviour change — it has been latent since the heuristic was introduced.

### Relationship to #35545

This cause was **already identified by a maintainer**. In [#35545](https://github.com/expo/expo/issues/35545), @brentvatne linked these exact lines and wrote:

> however, on ipads with home indicators but without notches, this won't be accurate

That issue was then closed against a *different* cause — the config plugin writing `EXDefaultScreenOrientationMask = UIInterfaceOrientationMaskAllButUpsideDown` when `initialOrientation: "DEFAULT"` is set. That diagnosis was correct for the symptom that reporter saw, but it is a separate problem, and closing on it left the heuristic untouched.

Worth stating plainly, because it is what rules the earlier explanation out here: **the app measured above sets no `initialOrientation` and writes no `EXDefaultScreenOrientationMask` at all.** Its generated `Info.plist` carries the standard four `UISupportedInterfaceOrientations~ipad` values. The plugin path from #35545 cannot be what produces these exceptions.

### Relationship to #48173

[#48173](https://github.com/expo/expo/pull/48173) established the intended posture for refused locks:

> The lock deliberately does not throw. Apps reasonably call it unconditionally, so rejecting would break them. If we ever want that, it belongs in a major.

`isSupportedByDevice()` is a pre-flight check that throws on exactly that path, and here it throws for a device that does support the requested orientation. This PR doesn't change the throwing behaviour — it just stops the check being wrong about iPad.

# How

Guard the flag on `isPad()`, which already exists in this file and is already used for iPad-specific behaviour in `ScreenOrientationViewController.swift`.

The guard goes *inside* the existing `EXUtilities.performSynchronously` block deliberately. `doesDeviceHaveNotch` is a lazily initialised global, so its closure runs on whichever thread first touches it — for a lock, that is `lockAsync`'s `AsyncFunction` body, which is not the main thread. Keeping the `UIDevice` read inside the block keeps every UIKit read on the main thread.

One flag, three consumers, all corrected consistently on iPad:

| consumer | before, on iPad | after |
|---|---|---|
| `isSupportedByDevice()` | rejects `.all` | accepts `.all` |
| `ScreenOrientationRegistry.swift:133` | seeds `.allButUpsideDown` | seeds `.all` |
| `ScreenOrientationViewController.swift:16,127` | defaults `.allButUpsideDown` | defaults `.all` |

All three now match what `UISupportedInterfaceOrientations~ipad` already permits. iPhone behaviour is byte-identical — `isPad()` is `false` and the original heuristic runs unchanged.

The local is renamed `bottomSafeAreaInsetIsPositive` → `deviceHasNotch` since it no longer means only the former. Happy to also rename `doesDeviceHaveNotch` itself to something like `deviceLacksUpsideDownSupport`, which is what all three call sites actually want — left out here to keep the diff reviewable.

# Test Plan

Being explicit about what is and isn't verified:

- **Verified:** the production device breakdown above, from a shipping app on real iPads across 3 models and iOS 18.7.8–26.6.1.
- **Verified:** the cause by source reading, matching the diagnosis @brentvatne gave in #35545.
- **Verified:** the affected app sets no `EXDefaultScreenOrientationMask`, ruling out the cause #35545 was closed against.
- **Not yet verified:** this Swift change running on a physical home-indicator iPad. This package has no native test target and the path needs a real device, so I have not been able to exercise the patched build yet. I'll follow up here once I have — flagging it rather than letting the diff imply more than it should.

Expected on a patched build: the exception stops occurring on iPad, and an iPad rotates through all four orientations including upside-down.

# Checklist

- [x] Documented changes in `CHANGELOG.md`
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — no docs changes
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — native change, requires a new build (not OTA-shippable)
