### PR TITLE
[docs] Fix link contrast on inline-code backgrounds

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -6,17 +6,15 @@
 /* Selectors are doubled to outrank the same-specificity declarations in
    @expo/styleguide/dist/expo-theme.css, which _app.tsx imports after this file. */
 :root:root {
-  /* AA contrast on the inline-code backgrounds, where text-link falls short */
+  /* AA contrast on inline-code and blue3/blue4 backgrounds, where text-link falls
+     short. blue4 clears by 0.02, so do not lighten this. */
   --expo-theme-text-link: #0c6bbf;
-  /* AA contrast on palette blue3/blue4 backgrounds, where text-link falls short */
-  --expo-theme-text-link-on-blue: #0c6bbf;
   /* AA contrast: styleguide maps tertiary text to slate-10, a solid-background step */
   --expo-theme-text-tertiary: #686c75;
 }
 
 .dark-theme.dark-theme {
   --expo-theme-text-link: var(--blue-11);
-  --expo-theme-text-link-on-blue: var(--blue-11);
   --expo-theme-text-tertiary: #888c94;
 }
 

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -6,6 +6,8 @@
 /* Selectors are doubled to outrank the same-specificity declarations in
    @expo/styleguide/dist/expo-theme.css, which _app.tsx imports after this file. */
 :root:root {
+  /* AA contrast on the inline-code backgrounds, where text-link falls short */
+  --expo-theme-text-link: #0c6bbf;
   /* AA contrast on palette blue3/blue4 backgrounds, where text-link falls short */
   --expo-theme-text-link-on-blue: #0c6bbf;
   /* AA contrast: styleguide maps tertiary text to slate-10, a solid-background step */
@@ -13,6 +15,7 @@
 }
 
 .dark-theme.dark-theme {
+  --expo-theme-text-link: var(--blue-11);
   --expo-theme-text-link-on-blue: var(--blue-11);
   --expo-theme-text-tertiary: #888c94;
 }

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -32,9 +32,6 @@ module.exports = {
     borderColor: {
       'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
     },
-    textColor: {
-      'link-on-blue': 'var(--expo-theme-text-link-on-blue)',
-    },
     backgroundImage: {
       'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
       'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -39,7 +39,7 @@ export const SidebarSingleEntry = ({
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-sm',
             isActive &&
-              'bg-palette-blue3! font-medium text-link-on-blue hocus:bg-palette-blue4! hocus:text-link-on-blue'
+              'bg-palette-blue3! font-medium text-link hocus:bg-palette-blue4! hocus:text-link'
           )}
           {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
           {...(isActive && mainSection && { 'data-main-section': mainSection })}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26119

# How

<!--
How did you build this feature or fix this bug and why?
-->
Fix link contrast on inline-code backgrounds

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2376" height="1678" alt="CleanShot 2026-08-24 at 17 09 04@2x" src="https://github.com/user-attachments/assets/c6245373-3154-454f-89c9-0d6fad811d69" />

<img width="2374" height="1650" alt="CleanShot 2026-08-24 at 17 10 18@2x" src="https://github.com/user-attachments/assets/b2fadd5c-4190-4568-b4c1-378d149d772d" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
