### PR TITLE
[metro-file-map] Watch new directories before listing them

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -56,6 +56,84 @@ env:
   SKIP_SKIA_DOWNLOAD: '1'
 
 jobs:
+  install-e2e-debian:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
+    runs-on: ubuntu-24.04
+    container: node:24-bookworm
+    strategy:
+      fail-fast: false
+      matrix:
+        pm: [bun, npm, pnpm]
+    steps:
+      - name: 🐧 Install container prerequisites
+        run: apt-get update && apt-get install -y unzip
+
+      - name: 👀 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 🏗️ Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10
+
+      - name: 🏗️ Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.x'
+
+      - name: 📦 Install node modules in root dir
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
+
+      - name: 🔨 Build the CLI and its dependencies
+        run: pnpm turbo run build --filter=@expo/cli
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
+
+      - name: 🧪 Install-while-running E2E
+        working-directory: packages/@expo/cli
+        run: pnpm test:e2e install-while-running --max-workers 1
+        env:
+          E2E_INSTALL_PM: ${{ matrix.pm }}
+
+  fallback-watcher-windows:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
+    runs-on: windows-2022
+    timeout-minutes: 25
+    steps:
+      - name: 🪟 Setup Windows
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: 👀 Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: 🏗️ Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10
+
+      - name: 🏗️ Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: 📦 Install node modules in root dir
+        run: pnpm install --frozen-lockfile --ignore-scripts
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: expo
+
+      - name: 🧪 FallbackWatcher unit tests
+        working-directory: packages/@expo/metro-file-map
+        run: pnpm exec jest src/watchers/__tests__/FallbackWatcher.test.ts --runInBand
+
   jest-ubuntu:
     if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04

--- a/packages/@expo/cli/e2e/__tests__/install-while-running.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/install-while-running.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ *
+ * #48950: install while the dev server runs. Skips Darwin (NativeWatcher).
+ */
+import fs from 'fs/promises';
+import path from 'path';
+
+import { createExpoStart, executeExpoAsync } from '../utils/expo';
+import { getTemporaryPath } from '../utils/path';
+import { executeAsync } from '../utils/process';
+
+jest.setTimeout(20 * 60 * 1000);
+
+const FIXTURE_DIR = path.join(__dirname, '../fixtures/with-blank');
+
+const PM = (process.env.E2E_INSTALL_PM ?? 'bun') as 'bun' | 'npm' | 'pnpm';
+const PM_COMMANDS: Record<typeof PM, { install: string[] }> = {
+  bun: { install: ['bun', 'install'] },
+  npm: { install: ['npm', 'install', '--no-audit', '--no-fund'] },
+  pnpm: { install: ['pnpm', 'install'] },
+};
+
+const CYCLES: string[][] = [
+  ['@react-native-async-storage/async-storage', 'expo-haptics', 'expo-clipboard'],
+  ['expo-crypto', 'expo-device', 'expo-network'],
+  ['expo-battery', 'expo-brightness', 'expo-keep-awake'],
+  ['expo-localization', 'expo-sharing', 'expo-blur'],
+];
+
+const POLL_TIMEOUT_MS = 45000;
+const POLL_INTERVAL_MS = 3000;
+
+const WATCH_ENV = {
+  CI: undefined,
+  CONTINUOUS_INTEGRATION: undefined,
+  GITHUB_ACTIONS: undefined,
+  BUILD_NUMBER: undefined,
+  RUN_ID: undefined,
+  DEBUG: 'Metro:Watcher',
+} as unknown as Record<string, string>;
+
+const describeInstall = process.platform === 'darwin' ? describe.skip : describe;
+
+function createWatchingExpo(): {
+  expo: ReturnType<typeof createExpoStart>;
+  output: string[];
+} {
+  const output: string[] = [];
+  const expo = createExpoStart({
+    env: WATCH_ENV,
+    onOutput: (chunk) => {
+      output.push(chunk);
+    },
+  });
+  return { expo, output };
+}
+
+async function startAndAssertFallbackWatcher(
+  expo: ReturnType<typeof createExpoStart>,
+  output: string[]
+): Promise<void> {
+  await expo.startAsync();
+  const logs = output.join('');
+  if (!/Using watcher: fallback/.test(logs)) {
+    throw new Error(`Expected FallbackWatcher. Output:\n${logs.slice(0, 2000)}`);
+  }
+}
+
+function appSource(packages: string[]): string {
+  const imports = packages.map((name, index) => `import * as installed${index} from '${name}';`);
+  const names = packages.map((_, index) => `installed${index}`).join(', ');
+  return [
+    ...imports,
+    '',
+    'export default function App() {',
+    `  return [${names}].map((mod) => Object.keys(mod).length).join(',');`,
+    '}',
+    '',
+  ].join('\n');
+}
+
+async function createProject(): Promise<string> {
+  const projectRoot = getTemporaryPath();
+  await fs.mkdir(projectRoot, { recursive: true });
+  for (const file of ['index.js', 'app.json', 'metro.config.js']) {
+    await fs.copyFile(path.join(FIXTURE_DIR, file), path.join(projectRoot, file));
+  }
+  await fs.writeFile(path.join(projectRoot, 'App.js'), appSource([]));
+  await fs.writeFile(
+    path.join(projectRoot, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'install-while-running',
+        version: '1.0.0',
+        main: 'index.js',
+        private: true,
+        dependencies: {
+          expo: '~57.0.0',
+          react: '19.2.3',
+          'react-native': '0.86.2',
+        },
+      },
+      null,
+      2
+    )
+  );
+  await executeAsync(projectRoot, PM_COMMANDS[PM].install);
+  return projectRoot;
+}
+
+async function pollBundle(
+  expo: ReturnType<typeof createExpoStart>
+): Promise<{ ok: boolean; lastError: Error | null }> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let lastError: Error | null = null;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    try {
+      const response = await expo.fetchBundleAsync('/App.bundle?platform=ios');
+      if (response.status === 200) {
+        return { ok: true, lastError: null };
+      }
+    } catch (error: any) {
+      lastError = error;
+    }
+  }
+  return { ok: false, lastError };
+}
+
+describeInstall(`installs while the dev server runs (${PM})`, () => {
+  const { expo, output } = createWatchingExpo();
+  let projectRoot: string;
+
+  beforeAll(async () => {
+    projectRoot = await createProject();
+    expo.options.cwd = projectRoot;
+    await startAndAssertFallbackWatcher(expo, output);
+  });
+
+  afterAll(async () => {
+    await expo.stopAsync();
+  });
+
+  it('resolves packages installed while the dev server runs (#48950)', async () => {
+    const warm = await expo.fetchBundleAsync('/App.bundle?platform=ios');
+    expect(warm.status).toBe(200);
+
+    const imported: string[] = [];
+    const staleCycles: string[] = [];
+
+    for (const [cycleIndex, packages] of CYCLES.entries()) {
+      await executeExpoAsync(projectRoot, ['install', ...packages]);
+      imported.push(...packages);
+      await fs.writeFile(path.join(projectRoot, 'App.js'), appSource(imported));
+
+      const result = await pollBundle(expo);
+      if (!result.ok) {
+        staleCycles.push(
+          `cycle ${cycleIndex + 1} (${packages.join(', ')}): ` +
+            `${result.lastError?.message?.slice(0, 300)}`
+        );
+      }
+    }
+
+    if (staleCycles.length > 0) {
+      throw new Error(
+        `The file map went stale in ${staleCycles.length} of ${CYCLES.length} ` +
+          `install cycles:\n${staleCycles.join('\n')}`
+      );
+    }
+  });
+});

--- a/packages/@expo/cli/e2e/utils/server.ts
+++ b/packages/@expo/cli/e2e/utils/server.ts
@@ -45,6 +45,8 @@ export type BackgroundServerOptions = ExpoSpawnOptions & {
    * When passing a URL, the port will be overridden using the configured port.
    */
   host(chunk: any): URL | string | null;
+  /** Called with each stdout/stderr chunk from the child, starting at spawn. */
+  onOutput?(chunk: string): void;
   /** Fully show the child process output, enabled when re-running GitHub Actions with debug mode */
   verbose?: boolean;
 };
@@ -70,6 +72,7 @@ export function createBackgroundServer({
   host: resolveHost,
   port: resolvePort = findFreePortAsync,
   verbose,
+  onOutput,
   ...spawnOptions
 }: BackgroundServerOptions): BackgroundServer {
   let child: ChildProcess | null = null;
@@ -132,6 +135,11 @@ export function createBackgroundServer({
       log = createVerboseLogger({ verbose, prefix: 'server' });
       log('startAsync()', bin, ...commandOrFlags, this.options);
       processCollectOutput(child, log.tag);
+      if (onOutput) {
+        const tap = (chunk: Buffer | string) => onOutput(String(chunk));
+        child.stdout?.on('data', tap);
+        child.stderr?.on('data', tap);
+      }
 
       try {
         // Wait until the host is resolved based on the process output

--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Pick up files written into a new directory while `FallbackWatcher` starts to watch it, so a package installed while the dev server runs is resolvable (fixes [#48950](https://github.com/expo/expo/issues/48950)).
+- Pick up files written into a new directory while `FallbackWatcher` starts to watch it, so a package installed while the dev server runs is resolvable (fixes [#48950](https://github.com/expo/expo/issues/48950)). ([#49363](https://github.com/expo/expo/pull/49363) by [@brentvatne](https://github.com/brentvatne))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Pick up files written into a new directory while `FallbackWatcher` starts to watch it, so a package installed while the dev server runs is resolvable (fixes [#48950](https://github.com/expo/expo/issues/48950)).
+
 ### 💡 Others
 
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-file-map/src/watchers/FallbackWatcher.ts
+++ b/packages/@expo/metro-file-map/src/watchers/FallbackWatcher.ts
@@ -165,12 +165,26 @@ export default class FallbackWatcher extends AbstractWatcher {
     if (this.#watched[dir]) {
       return false;
     }
-    const watcher = fs.watch(dir, { persistent: true }, (event, filename) =>
-      this.#normalizeChange(dir, event, filename as string)
-    );
+    let watcher: FSWatcher;
+    try {
+      watcher = fs.watch(dir, { persistent: true }, (event, filename) =>
+        this.#normalizeChange(dir, event, filename as string)
+      );
+    } catch (error: any) {
+      // Directory can vanish before watch; filterDir must not throw.
+      this.#checkedEmitError(error);
+      return false;
+    }
     this.#watched[dir] = watcher;
 
-    watcher.on('error', this.#checkedEmitError);
+    watcher.on('error', (error) => {
+      // Node emits no `close` after `error`.
+      if (this.#watched[dir] === watcher) {
+        delete this.#watched[dir];
+      }
+      watcher.close();
+      this.#checkedEmitError(error);
+    });
 
     if (this.root !== dir) {
       this.#register(dir, 'd');
@@ -183,13 +197,15 @@ export default class FallbackWatcher extends AbstractWatcher {
    */
   async #stopWatching(dir: string): Promise<void> {
     const watcher = this.#watched[dir];
-    if (watcher) {
-      await new Promise<void>((resolve) => {
-        watcher.once('close', () => process.nextTick(resolve));
-        watcher.close();
-        delete this.#watched[dir];
-      });
+    if (!watcher) {
+      return;
     }
+    delete this.#watched[dir];
+    await new Promise<void>((resolve) => {
+      watcher.once('close', () => process.nextTick(resolve));
+      watcher.once('error', () => process.nextTick(resolve));
+      watcher.close();
+    });
   }
 
   /**
@@ -244,6 +260,13 @@ export default class FallbackWatcher extends AbstractWatcher {
    */
   #normalizeChange(dir: string, event: string, file: string) {
     if (!file) {
+      if (!this.#dirRegistry[dir]) {
+        // Windows may omit filename; list the new directory.
+        this.#processChange(dir, event === 'change' ? 'rename' : event, '').catch((error) => {
+          this.emitError(error);
+        });
+        return;
+      }
       this.#detectChangedFile(dir, event, (actualFile) => {
         if (actualFile) {
           this.#processChange(dir, event, actualFile).catch((error) => {
@@ -423,11 +446,15 @@ function recReaddir(
   ignored: RegExp | undefined | null
 ) {
   const walk = walker(dir);
-  if (ignored) {
-    walk.filterDir((currentDir: string) => !common.posixPathMatchesPattern(ignored, currentDir));
-  }
+  // Watch before readdir so a file written in between is not missed.
+  walk.filterDir((currentDir: string, stats: Stats) => {
+    if (ignored && common.posixPathMatchesPattern(ignored, currentDir)) {
+      return false;
+    }
+    normalizeProxy(dirCallback)(currentDir, stats);
+    return true;
+  });
   walk
-    .on('dir', normalizeProxy(dirCallback))
     .on('file', normalizeProxy(fileCallback))
     .on('symlink', normalizeProxy(symlinkCallback))
     .on('error', errorCallback)

--- a/packages/@expo/metro-file-map/src/watchers/__tests__/FallbackWatcher.test.ts
+++ b/packages/@expo/metro-file-map/src/watchers/__tests__/FallbackWatcher.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import EventEmitter from 'events';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import type { WatcherBackendChangeEvent } from '../../types';
+import FallbackWatcher from '../FallbackWatcher';
+
+// Real fs.watch; jest.setup.ts mocks fs.
+jest.unmock('fs');
+jest.unmock('fs/promises');
+
+const WAIT_TIMEOUT_MS = 10000;
+const POLL_INTERVAL_MS = 10;
+
+jest.setTimeout(WAIT_TIMEOUT_MS * 4);
+
+let tornDown = false;
+
+async function waitFor(predicate: () => boolean, description: string): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (tornDown) {
+      throw new Error(`Test tore down while waiting for ${description}`);
+    }
+    if (Date.now() - start > WAIT_TIMEOUT_MS) {
+      throw new Error(`Timed out after ${WAIT_TIMEOUT_MS}ms while waiting for ${description}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+}
+
+function makeFsError(code: string, syscall: string, target: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(
+    `${code}: simulated ${syscall} error, '${target}'`
+  );
+  error.code = code;
+  error.syscall = syscall;
+  error.path = target;
+  return error;
+}
+
+class DeadWatcher extends EventEmitter {
+  close(): void {}
+}
+
+class StubWatcher extends EventEmitter {
+  close(): void {
+    this.emit('close');
+  }
+}
+
+// Native realpath: 8.3 temp paths crash libuv 1.52 (libuv#5010).
+const TMP_DIR = fs.realpathSync.native(os.tmpdir());
+
+describe('FallbackWatcher', () => {
+  let root: string;
+  let watcher: FallbackWatcher | null = null;
+  let events: WatcherBackendChangeEvent[] = [];
+
+  beforeEach(() => {
+    jest.useRealTimers();
+    tornDown = false;
+    events = [];
+    root = fs.mkdtempSync(path.join(TMP_DIR, 'expo-fallback-watcher-'));
+    fs.mkdirSync(path.join(root, 'node_modules'));
+  });
+
+  afterEach(async () => {
+    tornDown = true;
+    await watcher?.stopWatching();
+    watcher = null;
+    jest.restoreAllMocks();
+    fs.rmSync(root, { recursive: true, force: true });
+    jest.useFakeTimers();
+  });
+
+  async function startWatcher(): Promise<void> {
+    watcher = new FallbackWatcher(root, { dot: true, globs: [], ignored: null });
+    watcher.onFileEvent((event) => {
+      events.push(event);
+    });
+    await watcher.startWatching();
+
+    // Darwin fs.watch can miss events right after start.
+    const probeRelativePath = path.join('node_modules', '.watch-probe');
+    const probePath = path.join(root, probeRelativePath);
+    const start = Date.now();
+    while (!hasTouchEvent(probeRelativePath)) {
+      if (tornDown || Date.now() - start > WAIT_TIMEOUT_MS) {
+        throw new Error('Timed out while waiting for the probe event of a new watcher');
+      }
+      fs.writeFileSync(probePath, String(Date.now()));
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  }
+
+  function hasTouchEvent(relativePath: string): boolean {
+    return events.some(
+      (event) => event.event === 'touch' && event.relativePath === path.normalize(relativePath)
+    );
+  }
+
+  test('reports a file written into a new directory before the watch starts (#48950)', async () => {
+    await startWatcher();
+
+    const packageDir = path.join(root, 'node_modules', 'new-pkg');
+    const realWatch = fs.watch;
+    let watchedPackageDir = false;
+
+    jest.spyOn(fs, 'watch').mockImplementation(((dir: any, ...rest: any[]) => {
+      if (dir === packageDir && !watchedPackageDir) {
+        watchedPackageDir = true;
+        fs.writeFileSync(path.join(packageDir, 'package.json'), '{"name":"new-pkg"}');
+      }
+      return (realWatch as any)(dir, ...rest);
+    }) as typeof fs.watch);
+
+    fs.mkdirSync(packageDir);
+    fs.writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = 1;\n');
+
+    await waitFor(() => watchedPackageDir, 'the watcher to watch the new package directory');
+    await waitFor(
+      () => hasTouchEvent('node_modules/new-pkg/index.js'),
+      'a touch event for node_modules/new-pkg/index.js'
+    );
+    await waitFor(
+      () => hasTouchEvent('node_modules/new-pkg/package.json'),
+      'a touch event for node_modules/new-pkg/package.json'
+    );
+  });
+
+  test('reports a file written into a new directory after the watch starts', async () => {
+    await startWatcher();
+
+    const packageDir = path.join(root, 'node_modules', 'late-pkg');
+    fs.mkdirSync(packageDir);
+    fs.writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = 1;\n');
+    await waitFor(
+      () => hasTouchEvent('node_modules/late-pkg/index.js'),
+      'a touch event for node_modules/late-pkg/index.js'
+    );
+
+    fs.writeFileSync(path.join(packageDir, 'package.json'), '{"name":"late-pkg"}');
+    await waitFor(
+      () => hasTouchEvent('node_modules/late-pkg/package.json'),
+      'a touch event for node_modules/late-pkg/package.json'
+    );
+  });
+
+  test('stopWatching resolves after an errored watcher', async () => {
+    await startWatcher();
+
+    const packageDir = path.join(root, 'node_modules', 'dead-pkg');
+    const realWatch = fs.watch;
+    const deadWatcher = new DeadWatcher();
+    let watchedPackageDir = false;
+    jest.spyOn(fs, 'watch').mockImplementation(((dir: any, ...rest: any[]) => {
+      if (dir === packageDir && !watchedPackageDir) {
+        watchedPackageDir = true;
+        return deadWatcher as unknown as fs.FSWatcher;
+      }
+      return (realWatch as any)(dir, ...rest);
+    }) as typeof fs.watch);
+
+    fs.mkdirSync(packageDir);
+    await waitFor(() => watchedPackageDir, 'the watcher to watch the new directory');
+
+    deadWatcher.emit('error', makeFsError('ENOENT', 'watch', packageDir));
+
+    await watcher!.stopWatching();
+    await watcher!.stopWatching();
+  });
+
+  test('watches a directory recreated at the path of an errored watcher', async () => {
+    await startWatcher();
+
+    const packageDir = path.join(root, 'node_modules', 'err-pkg');
+    const realWatch = fs.watch;
+    const deadWatcher = new DeadWatcher();
+    let packageDirWatchCount = 0;
+    jest.spyOn(fs, 'watch').mockImplementation(((dir: any, ...rest: any[]) => {
+      if (dir === packageDir) {
+        packageDirWatchCount++;
+        if (packageDirWatchCount === 1) {
+          return deadWatcher as unknown as fs.FSWatcher;
+        }
+      }
+      return (realWatch as any)(dir, ...rest);
+    }) as typeof fs.watch);
+
+    fs.mkdirSync(packageDir);
+    await waitFor(() => packageDirWatchCount >= 1, 'the watcher to watch the new directory');
+
+    deadWatcher.emit('error', makeFsError('ENOENT', 'watch', packageDir));
+
+    fs.rmdirSync(packageDir);
+    fs.mkdirSync(packageDir);
+    await waitFor(() => packageDirWatchCount >= 2, 'a new watch on the recreated directory');
+
+    fs.writeFileSync(path.join(packageDir, 'index.js'), 'module.exports = 1;\n');
+    await waitFor(
+      () => hasTouchEvent('node_modules/err-pkg/index.js'),
+      'a touch event for node_modules/err-pkg/index.js'
+    );
+  });
+
+  test('lists a new directory when the watch event has no filename', async () => {
+    await startWatcher();
+
+    const packageDir = path.join(root, 'node_modules', 'empty-name-pkg');
+    const realWatch = fs.watch;
+    let listener: ((event: string, filename: string | Buffer | null) => void) | null = null;
+    jest.spyOn(fs, 'watch').mockImplementation(((dir: any, ...rest: any[]) => {
+      if (dir === packageDir && listener == null) {
+        listener = rest[rest.length - 1];
+        return new StubWatcher() as unknown as fs.FSWatcher;
+      }
+      return (realWatch as any)(dir, ...rest);
+    }) as typeof fs.watch);
+
+    fs.mkdirSync(packageDir);
+    await waitFor(() => listener != null, 'the watcher to watch the new directory');
+
+    fs.writeFileSync(path.join(packageDir, 'package.json'), '{"name":"empty-name-pkg"}');
+    listener!('rename', '');
+
+    await waitFor(
+      () => hasTouchEvent('node_modules/empty-name-pkg/package.json'),
+      'a touch event for node_modules/empty-name-pkg/package.json'
+    );
+  });
+});


### PR DESCRIPTION
## Why

`npx expo install` while Metro is running can miss new files until restart. Linux/Windows (`FallbackWatcher`). #48950

**The solution here is unlikely to be something we keep longterm, but #48950 is a significant problem that arises constantly for agents when running Metro inside of VMs like e2b, so there is a lot of value in us shipping a short-term fix.**

## How

`walker` runs `filterDir` before `readdir`, and `dir` after. We started `fs.watch` on `dir`, so a file written in between was invisible.

Start the existing `#watchdir` from `filterDir` instead.

- `fs.watch` is try/caught so a vanished dir cannot throw out of `filterDir`.
- If the watcher later errors (Node emits no `close`), drop it from `#watched` so the path can be watched again.
- Empty `filename` (Windows) on a new dir lists the directory instead of dropping the event.

`Watcher.recrawl()` updates the file map only. It does not start FallbackWatcher’s per-directory watches, so recrawl cannot replace this.

macOS (`NativeWatcher`) is unchanged.

## Test Plan

- Unit: race at `fs.watch` start; write after watch; errored-watcher shutdown/rewatch; empty filename.
- Linux: `check-packages`. Windows: `fallback-watcher-windows`.
- E2E: Debian 12, bun/npm/pnpm, asserts `Using watcher: fallback`. Skips Darwin.
