### PR TITLE
[docs] Soften floating surface radii off the 6px default

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -142,7 +142,7 @@ details > summary::-webkit-details-marker {
 /* Tippy */
 
 div.tippy-box {
-  @apply rounded-md;
+  @apply rounded-lg;
   transform: translateY(6px);
 }
 
@@ -151,7 +151,7 @@ div.tippy-box {
 }
 
 .tippy-box[data-theme~='expo'] .tippy-content {
-  @apply bg-palette-black text-palette-white rounded-md px-4 py-3 text-sm;
+  @apply bg-palette-black text-palette-white rounded-lg px-4 py-3 text-sm;
   line-height: 1.525;
 }
 

--- a/docs/ui/components/Snippet/CodeSelectionCopy.tsx
+++ b/docs/ui/components/Snippet/CodeSelectionCopy.tsx
@@ -170,7 +170,7 @@ export function CodeSelectionCopy() {
           left: position.left,
           transform: 'translateX(-50%)',
         }}
-        className="z-50 inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-default bg-default px-2 py-1 text-xs text-secondary shadow-md hover:text-default">
+        className="z-50 inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-default bg-default px-2.5 py-1 text-xs text-secondary shadow-md hover:text-default">
         <ClipboardIcon aria-hidden="true" className="icon-xs text-icon-secondary" />
         {intl.formatMessage({ id: copied ? 'codeCopied' : 'codeCopy' })}
       </button>

--- a/docs/ui/components/Tooltip/Content.tsx
+++ b/docs/ui/components/Tooltip/Content.tsx
@@ -10,7 +10,7 @@ export function Content({ children, className, sideOffset = 4, ...rest }: Toolti
       <TooltipPrimitive.Content
         sideOffset={sideOffset}
         className={mergeClasses(
-          'dark-theme relative z-101 flex flex-col rounded-md bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
+          'dark-theme relative z-101 flex flex-col rounded-lg bg-palette-gray2 px-3 py-1.5 text-default shadow-md',
           'data-[side=bottom]:animate-slideUpAndFade data-[side=left]:animate-slideRightAndFade data-[side=right]:animate-slideLeftAndFade data-[side=top]:animate-slideDownAndFade',
           className
         )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/49373

# How

<!--
How did you build this feature or fix this bug and why?
-->

Takes the last floating surfaces off the old 6px radius, moving both tooltip systems (Radix and the tippy code annotations) to 8px so they finally match each other, and making the floating code copy chip a pill like the rest of the buttons.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="1336" height="500" alt="CleanShot 2026-08-26 at 15 22 20@2x" src="https://github.com/user-attachments/assets/a665f3ad-e213-44b3-8af5-532c8108d4a9" />

<img width="868" height="338" alt="CleanShot 2026-08-26 at 15 22 23@2x" src="https://github.com/user-attachments/assets/131f7ab8-9058-4769-896b-6bd1aa5485e2" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
