### PR TITLE
[web][video] Remove stale event handlers when a view unmounts

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `VideoPlayer` constructor throwing `MissingActivity` when the player is created while the `Activity` is briefly unavailable. ([#48914](https://github.com/expo/expo/pull/48914) by [@huextrat](https://github.com/huextrat))
-- [Web] Remove video element event handlers when a `VideoView` unmounts so it cannot control views that remain mounted. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@huytdps13400](https://github.com/huytdps13400))
+- [Web] Remove video element event handlers when a `VideoView` unmounts so it cannot control views that remain mounted. ([#49364](https://github.com/expo/expo/pull/49364) by [@huytdps13400](https://github.com/huytdps13400))
 - [iOS] Fixed a data race on the video cache's open-file registry, which could crash the app while the cache was being trimmed. ([#49286](https://github.com/expo/expo/pull/49286) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))
 - [Android] Guard `PictureInPictureParams.Builder.setAutoEnterEnabled` against `NoSuchMethodError` on stock OEM firmwares that report API 31+ without shipping the method, which crashed the app from `VideoView.onLayout` even when Picture in Picture was disabled. ([#48957](https://github.com/expo/expo/pull/48957) by [@onlyshyun](https://github.com/onlyshyun))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix `VideoPlayer` constructor throwing `MissingActivity` when the player is created while the `Activity` is briefly unavailable. ([#48914](https://github.com/expo/expo/pull/48914) by [@huextrat](https://github.com/huextrat))
+- [Web] Remove video element event handlers when a `VideoView` unmounts so it cannot control views that remain mounted. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@huytdps13400](https://github.com/huytdps13400))
 - [iOS] Fixed a data race on the video cache's open-file registry, which could crash the app while the cache was being trimmed. ([#49286](https://github.com/expo/expo/pull/49286) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))
 - [Android] Guard `PictureInPictureParams.Builder.setAutoEnterEnabled` against `NoSuchMethodError` on stock OEM firmwares that report API 31+ without shipping the method, which crashed the app from `VideoView.onLayout` even when Picture in Picture was disabled. ([#48957](https://github.com/expo/expo/pull/48957) by [@onlyshyun](https://github.com/onlyshyun))

--- a/packages/expo-video/jest.config.js
+++ b/packages/expo-video/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, []);

--- a/packages/expo-video/package.json
+++ b/packages/expo-video/package.json
@@ -26,6 +26,7 @@
     "clean": "expo-module clean",
     "lint": "oxlint --config oxlint.config.mjs .",
     "format": "expo-module format",
+    "test": "jest",
     "prepublishOnly": "expo-module prepublishOnly",
     "depscheck": "expo-module depscheck",
     "typecheck": "tsc -b tsconfig.all.json"

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -269,6 +269,7 @@ export default class VideoPlayerWeb
   }
 
   unmountVideoView(video: HTMLVideoElement) {
+    this._removeListeners(video);
     this._mountedVideos.delete(video);
   }
 
@@ -392,6 +393,20 @@ export default class VideoPlayerWeb
     if (mountedVideos[0] === eventSource) {
       this.emit(eventName, ...args);
     }
+  }
+
+  _removeListeners(video: HTMLVideoElement): void {
+    video.onplay = null;
+    video.onpause = null;
+    video.onvolumechange = null;
+    video.onseeking = null;
+    video.onseeked = null;
+    video.onratechange = null;
+    video.onerror = null;
+    video.oncanplay = null;
+    video.onwaiting = null;
+    video.onended = null;
+    video.onloadstart = null;
   }
 
   _addListeners(video: HTMLVideoElement): void {

--- a/packages/expo-video/src/__tests__/VideoPlayerWeb-test.web.ts
+++ b/packages/expo-video/src/__tests__/VideoPlayerWeb-test.web.ts
@@ -1,0 +1,75 @@
+class FakeSharedObject {
+  emit() {}
+}
+
+(globalThis as any).expo = { SharedObject: FakeSharedObject };
+
+jest.mock('expo-modules-core', () => ({
+  useReleasingSharedObjectWithLifecycle: jest.fn(),
+}));
+jest.mock('react', () => ({ useState: jest.fn() }));
+jest.mock('../resolveAssetSource', () => jest.fn());
+
+const VideoPlayerWeb = require('../VideoPlayer.web').default;
+
+const listenerProperties = [
+  'onplay',
+  'onpause',
+  'onvolumechange',
+  'onseeking',
+  'onseeked',
+  'onratechange',
+  'onerror',
+  'oncanplay',
+  'onwaiting',
+  'onended',
+  'onloadstart',
+] as const;
+
+function createVideo(): HTMLVideoElement {
+  return {
+    preservesPitch: true,
+    loop: false,
+    volume: 1,
+    muted: false,
+    playbackRate: 1,
+    paused: false,
+    currentTime: 0,
+    readyState: 4,
+    play: jest.fn().mockResolvedValue(undefined),
+    pause: jest.fn(),
+    ...Object.fromEntries(listenerProperties.map((property) => [property, null])),
+  } as unknown as HTMLVideoElement;
+}
+
+describe('VideoPlayerWeb listener lifecycle', () => {
+  it('ignores events from a video view after it unmounts', () => {
+    const player = new VideoPlayerWeb(null);
+    const unmountedVideo = createVideo();
+    const mountedVideo = createVideo();
+
+    player.mountVideoView(unmountedVideo);
+    player.mountVideoView(mountedVideo);
+    (mountedVideo.pause as jest.Mock).mockClear();
+
+    player.unmountVideoView(unmountedVideo);
+    unmountedVideo.onpause?.({ target: unmountedVideo } as unknown as Event);
+
+    expect(mountedVideo.pause).not.toHaveBeenCalled();
+  });
+
+  it('clears every DOM event handler owned by the player', () => {
+    const player = new VideoPlayerWeb(null);
+    const video = createVideo();
+
+    player.mountVideoView(video);
+    for (const property of listenerProperties) {
+      expect(video[property]).toEqual(expect.any(Function));
+    }
+
+    player.unmountVideoView(video);
+    for (const property of listenerProperties) {
+      expect(video[property]).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
# Why

Fixes #49359.

On web, `VideoPlayerWeb` installs DOM property handlers on every mounted video element, but `unmountVideoView` only removed the element from `_mountedVideos`. A browser pause event from the detached element could therefore still update player state and pause every video view that remained mounted.

# How

- Clear every DOM handler owned by `VideoPlayerWeb` before removing a video from the mounted set.
- Add a focused listener-lifecycle regression that proves an unmounted element cannot pause a live one and verifies all installed handlers are removed.
- Add the package Jest script/config so the new web regression runs in CI.
- Add an `expo-video` changelog entry.

# Test Plan

- RED on `main`: the new test failed because stale `onpause` called `pause()` on the remaining view and all 11 handler properties stayed installed.
- `pnpm --filter expo-video test --runInBand` — 2 suites, 4 tests passed.
- `pnpm --filter expo-video typecheck`
- `pnpm --filter expo-video lint`
- `pnpm --filter expo-video format --check`
- `pnpm --filter expo-video build`
- `pnpm --filter expo-video depscheck`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (not applicable; no config plugin or native project changes)
- [ ] Conforms with the Documentation Writing Style Guide (not applicable; no documentation changes)