### PR TITLE
[ios][screen-capture] Fix repeated preventScreenCapture calls corrupting the layer hierarchy

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -607,6 +607,8 @@ PODS:
     - RNScreens
   - ExpoScreenCapture (57.0.1):
     - ExpoModulesCore
+  - ExpoScreenCapture/Tests (57.0.1):
+    - ExpoModulesCore
   - ExpoScreenOrientation (57.0.1):
     - ExpoModulesCore
     - hermes-engine
@@ -3215,6 +3217,7 @@ DEPENDENCIES:
   - ExpoRouter (from `../../../packages/expo-router/ios`)
   - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
   - ExpoScreenCapture (from `../../../packages/expo-screen-capture/ios`)
+  - ExpoScreenCapture/Tests (from `../../../packages/expo-screen-capture/ios`)
   - ExpoScreenOrientation (from `../../../packages/expo-screen-orientation/ios`)
   - ExpoSecureStore (from `../../../packages/expo-secure-store/ios`)
   - ExpoSensors (from `../../../packages/expo-sensors/ios`)
@@ -3917,7 +3920,7 @@ SPEC CHECKSUMS:
   ExpoObserve: aa4fcbe7ed0a7ba387984a38e24c2ecaa8895fd0
   ExpoPrint: 7e7a9bc7c12b9b336f34c4458d0c9ba14f243759
   ExpoRouter: 224087330cc8f5a39700e6f4d7a55f55ecb2f90d
-  ExpoScreenCapture: 1728376b2a32a05dc1f6bae6a8d19b1bd33926f9
+  ExpoScreenCapture: 387b18f4a51561916cbff71d6e0e7b386af31171
   ExpoScreenOrientation: 33c9de0c9e01dd8d1244f2b1ef433d0171079771
   ExpoSecureStore: 94793113049a2d7478dfe1a13aa15081e9f61755
   ExpoSensors: e71c7b6cb0c09d3427ef6ae29c69532a10c86b05

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4682,7 +4682,7 @@ SPEC CHECKSUMS:
   ExpoNotifications: 0f253ad90f108c1c4045b541294164865c6aadc8
   ExpoPrint: 7e7a9bc7c12b9b336f34c4458d0c9ba14f243759
   ExpoRouter: 224087330cc8f5a39700e6f4d7a55f55ecb2f90d
-  ExpoScreenCapture: 1728376b2a32a05dc1f6bae6a8d19b1bd33926f9
+  ExpoScreenCapture: 387b18f4a51561916cbff71d6e0e7b386af31171
   ExpoScreenOrientation: 799a4681fba805f73bf92bfbe98f38c16e3d1dd6
   ExpoSecureStore: 94793113049a2d7478dfe1a13aa15081e9f61755
   ExpoSensors: e71c7b6cb0c09d3427ef6ae29c69532a10c86b05
@@ -4713,11 +4713,11 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
-  glog: e56ede4028c4b7418e6b1195a36b1656bb35e225
+  glog: 0456694f3aaf09460b660ea327cfc11defbeea4c
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 349ded4feea539299cee22cb680b0d50402116e5
+  hermes-engine: 1aac0336ab06465103e89322838baf2911318c89
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4727,7 +4727,7 @@ SPEC CHECKSUMS:
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
-  RCT-Folly: 36c4f904fb6cd0219dcb76b94e9502d2a72fab0b
+  RCT-Folly: 121436bcc4611f6bde5c09bf35f0a7a82cef1969
   RCTDeprecation: cac9521ce0b8092a1fb13d32a768c5ba2752b55f
   RCTRequired: cfc25ba224a2a3dbb1b3368a7d19b0fb6ec5ed1e
   RCTSwiftUI: 20555e38bdfa7b5cc21d3201ec9c34ec24969919

--- a/apps/native-component-list/src/navigation/apiScreens.ts
+++ b/apps/native-component-list/src/navigation/apiScreens.ts
@@ -420,6 +420,12 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/ScreenCaptureAdvancedScreen'));
+    },
+    name: 'ScreenCaptureAdvanced',
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/SensorScreen'));
     },
     name: 'Sensor',

--- a/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
@@ -1,34 +1,10 @@
 import * as ScreenCapture from 'expo-screen-capture';
 import React from 'react';
-import { Button, ScrollView, StyleSheet, View } from 'react-native';
-import Svg, { Circle, Path, Rect } from 'react-native-svg';
+import { ScrollView, StyleSheet } from 'react-native';
 
 import { BodyText } from '../components/BodyText';
 import HeadingText from '../components/HeadingText';
 import TitleSwitch from '../components/TitledSwitch';
-
-function GuardedSvgSheet({ onClose }: { onClose: () => void }) {
-  ScreenCapture.usePreventScreenCapture('guarded-sheet');
-
-  return (
-    <View style={styles.sheet}>
-      <View style={styles.svgGrid}>
-        {Array.from({ length: 12 }, (_, index) => (
-          <Svg key={index} width={72} height={48}>
-            <Rect x={0} y={0} width={72} height={48} rx={8} fill="#4630eb" />
-            <Circle cx={16} cy={24} r={10} fill="#fc0" />
-            <Path d="M30 38 L42 10 L54 38 Z" fill="#0f9" />
-            <Path d="M56 12 h12 v24 h-12 Z" fill="#f36" stroke="#fff" strokeWidth={2} />
-          </Svg>
-        ))}
-      </View>
-      <BodyText style={styles.description}>
-        Every tile must show all four shapes each time this sheet opens.
-      </BodyText>
-      <Button title="Close guarded sheet" onPress={onClose} />
-    </View>
-  );
-}
 
 function KeyedProtectionSwitch({ holderKey }: { holderKey: string }) {
   const [isHolding, setHolding] = React.useState(false);
@@ -58,36 +34,8 @@ function KeyedProtectionSwitch({ holderKey }: { holderKey: string }) {
 }
 
 export default function ScreenCaptureAdvancedScreen() {
-  const [isSheetVisible, setSheetVisible] = React.useState(false);
-  const [isAutoCycling, setAutoCycling] = React.useState(false);
-
-  React.useEffect(() => {
-    if (!isAutoCycling) {
-      return;
-    }
-    const interval = setInterval(() => setSheetVisible((visible) => !visible), 1200);
-    return () => clearInterval(interval);
-  }, [isAutoCycling]);
-
   return (
     <ScrollView contentContainerStyle={styles.container}>
-      <HeadingText style={styles.heading}>Draw-Backed Content Under Protection</HeadingText>
-      <BodyText style={styles.description}>
-        The sheet arms screenshot prevention while SVG content mounts. The content must render fully
-        every time it opens, and screenshots of it must be blank.
-      </BodyText>
-      <Button
-        title={isSheetVisible ? 'Hide guarded SVG sheet' : 'Show guarded SVG sheet'}
-        onPress={() => setSheetVisible((visible) => !visible)}
-      />
-      <TitleSwitch
-        title="Auto cycle sheet"
-        value={isAutoCycling}
-        setValue={setAutoCycling}
-        style={styles.switchSpacing}
-      />
-      {isSheetVisible && <GuardedSvgSheet onClose={() => setSheetVisible(false)} />}
-
       <HeadingText style={styles.heading}>Multiple Protection Holders</HeadingText>
       <BodyText style={styles.description}>
         Each key holds protection independently. Screenshots stay blank, and the app keeps
@@ -112,20 +60,6 @@ const styles = StyleSheet.create({
   },
   switchSpacing: {
     marginTop: 16,
-  },
-  sheet: {
-    alignItems: 'center',
-    marginTop: 8,
-    padding: 12,
-    borderRadius: 12,
-    backgroundColor: '#00000010',
-  },
-  svgGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    gap: 4,
-    maxWidth: 320,
   },
   heading: {
     marginTop: 24,

--- a/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenCaptureAdvancedScreen.tsx
@@ -1,0 +1,134 @@
+import * as ScreenCapture from 'expo-screen-capture';
+import React from 'react';
+import { Button, ScrollView, StyleSheet, View } from 'react-native';
+import Svg, { Circle, Path, Rect } from 'react-native-svg';
+
+import { BodyText } from '../components/BodyText';
+import HeadingText from '../components/HeadingText';
+import TitleSwitch from '../components/TitledSwitch';
+
+function GuardedSvgSheet({ onClose }: { onClose: () => void }) {
+  ScreenCapture.usePreventScreenCapture('guarded-sheet');
+
+  return (
+    <View style={styles.sheet}>
+      <View style={styles.svgGrid}>
+        {Array.from({ length: 12 }, (_, index) => (
+          <Svg key={index} width={72} height={48}>
+            <Rect x={0} y={0} width={72} height={48} rx={8} fill="#4630eb" />
+            <Circle cx={16} cy={24} r={10} fill="#fc0" />
+            <Path d="M30 38 L42 10 L54 38 Z" fill="#0f9" />
+            <Path d="M56 12 h12 v24 h-12 Z" fill="#f36" stroke="#fff" strokeWidth={2} />
+          </Svg>
+        ))}
+      </View>
+      <BodyText style={styles.description}>
+        Every tile must show all four shapes each time this sheet opens.
+      </BodyText>
+      <Button title="Close guarded sheet" onPress={onClose} />
+    </View>
+  );
+}
+
+function KeyedProtectionSwitch({ holderKey }: { holderKey: string }) {
+  const [isHolding, setHolding] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isHolding) {
+      ScreenCapture.preventScreenCaptureAsync(holderKey);
+    } else {
+      ScreenCapture.allowScreenCaptureAsync(holderKey);
+    }
+  }, [isHolding]);
+
+  React.useEffect(() => {
+    return () => {
+      ScreenCapture.allowScreenCaptureAsync(holderKey);
+    };
+  }, []);
+
+  return (
+    <TitleSwitch
+      title={`Hold protection with key '${holderKey}'`}
+      value={isHolding}
+      setValue={setHolding}
+      style={styles.switchSpacing}
+    />
+  );
+}
+
+export default function ScreenCaptureAdvancedScreen() {
+  const [isSheetVisible, setSheetVisible] = React.useState(false);
+  const [isAutoCycling, setAutoCycling] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isAutoCycling) {
+      return;
+    }
+    const interval = setInterval(() => setSheetVisible((visible) => !visible), 1200);
+    return () => clearInterval(interval);
+  }, [isAutoCycling]);
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <HeadingText style={styles.heading}>Draw-Backed Content Under Protection</HeadingText>
+      <BodyText style={styles.description}>
+        The sheet arms screenshot prevention while SVG content mounts. The content must render fully
+        every time it opens, and screenshots of it must be blank.
+      </BodyText>
+      <Button
+        title={isSheetVisible ? 'Hide guarded SVG sheet' : 'Show guarded SVG sheet'}
+        onPress={() => setSheetVisible((visible) => !visible)}
+      />
+      <TitleSwitch
+        title="Auto cycle sheet"
+        value={isAutoCycling}
+        setValue={setAutoCycling}
+        style={styles.switchSpacing}
+      />
+      {isSheetVisible && <GuardedSvgSheet onClose={() => setSheetVisible(false)} />}
+
+      <HeadingText style={styles.heading}>Multiple Protection Holders</HeadingText>
+      <BodyText style={styles.description}>
+        Each key holds protection independently. Screenshots stay blank, and the app keeps
+        rendering, while any key is held.
+      </BodyText>
+      <KeyedProtectionSwitch holderKey="a" />
+      <KeyedProtectionSwitch holderKey="b" />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 16,
+    alignItems: 'center',
+  },
+  description: {
+    padding: 8,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  switchSpacing: {
+    marginTop: 16,
+  },
+  sheet: {
+    alignItems: 'center',
+    marginTop: 8,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: '#00000010',
+  },
+  svgGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 4,
+    maxWidth: 320,
+  },
+  heading: {
+    marginTop: 24,
+    marginBottom: 8,
+  },
+});

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected.
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected.
+- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,8 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed `drawRect`-backed views (for example `react-native-svg` content) staying blank after screenshot prevention re-parents the window layer, and made a failed attach reject instead of silently leaving the app unprotected. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app. ([#49099](https://github.com/expo/expo/pull/49099) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app, and made `preventScreenCaptureAsync` reject instead of silently leaving the app unprotected when the secure canvas cannot attach.
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app, and made `preventScreenCaptureAsync` reject instead of silently leaving the app unprotected when the secure canvas cannot attach.
+- [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app, and made `preventScreenCaptureAsync` reject instead of silently leaving the app unprotected when the secure canvas cannot attach. ([#49372](https://github.com/expo/expo/pull/49372) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
+++ b/packages/expo-screen-capture/ios/ExpoScreenCapture.podspec
@@ -20,8 +20,18 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = 'Tests/'
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.requires_app_host = false
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
+  end
 end

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -125,22 +125,21 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func preventScreenshots() throws {
-    if let canvas = secureCanvas {
-      if let protected = canvas.window, protected === keyWindow {
-        return
-      }
-      // The protected window changed or died; move protection to the current key window.
-      canvas.restore()
-      secureCanvas = nil
+    if let canvas = secureCanvas, let protected = canvas.window, protected === keyWindow {
+      return
     }
 
     guard let keyWindow else {
       throw NoKeyWindowException()
     }
 
+    // The protected window changed or died; move protection to the current key window.
+    // Attach the new canvas before releasing the old one so a failed attach keeps
+    // the existing protection in place.
     guard let canvas = SecureWindowCanvas(protecting: keyWindow) else {
       throw SecureCanvasAttachmentException()
     }
+    secureCanvas?.restore()
     secureCanvas = canvas
   }
 

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -6,8 +6,7 @@ public final class ScreenCaptureModule: Module {
   private var isBeingObserved = false
   private var isListening = false
   private var blockView: UIView?
-  private var protectionTextField: UITextField?
-  private var originalParent: CALayer?
+  private var secureCanvas: SecureWindowCanvas?
   private var blurEffectView: AnimatedBlurEffectView?
   private var blurIntensity: CGFloat = 0.5
   private var keyWindow: UIWindow? {
@@ -20,7 +19,11 @@ public final class ScreenCaptureModule: Module {
     Events(onScreenshotEventName)
 
     OnDestroy {
-      allowScreenshots()
+      let canvas = self.secureCanvas
+      self.secureCanvas = nil
+      DispatchQueue.main.async {
+        canvas?.restore()
+      }
       disableAppSwitcherProtection()
     }
 
@@ -34,7 +37,7 @@ public final class ScreenCaptureModule: Module {
 
     AsyncFunction("preventScreenCapture") {
       self.preventScreenRecording()
-      self.preventScreenshots()
+      try self.preventScreenshots()
 
       NotificationCenter.default.addObserver(
         self,
@@ -121,41 +124,29 @@ public final class ScreenCaptureModule: Module {
     return blockView
   }
 
-  private func preventScreenshots() {
-    guard let keyWindow = keyWindow else {
-      return
+  private func preventScreenshots() throws {
+    if let canvas = secureCanvas {
+      if let protected = canvas.window, protected === keyWindow {
+        return
+      }
+      // The protected window changed or died; move protection to the current key window.
+      canvas.restore()
+      secureCanvas = nil
     }
 
-    let textField = UITextField()
-    textField.isSecureTextEntry = true
-    textField.isUserInteractionEnabled = false
-    textField.backgroundColor = UIColor.clear
-    textField.frame = UIScreen.main.bounds
-
-    originalParent = keyWindow.layer.superlayer
-
-    keyWindow.layer.superlayer?.addSublayer(textField.layer)
-
-    if let firstTextFieldSublayer = textField.layer.sublayers?.first {
-      keyWindow.layer.removeFromSuperlayer()
-      firstTextFieldSublayer.addSublayer(keyWindow.layer)
+    guard let keyWindow else {
+      throw NoKeyWindowException()
     }
 
-    protectionTextField = textField
+    guard let canvas = SecureWindowCanvas(protecting: keyWindow) else {
+      throw SecureCanvasAttachmentException()
+    }
+    secureCanvas = canvas
   }
 
   private func allowScreenshots() {
-    guard let textField = protectionTextField,
-      let window = keyWindow,
-      let originalParentLayer = originalParent else {
-      return
-    }
-
-    window.layer.removeFromSuperlayer()
-    originalParentLayer.addSublayer(window.layer)
-    textField.layer.removeFromSuperlayer()
-    protectionTextField = nil
-    originalParent = nil
+    secureCanvas?.restore()
+    secureCanvas = nil
   }
 
   private func enableAppSwitcherProtection() {
@@ -244,5 +235,17 @@ public final class ScreenCaptureModule: Module {
         self.blurEffectView = nil
       }
     )
+  }
+}
+
+internal final class NoKeyWindowException: Exception {
+  override var reason: String {
+    "Screenshots cannot be prevented because the app has no key window yet. Retry after the app's first window is visible, for example after the first render"
+  }
+}
+
+internal final class SecureCanvasAttachmentException: Exception {
+  override var reason: String {
+    "Screenshots cannot be prevented because the window is not attached to the screen yet, so the secure canvas could not be installed. Screenshots remain possible. Retry after the window is fully presented"
   }
 }

--- a/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
+++ b/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
@@ -30,7 +30,8 @@ internal final class SecureWindowCanvas {
       return nil
     }
 
-    Self.reparent(window, into: canvasLayer)
+    window.layer.removeFromSuperlayer()
+    canvasLayer.addSublayer(window.layer)
 
     self.textField = textField
     self.originalParent = originalParent
@@ -44,34 +45,7 @@ internal final class SecureWindowCanvas {
     guard let window else {
       return
     }
-    Self.reparent(window, into: originalParent)
-  }
-
-  /**
-   Re-parenting drops pending display work on `drawRect`-backed views (for example
-   `react-native-svg` surfaces), leaving them blank until the next display pass. Complete
-   pending draws first so nothing is in flight, and re-issue display work once the commit
-   containing the re-parent lands, covering draws scheduled later in the same turn.
-   */
-  private static func reparent(_ window: UIWindow, into parent: CALayer) {
-    displayPendingDraws(in: window.layer)
     window.layer.removeFromSuperlayer()
-    parent.addSublayer(window.layer)
-    CATransaction.setCompletionBlock { [weak window] in
-      window.map { setNeedsDisplayRecursively(in: $0) }
-    }
-  }
-
-  // `displayIfNeeded` is not recursive; walk the subtree so dirty descendants display too.
-  private static func displayPendingDraws(in layer: CALayer) {
-    layer.displayIfNeeded()
-    layer.sublayers?.forEach { displayPendingDraws(in: $0) }
-  }
-
-  private static func setNeedsDisplayRecursively(in view: UIView) {
-    view.setNeedsDisplay()
-    for subview in view.subviews {
-      setNeedsDisplayRecursively(in: subview)
-    }
+    originalParent.addSublayer(window.layer)
   }
 }

--- a/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
+++ b/packages/expo-screen-capture/ios/SecureWindowCanvas.swift
@@ -1,0 +1,77 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import UIKit
+
+/**
+ Hides a window from screenshots by re-parenting its layer into the canvas layer of a
+ secure-entry `UITextField`. The init either fully attaches the canvas or fails without
+ mutating the layer hierarchy. Main thread only.
+ */
+internal final class SecureWindowCanvas {
+  private let textField: UITextField
+  private let originalParent: CALayer
+  private(set) weak var window: UIWindow?
+
+  init?(protecting window: UIWindow) {
+    guard let originalParent = window.layer.superlayer else {
+      return nil
+    }
+
+    let textField = UITextField()
+    textField.isSecureTextEntry = true
+    textField.isUserInteractionEnabled = false
+    textField.backgroundColor = .clear
+    textField.frame = UIScreen.main.bounds
+
+    originalParent.addSublayer(textField.layer)
+
+    guard let canvasLayer = textField.layer.sublayers?.first else {
+      textField.layer.removeFromSuperlayer()
+      return nil
+    }
+
+    Self.reparent(window, into: canvasLayer)
+
+    self.textField = textField
+    self.originalParent = originalParent
+    self.window = window
+  }
+
+  func restore() {
+    defer {
+      textField.layer.removeFromSuperlayer()
+    }
+    guard let window else {
+      return
+    }
+    Self.reparent(window, into: originalParent)
+  }
+
+  /**
+   Re-parenting drops pending display work on `drawRect`-backed views (for example
+   `react-native-svg` surfaces), leaving them blank until the next display pass. Complete
+   pending draws first so nothing is in flight, and re-issue display work once the commit
+   containing the re-parent lands, covering draws scheduled later in the same turn.
+   */
+  private static func reparent(_ window: UIWindow, into parent: CALayer) {
+    displayPendingDraws(in: window.layer)
+    window.layer.removeFromSuperlayer()
+    parent.addSublayer(window.layer)
+    CATransaction.setCompletionBlock { [weak window] in
+      window.map { setNeedsDisplayRecursively(in: $0) }
+    }
+  }
+
+  // `displayIfNeeded` is not recursive; walk the subtree so dirty descendants display too.
+  private static func displayPendingDraws(in layer: CALayer) {
+    layer.displayIfNeeded()
+    layer.sublayers?.forEach { displayPendingDraws(in: $0) }
+  }
+
+  private static func setNeedsDisplayRecursively(in view: UIView) {
+    view.setNeedsDisplay()
+    for subview in view.subviews {
+      setNeedsDisplayRecursively(in: subview)
+    }
+  }
+}

--- a/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
+++ b/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
@@ -5,14 +5,6 @@ import UIKit
 
 @testable import ExpoScreenCapture
 
-private final class DrawSpyView: UIView {
-  var drawCount = 0
-
-  override func draw(_ rect: CGRect) {
-    drawCount += 1
-  }
-}
-
 @Suite("SecureWindowCanvas", .serialized)
 @MainActor
 struct SecureWindowCanvasTests {
@@ -93,41 +85,6 @@ struct SecureWindowCanvasTests {
     canvas.restore()
 
     #expect(parent.sublayers?.isEmpty != false)
-  }
-
-  /// Adds a draw-recording view nested inside the window, mirroring a `drawRect`-backed
-  /// view (like a react-native-svg surface) whose display work is pending at re-parent time.
-  private func addDrawSpy(to window: UIWindow) -> DrawSpyView {
-    let container = UIView()
-    let spy = DrawSpyView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-    container.addSubview(spy)
-    window.addSubview(container)
-    return spy
-  }
-
-  @Test
-  func `protecting a window completes pending draws instead of dropping them`() throws {
-    let (window, _) = makeAttachedWindow()
-    let spy = addDrawSpy(to: window)
-    spy.setNeedsDisplay()
-    let pendingCount = spy.drawCount
-
-    _ = try #require(SecureWindowCanvas(protecting: window))
-
-    #expect(spy.drawCount == pendingCount + 1)
-  }
-
-  @Test
-  func `restoring a window completes pending draws instead of dropping them`() throws {
-    let (window, _) = makeAttachedWindow()
-    let spy = addDrawSpy(to: window)
-    let canvas = try #require(SecureWindowCanvas(protecting: window))
-    spy.setNeedsDisplay()
-    let pendingCount = spy.drawCount
-
-    canvas.restore()
-
-    #expect(spy.drawCount == pendingCount + 1)
   }
 
   @Test

--- a/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
+++ b/packages/expo-screen-capture/ios/Tests/SecureWindowCanvasTests.swift
@@ -1,0 +1,145 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+import UIKit
+
+@testable import ExpoScreenCapture
+
+private final class DrawSpyView: UIView {
+  var drawCount = 0
+
+  override func draw(_ rect: CGRect) {
+    drawCount += 1
+  }
+}
+
+@Suite("SecureWindowCanvas", .serialized)
+@MainActor
+struct SecureWindowCanvasTests {
+  /// Simulates an on-screen window: on device the window layer lives inside a host layer.
+  private func makeAttachedWindow() -> (window: UIWindow, parent: CALayer) {
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    let parent = CALayer()
+    parent.addSublayer(window.layer)
+    return (window, parent)
+  }
+
+  /// UIKit attaches a new window's layer to a host layer even off screen, so detach it
+  /// to simulate a window whose layer host is not set up yet.
+  private func makeDetachedWindow() -> UIWindow {
+    let window = UIWindow(frame: .zero)
+    window.layer.removeFromSuperlayer()
+    return window
+  }
+
+  @Test
+  func `init fails when the window layer has no superlayer`() {
+    let window = makeDetachedWindow()
+
+    #expect(SecureWindowCanvas(protecting: window) == nil)
+  }
+
+  @Test
+  func `failed init leaves the window untouched`() {
+    let window = makeDetachedWindow()
+
+    _ = SecureWindowCanvas(protecting: window)
+
+    #expect(window.layer.superlayer == nil)
+  }
+
+  @Test
+  func `init re-parents the window layer into a secure canvas under the original parent`() throws {
+    let (window, parent) = makeAttachedWindow()
+
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(canvas.window === window)
+    #expect(window.layer.superlayer !== parent)
+
+    var ancestor = window.layer.superlayer
+    var reachedOriginalParent = false
+    while let layer = ancestor {
+      if layer === parent {
+        reachedOriginalParent = true
+        break
+      }
+      ancestor = layer.superlayer
+    }
+    #expect(reachedOriginalParent)
+  }
+
+  @Test
+  func `restore returns the window layer to its original parent and removes the canvas`() throws {
+    let (window, parent) = makeAttachedWindow()
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+
+    canvas.restore()
+
+    #expect(window.layer.superlayer === parent)
+    #expect(parent.sublayers?.count == 1)
+  }
+
+  @Test
+  func `restore removes the secure canvas when the window is gone`() throws {
+    let parent = CALayer()
+    var window: UIWindow? = UIWindow(frame: UIScreen.main.bounds)
+    parent.addSublayer(window!.layer)
+    let canvas = try #require(SecureWindowCanvas(protecting: window!))
+
+    window = nil
+    #expect(canvas.window == nil)
+
+    canvas.restore()
+
+    #expect(parent.sublayers?.isEmpty != false)
+  }
+
+  /// Adds a draw-recording view nested inside the window, mirroring a `drawRect`-backed
+  /// view (like a react-native-svg surface) whose display work is pending at re-parent time.
+  private func addDrawSpy(to window: UIWindow) -> DrawSpyView {
+    let container = UIView()
+    let spy = DrawSpyView(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+    container.addSubview(spy)
+    window.addSubview(container)
+    return spy
+  }
+
+  @Test
+  func `protecting a window completes pending draws instead of dropping them`() throws {
+    let (window, _) = makeAttachedWindow()
+    let spy = addDrawSpy(to: window)
+    spy.setNeedsDisplay()
+    let pendingCount = spy.drawCount
+
+    _ = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(spy.drawCount == pendingCount + 1)
+  }
+
+  @Test
+  func `restoring a window completes pending draws instead of dropping them`() throws {
+    let (window, _) = makeAttachedWindow()
+    let spy = addDrawSpy(to: window)
+    let canvas = try #require(SecureWindowCanvas(protecting: window))
+    spy.setNeedsDisplay()
+    let pendingCount = spy.drawCount
+
+    canvas.restore()
+
+    #expect(spy.drawCount == pendingCount + 1)
+  }
+
+  @Test
+  func `a window can be protected again after restore`() throws {
+    let (window, parent) = makeAttachedWindow()
+    let first = try #require(SecureWindowCanvas(protecting: window))
+    first.restore()
+
+    let second = try #require(SecureWindowCanvas(protecting: window))
+
+    #expect(second.window === window)
+    second.restore()
+    #expect(window.layer.superlayer === parent)
+  }
+}

--- a/packages/expo-screen-capture/src/ScreenCapture.ts
+++ b/packages/expo-screen-capture/src/ScreenCapture.ts
@@ -46,7 +46,12 @@ export async function preventScreenCaptureAsync(key: string = 'default'): Promis
 
   if (!activeTags.has(key)) {
     activeTags.add(key);
-    await ExpoScreenCapture.preventScreenCapture();
+    try {
+      await ExpoScreenCapture.preventScreenCapture();
+    } catch (error) {
+      activeTags.delete(key);
+      throw error;
+    }
   }
 }
 

--- a/packages/expo-screen-capture/src/ScreenCapture.ts
+++ b/packages/expo-screen-capture/src/ScreenCapture.ts
@@ -87,7 +87,9 @@ export async function allowScreenCaptureAsync(key: string = 'default'): Promise<
  */
 export function usePreventScreenCapture(key: string = 'default'): void {
   useEffect(() => {
-    preventScreenCaptureAsync(key);
+    preventScreenCaptureAsync(key).catch((error) => {
+      console.error(`Failed to prevent screen capture: ${error}`);
+    });
 
     return () => {
       allowScreenCaptureAsync(key);

--- a/packages/expo-screen-capture/src/__tests__/ScreenCapture-test.native.js
+++ b/packages/expo-screen-capture/src/__tests__/ScreenCapture-test.native.js
@@ -61,6 +61,15 @@ describe('Test key functionality', () => {
     expect(ExpoScreenCapture.preventScreenCapture).toHaveBeenCalledTimes(1);
   });
 
+  it('a failed prevent call releases the key so a retry reaches the native method again', async () => {
+    ExpoScreenCapture.preventScreenCapture.mockRejectedValueOnce(new Error('no key window'));
+
+    await expect(ScreenCapture.preventScreenCaptureAsync('foo')).rejects.toThrow('no key window');
+    await ScreenCapture.preventScreenCaptureAsync('foo');
+
+    expect(ExpoScreenCapture.preventScreenCapture).toHaveBeenCalledTimes(2);
+  });
+
   it('enabling two keys but only removing one results in the allowScreenCapture native method not being called', async () => {
     await ScreenCapture.preventScreenCaptureAsync('foo');
     await ScreenCapture.preventScreenCaptureAsync('bar');

--- a/packages/expo-screen-capture/src/__tests__/ScreenCaptureHook-test.native.js
+++ b/packages/expo-screen-capture/src/__tests__/ScreenCaptureHook-test.native.js
@@ -1,4 +1,4 @@
-import { renderHook, cleanup } from '@testing-library/react-native';
+import { renderHook, cleanup, waitFor } from '@testing-library/react-native';
 
 import { allowScreenCapture, preventScreenCapture } from '../ExpoScreenCapture';
 import * as ScreenCapture from '../ScreenCapture';
@@ -47,6 +47,16 @@ describe('hooks', () => {
     hook.unmount();
     // Unmounting results in final allowScreenCapture native method call
     expect(allowScreenCapture).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs instead of leaving an unhandled rejection when the native prevent call fails', async () => {
+    preventScreenCapture.mockRejectedValueOnce(new Error('no key window'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    renderHook(ScreenCapture.usePreventScreenCapture);
+
+    await waitFor(() => expect(errorSpy).toHaveBeenCalledTimes(1));
+    errorSpy.mockRestore();
   });
 
   it('Unmounting one hook when two are active does not re-allow screen capturing', async () => {


### PR DESCRIPTION
# Why

Closes #48985
Supersedes #49099 and #49087

`preventScreenshots()` on iOS had no re-entrancy guard. A second `preventScreenCaptureAsync` call with a new key nested one secure canvas inside another, overwrote the only reference to the window layer's superlayer, and permanently black screened the app.

#49099 also carried a speculative fix for blank `drawRect`-backed views (#49088). Testing by the @maxlapides  showed that neither #49099 nor #49088 fixed that bug, the root cause was a presentation race in a third-party sheet library, not in `expo-screen-capture`. This PR drops the unverified redraw logic and keeps only the verified fixes.

# How

- Moved the re-parenting into a new `SecureWindowCanvas` class. Its init either fully attaches the secure canvas or fails without mutating the layer hierarchy.
- `preventScreenshots()` now returns early when a canvas already protects the current key window, so a repeated call can no longer nest canvases. If the key window changed, protection moves to the current key window. The new canvas attaches before the old one is released, so a failed attach keeps the existing protection in place.
- A failed attach now throws instead of silently leaving the app unprotected. `preventScreenCaptureAsync` releases the key again on failure so a retry reaches native, and `usePreventScreenCapture` catches the rejection and logs it instead of leaving an unhandled promise rejection.

# Test Plan

- Added `SecureWindowCanvasTests` covering attach, failed attach, restore, dead-window restore, and re-protect after restore.
- The re-entrancy fix in #49099 was A/B verified on device builds: the base build black screens permanently after `preventScreenCaptureAsync('a')` then `('b')`; the fixed build stays visible. The native changes here are that fix minus the redraw logic, plus the attach-before-release ordering.

