### PR TITLE
[docs] Serve smaller YouTube thumbnails and lazy-load `Talks` cards

### DIFF
--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -74,16 +74,19 @@ export function TalkGridCell({
       )}
       isStyled>
       <div>
-        <div
-          style={{
-            backgroundImage: `url(${
+        <div className="h-34.5 border-b border-b-default max-sm:h-42">
+          <img
+            src={
               thumbnail
                 ? `/static/thumbnails/${thumbnail}`
-                : `https://i.ytimg.com/vi_webp/${videoId}/maxresdefault.webp`
-            })`,
-          }}
-          className="h-34.5 border-b border-b-default bg-cover bg-center max-sm:h-42"
-        />
+                : `https://i.ytimg.com/vi_webp/${videoId}/sddefault.webp`
+            }
+            alt=""
+            loading="lazy"
+            decoding="async"
+            className="size-full object-cover object-center"
+          />
+        </div>
         <div className="flex min-h-7.5 items-start justify-between gap-1 bg-default px-4 py-3">
           <LABEL className="block leading-normal">{title}</LABEL>
           <ArrowUpRightIcon

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -57,9 +57,9 @@ export function VideoBoxLink({
             'max-sm:max-w-full max-sm:border-r-0 max-sm:border-b'
           )}>
           <img
-            src={`https://i.ytimg.com/vi_webp/${videoId}/maxresdefault.webp`}
+            src={`https://i.ytimg.com/vi_webp/${videoId}/sddefault.webp`}
             loading="lazy"
-            className="aspect-video transition duration-300 group-hover:scale-105 group-focus-visible:scale-105"
+            className="aspect-video object-cover object-center transition duration-300 group-hover:scale-105 group-focus-visible:scale-105"
             alt={title}
             aria-label={`Video thumbnail for ${title}`}
           />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/49287

# How

<!--
How did you build this feature or fix this bug and why?
-->

Switches YouTube thumbnails from `maxresdefault` (1280x720) to `sddefault` (640x480, cropped back to 16:9 by `object-cover`) and moves the home `Talks` cards from a CSS `background-image` to a lazy `<img>`, cutting each thumbnail from ~41 KB to ~19 KB.

On the home page that is ~350 KB and 8 fewer requests on initial load (1573 KB → ~1220 KB, median of 5 local Lighthouse runs, CLS still 0).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run docs app locally and note that thumbnails are loading.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
