### PR TITLE
[ios][autolinking] Add prebuilt-metadata command emitting the identity join [step 1]

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### 💡 Others
 
+- [iOS] Add a `prebuilt-metadata` command emitting the prebuilt-modules identity document (npm package ↔ pod ↔ product), verified field-by-field against the Ruby derivations fixture (ENG-25370 phase 1). ([#49335](https://github.com/expo/expo/pull/49335) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add a derivations snapshot dump for precompiled modules (`EXPO_PRECOMPILED_DUMP` / `dump_precompiled_derivations.rb`) with a committed bare-expo fixture enforced by an e2e test, guarding the migration of these derivations to autolinking metadata. ([#49150](https://github.com/expo/expo/pull/49150) by [@chrfalch](https://github.com/chrfalch))
 - [Android] Make the autolinking Gradle plugin compatible with Android Gradle Plugin 9. ([#46766](https://github.com/expo/expo/pull/46766) by [@lukmccall](https://github.com/lukmccall))
 - Add experimental `tvos` and `macos` resolution ([#46344](https://github.com/expo/expo/pull/46344) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/e2e/__tests__/precompiled-derivations-test.ts
+++ b/packages/expo-modules-autolinking/e2e/__tests__/precompiled-derivations-test.ts
@@ -3,6 +3,8 @@ import fs from 'fs';
 import os from 'os';
 import { join, resolve } from 'path';
 
+import { autolinkingRunAsync } from '../TestUtils';
+
 jest.unmock('fs');
 jest.unmock('fs/promises');
 jest.setTimeout(2 * 60 * 1000);
@@ -59,4 +61,34 @@ const canRun = rubyAvailable() && fs.existsSync(join(repoRoot, 'apps/bare-expo/n
       throw error;
     }
   });
+
+  it('prebuilt-metadata emits the same identity fields as the fixture', async () => {
+    const { stdout } = await autolinkingRunAsync(['prebuilt-metadata', '--json'], {
+      cwd: bareExpoIosPath,
+    });
+    const pickIdentity = (entries: Record<string, any>, normalizePaths: boolean) =>
+      Object.fromEntries(
+        Object.entries(entries).map(([podName, e]) => [
+          podName,
+          {
+            type: e.type,
+            npmPackage: e.npmPackage,
+            packageRoot: normalizePaths ? repoRelative(e.packageRoot) : e.packageRoot,
+            podspecDir: normalizePaths ? repoRelative(e.podspecDir) : e.podspecDir,
+            productName: e.productName,
+          },
+        ])
+      );
+    const actual = pickIdentity(JSON.parse(stdout), true);
+    const expected = pickIdentity(JSON.parse(fs.readFileSync(fixturePath, 'utf8')), false);
+    expect(actual).toEqual(expected);
+  });
 });
+
+// Mirrors the Ruby dump's path canonicalization: repo-relative, pnpm store collapsed.
+function repoRelative(p: string): string {
+  return p
+    .replace(`${fs.realpathSync(repoRoot)}/`, '')
+    .replace(`${repoRoot}/`, '')
+    .replace(/^node_modules\/\.pnpm\/[^/]+\/node_modules\//, 'node_modules/');
+}

--- a/packages/expo-modules-autolinking/src/commands/prebuiltMetadataCommand.ts
+++ b/packages/expo-modules-autolinking/src/commands/prebuiltMetadataCommand.ts
@@ -1,0 +1,147 @@
+import type commander from 'commander';
+import fs from 'fs';
+import path from 'path';
+
+import { scanDependenciesInSearchPath } from '../dependencies';
+import { createReactNativeConfigAsync } from '../reactNativeConfig';
+import type { RNConfigDependency } from '../reactNativeConfig/reactNativeConfig.types';
+import { scanFilesRecursively } from '../utils';
+import type { AutolinkingCommonArguments } from './autolinkingOptions';
+import { createAutolinkingOptionsLoader, registerAutolinkingArguments } from './autolinkingOptions';
+
+interface PrebuiltMetadataArguments extends AutolinkingCommonArguments {
+  json?: boolean | null;
+}
+
+export interface PrebuiltMetadataEntry {
+  type: 'internal' | 'external';
+  npmPackage: string;
+  packageRoot: string;
+  podspecDir: string;
+  productName: string;
+}
+
+function readJsonFile(filePath: string): any | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    console.warn(`[prebuilt-metadata] Failed to read ${filePath}: ${error}`);
+    return null;
+  }
+}
+
+/** The expo repository root when this package runs from its packages/ checkout
+ * (its own location is the same anchor used for external-configs below). */
+function findExpoRepoRoot(): string | null {
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+  return fs.existsSync(path.join(repoRoot, 'packages', 'expo-modules-core', 'spm.config.json'))
+    ? repoRoot
+    : null;
+}
+
+async function scanInternalConfigs(
+  repoRoot: string,
+  entries: Record<string, PrebuiltMetadataEntry>
+) {
+  const resolutions = await scanDependenciesInSearchPath(path.join(repoRoot, 'packages'));
+  for (const npmPackage of Object.keys(resolutions).sort()) {
+    const packageRoot = resolutions[npmPackage]!.path;
+    const config = readJsonFile(path.join(packageRoot, 'spm.config.json'));
+    if (!config) {
+      continue;
+    }
+    for (const product of config.products ?? []) {
+      const podName = product.podName;
+      if (podName == null) {
+        continue;
+      }
+      const podspecDir =
+        !fs.existsSync(path.join(packageRoot, 'ios', `${podName}.podspec`)) &&
+        fs.existsSync(path.join(packageRoot, `${podName}.podspec`))
+          ? packageRoot
+          : path.join(packageRoot, 'ios');
+      entries[podName] = {
+        type: 'internal',
+        npmPackage,
+        packageRoot,
+        podspecDir,
+        productName: product.name || podName,
+      };
+    }
+  }
+}
+
+async function scanExternalConfigs(
+  dependencies: Record<string, RNConfigDependency>,
+  entries: Record<string, PrebuiltMetadataEntry>
+) {
+  const externalConfigsDir = path.join(__dirname, '..', '..', 'external-configs', 'ios');
+  for await (const file of scanFilesRecursively(externalConfigsDir, undefined, true)) {
+    if (file.name !== 'spm.config.json') {
+      continue;
+    }
+    const npmPackage = path.relative(externalConfigsDir, file.parentPath).split(path.sep).join('/');
+    const packageRoot = dependencies[npmPackage]?.root;
+    if (!packageRoot) {
+      continue;
+    }
+    const config = readJsonFile(file.path);
+    for (const product of config?.products ?? []) {
+      const podName = product.podName;
+      if (podName == null) {
+        continue;
+      }
+      entries[podName] = {
+        type: 'external',
+        npmPackage,
+        packageRoot,
+        podspecDir: packageRoot,
+        productName: product.name || podName,
+      };
+    }
+  }
+}
+
+/** Emits the prebuilt-modules metadata document (ENG-25370): the identity join
+ * between npm packages, pods, and products, for internal and external products. */
+export function prebuiltMetadataCommand(cli: commander.CommanderStatic) {
+  return registerAutolinkingArguments(cli.command('prebuilt-metadata [searchPaths...]'))
+    .option('-j, --json', 'Output results in the plain JSON format.', () => true, false)
+    .action(async (searchPaths: string[] | null, commandArguments: PrebuiltMetadataArguments) => {
+      const autolinkingOptionsLoader = createAutolinkingOptionsLoader({
+        ...commandArguments,
+        searchPaths,
+      });
+      const appRoot = await autolinkingOptionsLoader.getAppRoot();
+      const repoRoot = findExpoRepoRoot();
+      if (!repoRoot) {
+        throw new Error(
+          'prebuilt-metadata currently requires an expo repository checkout. Support for standalone projects arrives with a later ENG-25370 phase.'
+        );
+      }
+
+      const entries: Record<string, PrebuiltMetadataEntry> = {};
+      await scanInternalConfigs(repoRoot, entries);
+
+      const reactNativeConfig = await createReactNativeConfigAsync({
+        autolinkingOptions: await autolinkingOptionsLoader.getPlatformOptions('ios'),
+        appRoot,
+        sourceDir: undefined,
+      });
+      await scanExternalConfigs(reactNativeConfig.dependencies ?? {}, entries);
+
+      const sorted = Object.fromEntries(
+        Object.keys(entries)
+          .sort()
+          .map((podName) => [podName, entries[podName]])
+      );
+      if (commandArguments.json) {
+        console.log(JSON.stringify(sorted));
+      } else {
+        console.log(require('util').inspect(sorted, false, null, true));
+      }
+    });
+}

--- a/packages/expo-modules-autolinking/src/index.ts
+++ b/packages/expo-modules-autolinking/src/index.ts
@@ -2,6 +2,7 @@ import commander from 'commander';
 
 import { generateModulesProviderCommand } from './commands/generateModulesProviderCommand';
 import { mirrorKotlinInlineModulesCommand } from './commands/mirrorKotlinInlineModulesCommand';
+import { prebuiltMetadataCommand } from './commands/prebuiltMetadataCommand';
 import { reactNativeConfigCommand } from './commands/reactNativeConfigCommand';
 import { resolveCommand } from './commands/resolveCommand';
 import { searchCommand } from './commands/searchCommand';
@@ -16,6 +17,7 @@ async function main(args: string[]) {
   verifyCommand(cli);
   searchCommand(cli);
   resolveCommand(cli);
+  prebuiltMetadataCommand(cli);
   mirrorKotlinInlineModulesCommand(cli);
   generateModulesProviderCommand(cli);
   reactNativeConfigCommand(cli);


### PR DESCRIPTION
# Why

**Phase 1** (PR A) of [ENG-25370](https://linear.app/expo/issue/ENG-26085/phase-1-config-discovery-identity-join): migrate the prebuilt-modules derivations from Ruby to autolinking metadata. 

This PR makes the TS autolinker emit a similar output as the ruby fixture (from #49150) and contains a unit test that will verify that the json data is the same for both outputs.

Schema decisions recorded on the ticket: a dedicated subcommand (not `resolve` output — fingerprint isolation, and externals have no home in `modules[]`), one document for internal + external products keyed by pod name.

# How

Added a new `expo-modules-autolinking prebuilt-metadata --json` subcommand emitting the following json schema: 

```ts
{
  [podName]: { 
    type, 
    npmPackage, 
    packageRoot, 
    podspecDir, 
    productName 
  } 
}
``` 

This mirrors the Ruby json schema and its semantics where we get the data from the following places:

Our e2e differential test runs the command over bare-expo and asserts the identity fields equal the committed Ruby fixture, after the same path canonicalization (repo-relative, pnpm store collapsed), and this now match byte-for-byte.

The test only works in our monorepo, but that is ok since its only consumer is the test in the monorepo that validates that the output from Ruby and `expo-modules-autolinking` is the same.

# Test Plan

✅ Red: differential test added first, failed with `unknown command 'prebuilt-metadata'`.
✅ Green: `pnpm exec jest e2e/__tests__/precompiled-derivations-test.ts` — both tests pass (existing Ruby-vs-fixture snapshot + new TS-vs-fixture differential)

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).