### PR TITLE
[ui] Reference the TextInputState declaration so consumers typecheck

### DIFF
--- a/packages/expo-ui/src/keyboard/textInputState.ts
+++ b/packages/expo-ui/src/keyboard/textInputState.ts
@@ -1,1 +1,2 @@
+/// <reference path="../ts-declarations/react-native-text-input-state.d.ts" />
 export { default as TextInputState } from 'react-native/Libraries/Components/TextInput/TextInputState';


### PR DESCRIPTION
# Why

Expo router is failing at check packages step - https://github.com/expo/expo/actions/runs/32749280254/job/97502111587

```
Error: expo-router#typecheck: command (/home/runner/work/expo/expo/packages/expo-router) /home/runner/setup-pnpm/node_modules/.bin/bin/pnpm run typecheck exited (2)
 ERROR  expo-router#typecheck: command (/home/runner/work/expo/expo/packages/expo-router) /home/runner/setup-pnpm/
```

Caused by https://github.com/expo/expo/pull/48788

React Native ships `Libraries/Components/TextInput/TextInputState` as JS only, so the deep import needs the ambient declaration in `src/ts-declarations`. That declaration reached expo-ui's own program only through its `include` glob, and a `declare module` block applies solely inside the program that contains it.

`customConditions: ["expo-source"]` makes every monorepo consumer resolve `@expo/ui` to source, so expo-router compiled `keyboard/textInputState.ts` without ever pulling the declaration in, and failed with TS7016.



<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How


Reference the declaration from the module that needs it, the way `expo-modules-core/src/NativeViewManagerAdapter.native.tsx` does, so the types travel with the import instead of relying on the owning package's tsconfig.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Check packages passes

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
