### PR TITLE
[docs] Serve YouTube thumbnails as WebP and lazy-load `VideoBoxLink` images

### DIFF
--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -79,7 +79,7 @@ export function TalkGridCell({
             backgroundImage: `url(${
               thumbnail
                 ? `/static/thumbnails/${thumbnail}`
-                : `https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`
+                : `https://i.ytimg.com/vi_webp/${videoId}/maxresdefault.webp`
             })`,
           }}
           className="h-34.5 border-b border-b-default bg-cover bg-center max-sm:h-42"

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -57,7 +57,8 @@ export function VideoBoxLink({
             'max-sm:max-w-full max-sm:border-r-0 max-sm:border-b'
           )}>
           <img
-            src={`https://i3.ytimg.com/vi/${videoId}/maxresdefault.jpg`}
+            src={`https://i.ytimg.com/vi_webp/${videoId}/maxresdefault.webp`}
+            loading="lazy"
             className="aspect-video transition duration-300 group-hover:scale-105 group-focus-visible:scale-105"
             alt={title}
             aria-label={`Video thumbnail for ${title}`}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26116

# How

<!--
How did you build this feature or fix this bug and why?
-->
-  Serve YouTube thumbnails as WebP and lazy-load `VideoBoxLink` images

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
