### PR TITLE
[ios][expo] Allow scene URL transformation

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add a scene URL transformation hook to `ExpoAppSceneDelegate`.
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add a scene URL transformation hook to `ExpoAppSceneDelegate`.
+- [iOS] Add a scene URL transformation hook to `ExpoAppSceneDelegate`. ([#49391](https://github.com/expo/expo/pull/49391) by [@Shahroz16](https://github.com/Shahroz16))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
@@ -102,8 +102,9 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
    Gives a scene delegate subclass an opportunity to replace or consume a URL before Expo forwards
    it to app delegate subscribers and React Native Linking.
 
-   Return the URL to forward, or `nil` when the URL was fully handled and should not be forwarded.
-   The default implementation returns the original URL unchanged.
+   Return the URL to forward, or `nil` when the URL was fully handled and should not be forwarded
+   to either app delegate subscribers or React Native Linking. The default implementation returns
+   the original URL unchanged.
 
    This hook applies to URL contexts. `NSUserActivity` values are routed separately and unchanged.
    */
@@ -156,6 +157,8 @@ extension ExpoAppSceneDelegate {
   }
 
   /// Pass incoming URL contexts to both the subscriber manager and `RCTLinkingManager`.
+  /// This static helper routes the contexts as provided; it does not invoke an instance's
+  /// `transformURL(_:)` override.
   public static func route(urlContexts: Set<UIOpenURLContext>) {
     route(urlContexts: urlContexts.map { ($0.url, $0.options) })
   }

--- a/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
+++ b/packages/expo/ios/AppDelegates/ExpoAppSceneDelegate.swift
@@ -44,6 +44,8 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
     // `UIApplication.shared.delegate?.window` keeps working (e.g. expo-system-ui).
     provider.window = window
 
+    let urlContexts = transformedURLContexts(connectionOptions.urlContexts)
+
     // Under the scene life cycle UIKit passes cold-start URLs and activities in `connectionOptions`
     // rather than in the app delegate's launch options. React Native's `Linking.getInitialURL()`
     // only reads them from launch options, so rebuild them here; otherwise a link that cold-starts
@@ -55,13 +57,13 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
       withModuleName: provider.reactNativeFactoryModuleName,
       in: window,
       launchOptions: Self.launchOptions(
-        url: connectionOptions.urlContexts.first?.url,
+        url: urlContexts.first?.url,
         userActivity: browsingWebActivity
       )
     )
 
     // Deep links / universal links.
-    Self.route(urlContexts: connectionOptions.urlContexts)
+    Self.route(urlContexts: urlContexts)
     connectionOptions.userActivities.forEach { Self.route(userActivity: $0) }
   }
 
@@ -89,11 +91,35 @@ open class ExpoAppSceneDelegate: UIResponder, UIWindowSceneDelegate {
   }
 
   open func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    Self.route(urlContexts: URLContexts)
+    Self.route(urlContexts: transformedURLContexts(URLContexts))
   }
 
   open func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
     Self.route(userActivity: userActivity)
+  }
+
+  /**
+   Gives a scene delegate subclass an opportunity to replace or consume a URL before Expo forwards
+   it to app delegate subscribers and React Native Linking.
+
+   Return the URL to forward, or `nil` when the URL was fully handled and should not be forwarded.
+   The default implementation returns the original URL unchanged.
+
+   This hook applies to URL contexts. `NSUserActivity` values are routed separately and unchanged.
+   */
+  open func transformURL(_ url: URL) -> URL? {
+    url
+  }
+
+  private func transformedURLContexts(
+    _ urlContexts: Set<UIOpenURLContext>
+  ) -> [(url: URL, options: UIScene.OpenURLOptions)] {
+    urlContexts.compactMap { context in
+      guard let url = transformURL(context.url) else {
+        return nil
+      }
+      return (url, context.options)
+    }
   }
 }
 
@@ -131,6 +157,12 @@ extension ExpoAppSceneDelegate {
 
   /// Pass incoming URL contexts to both the subscriber manager and `RCTLinkingManager`.
   public static func route(urlContexts: Set<UIOpenURLContext>) {
+    route(urlContexts: urlContexts.map { ($0.url, $0.options) })
+  }
+
+  private static func route(
+    urlContexts: [(url: URL, options: UIScene.OpenURLOptions)]
+  ) {
     for context in urlContexts {
       let options = openURLOptions(from: context.options)
       _ = ExpoAppDelegateSubscriberManager.application(UIApplication.shared, open: context.url, options: options)

--- a/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
+++ b/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
@@ -61,6 +61,39 @@ struct ExpoAppSceneDelegateTests {
     let url = URL(string: "https://expo.dev/link")!
     #expect(ExpoAppSceneDelegate().transformURL(url) == url)
   }
+
+  @Test
+  @MainActor
+  func `allows subclasses to replace a scene URL`() {
+    let url = URL(string: "https://customer.io/live-activity")!
+    let replacement = URL(string: "bareexpo://live-activity")!
+    #expect(RewritingSceneDelegate(replacement: replacement).transformURL(url) == replacement)
+  }
+
+  @Test
+  @MainActor
+  func `allows subclasses to consume a scene URL`() {
+    let url = URL(string: "https://customer.io/live-activity")!
+    #expect(ConsumingSceneDelegate().transformURL(url) == nil)
+  }
+}
+
+private final class RewritingSceneDelegate: ExpoAppSceneDelegate {
+  private let replacement: URL
+
+  init(replacement: URL) {
+    self.replacement = replacement
+  }
+
+  override func transformURL(_ url: URL) -> URL? {
+    replacement
+  }
+}
+
+private final class ConsumingSceneDelegate: ExpoAppSceneDelegate {
+  override func transformURL(_ url: URL) -> URL? {
+    nil
+  }
 }
 
 #endif

--- a/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
+++ b/packages/expo/ios/Tests/ExpoAppSceneDelegateTests.swift
@@ -54,6 +54,13 @@ struct ExpoAppSceneDelegateTests {
   func `returns nil launch options without a URL or user activity`() {
     #expect(ExpoAppSceneDelegate.launchOptions(url: nil, userActivity: nil) == nil)
   }
+
+  @Test
+  @MainActor
+  func `forwards scene URLs unchanged by default`() {
+    let url = URL(string: "https://expo.dev/link")!
+    #expect(ExpoAppSceneDelegate().transformURL(url) == url)
+  }
 }
 
 #endif


### PR DESCRIPTION
# Why

Config plugins need a supported way to transform scene-delivered URLs before Expo and React Native consume them. Without an extension point, integrations must either take scene ownership from Expo or duplicate Expo's lifecycle forwarding.

# How

- add an overridable, pass-through `transformURL(_:)` hook to `ExpoAppSceneDelegate`
- apply it consistently to cold launch options, Expo subscribers, and React Native Linking
- leave user activities and default Expo behavior unchanged

# Test Plan

- added default pass-through unit coverage
- generated Expo SDK 58 app builds and launches
- exercised warm and cold URL delivery through the scene delegate in the iOS simulator

# Checklist

- [x] I added a `CHANGELOG.md` entry; this source-only change has no generated package output
- [x] This diff will work correctly for `npx expo prebuild` and EAS Build
- [x] Conforms with the Documentation Writing Style Guide
