### PR TITLE
[tools][github-metrics] Fix CI success rate denominator and workflow grouping

### DIFF
--- a/tools/src/commands/GitHubMetricsCommand.test.ts
+++ b/tools/src/commands/GitHubMetricsCommand.test.ts
@@ -1,10 +1,22 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { computeRunConclusionCounts } from './GitHubMetricsCommand';
+import {
+  computeRunConclusionCounts,
+  computeWorkflowStats,
+  formatSuccessRate,
+} from './GitHubMetricsCommand';
 
 function runs(conclusions: (string | null)[]) {
   return conclusions.map((conclusion) => ({ conclusion }));
+}
+
+function repeat(conclusion: string | null, count: number) {
+  return Array.from({ length: count }, () => conclusion);
+}
+
+function workflowRun(workflowId: number, name: string | null, filePath: string) {
+  return { workflow_id: workflowId, name, path: filePath, conclusion: 'success' };
 }
 
 describe('computeRunConclusionCounts', () => {
@@ -15,27 +27,126 @@ describe('computeRunConclusionCounts', () => {
 
   it('counts cancelled runs as successful', () => {
     const result = computeRunConclusionCounts(runs(['success', 'cancelled', 'failure']));
-    assert.equal(result.totalRuns - result.skippedRuns, 3);
+    assert.equal(result.resolvedRuns, 3);
     assert.equal(result.successRate, (2 / 3) * 100);
   });
 
   it('excludes skipped runs from the success-rate denominator', () => {
     const result = computeRunConclusionCounts(runs(['skipped', 'skipped', 'skipped', 'success']));
     assert.equal(result.skippedRuns, 3);
-    assert.equal(result.totalRuns - result.skippedRuns, 1);
+    assert.equal(result.resolvedRuns, 1);
     assert.equal(result.successRate, 100);
   });
 
   it('does not divide by zero when every run was skipped', () => {
     const result = computeRunConclusionCounts(runs(['skipped', 'skipped']));
-    assert.equal(result.totalRuns - result.skippedRuns, 0);
+    assert.equal(result.resolvedRuns, 0);
     assert.equal(result.successRate, 0);
   });
 
-  it('leaves ambiguous conclusions (in progress, neutral, etc.) in the denominator', () => {
+  it('excludes unresolved runs (in progress, queued, neutral) from the denominator', () => {
     const result = computeRunConclusionCounts(runs([null, 'neutral', 'success']));
     assert.equal(result.otherRuns, 2);
-    assert.equal(result.totalRuns - result.skippedRuns, 3);
-    assert.equal(result.successRate, (1 / 3) * 100);
+    assert.equal(result.resolvedRuns, 1);
+    assert.equal(result.successRate, 100);
+  });
+
+  it('reports the resolved success rate for a real week of runs', () => {
+    const result = computeRunConclusionCounts(
+      runs([
+        ...repeat('success', 335),
+        ...repeat('failure', 31),
+        ...repeat('cancelled', 96),
+        ...repeat('skipped', 468),
+        ...repeat(null, 70),
+      ])
+    );
+
+    assert.equal(result.totalRuns, 1000);
+    assert.equal(result.otherRuns, 70);
+    assert.equal(result.resolvedRuns, 462);
+    assert.equal(result.successRate.toFixed(1), '93.3');
+    assert.notEqual(result.successRate.toFixed(1), '81.0');
+  });
+
+  it('rates a failure-free set at 100% however many runs are still unresolved', () => {
+    const result = computeRunConclusionCounts(
+      runs(['success', 'cancelled', null, 'action_required', 'queued'])
+    );
+    assert.equal(result.failedRuns, 0);
+    assert.equal(result.successRate, 100);
+  });
+});
+
+describe('formatSuccessRate', () => {
+  it('has no rate to report when nothing resolved', () => {
+    const result = computeRunConclusionCounts(runs([null, null, 'action_required']));
+    assert.equal(formatSuccessRate(result), 'N/A (no executed runs)');
+  });
+
+  it('rounds the resolved rate to one decimal', () => {
+    const result = computeRunConclusionCounts(
+      runs([...repeat('success', 431), ...repeat('failure', 31), ...repeat(null, 70)])
+    );
+    assert.equal(formatSuccessRate(result), '93.3%');
+  });
+});
+
+describe('computeWorkflowStats', () => {
+  const verifyPath = '.github/workflows/verify-comment.yml';
+
+  it('groups runs of one workflow together despite dynamic run names', () => {
+    const stats = computeWorkflowStats([
+      workflowRun(342612912, 'verify', verifyPath),
+      workflowRun(342612912, 'verify #49383 — expo-bot', verifyPath),
+      workflowRun(342612912, 'verify #48626 — brentvatne', verifyPath),
+    ]);
+
+    assert.equal(stats.length, 1);
+    assert.equal(stats[0].name, 'verify');
+    assert.equal(stats[0].totalRuns, 3);
+  });
+
+  it('keeps distinct workflows apart even when they share a name', () => {
+    const stats = computeWorkflowStats([
+      workflowRun(1, 'test', '.github/workflows/test-suite.yml'),
+      workflowRun(2, 'test', '.github/workflows/test-tools.yml'),
+    ]);
+
+    assert.equal(stats.length, 2);
+  });
+
+  it('falls back to the workflow file name when no run is named', () => {
+    const stats = computeWorkflowStats([
+      workflowRun(1, null, verifyPath),
+      workflowRun(1, null, verifyPath),
+    ]);
+
+    assert.deepEqual(
+      stats.map((workflow) => workflow.name),
+      ['verify-comment.yml']
+    );
+  });
+
+  it('breaks shortest-name ties alphabetically', () => {
+    const stats = computeWorkflowStats([
+      workflowRun(1, 'beta', verifyPath),
+      workflowRun(1, 'alfa', verifyPath),
+    ]);
+
+    assert.equal(stats[0].name, 'alfa');
+  });
+
+  it('orders workflows by total runs, descending', () => {
+    const stats = computeWorkflowStats([
+      workflowRun(1, 'once', '.github/workflows/once.yml'),
+      workflowRun(2, 'twice', '.github/workflows/twice.yml'),
+      workflowRun(2, 'twice', '.github/workflows/twice.yml'),
+    ]);
+
+    assert.deepEqual(
+      stats.map((workflow) => workflow.name),
+      ['twice', 'once']
+    );
   });
 });

--- a/tools/src/commands/GitHubMetricsCommand.ts
+++ b/tools/src/commands/GitHubMetricsCommand.ts
@@ -64,7 +64,8 @@ interface WorkflowStats {
   cancelledRuns: number;
   skippedRuns: number;
   otherRuns: number; // timed_out, action_required, neutral, stale, in_progress, etc.
-  successRate: number; // percentage of (totalRuns - skippedRuns) that succeeded or were cancelled
+  resolvedRuns: number; // runs that reached an outcome: successful + failed + cancelled
+  successRate: number; // percentage of resolvedRuns that succeeded or were cancelled
 }
 
 interface CIMetrics {
@@ -74,7 +75,8 @@ interface CIMetrics {
   cancelledRuns: number;
   skippedRuns: number;
   otherRuns: number; // timed_out, action_required, neutral, stale, in_progress, etc.
-  successRate: number; // percentage of (totalRuns - skippedRuns) that succeeded or were cancelled
+  resolvedRuns: number; // runs that reached an outcome: successful + failed + cancelled
+  successRate: number; // percentage of resolvedRuns that succeeded or were cancelled
   workflows: WorkflowStats[];
 }
 
@@ -360,9 +362,9 @@ export function computeRunConclusionCounts(runs: { conclusion: string | null }[]
   const skippedRuns = runs.filter((run) => run.conclusion === 'skipped').length;
   const otherRuns = totalRuns - successfulRuns - failedRuns - cancelledRuns - skippedRuns;
 
-  const executedRuns = totalRuns - skippedRuns;
+  const resolvedRuns = successfulRuns + failedRuns + cancelledRuns;
   const effectiveSuccessfulRuns = successfulRuns + cancelledRuns;
-  const successRate = executedRuns > 0 ? (effectiveSuccessfulRuns / executedRuns) * 100 : 0;
+  const successRate = resolvedRuns > 0 ? (effectiveSuccessfulRuns / resolvedRuns) * 100 : 0;
 
   return {
     totalRuns,
@@ -371,8 +373,57 @@ export function computeRunConclusionCounts(runs: { conclusion: string | null }[]
     cancelledRuns,
     skippedRuns,
     otherRuns,
+    resolvedRuns,
     successRate,
   };
+}
+
+export function formatSuccessRate(stats: { resolvedRuns: number; successRate: number }): string {
+  return stats.resolvedRuns > 0 ? `${stats.successRate.toFixed(1)}%` : 'N/A (no executed runs)';
+}
+
+type WorkflowRunSummary = {
+  workflow_id: number;
+  name?: string | null;
+  path?: string | null;
+  conclusion: string | null;
+};
+
+/**
+ * Group runs per workflow, ordered by run count descending.
+ *
+ * Runs are grouped by `workflow_id` rather than by `name`: a workflow that sets `run-name:` gets a
+ * fresh name on every run (`verify`, `verify #49383 — expo-bot`, …), which would otherwise scatter
+ * one workflow across dozens of single-run rows.
+ */
+export function computeWorkflowStats(workflowRuns: WorkflowRunSummary[]): WorkflowStats[] {
+  const runsByWorkflowId = new Map<number, WorkflowRunSummary[]>();
+  for (const run of workflowRuns) {
+    const runs = runsByWorkflowId.get(run.workflow_id);
+    if (runs) {
+      runs.push(run);
+    } else {
+      runsByWorkflowId.set(run.workflow_id, [run]);
+    }
+  }
+
+  return Array.from(runsByWorkflowId.values())
+    .map((runs) => ({ name: workflowLabel(runs), ...computeRunConclusionCounts(runs) }))
+    .sort((a, b) => b.totalRuns - a.totalRuns);
+}
+
+/**
+ * The shortest run name of a group, which is the workflow's own name without any run-specific
+ * suffix. Falls back to the workflow file name for workflows whose runs are all unnamed.
+ */
+function workflowLabel(runs: WorkflowRunSummary[]): string {
+  const names = runs.flatMap((run) => (run.name ? [run.name] : []));
+  if (names.length > 0) {
+    return names.sort((a, b) => a.length - b.length || a.localeCompare(b))[0];
+  }
+
+  const workflowPath = runs.find((run) => run.path)?.path;
+  return workflowPath ? path.basename(workflowPath) : 'unknown';
 }
 
 /**
@@ -397,22 +448,9 @@ async function fetchCIMetrics(
     return data.workflow_runs;
   });
 
-  const workflowMap = new Map<string, typeof workflowRuns>();
-  for (const run of workflowRuns) {
-    const workflowName = run.name ?? 'unknown';
-    if (!workflowMap.has(workflowName)) {
-      workflowMap.set(workflowName, []);
-    }
-    workflowMap.get(workflowName)!.push(run);
-  }
-
-  const workflows: WorkflowStats[] = Array.from(workflowMap.entries())
-    .map(([name, runs]) => ({ name, ...computeRunConclusionCounts(runs) }))
-    .sort((a, b) => b.totalRuns - a.totalRuns);
-
   return {
     ...computeRunConclusionCounts(workflowRuns),
-    workflows,
+    workflows: computeWorkflowStats(workflowRuns),
   };
 }
 
@@ -490,15 +528,6 @@ function generateMarkdownReport(metrics: MetricsData, options: MetricsOptions): 
   const startDateStr = startDate.toISOString().split('T')[0];
   const endDateStr = endDate.toISOString().split('T')[0];
 
-  const formatSuccessRate = (stats: {
-    totalRuns: number;
-    skippedRuns: number;
-    successRate: number;
-  }): string =>
-    stats.totalRuns - stats.skippedRuns > 0
-      ? `${stats.successRate.toFixed(1)}%`
-      : 'N/A (no executed runs)';
-
   const report = `# GitHub Metrics Report
 
 **Repository:** ${owner}/${repo}
@@ -552,15 +581,15 @@ function generateMarkdownReport(metrics: MetricsData, options: MetricsOptions): 
 | Failed runs | ${metrics.ci.failedRuns} | ${metrics.ci.totalRuns > 0 ? ((metrics.ci.failedRuns / metrics.ci.totalRuns) * 100).toFixed(1) : '0.0'}% |
 | Cancelled runs (concurrency) | ${metrics.ci.cancelledRuns} | ${metrics.ci.totalRuns > 0 ? ((metrics.ci.cancelledRuns / metrics.ci.totalRuns) * 100).toFixed(1) : '0.0'}% |
 | Skipped runs (never executed) | ${metrics.ci.skippedRuns} | ${metrics.ci.totalRuns > 0 ? ((metrics.ci.skippedRuns / metrics.ci.totalRuns) * 100).toFixed(1) : '0.0'}% |
-| Other runs (in progress, neutral, etc.) | ${metrics.ci.otherRuns} | ${metrics.ci.totalRuns > 0 ? ((metrics.ci.otherRuns / metrics.ci.totalRuns) * 100).toFixed(1) : '0.0'}% |
-| **Success rate** | **${metrics.ci.successfulRuns + metrics.ci.cancelledRuns}/${metrics.ci.totalRuns - metrics.ci.skippedRuns}** | **${formatSuccessRate(metrics.ci)}** |
+| Unresolved runs (in progress, queued, awaiting approval) | ${metrics.ci.otherRuns} | ${metrics.ci.totalRuns > 0 ? ((metrics.ci.otherRuns / metrics.ci.totalRuns) * 100).toFixed(1) : '0.0'}% |
+| **Success rate** | **${metrics.ci.successfulRuns + metrics.ci.cancelledRuns}/${metrics.ci.resolvedRuns}** | **${formatSuccessRate(metrics.ci)}** |
 
-> **Note:** Cancelled runs are counted as successful since they're typically due to concurrency settings (newer runs superseding older ones). Skipped runs are excluded from the success rate entirely, since a \`skipped\` conclusion means the workflow never executed (usually because an \`if:\` condition gated it, like a fork-only check).
+> **Note:** Cancelled runs are counted as successful since they're typically due to concurrency settings (newer runs superseding older ones). Skipped runs are excluded from the success rate entirely, since a \`skipped\` conclusion means the workflow never executed (usually because an \`if:\` condition gated it, like a fork-only check). Unresolved runs are excluded for the same reason — they had no outcome yet when the report was generated, so counting them as failures would make the rate rise and fall with how much CI happened to be in flight.
 
 ### Workflow Breakdown
 
-| Workflow | Total | Success | Failed | Cancelled | Skipped | Other | Success Rate |
-|----------|-------|---------|--------|-----------|---------|-------|--------------|
+| Workflow | Total | Success | Failed | Cancelled | Skipped | Unresolved | Success Rate |
+|----------|-------|---------|--------|-----------|---------|------------|--------------|
 ${metrics.ci.workflows
   .map(
     (w) =>
@@ -580,7 +609,7 @@ ${metrics.ci.workflows
 
 - **Issue velocity:** ${metrics.issues.closedDuringPeriod} issues closed, ${metrics.issues.openedDuringPeriod} new issues opened
 - **PR velocity:** ${metrics.pullRequests.mergedDuringPeriod} PRs merged, ${metrics.pullRequests.openedDuringPeriod} new PRs opened
-- **CI reliability:** ${formatSuccessRate(metrics.ci)} success rate across ${metrics.ci.totalRuns - metrics.ci.skippedRuns} executed workflow runs (${metrics.ci.skippedRuns} skipped, ${metrics.ci.failedRuns} failures)
+- **CI reliability:** ${formatSuccessRate(metrics.ci)} success rate across ${metrics.ci.resolvedRuns} resolved workflow runs (${metrics.ci.skippedRuns} skipped, ${metrics.ci.otherRuns} unresolved, ${metrics.ci.failedRuns} failures)
 
 ---
 


### PR DESCRIPTION
# Why

We had two bugs in the `et github-metrics` command that caused the CI health report to be wrong.

1. Success rate counted unresolved runs as failures.
2. Workflow breakdown grouped by name - breaks when workflow sets dynamic name.

# How

1. Fixed by moving the denominator: `computeRunConclusionCounts` now returns `resolvedRuns = successfulRuns + failedRuns + cancelledRuns` and divides by that.
2. Runs are grouped by `workflow_id` and not name anymore

# Test Plan

✅ Unit tests (`tools/src/commands/GitHubMetricsCommand.test.ts` covers both fixes)

# Checklist

- [x] Builds, type-checks, lints, and tests pass (the three checks in `tools/AGENTS.md`, which is what `.github/workflows/expotools.yml` runs).
- [x] Conforms to the documentation style guide.