### PR TITLE
[docs] Update EAS dashboard entries

### DIFF
--- a/docs/ui/components/Search/expoEntries.ts
+++ b/docs/ui/components/Search/expoEntries.ts
@@ -3,16 +3,22 @@ import { BranchIcon } from '@expo/styleguide-icons/custom/BranchIcon';
 import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { CredentialIcon } from '@expo/styleguide-icons/custom/CredentialIcon';
 import { EasSubmitIcon } from '@expo/styleguide-icons/custom/EasSubmitIcon';
+import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { Smartphone01Icon } from '@expo/styleguide-icons/custom/Smartphone01Icon';
 import { Cloud01DuotoneIcon } from '@expo/styleguide-icons/duotone/Cloud01DuotoneIcon';
 import { Fingerprint03DuotoneIcon } from '@expo/styleguide-icons/duotone/Fingerprint03DuotoneIcon';
+import { ActivityHeartIcon } from '@expo/styleguide-icons/outline/ActivityHeartIcon';
+import { BarChart01Icon } from '@expo/styleguide-icons/outline/BarChart01Icon';
 import { BracketsXIcon } from '@expo/styleguide-icons/outline/BracketsXIcon';
+import { CpuChip01Icon } from '@expo/styleguide-icons/outline/CpuChip01Icon';
 import { Cube02Icon } from '@expo/styleguide-icons/outline/Cube02Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
+import { Database01Icon } from '@expo/styleguide-icons/outline/Database01Icon';
 import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { FileSearch02Icon } from '@expo/styleguide-icons/outline/FileSearch02Icon';
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon';
+import { Monitor01Icon } from '@expo/styleguide-icons/outline/Monitor01Icon';
 import { NotificationBoxIcon } from '@expo/styleguide-icons/outline/NotificationBoxIcon';
 import { Settings01Icon } from '@expo/styleguide-icons/outline/Settings01Icon';
 import type { ComponentType, HTMLAttributes } from 'react';
@@ -60,6 +66,16 @@ export const entries: ExpoItemType[] = [
     Icon: DataIcon,
   },
   {
+    label: 'Project usage',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/usage',
+    Icon: BarChart01Icon,
+  },
+  {
+    label: 'Project observe',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/observe',
+    Icon: ActivityHeartIcon,
+  },
+  {
     label: 'Project workflows',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/workflows',
     Icon: Dataflow03Icon,
@@ -68,6 +84,11 @@ export const entries: ExpoItemType[] = [
     label: 'Project development builds',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/development-builds',
     Icon: Smartphone01Icon,
+  },
+  {
+    label: 'Project simulator sessions',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/simulator-sessions',
+    Icon: Monitor01Icon,
   },
   {
     label: 'Project builds',
@@ -95,6 +116,11 @@ export const entries: ExpoItemType[] = [
     Icon: LayersTwo02Icon,
   },
   {
+    label: 'Project update runtimes',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/runtimes',
+    Icon: CpuChip01Icon,
+  },
+  {
     label: 'Project hosting',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/hosting',
     Icon: Cloud01DuotoneIcon,
@@ -103,6 +129,11 @@ export const entries: ExpoItemType[] = [
     label: 'Project push notifications',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/push-notifications',
     Icon: NotificationBoxIcon,
+  },
+  {
+    label: 'Project caches',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/caches',
+    Icon: Database01Icon,
   },
   {
     label: 'Project fingerprints',
@@ -123,5 +154,10 @@ export const entries: ExpoItemType[] = [
     label: 'Project environment variables',
     url: 'https://expo.dev/accounts/[account]/projects/[project]/environment-variables',
     Icon: BracketsXIcon,
+  },
+  {
+    label: 'Project GitHub',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/github',
+    Icon: GithubIcon,
   },
 ];

--- a/docs/ui/components/Search/expoEntries.ts
+++ b/docs/ui/components/Search/expoEntries.ts
@@ -106,7 +106,7 @@ export const entries: ExpoItemType[] = [
   },
   {
     label: 'Project fingerprints',
-    url: 'https://expo.dev/accounts/[account]/projects/[project]/distribution',
+    url: 'https://expo.dev/accounts/[account]/projects/[project]/fingerprints',
     Icon: Fingerprint03DuotoneIcon,
   },
   {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add missing EAS dashboard entries (for example, Observe, Runtimes, etc.) in the Search UI box and fix the broken one.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2004" height="2000" alt="CleanShot 2026-08-26 at 17 10 51@2x" src="https://github.com/user-attachments/assets/8c74b812-ce01-4e55-8095-31aefa8290d1" />

<img width="1726" height="1860" alt="CleanShot 2026-08-26 at 17 10 59@2x" src="https://github.com/user-attachments/assets/7c174990-5dac-4762-be7f-a814f0bfdffa" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
