### PR TITLE
[docs] Darken TOC entries so deprecated items meet AA contrast

### DIFF
--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -52,10 +52,10 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
             )}>
             <TitleElement
               className={mergeClasses(
-                'w-full text-secondary! hocus:text-link!',
+                'w-full text-default! hocus:text-link!',
                 isCodeOrFilePath && 'truncate text-xs!',
                 isActive && 'text-link!',
-                isDeprecated && 'line-through opacity-80'
+                isDeprecated && 'line-through opacity-70'
               )}>
               {displayTitle}
               {hasOverloads && (

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
           href="#base-level-heading"
         >
           <p
-            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full text-secondary! hocus:text-link!"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full text-default! hocus:text-link!"
             data-text="true"
           >
             Base level heading
@@ -92,7 +92,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
           href="#level-3-subheading"
         >
           <p
-            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full text-secondary! hocus:text-link!"
+            class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] w-full text-default! hocus:text-link!"
             data-text="true"
           >
             Level 3 subheading
@@ -109,7 +109,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
           href="#code-heading-depth-1"
         >
           <code
-            class="leading-[1.6154] text-inherit w-full text-secondary! hocus:text-link! truncate text-xs!"
+            class="leading-[1.6154] text-inherit w-full text-default! hocus:text-link! truncate text-xs!"
             data-text="true"
           >
             Code heading depth 1


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26122

# How

<!--
How did you build this feature or fix this bug and why?
-->

Darken TOC entries so deprecated items meet AA contrast.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="530" height="1302" alt="CleanShot 2026-08-24 at 19 17 40@2x" src="https://github.com/user-attachments/assets/b4cbc18d-31cc-4ed2-8b56-6be16c20a8ce" />

<img width="536" height="1326" alt="CleanShot 2026-08-24 at 19 17 45@2x" src="https://github.com/user-attachments/assets/4095e03e-4b73-4f8a-86c5-acc47395265e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
