### PR TITLE
[docs] Replace `lodash/partition` with a local helper

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -1,4 +1,3 @@
-import partition from 'lodash/partition';
 import { Language, Prism } from 'prism-react-renderer';
 import { Children, ReactElement, ReactNode, PropsWithChildren, isValidElement } from 'react';
 
@@ -206,6 +205,15 @@ export function replaceSlashCommentsWithAnnotationsForTutorial(value: string) {
       /\s*<span clas{2}="token (com{2}ent|plain-text)">\s*\/\* @end \*\/(\s*)<\/span>/g,
       (match, type, afterWhitespace) => `</span>${afterWhitespace}`
     );
+}
+
+function partition<T>(items: T[], predicate: (item: T) => boolean): [T[], T[]] {
+  const matched: T[] = [];
+  const rest: T[] = [];
+  for (const item of items) {
+    (predicate(item) ? matched : rest).push(item);
+  }
+  return [matched, rest];
 }
 
 export function parseValue(value: string) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Replaces the single `lodash/partition` call in `common/code-utilities.ts` with a six-line local helper. It was the only lodash import that reaches the browser bundle, and `_app` loads on every page.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Saves ~7 KB transferred per page (measured on `/versions/latest/sdk/calendar/`: 1363 KB → 1356 KB, median of 5 local Lighthouse runs).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
