### PR TITLE
[fingerprint] Sort sources with a locale-independent collator

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed fingerprints differing between machines with different locales (for example Croatian, Czech, Swedish, or Turkish versus English), which made a locally computed runtime version never match the one computed on EAS. Sources, directory entries, and `.gitignore` files are now sorted with a fixed English collator instead of the process default locale. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@filipfrlic](https://github.com/filipfrlic))
 - Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fixed ignore patterns (built-in and `.fingerprintignore`) not matching on Windows, which made fingerprints differ between Windows machines and EAS builds ("Runtime version mismatch"). ([#46816](https://github.com/expo/expo/pull/46816) by [@blurbyte](https://github.com/blurbyte))
 

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed fingerprints differing between machines with different locales (for example Croatian, Czech, Swedish, or Turkish versus English), which made a locally computed runtime version never match the one computed on EAS. Sources, directory entries, and `.gitignore` files are now sorted with a fixed English collator instead of the process default locale. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@filipfrlic](https://github.com/filipfrlic))
+- Fixed fingerprints differing between machines with different locales (for example Croatian, Czech, Swedish, or Turkish versus English), which made a locally computed runtime version never match the one computed on EAS. Sources, directory entries, and `.gitignore` files are now sorted with a fixed English collator instead of the process default locale. ([#49334](https://github.com/expo/expo/pull/49334) by [@filipfrlic](https://github.com/filipfrlic))
 - Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fixed ignore patterns (built-in and `.fingerprintignore`) not matching on Windows, which made fingerprints differ between Windows machines and EAS builds ("Runtime version mismatch"). ([#46816](https://github.com/expo/expo/pull/46816) by [@blurbyte](https://github.com/blurbyte))
 

--- a/packages/@expo/fingerprint/src/ProjectWorkflow.ts
+++ b/packages/@expo/fingerprint/src/ProjectWorkflow.ts
@@ -8,6 +8,7 @@ import path from 'path';
 
 import { resolveExpoConfigPluginsPackagePath } from './ExpoResolver';
 import type { Platform, ProjectWorkflow } from './Fingerprint.types';
+import { collator } from './utils/Collator';
 import { isIgnoredPathWithMatchObjects, pathExistsAsync, toPosixPath } from './utils/Path';
 
 /**
@@ -163,7 +164,7 @@ class Ignore {
       })
     )
       // ensure that parent dir is before child directories
-      .sort((a, b) => a.length - b.length && a.localeCompare(b));
+      .sort((a, b) => a.length - b.length && collator.compare(a, b));
 
     const ignoreMapping = await Promise.all(
       ignoreFilePaths.map(async (filePath) => {

--- a/packages/@expo/fingerprint/src/Sort.ts
+++ b/packages/@expo/fingerprint/src/Sort.ts
@@ -1,4 +1,5 @@
 import type { HashSource } from './Fingerprint.types';
+import { collator } from './utils/Collator';
 
 export function sortSources<T extends HashSource>(sources: T[]): T[] {
   return sources.sort(compareSource);
@@ -25,17 +26,17 @@ export function compareSource(a: HashSource, b: HashSource): number {
     if (a.type === 'file' && b.type === 'file') {
       const aValue = a.overrideHashKey ?? a.filePath;
       const bValue = b.overrideHashKey ?? b.filePath;
-      return aValue.localeCompare(bValue);
+      return collator.compare(aValue, bValue);
     } else if (a.type === 'dir' && b.type === 'dir') {
       const aValue = a.overrideHashKey ?? a.filePath;
       const bValue = b.overrideHashKey ?? b.filePath;
-      return aValue.localeCompare(bValue);
+      return collator.compare(aValue, bValue);
     } else if (a.type === 'contents' && b.type === 'contents') {
-      return a.id.localeCompare(b.id);
+      return collator.compare(a.id, b.id);
     } else if (a.type === 'package' && b.type === 'package') {
       const aValue = a.overrideHashKey ?? `${a.name}@${a.version}`;
       const bValue = b.overrideHashKey ?? `${b.name}@${b.version}`;
-      return aValue.localeCompare(bValue);
+      return collator.compare(aValue, bValue);
     }
   }
   return typeResult;

--- a/packages/@expo/fingerprint/src/__tests__/Sort-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/Sort-test.ts
@@ -1,3 +1,6 @@
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+
 import type { FingerprintSource, HashSource } from '../Fingerprint.types';
 import { sortSources } from '../Sort';
 
@@ -69,4 +72,64 @@ describe(sortSources, () => {
       { type: 'dir', filePath: '/app/android', reasons: ['bareNativeDir'] },
     ]);
   });
+
+  it('should sort independently of the process locale', async () => {
+    // Croatian collation treats "nj" as a digraph sorted after "nz", the opposite of English.
+    // The fingerprint must not depend on the developer's locale, otherwise a runtime version
+    // computed locally never matches the one computed on EAS.
+    const sources: HashSource[] = [
+      { type: 'file', filePath: '/app/nz.json', reasons: ['x'] },
+      { type: 'file', filePath: '/app/nj.json', reasons: ['x'] },
+      { type: 'dir', filePath: '/app/nz', reasons: ['x'] },
+      { type: 'dir', filePath: '/app/nj', reasons: ['x'] },
+      { type: 'contents', id: 'nz', contents: '', reasons: ['x'] },
+      { type: 'contents', id: 'nj', contents: '', reasons: ['x'] },
+      {
+        type: 'package',
+        filePath: '/app/node_modules/nz/package.json',
+        name: 'nz',
+        version: '1.0.0',
+        reasons: ['x'],
+      },
+      {
+        type: 'package',
+        filePath: '/app/node_modules/nj/package.json',
+        name: 'nj',
+        version: '1.0.0',
+        reasons: ['x'],
+      },
+    ];
+
+    expect(await sortSourcesInLocaleAsync(sources, 'hr_HR.UTF-8')).toEqual(
+      await sortSourcesInLocaleAsync(sources, 'en_US.UTF-8')
+    );
+  });
 });
+
+/**
+ * Sorts sources in a child Node process whose default locale is `locale`,
+ * since the default locale of the current process cannot be changed at runtime.
+ */
+async function sortSourcesInLocaleAsync(sources: HashSource[], locale: string): Promise<string[]> {
+  const script = `
+    const { compareSource } = require(${JSON.stringify(path.join(__dirname, '..', 'Sort.ts'))});
+    const sources = JSON.parse(process.argv[1]);
+    const sorted = sources.sort(compareSource);
+    console.log(JSON.stringify(sorted.map((source) => source.filePath ?? source.id ?? source.name)));
+  `;
+  const { stdout } = await spawnAsync(
+    process.execPath,
+    [
+      '-r',
+      require.resolve('ts-node/register/transpile-only'),
+      '-e',
+      script,
+      JSON.stringify(sources),
+    ],
+    {
+      cwd: path.join(__dirname, '..', '..'),
+      env: { ...process.env, LC_ALL: locale, LANG: locale },
+    }
+  );
+  return JSON.parse(stdout);
+}

--- a/packages/@expo/fingerprint/src/hash/Hash.ts
+++ b/packages/@expo/fingerprint/src/hash/Hash.ts
@@ -19,6 +19,7 @@ import type {
   HashSourcePackage,
   NormalizedOptions,
 } from '../Fingerprint.types';
+import { collator } from '../utils/Collator';
 import { createLimiter, type Limiter } from '../utils/Concurrency';
 import { isIgnoredPathWithMatchObjects, toPosixPath } from '../utils/Path';
 import { nonNullish } from '../utils/Predicates';
@@ -206,7 +207,7 @@ export async function createDirHashResultsAsync(
     return null;
   }
   const dirents = (await fs.readdir(path.join(projectRoot, dirPath), { withFileTypes: true })).sort(
-    (a, b) => a.name.localeCompare(b.name)
+    (a, b) => collator.compare(a.name, b.name)
   );
 
   const results = (

--- a/packages/@expo/fingerprint/src/utils/Collator.ts
+++ b/packages/@expo/fingerprint/src/utils/Collator.ts
@@ -1,0 +1,10 @@
+/**
+ * Collator for sorting strings in a locale-independent order.
+ *
+ * `String.prototype.localeCompare()` without an explicit locale uses the process default locale
+ * (e.g. `LANG`/`LC_ALL`), so the same sources would sort differently on a Croatian, Czech, Swedish,
+ * or Turkish machine than on EAS Build servers, producing a different fingerprint and runtime version.
+ * Pinning the collator to `en` keeps the order stable across machines and matches the order that
+ * English-locale machines have always produced, so existing fingerprints are unchanged.
+ */
+export const collator = new Intl.Collator('en');


### PR DESCRIPTION
# Why

`@expo/fingerprint` sorts sources, directory entries, and `.gitignore` files with `String.prototype.localeCompare()` and no explicit locale, so the order follows the process default locale (`LANG`/`LC_ALL`). Any locale whose collation differs from English changes the order and therefore the hash — Croatian, Czech, Slovak, Swedish, Danish, Turkish and others all do (e.g. in `hr` the digraph `nj` sorts *after* `nz`).

The practical symptom: a developer on such a machine runs `eas update` locally and publishes a `runtimeVersion` (with the `fingerprint` policy) that never matches the one EAS Build computed for the binary, so updates are never delivered. It's the same class of cross-machine mismatch as #46816 (Windows ignore patterns), just triggered by locale instead of path separators.

Reproduction on any Node with full ICU (the default):

```sh
$ LC_ALL=en_US.UTF-8 node -e 'console.log(["nz","nj"].sort((a,b)=>a.localeCompare(b)))'
[ 'nj', 'nz' ]
$ LC_ALL=hr_HR.UTF-8 node -e 'console.log(["nz","nj"].sort((a,b)=>a.localeCompare(b)))'
[ 'nz', 'nj' ]
```

# How

- Added `src/utils/Collator.ts` exporting a single shared `new Intl.Collator('en')`.
- Replaced all six bare `localeCompare` calls with `collator.compare(...)`: the four source-type branches in `Sort.ts`, the `readdir` sort in `hash/Hash.ts`, and the `.gitignore` sort in `ProjectWorkflow.ts`.

Why `en` rather than a plain code-point sort: `en` yields exactly the order that English-locale machines (including EAS workers) have always produced, so **no existing fingerprint changes** and this ships as a bug fix rather than a breaking change, and can be backported to the 0.20.x line. Switching to a pure code-point comparison would be a slightly stronger guarantee (independent of ICU data too) but would change every fingerprint containing case- or punctuation-adjacent names; happy to do that as a follow-up if you'd prefer it.

A shared collator also avoids constructing one per comparison across thousands of files, which is what `localeCompare(b, 'en')` would do.

# Test Plan

- New test in `src/__tests__/Sort-test.ts`: spawns a child Node (via `ts-node/register/transpile-only`, already a root devDependency) once with `LC_ALL=hr_HR.UTF-8` and once with `en_US.UTF-8`, sorts an `nj`/`nz` pair of every source type, and asserts identical order. It fails on `main` (all four types differ) and passes with this change. Node reads the default locale from the env var directly, so no system locale needs to be installed on CI.
- `et check-packages @expo/fingerprint` passes (build, typecheck, lint, format, 25 suites / 220 tests).
- Manually verified on a machine whose Node defaults to `hr-HR`: fingerprints now match those computed under `en_US`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — N/A, no config plugin changes
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

Could this be backported to the `sdk-57` / `0.20.x` line? Until it's released there, affected projects have to patch the package.

Unrelated note noticed while here: `ProjectWorkflow.ts` sorts `.gitignore` files with `a.length - b.length && compare(a, b)`, which returns `0` for equal lengths and otherwise the collator result — i.e. the intended "parent dir before child" ordering isn't actually applied; it likely wants `||`. Left untouched here to keep this a pure locale fix; can open a separate PR.
