### PR TITLE
[image-picker][ios] Don't read the photo library on the video fast path without read access

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Fixed crop square detection using the main screen's scale instead of the scale of the view being measured. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix a failed crop resolving with the uncropped original image instead of rejecting when `allowsEditing` is `true`. ([#48524](https://github.com/expo/expo/issues/48524) by [@aashishshrestha5532](https://github.com/aashishshrestha5532), [#48541](https://github.com/expo/expo/pull/48541) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix the video `PHAssetResourceManager` fast path rejecting instead of falling back to the slower path that can fetch iCloud assets, and pass `shouldDownloadFromNetwork` through when reading Live Photo resources. As a result, a video whose data is not stored locally is now downloaded through the fallback path even when `shouldDownloadFromNetwork` is `false` and `videoExportPreset` is `Passthrough`. ([#48658](https://github.com/expo/expo/issues/48658) by [@gcampoyf-cloud](https://github.com/gcampoyf-cloud), [#48794](https://github.com/expo/expo/pull/48794) by [@expo-bot](https://github.com/expo-bot))
+- [iOS] Fix picking a video terminating apps that ship no `NSPhotoLibraryUsageDescription` by only taking the `PHAssetResourceManager` fast path when photo library read access has already been granted. ([#49362](https://github.com/expo/expo/pull/49362) by [@OlegBezr](https://github.com/OlegBezr))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -420,7 +420,15 @@ internal struct MediaHandler {
     // asset as *adjusted* and will re-render a temporary file for us. Copying the resource bytes
     // ourselves is dramatically faster because it just streams the already-existing file.
 
-    if options.videoExportPreset == .passthrough, let assetId = selectedVideo.assetIdentifier {
+    // `PHAsset.fetchAssets` reads the photo library, so it triggers a `kTCCServicePhotos`
+    // authorization check. `PHPickerViewController` itself needs no authorization, so apps that only
+    // pick media never request it - and an app with no `NSPhotoLibraryUsageDescription` in its
+    // Info.plist is terminated by the system rather than merely denied. Only take the fast path when
+    // read access has already been granted; otherwise fall through to the picker's own item provider.
+    let photoLibraryReadStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+    let hasPhotoLibraryReadAccess = photoLibraryReadStatus == .authorized || photoLibraryReadStatus == .limited
+
+    if options.videoExportPreset == .passthrough, hasPhotoLibraryReadAccess, let assetId = selectedVideo.assetIdentifier {
       let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [assetId], options: nil)
       if let asset = fetchResult.firstObject {
         // Prefer the full-size resource when available, otherwise fall back to the default `.video`.

--- a/packages/expo-image-picker/ios/MediaHandler.swift
+++ b/packages/expo-image-picker/ios/MediaHandler.swift
@@ -420,11 +420,6 @@ internal struct MediaHandler {
     // asset as *adjusted* and will re-render a temporary file for us. Copying the resource bytes
     // ourselves is dramatically faster because it just streams the already-existing file.
 
-    // `PHAsset.fetchAssets` reads the photo library, so it triggers a `kTCCServicePhotos`
-    // authorization check. `PHPickerViewController` itself needs no authorization, so apps that only
-    // pick media never request it - and an app with no `NSPhotoLibraryUsageDescription` in its
-    // Info.plist is terminated by the system rather than merely denied. Only take the fast path when
-    // read access has already been granted; otherwise fall through to the picker's own item provider.
     let photoLibraryReadStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     let hasPhotoLibraryReadAccess = photoLibraryReadStatus == .authorized || photoLibraryReadStatus == .limited
 


### PR DESCRIPTION
# Why

Picking a video with `launchImageLibraryAsync` terminates apps that ship no `NSPhotoLibraryUsageDescription` in their `Info.plist`.

`PHPickerViewController` requires **no** photo library authorization — that is its whole design purpose: the user picks out-of-process and the app receives only the chosen items. `expo-image-picker` builds its picker with `PHPickerConfiguration(photoLibrary: PHPhotoLibrary.shared())`, which is fine on its own: it just makes the results Photos-backed so `assetIdentifier` is populated.

However, the passthrough fast path added in #37569 calls `PHAsset.fetchAssets(withLocalIdentifiers:)`. That is a photo library **read**, so it trips a `kTCCServicePhotos` authorization check. For an app that ships no `NSPhotoLibraryUsageDescription` — perfectly legal, and the recommended configuration for an app that only uses the system picker — that check does not merely fail: iOS terminates the app. `tccd` logs:

```
Refusing authorization request for service kTCCServicePhotos ... without NSPhotoLibraryUsageDescription key
```

The termination happens after the user taps "Done" in the picker, so it looks like a picker bug rather than a permission bug, and no crash report is written to `DiagnosticReports`, which makes it hard to diagnose.

This is a regression: before #37569, the video path used only `loadFileRepresentation` on the item provider, which needs no authorization.

The effect today is that `expo-image-picker` forces every app that picks videos to request full read access to the photo library, purely to keep an optimization that only matters for *adjusted* assets — even though the config plugin exposes `photosPermission: false` for exactly the case of an app that doesn't want that permission.

# How

Only take the fast path when the app actually holds the read access that path requires:

```swift
let photoLibraryReadStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
let hasPhotoLibraryReadAccess = photoLibraryReadStatus == .authorized || photoLibraryReadStatus == .limited

if options.videoExportPreset == .passthrough, hasPhotoLibraryReadAccess, let assetId = selectedVideo.assetIdentifier {
```

- Apps holding read access keep the optimization unchanged.
- Apps without it fall through to the pre-existing `loadVideoRepresentation` path — the behavior before the fast path was introduced. That path still preserves the original bytes under `.passthrough`, and still returns `selectedVideo.assetIdentifier` as `assetId`, so the resolved asset is unchanged apart from timing.
- `PHPhotoLibrary.authorizationStatus(for:)` does not prompt and is safe to call without a usage-description key.

`.limited` is included because in limited mode `fetchAssets` legitimately succeeds for assets in the user's granted set, and gracefully returns empty (falling through) for ones outside it — so the optimization is preserved there too.

# Test Plan

I do not have a self-contained repro app to attach; the following was verified downstream by the reporter in a real Expo/React Native app (NavigateAI), against `expo-image-picker@57.0.8` patched with exactly this change, on an iOS 18.6 simulator:

- With all photo permissions revoked and no `NSPhotoLibraryUsageDescription` in the built `Info.plist`, picking a video from the library previously terminated the app on "Done". With this change the pick completes and resolves an asset whose `assetId` is populated.
- With full read access granted, the fast path is still taken and behavior is unchanged.

I have not run the expo repo's own test-suites for this package beyond confirming the change is a compile-level no-op for callers (no public API change, no JS/TS change).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — changelog entry added; there is no JS/TS source to rebuild, this is an iOS-only change.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — not applicable, no config plugin change.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — not applicable, no docs change.
