### PR TITLE
[android][expo-go] Build the codegen CLI when the submodule is missing it

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -91,6 +91,20 @@ project(":packages:react-native:ReactAndroid").afterEvaluate { reactAndroid ->
   reactAndroid.tasks.named("buildCodegenCLI").configure { it.enabled = false }
 }
 
+// Every module's generateCodegenSchemaFromJavaScript reads react-native-codegen/lib
+// directly, so build it once when it is missing.
+def labCodegenDir = file("$rootDir/../../../react-native-lab/react-native/packages/react-native-codegen")
+tasks.register("buildLabCodegenCli", Exec) {
+  onlyIf { !new File(labCodegenDir, "lib/cli/combine/combine-js-to-schema-cli.js").exists() }
+  workingDir labCodegenDir
+  commandLine "bash", "scripts/oss/build.sh"
+}
+allprojects {
+  tasks.matching { it.name == "generateCodegenSchemaFromJavaScript" }.configureEach {
+    it.dependsOn(":buildLabCodegenCli")
+  }
+}
+
 // Expo Go ships a release build that keeps the JS debugger. React Native gates those native defines
 // behind REACT_NATIVE_DEBUG_OPTIMIZED, and its CMake guard only passes automatically when
 // CMAKE_BUILD_TYPE is Debug. Release maps to RelWithDebInfo, which does not match, so set the flag


### PR DESCRIPTION
# Why
 #48279 stopped committing the generated codegen output to the fork and moved the build step into the EAS pre-install script. Nothing recreates it locally, so a fresh submodule checkout fails every `generateCodegenSchemaFromJavaScript` task.

# How
Register a `buildLabCodegenCli` task in the root build.gradle that runs the codegen package's scripts/oss/build.sh. It only runs when the built CLI is missing. Every module's generateCodegenSchemaFromJavaScript task depends on it, so the ordering holds no matter which project's codegen runs first.

# Test Plan
Deleted the codegen lib/ output to reproduce a fresh checkout and ran the slider and expoview codegen tasks. The build is successful. The task is also skipped when the lib dir exists