### PR TITLE
[cli][server] Fix CorsMiddleware local-hostname regex allowing non-loopback origins

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `CorsMiddleware`'s local-hostname check to require a literal dot between IPv4 octets, instead of an unescaped regex wildcard that let non-loopback hostnames starting with `127` (e.g. `127a1b1c1`) bypass the dev server's cross-origin request guard.
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/start/server/middleware/CorsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/CorsMiddleware.ts
@@ -37,7 +37,7 @@ export const _isLocalHostname = (hostname: string) => {
   }
   if (maybeIp === '::1') {
     return true;
-  } else if (/^127(?:.\d+){3}$/.test(maybeIp)) {
+  } else if (/^127(?:\.\d+){3}$/.test(maybeIp)) {
     return maybeIp.split('.').every((part) => {
       const num = parseInt(part, 10);
       return num >= 0 && num <= 255;

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/CorsMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/CorsMiddleware-test.ts
@@ -220,4 +220,9 @@ describe(_isLocalHostname, () => {
     expect(_isLocalHostname('localghost')).toBe(false);
     expect(_isLocalHostname('example.com')).toBe(false);
   });
+
+  it('rejects dot-free hostnames that merely start with 127', () => {
+    expect(_isLocalHostname('127a1b1c1')).toBe(false);
+    expect(_isLocalHostname('127x999x999x999')).toBe(false);
+  });
 });


### PR DESCRIPTION
# Why

Fixes #49301.

`_isLocalHostname` in `packages/@expo/cli/src/start/server/middleware/CorsMiddleware.ts` is meant to match only `localhost`, `::1`, and IPv4 addresses in `127.0.0.0/8` (dotted-quad form, optionally `::ffff:`-prefixed). Its regex, `/^127(?:.\d+){3}$/`, has an unescaped `.` where a literal dot between octets was intended, so `.` matches any character instead. The follow-up validation (`maybeIp.split('.').every(part => parseInt(part, 10) <= 255 ...)`) doesn't catch this either: splitting a dot-free string just returns the whole string as one element, and `parseInt` truncates at the first non-digit rather than failing.

Net effect: any hostname shaped like `127<char><digits><char><digits><char><digits>` (e.g. `127a1b1c1`, no dots required) is classified as local:

```js
_isLocalHostname('127a1b1c1') // true, should be false
```

This function backs `isLocalhost` in `createCorsMiddleware`, which is OR'd into the check that lets a cross-origin request past the dev server's `Unauthorized request` rejection — its whole stated purpose is to block non-dev-server origins. A hostname matching the loose pattern above bypasses that rejection even though it isn't the local dev server or a loopback address.

# How

Escaped the dot: `/^127(?:\.\d+){3}$/`. That alone is enough to make the subsequent `split('.')`/`parseInt` octet check operate only on genuinely dotted input, since the regex now requires 3 literal-dot-separated digit groups before that code ever runs.

# Test Plan

Added a red/green test in `CorsMiddleware-test.ts` (`rejects dot-free hostnames that merely start with 127`) covering `127a1b1c1` and `127x999x999x999`. Confirmed it fails against the pre-fix regex and passes after the fix; all existing `_isLocalHostname` and `createCorsMiddleware` tests (dotted IPs, IPv6, `localhost`, devtools, forwarded-host cases) still pass.

Ran `et check-packages @expo/cli` — build, typecheck, depscheck, test, lint, and format all pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — n/a, dev-server-only middleware, no native/config-plugin surface.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
