### PR TITLE
[cli] Pin agent-cli-detector to 0.1.7

### DIFF
--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -79,7 +79,7 @@
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.86.0",
     "accepts": "^1.3.8",
-    "agent-cli-detector": "0.1.6",
+    "agent-cli-detector": "0.1.7",
     "arg": "^5.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1884,8 +1884,8 @@ importers:
         specifier: ^1.3.8
         version: 1.3.8
       agent-cli-detector:
-        specifier: 0.1.6
-        version: 0.1.6
+        specifier: 0.1.7
+        version: 0.1.7
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -10172,6 +10172,11 @@ packages:
 
   agent-cli-detector@0.1.6:
     resolution: {integrity: sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+
+  agent-cli-detector@0.1.7:
+    resolution: {integrity: sha512-d8OWDVdZMgjhLUT9ZPgSv/BdFFF9pVuscC0JdUSz3bjwE15gcp6u/o0/JooM2yyAWC49KThFhXlgTXRa9B7yng==}
     engines: {node: '>=18.18'}
     hasBin: true
 
@@ -19086,6 +19091,8 @@ snapshots:
   agent-base@7.1.4: {}
 
   agent-cli-detector@0.1.6: {}
+
+  agent-cli-detector@0.1.7: {}
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:


### PR DESCRIPTION
updates agent-cli-detector to 0.1.7 to detect grok in telemetry context