### PR TITLE
[font][web] Match @font-face rules by the rule's bare family name, fix unloadAsync rule deletion

### DIFF
--- a/packages/expo-font/CHANGELOG.md
+++ b/packages/expo-font/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [android] Apply `fontWeight` and `fontStyle` to fonts loaded with `useFonts`, instancing a variable font's `wght` axis at each weight. Bold and italic text previously fell back to a system font. ([#48129](https://github.com/expo/expo/pull/48129) by [@L65FREAD](https://github.com/L65FREAD))
 - [iOS] Fixed `renderToImageAsync` reporting the main screen's scale rather than the scale the image was rendered at. ([#48172](https://github.com/expo/expo/pull/48172) by [@alanjhughes](https://github.com/alanjhughes))
 - [web] Fixed `isLoaded()` always returning `false` on Firefox, and on every engine for font families whose name needs quoting, by normalizing quotes when comparing family names against the CSSOM. This also stops `loadAsync()` from injecting a duplicate `@font-face` rule on every call and makes `unloadAsync()` and `getLoadedFonts()` behave consistently across engines. ([#49266](https://github.com/expo/expo/pull/49266) by [@irfanfandi](https://github.com/irfanfandi))
+- [web] Match `@font-face` rules by comparing the rule's bare family name against the caller's literal name, so families whose names contain quotes or padding resolve correctly, and fixed `unloadAsync()` deleting wrong rules when several rules match. ([#49379](https://github.com/expo/expo/pull/49379) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -82,8 +82,8 @@ const ExpoFontLoader: Required<ExpoFontLoaderModule> = {
     const sheet = getFontFaceStyleSheet();
     if (!sheet) return;
     const items = getFontFaceRulesMatchingResource(fontFamilyName, options);
-    for (let i = items.length - 1; i >= 0; i--) {
-      sheet.deleteRule(items[i].index);
+    for (const item of items.reverse()) {
+      sheet.deleteRule(item.index);
     }
   },
 

--- a/packages/expo-font/src/ExpoFontLoader.web.ts
+++ b/packages/expo-font/src/ExpoFontLoader.web.ts
@@ -40,10 +40,8 @@ function getFontFaceRules(): RuleItem[] {
   return [];
 }
 
-// Engines disagree about whether the CSSOM keeps the quotes from a `font-family`
-// declaration: Firefox keeps them for every name, while Chromium and WebKit keep them only
-// for names that need quoting, such as anything containing a space. `_createWebFontTemplate`
-// always writes the name quoted, so the quoting has to be normalized away before comparing.
+// `_createWebFontTemplate` writes the family name quoted, but engines disagree about whether
+// the CSSOM keeps the quotes (Firefox always does), so normalize them away before comparing.
 function normalizeFontFamilyName(fontFamily: string): string {
   // jsdom leaves `style.fontFamily` undefined on the `@font-face` rules it parses.
   const trimmed = fontFamily?.trim();
@@ -62,10 +60,9 @@ function getFontFaceRulesMatchingResource(
   options?: UnloadFontOptions
 ): RuleItem[] {
   const rules = getFontFaceRules();
-  const normalizedFontFamilyName = normalizeFontFamilyName(fontFamilyName);
   return rules.filter(({ rule }) => {
     return (
-      normalizeFontFamilyName(rule.style.fontFamily) === normalizedFontFamilyName &&
+      normalizeFontFamilyName(rule.style.fontFamily) === fontFamilyName &&
       (options && options.display ? options.display === (rule.style as any).fontDisplay : true)
     );
   });
@@ -85,8 +82,8 @@ const ExpoFontLoader: Required<ExpoFontLoaderModule> = {
     const sheet = getFontFaceStyleSheet();
     if (!sheet) return;
     const items = getFontFaceRulesMatchingResource(fontFamilyName, options);
-    for (const item of items) {
-      sheet.deleteRule(item.index);
+    for (let i = items.length - 1; i >= 0; i--) {
+      sheet.deleteRule(items[i].index);
     }
   },
 

--- a/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
+++ b/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
@@ -79,6 +79,30 @@ if (typeof window === 'undefined') {
 
       expect(ExpoFontLoader.isLoaded('DIN 2015')).toBe(false);
     });
+
+    it(`matches a family whose name itself contains quotes`, () => {
+      installFontFaceRules(['"\\"Weird\\""']);
+
+      expect(ExpoFontLoader.isLoaded('"Weird"')).toBe(true);
+    });
+
+    it(`matches a family name with significant surrounding whitespace`, () => {
+      installFontFaceRules(['"  Padded  "']);
+
+      expect(ExpoFontLoader.isLoaded('  Padded  ')).toBe(true);
+    });
+
+    it(`does not conflate a padded name with its trimmed form`, () => {
+      installFontFaceRules(['"  Padded  "']);
+
+      expect(ExpoFontLoader.isLoaded('Padded')).toBe(false);
+    });
+
+    it(`does not treat quotes in the caller's name as CSS quoting`, () => {
+      installFontFaceRules(['"MyFont"']);
+
+      expect(ExpoFontLoader.isLoaded('"MyFont"')).toBe(false);
+    });
   });
 
   describe('getLoadedFonts', () => {
@@ -100,6 +124,15 @@ if (typeof window === 'undefined') {
       await ExpoFontLoader.unloadAsync('DIN 2014');
 
       expect(sheet.cssRules).toHaveLength(0);
+    });
+
+    it(`removes every matching rule when more than one matches`, async () => {
+      const sheet = installFontFaceRules(['"DIN 2014"', '"DIN 2014"', '"Other"']);
+
+      await ExpoFontLoader.unloadAsync('DIN 2014');
+
+      expect(sheet.cssRules).toHaveLength(1);
+      expect(sheet.cssRules[0].style.fontFamily).toBe('"Other"');
     });
   });
 }

--- a/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
+++ b/packages/expo-font/src/__tests__/ExpoFontLoader-test.web.ts
@@ -132,7 +132,7 @@ if (typeof window === 'undefined') {
       await ExpoFontLoader.unloadAsync('DIN 2014');
 
       expect(sheet.cssRules).toHaveLength(1);
-      expect(sheet.cssRules[0].style.fontFamily).toBe('"Other"');
+      expect(sheet.cssRules[0]?.style.fontFamily).toBe('"Other"');
     });
   });
 }


### PR DESCRIPTION
# Why

Follow-up to #49266 (and closes the gap #49192 argued for). Tow issues:

1. `getFontFaceRulesMatchingResource` normalized quotes away from **both** sides of the comparison. The left side of comparison comes from the browsers and they report inconsistent results so we normalize it. The right side is a literal family name, so we take it as the user provides it.

2. `unloadAsync` deletes matching rules in ascending index order so with more than one match it deletes wrong rules. 

# How

- Normalize only the rule's side: `normalizeFontFamilyName(rule.style.fontFamily) === fontFamilyName`. 
- `unloadAsync` flip deletion order

# Test Plan

Extended `ExpoFontLoader-test.web.ts` 

# Checklist

- [ ] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Added a `CHANGELOG.md` entry.

