### PR TITLE
fix(expo-image): run android transition cleanup when the fade is cancelled

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed images in recycled lists going permanently blank: the transition's cleanup ran through `withEndAction`, which `ViewPropertyAnimator` drops when the animation is cancelled, so the Glide target was never returned to the pool. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@oscnord](https://github.com/oscnord))
+- [Android] Fixed images in recycled lists going permanently blank: the transition's cleanup ran through `withEndAction`, which `ViewPropertyAnimator` drops when the animation is cancelled, so the Glide target was never returned to the pool. ([#49283](https://github.com/expo/expo/pull/49283) by [@oscnord](https://github.com/oscnord))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Replaced the deprecated RenderScript-based `blurRadius` blur with a software stack blur to fix a use-after-free crash under concurrent image loads (aborts under GrapheneOS hardened_malloc). ([#PR](https://github.com/expo/expo/pull/PR) by [@DimitrisTzimikas](https://github.com/DimitrisTzimikas))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed images in recycled lists going permanently blank: the transition's cleanup ran through `withEndAction`, which `ViewPropertyAnimator` drops when the animation is cancelled, so the Glide target was never returned to the pool. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@oscnord](https://github.com/oscnord))
 - [web] Fixed Expo Image's internal `dataSet` marker being overwritten by a user-provided `dataSet`. ([#48821](https://github.com/expo/expo/pull/48821) by [@Brentlok](https://github.com/Brentlok))
 - [iOS] Fixed `generateThumbhashAsync` crashing on images with extreme aspect ratios. ([#47189](https://github.com/expo/expo/issues/47189) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Replaced the deprecated RenderScript-based `blurRadius` blur with a software stack blur to fix a use-after-free crash under concurrent image loads (aborts under GrapheneOS hardened_malloc). ([#PR](https://github.com/expo/expo/pull/PR) by [@DimitrisTzimikas](https://github.com/DimitrisTzimikas))

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -38,6 +38,9 @@ android {
 dependencies {
   def GLIDE_VERSION = "5.0.5"
 
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.16'
+
   implementation 'com.facebook.react:react-android'
 
   api "com.github.bumptech.glide:glide:${GLIDE_VERSION}"

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -20,8 +20,26 @@ import expo.modules.image.records.ContentPosition
 class ExpoImageView(
   context: Context
 ) : AppCompatImageView(context) {
+  internal var targetBindingId = 0L
+    private set
+
   var currentTarget: ImageViewWrapperTarget? = null
+    set(value) {
+      field = value
+      targetBindingId += 1
+    }
+
   var isPlaceholder: Boolean = false
+
+  internal fun recycleViewIfBindingMatches(
+    target: ImageViewWrapperTarget?,
+    bindingId: Long
+  ): ImageViewWrapperTarget? {
+    if (currentTarget !== target || targetBindingId != bindingId) {
+      return null
+    }
+    return recycleView()
+  }
 
   fun recycleView(): ImageViewWrapperTarget? {
     val target = currentTarget?.apply {
@@ -36,6 +54,9 @@ class ExpoImageView(
     // an alpha it no longer wants, and can be left partially or fully transparent once it is bound
     // to its next image.
     animate().cancel()
+    // ViewPropertyAnimator keeps its listener across animations, so leaving it attached can run
+    // cleanup from the previous image after this view has been rebound to a new one.
+    animate().setListener(null)
     alpha = 1f
     setImageDrawable(null)
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -24,13 +24,21 @@ class ExpoImageView(
   var isPlaceholder: Boolean = false
 
   fun recycleView(): ImageViewWrapperTarget? {
-    setImageDrawable(null)
-
     val target = currentTarget?.apply {
       isUsed = false
     }
-
+    // Cleared before the animation is cancelled, so the cancellation callback of a transition
+    // still running on this view sees that the view no longer holds that target and skips its
+    // cleanup instead of re-entering this method.
     currentTarget = null
+
+    // A view can be recycled midway through a fade. Without this the view keeps animating towards
+    // an alpha it no longer wants, and can be left partially or fully transparent once it is bound
+    // to its next image.
+    animate().cancel()
+    alpha = 1f
+    setImageDrawable(null)
+
     isVisible = false
     isPlaceholder = false
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -1,5 +1,7 @@
 package expo.modules.image
 
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
@@ -317,18 +319,32 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
             newView.bringToFront()
             previousView.alpha = 1f
             newView.alpha = 0f
-            // A newer source can reuse this view as its `newView` before the fade-out ends. That
-            // cancels this animation, and the end action runs on cancel too, so without this guard
-            // it would recycle the view now holding the new image. See issue #46703.
+            // A newer source can reuse this view as its `newView` before the fade-out ends, so the
+            // cleanup is guarded on the view still holding the target it was scheduled for.
+            // See issue #46703.
             val previousTarget = previousView.currentTarget
             previousView.animate().apply {
               duration = transitionDuration
               alpha(0f)
-              withEndAction {
-                if (previousView.currentTarget === previousTarget) {
-                  clearPreviousView()
+              // Deliberately not `withEndAction`: `ViewPropertyAnimator` drops the end action when
+              // the animation is cancelled, and starting a new animation on the same view cancels
+              // this one. In a recycling list that happens constantly, so the target would never be
+              // returned to the pool and the view would stay blank.
+              setListener(object : AnimatorListenerAdapter() {
+                private var handled = false
+
+                override fun onAnimationCancel(animation: Animator) = onAnimationEnd(animation)
+
+                override fun onAnimationEnd(animation: Animator) {
+                  if (handled) {
+                    return
+                  }
+                  handled = true
+                  if (previousView.currentTarget === previousTarget) {
+                    clearPreviousView()
+                  }
                 }
-              }
+              })
             }
             newView.animate().apply {
               duration = transitionDuration

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -292,16 +292,14 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
             ?.toLong()
             ?: 0L
 
-          val clearPreviousView = {
-            previousView
-              .recycleView()
-              ?.apply {
-                // When the placeholder is loaded, one target is displayed in both views.
-                // So we just have to move the reference to a new view instead of clearing the target.
-                if (this != target) {
-                  clear(requestManager)
-                }
+          val clearRecycledTarget = { recycledTarget: ImageViewWrapperTarget? ->
+            recycledTarget?.apply {
+              // When the placeholder is loaded, one target is displayed in both views.
+              // So we just have to move the reference to a new view instead of clearing the target.
+              if (this != target) {
+                clear(requestManager)
               }
+            }
           }
 
           configureView(newView, target, resource, isPlaceholder)
@@ -312,7 +310,7 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
           }
 
           if (transitionDuration <= 0) {
-            clearPreviousView()
+            clearRecycledTarget(previousView.recycleView())
             newView.alpha = 1f
             newView.bringToFront()
           } else {
@@ -320,9 +318,12 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
             previousView.alpha = 1f
             newView.alpha = 0f
             // A newer source can reuse this view as its `newView` before the fade-out ends, so the
-            // cleanup is guarded on the view still holding the target it was scheduled for.
+            // cleanup is guarded on the view still holding the exact binding it was scheduled for.
+            // The same target object can be recycled for a newer source, so target identity alone
+            // is not sufficient.
             // See issue #46703.
             val previousTarget = previousView.currentTarget
+            val previousTargetBindingId = previousView.targetBindingId
             previousView.animate().apply {
               duration = transitionDuration
               alpha(0f)
@@ -340,9 +341,12 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
                     return
                   }
                   handled = true
-                  if (previousView.currentTarget === previousTarget) {
-                    clearPreviousView()
-                  }
+                  clearRecycledTarget(
+                    previousView.recycleViewIfBindingMatches(
+                      previousTarget,
+                      previousTargetBindingId
+                    )
+                  )
                 }
               })
             }

--- a/packages/expo-image/android/src/test/java/expo/modules/image/ExpoImageViewTest.kt
+++ b/packages/expo-image/android/src/test/java/expo/modules/image/ExpoImageViewTest.kt
@@ -1,0 +1,109 @@
+package expo.modules.image
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Looper
+import androidx.core.view.isVisible
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import java.lang.ref.WeakReference
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+class ExpoImageViewTest {
+  @Test
+  fun recycledViewDoesNotRunStaleAnimationCleanupAfterBeingRebound() {
+    val view = ExpoImageView(RuntimeEnvironment.getApplication())
+    var cleanupCalls = 0
+
+    view.animate()
+      .alpha(0f)
+      .setDuration(100)
+      .setListener(object : AnimatorListenerAdapter() {
+        override fun onAnimationEnd(animation: Animator) {
+          cleanupCalls += 1
+          view.recycleView()
+        }
+      })
+
+    view.recycleView()
+    val cleanupCallsAfterRecycle = cleanupCalls
+
+    val replacement = ColorDrawable(Color.RED)
+    view.setImageDrawable(replacement)
+    view.isVisible = true
+    view.alpha = 0f
+    view.animate()
+      .alpha(1f)
+      .setDuration(100)
+      .start()
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(200))
+
+    assertEquals(cleanupCallsAfterRecycle, cleanupCalls)
+    assertSame(replacement, view.drawable)
+    assertTrue(view.isVisible)
+  }
+
+  @Test
+  fun staleAnimationCleanupDoesNotRecycleANewerBindingOfTheSameTarget() {
+    val view = ExpoImageView(RuntimeEnvironment.getApplication())
+    val target = ImageViewWrapperTarget(WeakReference<ExpoImageViewWrapper>(null))
+    view.currentTarget = target
+    val previousBindingId = view.targetBindingId
+    var cleanupCalls = 0
+
+    view.animate()
+      .alpha(0f)
+      .setDuration(100)
+      .setListener(object : AnimatorListenerAdapter() {
+        override fun onAnimationEnd(animation: Animator) {
+          cleanupCalls += 1
+          view.recycleViewIfBindingMatches(target, previousBindingId)
+        }
+      })
+
+    val replacement = ColorDrawable(Color.BLUE)
+    view.currentTarget = target
+    view.setImageDrawable(replacement)
+    view.isVisible = true
+    view.alpha = 0f
+    view.animate()
+      .alpha(1f)
+      .setDuration(100)
+      .start()
+
+    shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(200))
+
+    assertEquals(1, cleanupCalls)
+    assertSame(replacement, view.drawable)
+    assertTrue(view.isVisible)
+  }
+
+  @Test
+  fun matchingBindingIsRecycledOnlyOnce() {
+    val view = ExpoImageView(RuntimeEnvironment.getApplication())
+    val target = ImageViewWrapperTarget(WeakReference<ExpoImageViewWrapper>(null))
+    target.isUsed = true
+    view.currentTarget = target
+    val bindingId = view.targetBindingId
+    view.setImageDrawable(ColorDrawable(Color.GREEN))
+    view.isVisible = true
+
+    assertSame(target, view.recycleViewIfBindingMatches(target, bindingId))
+    assertNull(view.recycleViewIfBindingMatches(target, bindingId))
+    assertNull(view.drawable)
+    assertFalse(view.isVisible)
+    assertFalse(target.isUsed)
+  }
+}


### PR DESCRIPTION
# Why

On Android, images can become permanently blank when their source changes or their view is recycled during a transition.

Fade-out cleanup used `ViewPropertyAnimator.withEndAction`, but Android drops that runnable when the animation is cancelled. Since starting another alpha animation cancels the previous one, the Glide target may never be returned to the pool. Once both targets remain marked as used, the wrapper has no target available for the next image.

Running cleanup through `setListener` fixes cancellation, but the listener persists across later animations. A stale listener can therefore recycle a newer image, and target identity alone is insufficient because the same target object can be rebound.

Related: #46703. Follow-up to #46752; this retains and strengthens its target-ownership guard.

# How

- Replace `withEndAction` with an `AnimatorListenerAdapter` that performs cleanup once on either completion or cancellation.
- Assign each view/target binding an ID and recycle only when both the target and binding ID still match.
- In `recycleView`, invalidate the binding before cancelling, remove the persistent listener after cancellation, and reset alpha to `1f`.
- Add Robolectric coverage for listener persistence, same-target rebinding, and valid cleanup.

## Transition behavior

If `source` changes faster than the transition duration, cancellation frees the outgoing target immediately. The incoming image fades in from the background rather than maintaining an uninterrupted two-image crossfade. Redesigning that behavior is outside this PR.

# Test Plan

- Android API 33 emulator: 16 images without `recyclingKey`, `cachePolicy="none"`, sources changing every 250 ms, and 800 ms transitions. After 120 swaps and the final transition settling, all 16 images remained visible.
- Physical Samsung SM-A146P (Android 15): repeatedly scrolled a horizontal list of about 20 covers inside a vertical list. Before the fix, blanking accumulated to 71%; after the fix, it stayed at the freshly loaded baseline of 11–19% across two runs.
- `:expo-image:testDebugUnitTest`: 3 tests, 0 failures.
- `:expo-image:spotlessCheck`: passed.
- `pnpm --filter expo-image lint`: passed.

The physical-device comparison used the released `55.0.10` sources with the target guard from `main` applied locally.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
