### PR TITLE
feat(expo-file-system): support null-scheme resource URIs in UnifiedFile

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Add `File.preview()` and `File.canPreview()` methods for opening files with platform-native preview flows. (by [@eliotgevers](https://github.com/eliotgevers))
 - Added `File.digest()` for asynchronously calculating MD5, SHA-1, SHA-256, SHA-384 and SHA-512 file digests. ([#48089](https://github.com/expo/expo/pull/48089) by [@wh201906](https://github.com/wh201906))
+- [Android] Add support for resource URIs (null scheme) to the new file system API, enabling resolution of assets in release builds. ([#49318](https://github.com/expo/expo/pull/49318) by [@CatLover01](https://github.com/CatLover01))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -8,6 +8,7 @@ import expo.modules.filesystem.unifiedfile.AssetFile
 import expo.modules.filesystem.unifiedfile.ContentProviderFile
 import expo.modules.filesystem.fsops.DestinationSpec
 import expo.modules.filesystem.unifiedfile.JavaFile
+import expo.modules.filesystem.unifiedfile.ResourceFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
 import expo.modules.kotlin.exception.Exceptions
@@ -40,6 +41,11 @@ val Uri.isAssetUri
     return scheme == "asset"
   }
 
+val Uri.isResourceUri
+  get(): Boolean {
+    return scheme == null
+  }
+
 fun Uri.isSAFUri(context: Context): Boolean =
   isContentUri && (
     DocumentsContract.isDocumentUri(context, this) || DocumentsContract.isTreeUri(this)
@@ -70,6 +76,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
         uri.isSAFUri(context) -> SAFDocumentFile(context, uri)
         uri.isContentUri -> ContentProviderFile(context, uri)
         uri.isAssetUri -> AssetFile(context, uri)
+        uri.isResourceUri -> ResourceFile(context, uri)
         else -> JavaFile(uri)
       }
       return newAdapter.also { fileAdapter = it }
@@ -77,10 +84,10 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
 
   val javaFile: File
     get() =
-      if (uri.isContentUri) {
-        throw Exception("This method cannot be used with content URIs: $uri")
+      if (file is File) {
+        file as File
       } else {
-        (file as File)
+        throw Exception("This method cannot be used with URI: $uri")
       }
 
   fun delete() {
@@ -143,6 +150,9 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     if (uri.isAssetUri) {
       // TODO: Consider adding a check for asset URIs – this returns asset files of Expo Go (such as root-cert), but these are already freely available on apk mirrors etc.
       return true
+    }
+    if (uri.isResourceUri) {
+      return permission == FilePermissionService.Permission.READ
     }
     return checkPermissionForPath(javaFile.path, permission)
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -12,6 +12,7 @@ import expo.modules.filesystem.UnableToMoveException
 import expo.modules.filesystem.unifiedfile.AssetFile
 import expo.modules.filesystem.unifiedfile.ContentProviderFile
 import expo.modules.filesystem.unifiedfile.JavaFile
+import expo.modules.filesystem.unifiedfile.ResourceFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
 import expo.modules.kotlin.exception.Exceptions
@@ -197,6 +198,17 @@ sealed class CopyMoveStrategy(
 
     override suspend fun moveTo(spec: DestinationSpec): Uri {
       throw UnableToMoveException("Assets cannot be moved (provider-dependent)")
+    }
+  }
+
+  class Resource(override val file: ResourceFile) : CopyMoveStrategy(file) {
+    override fun prepareAsDestination(source: UnifiedFileInterface, spec: DestinationSpec): DestinationSink {
+      if (file.exists() && !spec.overwrite) throw DestinationAlreadyExistsException()
+      return DestinationSink.Resource(spec)
+    }
+
+    override suspend fun moveTo(spec: DestinationSpec): Uri {
+      throw UnableToMoveException("Resources cannot be moved")
     }
   }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -108,4 +108,10 @@ sealed class DestinationSink(val spec: DestinationSpec) {
       throw UnableToCopyException("Cannot copy to read-only destination")
     }
   }
+
+  class Resource(spec: DestinationSpec) : DestinationSink(spec) {
+    override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
+      throw UnableToCopyException("Cannot copy to read-only destination")
+    }
+  }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ResourceFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ResourceFile.kt
@@ -1,0 +1,89 @@
+package expo.modules.filesystem.unifiedfile
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+import expo.modules.filesystem.fsops.CopyMoveStrategy
+import expo.modules.kotlin.AppContext
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+class ResourceFile(private val context: Context, override val uri: Uri) : UnifiedFileInterface {
+  private val resourceName: String = uri.toString()
+
+  private fun getResourceId(): Int {
+    var resourceId = context.resources.getIdentifier(resourceName, "raw", context.packageName)
+    if (resourceId == 0) {
+      resourceId = context.resources.getIdentifier(resourceName, "drawable", context.packageName)
+    }
+    return resourceId
+  }
+
+  override fun exists(): Boolean = getResourceId() != 0
+
+  override fun isDirectory(): Boolean = false
+
+  override fun isFile(): Boolean = exists()
+
+  override val parentFile: UnifiedFileInterface? = null
+
+  override fun createFile(mimeType: String, displayName: String): UnifiedFileInterface? {
+    throw UnsupportedOperationException("Resource files are not writable and cannot be created")
+  }
+
+  override fun createDirectory(displayName: String): UnifiedFileInterface? {
+    throw UnsupportedOperationException("Resource directories are not writable and cannot be created")
+  }
+
+  override fun delete(): Boolean = throw UnsupportedOperationException("Resource files are not writable and cannot be deleted")
+
+  override fun deleteRecursively(): Boolean = throw UnsupportedOperationException("Resource files are not writable and cannot be deleted")
+
+  override fun listFilesAsUnified(): List<UnifiedFileInterface> = emptyList()
+
+  override val type: String? = null
+
+  override fun lastModified(): Long? = null
+
+  override val fileName: String?
+    get() = resourceName
+
+  override val creationTime: Long? = null
+
+  override fun getContentUri(appContext: AppContext): Uri {
+    inputStream().use { inputStream ->
+      val outputFile = File(context.cacheDir, "expo_shared_resources/$resourceName")
+      outputFile.parentFile?.mkdirs()
+      FileOutputStream(outputFile).use { outputStream ->
+        inputStream.copyTo(outputStream)
+      }
+      val newContentUri = JavaFile(outputFile.toUri()).getContentUri(appContext)
+      return newContentUri
+    }
+  }
+
+  override fun outputStream(append: Boolean): OutputStream {
+    throw UnsupportedOperationException("Resource files are not writable")
+  }
+
+  override fun inputStream(): InputStream {
+    val resourceId = getResourceId()
+    if (resourceId == 0) {
+      throw FileNotFoundException("No resource found with the name '$resourceName'")
+    }
+    return context.resources.openRawResource(resourceId)
+  }
+
+  override fun length(): Long {
+    return runCatching {
+      inputStream().use { it.available().toLong() }
+    }.getOrElse { 0L }
+  }
+
+  override fun walkTopDown(): Sequence<UnifiedFileInterface> = sequenceOf(this)
+
+  override val copyMoveStrategy: CopyMoveStrategy = CopyMoveStrategy.Resource(this)
+}


### PR DESCRIPTION
# Why

This PR adds support for Android resource URIs (URIs with a `null` scheme) to the new `expo-file-system` API. 

In the legacy implementation, paths without a scheme were treated as Android resources (e.g., in `res/raw` or `res/drawable`). This functionality was missing in the new `UnifiedFile` architecture, causing parity issues when migrating code to the new API.

This support is necessary because in Android release builds, `expo-asset` URIs are generated as resource identifiers (e.g. `"assets_images_x"`). Without this support, these assets cannot be resolved by the new `expo-file-system` API, which breaks production functionality for apps that have migrated.

See: https://github.com/expo/expo/issues/41996

# How

- **Added ResourceFile**: Implemented a new `UnifiedFileInterface` backend that wraps Android's `Resources`. It supports standard operations like `exists()`, `length()`, and `inputStream()`.
- **Integrated with FileSystemPath**: Updated the URI detection logic to recognize `null` schemes as resources and instantiate the `ResourceFile` adapter.
- **Added Shareable Content URIs**: Implemented `getContentUri()` for resources by using a "copy-to-cache" strategy (consistent with `AssetFile`), allowing bundled resources to be shared with external applications.
- **Hardened javaFile access**: Refactored the `javaFile` getter in `FileSystemPath` to use safe type-checking (`is File`) instead of fragile scheme-based checks, preventing `ClassCastExceptions`.
- **Defined Permissions**: Set resources to be read-only (enforced in `checkPermission` and via `CopyMoveStrategy.Resource`), matching the security model of the legacy module.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
