### PR TITLE
[expo-go][android] Remove dead and duplicated dependencies from expoview and app modules

### DIFF
--- a/apps/expo-go/android/app/build.gradle
+++ b/apps/expo-go/android/app/build.gradle
@@ -230,35 +230,8 @@ dependencies {
   implementation 'androidx.core:core-splashscreen:1.0.1'
 
   // Our dependencies from ExpoView
-  // DON'T ADD ANYTHING HERE THAT ISN'T IN EXPOVIEW. ONLY COPY THINGS FROM EXPOVIEW TO HERE.
   compileOnly 'org.glassfish:javax.annotation:3.1.1'
-  implementation 'com.jakewharton:butterknife:10.2.1'
-  implementation 'de.greenrobot:eventbus:2.4.0'
-
-  implementation 'com.squareup.picasso:picasso:2.5.2'
-  implementation 'com.google.android.gms:play-services-analytics:16.0.1'
-  implementation 'com.google.android.gms:play-services-maps:18.0.0'
-  implementation 'com.google.android.gms:play-services-auth:15.0.1'
-  implementation 'com.google.android.gms:play-services-location:15.0.1'
-  debugImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
-  // debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.4-beta1'
-  releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
-  implementation 'com.facebook.device.yearclass:yearclass:2.1.0'
-  implementation 'commons-io:commons-io:1.4'
-  implementation 'com.airbnb.android:lottie:6.5.2'
-  implementation 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation 'com.vanniktech:android-image-cropper:4.6.0'
-  implementation 'commons-codec:commons-codec:1.10'
-  implementation 'com.google.zxing:core:3.3.3'
-  implementation 'net.openid:appauth:0.4.1'
-  implementation "androidx.exifinterface:exifinterface:1.3.3"
-  implementation 'com.squareup.okio:okio:1.9.0'
-  implementation 'com.facebook.soloader:soloader:0.12.1'
   implementation 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
-
-  // expo-file-system
-  implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-  implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
 
   // Testing
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -170,7 +170,6 @@ dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0"
   implementation "androidx.compose.ui:ui:1.7.6"
   implementation "androidx.compose.runtime:runtime-saveable:1.7.6"
-  implementation "androidx.compose.material3:material3:1.3.1"
   implementation "androidx.compose.animation:animation:1.7.6"
   implementation "androidx.compose.foundation:foundation:1.7.6"
   implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7"
@@ -225,7 +224,6 @@ dependencies {
   api 'de.greenrobot:eventbus:2.4.0'
   api 'com.google.firebase:firebase-crashlytics:19.3.0'
   api 'com.google.firebase:firebase-crashlytics-ndk:19.3.0'
-  api "androidx.room:room-runtime:2.1.0"
   implementation 'com.google.android.material:material:1.3.0'
   implementation 'com.google.code.gson:gson:2.13.2'
 
@@ -233,20 +231,9 @@ dependencies {
   api(expoLibs.fresco.animated.webp)
   api(expoLibs.fresco.webpsupport)
 
-  api 'com.squareup.picasso:picasso:2.5.2'
-  api 'com.google.android.gms:play-services-analytics:17.0.0'
-  api 'com.google.android.gms:play-services-maps:18.0.1'
-  api 'com.google.android.gms:play-services-auth:17.0.0'
-  api 'com.google.android.gms:play-services-location:20.0.0'
   api 'com.google.android.gms:play-services-fitness:17.0.0'
-  api 'com.google.android.gms:play-services-wallet:17.0.0' //may need 10.+
-  debugApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
-  // debugApi 'com.squareup.leakcanary:leakcanary-android:1.4-beta1'
-  releaseApi 'com.squareup.leakcanary:leakcanary-android-no-op:1.4-beta1'
   api 'commons-io:commons-io:2.6'
   api 'me.leolin:ShortcutBadger:1.1.4@aar'
-  implementation "com.vanniktech:android-image-cropper:4.6.0"
-  api 'commons-codec:commons-codec:1.10'
   api 'net.openid:appauth:0.7.1'
   api 'com.airbnb.android:lottie:6.5.2'
   compileOnly 'io.branch.sdk.android:library:4.1.0'
@@ -255,22 +242,10 @@ dependencies {
   api "androidx.browser:browser:1.0.0"
   implementation "androidx.tracing:tracing-ktx:1.1.0"
 
-  api 'com.google.firebase:firebase-core:21.1.0'
   api 'com.google.firebase:firebase-messaging:22.0.0'
-  api 'com.google.maps.android:android-maps-utils:3.4.0'
   // Remember to update DetachAppTemplate build.gradle if you add any excludes or transitive = false here!
 
-  // expo-file-system
-  api 'com.squareup.okhttp3:okhttp:3.10.0'
-  api 'com.squareup.okhttp3:okhttp-urlconnection:3.10.0'
-
-  // expo-application
-  api 'com.android.installreferrer:installreferrer:1.0'
-
-  // expo-blur
-  implementation 'com.github.Dimezis:BlurView:version-2.0.3'
-
-  // expo-camera
+  // Home screen QR scanner (QRScannerActivity, HomeAppViewModel)
   def camerax_version = "1.4.0-alpha02"
   implementation "androidx.camera:camera-core:${camerax_version}"
   implementation "androidx.camera:camera-camera2:${camerax_version}"
@@ -282,7 +257,7 @@ dependencies {
   implementation "com.google.mlkit:barcode-scanning:17.3.0"
   implementation 'androidx.camera:camera-mlkit-vision:1.4.0-alpha02'
 
-  // expo-store-review
+  // In-app review prompt (HomeAppViewModel)
   implementation "com.google.android.play:review:2.0.1"
   implementation "com.google.android.play:review-ktx:2.0.0"
 
@@ -293,17 +268,6 @@ dependencies {
 
   implementation 'com.cronutils:cron-utils:4.1.3'
 
-  // @react-native-community/viewpager
-  api 'com.github.troZee:ViewPager2:v1.0.6'
-
-  // react-native-webview
-  implementation "androidx.webkit:webkit:1.4.0"
-
-  // expo-updates
-  implementation 'org.bouncycastle:bcutil-jdk15to18:1.70'
-
-  // react-native-maps
-  implementation "androidx.work:work-runtime:2.7.1"
 }
 
 project.afterEvaluate {

--- a/template-files/android/AndroidManifest.xml
+++ b/template-files/android/AndroidManifest.xml
@@ -201,29 +201,6 @@
             android:name=".ExponentIntentService"
             android:exported="false" />
 
-        <!-- Analytics -->
-        <!--
-        This crashes: https://code.google.com/p/analytics-issues/issues/detail?id=667
-        TODO: turn it back on when it's fixed
-        <service
-          android:name="com.google.android.gms.analytics.CampaignTrackingService"
-          android:enabled="true"
-          android:exported="false" />-->
-
-        <receiver
-            android:name="com.google.android.gms.analytics.AnalyticsReceiver"
-            android:enabled="true"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.android.gms.analytics.ANALYTICS_DISPATCH" />
-            </intent-filter>
-        </receiver>
-
-        <service
-            android:name="com.google.android.gms.analytics.AnalyticsService"
-            android:enabled="true"
-            android:exported="false" />
-
         <!-- FCM -->
         <service
             android:name=".fcm.ExpoFcmMessagingService"
@@ -250,12 +227,6 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
             android:resource="@color/notification_icon_color" />
-
-
-        <!-- ImagePicker native module -->
-        <activity
-            android:name="com.canhub.cropper.CropImageActivity"
-            android:theme="@style/Base.Theme.AppCompat" />
 
     </application>
 </manifest>


### PR DESCRIPTION
# Why
Cleans up expoview's dependency block. Many declarations existed for vendored module copies that no longer exist, SDK packages that left the SDK years ago, or for third-party libraries the SDK packages now declare themselves. The app module carried its own copies of the same. They inflate the release classpath that R8 has to trace on every build.

# How
Removed every dependency with no source reference in expoview or app, the Google Analytics receivers from the manifest template along with their artifact, and the orphaned cropper activity entry whose library expo-image-picker declares in its own manifest. Also removed declarations the owning SDK packages provide, and the app module's copies of expoview's api dependencies. The camera and review dependencies stay: the home QR scanner and review prompt use them.

# Test Plan
Release build of Expo Go and NCL: home QR scan, image picker with editing, notifications token, install referrer, webview, location, sign in.
