### PR TITLE
[android][updates] Disallow main thread queries on the updates database

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Link `libc++` in the test spec so the unit test bundle resolves the C++ symbols it pulls from `ExpoModulesCore`. ([#48762](https://github.com/expo/expo/pull/48762) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Run the build data consistency check inside the startup procedure so it no longer queries the database on the main thread. ([#49374](https://github.com/expo/expo/pull/49374) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Disallow main thread queries on the updates database. ([#49375](https://github.com/expo/expo/pull/49375) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/UpdatesDatabase.kt
@@ -81,7 +81,6 @@ abstract class UpdatesDatabase : RoomDatabase() {
           MIGRATION_11_12,
           MIGRATION_12_13
         )
-          .allowMainThreadQueries()
           .fallbackToDestructiveMigration()
           .build()
 


### PR DESCRIPTION
# Why
The database was built with allowMainThreadQueries(), which hides regressions. With the build data check moved off the main thread in the previous PR, no production code path queries on main anymore, so the escape hatch can go.

# How
Removed .allowMainThreadQueries() from the builder in UpdatesDatabase.getInstance. Any future main-thread query now throws immediately instead of janking startup. Tests are unaffected because they build their own in-memory databases.

# Test Plan
CI and local runs