### PR TITLE
[notifications][android] Fix a crash reading the large icon from the manifest

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent a crash when reading the notification large icon from a manifest without meta-data. ([#49273](https://github.com/expo/expo/pull/49273) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Prevented `onUserLeaveHint` from firing when a notification tap opens the app, which made picture-in-picture implementations enter PiP unexpectedly. ([#48471](https://github.com/expo/expo/pull/48471) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
@@ -1,16 +1,10 @@
 package expo.modules.notifications.notifications.model;
 
-import static expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder.META_DATA_LARGE_ICON_KEY;
-
 import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.util.Log;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -25,6 +19,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import expo.modules.notifications.notifications.enums.NotificationPriority;
 import expo.modules.notifications.notifications.interfaces.INotificationContent;
+import expo.modules.notifications.notifications.presentation.builders.ExpoNotificationBuilder;
 import kotlin.coroutines.Continuation;
 
 /**
@@ -103,16 +98,7 @@ public class NotificationContent implements Parcelable, Serializable, INotificat
   @Nullable
   @Override
   public Object getImage(@NonNull Context context, @NonNull Continuation<? super Bitmap> $completion) {
-    try {
-      ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
-      if (ai.metaData.containsKey(META_DATA_LARGE_ICON_KEY)) {
-        int resourceId = ai.metaData.getInt(META_DATA_LARGE_ICON_KEY);
-        return BitmapFactory.decodeResource(context.getResources(), resourceId);
-      }
-    } catch (PackageManager.NameNotFoundException | ClassCastException e) {
-      Log.e("expo-notifications", "Could not fetch large notification icon.", e);
-    }
-    return null;
+    return ExpoNotificationBuilder.largeIconFromManifest(context);
   }
 
   @Override

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.kt
@@ -317,27 +317,7 @@ open class ExpoNotificationBuilder(
     }
 
   protected val largeIcon: Bitmap?
-    /**
-     * The method first tries to get the large icon from the manifest's meta-data [.META_DATA_DEFAULT_ICON_KEY].
-     * If a custom setting is not found, the method falls back to null.
-     *
-     * @return Bitmap containing larger icon or null if a custom settings was not provided.
-     */
-    get() {
-      try {
-        val ai = context.packageManager.getApplicationInfo(
-          context.packageName,
-          PackageManager.GET_META_DATA
-        )
-        if (ai.metaData.containsKey(META_DATA_LARGE_ICON_KEY)) {
-          val resourceId = ai.metaData.getInt(META_DATA_LARGE_ICON_KEY)
-          return BitmapFactory.decodeResource(context.resources, resourceId)
-        }
-      } catch (e: Exception) {
-        Log.e("expo-notifications", "Could not fetch large notification icon.", e)
-      }
-      return null
-    }
+    get() = largeIconFromManifest(context)
 
   protected open val icon: Int
     /**
@@ -405,5 +385,22 @@ open class ExpoNotificationBuilder(
       "expo.modules.notifications.default_notification_color"
     const val EXTRAS_MARSHALLED_NOTIFICATION_REQUEST_KEY: String = "expo.notification_request"
     const val EXTRAS_BODY_KEY = "body"
+
+    @JvmStatic
+    fun largeIconFromManifest(context: Context): Bitmap? {
+      try {
+        val metaData = context.packageManager.getApplicationInfo(
+          context.packageName,
+          PackageManager.GET_META_DATA
+        ).metaData
+        if (metaData != null && metaData.containsKey(META_DATA_LARGE_ICON_KEY)) {
+          val resourceId = metaData.getInt(META_DATA_LARGE_ICON_KEY)
+          return BitmapFactory.decodeResource(context.resources, resourceId)
+        }
+      } catch (e: Exception) {
+        Log.e("expo-notifications", "Could not fetch large notification icon.", e)
+      }
+      return null
+    }
   }
 }


### PR DESCRIPTION
# Why

when an app’s merged Android manifest contains no <meta-data> entries, ApplicationInfo.metaData is null. This PR is more defensive about accessing it, and also removes a duplication

# How

make the code null-safe, extract into one helper

# Test Plan

- tested locally

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>