### PR TITLE
[fingerprint] Normalize virtual store paths before hashing them

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fixed ignore patterns (built-in and `.fingerprintignore`) not matching on Windows, which made fingerprints differ between Windows machines and EAS builds ("Runtime version mismatch"). ([#46816](https://github.com/expo/expo/pull/46816) by [@blurbyte](https://github.com/blurbyte))
+- Collapsed the virtual store segment of a path, e.g. pnpm's **node_modules/.pnpm**, before hashing it, so a peer dependency reshuffle no longer changes `dir` hashes when no file content changed. ([#49288](https://github.com/expo/expo/pull/49288) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/@expo/fingerprint/src/hash/Hash.ts
+++ b/packages/@expo/fingerprint/src/hash/Hash.ts
@@ -20,7 +20,11 @@ import type {
   NormalizedOptions,
 } from '../Fingerprint.types';
 import { createLimiter, type Limiter } from '../utils/Concurrency';
-import { isIgnoredPathWithMatchObjects, toPosixPath } from '../utils/Path';
+import {
+  isIgnoredPathWithMatchObjects,
+  normalizeVirtualStorePath,
+  toPosixPath,
+} from '../utils/Path';
 import { nonNullish } from '../utils/Predicates';
 import { profile } from '../utils/Profile';
 import { FileHookTransform } from './FileHookTransform';
@@ -42,7 +46,7 @@ export async function createFingerprintFromSourcesAsync(
   const hasher = createHash(options.hashAlgorithm);
   for (const source of fingerprintSources) {
     if (source.hash != null) {
-      hasher.update(createSourceId(source));
+      hasher.update(normalizeVirtualStorePath(createSourceId(source)));
       hasher.update(source.hash);
     }
   }
@@ -238,7 +242,7 @@ export async function createDirHashResultsAsync(
 
   const children: (DebugInfoFile | DebugInfoDir | undefined)[] = [];
   for (const result of results) {
-    hasher.update(result.id);
+    hasher.update(normalizeVirtualStorePath(result.id));
     hasher.update(result.hex);
     children.push(result.debugInfo);
   }

--- a/packages/@expo/fingerprint/src/hash/__tests__/Hash-test.ts
+++ b/packages/@expo/fingerprint/src/hash/__tests__/Hash-test.ts
@@ -274,6 +274,124 @@ describe(createDirHashResultsAsync, () => {
   });
 });
 
+describe('virtual store paths', () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
+  // pnpm and the other isolated installers place a package under a store directory whose name
+  // encodes the resolved peer dependencies. The default ignore paths currently drop those paths as
+  // nested `node_modules`, so opt them back in to exercise the hashing itself.
+  const optIn = { ignorePaths: ['!**/node_modules/**/node_modules/**'] };
+
+  const cameraA =
+    'node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera';
+  // Same package and version, a peer dependency elsewhere in the tree was bumped.
+  const cameraB =
+    'node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.1_@babel+core@7.28.4/node_modules/expo-camera';
+
+  async function hashDirAsync(volJSON: Record<string, string>, dirPath: string) {
+    vol.reset();
+    vol.fromJSON(volJSON);
+    const options = await normalizeOptionsAsync('/app', optIn);
+    const result = await createDirHashResultsAsync(dirPath, createLimiter(3), '/app', options);
+    return result?.hex ?? null;
+  }
+
+  async function fingerprintDirSourceAsync(volJSON: Record<string, string>, dirPath: string) {
+    vol.reset();
+    vol.fromJSON(volJSON);
+    const options = await normalizeOptionsAsync('/app', optIn);
+    const sources: HashSource[] = [
+      { type: 'dir', filePath: dirPath, reasons: ['expoAutolinkingAndroid'] },
+    ];
+    return (await createFingerprintFromSourcesAsync(sources, '/app', options)).hash;
+  }
+
+  it('should return the same dir hash when only the store suffix changed', async () => {
+    const hexA = await hashDirAsync(
+      { [`/app/${cameraA}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+    const hexB = await hashDirAsync(
+      { [`/app/${cameraB}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraB}/android`
+    );
+
+    expect(hexA).not.toBeNull();
+    expect(hexB).toEqual(hexA);
+  });
+
+  it('should return the same fingerprint when only the store suffix changed', async () => {
+    const hashA = await fingerprintDirSourceAsync(
+      { [`/app/${cameraA}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+    const hashB = await fingerprintDirSourceAsync(
+      { [`/app/${cameraB}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraB}/android`
+    );
+
+    expect(hashB).toEqual(hashA);
+  });
+
+  it('should still change the dir hash when a file is renamed', async () => {
+    const before = await hashDirAsync(
+      { [`/app/${cameraA}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+    const after = await hashDirAsync(
+      { [`/app/${cameraA}/android/settings.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+
+    expect(after).not.toEqual(before);
+  });
+
+  it('should still change the dir hash when a file is moved into a subdirectory', async () => {
+    const before = await hashDirAsync(
+      { [`/app/${cameraA}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+    const after = await hashDirAsync(
+      { [`/app/${cameraA}/android/gradle/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+
+    expect(after).not.toEqual(before);
+  });
+
+  it('should still change the dir hash when a file moves out of a nested dependency', async () => {
+    const before = await hashDirAsync(
+      {
+        [`/app/${cameraA}/node_modules/nested/android/build.gradle`]:
+          'apply plugin: com.android.library',
+      },
+      cameraA
+    );
+    const after = await hashDirAsync(
+      { [`/app/${cameraA}/nested/android/build.gradle`]: 'apply plugin: com.android.library' },
+      cameraA
+    );
+
+    expect(after).not.toEqual(before);
+  });
+
+  it('should keep two store packages with identical contents apart', async () => {
+    const media = 'node_modules/.pnpm/expo-media-library@1.0.0/node_modules/expo-media-library';
+    const cameraHash = await fingerprintDirSourceAsync(
+      { [`/app/${cameraA}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${cameraA}/android`
+    );
+    const mediaHash = await fingerprintDirSourceAsync(
+      { [`/app/${media}/android/build.gradle`]: 'apply plugin: com.android.library' },
+      `${media}/android`
+    );
+
+    expect(mediaHash).not.toEqual(cameraHash);
+  });
+});
+
 describe(createSourceId, () => {
   it(`should use filePath as id for file or dir`, () => {
     const fileSource: HashSource = {

--- a/packages/@expo/fingerprint/src/utils/Path.ts
+++ b/packages/@expo/fingerprint/src/utils/Path.ts
@@ -173,3 +173,31 @@ export function getNodeModulesPackageJsonPath(relativePosixPath: string): string
   }
   return `${packageDir}/package.json`;
 }
+
+/**
+ * Matches the virtual store segment of a path from a package manager that installs packages in
+ * isolation: pnpm's `node_modules/.pnpm`, Bun's `node_modules/.bun`, and Yarn's pnpm linker's
+ * `node_modules/.store`.
+ *
+ * The store directory name is not stable. It encodes the package version and a suffix derived from
+ * how peer dependencies resolved, e.g.
+ * `node_modules/.pnpm/expo@52.0.49_react@19.0.0_react-native@0.76.7/node_modules/expo`.
+ */
+const VIRTUAL_STORE_REGEX = /(^|\/)node_modules\/\.(?:pnpm|bun|store)\/[^/]+\/node_modules\//g;
+
+/**
+ * Collapse the virtual store segment of a project relative path down to the package path, so a
+ * name a package manager derives from peer dependency resolution never reaches a hash.
+ *
+ * ```
+ * node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera/android
+ *   -> node_modules/expo-camera/android
+ * ```
+ *
+ * Only the store segment is collapsed. A scoped package keeps its scope, a `../` prefix is kept, a
+ * genuinely nested `node_modules` inside a store package is left alone, and a path that merely
+ * contains `.pnpm` is returned unchanged.
+ */
+export function normalizeVirtualStorePath(filePath: string): string {
+  return filePath.replace(VIRTUAL_STORE_REGEX, '$1node_modules/');
+}

--- a/packages/@expo/fingerprint/src/utils/__tests__/Path-test.ts
+++ b/packages/@expo/fingerprint/src/utils/__tests__/Path-test.ts
@@ -7,6 +7,7 @@ import {
   getNodeModulesPackageJsonPath,
   isIgnoredPath,
   normalizeFilePath,
+  normalizeVirtualStorePath,
   pathExistsAsync,
   toPosixPath,
 } from '../Path';
@@ -226,5 +227,77 @@ describe(pathExistsAsync, () => {
 
   it('should return false if the file does not exist', async () => {
     expect(await pathExistsAsync('/app.json')).toBe(false);
+  });
+});
+
+describe(normalizeVirtualStorePath, () => {
+  it('should collapse a pnpm virtual store segment down to the package path', () => {
+    expect(
+      normalizeVirtualStorePath(
+        'node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera/android'
+      )
+    ).toBe('node_modules/expo-camera/android');
+  });
+
+  it('should keep the scope of a scoped package', () => {
+    expect(
+      normalizeVirtualStorePath(
+        'node_modules/.pnpm/@react-native-firebase+app@23.8.2_react-native@0.86.0/node_modules/@react-native-firebase/app/android'
+      )
+    ).toBe('node_modules/@react-native-firebase/app/android');
+  });
+
+  it('should collapse the same shape for other isolated installers', () => {
+    expect(
+      normalizeVirtualStorePath('node_modules/.bun/expo-camera@1.0.0/node_modules/expo-camera/ios')
+    ).toBe('node_modules/expo-camera/ios');
+    expect(
+      normalizeVirtualStorePath(
+        'node_modules/.store/expo-camera-npm-1.0.0-abcdef/node_modules/expo-camera/ios'
+      )
+    ).toBe('node_modules/expo-camera/ios');
+  });
+
+  it('should keep a parent directory prefix', () => {
+    expect(
+      normalizeVirtualStorePath(
+        '../../node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera/ios'
+      )
+    ).toBe('../../node_modules/expo-camera/ios');
+  });
+
+  it('should collapse every store segment of a nested workspace path', () => {
+    expect(
+      normalizeVirtualStorePath(
+        'packages/app/node_modules/.pnpm/a@1.0.0/node_modules/a/node_modules/.pnpm/b@1.0.0/node_modules/b/ios'
+      )
+    ).toBe('packages/app/node_modules/a/node_modules/b/ios');
+  });
+
+  it('should keep a real nested dependency inside a store package', () => {
+    expect(
+      normalizeVirtualStorePath(
+        'node_modules/.pnpm/expo-camera@1.0.0/node_modules/expo-camera/node_modules/nested/index.js'
+      )
+    ).toBe('node_modules/expo-camera/node_modules/nested/index.js');
+  });
+
+  it('should leave paths that only look like a virtual store alone', () => {
+    // No store directory name between `.pnpm` and `node_modules`: pnpm's hoisted dependencies.
+    expect(normalizeVirtualStorePath('node_modules/.pnpm/node_modules/debug/index.js')).toBe(
+      'node_modules/.pnpm/node_modules/debug/index.js'
+    );
+    // `.pnpm` as ordinary path text, outside node_modules.
+    expect(normalizeVirtualStorePath('docs/.pnpm/expo@1.0.0/node_modules/expo/ios')).toBe(
+      'docs/.pnpm/expo@1.0.0/node_modules/expo/ios'
+    );
+    // An unrelated dot directory.
+    expect(normalizeVirtualStorePath('node_modules/.cache/expo@1.0.0/node_modules/expo')).toBe(
+      'node_modules/.cache/expo@1.0.0/node_modules/expo'
+    );
+    // A plain install layout.
+    expect(normalizeVirtualStorePath('node_modules/expo-camera/android/build.gradle')).toBe(
+      'node_modules/expo-camera/android/build.gradle'
+    );
   });
 });


### PR DESCRIPTION
# Why

Fixes #44808.

pnpm and the other isolated installers put a package under a store directory whose name encodes how peer dependencies resolved:

```
node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera/android
```

That directory name changes whenever any unrelated dependency is added, removed, or bumped. `Hash.ts` feeds project relative paths into the hasher, so every one of those paths changes and the fingerprint changes with it, even though every file content hash is identical.

@kitten already pointed at the fix in the issue:

> @Kudo: I'm not sure which exact procedure this is a part of, but if this is part of the native modules one, we might want to normalise paths to the package path, if we aren't yet, for the hashing?

That is what this does.

This issue is assigned to @Kudo. If it is already being handled on your side, say the word and I will close this.

## How this sits next to #48704

Worth flagging, because I did not expect it. On current `main` these paths never reach the hasher at all: `**/node_modules/**/node_modules/**` in `DEFAULT_IGNORE_PATHS` (`src/Options.ts:66`) matches the whole store layout, so `createDirHashResultsAsync` returns `null` for anything inside it. Measured with memfs on `main`, with two trees whose file contents are identical and whose store suffix differs:

```
default options       dirA = null
                      dirB = null

ignore negated        dirA.hex = 1c33378fe84ecf927177b72e9518cc59810566fa
                      dirB.hex = 9190136ef6b0e0bb5b07902643993fcf8bb1df2a
                      fpA.hash = bbcc4b5d9ab8abce5a26a37eccc867ed4391b049
                      fpB.hash = e47cfa42f4afecc9f3aa555e69b2ca8ccf74497b
```

So today this bug is latent, and it goes live the moment #48704 restores those sources. This change is what keeps them stable afterwards.

It also means this should not move any existing fingerprint on `main`. Every source type that can carry a store path (`dir`, `file`, `package`, and the config plugin sources from `resolveLoadedModuleSourcesAsync`) is filtered through the same ignore paths. The exception is a project that re-includes nested `node_modules` through its own `ignorePaths`, which is also how the tests exercise the behavior.

# How

`normalizeVirtualStorePath` in `src/utils/Path.ts` collapses the store segment down to the package path:

```
node_modules/.pnpm/expo-camera@1.0.0_react-native@0.86.0/node_modules/expo-camera/android
  -> node_modules/expo-camera/android
```

It is applied at the two places in `Hash.ts` where a path enters a hasher: the source id in `createFingerprintFromSourcesAsync`, and each child id in `createDirHashResultsAsync`.

Both are needed. With only the `createDirHashResultsAsync` site normalized, the dir hash is stable but the fingerprint hash still moves, because `createSourceId` feeds `source.filePath` straight into the top level hasher. Measured, that half fix gives:

```
  virtual store paths
    ✓ should return the same dir hash when only the store suffix changed (78 ms)
    ✕ should return the same fingerprint when only the store suffix changed (37 ms)

    expect(received).toEqual(expected) // deep equality

    Expected: "c37284669ae52db3a8124d15b6be62a4d54cfd3f"
    Received: "3adb115e28d48e8219cb43589aac3dfc418b6b44"
```

Only the store segment is collapsed, so path information still carries everywhere else and a real move or rename is still detected. A scoped package keeps its scope, a `../` prefix is kept, a genuinely nested `node_modules` inside a store package is left alone, and a path that merely contains `.pnpm` is returned unchanged. Sources keep their real path for reading files and for `debugInfo`.

The regex covers `.pnpm`, Bun's `.bun`, and Yarn's pnpm linker `.store`, matching the one #48704 adds to `normalizeFilePath` for ignore matching. If #48704 lands first I am happy to rebase and have the two share a single regex.

## Known gap

The `expoAutolinkingConfig:*` and `rncoreAutolinkingConfig:*` `contents` sources embed the same unstable paths inside their JSON (`project.sourceDir`, `pod.podspecDir`, `aarProject.projectDir`). Those are `contents` sources, so they do not go through this code. Fixing that means normalizing in the sourcer, which overlaps with #48661, so I left it out. Happy to follow up.

# Test Plan

`pnpm test` in `packages/@expo/fingerprint`.

New tests, 7 for the helper and 6 for the hashing behavior:

```
  virtual store paths
    ✓ should return the same dir hash when only the store suffix changed (3 ms)
    ✓ should return the same fingerprint when only the store suffix changed (2 ms)
    ✓ should still change the dir hash when a file is renamed (2 ms)
    ✓ should still change the dir hash when a file is moved into a subdirectory (2 ms)
    ✓ should still change the dir hash when a file moves out of a nested dependency (3 ms)
    ✓ should keep two store packages with identical contents apart (2 ms)

  normalizeVirtualStorePath
    ✓ should collapse a pnpm virtual store segment down to the package path
    ✓ should keep the scope of a scoped package
    ✓ should collapse the same shape for other isolated installers (1 ms)
    ✓ should keep a parent directory prefix
    ✓ should collapse every store segment of a nested workspace path
    ✓ should keep a real nested dependency inside a store package
    ✓ should leave paths that only look like a virtual store alone

Test Suites: 2 passed, 2 total
Tests:       53 passed, 53 total
```

Four of the six hashing tests assert that a hash still *changes*, so the suite is not vacuous: a rename, a move into a subdirectory, a file moving out of a nested `node_modules`, and two different store packages with byte identical contents.

Counterfactual, reverting only `Hash.ts` and keeping the helper and the tests:

```
  ● virtual store paths › should return the same dir hash when only the store suffix changed

    Expected: "956b8e556d4ff79d61596a0897f7f5aead403692"
    Received: "8b78e512a5842e6b411f9f2d1eeed754a57f8bc8"

  ● virtual store paths › should return the same fingerprint when only the store suffix changed

    Expected: "b35dbd278614baee52c7d623186b9b2a5f4737c6"
    Received: "277871f513f7a15c46bcf2eadab1b6ce1c3f13bb"

Tests:       2 failed, 51 passed, 53 total
```

Two failures, both on unequal hashes, and the four non-vacuity tests stay green because they assert inequality either way.

Whole package suite, run on this branch and on a clean `main` for comparison:

```
main         Tests: 12 failed, 141 passed, 153 total
this branch  Tests: 12 failed, 154 passed, 166 total
```

Same 8 failing suites before and after, so this adds 13 passing tests and breaks nothing. Those 8 pre-existing failures are in `Sourcer`, `Bare`, `Expo`, `Fingerprint`, `ProjectWorkflow`, `ExpoConfig`, `PatchPackage`, and `Fingerprint-filehook`, and are unrelated to paths.

`oxlint --config oxlint.config.mjs .` exits 0. `oxfmt --check` reports all four changed files correctly formatted. `tsc -b tsconfig.all.json` produces byte identical output before and after the change, with no diagnostic in any file I touched.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
