### PR TITLE
[notifications][android] Drop the unreachable JSON null-stripping fallback

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 💡 Others
 
+- [Android] Remove an unreachable legacy JSON null-stripping fallback. ([#49272](https://github.com/expo/expo/pull/49272) by [@vonovak](https://github.com/vonovak))
 - [Android] Correct native-value lookup semantics for audio usage and content type enums. ([#49270](https://github.com/expo/expo/pull/49270) by [@vonovak](https://github.com/vonovak))
 - Drop usage of the deprecated `LegacyEventEmitter`. ([#49080](https://github.com/expo/expo/pull/49080) by [@vonovak](https://github.com/vonovak))
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/NotificationSerializer.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import expo.modules.notifications.notifications.interfaces.INotificationContent;
 import expo.modules.notifications.notifications.interfaces.NotificationTrigger;
@@ -152,22 +151,7 @@ public class NotificationSerializer {
         notificationMap.put(key, value);
       }
     }
-    try {
-      return new MapArguments(notificationMap).toBundle();
-    } catch (NullPointerException e) {
-      // If a NullPointerException was thrown it most probably means
-      // that @unimodules/core is at < 5.1.1 where we introduced
-      // support for null values in MapArguments' map). Let's go through
-      // the map and remove the null values to be backwards compatible.
-
-      Set<String> keySet = notificationMap.keySet();
-      for (String key : keySet) {
-        if (notificationMap.get(key) == null) {
-          notificationMap.remove(key);
-        }
-      }
-      return new MapArguments(notificationMap).toBundle();
-    }
+    return new MapArguments(notificationMap).toBundle();
   }
 
   private static List<Object> toList(JSONArray array) {

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationSerializerTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/NotificationSerializerTest.kt
@@ -1,0 +1,36 @@
+package expo.modules.notifications
+
+import expo.modules.notifications.notifications.NotificationSerializer
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NotificationSerializerTest {
+  @Test
+  fun `JSON nulls are kept as present keys with null values`() {
+    val bundle = NotificationSerializer.toBundle(JSONObject("""{"present":"value","absent":null}"""))
+
+    assertEquals("value", bundle.getString("present"))
+    assertTrue(bundle.containsKey("absent"))
+    assertNull(bundle.getString("absent"))
+  }
+
+  @Test
+  fun `nested objects and arrays are converted`() {
+    val bundle = NotificationSerializer.toBundle(JSONObject("""{"nested":{"a":1},"list":[1,null]}"""))
+
+    assertEquals(1, bundle.getBundle("nested")?.getInt("a"))
+    @Suppress("DEPRECATION") // JSON arrays are stored as untyped ArrayLists.
+    assertEquals(listOf(1, null), bundle.get("list"))
+  }
+
+  @Test
+  fun `a null input serializes to null`() {
+    assertNull(NotificationSerializer.toBundle(null as JSONObject?))
+  }
+}


### PR DESCRIPTION
# Why

remove old fallback code

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>