### PR TITLE
[docs] Update text style in Footer

### DIFF
--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -106,12 +106,12 @@ export const Footer = ({
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
             <LlmsTxtLink />
             {!isDev && shouldShowModifiedDate && modificationDate && (
-              <LI className="mt-4! text-xs! text-quaternary!">
+              <LI className="mt-4! text-xs! text-tertiary!">
                 Last updated on <time dateTime={modificationDate}>{modificationDate}</time>
               </LI>
             )}
             {isDev && shouldShowModifiedDate && (
-              <LI className="mt-4! text-xs! text-quaternary!">
+              <LI className="mt-4! text-xs! text-tertiary!">
                 Last updated data is not available in dev mode
               </LI>
             )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26117
# How

<!--
How did you build this feature or fix this bug and why?
-->

Update text style in Footer.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Only the color of the last update line changed here:

<img width="808" height="484" alt="CleanShot 2026-08-24 at 16 08 22@2x" src="https://github.com/user-attachments/assets/49b1084b-97ad-4476-84f7-f7345d16dec1" />

<img width="1038" height="542" alt="CleanShot 2026-08-24 at 16 10 28@2x" src="https://github.com/user-attachments/assets/11b23644-754e-4536-ad6e-78e9474c046b" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
