### PR TITLE
[docs] Pick light and dark images in CSS

### DIFF
--- a/docs/common/window.ts
+++ b/docs/common/window.ts
@@ -21,3 +21,7 @@ export function prefersDarkTheme() {
 export function prefersReducedMotion() {
   return window?.matchMedia('(prefers-reduced-motion)').matches ?? false;
 }
+
+export function isDarkTheme() {
+  return document.documentElement.classList.contains('dark-theme');
+}

--- a/docs/common/window.ts
+++ b/docs/common/window.ts
@@ -14,10 +14,6 @@ export function getViewportSize() {
   };
 }
 
-export function prefersDarkTheme() {
-  return window?.matchMedia('(prefers-color-scheme: dark)').matches ?? false;
-}
-
 export function prefersReducedMotion() {
   return window?.matchMedia('(prefers-reduced-motion)').matches ?? false;
 }

--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -1,4 +1,4 @@
-import { ButtonBase, mergeClasses, useTheme } from '@expo/styleguide';
+import { ButtonBase, mergeClasses } from '@expo/styleguide';
 
 import { CALLOUT, HEADLINE } from '~/ui/components/Text';
 
@@ -21,7 +21,7 @@ export function SelectCard({
   isSelected,
   onClick,
 }: Props) {
-  const { themeName } = useTheme();
+  const imageClasses = isSelected ? 'grayscale-0' : 'opacity-80 grayscale';
 
   return (
     <ButtonBase onClick={onClick}>
@@ -35,20 +35,30 @@ export function SelectCard({
             'border-b border-default',
             isSelected ? 'bg-linear-to-b from-palette-blue3 to-palette-blue4' : 'bg-subtle'
           )}>
-          <picture className="relative flex h-full w-auto items-end">
-            {themeName !== 'light' && (
-              <source
-                srcSet={darkImgSrc}
-                type="image/png"
-                media={themeName === 'auto' ? '(prefers-color-scheme: dark)' : undefined}
-              />
-            )}
+          <picture
+            className={mergeClasses(
+              'relative flex h-full w-auto items-end',
+              darkImgSrc && 'dark:hidden'
+            )}>
             <img
               src={imgSrc}
               alt={alt}
-              className={mergeClasses(isSelected ? 'grayscale-0' : 'opacity-80 grayscale')}
+              loading={darkImgSrc ? 'lazy' : undefined}
+              decoding={darkImgSrc ? 'async' : undefined}
+              className={imageClasses}
             />
           </picture>
+          {darkImgSrc && (
+            <picture className="relative flex h-full w-auto items-end light:hidden">
+              <img
+                src={darkImgSrc}
+                alt={alt}
+                loading="lazy"
+                decoding="async"
+                className={imageClasses}
+              />
+            </picture>
+          )}
         </div>
         <div className="flex flex-col gap-2 p-4">
           <div className="flex items-center gap-2">

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/Content.tsx
@@ -1,8 +1,6 @@
-import { Button, useTheme } from '@expo/styleguide';
+import { Button, mergeClasses } from '@expo/styleguide';
 import { ArrowRightIcon } from '@expo/styleguide-icons/outline/ArrowRightIcon';
-import { ReactNode, useEffect, useState } from 'react';
-
-import { prefersDarkTheme } from '~/common/window';
+import { ReactNode } from 'react';
 
 type Props = {
   imgSrc: string;
@@ -13,23 +11,23 @@ type Props = {
 };
 
 export function Content({ imgSrc, darkImgSrc, alt, href, content }: Props) {
-  const { themeName } = useTheme();
-  const [isDarkMode, setIsDarkMode] = useState(false);
-
-  useEffect(
-    function didMount() {
-      setIsDarkMode(themeName === 'dark' || (themeName === 'auto' && prefersDarkTheme()));
-    },
-    [themeName]
-  );
-
   return (
     <div>
       <div className="flex items-center justify-center bg-screen">
-        <picture className="relative">
-          {isDarkMode && <source srcSet={darkImgSrc} type="image/png" />}
-          <img src={imgSrc} alt={alt} className="size-75" />
+        <picture className={mergeClasses('relative', darkImgSrc && 'dark:hidden')}>
+          <img
+            src={imgSrc}
+            alt={alt}
+            loading={darkImgSrc ? 'lazy' : undefined}
+            decoding={darkImgSrc ? 'async' : undefined}
+            className="size-75"
+          />
         </picture>
+        {darkImgSrc && (
+          <picture className="relative light:hidden">
+            <img src={darkImgSrc} alt={alt} loading="lazy" decoding="async" className="size-75" />
+          </picture>
+        )}
       </div>
       <div className="flex flex-col items-start gap-3 border-t border-default bg-default px-6 pb-6">
         <div>

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -1,5 +1,10 @@
 const expoTheme = require('@expo/styleguide/tailwind');
 const merge = require('lodash/merge');
+const plugin = require('tailwindcss/plugin');
+
+const lightVariant = plugin(({ addVariant }) => {
+  addVariant('light', '&:is([class*="light-theme"] *)');
+});
 
 function getExpoTheme(extend = {}, plugins = []) {
   const customizedTheme = Object.assign({}, expoTheme);
@@ -21,45 +26,48 @@ module.exports = {
     './node_modules/@expo/styleguide-search-ui/dist/**/*.{js,ts,jsx,tsx}',
     './node_modules/@expo/styleguide-cookie-consent/dist/**/*.{js,ts,jsx,tsx}',
   ],
-  ...getExpoTheme({
-    screens: {
-      sm: '468px',
-      md: '788px',
-      lg: '1008px',
-      xl: '1328px',
-      '2xl': '1572px',
-    },
-    borderColor: {
-      'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
-    },
-    backgroundImage: {
-      'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
-      'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
-      'cell-workflows-pattern': "url('/static/images/home/WorkflowsPattern.svg')",
-    },
-    keyframes: {
-      wave: {
-        '0%, 100%': {
-          transform: 'rotate(0deg)',
+  ...getExpoTheme(
+    {
+      screens: {
+        sm: '468px',
+        md: '788px',
+        lg: '1008px',
+        xl: '1328px',
+        '2xl': '1572px',
+      },
+      borderColor: {
+        'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
+      },
+      backgroundImage: {
+        'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
+        'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
+        'cell-workflows-pattern': "url('/static/images/home/WorkflowsPattern.svg')",
+      },
+      keyframes: {
+        wave: {
+          '0%, 100%': {
+            transform: 'rotate(0deg)',
+          },
+          '50%': {
+            transform: 'rotate(20deg)',
+          },
         },
-        '50%': {
-          transform: 'rotate(20deg)',
+        slideUpAndFadeIn: {
+          '0%': {
+            opacity: 0,
+            transform: 'translateY(16px)',
+          },
+          '100%': {
+            opacity: 1,
+            transform: 'translateY(0)',
+          },
         },
       },
-      slideUpAndFadeIn: {
-        '0%': {
-          opacity: 0,
-          transform: 'translateY(16px)',
-        },
-        '100%': {
-          opacity: 1,
-          transform: 'translateY(0)',
-        },
+      animation: {
+        slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
+        wave: 'wave 0.25s ease-in-out 4',
       },
     },
-    animation: {
-      slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
-      wave: 'wave 0.25s ease-in-out 4',
-    },
-  }),
+    [lightVariant]
+  ),
 };

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -3,7 +3,7 @@ const merge = require('lodash/merge');
 const plugin = require('tailwindcss/plugin');
 
 const lightVariant = plugin(({ addVariant }) => {
-  addVariant('light', '&:is([class*="light-theme"] *)');
+  addVariant('light', '&:is(:root:not([class*="dark-theme"]) *)');
 });
 
 function getExpoTheme(extend = {}, plugins = []) {

--- a/docs/ui/components/ComponentExample.tsx
+++ b/docs/ui/components/ComponentExample.tsx
@@ -1,9 +1,7 @@
-import { useTheme } from '@expo/styleguide';
 import { FileCode01Icon } from '@expo/styleguide-icons/outline/FileCode01Icon';
-import { PropsWithChildren, useEffect, useState } from 'react';
+import { PropsWithChildren } from 'react';
 
 import { cleanCopyValue, getCodeBlockDataFromChildren } from '~/common/code-utilities';
-import { prefersDarkTheme } from '~/common/window';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import { LightboxImage } from '~/ui/components/ContentSpotlight/LightboxImage';
 import { PlatformTabs } from '~/ui/components/PlatformTabs';
@@ -89,25 +87,14 @@ function resolveImages({
  * every capture carries as `-ios-` or `-android-`, so pages need no extra prop.
  */
 export function ComponentExample({ title, src, darkSrc, alt, android, ios, children }: Props) {
-  const { themeName } = useTheme();
   const context = usePageApiVersion();
-  const [isDark, setDark] = useState(false);
 
   const images = resolveImages({ src, darkSrc, alt, android, ios });
   const available = orderPlatforms(images);
   const { active, select } = usePlatformSelection(available);
 
-  useEffect(() => {
-    if (themeName === 'auto') {
-      setDark(prefersDarkTheme());
-    } else {
-      setDark(themeName === 'dark');
-    }
-  }, [themeName]);
-
   const { value } = getCodeBlockDataFromChildren(children);
   const image = images[active];
-  const activeSrc = image && isDark && image.darkSrc ? image.darkSrc : image?.src;
   const device = active === 'android' ? DEVICE_FRAMES.android : DEVICE_FRAMES.ios;
 
   return (
@@ -120,7 +107,7 @@ export function ComponentExample({ title, src, darkSrc, alt, android, ios, child
           </SnippetHeader>
           <SnippetContent className="flex-1 rounded-none border-0 p-0">{children}</SnippetContent>
         </div>
-        {image && activeSrc && (
+        {image && (
           <div className="flex w-56 shrink-0 flex-col items-center justify-center gap-3 border-l border-default bg-subtle p-4 max-lg:w-full max-lg:border-t max-lg:border-l-0">
             <PlatformTabs available={available} active={active} select={select} />
             <div
@@ -143,7 +130,8 @@ export function ComponentExample({ title, src, darkSrc, alt, android, ios, child
                 className="overflow-hidden [&_button]:block [&_button]:w-full [&_button]:cursor-pointer"
                 style={{ borderRadius: device.screenRadius }}>
                 <LightboxImage
-                  src={activeSrc}
+                  src={image.src}
+                  darkSrc={image.darkSrc}
                   alt={image.alt}
                   width={device.width}
                   height={device.height}

--- a/docs/ui/components/ContentSpotlight/LightboxImage.tsx
+++ b/docs/ui/components/ContentSpotlight/LightboxImage.tsx
@@ -1,5 +1,8 @@
+import { mergeClasses } from '@expo/styleguide';
 import dynamic from 'next/dynamic';
 import { ImgHTMLAttributes, useState } from 'react';
+
+import { isDarkTheme } from '~/common/window';
 
 // Loaded on first click so the lightbox JS and its stylesheet stay out of the
 // render-blocking path; the inline image below is independent of it.
@@ -7,25 +10,47 @@ const LightboxModal = dynamic(() => import('./LightboxModal'), { ssr: false });
 
 type Props = ImgHTMLAttributes<HTMLImageElement> & {
   src: string;
+  darkSrc?: string;
 };
 
-export function LightboxImage({ src, alt, ...rest }: Props) {
+export function LightboxImage({ src, darkSrc, alt, className, ...rest }: Props) {
   const [open, setOpen] = useState(false);
-  const [lightboxRequested, setLightboxRequested] = useState(false);
+  const [lightboxSrc, setLightboxSrc] = useState<string>();
 
   return (
     <>
       <button
         type="button"
         onClick={() => {
-          setLightboxRequested(true);
+          setLightboxSrc(darkSrc && isDarkTheme() ? darkSrc : src);
           setOpen(true);
         }}>
-        <img src={src} alt={alt} {...rest} />
+        {darkSrc ? (
+          <>
+            <img
+              src={src}
+              alt={alt}
+              loading="lazy"
+              decoding="async"
+              className={mergeClasses(className, 'dark:hidden')}
+              {...rest}
+            />
+            <img
+              src={darkSrc}
+              alt={alt}
+              loading="lazy"
+              decoding="async"
+              className={mergeClasses(className, 'light:hidden')}
+              {...rest}
+            />
+          </>
+        ) : (
+          <img src={src} alt={alt} className={className} {...rest} />
+        )}
       </button>
-      {lightboxRequested && (
+      {lightboxSrc && (
         <LightboxModal
-          src={src}
+          src={lightboxSrc}
           open={open}
           close={() => {
             setOpen(false);

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -1,9 +1,8 @@
-import { mergeClasses, useTheme } from '@expo/styleguide';
+import { mergeClasses } from '@expo/styleguide';
 import { useInView } from 'framer-motion';
 import dynamic from 'next/dynamic';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
-import { prefersDarkTheme } from '~/common/window';
 import { DotGrid } from '~/ui/components/Diagram/DotGrid';
 
 import { LightboxImage } from './LightboxImage';
@@ -61,16 +60,6 @@ export function ContentSpotlight({
   aspect,
 }: ContentSpotlightProps) {
   const [forceShowControls, setForceShowControls] = useState<boolean>();
-  const { themeName } = useTheme();
-  const [isDark, setDark] = useState(themeName === 'dark');
-
-  useEffect(() => {
-    if (themeName === 'auto') {
-      setDark(prefersDarkTheme());
-    } else {
-      setDark(themeName === 'dark');
-    }
-  }, [themeName]);
 
   const resolvedPlayerWidth = playerWidth ?? PLAYER_WIDTH;
   const resolvedPlayerHeight = playerHeight ?? PLAYER_HEIGHT;
@@ -87,7 +76,6 @@ export function ContentSpotlight({
   const shouldAutoplay = isInView && isVideo && (!videoId || autoplayYT);
 
   const isComponentVariant = variant === 'component' && !isVideo;
-  const activeSrc = isDark && darkSrc ? darkSrc : src;
 
   return (
     <figure
@@ -107,14 +95,19 @@ export function ContentSpotlight({
       {src && isComponentVariant ? (
         <>
           <DotGrid />
-          <picture className="relative block size-full">
-            {isDark && darkSrc && <source srcSet={darkSrc} />}
+          <picture className={mergeClasses('relative block size-full', darkSrc && 'dark:hidden')}>
             <img src={src} alt={alt} className="size-full object-cover" />
           </picture>
+          {darkSrc && (
+            <picture className="relative block size-full light:hidden">
+              <img src={darkSrc} alt={alt} className="size-full object-cover" />
+            </picture>
+          )}
         </>
       ) : src ? (
         <LightboxImage
-          src={activeSrc ?? src}
+          src={src}
+          darkSrc={darkSrc}
           alt={alt}
           width={width}
           height={height}

--- a/docs/ui/components/Diagram/Diagram.tsx
+++ b/docs/ui/components/Diagram/Diagram.tsx
@@ -1,7 +1,4 @@
-import { useTheme } from '@expo/styleguide';
-import { useEffect, useState } from 'react';
-
-import { prefersDarkTheme } from '~/common/window';
+import { mergeClasses } from '@expo/styleguide';
 
 import { DotGrid } from './DotGrid';
 
@@ -12,49 +9,51 @@ type Props = {
   disableSrcSet?: boolean;
 };
 
+type PictureProps = {
+  src: string;
+  alt: string;
+  withFormats: boolean;
+  isPaired: boolean;
+  className: string;
+};
+
+function DiagramPicture({ src, alt, withFormats, isPaired, className }: PictureProps) {
+  return (
+    <picture className={className}>
+      {withFormats && <source srcSet={src.replace('.png', '.avif')} type="image/avif" />}
+      {withFormats && <source srcSet={src.replace('.png', '.webp')} type="image/webp" />}
+      <img
+        src={src}
+        alt={alt}
+        loading={isPaired ? 'lazy' : undefined}
+        decoding={isPaired ? 'async' : undefined}
+      />
+    </picture>
+  );
+}
+
 export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
-  const { themeName } = useTheme();
-  const [isDark, setDark] = useState(themeName === 'dark');
-
-  useEffect(() => {
-    if (themeName === 'auto') {
-      setDark(prefersDarkTheme());
-    } else {
-      setDark(themeName === 'dark');
-    }
-  }, [themeName]);
-
-  if (!source.endsWith('.png')) {
-    return (
-      <div className="relative m-auto my-6 max-w-187.5 overflow-hidden rounded-md border border-default bg-default">
-        <DotGrid />
-        <picture className="relative">
-          {isDark && darkSource && <source srcSet={darkSource} />}
-          <img src={source} alt={alt} />
-        </picture>
-      </div>
-    );
-  }
+  const withFormats = source.endsWith('.png') && !disableSrcSet;
 
   return (
     <div className="relative m-auto my-6 max-w-187.5 overflow-hidden rounded-md border border-default bg-default">
       <DotGrid />
-      <picture className="relative">
-        {!isDark && !disableSrcSet && (
-          <source srcSet={source.replace('.png', '.avif')} type="image/avif" />
-        )}
-        {darkSource && isDark && !disableSrcSet && (
-          <source srcSet={darkSource.replace('.png', '.avif')} type="image/avif" />
-        )}
-        {!isDark && !disableSrcSet && (
-          <source srcSet={source.replace('.png', '.webp')} type="image/webp" />
-        )}
-        {darkSource && isDark && !disableSrcSet && (
-          <source srcSet={darkSource.replace('.png', '.webp')} type="image/webp" />
-        )}
-        {darkSource && isDark && <source srcSet={darkSource} />}
-        <img src={source} alt={alt} />
-      </picture>
+      <DiagramPicture
+        src={source}
+        alt={alt}
+        withFormats={withFormats}
+        isPaired={!!darkSource}
+        className={mergeClasses('relative', darkSource && 'dark:hidden')}
+      />
+      {darkSource && (
+        <DiagramPicture
+          src={darkSource}
+          alt={alt}
+          withFormats={withFormats}
+          isPaired
+          className="relative light:hidden"
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26172

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Pick light and dark images in CSS instead of JavaScript in all image based components. When images are picked by JavaScript, they happen after the first hydration which is why, previously, there was a frame where light mode images were picked first before dark mode images when dark mode theme was selected.
- Remove unused `prefersDarkTheme` code.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**Examples after fix of the image loading:**


https://github.com/user-attachments/assets/a2ed08fd-0e54-467b-81c5-261414f8184f


https://github.com/user-attachments/assets/f14ada33-d192-4d85-a945-5430c4665912

**How to test manually:**
- Go to https://pr-49347.expo-docs.pages.dev/eas/observe/introduction/
- Either switch to dark mode theme
- Hard refresh the page and ensure that light mode image doesn't load

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
