### PR TITLE
[cli][playwright] Change the server loader assertion

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/server-loader.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
-import { pageCollectErrors, trackLoaderNetworkStatuses } from '../page';
+import { pageCollectErrors, trackLoaderNetworkStatuses, waitForLoaderData } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -51,7 +51,7 @@ for (const outputMode of outputModes) {
       expect(loaderRequests).toHaveLength(0);
 
       await page.click('a[href="/posts/static-post-1"]');
-      await page.waitForSelector('[data-testid="loader-result"]');
+      await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
       expect(loaderRequests).toContainEqual(
         expect.stringContaining('/_expo/loaders/posts/static-post-1')
       );
@@ -85,17 +85,19 @@ for (const outputMode of outputModes) {
       await page.goto(expoStart.url.href);
 
       await page.click('a[href="/posts/static-post-1"]');
-      await page.waitForSelector('[data-testid="loader-result"]');
+      await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
       await page.click('a[href="/"]');
+      await waitForLoaderData(page, { data: 'root-index' });
 
       await page.click('a[href="/posts/static-post-2"]');
-      await page.waitForSelector('[data-testid="loader-result"]');
+      await waitForLoaderData(page, { params: { postId: 'static-post-2' } });
 
       await page.click('a[href="/"]');
+      await waitForLoaderData(page, { data: 'root-index' });
 
       await page.click('a[href="/posts/static-post-1"]');
-      await page.waitForSelector('[data-testid="loader-result"]');
+      await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
       expect(loaderRequests).toEqual([
         expect.stringContaining('/_expo/loaders/posts/static-post-1'),
@@ -183,7 +185,7 @@ for (const outputMode of outputModes) {
 
       // Navigate to index route (has loader)
       await page.click('a[href="/"]');
-      await page.waitForSelector('[data-testid="loader-result"]');
+      await waitForLoaderData(page, { data: 'root-index' });
 
       const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
       expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'root-index' });
@@ -208,6 +210,7 @@ for (const outputMode of outputModes) {
 
       // Navigate to posts route (has loader)
       await page.click('a[href="/posts/static-post-1"]');
+      await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
       const postsLoaderDataContent = await page
         .locator('[data-testid="loader-result"]')
         .textContent();

--- a/packages/@expo/cli/e2e/playwright/page.ts
+++ b/packages/@expo/cli/e2e/playwright/page.ts
@@ -1,4 +1,10 @@
-import type { ConsoleMessage, Page, Request } from '@playwright/test';
+import { expect, type ConsoleMessage, type Page, type Request } from '@playwright/test';
+
+export async function waitForLoaderData(page: Page, data: unknown) {
+  await expect(page.locator('[data-testid="loader-result"]')).toHaveText(
+    JSON.stringify(data, null, 2)
+  );
+}
 
 /** Collect all console and thrown errors of the page */
 export function pageCollectErrors(page: Page) {

--- a/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-loader.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoServe, executeExpoAsync } from '../../utils/expo';
-import { pageCollectErrors, trackLoaderNetworkStatuses } from '../page';
+import { pageCollectErrors, trackLoaderNetworkStatuses, waitForLoaderData } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -56,7 +56,7 @@ test.describe('server loaders in production', () => {
     expect(loaderRequests).toHaveLength(0);
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
     expect(loaderRequests).toContainEqual(expect.stringContaining('/_expo/loaders/posts'));
 
     const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
@@ -74,17 +74,19 @@ test.describe('server loaders in production', () => {
     await page.goto(expoServe.url.href);
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
     await page.click('a[href="/"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     await page.click('a[href="/posts/static-post-2"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-2' } });
 
     await page.click('a[href="/"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
     expect(loaderRequests).toEqual([
       expect.stringContaining('/_expo/loaders/posts/static-post-1'),
@@ -168,11 +170,11 @@ test.describe('server loaders in production', () => {
     url.pathname = '/no-loader';
 
     // Start on no loader route
-    await page.goto(url.toString());
+    await page.goto(url.toString(), { waitUntil: 'networkidle' });
 
     // Navigate to index route (has loader)
     await page.click('a[href="/"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
     expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'root-index' });
@@ -197,6 +199,7 @@ test.describe('server loaders in production', () => {
 
     // Navigate to posts route (has loader)
     await page.click('a[href="/posts/static-post-1"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
     const postsLoaderDataContent = await page
       .locator('[data-testid="loader-result"]')
       .textContent();

--- a/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/static-loader.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects';
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoServe, executeExpoAsync } from '../../utils/expo';
-import { pageCollectErrors } from '../page';
+import { pageCollectErrors, waitForLoaderData } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -51,7 +51,7 @@ test.describe('static loaders in production', () => {
     expect(loaderRequests).toHaveLength(0);
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
     expect(loaderRequests).toContainEqual(
       expect.stringContaining('/_expo/loaders/posts/static-post-1')
     );
@@ -71,17 +71,19 @@ test.describe('static loaders in production', () => {
     await page.goto(expoServe.url.href);
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
     await page.click('a[href="/"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     await page.click('a[href="/posts/static-post-2"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-2' } });
 
     await page.click('a[href="/"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     await page.click('a[href="/posts/static-post-1"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
 
     expect(loaderRequests).toEqual([
       expect.stringContaining('/_expo/loaders/posts/static-post-1'),
@@ -128,11 +130,11 @@ test.describe('static loaders in production', () => {
     url.pathname = '/no-loader';
 
     // Start on no loader route
-    await page.goto(url.toString());
+    await page.goto(url.toString(), { waitUntil: 'networkidle' });
 
     // Navigate to index route (has loader)
     await page.click('a[href="/"]');
-    await page.waitForSelector('[data-testid="loader-result"]');
+    await waitForLoaderData(page, { data: 'root-index' });
 
     const loaderDataContent = await page.locator('[data-testid="loader-result"]').textContent();
     expect(JSON.parse(loaderDataContent!)).toEqual({ data: 'root-index' });
@@ -157,6 +159,7 @@ test.describe('static loaders in production', () => {
 
     // Navigate to posts route (has loader)
     await page.click('a[href="/posts/static-post-1"]');
+    await waitForLoaderData(page, { params: { postId: 'static-post-1' } });
     const postsLoaderDataContent = await page
       .locator('[data-testid="loader-result"]')
       .textContent();


### PR DESCRIPTION
# Why

This tests started to fail when I introduced navigation queue using context. Codex claims, the failures were due to old loader data still being shown on the screen.

https://github.com/expo/expo/actions/runs/32878613868/job/97902823552

# How

1. Assert not only loader-data presence, but also its content

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
