### PR TITLE
[docs] Defer the search bundle on every page

### DIFF
--- a/docs/ui/components/Search/Search.tsx
+++ b/docs/ui/components/Search/Search.tsx
@@ -5,7 +5,6 @@ import { lazy, ReactNode, Suspense, useEffect, useRef, useState } from 'react';
 import { usePageApiVersion } from '~/providers/page-api-version';
 import versions from '~/public/static/constants/versions.json';
 
-import { ExpoDashboardItem } from './ExpoDashboardItem';
 import { entries } from './expoEntries';
 
 const CommandMenu = lazy(() =>
@@ -57,6 +56,7 @@ export const Search = ({ mainSection }: SearchProps) => {
     const filteredEntries = entries.filter(entry =>
       entry.label.toLowerCase().includes(query.toLowerCase())
     );
+    const { ExpoDashboardItem } = await import('./ExpoDashboardItem');
     setExpoDashboardItems(
       filteredEntries.map(item => <ExpoDashboardItem item={item} query={query} key={item.url} />)
     );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

`Search.tsx` already lazy-loads the command menu. `CommandMenu` sits behind `React.lazy`, and the trigger comes from the package's separate lightweight `/trigger` entry. The intent was right and the code looked right but it wasn't working as expected.

`ExpoDashboardItem.tsx` imports `addHighlight` and `CommandItemBaseWithCopy` from the main `@expo/styleguide-search-ui` entry, and `Search.tsx` imported that component at the top level. One static import is enough for webpack to pull the whole package into the sync graph, so it all landed in `_app` anyway and the `lazy()` ended up resolving a module that was already loaded.

The `_app` chunk goes from 617,870 to 406,383 bytes (gzip -9), so about 207 KB off every page, and 16 packages leave the chunk entirely. Measured on `/versions/latest/sdk/calendar/` with local Lighthouse at median of 5: page weight 1363 KB to 1138 KB, Total Blocking Time 818 ms to 715 ms. The TBT ranges don't overlap (799-832 before, 700-729 after).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
