### PR TITLE
fix(dev-launcher): [iOS] stop Bonjour discovery when an app launch starts

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Stop `_expo._tcp` discovery when an app launch starts, and don't start it while an app is loading or running, so the browse no longer runs alongside a launch that already knows the server address. ([#49308](https://github.com/expo/expo/pull/49308) by [@saileshbro](https://github.com/saileshbro))
 - [Android] Fix SIGABRT when loading a development server URL that has no path (e.g. `http://192.168.1.2:8081`): Android's `URI.resolve` omits the path separator for an empty-path base, so the first segment of a relative `bundleUrl` was spliced onto the port and the resulting authority failed to parse. ([#48625](https://github.com/expo/expo/pull/48625) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -24,6 +24,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/** Posted when a `loadApp:` launch begins, from any entry point (deep link, initial URL, launcher UI). */
+extern NSNotificationName const EXDevLauncherAppLoadingDidStartNotification;
+
 @class EXAppContext;
 @class EXDevLauncherInstallationIDHelper;
 @class EXDevLauncherPendingDeepLinkRegistry;
@@ -78,6 +81,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSURL *)appManifestURLWithFallback;
 
 - (BOOL)isAppRunning;
+
+/** YES while a `loadApp:` launch is in flight. */
+- (BOOL)isLoadingApp;
 
 - (UIWindow * _Nullable)currentWindow;
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -44,6 +44,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 @property (nonatomic, strong) NSURL *manifestURL;
 @property (nonatomic, strong) NSURL *possibleManifestURL;
 @property (nonatomic, strong) EXDevLauncherErrorManager *errorManager;
+@property (nonatomic, assign) BOOL isLoadingApp;
 @property (nonatomic, strong) EXDevLauncherInstallationIDHelper *installationIDHelper;
 @property (nonatomic, strong, nullable) EXDevLauncherNetworkInterceptor *networkInterceptor;
 @property (nonatomic, strong) DevLauncherViewController *devLauncherViewController;
@@ -55,6 +56,8 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
 @end
 
+
+NSNotificationName const EXDevLauncherAppLoadingDidStartNotification = @"EXDevLauncherAppLoadingDidStart";
 
 @implementation EXDevLauncherController
 
@@ -407,6 +410,8 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   EXDevLauncherUrl *devLauncherUrl = [[EXDevLauncherUrl alloc] init:url];
   NSURL *expoUrl = devLauncherUrl.url;
   _possibleManifestURL = expoUrl;
+  _isLoadingApp = YES;
+  [[NSNotificationCenter defaultCenter] postNotificationName:EXDevLauncherAppLoadingDidStartNotification object:self];
   BOOL isEASUpdate = [self isEASUpdateURL:expoUrl];
 
   // an update url requires a matching projectUrl
@@ -508,6 +513,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
   __block BOOL shouldRetry = YES;
   [manifestParser isManifestURLWithCompletion:onIsManifestURL onError:^(NSError * _Nonnull error) {
+    self->_isLoadingApp = NO;
     // Try to retry if the network connection was rejected because of the lack of the lan network permission.
     NSString *host = expoUrl.host;
 
@@ -535,6 +541,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   self.manifest = manifest;
   self.manifestURL = appUrl;
   _possibleManifestURL = nil;
+  _isLoadingApp = NO;
   __block UIColor *backgroundColor = [EXDevLauncherManifestHelper hexStringToColor:manifest.iosOrRootBackgroundColor];
 
   __weak __typeof(self) weakSelf = self;
@@ -611,6 +618,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 - (BOOL)isAppRunning
 {
   return [self.delegate isReactInstanceValid];
+}
+
+- (BOOL)isLoadingApp
+{
+  return _isLoadingApp;
 }
 
 #if !TARGET_OS_OSX

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -133,6 +133,19 @@ class DevLauncherViewModel: ObservableObject {
     loadData()
     checkAuthenticationStatus()
     checkForStoredCrashes()
+
+    // A launch can start without going through this view model — a deep link or an initial URL
+    // reaches `EXDevLauncherController.loadApp` directly — so stop discovery from the launch
+    // itself rather than only from `openApp(url:)`.
+    NotificationCenter.default.addObserver(
+      forName: .EXDevLauncherAppLoadingDidStart,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      MainActor.assumeIsolated {
+        self?.stopServerDiscovery()
+      }
+    }
   }
 
   private func updateDevServers(_ servers: [DevServer]) {
@@ -269,7 +282,13 @@ class DevLauncherViewModel: ObservableObject {
   }
 
   func startServerDiscovery() {
-    if browser != nil {
+    // Don't browse while an app is loading or already running — the launcher UI that consumes
+    // the results isn't on screen, and the browse's mDNS resolution runs alongside the launch.
+    // Discovery restarts when the launcher UI reappears.
+    if isLoadingServer
+      || browser != nil
+      || EXDevLauncherController.sharedInstance().isLoadingApp()
+      || EXDevLauncherController.sharedInstance().isAppRunning() {
       return
     }
 


### PR DESCRIPTION
# Why

Fixes #49307.

The launcher's `_expo._tcp` browse populates the "Development servers" list in the launcher UI.
Once an app launch begins, it has no consumer — but nothing stops it:

- `startServerDiscovery()` guards only on `browser != nil`, not on a launch being in flight or an
  app already running.
- A launch from a deep link or `--initialUrl` never goes through `DevLauncherViewModel` at all —
  `onDeepLink:` calls `EXDevLauncherController.loadApp` directly — so on a cold deep-link launch the
  launcher UI has already started a browse and nothing tells it to stop.

So the browse keeps resolving, on every interface, alongside a launch whose server address is
already known.

# How

- `loadApp:` posts `EXDevLauncherAppLoadingDidStartNotification`; `DevLauncherViewModel` observes it
  and cancels discovery. Driving this from the launch itself covers every entry point (deep link
  cold and warm, `--initialUrl`, launcher UI), which a check inside `openApp(url:)` does not.
- `startServerDiscovery()` additionally returns early while a launch is in flight or an app is
  running. It restarts when the launcher UI reappears, which is the only place the results are shown.
- `EXDevLauncherController` exposes `isLoadingApp`, mirroring the existing `isAppRunning`.

# Test Plan

Stock SDK 57 app + `expo-dev-client@57.0.15` on an iOS 26.4 simulator, Metro on loopback, launched
by deep link, measured from the simulator's unified log. Repro and script:
https://github.com/saileshbro/repro-dev-launcher-49249 (`repro-bonjour.sh`). 3 runs each:

| build | browse running during the launch | launch → bundle GET |
| - | - | - |
| stock | 0.452s / 0.236s / 0.420s | 0.951 / 0.878 / 0.919s |
| this PR | **0.000s / 0.000s / 0.000s** (cancelled ~3ms before the launch's first request) | 1.057 / 0.933 / 1.037s |

Being explicit about what this does and doesn't buy: **the launch is not measurably faster**, on
loopback or on a LAN. The change removes work that has no consumer.

On a LAN address (`--host lan`, 4 runs per cell, same two builds) the mDNS resolver's query timer —
`nw_resolver_start_query_timer_block_invoke Query fired: did not receive all answers in time` —
fires in 2 of 8 stock runs and 0 of 8 patched runs, and on the cold `--initialUrl` path the patched
build never creates a browse at all. But in the runs where it fired it fired ~1.6s *after* the
bundle GET, i.e. concurrent with the launch rather than blocking it, and launch → bundle is
indistinguishable between the builds (1.26–2.21s stock vs 1.35–2.41s patched over 16 runs). An
earlier "~2s per launch" figure I quoted came from a trace of a much larger app where the timeout
completed before the bundle request; I have no measurement that establishes the launch was waiting
on it, so please read this as removing concurrent work, not latency.

Also checked: returning to the launcher restarts discovery and the dev server still appears in the
list.

**Not covered:** Android — this is iOS-only and I haven't looked at whether the Android discovery
path has the same behaviour.
