### PR TITLE
[cli][server] Fix Content-Length header in JS inspector middleware for non-ASCII response bodies

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `createJsInspectorMiddleware`'s `Content-Length` header to reflect the UTF-8 byte length of the response, instead of its UTF-16 string length, which undersized the header for any inspector app metadata (e.g. a device name) containing non-ASCII characters.
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
@@ -108,6 +108,25 @@ describe('createJsInspectorMiddleware', () => {
     expect(JsInspector.queryInspectorAppAsync).not.toHaveBeenCalled();
   });
 
+  it('should set Content-Length to the byte length of the response, not its UTF-16 string length', async () => {
+    const app = { ...METRO_INSPECTOR_RESPONSE_FIXTURE[0]!, deviceName: 'José’s iPhone 📱' };
+    const req = createRequest(`http://localhost:8081/inspector?applicationId=${app.description}`);
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(app));
+
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    const body = JSON.stringify(app);
+    const headers = res.writeHead.mock.calls[0][1];
+    expect(Number(headers['Content-Length'])).toBe(Buffer.byteLength(body, 'utf8'));
+  });
+
   it('should open browser for PUT request with given applicationId', async () => {
     const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0]!;
     const req = createRequest(

--- a/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
@@ -47,7 +47,7 @@ export function createJsInspectorMiddleware({
       res.writeHead(200, {
         'Content-Type': 'application/json; charset=UTF-8',
         'Cache-Control': 'no-cache',
-        'Content-Length': data.length.toString(),
+        'Content-Length': Buffer.byteLength(data, 'utf8').toString(),
       });
       res.end(data);
     } else if (req.method === 'POST' || req.method === 'PUT') {


### PR DESCRIPTION
# Why

`createJsInspectorMiddleware`'s `GET` handler (`packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts`) serves inspector app metadata as JSON and sets:

```ts
const data = JSON.stringify(app);
res.writeHead(200, {
  'Content-Type': 'application/json; charset=UTF-8',
  'Cache-Control': 'no-cache',
  'Content-Length': data.length.toString(),
});
res.end(data);
```

`data.length` is the JS string's length in UTF-16 code units, not its size in bytes. `res.end(data)` writes the string UTF-8-encoded (the default for Node's `http` module and consistent with the declared `charset=UTF-8`). Any multi-byte character in the response — e.g. a connected device's name with an accent or emoji, which is metadata from the client, not something Expo CLI controls — makes the UTF-8 byte length larger than the declared `Content-Length`:

```js
const data = JSON.stringify({ title: 'café ☕ App' });
data.length                        // 22 (UTF-16 code units)
Buffer.byteLength(data, 'utf8')    // 25 (actual bytes written)
```

An undersized `Content-Length` is invalid HTTP framing: the client either truncates the body before the trailing bytes or, on a persistent connection, mistakes the leftover bytes for the start of the next response. This surfaced while investigating an unrelated HTTP-framing report in #49111, where it was noted in passing as a separate, pre-existing defect in this file — this PR addresses that specific issue.

# How

Use `Buffer.byteLength(data, 'utf8')` instead of `data.length` to compute `Content-Length`.

# Test Plan

Added a red/green test (`should set Content-Length to the byte length of the response, not its UTF-16 string length`) in `createJsInspectorMiddleware-test.ts`, using an app fixture with a non-ASCII `deviceName`. Confirmed it fails against `data.length` and passes with `Buffer.byteLength`; all other tests in the file still pass.

Ran `et check-packages @expo/cli` — build, typecheck, depscheck, test, lint, and format all pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — n/a, dev-server-only middleware, no native/config-plugin surface.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
