### PR TITLE
[task-manager] Warn when defining task not from the global scope

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Warn when defining tasks after the JavaScript bundle has finished loading.
+- Warn when defining tasks after the JavaScript bundle has finished loading. ([#49398](https://github.com/expo/expo/pull/49398) by [@HubertBer](https://github.com/HubertBer))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Warn when defining tasks after the JavaScript bundle has finished loading.
+
 ### 🐛 Bug fixes
 
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-task-manager/src/TaskManager.ts
+++ b/packages/expo-task-manager/src/TaskManager.ts
@@ -111,6 +111,17 @@ function _validate(taskName: unknown) {
   }
 }
 
+// The hasFinishedInitPhase variable tracks whether the initial, synchronous evaluation of the JavaScript bundle has finished:
+// Its value is:
+// - false - when accessing it from the global scope in synchronous functions
+// - true - when accessing it from React components, effects, event handlers, timers.
+// It may be either value, when:
+// - accessing it in an async function called from the global scope.
+let hasFinishedInitPhase = false;
+Promise.resolve().then(() => {
+  hasFinishedInitPhase = true;
+});
+
 // @needsAudit
 /**
  * Defines task function. It must be called in the global scope of your JavaScript bundle,
@@ -132,6 +143,13 @@ export function defineTask<T = unknown>(
   if (!taskExecutor || typeof taskExecutor !== 'function') {
     console.warn(`TaskManager.defineTask: 'task' argument must be a function.`);
     return;
+  }
+  if (!tasks.has(taskName) && hasFinishedInitPhase) {
+    console.warn(
+      `TaskManager.defineTask: the task "${taskName}" was defined after the JavaScript bundle finished loading.
+The call was most likely inside a React component. Components are not mounted when the app is launched in the background. In that case this task will not be defined.
+Call \`TaskManager.defineTask\` synchronously in the global scope of a module imported at startup.`
+    );
   }
   tasks.set(taskName, taskExecutor);
 }


### PR DESCRIPTION
# Why
`defineTask` needs to be called from a global scope, but there is no warning/error when it is called otherwise e.g. from a React component.

# How
Add a warning when trying to define a new task after the JavaScript bundle has been loaded.

# Test Plan
Tested multiple scenarios in bare-expo, most importantly:

1. Defining in the `Index` warns
2. Defining in the global scope doesn't:
<img width="870" height="604" alt="image" src="https://github.com/user-attachments/assets/c48cc0d2-b889-44b7-a7e2-5944a3df762e" />

3. Redefining task doesn't warn
4. Defining task in a lazily loaded module warns

<img width="856" height="285" alt="image" src="https://github.com/user-attachments/assets/0b9de7dd-35ea-4119-89b6-1cc8e9a58bbc" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
