### PR TITLE
[maps] Add camera tilt and bearing

### DIFF
--- a/apps/native-component-list/src/screens/ExpoMaps/apple/MapsCameraPositionScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoMaps/apple/MapsCameraPositionScreen.tsx
@@ -1,6 +1,6 @@
-import { AppleMaps } from 'expo-maps';
-import { useRef } from 'react';
-import { Button, StyleSheet, View } from 'react-native';
+import { AppleMaps } from "expo-maps";
+import { useRef } from "react";
+import { Button, StyleSheet, View } from "react-native";
 
 export default function MapsCameraPositionScreen() {
   const ref = useRef<AppleMaps.MapView>(null);
@@ -10,23 +10,52 @@ export default function MapsCameraPositionScreen() {
       <View style={styles.container}>
         <AppleMaps.View
           ref={ref}
-          style={{ width: 'auto', height: '100%' }}
+          style={{ width: "auto", height: "100%" }}
           cameraPosition={{
             coordinates: {
               latitude: 37.78825,
               longitude: -122.4324,
             },
             zoom: 15,
+            tilt: 45,
+            bearing: 30,
           }}
         />
       </View>
 
       <View style={styles.configurator}>
-        <Button title="Set empty" onPress={() => ref.current?.setCameraPosition()} />
+        <Button
+          title="Set empty"
+          onPress={() => ref.current?.setCameraPosition()}
+        />
+        <Button
+          title="Set 3D"
+          onPress={() =>
+            ref.current?.setCameraPosition({
+              coordinates: { latitude: 37.78825, longitude: -122.4324 },
+              zoom: 15,
+              tilt: 45,
+              bearing: 30,
+            })
+          }
+        />
+        <Button
+          title="Set 2D"
+          onPress={() =>
+            ref.current?.setCameraPosition({
+              coordinates: { latitude: 37.78825, longitude: -122.4324 },
+              zoom: 15,
+              tilt: 0,
+              bearing: 0,
+            })
+          }
+        />
         <Button
           title="Set 0, 0"
           onPress={() =>
-            ref.current?.setCameraPosition({ coordinates: { latitude: 0, longitude: 0 } })
+            ref.current?.setCameraPosition({
+              coordinates: { latitude: 0, longitude: 0 },
+            })
           }
         />
         <Button

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add `Circle` type to the `GoogleMaps` namespace. ([#49124](https://github.com/expo/expo/pull/49124) by [@CatLover01](https://github.com/CatLover01))
+- Add `tilt` and `bearing` to map camera positions.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -228,10 +228,12 @@ class GoogleMapsView(context: Context, appContext: AppContext) :
     val cameraPosition = props.cameraPosition.value
     cameraState = remember(cameraPosition) {
       CameraPositionState(
-        position = CameraPosition.fromLatLngZoom(
-          cameraPosition.coordinates.toLatLng(),
-          cameraPosition.zoom
-        )
+        position = CameraPosition.Builder()
+          .target(cameraPosition.coordinates.toLatLng())
+          .zoom(cameraPosition.zoom)
+          .tilt(cameraPosition.tilt)
+          .bearing(cameraPosition.bearing)
+          .build()
       )
     }
 
@@ -369,8 +371,16 @@ class GoogleMapsView(context: Context, appContext: AppContext) :
       ?: props.userLocation.value.coordinates?.toLatLng()
       ?: return
 
-    val cameraUpdate = config?.zoom?.let { CameraUpdateFactory.newLatLngZoom(coordinates, it) }
-      ?: CameraUpdateFactory.newLatLng(coordinates)
+    val cameraUpdate = CameraUpdateFactory.newCameraPosition(
+      CameraPosition.Builder(cameraState.position)
+        .target(coordinates)
+        .apply {
+          config?.zoom?.let { zoom(it) }
+          config?.tilt?.let { tilt(it) }
+          config?.bearing?.let { bearing(it) }
+        }
+        .build()
+    )
 
     // When Int.MAX_VALUE is provided as durationMs, the default animation duration will be used.
     cameraState.animate(cameraUpdate, config?.duration ?: Int.MAX_VALUE)

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
@@ -27,6 +27,12 @@ data class SetCameraPositionConfig(
   val zoom: Float?,
 
   @Field
+  val tilt: Float?,
+
+  @Field
+  val bearing: Float?,
+
+  @Field
   val duration: Int?
 ) : Record
 
@@ -130,7 +136,13 @@ data class CameraPositionRecord(
   val coordinates: Coordinates = Coordinates(),
 
   @Field
-  val zoom: Float = 10f
+  val zoom: Float = 10f,
+
+  @Field
+  val tilt: Float = 0f,
+
+  @Field
+  val bearing: Float = 0f
 ) : Record
 
 @OptimizedRecord

--- a/packages/expo-maps/ios/MapRecords.swift
+++ b/packages/expo-maps/ios/MapRecords.swift
@@ -41,10 +41,13 @@ struct MapMarker: Identifiable, Record {
 struct CameraPosition: Record, Equatable {
   @Field var coordinates: Coordinate
   @Field var zoom: Double = 1
+  @Field var tilt: Double?
+  @Field var bearing: Double?
 
   static func == (lhs: CameraPosition, rhs: CameraPosition) -> Bool {
     return lhs.coordinates.latitude == rhs.coordinates.latitude
       && lhs.coordinates.longitude == rhs.coordinates.longitude && lhs.zoom == rhs.zoom
+      && lhs.tilt == rhs.tilt && lhs.bearing == rhs.bearing
   }
 }
 

--- a/packages/expo-maps/ios/MapUtils.swift
+++ b/packages/expo-maps/ios/MapUtils.swift
@@ -7,7 +7,25 @@ func convertToMapCamera(position: CameraPosition) -> MapCameraPosition {
     latitude: position.coordinates.latitude,
     longitude: position.coordinates.longitude
   )
+
+  if position.tilt != nil || position.bearing != nil {
+    return MapCameraPosition.camera(
+      MapCamera(
+        centerCoordinate: coordinate,
+        distance: cameraDistance(coordinate: coordinate, zoom: position.zoom),
+        heading: position.bearing ?? 0,
+        pitch: position.tilt ?? 0
+      )
+    )
+  }
+
   return convertToMapCameraPosition(coordinate: coordinate, zoom: position.zoom)
+}
+
+private func cameraDistance(coordinate: CLLocationCoordinate2D, zoom: Double) -> CLLocationDistance {
+  let earthCircumference = 40_075_016.686
+  let latitudeScale = cos(coordinate.latitude * .pi / 180)
+  return max(earthCircumference * latitudeScale / pow(2, zoom), 1)
 }
 
 @available(iOS 17.0, *)

--- a/packages/expo-maps/src/shared.types.ts
+++ b/packages/expo-maps/src/shared.types.ts
@@ -23,6 +23,16 @@ export type CameraPosition = {
    * For some view sizes, lower zoom levels might not be available.
    */
   zoom?: number;
+
+  /**
+   * The tilt of the camera in degrees.
+   */
+  tilt?: number;
+
+  /**
+   * The bearing of the camera in degrees.
+   */
+  bearing?: number;
 };
 
 /**


### PR DESCRIPTION
## Why

`onCameraMove` reports camera tilt and bearing, but `cameraPosition` and `setCameraPosition` cannot set them. In particular, Apple Maps users cannot start a map with a pitched 3D camera without first pressing the native 3D control.

## How

- Add optional `tilt` and `bearing` fields to the shared `CameraPosition` type.
- Apply both fields to initial and imperative camera updates on Apple Maps and Google Maps.
- Preserve the existing flat camera behavior when neither field is provided.
- Add 2D and 3D cases to the Apple Maps camera-position screen in Native Component List.

Example:

```tsx
<AppleMaps.View
  properties={{ elevation: AppleMaps.MapStyleElevation.REALISTIC }}
  cameraPosition={{
    coordinates: { latitude: 37.78825, longitude: -122.4324 },
    zoom: 15,
    tilt: 45,
    bearing: 30,
  }}
/>
```

## Test Plan

- `pnpm run lint` in `packages/expo-maps`
- `pnpm run format --check` in `packages/expo-maps`
- Prettier check for the Native Component List camera-position screen
- Compiled a SwiftUI/MapKit smoke test using `MapCameraPosition.camera` with the new distance, heading, and pitch arguments
- Full package build was attempted from a sparse checkout, but could not resolve unrelated local workspace packages that were not checked out; Expo CI will run the complete monorepo build.

## Checklist

- [x] I added a changelog entry.
- [x] This change does not require config-plugin or prebuild changes.
- [x] New public API fields include source documentation.
