### PR TITLE
[expo-video][iOS] Fix crash when the device runs out of storage while caching

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@huextrat](https://github.com/huextrat))
+- [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))
 - [Android] Guard `PictureInPictureParams.Builder.setAutoEnterEnabled` against `NoSuchMethodError` on stock OEM firmwares that report API 31+ without shipping the method, which crashed the app from `VideoView.onLayout` even when Picture in Picture was disabled. ([#48957](https://github.com/expo/expo/pull/48957) by [@onlyshyun](https://github.com/onlyshyun))
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@huextrat](https://github.com/huextrat))
 - [Android] Guard `PictureInPictureParams.Builder.setAutoEnterEnabled` against `NoSuchMethodError` on stock OEM firmwares that report API 31+ without shipping the method, which crashed the app from `VideoView.onLayout` even when Picture in Picture was disabled. ([#48957](https://github.com/expo/expo/pull/48957) by [@onlyshyun](https://github.com/onlyshyun))
 - [iOS] Fix races between overlapping source loads and player release. ([#47967](https://github.com/expo/expo/pull/47967) by [@behenate](https://github.com/behenate))
 - [iOS] Set the default `audioMixingMode` to `auto`, [as documented](https://docs.expo.dev/versions/latest/sdk/video/#audiomixingmode); was `doNotMix`. ([#47363](https://github.com/expo/expo/issues/47363) by [@andymatuschak](https://github.com/andymatuschak))

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -88,7 +88,7 @@ internal class MediaFileHandle {
 
     do {
       try readHandle.seek(toOffset: UInt64(offset))
-      let data = readHandle.readData(ofLength: length)
+      let data = try readHandle.read(upToCount: length) ?? Data()
 
       if data.count < length && offset + Int64(data.count) < currentSize {
         log.warn("[expo-video] Read \(data.count) bytes but expected \(length) bytes")
@@ -116,8 +116,8 @@ internal class MediaFileHandle {
 
     try writeHandle.seek(toOffset: UInt64(offset))
 
-    writeHandle.write(data)
-    writeHandle.synchronizeFile()
+    try writeHandle.write(contentsOf: data)
+    try writeHandle.synchronize()
   }
 
   func append(data: Data) {
@@ -127,13 +127,17 @@ internal class MediaFileHandle {
       return
     }
 
-    writeHandle.seekToEndOfFile()
-    writeHandle.write(data)
-    writeHandle.synchronizeFile()
+    do {
+      try writeHandle.seekToEnd()
+      try writeHandle.write(contentsOf: data)
+      try writeHandle.synchronize()
+    } catch {
+      log.warn("[expo-video] Failed to append data to the file at \(filePath): \(error)")
+    }
   }
 
   func close() {
-    readHandle?.closeFile()
-    writeHandle?.closeFile()
+    try? readHandle?.close()
+    try? writeHandle?.close()
   }
 }


### PR DESCRIPTION
# Why

fixes https://github.com/expo/expo/issues/49133

`expo-video`'s disk cache crashes the app when the device runs out of storage.

`MediaFileHandle` writes cached media through the legacy `NSFileHandle` API (`writeData:`, `synchronizeFile`, `readData(ofLength:)`, `closeFile`). Those methods report I/O failures by raising an Objective-C `NSFileHandleOperationException`, which a Swift `do`/`catch` cannot catch. So when a write hits `ENOSPC` the exception unwinds straight past the error handling that `CachedResource.writeData` already has, and the process is terminated:

```
NSFileHandleOperationException: *** -[NSConcreteFileHandle writeData:]: No space left on device
  at MediaFileHandle.write
  at CachedResource.writeData
  at CachableRequest.saveData

NSFileHandleOperationExceptionUnderlyingError:
  Error Domain=NSCocoaErrorDomain Code=640 "…not enough space."
  UserInfo={NSUnderlyingError=… Error Domain=NSPOSIXErrorDomain Code=28 "No space left on device"}
```

We see this in production on iOS: it is fully fatal, and it is triggered by nothing more than a user with a full phone watching a video.

# How

Switch `MediaFileHandle` to the throwing Swift replacements, all available since iOS 13.4 (`ExpoVideo.podspec` targets iOS 16.4, so no availability guard is needed):

| before | after |
| --- | --- |
| `writeHandle.write(data)` | `try writeHandle.write(contentsOf: data)` |
| `writeHandle.synchronizeFile()` | `try writeHandle.synchronize()` |
| `writeHandle.seekToEndOfFile()` | `try writeHandle.seekToEnd()` |
| `readHandle.readData(ofLength:)` | `try readHandle.read(upToCount:)` |
| `handle.closeFile()` | `try? handle.close()` |

`write(data:atOffset:)` is already `throws`, so the failure now propagates to the existing `catch` in `CachedResource.writeData`, which logs a warning. The consequence of a full disk becomes "this segment is not cached" instead of "the app dies".

Two details worth noting for review:

- In `WriteCoordinator.performWrite` the write happens *before* `mediaInfo.addDataRange(…)`, so a throw leaves the range unmarked. A partially written chunk is never recorded as cached and will not be served back — the cache index cannot be corrupted by this path.
- `read(upToCount:)` returns `nil` at EOF where `readData(ofLength:)` returned empty `Data`, so it is mapped through `?? Data()` to keep the existing semantics.

`append(data:)` has no callers today, but it had the same defect; it now catches and logs rather than raising, keeping its non-throwing signature.

# Test Plan

Reproduced both behaviours directly against a full filesystem — an 8 MB HFS+ disk image — writing 256 KB chunks until `ENOSPC`, with each API in its own process (the Objective-C exception terminates the process, so they cannot share one).

Legacy API, i.e. the current `main` behaviour — the production crash, reproduced exactly:

```
*** Terminating app due to uncaught exception 'NSFileHandleOperationException',
    reason: '*** -[NSConcreteFileHandle writeData:]: No space left on device'
    1 libobjc.A.dylib   objc_exception_throw + 88
    3 Foundation        -[NSConcreteFileHandle writeData:] + 292
libc++abi: terminating due to uncaught exception of type NSException
```

Same scenario with `write(contentsOf:)` — same underlying failure, now a catchable Swift error:

```
caught Swift error -> Error Domain=NSCocoaErrorDomain Code=640
  "The file couldn't be saved because there isn't enough space."
  UserInfo={NSUnderlyingError=… Error Domain=NSPOSIXErrorDomain Code=28 "No space left on device"}
```

`NSCocoaErrorDomain 640` / `NSPOSIXErrorDomain 28` match the `NSFileHandleOperationExceptionUnderlyingError` captured in the production reports, confirming this is the same failure path rather than a different one.

`swiftc -typecheck` passes on the modified file, and SwiftLint reports no violations on it.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
