### PR TITLE
[sdk-57] Backport #49055: fix app config build phase when the project path contains a space

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed the app config build phase failing when the project path contains a space.
+
 ### 💡 Others
 
 ## 57.0.14 — 2026-08-24

--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -34,10 +34,10 @@ Pod::Spec.new do |s|
     s.source_files = "**/*.{h,m,swift}"
   end
 
-  env_vars = ENV['PROJECT_ROOT'] ? "PROJECT_ROOT=#{ENV['PROJECT_ROOT']} " : ""
+  env_vars = ENV['PROJECT_ROOT'] ? "PROJECT_ROOT=\\\"#{ENV['PROJECT_ROOT']}\\\" " : ""
   script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
-    :script => "bash -l -c \"#{env_vars}$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh\"",
+    :script => "bash -l -c \"#{env_vars}\\\"$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh\\\"\"",
     :execution_position => :before_compile
   }
   # :always_out_of_date is only available in CocoaPods 1.13.0 and later

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -11,7 +11,7 @@ EXPO_CONSTANTS_PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 # `$PROJECT_DIR` is passed by Xcode as the directory to the xcodeproj file.
 # in classic main project setup it is something like /path/to/app/ios
 # in new style pod project setup it is something like /path/to/app/ios/Pods
-PROJECT_DIR_BASENAME=$(basename $PROJECT_DIR)
+PROJECT_DIR_BASENAME=$(basename "$PROJECT_DIR")
 if [ "x$PROJECT_DIR_BASENAME" != "xPods" ]; then
   exit 0
 fi


### PR DESCRIPTION
# Why

Backport of #49055 to `sdk-57`, as requested/offered in #49341.

The fix merged to `main` on 2026-08-18, but `expo-constants@57.0.14` (latest SDK 57 patch) still ships the unquoted `basename $PROJECT_DIR`, so on a project path containing a space, `get-app-config-ios.sh` silently exits without generating `EXConstants.bundle/app.config` and the Release app crashes at boot in expo-linking. Details and version evidence in #49341.

# How

Clean cherry-pick of d9dd43a (`-x -m 1`, no conflicts): quotes `$PROJECT_DIR` in `get-app-config-ios.sh`, quotes the script-phase paths in `EXConstants.podspec`, and adds the CHANGELOG entry under the branch's Unpublished → Bug fixes section.

# Test Plan

Failure mode reproduced and fix verified on SDK 54 (see the sibling sdk-54 backport PR); the affected files are identical on this branch and the cherry-pick applied without conflicts. EAS builds are unaffected either way (no spaces in cloud build paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)