### PR TITLE
[router] Base useNavigationState on global state

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,4 @@
+## 2026-08-26 02:33 — Use global state for `useNavigationState`
+
+**Asked:** Implement ENG-26198 from the supplied preview on top of `main` and open a pull request.
+**Did / why:** Replaced the per-navigator subscription mirror with render-time context so the hook reads the same global navigation state as its navigator. Memoized declared-route filtering to keep the context value stable when the effective screen list is unchanged, and added coverage for memoized consumers.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,0 @@
-## 2026-08-26 02:33 — Use global state for `useNavigationState`
-
-**Asked:** Implement ENG-26198 from the supplied preview on top of `main` and open a pull request.
-**Did / why:** Replaced the per-navigator subscription mirror with render-time context so the hook reads the same global navigation state as its navigator. Memoized declared-route filtering to keep the context value stable when the effective screen list is unchanged, and added coverage for memoized consumers.

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 ### 💡 Others
 
+- Base `useNavigationState` on global state. ([#49381](https://github.com/expo/expo/pull/49381) by [@jakub-agent](https://github.com/jakub-agent))
 - Move Expo Router store values into React context. ([#49218](https://github.com/expo/expo/pull/49218) by [@Ubax](https://github.com/Ubax))
 - Remove the ignored `linking.enabled` option. ([#49103](https://github.com/expo/expo/pull/49103) by [@Ubax](https://github.com/Ubax))
 - Build the complete initial navigation state from a deep link. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
@@ -162,6 +162,69 @@ test('updates a memoized consumer', () => {
   expect(callback).toHaveBeenLastCalledWith(1);
 });
 
+test('keeps filtered state stable when the container rerenders', () => {
+  const TestRouter = (options: any) => {
+    const router = MockRouter(options);
+
+    return {
+      ...router,
+      getStateForAction(state: NavigationState, action: any) {
+        if (action.type === 'ROUTE_NAMES_CHANGED') {
+          return null;
+        }
+
+        return router.getStateForAction(state, action, options);
+      },
+    };
+  };
+
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(TestRouter, props);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  };
+
+  const callback = jest.fn();
+
+  const Test = React.memo(() => {
+    callback(useNavigationState((state) => state));
+
+    return null;
+  });
+
+  const initialState = {
+    stale: false as const,
+    routeKeySeq: 0,
+    key: 'root',
+    index: 0,
+    routeNames: ['first', 'hidden'],
+    routes: [
+      { key: 'first-0', name: 'first' },
+      { key: 'hidden-0', name: 'hidden' },
+    ],
+  };
+
+  const App = (_props: { value: string }) => (
+    <BaseNavigationContainer initialState={initialState}>
+      <TestNavigator>
+        <Screen name="first" component={Test} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  const root = render(<App value="first" />);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+
+  root.update(<App value="second" />);
+
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
 test('gets the correct value if selector changes', () => {
   const TestNavigator = (props: any): any => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationState.test.ios.tsx
@@ -125,6 +125,43 @@ test('gets the current navigation state with selector', () => {
   expect(callback.mock.calls[3]![0]).toBe(1);
 });
 
+test('updates a memoized consumer', () => {
+  const TestNavigator = (props: any): any => {
+    const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  };
+
+  const callback = jest.fn();
+
+  const Test = React.memo(() => {
+    callback(useNavigationState((state) => state.index));
+
+    return null;
+  });
+
+  const navigation = React.createRef<any>();
+
+  render(
+    <BaseNavigationContainer ref={navigation}>
+      <TestNavigator>
+        <Screen name="first" component={Test} />
+        <Screen name="second">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(callback).toHaveBeenLastCalledWith(0);
+
+  act(() => navigation.current.navigate('second'));
+
+  expect(callback).toHaveBeenLastCalledWith(1);
+});
+
 test('gets the correct value if selector changes', () => {
   const TestNavigator = (props: any): any => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(MockRouter, props);

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -48,7 +48,7 @@ import { FocusedRouteKeyContext } from './useIsFocused';
 import { useKeyedChildListeners } from './useKeyedChildListeners';
 import { useLazyValue } from './useLazyValue';
 import { useNavigationHelpers } from './useNavigationHelpers';
-import { NavigationStateListenerProvider } from './useNavigationState';
+import { NavigatorStateContext } from './useNavigationState';
 import {
   emitBeforeRemove,
   getPreventableRoutes,
@@ -327,6 +327,9 @@ export function useNavigationBuilder<
     );
   }
 
+  // Screen-list changes invalidate render consumers even though the reducer reads committed config.
+  const routeNamesKey = routeNames.join('\0');
+
   const { state: currentState } = use(NavigationStateContext);
 
   const { getStateForKey, resetNavigator, handleAction } = use(NavigationBuilderContext);
@@ -346,7 +349,10 @@ export function useNavigationBuilder<
   const committedState = (
     isForeignType ? resetNavigatorState(currentState, router.type) : currentState
   ) as State;
-  const state = router.getStateForDeclaredRoutes(committedState, routeNames);
+  const state = React.useMemo(
+    () => router.getStateForDeclaredRoutes(committedState, routeNames),
+    [committedState, routeNamesKey, router]
+  ) as State;
   // TODO(@ubax): Check whether this ref can be safely removed.
   const stateKeyRef = React.useRef(committedState.key);
 
@@ -359,8 +365,6 @@ export function useNavigationBuilder<
   React.useInsertionEffect(() => {
     registryConfigRef.current = { routeNames, routeGetIdList };
   });
-  // Screen-list changes invalidate render consumers even though the reducer reads committed config.
-  const routeNamesKey = routeNames.join('\0');
   const reduce = React.useCallback<RouterRegistryEntry['reduce']>(
     (registryState, action) =>
       // The registry stores states from different router types; this entry only receives its own state key.
@@ -587,7 +591,7 @@ export function useNavigationBuilder<
     return (
       <NavigationMetaContext.Provider value={undefined}>
         <NavigationHelpersContext.Provider value={navigation}>
-          <NavigationStateListenerProvider state={state}>
+          <NavigatorStateContext.Provider value={state}>
             <FocusedRouteKeyContext.Provider value={state.routes[state.index]?.key}>
               <PreventRemoveContext.Provider value={preventRemoveContextValue}>
                 <NavigatorTypeContext.Provider value={router.type}>
@@ -595,7 +599,7 @@ export function useNavigationBuilder<
                 </NavigatorTypeContext.Provider>
               </PreventRemoveContext.Provider>
             </FocusedRouteKeyContext.Provider>
-          </NavigationStateListenerProvider>
+          </NavigatorStateContext.Provider>
         </NavigationHelpersContext.Provider>
       </NavigationMetaContext.Provider>
     );

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -352,7 +352,7 @@ export function useNavigationBuilder<
   const state = React.useMemo(
     () => router.getStateForDeclaredRoutes(committedState, routeNames),
     [committedState, routeNamesKey, router]
-  ) as State;
+  );
   // TODO(@ubax): Check whether this ref can be safely removed.
   const stateKeyRef = React.useRef(committedState.key);
 

--- a/packages/expo-router/src/react-navigation/core/useNavigationState.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationState.tsx
@@ -1,8 +1,6 @@
 'use client';
 import React, { use } from 'react';
 
-import useLatestCallback from '../../utils/useLatestCallback';
-import { useSyncExternalStoreWithSelector } from '../../utils/useSyncExternalStoreWithSelector';
 import type { NavigationState, ParamListBase } from '../routers';
 
 type Selector<ParamList extends ParamListBase, T> = (state: NavigationState<ParamList>) => T;
@@ -15,67 +13,16 @@ type Selector<ParamList extends ParamListBase, T> = (state: NavigationState<Para
 export function useNavigationState<ParamList extends ParamListBase, T>(
   selector: Selector<ParamList, T>
 ): T {
-  const stateListener = use(NavigationStateListenerContext);
+  const state = use(NavigatorStateContext);
 
-  if (stateListener == null) {
+  if (state == null) {
     throw new Error("Couldn't get the navigation state. Is your component inside a navigator?");
   }
 
-  const value = useSyncExternalStoreWithSelector(
-    stateListener.subscribe,
-    // @ts-expect-error: this is unsafe, but needed to make the generic work
-    stateListener.getState,
-    stateListener.getState,
-    selector
-  );
-
-  return value;
+  // @ts-expect-error: this is unsafe, but needed to make the generic work
+  return selector(state);
 }
 
-export function NavigationStateListenerProvider({
-  state,
-  children,
-}: {
-  state: NavigationState<ParamListBase>;
-  children: React.ReactNode;
-}) {
-  const listeners = React.useRef<(() => void)[]>([]);
-  const stateRef = React.useRef(state);
-
-  const getState = useLatestCallback(() => stateRef.current);
-
-  const subscribe = useLatestCallback((callback: () => void) => {
-    listeners.current.push(callback);
-
-    return () => {
-      listeners.current = listeners.current.filter((cb) => cb !== callback);
-    };
-  });
-
-  React.useLayoutEffect(() => {
-    stateRef.current = state;
-    listeners.current.forEach((callback) => callback());
-  }, [state]);
-
-  const context = React.useMemo(
-    () => ({
-      getState,
-      subscribe,
-    }),
-    [getState, subscribe]
-  );
-
-  return (
-    <NavigationStateListenerContext.Provider value={context}>
-      {children}
-    </NavigationStateListenerContext.Provider>
-  );
-}
-
-const NavigationStateListenerContext = React.createContext<
-  | {
-      getState: () => NavigationState<ParamListBase>;
-      subscribe: (callback: () => void) => () => void;
-    }
-  | undefined
+export const NavigatorStateContext = React.createContext<
+  NavigationState<ParamListBase> | undefined
 >(undefined);

--- a/packages/expo-router/src/react-navigation/core/useNavigationState.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationState.tsx
@@ -19,6 +19,7 @@ export function useNavigationState<ParamList extends ParamListBase, T>(
     throw new Error("Couldn't get the navigation state. Is your component inside a navigator?");
   }
 
+  // TODO(@ubax): Restore selector equality bail-outs and stable result identity without a subscription.
   // @ts-expect-error: this is unsafe, but needed to make the generic work
   return selector(state);
 }


### PR DESCRIPTION
# Why

In order to remove `useSyncExternalStoreWithSelector` from `useNavigationState`.

# How

1. Add `NavigatorStateContext` and use it to pass current navigator slice down in the tree
2. Remove `NavigationStateListenerProvider` and `useSyncExternalStoreWithSelector` usage

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
