### PR TITLE
[cli] Cache the fingerprint runtime version resolved for the dev manifest

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
+- Cache the runtime version resolved for the dev server manifest, instead of re-running the `expo-updates` fingerprint on every request, and invalidate it when the file watcher observes a change ([#49289](https://github.com/expo/expo/pull/49289) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1484,6 +1484,15 @@ export class MetroBundlerDevServer extends BundlerDevServer {
         );
       }
 
+      // The manifest middleware caches the runtime version resolved by the `expo-updates` CLI,
+      // because resolving a fingerprint policy re-hashes the whole project in a subprocess and
+      // would otherwise run on every manifest request. We can't know exactly which files the
+      // fingerprint covers, so invalidate on any observed change rather than risk serving a
+      // stale runtime version.
+      observeAnyFileChanges({ metro, server }, () => {
+        manifestMiddleware.invalidateRuntimeVersionCache();
+      });
+
       // If React 19 is enabled, then add RSC middleware to the dev server.
       if (isReactServerComponentsEnabled) {
         this.bindRSCDevModuleInjectionHandler();

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -18,6 +18,7 @@ import type { ManifestRequestInfo } from './ManifestMiddleware';
 import { ManifestMiddleware } from './ManifestMiddleware';
 import { manifestDebugEvent } from './events';
 import { parseForwardedRequestInfo } from './resolveForwarded';
+import type { RuntimePlatform } from './resolvePlatform';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { resolveRuntimeVersionWithExpoUpdatesAsync } from './resolveRuntimeVersionWithExpoUpdatesAsync';
 import type { ServerRequest } from './server.types';
@@ -55,6 +56,24 @@ interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
 }
 
 export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
+  /**
+   * Runtime versions resolved by the `expo-updates` CLI, keyed by platform.
+   *
+   * Resolving a `{ policy: 'fingerprint' }` runtime version spawns an `expo-updates
+   * runtimeversion:resolve` subprocess that re-hashes the whole project, which takes
+   * seconds on a real app. Because it runs in a subprocess, nothing survives between
+   * requests, so every manifest request used to pay the full cost. Dev clients fetch the
+   * manifest before the bundle, and the iOS launcher times out well before a large
+   * project finishes fingerprinting.
+   *
+   * The pending promise is cached rather than the resolved value, so concurrent requests
+   * share a single subprocess instead of racing several of them.
+   *
+   * This is cleared by `invalidateRuntimeVersionCache` whenever the file watcher observes
+   * a change, so a cached value never outlives its inputs.
+   */
+  private runtimeVersionCache = new Map<RuntimePlatform, Promise<string | null>>();
+
   public getParsedHeaders(req: ServerRequest): ExpoGoManifestRequestInfo {
     let platform = parsePlatformHeader(req);
 
@@ -116,6 +135,37 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     return headers;
   }
 
+  /**
+   * Drop all cached runtime versions, forcing the next manifest request to resolve
+   * them again. Called when the file watcher observes any change in the project.
+   */
+  public invalidateRuntimeVersionCache(): void {
+    this.runtimeVersionCache.clear();
+  }
+
+  /** Resolve the runtime version through `expo-updates`, reusing an in-flight or cached result. */
+  private getRuntimeVersionWithExpoUpdatesAsync(platform: RuntimePlatform): Promise<string | null> {
+    const cached = this.runtimeVersionCache.get(platform);
+    if (cached) {
+      return cached;
+    }
+
+    const pending = Promise.resolve(
+      resolveRuntimeVersionWithExpoUpdatesAsync({ projectRoot: this.projectRoot, platform })
+    );
+    this.runtimeVersionCache.set(platform, pending);
+
+    // Never leave a failure cached, otherwise a transient error would be pinned for the
+    // rest of the dev server session.
+    pending.catch(() => {
+      if (this.runtimeVersionCache.get(platform) === pending) {
+        this.runtimeVersionCache.delete(platform);
+      }
+    });
+
+    return pending;
+  }
+
   public async _getManifestResponseAsync(
     requestOptions: ExpoGoManifestRequestInfo
   ): Promise<Response> {
@@ -123,10 +173,7 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
       await this._resolveProjectSettingsAsync(requestOptions);
 
     const runtimeVersion =
-      (await resolveRuntimeVersionWithExpoUpdatesAsync({
-        projectRoot: this.projectRoot,
-        platform: requestOptions.platform,
-      })) ??
+      (await this.getRuntimeVersionWithExpoUpdatesAsync(requestOptions.platform)) ??
       // if expo-updates can't determine runtime version, fall back to calculation from config-plugin.
       // this happens when expo-updates is installed but runtimeVersion hasn't yet been configured or when
       // expo-updates is not installed.

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -848,4 +848,121 @@ describe('_getManifestResponseAsync', () => {
 
     expect(partsSeen.has('manifest')).toBeTruthy();
   });
+
+  describe('runtime version caching', () => {
+    /** Request a manifest and fully consume the response so no stream is left dangling. */
+    async function requestManifestAsync(
+      middleware: ExpoGoManifestHandlerMiddleware,
+      platform: 'android' | 'ios' = 'android'
+    ) {
+      const response = await middleware._getManifestResponseAsync({
+        responseContentType: ResponseContentType.TEXT_PLAIN,
+        platform,
+        expectSignature: null,
+        hostname: 'localhost',
+      });
+      await response.text();
+      return response;
+    }
+
+    beforeEach(() => {
+      process.env.EXPO_OFFLINE = '1';
+      jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockClear();
+      jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('testrtv');
+    });
+
+    it('resolves the runtime version once for repeated sequential manifest requests', async () => {
+      const middleware = createMiddleware();
+
+      await requestManifestAsync(middleware);
+      await requestManifestAsync(middleware);
+      await requestManifestAsync(middleware);
+
+      // Resolving a fingerprint runtime version spawns a subprocess that re-hashes the
+      // whole project, so it must not run again while nothing has changed.
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves the runtime version once for concurrent manifest requests', async () => {
+      const middleware = createMiddleware();
+
+      await Promise.all([
+        requestManifestAsync(middleware),
+        requestManifestAsync(middleware),
+        requestManifestAsync(middleware),
+      ]);
+
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches the runtime version per platform', async () => {
+      const middleware = createMiddleware();
+
+      await requestManifestAsync(middleware, 'android');
+      await requestManifestAsync(middleware, 'ios');
+      await requestManifestAsync(middleware, 'android');
+      await requestManifestAsync(middleware, 'ios');
+
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ platform: 'android' })
+      );
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ platform: 'ios' })
+      );
+    });
+
+    it('resolves the runtime version again after the cache is invalidated', async () => {
+      const middleware = createMiddleware();
+
+      await requestManifestAsync(middleware);
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+
+      middleware.invalidateRuntimeVersionCache();
+
+      jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('changedrtv');
+      const response = await middleware._getManifestResponseAsync({
+        responseContentType: ResponseContentType.MULTIPART_MIXED,
+        platform: 'android',
+        expectSignature: null,
+        hostname: 'localhost',
+      });
+
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
+
+      const contentType = response.headers.get('content-type')!;
+      for await (const part of parseMultipart(response.body!, { contentType })) {
+        if (part.name === 'manifest') {
+          // The new value must be served, not the value cached before invalidation.
+          expect(await part.json()).toMatchObject({ runtimeVersion: 'changedrtv' });
+        }
+      }
+    });
+
+    it('does not cache a failed resolution', async () => {
+      const middleware = createMiddleware();
+
+      jest
+        .mocked(resolveRuntimeVersionWithExpoUpdatesAsync)
+        .mockRejectedValueOnce(new Error('expo-updates exploded'));
+
+      await expect(requestManifestAsync(middleware)).rejects.toThrow('expo-updates exploded');
+
+      // A transient failure must not be pinned for the rest of the dev server session.
+      await requestManifestAsync(middleware);
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not re-resolve when expo-updates reports no runtime version', async () => {
+      const middleware = createMiddleware();
+      jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue(null);
+
+      await requestManifestAsync(middleware);
+      await requestManifestAsync(middleware);
+
+      // `null` means expo-updates is absent or unconfigured, which is just as expensive
+      // to determine, so it is cached too and the config-plugin fallback is used.
+      expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
# Why

Fixes #46415.

With `runtimeVersion: { policy: "fingerprint" }`, the dev server resolves the runtime version by shelling out to `expo-updates runtimeversion:resolve`, which re-hashes the whole project with `@expo/fingerprint`. That happened on **every** manifest request, with no reuse between requests.

Because the resolver runs in a subprocess (`spawnAsync` in `src/utils/expoUpdatesCli.ts`), no in-process cache in `@expo/fingerprint` can survive between requests, so every request paid the full cold cost. Dev clients fetch the manifest before the bundle, and the iOS launcher times out well before a large project finishes fingerprinting, which is why this shows up as "Metro only works on Android".

I measured this on a blank SDK 57 app with `expo-updates` and the fingerprint policy, against `expo start`:

```
=== SEQUENTIAL: 5 manifest requests, one after another ===
manifest #1: 200 in 1.242849s
manifest #2: 200 in 0.617490s
manifest #3: 200 in 0.645583s
manifest #4: 200 in 0.722984s
manifest #5: 200 in 0.798277s
```

Five requests, five full fingerprints. Requests 2 to 5 never get cheaper, so this is waste on **sequential** requests, not just concurrent bursts. Firing the same five requests concurrently instead makes each one slower, because five fingerprint subprocesses compete for CPU:

```
=== CONCURRENT: 5 manifest requests fired at once ===
concurrent #1: 200 in 1.223848s
concurrent #2: 200 in 1.226151s
concurrent #5: 200 in 1.245720s
concurrent #3: 200 in 1.253635s
concurrent #4: 200 in 1.256338s
```

A blank app is cheap here. The cost scales with project size, which is where the reported timeouts come from.

# How

Cache the resolved runtime version per platform on `ExpoGoManifestHandlerMiddleware`, and clear it whenever Metro's file watcher observes a change.

The cache stores the **pending promise** rather than the resolved value, so concurrent requests share a single subprocess instead of racing several of them. A rejected resolution is removed from the cache so a transient failure is not pinned for the rest of the session. The key is platform only, since `projectRoot` is fixed for the middleware instance.

## On invalidation

A cache that never invalidates would be a bug here, so this is the part worth reviewing.

`ManifestMiddleware` re-reads `getConfig()` on every request today, so app config edits are picked up live. A cache that outlived those edits would serve a fresh `exp` next to a stale `runtimeVersion`. Invalidating from the watcher keeps those consistent.

I followed the precedent already in `MetroBundlerDevServer`, where the API route cache is invalidated from `observeAnyFileChanges` with the same reasoning: we cannot know exactly which files the computation depends on, so invalidate aggressively rather than risk staleness. Over-invalidating only costs a recompute, which is exactly today's behaviour, so the worst case here is no worse than before.

One thing worth flagging, because it contradicts a suggestion in the issue thread. The issue suggests invalidating on watched-file changes because "Metro already watches those". That is only partly true. I attached a probe to Metro's watcher and checked what it actually reports:

- observed: `app.json`, `package.json`, JS sources
- **not** observed: `ios/`, `android/`, or native sources inside `node_modules`

So this covers app config and dependency changes, including installing a native module (which touches `package.json`), but a mid-session `expo prebuild` or a hand edit to `ios/`/`android/` is not observed and would need a dev server restart. That matches how `metro.config.js` and `babel.config.js` are already handled via `FileNotifier` ("Restart the server to see the new results"). I kept the scope here rather than adding a second watcher for the native directories, but I am happy to extend it if you would prefer that.

# Test Plan

Added tests to `ExpoGoManifestHandlerMiddleware-test.ts` covering sequential reuse, concurrent de-duplication, per-platform keying, invalidation, and not caching failures.

```
  _getManifestResponseAsync
    runtime version caching
      ✓ resolves the runtime version once for repeated sequential manifest requests (1 ms)
      ✓ resolves the runtime version once for concurrent manifest requests (1 ms)
      ✓ caches the runtime version per platform (1 ms)
      ✓ resolves the runtime version again after the cache is invalidated (1 ms)
      ✓ does not cache a failed resolution (5 ms)
      ✓ does not re-resolve when expo-updates reports no runtime version (1 ms)

Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
```

Reverting only the source change and keeping the new tests fails for the right reason, the resolver running more times than expected:

```
  ● runtime version caching › resolves the runtime version once for repeated sequential manifest requests
    Expected number of calls: 1
    Received number of calls: 3
  ● runtime version caching › resolves the runtime version once for concurrent manifest requests
    Expected number of calls: 1
    Received number of calls: 3
  ● runtime version caching › caches the runtime version per platform
    Expected number of calls: 2
    Received number of calls: 4
  ● runtime version caching › does not re-resolve when expo-updates reports no runtime version
    Expected number of calls: 1
    Received number of calls: 2

Tests:       5 failed, 18 passed, 23 total
```

For completeness: `does not cache a failed resolution` passes with and without the fix, since with no cache there is nothing to pin. It is a guard on the implementation rather than a proof of the fix.

Full package suite, type check, lint, and format:

```
Test Suites: 244 passed, 244 total
Tests:       7 skipped, 1944 passed, 1951 total

$ tsc -p tsconfig.json      # exit 0
$ oxlint --config oxlint.config.mjs .   # exit 0
$ oxfmt --check .
All matched files use the correct format.
```

The existing `MetroBundlerDevServer-test.ts` is unchanged and still passes 13/13.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
