### PR TITLE
[docs] Match feedback dialog radius with the EAS modal

### DIFF
--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -110,7 +110,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                       <LABEL>Feedback</LABEL>
                       <Textarea
                         autoFocus
-                        className="h-45 resize-none"
+                        className="h-45 resize-none rounded-2xl"
                         characterLimit={1000}
                         value={feedback}
                         onChange={event => {
@@ -125,6 +125,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                       </CALLOUT>
                       <Input
                         type="email"
+                        className="rounded-3xl"
                         placeholder="your@email.com"
                         value={email}
                         onChange={event => {

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -64,7 +64,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
           <Dialog.Content
             className={mergeClasses(
               'dialog-content',
-              'top-0 left-0 max-h-[90vh] w-[90vw] max-w-125 overflow-hidden rounded-lg border border-default bg-default wrap-break-word shadow-md outline-0 backface-hidden',
+              'top-0 left-0 max-h-[90vh] w-[90vw] max-w-125 overflow-hidden rounded-[40px] border border-default bg-default wrap-break-word shadow-md outline-0 backface-hidden',
               'data-[state=open]:animate-slideUpAndFadeIn',
               'data-[state=closed]:animate-fadeOut'
             )}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Rounds the feedback dialog to 40px so it matches the EAS dashboard modal, which is the same forked component at the same 500px width and has been on `rounded-[40px]` while ours sat at 8px.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1106" height="1124" alt="CleanShot 2026-08-26 at 15 30 53@2x" src="https://github.com/user-attachments/assets/50a69027-9d79-4253-bc7a-e2712f852340" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
