### PR TITLE
[docs] Resolve Chrome-only flicker issue and update Selector design

### DIFF
--- a/docs/ui/components/Dropdown/Item.tsx
+++ b/docs/ui/components/Dropdown/Item.tsx
@@ -33,7 +33,7 @@ export function Item({
     <DropdownMenu.Item
       aria-disabled={disabled}
       className={mergeClasses(
-        'group relative z-40 flex cursor-pointer items-center justify-between rounded-sm px-2 py-1 transition-colors select-none',
+        'group relative z-40 flex cursor-pointer items-center justify-between rounded-lg px-2 py-1 transition-colors select-none',
         'hover:outline-0 hocus:bg-hover',
         disabled && 'cursor-default opacity-60 hocus:bg-default'
       )}

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -29,7 +29,7 @@ export function Dropdown({
         <div className="bg-danger">
           <Content
             className={mergeClasses(
-              'flex min-w-45 flex-col gap-0.5 rounded-md border border-default bg-default p-1 shadow-md',
+              'flex min-w-45 flex-col gap-1 rounded-xl border border-default bg-default p-2 shadow-md',
               'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
               className
             )}

--- a/docs/ui/components/Dropdown/index.tsx
+++ b/docs/ui/components/Dropdown/index.tsx
@@ -26,23 +26,21 @@ export function Dropdown({
     <Root modal={false}>
       <Trigger asChild>{trigger}</Trigger>
       <Portal>
-        <div className="bg-danger">
-          <Content
-            className={mergeClasses(
-              'flex min-w-45 flex-col gap-1 rounded-xl border border-default bg-default p-2 shadow-md',
-              'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
-              className
-            )}
-            side={side}
-            sideOffset={sideOffset}
-            collisionPadding={collisionPadding}
-            {...rest}>
-            <Arrow asChild>
-              <div className="relative -top-1 size-2.5 rotate-45 border-r border-b border-default bg-default" />
-            </Arrow>
-            {children}
-          </Content>
-        </div>
+        <Content
+          className={mergeClasses(
+            'flex min-w-45 flex-col gap-1 rounded-xl border border-default bg-default p-2 shadow-md',
+            'will-change-[opacity,transform] data-[side=bottom]:animate-slideUpAndFadeIn',
+            className
+          )}
+          side={side}
+          sideOffset={sideOffset}
+          collisionPadding={collisionPadding}
+          {...rest}>
+          <Arrow asChild>
+            <div className="relative -top-1 size-2.5 rotate-45 border-r border-b border-default bg-default" />
+          </Arrow>
+          {children}
+        </Content>
       </Portal>
     </Root>
   );

--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -63,7 +63,7 @@ export function Select({
             />
           }
           className={mergeClasses(
-            'min-h-9 transform-none justify-between truncate px-3',
+            'min-h-9 justify-between truncate px-3 active:scale-100',
             !value && 'text-quaternary',
             size === 'lg' && 'min-h-13',
             className

--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -81,13 +81,14 @@ export function Select({
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>
         <SelectPrimitive.Content
-          // z-[605] to be above the dialogs (601)
+          position="popper"
+          sideOffset={4}
           className={mergeClasses(
-            'relative z-605 max-w-[87.5vw] overflow-hidden rounded-md border border-default bg-overlay shadow-md',
-            'max-md:max-w-[unset]'
-          )}
-          data-orientation="horizontal">
-          <SelectPrimitive.ScrollUpButton className="flex h-7 items-center justify-center rounded-t-md bg-element">
+            'relative z-605 overflow-hidden rounded-xl border border-default bg-overlay shadow-md',
+            'max-h-(--radix-select-content-available-height) min-w-(--radix-select-trigger-width)',
+            'max-w-[87.5vw] max-md:max-w-[unset]'
+          )}>
+          <SelectPrimitive.ScrollUpButton className="flex h-7 items-center justify-center bg-element">
             <ChevronUpIcon aria-hidden="true" className="icon-sm text-icon-secondary" />
           </SelectPrimitive.ScrollUpButton>
           <SelectPrimitive.Viewport>
@@ -141,7 +142,7 @@ export function Select({
               ))}
             </SelectPrimitive.Group>
           </SelectPrimitive.Viewport>
-          <SelectPrimitive.ScrollDownButton className="flex h-7 items-center justify-center rounded-b-md bg-element">
+          <SelectPrimitive.ScrollDownButton className="flex h-7 items-center justify-center bg-element">
             <ChevronDownIcon aria-hidden="true" className="icon-sm text-icon-secondary" />
           </SelectPrimitive.ScrollDownButton>
         </SelectPrimitive.Content>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26186 ENG-26187

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fixes the Chrome-only theme selector flicker. Radix Select's default item-aligned positioning can't line the menu up with a trigger that sits near the top of the window, so it writes a scroll offset and then a min-height that cancels it, and Chrome sometimes paints the state in between. `position="popper"` drops that math and the menu now opens below the trigger.

Also matches the menu radius to the trigger on all four selectors (theme, language, reference version, and both bare upgrade pickers), so a 6px box becomes a 16px panel sitting at the trigger's width. Same treatment applied to  Copy page and code block settings dropdowns. Both radius and padding are taken from the EAS dashboard menus.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="288" height="332" alt="CleanShot 2026-08-26 at 14 06 28@2x" src="https://github.com/user-attachments/assets/48c22807-c95e-43d3-a0c1-f859e2dd3c22" />


<img width="428" height="416" alt="CleanShot 2026-08-26 at 14 06 12@2x" src="https://github.com/user-attachments/assets/72dab271-4c73-4be2-933e-1632b3cac66e" />

<img width="612" height="670" alt="CleanShot 2026-08-26 at 14 06 18@2x" src="https://github.com/user-attachments/assets/8ef14505-6d46-4017-a21c-c3dbf9d5eeda" />

<img width="668" height="712" alt="CleanShot 2026-08-26 at 14 06 36@2x" src="https://github.com/user-attachments/assets/4a2e6332-c59d-4ee0-a800-f464b847c1cf" />

<img width="2282" height="700" alt="CleanShot 2026-08-26 at 14 06 52@2x" src="https://github.com/user-attachments/assets/041c39bd-4a4a-48d2-a32a-3b2435905976" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
