### PR TITLE
[docs] Fix code syntax token contrast by using palette text steps

### DIFF
--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -23,9 +23,10 @@ import { CodeSelectionCopy } from '~/ui/components/Snippet/CodeSelectionCopy';
 import { StructuredData } from '~/ui/components/StructuredData';
 import * as Tooltip from '~/ui/components/Tooltip';
 import '~/common/suppress-trailing-slash-warning';
-import '~/styles/global.css';
 import '@expo/styleguide/dist/expo-theme.css';
 import '@expo/styleguide-search-ui/dist/expo-search-ui.css';
+
+import '~/styles/global.css';
 
 const isDev = process.env.NODE_ENV === 'development';
 

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -267,12 +267,12 @@ div.tippy-box {
 .token.prolog,
 .token.doctype,
 .token.cdata {
-  @apply text-palette-gray10;
+  @apply text-palette-gray11;
 }
 
 .token.operator,
 .token.punctuation {
-  @apply text-palette-gray9;
+  @apply text-palette-gray11;
 }
 
 .token.attr-name,
@@ -281,7 +281,7 @@ div.tippy-box {
 .token.constant,
 .token.symbol,
 .token.deleted {
-  @apply text-palette-red10;
+  @apply text-palette-red11;
 }
 
 .token.selector,
@@ -289,7 +289,7 @@ div.tippy-box {
 .token.builtin,
 .token.script,
 .token.inserted {
-  @apply text-palette-green10;
+  @apply text-palette-green11;
 }
 
 .token.entity,
@@ -298,7 +298,7 @@ div.tippy-box {
 }
 
 .token.keyword {
-  @apply text-palette-pink10;
+  @apply text-palette-pink11;
 }
 
 .token.property,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26118

# How

<!--
How did you build this feature or fix this bug and why?
-->
Fix code syntax token contrast by using palette text steps.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Run docs app locally.
- Open any page with a code block, like `/versions/latest/sdk/calendar/`, and check that punctuation, comments and keywords read darker and clearer in both light and dark themes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
