### PR TITLE
[android][notifications] Handle a null result bundle from ResultReceiver

### DIFF
--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTask.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.ResultReceiver;
 
+import java.io.Serializable;
+
 import expo.modules.kotlin.Promise;
 import expo.modules.core.interfaces.services.EventEmitter;
 import expo.modules.notifications.notifications.NotificationSerializer;
@@ -98,7 +100,8 @@ public class SingleNotificationHandlerTask {
             if (resultCode == NotificationsService.SUCCESS_CODE) {
               promise.resolve();
             } else {
-              Exception e = (Exception) resultData.getSerializable(NotificationsService.EXCEPTION_KEY);
+              Serializable serialized = resultData == null ? null : resultData.getSerializable(NotificationsService.EXCEPTION_KEY);
+              Exception e = serialized instanceof Exception ? (Exception) serialized : null;
               promise.reject("ERR_NOTIFICATION_PRESENTATION_FAILED", "Notification presentation failed.", e);
             }
           }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/scheduling/NotificationScheduler.kt
@@ -55,7 +55,7 @@ open class NotificationScheduler : Module() {
               promise.resolve(serializeScheduledNotificationRequests(requests))
             }
           } else {
-            val e = resultData?.getSerializable(NotificationsService.EXCEPTION_KEY) as Exception
+            val e = resultData?.getSerializable(NotificationsService.EXCEPTION_KEY) as? Exception
             promise.reject("ERR_NOTIFICATIONS_FAILED_TO_FETCH", "Failed to fetch scheduled notifications.", e)
           }
         }

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTaskTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/notifications/handling/SingleNotificationHandlerTaskTest.kt
@@ -1,0 +1,87 @@
+package expo.modules.notifications.notifications.handling
+
+import android.os.Handler
+import android.os.Looper
+import android.os.Parcel
+import android.os.ResultReceiver
+import androidx.core.os.bundleOf
+import androidx.test.core.app.ApplicationProvider
+import expo.modules.core.interfaces.services.EventEmitter
+import expo.modules.kotlin.Promise
+import expo.modules.notifications.notifications.interfaces.NotificationTrigger
+import expo.modules.notifications.notifications.model.Notification
+import expo.modules.notifications.notifications.model.NotificationBehaviorRecord
+import expo.modules.notifications.notifications.model.NotificationContent
+import expo.modules.notifications.notifications.model.NotificationRequest
+import expo.modules.notifications.service.NotificationsService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class SingleNotificationHandlerTaskTest {
+  private val eventEmitter: EventEmitter = mockk(relaxed = true)
+  private val delegate: NotificationsHandler = mockk(relaxed = true)
+  private val promise: Promise = mockk(relaxed = true)
+  private lateinit var handler: Handler
+
+  @Before
+  fun setup() {
+    handler = Handler(Looper.getMainLooper())
+    mockkObject(NotificationsService)
+  }
+
+  @Test
+  fun `presentation failure without result data rejects the promise`() {
+    val receiver = slot<ResultReceiver>()
+    every { NotificationsService.present(any(), any(), any(), capture(receiver)) } answers {
+      receiver.captured.send(NotificationsService.ERROR_CODE, null)
+    }
+
+    task().processNotificationWithBehavior(NotificationBehaviorRecord.ALLOW_ALL, promise)
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify { promise.reject("ERR_NOTIFICATION_PRESENTATION_FAILED", any(), any()) }
+  }
+
+  @Test
+  fun `successful presentation resolves the promise`() {
+    val receiver = slot<ResultReceiver>()
+    every { NotificationsService.present(any(), any(), any(), capture(receiver)) } answers {
+      receiver.captured.send(NotificationsService.SUCCESS_CODE, null)
+    }
+
+    task().processNotificationWithBehavior(NotificationBehaviorRecord.ALLOW_ALL, promise)
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify { promise.resolve() }
+  }
+
+  private fun task() = SingleNotificationHandlerTask(
+    ApplicationProvider.getApplicationContext(),
+    eventEmitter,
+    handler,
+    notification(),
+    delegate
+  )
+
+  private fun notification() = Notification(
+    NotificationRequest(
+      "identifier",
+      NotificationContent.Builder().setTitle("title").setText("text").build(),
+      object : NotificationTrigger {
+        override fun toBundle() = bundleOf()
+
+        override fun describeContents(): Int = -1
+        override fun writeToParcel(dest: Parcel, flags: Int) {}
+      }
+    )
+  )
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>