### PR TITLE
[notifications][android] Stop a dataString payload entry shadowing the derived value

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Show notifications that arrive while the app is in the foreground, unless the app asks for another behavior with `setNotificationHandler`. A handler that doesn't answer within 3 seconds no longer drops the notification. `setNotificationHandler(null)` still stops `expo-notifications` from showing a notification. ([#49072](https://github.com/expo/expo/pull/49072) by [@vonovak](https://github.com/vonovak))
+- [Android] Prevent an FCM `dataString` field from overriding the notification's derived data. ([#49274](https://github.com/expo/expo/pull/49274) by [@vonovak](https://github.com/vonovak))
 
 ### 🎉 New features
 

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/RemoteMessageSerializer.java
@@ -38,14 +38,14 @@ public class RemoteMessageSerializer {
 
   private static Bundle toBundle(Map<String, String> data) {
     Bundle serializedData = new Bundle();
+    for (Map.Entry<String, String> dataEntry : data.entrySet()) {
+      serializedData.putString(dataEntry.getKey(), dataEntry.getValue());
+    }
     // we put the dataString in the bundle to achieve a cross-platform behavior
     // users can call JSON.parse() on the dataString to get the data in JS.
     // Converting to Bundle which would seem to be the equivalent of JSON.parse
     // lacks some dynamic properties of JSON.parse so we don't do it.
     serializedData.putString("dataString", data.getOrDefault("body", null));
-    for (Map.Entry<String, String> dataEntry : data.entrySet()) {
-      serializedData.putString(dataEntry.getKey(), dataEntry.getValue());
-    }
     return serializedData;
   }
 

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/RemoteMessageSerializerTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/RemoteMessageSerializerTest.kt
@@ -1,0 +1,41 @@
+package expo.modules.notifications
+
+import com.google.firebase.messaging.RemoteMessage
+import expo.modules.notifications.notifications.RemoteMessageSerializer
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class RemoteMessageSerializerTest {
+  @Test
+  fun `dataString is derived from the body entry`() {
+    val data = RemoteMessageSerializer.toBundle(messageWith(mapOf("body" to """{"a":1}""")))
+      .getBundle("data")
+
+    assertEquals("""{"a":1}""", data?.getString("dataString"))
+  }
+
+  @Test
+  fun `a dataString data entry does not overwrite the derived value`() {
+    val data = RemoteMessageSerializer.toBundle(
+      messageWith(mapOf("body" to """{"a":1}""", "dataString" to "from the payload"))
+    ).getBundle("data")
+
+    assertEquals("""{"a":1}""", data?.getString("dataString"))
+  }
+
+  @Test
+  fun `other data entries are copied as is`() {
+    val data = RemoteMessageSerializer.toBundle(messageWith(mapOf("custom" to "value")))
+      .getBundle("data")
+
+    assertEquals("value", data?.getString("custom"))
+  }
+
+  private fun messageWith(data: Map<String, String>) =
+    RemoteMessage.Builder("expo@fcm.googleapis.com")
+      .also { builder -> data.forEach { (key, value) -> builder.addData(key, value) } }
+      .build()
+}


### PR DESCRIPTION
# Why

 we put the dataString in the bundle to achieve a cross-platform behavior, and the entry should not be overridable from the outside, but it currently is

# How

run `serializedData.putString("dataString", data.getOrDefault("body", null));` at the end of conversion to JS bundle

# Test Plan

- added tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>