### PR TITLE
[screen-orientation]: avoid main thread deadlock

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed a main-thread deadlock when notifying screen orientation listeners.
 - [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed a main-thread deadlock when notifying screen orientation listeners.
+- [iOS] Fixed a main-thread deadlock when notifying screen orientation listeners. ([#49367](https://github.com/expo/expo/pull/49367) by [@ryan-saffer](https://github.com/ryan-saffer))
 - [iOS] Added a development warning when the system refuses an orientation lock request, and switched to reading interface orientation from the scene's effective geometry. ([#48173](https://github.com/expo/expo/pull/48173) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -19,6 +19,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   var orientationControllers: [ScreenOrientationController] = []
   var controllerInterfaceMasks: [ObjectIdentifier: UIInterfaceOrientationMask] = [:]
   private let queue = DispatchQueue(label: "expo.screenorientationregistry", attributes: .concurrent)
+  private let notificationQueue = DispatchQueue(label: "expo.screenorientationregistry.notifications")
   @objc
   public var currentTraitCollection: UITraitCollection?
   var lastOrientationMask: UIInterfaceOrientationMask
@@ -204,23 +205,23 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
    Called at the end of the screen orientation change. Notifies the controllers about the orientation change.
    */
   func screenOrientationDidChange(_ newScreenOrientation: UIInterfaceOrientation) {
-    queue.sync(flags: .barrier) {
+    let controllers = queue.sync(flags: .barrier) {
       // Write with the barrier:
       if self.currentScreenOrientation != newScreenOrientation {
         // Only change if necessary, to prevent listeners from re-calling this method.
         self.currentScreenOrientation = newScreenOrientation
       }
+      return self.orientationControllers
     }
-    queue.async {
-      // Read without the barrier:
-      for controller in self.orientationControllers {
+    notificationQueue.async {
+      for controller in controllers {
         controller.screenOrientationDidChange(newScreenOrientation)
       }
     }
   }
 
   public func registerController(_ controller: ScreenOrientationController) {
-    queue.sync {
+    queue.sync(flags: .barrier) {
       self.orientationControllers.append(controller)
     }
   }
@@ -228,7 +229,7 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
   public func unregisterController(_ controller: ScreenOrientationController) {
     let controllerIdentifier = ObjectIdentifier(controller)
 
-    queue.sync {
+    queue.sync(flags: .barrier) {
       self.controllerInterfaceMasks.removeValue(forKey: controllerIdentifier)
       self.orientationControllers.removeAll(where: { $0 === controller })
     }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/49365.
closes #44276

On iOS, ScreenOrientationRegistry can enter a circular wait that permanently blocks the main thread:
1. A controller notification runs on expo.screenorientationregistry.
2. ScreenOrientationModule.screenOrientationDidChange reads currentOrientationMask, which synchronously waits for the main thread.
3. UIKit queries supportedInterfaceOrientations on the main thread.
4. This reaches requiredOrientationMask(), which synchronously waits for expo.screenorientationregistry.
The registry queue and main thread then wait for each other, causing an app hang. We observed this frequently in production after upgrading from expo-screen-orientation 9.0.8 to 57.0.1.

# How

Controller notifications are now delivered on a dedicated notification queue rather than the registry's state-protection queue.
screenOrientationDidChange snapshots the registered controllers while holding a barrier on the registry queue, then releases that queue before notifying them. This prevents controller callbacks that synchronously access the main thread from blocking registry state reads made by the main thread.
Controller registration and removal now also use barrier writes, ensuring mutations cannot race with the controller snapshot.

# Test Plan

Test Plan
The issue includes a minimal iOS development-build reproduction that deterministically arranges the production wait cycle.
1. Clone the reproduction linked in https://github.com/expo/expo/issues/49365.
2. Run npm install.
3. Run npm run ios.
4. Wait three seconds or press Trigger now.
5. Without this fix, the app remains on TESTING... and stops responding.
6. Pause the process in Xcode and inspect the main thread. It is blocked in ScreenOrientationRegistry.requiredOrientationMask().
7. Apply this change to expo-screen-orientation and rebuild the native app.
8. The status changes from TESTING... to RESPONSIVE, and the app continues handling touches.
The equivalent change was also tested locally as a patch-package patch against expo-screen-orientation@57.0.1. The reproduction remained responsive after the deterministic trigger.
Expo Doctor output for the reproduction:
Running 21 checks on your project...
21/21 checks passed. No issues detected!

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
