### PR TITLE
[docs]  Darken three syntax token colours to meet AA on the code background

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -312,18 +312,18 @@ div.tippy-box {
 .token.regex,
 .token.important,
 .token.tag {
-  @apply text-palette-orange11;
+  @apply text-[#c24900] dark:text-palette-orange11;
 }
 
 .token.number,
 .token.string {
-  @apply text-palette-yellow11;
+  @apply text-[#a65e00] dark:text-palette-yellow11;
 }
 
 .token.url,
 .token.literal-property,
 .token.property-access {
-  @apply text-palette-blue11;
+  @apply text-[#006fd7] dark:text-palette-blue11;
 }
 
 .token.important {


### PR DESCRIPTION

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26120

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Darken three syntax token colors to meet AA on the code background

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1446" height="840" alt="eng-26120-syntax-token-contrast-after" src="https://github.com/user-attachments/assets/4b079ee5-a47c-404e-b45f-4b91add5acdc" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
