### PR TITLE
docs: recommend maintained React Native passkey library

### DIFF
--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -282,7 +282,7 @@ An authentication provider can combine the system biometric prompt with a device
 
 Passkeys offer a seamless and secure experience, but they require a user to already be authenticated before registering one. They also require extra configuration if you're not using a provider that handles them for you.
 
-- React Native passkey support: [`react-native-passkeys`](https://github.com/peterferguson/react-native-passkeys)
+- React Native passkey support: [`react-native-passkey`](https://github.com/f-23/react-native-passkey)
 - Native passkey support with Clerk: [Clerk Passkeys for Expo](https://clerk.com/docs/references/expo/passkeys)
 
 </Collapsible>


### PR DESCRIPTION
# Why

The currently recommended `react-native-passkeys` package pins an outdated alpha version of AndroidX Credential Manager, which may require consumers to maintain local patches.

This PR updates the recommendation to [`react-native-passkey`](https://github.com/f-23/react-native-passkey), which uses a current stable Credential Manager version and provides actively maintained Android and iOS passkey support.


# How

 Updated the React Native passkey recommendation from `react-native-passkeys` to [`react-native-passkey`](https://github.com/f-23/react-native-passkey).

The replacement uses AndroidX Credential Manager 1.6.0, supports React Native autolinking, and provides normalized native error handling. The previously linked package currently pins an outdated alpha Credential Manager dependency that may require consumers to maintain a local patch.

# Test Plan

This is a documentation-only change.

Verified that:
- The new repository link resolves correctly.
- `react-native-passkey@3.6.1` installs successfully in an Expo SDK 57 project.
- Expo prebuild autolinks the native module.
- The generated Android project compiles successfully with React Native 0.86 and the New Architecture enabled.

Commands used:
```sh
bunx expo install react-native-passkey@latest
bunx expo prebuild --platform android --no-install
cd android
./gradlew :app:compileDebugKotlin
```

# Checklist
- [ ] I added a changelog.md entry and rebuilt the package sources according to this short guide (https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for npx expo prebuild & EAS Build (eg: updated a module plugin).
- [x] Conforms with the Documentation Writing Style Guide (https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)  
