### PR TITLE
[notifications][android] Fix fromNativeValue in AudioUsage and AudioContentType

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 💡 Others
 
+- [Android] Correct native-value lookup semantics for audio usage and content type enums. ([#49270](https://github.com/expo/expo/pull/49270) by [@vonovak](https://github.com/vonovak))
 - Drop usage of the deprecated `LegacyEventEmitter`. ([#49080](https://github.com/expo/expo/pull/49080) by [@vonovak](https://github.com/vonovak))
 
 ## 57.0.8 - 2026-07-29

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/enums/AudioContentType.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/enums/AudioContentType.java
@@ -36,7 +36,7 @@ public enum AudioContentType {
 
   public static AudioContentType fromNativeValue(int value) {
     for (AudioContentType visibility : AudioContentType.values()) {
-      if (visibility.getEnumValue() == value) {
+      if (visibility.getNativeValue() == value) {
         return visibility;
       }
     }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/enums/AudioUsage.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/enums/AudioUsage.java
@@ -46,7 +46,7 @@ public enum AudioUsage {
 
   public static AudioUsage fromNativeValue(int value) {
     for (AudioUsage usage : AudioUsage.values()) {
-      if (usage.getEnumValue() == value) {
+      if (usage.getNativeValue() == value) {
         return usage;
       }
     }

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationEnumsTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationEnumsTest.kt
@@ -1,0 +1,53 @@
+package expo.modules.notifications
+
+import android.app.Notification
+import android.media.AudioAttributes
+import androidx.core.app.NotificationManagerCompat
+import expo.modules.notifications.notifications.enums.AudioContentType
+import expo.modules.notifications.notifications.enums.AudioUsage
+import expo.modules.notifications.notifications.enums.NotificationImportance
+import expo.modules.notifications.notifications.enums.NotificationVisibility
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NotificationEnumsTest {
+  private fun <T> assertRoundTrips(
+    values: Array<T>,
+    enumValue: (T) -> Int,
+    nativeValue: (T) -> Int,
+    fromEnumValue: (Int) -> T,
+    fromNativeValue: (Int) -> T
+  ) {
+    values.forEach {
+      assertEquals(it, fromEnumValue(enumValue(it)))
+      // Multiple enum members may share the same native value.
+      assertEquals(nativeValue(it), nativeValue(fromNativeValue(nativeValue(it))))
+    }
+  }
+
+  @Test
+  fun `lookups round-trip through their own value space`() {
+    assertRoundTrips(AudioUsage.values(), { it.enumValue }, { it.nativeValue }, AudioUsage::fromEnumValue, AudioUsage::fromNativeValue)
+    assertRoundTrips(AudioContentType.values(), { it.enumValue }, { it.nativeValue }, AudioContentType::fromEnumValue, AudioContentType::fromNativeValue)
+    assertRoundTrips(NotificationImportance.values(), { it.enumValue }, { it.nativeValue }, NotificationImportance::fromEnumValue, NotificationImportance::fromNativeValue)
+    assertRoundTrips(NotificationVisibility.values(), { it.enumValue }, { it.nativeValue }, NotificationVisibility::fromEnumValue, NotificationVisibility::fromNativeValue)
+  }
+
+  @Test
+  fun `native lookups read the native value, not the enum value`() {
+    assertEquals(NotificationVisibility.SECRET, NotificationVisibility.fromNativeValue(Notification.VISIBILITY_SECRET))
+    assertEquals(NotificationVisibility.PRIVATE, NotificationVisibility.fromNativeValue(Notification.VISIBILITY_PRIVATE))
+    assertEquals(NotificationImportance.UNSPECIFIED, NotificationImportance.fromNativeValue(NotificationManagerCompat.IMPORTANCE_UNSPECIFIED))
+    assertEquals(NotificationImportance.MAX, NotificationImportance.fromNativeValue(NotificationManagerCompat.IMPORTANCE_MAX))
+    assertEquals(AudioUsage.ALARM, AudioUsage.fromNativeValue(AudioAttributes.USAGE_ALARM))
+    assertEquals(AudioContentType.MUSIC, AudioContentType.fromNativeValue(AudioAttributes.CONTENT_TYPE_MUSIC))
+  }
+
+  @Test
+  fun `unmatched values fall back to the default member`() {
+    assertEquals(AudioUsage.UNKNOWN, AudioUsage.fromEnumValue(999))
+    assertEquals(AudioContentType.UNKNOWN, AudioContentType.fromEnumValue(999))
+    assertEquals(NotificationImportance.UNKNOWN, NotificationImportance.fromEnumValue(999))
+    assertEquals(NotificationVisibility.UNKNOWN, NotificationVisibility.fromEnumValue(999))
+  }
+}


### PR DESCRIPTION
# Why

conversion of AudioUsage from native to JS previously wasn't correct

# How

fix conversion

# Test Plan

- unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>