### PR TITLE
[updates][ios] Harden embedded-asset copy against interruption

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,7 +25,7 @@
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))
 - [Android] Register the embedded update in a single transaction. An interrupted registration previously left an update row with no launch asset, which is treated as launchable and then fails every cold start with "Launch asset not found for update"; it now leaves no row, so the next launch registers it cleanly. ([#49130](https://github.com/expo/expo/pull/49130) by [@gwdp](https://github.com/gwdp))
 - [Android] Apply `reactNativeArchitectures` as a CMake ABI filter so single-ABI builds no longer compile the native code for unused ABIs. ([#49299](https://github.com/expo/expo/pull/49299) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Harden the embedded-asset copy when `EX_UPDATES_COPY_EMBEDDED_ASSETS` is enabled: stage the copy through a temp sibling and rename it into place, and size-check a cached embedded launch asset against its app-binary source, so an interrupted copy can neither strand a truncated bundle at the launch path nor survive being read there. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@spsaucier](https://github.com/spsaucier))
+- [iOS] Harden the embedded-asset copy when `EX_UPDATES_COPY_EMBEDDED_ASSETS` is enabled: stage the copy through a temp sibling and rename it into place, and size-check a cached embedded launch asset against its app-binary source, so an interrupted copy can neither strand a truncated bundle at the launch path nor survive being read there. ([#49310](https://github.com/expo/expo/pull/49310) by [@spsaucier](https://github.com/spsaucier))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))
 - [Android] Register the embedded update in a single transaction. An interrupted registration previously left an update row with no launch asset, which is treated as launchable and then fails every cold start with "Launch asset not found for update"; it now leaves no row, so the next launch registers it cleanly. ([#49130](https://github.com/expo/expo/pull/49130) by [@gwdp](https://github.com/gwdp))
 - [Android] Apply `reactNativeArchitectures` as a CMake ABI filter so single-ABI builds no longer compile the native code for unused ABIs. ([#49299](https://github.com/expo/expo/pull/49299) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Harden the embedded-asset copy when `EX_UPDATES_COPY_EMBEDDED_ASSETS` is enabled: stage the copy through a temp sibling and rename it into place, and size-check a cached embedded launch asset against its app-binary source, so an interrupted copy can neither strand a truncated bundle at the launch path nor survive being read there. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@spsaucier](https://github.com/spsaucier))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -281,9 +281,41 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     }
   }
 
+  /// Resolves an asset's source path inside the app binary, or nil when it has none.
+  /// Assets read back from SQLite never carry `mainBundleFilename` -- the assets table has no such
+  /// column -- so the embedded counterpart is matched on `key` instead.
+  private func bundledSourcePath(forAsset asset: UpdateAsset) -> String? {
+    guard let embeddedManifest = EmbeddedAppLoader.embeddedManifest(withConfig: config, database: database),
+      let matchingAsset = embeddedManifest.assets()?.first(where: { $0.key != nil && $0.key == asset.key }),
+      matchingAsset.mainBundleFilename != nil else {
+      return nil
+    }
+    return UpdatesUtils.path(forBundledAsset: matchingAsset)
+  }
+
+  private func fileSize(at url: URL) -> Int? {
+    return (try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize
+  }
+
+  /// A partially copied launch asset satisfies `fileExists` forever, and `ErrorRecovery` cannot
+  /// relaunch out of it once the update has one successful launch, so its size is also compared
+  /// against the app-binary source that produced it. Falls back to accepting the cached file
+  /// whenever no source is resolvable, since there is then nothing authoritative to compare to.
+  private func isCachedLaunchAssetComplete(_ asset: UpdateAsset, at assetLocalUrl: URL) -> Bool {
+    var isComplete = true
+    if asset.isLaunchAsset,
+      let bundlePath = bundledSourcePath(forAsset: asset),
+      let sourceSize = fileSize(at: URL(fileURLWithPath: bundlePath)),
+      let cachedSize = fileSize(at: assetLocalUrl) {
+      isComplete = sourceSize == cachedSize
+    }
+    return isComplete
+  }
+
   private func checkExistence(ofAsset asset: UpdateAsset, withLocalUrl assetLocalUrl: URL, completion: @escaping (Bool) -> Void) {
     FileDownloader.assetFilesQueue.async {
       let exists = FileManager.default.fileExists(atPath: assetLocalUrl.path)
+        && self.isCachedLaunchAssetComplete(asset, at: assetLocalUrl)
       self.launcherQueue.async {
         completion(exists)
       }
@@ -316,12 +348,19 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
           return
         }
 
+        // Staged through a sibling temp file and renamed into place, so an interrupted copy cannot
+        // leave a truncated asset at the launch path where every later existence check accepts it.
+        let stagingUrl = assetLocalUrl.deletingLastPathComponent()
+          .appendingPathComponent(".tmp-\(UUID().uuidString)-\(assetLocalUrl.lastPathComponent)")
         do {
-          try FileManager.default.copyItem(atPath: bundlePath, toPath: assetLocalUrl.path)
+          try FileManager.default.copyItem(atPath: bundlePath, toPath: stagingUrl.path)
+          try? FileManager.default.removeItem(at: assetLocalUrl)
+          try FileManager.default.moveItem(at: stagingUrl, to: assetLocalUrl)
           self.launcherQueue.async {
             completion(true, nil)
           }
         } catch {
+          try? FileManager.default.removeItem(at: stagingUrl)
           self.launcherQueue.async {
             completion(
               false,


### PR DESCRIPTION
# Why

`AppLauncherWithDatabase` copies an embedded asset into the updates cache with a bare, non-atomic `copyItem` straight to its final path:

https://github.com/expo/expo/blob/main/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift#L320

If that copy is interrupted, a truncated file is left at exactly the path every subsequent launch reads. Nothing downstream can detect it, because every later check is existence-only — `checkExistence` (`AppLauncherWithDatabase.swift:286`), `AppLoader.swift:244`, and `UpdatesDatabaseIntegrityCheck.swift:38` all just call `fileExists`. `AppLoader.swift` already carries a `TODO` naming this assumption:

> `// TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset`

When the truncated file is the launch asset, Hermes fails to compile it and the app aborts in the first second:

```
RCTFatalException: Unhandled JS Exception: [runtime not ready]: Error: Non-js exception:
Compiling JS failed: Buffer is smaller than the size stated in the file header.
Expected at least 1570550 bytes but got 786432 bytes,
sourceURL: .../Library/Application Support/.expo-internal/bundle-<updateId>.jsbundle
```

**The device cannot recover on its own.** Because the update already had one successful launch, `successfulLaunchCount > 0`, so `ErrorRecovery.startPipeline` removes `.launchCached` from the pipeline entirely and never increments `failed_launch_count` (`ErrorRecovery.swift:159-164`). The pipeline degenerates to `.waitForRemoteUpdate -> .crash`. A symbolicated crash confirms it — the stack goes `notify -> runNextTask -> crash()` with no `tryRelaunchFromCache` frame anywhere. Deleting and reinstalling the app is the only way out.

## Scope on `main` today

I want to be accurate about how much this matters here, because #47284 substantially narrowed it.

With `shouldCopyEmbeddedAssets()` defaulting to `false`, `markUpdateFinished` now keeps the embedded update at `StatusEmbedded`, `ensureAllAssetsExist` takes the app-binary shortcut, and this copy path is never entered. **So on `main`, by default, the bug described above is already unreachable.**

It is still reachable in two places:

- on `main`, for anyone who sets `EX_UPDATES_COPY_EMBEDDED_ASSETS`, which is a supported configuration;
- unconditionally on every released SDK — 56 and 57 both copy on the first launch of a new binary with no opt-out.

So this is hardening of a path that is now opt-in, not an urgent fix for current `main`. It felt worth sending anyway because the failure mode is unrecoverable-without-reinstall, the fix is small and local, and #49130 recently fixed the same *class* of problem on Android (an interrupted embedded registration leaving permanently unlaunchable state).

# How

Two changes, both in `AppLauncherWithDatabase.swift`:

1. **`maybeCopyAssetFromMainBundle` stages the copy.** Copy to a sibling temp file, then rename into place, removing any existing destination first. An interrupted copy now leaves nothing at the launch path. The existing error type and completion shape are unchanged.

2. **`checkExistence` size-checks a cached embedded launch asset** against its app-binary source and returns `false` on a mismatch, so `ensureAssetExists` re-copies it. This is what repairs an install that is already broken.

Two notes on the design:

**Size, not hash.** The embedded manifest sets no `expectedHash` (`EmbeddedUpdate.swift:31`), and the DB `contentHash` is computed *from the on-disk file* (`AppLoader.swift:377-388`), so a hash check would happily certify the corruption. The app-binary `main.jsbundle` is the only authoritative local reference. This does mean a corruption that preserves byte length would still pass — size is the strongest check available without a manifest change.

**Why not gate on `asset.mainBundleFilename`.** That was my first attempt and it is dead code: the `assets` table has no `main_bundle_filename` column and `UpdatesDatabase.asset(withRow:)` never populates it, so the field is `nil` for every asset arriving via `launchedUpdate.assets()`. The source is instead resolved by matching the embedded manifest on `key` — the same sequence `maybeCopyAssetFromMainBundle` already uses. `isLaunchAsset` is unaffected; `asset(withRow:)` does set it, from `launch_asset_id`.

The check fails open at every unresolvable step (no manifest, no key match, nil `mainBundleFilename`, nil `path(forBundledAsset:)`, unreadable size) — with no authoritative source there is nothing to compare against, so the cached file is accepted as before. Remote assets have no embedded counterpart and are already SHA-256 verified and atomically written in `FileDownloader.swift:271-284`; they are untouched.

# Test Plan

Verified on a minimal SDK 56 app (the released line, where this path is unconditional), Release configuration, iPhone 16 Pro / iOS 18.5, by truncating the cached bundle to simulate an interrupted copy.

Before, every launch aborted with the `Compiling JS failed` exception above. After:

```
launch#1 fresh install : cached=1570550 source=1570550
stray .tmp files       : 0
truncate 786432 -> healed to 1570550  strays=0
truncate 262144 -> healed to 1570550  strays=0
truncate 0      -> healed to 1570550  strays=0
3 consecutive clean launches: size=1570550
fatals across entire run: 0
```

The app renders normally in every post-fix case, and the cached bundle returns to its full size without a reinstall or any network access.

# Known tradeoff

If the process dies between the copy and the rename, the staging file survives; `UpdatesReaper` only deletes assets it knows from SQLite, so nothing sweeps it. That is a bounded disk cost in exchange for removing an unrecoverable brick, but I am happy to add a sweep of stale `.tmp-*` siblings before staging if you would prefer it in the same PR.

# Checklist

- [x] Documented changes in `CHANGELOG.md`.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — no docs changes.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — iOS runtime only, no config plugin or build changes.
