### PR TITLE
[expo-go][android] Migrate AccountScreen to Coil 3 and drop Coil 2

### DIFF
--- a/apps/expo-go/android/expoview/build.gradle
+++ b/apps/expo-go/android/expoview/build.gradle
@@ -165,7 +165,6 @@ dependencies {
   implementation 'io.coil-kt.coil3:coil-network-okhttp:3.2.0'
   implementation 'androidx.compose.material3:material3:1.4.0-alpha10'
   implementation 'androidx.core:core-splashscreen:1.0.1'
-  implementation 'io.coil-kt:coil-compose:2.6.0'
   implementation "androidx.navigation:navigation-compose:2.8.5"
   implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0"
   implementation "androidx.compose.ui:ui:1.7.6"

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import host.exp.exponent.graphql.fragment.CurrentUserActorData
 import host.exp.expoview.R
 


### PR DESCRIPTION
# Why
We declared both Coil 2 and Coil 3. AccountScreen, still used Coil 2's AsyncImage but the rest of the home UI is on Coil 3, so both libraries shipped in the app.

# How
Switched the import

# Test Plan
Expo go. Avatars load as before
