### PR TITLE
fix(babel-preset-expo): Move leftover `transform-object-rest-spread` (address missed computed property exclusion)

### DIFF
--- a/apps/test-suite/tests/JSDestructuring.js
+++ b/apps/test-suite/tests/JSDestructuring.js
@@ -8,6 +8,9 @@
 
 export const name = 'JS Destructuring';
 
+// Keep object rest in an exported declaration to cover the export-specific transform path.
+export const { exportedValue, ...exportedRest } = { exportedValue: 1, exportedOther: 2 };
+
 export function test({ describe, it, expect }) {
   describe('JS Destructuring', () => {
     describe('object patterns', () => {
@@ -79,6 +82,11 @@ export function test({ describe, it, expect }) {
         expect(rest).toEqual({});
       });
 
+      it('collects a rest-only object pattern', () => {
+        const { ...copy } = { a: 1, b: 2 };
+        expect(copy).toEqual({ a: 1, b: 2 });
+      });
+
       it('handles nested object patterns', () => {
         const {
           a: { b },
@@ -91,6 +99,33 @@ export function test({ describe, it, expect }) {
           a: { b = 99 },
         } = { a: {} };
         expect(b).toBe(99);
+      });
+
+      it('collects nested object rest at multiple levels', () => {
+        const {
+          outer: {
+            inner: { selected, ...innerRest },
+            ...outerRest
+          },
+          ...rootRest
+        } = {
+          outer: { inner: { selected: 1, kept: 2 }, sibling: 3 },
+          root: 4,
+        };
+        expect(selected).toBe(1);
+        expect(innerRest).toEqual({ kept: 2 });
+        expect(outerRest).toEqual({ sibling: 3 });
+        expect(rootRest).toEqual({ root: 4 });
+      });
+
+      it('collects object rest behind a computed nested object reference', () => {
+        let key = 0;
+        const {
+          [key++]: { selected, ...rest },
+        } = { 0: { selected: 1, kept: 2 } };
+        expect(key).toBe(1);
+        expect(selected).toBe(1);
+        expect(rest).toEqual({ kept: 2 });
       });
 
       it('handles shorthand for prototype properties', () => {
@@ -143,6 +178,76 @@ export function test({ describe, it, expect }) {
         expect(rest).toEqual({});
       });
 
+      // From: transform-object-rest-spread/object-rest/remove-unused-computed-key-loose/exec.js
+      // Regression test for https://github.com/babel/babel/pull/18197
+      it('object rest preserves an unused computed-key exclusion', () => {
+        function omit(obj, spec) {
+          const { [spec.key]: unused, ...rest } = obj;
+          return rest;
+        }
+
+        expect(omit({ a: 1, b: 2 }, { key: 'a' })).toEqual({ b: 2 });
+      });
+
+      it('object rest excludes unused computed element and call keys', () => {
+        const spec = { keys: ['b'] };
+        const getKey = () => 'c';
+        const {
+          [spec.keys[0]]: _element,
+          [getKey()]: _call,
+          ...rest
+        } = {
+          b: 2,
+          c: 3,
+          keep: 4,
+        };
+        expect(rest).toEqual({ keep: 4 });
+      });
+
+      it('object rest excludes computed symbol keys and retains other symbols', () => {
+        const excluded = Symbol('excluded');
+        const retained = Symbol('retained');
+        const { [excluded]: _excluded, ...rest } = { [excluded]: 1, [retained]: 2, kept: 3 };
+        expect(rest[excluded]).toBeUndefined();
+        expect(rest[retained]).toBe(2);
+        expect(rest.kept).toBe(3);
+      });
+
+      it('object rest coerces non-string computed exclusion keys', () => {
+        const keys = [null, undefined, true, false];
+        const source = { null: 1, undefined: 2, true: 3, false: 4, kept: 5 };
+        const {
+          [keys[0]]: nullValue,
+          [keys[1]]: undefinedValue,
+          [keys[2]]: trueValue,
+          [keys[3]]: falseValue,
+          ...rest
+        } = source;
+        expect([nullValue, undefinedValue, trueValue, falseValue]).toEqual([1, 2, 3, 4]);
+        expect(rest).toEqual({ kept: 5 });
+      });
+
+      it('object rest excludes template-literal computed keys', () => {
+        const prefix = 'user';
+        const { [`${prefix}_name`]: name, ...rest } = { user_name: 'Ada', role: 'admin' };
+        expect(name).toBe('Ada');
+        expect(rest).toEqual({ role: 'admin' });
+      });
+
+      it('evaluates an excluded getter even when its binding is unused', () => {
+        let called = 0;
+        const source = {
+          get excluded() {
+            called++;
+            return 1;
+          },
+          kept: 2,
+        };
+        const { excluded: unused, ...rest } = source;
+        expect(called).toBe(1);
+        expect(rest).toEqual({ kept: 2 });
+      });
+
       // From: destructuring/object-rest-impure-computed-keys/exec.js
       it('object rest with impure computed keys', () => {
         var key, x, y, z;
@@ -186,6 +291,95 @@ export function test({ describe, it, expect }) {
         expect(function () {
           var {} = null;
         }).toThrow();
+      });
+
+      it('rest-only object pattern throws on null and undefined', () => {
+        expect(() => {
+          const { ...rest } = null;
+        }).toThrow();
+        expect(() => {
+          const { ...rest } = undefined;
+        }).toThrow();
+      });
+    });
+
+    describe('object spread', () => {
+      it('copies properties and applies sources from left to right', () => {
+        const result = {
+          first: 1,
+          shared: 'initial',
+          ...{ second: 2, shared: 'middle' },
+          shared: 'last',
+        };
+        expect(result).toEqual({ first: 1, second: 2, shared: 'last' });
+      });
+
+      it('combines multiple spread sources', () => {
+        const result = { ...{ a: 1 }, b: 2, ...{ c: 3 }, ...{ d: 4 } };
+        expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+      });
+
+      it('transforms object spread in assignment and nested expression contexts', () => {
+        let assigned;
+        assigned = { before: 1, ...{ middle: 2 }, after: 3 };
+        const nested = { value: { ...assigned, final: 4 } };
+        expect(assigned).toEqual({ before: 1, middle: 2, after: 3 });
+        expect(nested).toEqual({ value: { before: 1, middle: 2, after: 3, final: 4 } });
+      });
+
+      it('evaluates spread source expressions once from left to right', () => {
+        const calls = [];
+        const source = (name, value) => {
+          calls.push(name);
+          return value;
+        };
+        const result = { ...source('first', { a: 1 }), ...source('second', { b: 2 }) };
+        expect(result).toEqual({ a: 1, b: 2 });
+        expect(calls).toEqual(['first', 'second']);
+      });
+
+      it('ignores null and undefined spread sources', () => {
+        expect({ before: 1, ...null, ...undefined, after: 2 }).toEqual({ before: 1, after: 2 });
+      });
+
+      it('copies own enumerable properties but not inherited or non-enumerable properties', () => {
+        const source = Object.create({ inherited: 1 });
+        source.enumerable = 2;
+        Object.defineProperty(source, 'hidden', { enumerable: false, value: 3 });
+        const result = { ...source };
+        expect(result).toEqual({ enumerable: 2 });
+        expect(result.inherited).toBeUndefined();
+        expect(result.hidden).toBeUndefined();
+      });
+
+      it('copies enumerable symbol properties', () => {
+        const symbol = Symbol('spread');
+        const result = { ...{ visible: 1, [symbol]: 2 } };
+        expect(result.visible).toBe(1);
+        expect(result[symbol]).toBe(2);
+      });
+
+      it('evaluates spread getters once and in source order', () => {
+        const order = [];
+        const first = {
+          get a() {
+            order.push('first');
+            return 1;
+          },
+        };
+        const second = {
+          get b() {
+            order.push('second');
+            return 2;
+          },
+        };
+        expect({ ...first, ...second }).toEqual({ a: 1, b: 2 });
+        expect(order).toEqual(['first', 'second']);
+      });
+
+      it('spreads enumerable properties from primitive values', () => {
+        expect({ ...'abc' }).toEqual({ 0: 'a', 1: 'b', 2: 'c' });
+        expect({ ...42, ...true }).toEqual({});
       });
     });
 
@@ -439,6 +633,22 @@ export function test({ describe, it, expect }) {
         expect(tail).toEqual([2, 3]);
         expect(meta).toEqual({ type: 'test', version: 2 });
       });
+
+      it('object rest nested inside array declaration and assignment patterns', () => {
+        const [first, { selected, ...declaredRest }] = [1, { selected: 2, kept: 3 }];
+        let assignedFirst, assignedValue, assignedRest;
+        [assignedFirst, { selected: assignedValue, ...assignedRest }] = [
+          4,
+          { selected: 5, kept: 6 },
+        ];
+        expect([first, selected, declaredRest]).toEqual([1, 2, { kept: 3 }]);
+        expect([assignedFirst, assignedValue, assignedRest]).toEqual([4, 5, { kept: 6 }]);
+      });
+
+      it('supports object rest nested in an array rest target', () => {
+        const [...{ ...properties }] = ['a', 'b'];
+        expect(properties).toEqual({ 0: 'a', 1: 'b' });
+      });
     });
 
     describe('function parameters', () => {
@@ -505,6 +715,25 @@ export function test({ describe, it, expect }) {
         expect(f()).toBe(3);
         expect(f({})).toBe(3);
         expect(f({ x: 10 })).toBe(12);
+      });
+
+      it('makes object rest available to a later parameter default', () => {
+        function f({ selected, ...rest }, value = rest.kept) {
+          return [selected, rest, value];
+        }
+        expect(f({ selected: 1, kept: 2 })).toEqual([1, { kept: 2 }, 2]);
+        expect(f({ selected: 1, kept: 2 }, 3)).toEqual([1, { kept: 2 }, 3]);
+      });
+
+      it('supports nested object rest in function parameters', () => {
+        function f({ outer: { selected, ...innerRest }, ...outerRest } = { outer: {} }) {
+          return [selected, innerRest, outerRest];
+        }
+        expect(f({ outer: { selected: 1, kept: 2 }, root: 3 })).toEqual([
+          1,
+          { kept: 2 },
+          { root: 3 },
+        ]);
       });
 
       // From: destructuring/default-precedence/exec.js
@@ -584,6 +813,39 @@ export function test({ describe, it, expect }) {
         expect(result).toEqual({ x: 1, y: 2 });
       });
 
+      it('for-of supports object rest in declaration and assignment patterns', () => {
+        const declared = [];
+        for (const { selected, ...rest } of [{ selected: 1, kept: 2 }]) {
+          declared.push([selected, rest]);
+        }
+
+        let selected, rest;
+        for ({ selected, ...rest } of [{ selected: 3, kept: 4 }]) {
+          // Assignment happens in the loop head.
+        }
+        expect(declared).toEqual([[1, { kept: 2 }]]);
+        expect([selected, rest]).toEqual([3, { kept: 4 }]);
+      });
+
+      it('for-of supports object rest nested in an array pattern', () => {
+        const results = [];
+        for (const [index, { selected, ...rest }] of [[0, { selected: 1, kept: 2 }]]) {
+          results.push([index, selected, rest]);
+        }
+        expect(results).toEqual([[0, 1, { kept: 2 }]]);
+      });
+
+      it('for-await-of supports object rest', async () => {
+        async function* values() {
+          yield { selected: 1, kept: 2 };
+        }
+        const results = [];
+        for await (const { selected, ...rest } of values()) {
+          results.push([selected, rest]);
+        }
+        expect(results).toEqual([[1, { kept: 2 }]]);
+      });
+
       // NOTE(@kitten): Broken test case
       // From: destructuring/for-of-shadowed-block-scoped/exec.js
       // @babel/plugin-transform-block-scoping bug: when it renames the inner
@@ -646,6 +908,15 @@ export function test({ describe, it, expect }) {
         expect(rest).toEqual([2, 3, 4]);
       });
 
+      it('object-rest assignment returns the right-hand value', () => {
+        let selected, rest;
+        const source = { selected: 1, kept: 2 };
+        const result = ({ selected, ...rest } = source);
+        expect(result).toBe(source);
+        expect(selected).toBe(1);
+        expect(rest).toEqual({ kept: 2 });
+      });
+
       // From: destructuring/chained/exec.js
       it('chained destructuring assignment', () => {
         var a, b, c, d;
@@ -679,9 +950,36 @@ export function test({ describe, it, expect }) {
         }
         expect(msg).toBe('bad type');
       });
+
+      it('collects object rest from a catch binding', () => {
+        let code, details;
+        try {
+          throw { code: 'E_TEST', message: 'failed', retryable: true };
+        } catch ({ code: caughtCode, ...rest }) {
+          code = caughtCode;
+          details = rest;
+        }
+        expect(code).toBe('E_TEST');
+        expect(details).toEqual({ message: 'failed', retryable: true });
+      });
+
+      it('collects nested object rest from a catch binding', () => {
+        let details;
+        try {
+          throw { error: { message: 'failed', code: 42 } };
+        } catch ({ error: { message, ...rest } }) {
+          details = [message, rest];
+        }
+        expect(details).toEqual(['failed', { code: 42 }]);
+      });
     });
 
     describe('declaration variants', () => {
+      it('supports object rest in exported declarations', () => {
+        expect(exportedValue).toBe(1);
+        expect(exportedRest).toEqual({ exportedOther: 2 });
+      });
+
       it('const with object destructuring', () => {
         const { x, y } = { x: 1, y: 2 };
         expect(x).toBe(1);
@@ -710,6 +1008,105 @@ export function test({ describe, it, expect }) {
         const getState = () => ({});
         const { data: { courses: oldCourses = [] } = {} } = getState();
         expect(oldCourses).toEqual([]);
+      });
+    });
+
+    describe('object-rest-spread regressions', () => {
+      // Adapted from Babel regression fixture T7178.
+      it('does not collide with a shadowed outer binding', () => {
+        const props = { outer: true };
+        const inner = function () {
+          const { ...props } = this.props;
+          return props;
+        }.call({ props: { inner: true } });
+        expect(props).toEqual({ outer: true });
+        expect(inner).toEqual({ inner: true });
+      });
+
+      // Adapted from Babel regression fixture gh-17274.
+      it('preserves computed-key order through nested object rest', () => {
+        const order = [];
+        const key = (value) => {
+          order.push(value);
+          return 'x';
+        };
+        const {
+          [key(0)]: { [key(1)]: first, [key(2)]: second, ...rest },
+          [key(3)]: outer,
+        } = { x: { x: {} } };
+        expect(order).toEqual([0, 1, 2, 3]);
+        expect(rest).toEqual({});
+        expect(outer).toEqual({ x: {} });
+      });
+
+      // Adapted from Babel regression fixture gh-4904.
+      it('supports nested rest and rest inside a callback parameter', () => {
+        const receive = (value, callback) => callback(value);
+        const {
+          nested: { selected, ...nestedRest },
+          ...outerRest
+        } = { nested: { selected: 1, kept: 2 }, root: 3 };
+        const callbackResult = receive({ selected: 4, kept: 5 }, ({ selected, ...rest }) => [
+          selected,
+          rest,
+        ]);
+        expect([selected, nestedRest, outerRest]).toEqual([1, { kept: 2 }, { root: 3 }]);
+        expect(callbackResult).toEqual([4, { kept: 5 }]);
+      });
+
+      // Adapted from Babel regression fixture gh-5151.
+      it('makes rest bindings available to later declarators and preserves declarator order', () => {
+        const order = [];
+        const record = (name, value) => {
+          order.push(name);
+          return value;
+        };
+        const { selected, ...rest } = record('source', { selected: 1, kept: 2 }),
+          later = record('later', rest.kept);
+        var before = record('before', true),
+          {
+            nested: { value, ...nestedRest },
+            ...outerRest
+          } = record('nested', { nested: { value: 3, kept: 4 }, root: 5 }),
+          after = record('after', true);
+        expect([selected, rest, later]).toEqual([1, { kept: 2 }, 2]);
+        expect([value, nestedRest, outerRest]).toEqual([3, { kept: 4 }, { root: 5 }]);
+        expect([before, after]).toEqual([true, true]);
+        expect(order).toEqual(['source', 'later', 'before', 'nested', 'after']);
+      });
+
+      // Adapted from Babel regression fixture gh-7388.
+      it('transforms object rest inside deeply nested default arrow functions', () => {
+        function outer(value) {
+          const {
+            first = (firstValue = {}) => {
+              const {
+                second = (secondValue = {}) => {
+                  const { selected, ...rest } = secondValue;
+                  return [selected, rest];
+                },
+              } = firstValue;
+              return second;
+            },
+          } = value;
+          return first;
+        }
+        const first = outer({});
+        const second = first({});
+        expect(second({ selected: 1, kept: 2 })).toEqual([1, { kept: 2 }]);
+      });
+
+      // Adapted from Babel regression fixture gh-8323.
+      it('preserves defaults when an object parameter also contains rest', () => {
+        let defaults = 0;
+        const fallback = () => {
+          defaults++;
+          return 3;
+        };
+        const extract = ({ a = fallback(), b, c, ...rest }) => [a, b, c, rest];
+        expect(extract({ b: 2, c: 3, kept: 4 })).toEqual([3, 2, 3, { kept: 4 }]);
+        expect(extract({ a: 1, b: 2, c: 3, kept: 4 })).toEqual([1, 2, 3, { kept: 4 }]);
+        expect(defaults).toBe(1);
       });
     });
 

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/expo-plugins.test.ts
@@ -704,19 +704,104 @@ it('uses the Babel WebView preflight for DOM components', async () => {
   expect(result.result.code).toContain('decorate');
 });
 
-it('matches Babel by lowering object spread for a modern non-Hermes target', async () => {
-  const result = await transformFileFullyWithNoxcturnal({
-    filename: '/app/src/web.js',
-    projectRoot: '/app',
-    source: 'module.exports = { ...source, value: 1 };',
-    options: options({ platform: 'web', customTransformOptions: { engine: undefined } }),
-    isDefaultExpoTransformer: true,
-    config: fullConfig(),
+describe('object rest/spread transform profiles', () => {
+  it.each([
+    ['Hermes v0', options({ unstable_transformProfile: 'default' })],
+    [
+      'WebView',
+      options({
+        unstable_transformProfile: 'hermes-stable',
+        customTransformOptions: { engine: 'hermes', dom: 'true' },
+      }),
+    ],
+  ])('lowers object spread for %s', async (_profile, transformOptions) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: '/app/src/native.js',
+      projectRoot: '/app',
+      source: 'module.exports = { ...source, value: 1 };',
+      options: transformOptions,
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).not.toContain('...source');
   });
 
-  expect(result.status).toBe('complete');
-  if (result.status !== 'complete') return;
-  expect(result.result.code).not.toContain('...source');
+  it.each([
+    ['Hermes v1', options({ unstable_transformProfile: 'hermes-stable' })],
+    [
+      'web',
+      options({
+        platform: 'web',
+        customTransformOptions: { engine: undefined },
+      }),
+    ],
+    [
+      'server',
+      options({
+        customTransformOptions: { engine: 'hermes', environment: 'node' },
+      }),
+    ],
+  ])('preserves object spread for %s', async (_profile, transformOptions) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: '/app/src/modern.js',
+      projectRoot: '/app',
+      source: 'module.exports = { ...source, value: 1 };',
+      options: transformOptions,
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).toContain('...source');
+  });
+
+  it.each([
+    ['Hermes v0', options({ unstable_transformProfile: 'default' })],
+    [
+      'WebView',
+      options({
+        unstable_transformProfile: 'hermes-stable',
+        customTransformOptions: { engine: 'hermes', dom: 'true' },
+      }),
+    ],
+  ])('preserves computed-key exclusion semantics for %s', async (_profile, transformOptions) => {
+    const result = await transformFileFullyWithNoxcturnal({
+      filename: '/app/src/native.js',
+      projectRoot: '/app',
+      source: `function omit(obj, spec) {
+        const { [spec.key]: unused, ...rest } = obj;
+        return rest;
+      }
+      module.exports = omit({ a: 1, b: 2 }, { key: 'a' });`,
+      options: transformOptions,
+      isDefaultExpoTransformer: true,
+      config: fullConfig(),
+    });
+
+    expect(result.status).toBe('complete');
+    if (result.status !== 'complete') return;
+    expect(result.result.code).not.toContain('...rest');
+
+    let factory: Function | undefined;
+    new Function('__d', result.result.code)((value: Function) => {
+      factory = value;
+    });
+    const module = { exports: {} as unknown };
+    factory?.(
+      globalThis,
+      (_id: unknown, name: string) => requireFromBabelPresetExpo(name),
+      (_id: unknown, name: string) => requireFromBabelPresetExpo(name),
+      (_id: unknown, name: string) => requireFromBabelPresetExpo(name),
+      module,
+      module.exports,
+      []
+    );
+    expect(module.exports).toEqual({ b: 2 });
+  });
 });
 
 it('matches Babel by preserving async generators on modern web targets', async () => {

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v0.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/hermes-v0.ts
@@ -13,6 +13,7 @@ export function getHermesV0PreflightConfig(facts: ProfilePreflightFacts): Profil
     destructuring: true,
     asyncGeneratorFunctions: facts.hasAsyncGenerator,
     asyncFunctions: facts.hasAsync,
+    objectRestSpread: facts.hasSpread ? { loose: true, useBuiltIns: true } : undefined,
     parameters: true,
   };
 }

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/types.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/types.ts
@@ -8,6 +8,7 @@ export interface ProfilePreflightFacts {
   hasForOf: boolean;
   hasPrivateSyntax: boolean;
   hasRegexpLiteral: boolean;
+  hasSpread: boolean;
   hasStaticBlock: boolean;
 }
 

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/webview.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/configs/webview.ts
@@ -19,5 +19,6 @@ export function getWebViewPreflightConfig(facts: ProfilePreflightFacts): Profile
     optionalChaining: { loose: true },
     nullishCoalescingOperator: { loose: true },
     logicalAssignmentOperators: true,
+    objectRestSpread: facts.hasSpread ? { loose: true, useBuiltIns: true } : undefined,
   };
 }

--- a/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/noxcturnal/noxcturnal-transformer.ts
@@ -678,8 +678,6 @@ function createProfilePreflight(
   const hasAsyncCandidate = sourceFacts.hasAsync;
   const hasRegexpLiteralCandidate = sourceFacts.hasSlash;
   const hasDecoratorCandidate = /@\w/.test(input.source);
-  const nonHermes = options.customTransformOptions?.engine !== 'hermes';
-  const hasObjectRestSpread = nonHermes && hasSpreadCandidate;
   const profileTransforms = getProfilePreflightConfig(input, {
     hasAsync: hasAsyncCandidate,
     hasAsyncGenerator,
@@ -688,15 +686,12 @@ function createProfilePreflight(
     hasForOf: hasForOfCandidate,
     hasPrivateSyntax: sourceFacts.hasPrivateSyntax,
     hasRegexpLiteral: hasRegexpLiteralCandidate,
+    hasSpread: hasSpreadCandidate,
     hasStaticBlock,
   });
   const hasProfileWork = Object.values(profileTransforms).some(Boolean);
   const hasOtherLanguageWork =
-    isTypeScript ||
-    enableReactRefresh ||
-    hasProfileWork ||
-    hasDecoratorCandidate ||
-    hasObjectRestSpread;
+    isTypeScript || enableReactRefresh || hasProfileWork || hasDecoratorCandidate;
   // Avoid a parse/codegen boundary for the overwhelmingly common file that has
   // none of this recipe's language work. Flow without JSX is already rendered by
   // its focused native erasure and does not need a second print.
@@ -706,7 +701,6 @@ function createProfilePreflight(
     !mayContainJsx &&
     !hasProfileWork &&
     !hasDecoratorCandidate &&
-    !hasObjectRestSpread &&
     !enableReactRefresh
   ) {
     return null;
@@ -715,12 +709,6 @@ function createProfilePreflight(
     transforms: {
       ...profileTransforms,
       legacyDecorators: hasDecoratorCandidate,
-      objectRestSpread: hasObjectRestSpread
-        ? {
-            loose: true,
-            useBuiltIns: true,
-          }
-        : undefined,
     },
     // Expo owns this recipe. These choices mirror its Hermes-v1 and React configs
     // without exposing either config name through Noxcturnal's capability API.

--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
+- Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -281,8 +281,10 @@ const LANGUAGE_SAMPLES: {
     code: `var y = {};
     var x = 1;
     var k = { x, ...y };`,
-    getCompiledCode() {
-      return `var y={};var x=1;var k={x,...y};`;
+    getCompiledCode({ platform }) {
+      return platform === 'web'
+        ? `var y={};var x=1;var k={x,...y};`
+        : `var y={};var x=1;var k=Object.assign({x},y);`;
     },
   },
   {

--- a/packages/babel-preset-expo/src/__tests__/object-rest-spread.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/object-rest-spread.test.ts
@@ -1,0 +1,67 @@
+import * as babel from '@babel/core';
+
+import preset from '..';
+
+jest.mock('../utils/resolveModule.ts', () => ({
+  ...jest.requireActual('../utils/resolveModule.ts'),
+  resolveModule: jest.fn(() => null),
+  hasModule: jest.fn(() => false),
+}));
+
+const profiles = [
+  ['web', { name: 'metro', platform: 'web', isDev: true }, false],
+  ['hermes-v1', { name: 'metro', platform: 'ios', engine: 'hermes', isDev: true }, false],
+  ['hermes-v0', { name: 'metro', platform: 'ios', isDev: true }, true],
+  ['webview', { name: 'metro', platform: 'web', isDomComponent: true, isDev: true }, true],
+] as const;
+
+function transformObjectRest(caller: Record<string, any>): string {
+  const result = babel.transformSync(
+    `
+      function omit(obj, spec) {
+        const { [spec.key]: unused, ...rest } = obj;
+        return rest;
+      }
+    `,
+    {
+      babelrc: false,
+      configFile: false,
+      filename: '/test.js',
+      presets: [[preset, { enableBabelRuntime: false }]],
+      caller: caller as babel.TransformCaller,
+    }
+  );
+  if (!result?.code) throw new Error('Babel transform returned no code');
+  return result.code;
+}
+
+describe('object-rest-spread transforms', () => {
+  it.each(profiles)('%s selects the expected transform', (_name, caller, transformsObjectRest) => {
+    const code = transformObjectRest(caller);
+
+    expect(code.includes('...rest')).toBe(!transformsObjectRest);
+    expect(code.includes('objectWithoutProperties')).toBe(transformsObjectRest);
+  });
+});
+
+describe('computed object-rest exclusions', () => {
+  it.each(profiles.filter(([, , transformsObjectRest]) => transformsObjectRest))(
+    '%s assigns the computed key temporary before the loose object-rest transform',
+    (_name, caller) => {
+      const code = transformObjectRest(caller);
+
+      expect(code).toMatch(/var _spec\$key\s*=\s*spec\.key/);
+      expect(code).not.toMatch(/var _spec\$key\s*;/);
+    }
+  );
+
+  it.each(profiles)('%s preserves the computed exclusion key', (_name, caller) => {
+    const code = transformObjectRest(caller);
+    const omit = new Function(`${code}; return omit;`)() as (
+      obj: Record<string, number>,
+      spec: { key: string }
+    ) => Record<string, number>;
+
+    expect(omit({ a: 1, b: 2 }, { key: 'a' })).toEqual({ b: 2 });
+  });
+});

--- a/packages/babel-preset-expo/src/__tests__/preset-config.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/preset-config.test.ts
@@ -60,7 +60,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-strip-types",
         "transform-typescript",
         "base$0$2$0",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-inline-or-reference-env-vars",
         "expo-inline-manifest-plugin",
@@ -88,6 +87,7 @@ describe('plugin list snapshots', () => {
         "transform-destructuring",
         "transform-async-generator-functions",
         "transform-async-to-generator",
+        "transform-object-rest-spread",
         "transform-parameters",
         "transform-react-display-name",
         "transform-runtime",
@@ -213,7 +213,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-enums",
         "transform-flow-strip-types",
         "transform-typescript",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-inline-or-reference-env-vars",
         "Rewrite react-native to react-native-web",
@@ -259,7 +258,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-enums",
         "transform-flow-strip-types",
         "transform-typescript",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-minify-platform-select",
         "expo-inline-or-reference-env-vars",
@@ -307,7 +305,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-enums",
         "transform-flow-strip-types",
         "transform-typescript",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-inline-manifest-plugin",
         "expo-router",
@@ -352,7 +349,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-enums",
         "transform-flow-strip-types",
         "transform-typescript",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-inline-or-reference-env-vars",
         "Rewrite react-native to react-native-web",
@@ -400,7 +396,6 @@ describe('plugin list snapshots', () => {
         "transform-flow-strip-types",
         "transform-typescript",
         "base$0$2$0",
-        "transform-object-rest-spread",
         "expo-define-globals",
         "expo-inline-or-reference-env-vars",
         "Rewrite react-native to react-native-web",
@@ -436,6 +431,7 @@ describe('plugin list snapshots', () => {
         "transform-optional-chaining",
         "transform-nullish-coalescing-operator",
         "transform-logical-assignment-operators",
+        "transform-object-rest-spread",
         "transform-runtime",
         "transform-export-namespace-from",
         "proposal-export-default-from",
@@ -560,13 +556,23 @@ describe('isDomComponent', () => {
   });
 });
 
-describe('engine-driven plugins', () => {
-  it('adds transform-object-rest-spread for non-hermes engine', () => {
+describe('profile-driven plugins', () => {
+  it('adds transform-object-rest-spread for the hermes-v0 profile', () => {
     const keys = getPluginKeys({ name: 'metro', platform: 'ios', isDev: true });
     expect(keys).toContain('transform-object-rest-spread');
   });
 
-  it('does not add transform-object-rest-spread for hermes engine', () => {
+  it('adds transform-object-rest-spread for the webview profile', () => {
+    const keys = getPluginKeys({
+      name: 'metro',
+      platform: 'web',
+      isDomComponent: true,
+      isDev: true,
+    });
+    expect(keys).toContain('transform-object-rest-spread');
+  });
+
+  it('does not add transform-object-rest-spread for the hermes-v1 profile', () => {
     const keys = getPluginKeys({
       name: 'metro',
       engine: 'hermes',
@@ -574,6 +580,13 @@ describe('engine-driven plugins', () => {
       isDev: true,
     });
     expect(keys).not.toContain('transform-object-rest-spread');
+  });
+
+  it.each([
+    ['web', { name: 'metro', platform: 'web', isDev: true }],
+    ['server', { name: 'metro', platform: 'ios', isServer: true, isDev: true }],
+  ])('does not add transform-object-rest-spread for the modern %s profile', (_name, caller) => {
+    expect(getPluginKeys(caller)).not.toContain('transform-object-rest-spread');
   });
 
   it('adds transform-parameters for default engine (hermes-v0)', () => {

--- a/packages/babel-preset-expo/src/configs/expo.ts
+++ b/packages/babel-preset-expo/src/configs/expo.ts
@@ -64,18 +64,6 @@ module.exports = function (api: ConfigAPI, options: ExpoConfigOptions) {
     plugins.push(reactCompilerPlugin);
   }
 
-  // TODO(@kitten): Remove or add non-hermes config
-  if (options.engine !== 'hermes') {
-    // `@react-native/babel-preset` configures this plugin with `{ loose: true }`, which breaks all
-    // getters and setters in spread objects. We need to add this plugin ourself without that option.
-    // @see https://github.com/expo/expo/pull/11960#issuecomment-887796455
-    plugins.push([
-      require('@babel/plugin-transform-object-rest-spread'),
-      // Assume no dependence on getters or evaluation order. See https://github.com/babel/babel/pull/11520
-      { loose: true, useBuiltIns: true },
-    ]);
-  }
-
   const inlines = getInlinesFromOptions(options);
   plugins.push([require('../plugins/define-plugin'), inlines]);
 

--- a/packages/babel-preset-expo/src/configs/hermes-v0.ts
+++ b/packages/babel-preset-expo/src/configs/hermes-v0.ts
@@ -24,6 +24,9 @@ module.exports = function (_api: ConfigAPI, _options: HermesV0ConfigOptions) {
       [require('@babel/plugin-transform-destructuring'), { useBuiltIns: true }],
       [require('@babel/plugin-transform-async-generator-functions')],
       [require('@babel/plugin-transform-async-to-generator')],
+      // Keep this after transform-destructuring to avoid the loose-mode computed exclusion bug.
+      // See: https://github.com/babel/babel/pull/18197
+      [require('@babel/plugin-transform-object-rest-spread'), { loose: true, useBuiltIns: true }],
       // Ensure the react-jsx-dev plugin works as expected when JSX is used in a function body.
       require('@babel/plugin-transform-parameters'),
       [require('@babel/plugin-transform-react-display-name')],

--- a/packages/babel-preset-expo/src/configs/webview.ts
+++ b/packages/babel-preset-expo/src/configs/webview.ts
@@ -33,6 +33,9 @@ module.exports = function (_api: ConfigAPI, _options: WebviewConfigOptions) {
       [require('@babel/plugin-transform-optional-chaining'), { loose: true }],
       [require('@babel/plugin-transform-nullish-coalescing-operator'), { loose: true }],
       [require('@babel/plugin-transform-logical-assignment-operators'), { loose: true }],
+      // Keep this after transform-destructuring to avoid the loose-mode computed exclusion bug.
+      // See: https://github.com/babel/babel/pull/18197
+      [require('@babel/plugin-transform-object-rest-spread'), { loose: true, useBuiltIns: true }],
     ] as PluginItem[],
   };
 };


### PR DESCRIPTION
# Why

Resolves #49232
Related #45337

Previously, the split of `babel-preset-expo` into separate sub-presets missed the `@babel/transform-object-rest-spread` plugin. I've likely left it alone since I was unable to confirm that moving it wouldn't cause the order-dependent issues the bug details.

This plugin should instead be only exercised for Hermes v0 and Webviews, not for the Hermes v1 and Modern Web presets. It should be safely movable assuming that it's added after `@babel/plugin-transform-destructuring` (to avoid the ordering dependent bug).

This is safe as long as we trust that Hermes does not have any bugs/quirks in its implementation.

# How

- Move `transform-object-rest-spread` to individual `hermes-v0` and `webview` presets
  - Note added to capture order dependence
- Update noxcturnal transformer config to mirror changes (main-only, no changelog entry)

# Test Plan

- Unit tests added to capture transform bug related to #49232
- Unit tests added to capture plugin change in configs
- `test-suite` updated `JSDestructuring` with all relevant cases for `transform-object-rest-spread`
  - **Note:** This is fully LLM-derived but looks comprehensive to me
  - These tests have passed on a test run of `E2E_FORCE_BABEL=1 expo start --clear` against a clean iOS simulator build
  - Agent confirmed that the iOS bundle does not contain `transform-object-rest-spread` transform outputs and instead contains raw rest-spread patterns (Asked to validate with `pnpx 2g` and fetch the raw iOS bundle identically to the simulator)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
