### PR TITLE
[docs] Update docs paths for AI agents with expo to use official plugins

### DIFF
--- a/docs/pages/agents/claude.mdx
+++ b/docs/pages/agents/claude.mdx
@@ -52,7 +52,7 @@ Install the official Expo plugin so Claude Code knows Expo conventions and can r
 
 Then run `/mcp` inside your Claude Code session to sign in to your Expo account.
 
-The guides below cover the skills the plugin provides and the rest of what the MCP Server can do:
+The guides below cover the available skills and everything else the MCP Server can do:
 
 <BoxLink
   title="Expo Skills"

--- a/docs/pages/agents/claude.mdx
+++ b/docs/pages/agents/claude.mdx
@@ -46,7 +46,7 @@ Create a project with the following command or ensure your existing project has 
 
 ### Install the Expo plugin
 
-Install the official Expo plugin so Claude Code knows Expo conventions and can reach your EAS. One command installs Expo Skills and registers the Expo MCP Server:
+Install the official Expo plugin so Claude Code knows Expo conventions and can work with your EAS projects. One command installs Expo Skills and registers the Expo MCP Server:
 
 <Terminal cmd={['$ claude plugin install expo@claude-plugins-official']} />
 

--- a/docs/pages/agents/claude.mdx
+++ b/docs/pages/agents/claude.mdx
@@ -44,13 +44,19 @@ Create a project with the following command or ensure your existing project has 
 
 <Step label="3">
 
-### Set up Expo Skills and the Expo MCP Server
+### Install the Expo plugin
 
-Install Expo Skills and connect the Expo MCP Server so Claude Code knows Expo conventions and can reach your EAS.
+Install the official Expo plugin so Claude Code knows Expo conventions and can reach your EAS. One command installs Expo Skills and registers the Expo MCP Server:
+
+<Terminal cmd={['$ claude plugin install expo@claude-plugins-official']} />
+
+Then run `/mcp` inside your Claude Code session to sign in to your Expo account.
+
+The guides below cover the skills the plugin provides and the rest of what the MCP Server can do:
 
 <BoxLink
   title="Expo Skills"
-  description="Install the plugin that teaches agents known-good Expo patterns, and browse the full list of available skills."
+  description="Browse the full list of skills the plugin provides, and see install options for other agents."
   href="/skills/#install-expo-skills"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/agents/codex.mdx
+++ b/docs/pages/agents/codex.mdx
@@ -43,13 +43,21 @@ Create a project with the following command or ensure your existing project has 
 
 <Step label="3">
 
-### Set up Expo Skills and the Expo MCP Server
+### Install the Expo plugin
 
-Install Expo Skills and connect the Expo MCP Server so Codex knows Expo conventions and can reach your EAS.
+Install the official Expo plugin so Codex knows Expo conventions and can reach your EAS. One command installs Expo Skills and registers the Expo MCP Server:
+
+<Terminal cmd={['$ codex plugin add expo@openai-curated']} />
+
+Then sign in to your Expo account:
+
+<Terminal cmd={['$ codex mcp login expo']} />
+
+The guides below cover the skills the plugin provides and the rest of what the MCP Server can do:
 
 <BoxLink
   title="Expo Skills"
-  description="Install the plugin that teaches agents known-good Expo patterns, and browse the full list of available skills."
+  description="Browse the full list of skills the plugin provides, and see install options for other agents."
   href="/skills/#install-expo-skills"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/agents/codex.mdx
+++ b/docs/pages/agents/codex.mdx
@@ -45,7 +45,7 @@ Create a project with the following command or ensure your existing project has 
 
 ### Install the Expo plugin
 
-Install the official Expo plugin so Codex knows Expo conventions and can reach your EAS. One command installs Expo Skills and registers the Expo MCP Server:
+Install the official Expo plugin so Codex knows Expo conventions and can work with your EAS projects. One command installs Expo Skills and registers the Expo MCP Server:
 
 <Terminal cmd={['$ codex plugin add expo@openai-curated']} />
 

--- a/docs/pages/agents/codex.mdx
+++ b/docs/pages/agents/codex.mdx
@@ -53,7 +53,7 @@ Then sign in to your Expo account:
 
 <Terminal cmd={['$ codex mcp login expo']} />
 
-The guides below cover the skills the plugin provides and the rest of what the MCP Server can do:
+The guides below cover the available skills and everything else the MCP Server can do:
 
 <BoxLink
   title="Expo Skills"

--- a/docs/pages/agents/cursor.mdx
+++ b/docs/pages/agents/cursor.mdx
@@ -43,7 +43,7 @@ Create a project with the following command or ensure your existing project has 
 
 ### Set up Expo Skills and the Expo MCP Server
 
-Install Expo Skills and connect the Expo MCP Server so Cursor knows Expo conventions and can reach your EAS.
+Install Expo Skills and connect the Expo MCP Server so Cursor knows Expo conventions and can work with your EAS projects.
 
 <BoxLink
   title="Expo Skills"

--- a/docs/pages/agents/index.mdx
+++ b/docs/pages/agents/index.mdx
@@ -20,7 +20,7 @@ Claude Code, Codex, Cursor, and other AI coding agents can help you build, upgra
 
 ## Quick start
 
-Claude Code and Codex have an official Expo plugin. It is the most convenient way to configure an agent for Expo, because one command installs [Expo Skills](/skills/) and registers the [Expo MCP Server](/mcp/).
+Claude Code and Codex have an official Expo plugin. One command installs [Expo Skills](/skills/) and registers the [Expo Model Context Protocol (MCP) Server](/mcp/).
 
 <Tabs>
 
@@ -44,7 +44,7 @@ Then sign in to your Expo account:
 
 </Tabs>
 
-Cursor and other agents do not have an official Expo plugin. To set one up, install [Expo Skills](/skills/) and the [Expo MCP Server](/mcp/) separately.
+Cursor and other agents do not have an official Expo plugin. To configure them, install [Expo Skills](/skills/) and the [Expo MCP Server](/mcp/) separately.
 
 ## How Expo supports AI agents
 

--- a/docs/pages/agents/index.mdx
+++ b/docs/pages/agents/index.mdx
@@ -14,20 +14,49 @@ import {
 } from '~/ui/components/CustomIcons/AIProviderIcons';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 Claude Code, Codex, Cursor, and other AI coding agents can help you build, upgrade, debug, and deploy your Expo and React Native projects. When you use [`create-expo-app`](/more/create-expo/) to create a new project, that new project is already set up with the configuration files required by an AI agent. This setup is also committed to your project, so everyone on your team starts from the same SDK version and project instructions, and their agents read the same project context.
+
+## Quick start
+
+Claude Code and Codex have an official Expo plugin. It is the most convenient way to configure an agent for Expo, because one command installs [Expo Skills](/skills/) and registers the [Expo MCP Server](/mcp/).
+
+<Tabs>
+
+<Tab label="Claude Code">
+
+<Terminal cmd={['$ claude plugin install expo@claude-plugins-official']} />
+
+Then run `/mcp` inside your Claude Code session to sign in to your Expo account.
+
+</Tab>
+
+<Tab label="Codex">
+
+<Terminal cmd={['$ codex plugin add expo@openai-curated']} />
+
+Then sign in to your Expo account:
+
+<Terminal cmd={['$ codex mcp login expo']} />
+
+</Tab>
+
+</Tabs>
+
+Cursor and other agents do not have an official Expo plugin. To set one up, install [Expo Skills](/skills/) and the [Expo MCP Server](/mcp/) separately.
 
 ## How Expo supports AI agents
 
 Three pieces work together to give an AI agent consistent, Expo-specific context:
 
-- **Expo Skills:** A plugin that adds Expo-specific instructions and slash commands to the agent. The agent applies known-good Expo patterns (SDK upgrades, EAS Workflows, native UI with Jetpack Compose and SwiftUI, API routes) instead of guessing from training data. Skills install once per machine.
-- **Expo MCP Server:** A remote Model Context Protocol (MCP) server that gives the agent live access to the latest Expo documentation, EAS Build history, EAS Update channels, and TestFlight metadata. The agent can install SDK-matching packages, read build logs, and take simulator screenshots through it.
+- **Expo Skills:** The `expo` plugin adds Expo-specific instructions and slash commands to the agent. The agent applies known-good Expo patterns (SDK upgrades, EAS Workflows, native UI with Jetpack Compose and SwiftUI, API routes) instead of guessing from training data. Skills install once per machine.
+- **Expo MCP Server:** A remote Model Context Protocol (MCP) server that gives the agent live access to the latest Expo documentation, EAS Build history, EAS Update channels, and TestFlight metadata. The agent can install SDK-matching packages, read build logs, and take simulator screenshots through it. For Claude Code and Codex, the `expo` plugin registers this server, so you do not add it separately.
 - **Project context files:** `create-expo-app` writes **AGENTS.md**, **CLAUDE.md**, and **.claude/settings.json** at the project root. These are the first thing the agent reads when you open the project. They point the agent to the documentation for the Expo SDK version your project targets.
 
 ## Set up Expo Skills and Expo MCP Server
 
-Expo Skills and the Expo MCP Server work with every supported agent. Set up each one by following the guides below:
+Expo Skills and the Expo MCP Server work with every supported agent. If you installed the `expo` plugin above, both are already set up. The guides below cover every install option, including agents that have no plugin:
 
 <BoxLink
   title="Expo Skills"
@@ -123,6 +152,8 @@ Create **.claude/settings.json** to enable the official Expo plugin from the Cla
   }
 }
 ```
+
+This file enables the plugin for everyone who opens the project. Each developer still installs it once on their own machine with `claude plugin install expo@claude-plugins-official`.
 
 </Step>
 

--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -115,7 +115,7 @@ On a Claude Team or Enterprise plan, the Expo connector can be enabled for the e
 
 **Claude Code**
 
-If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Run `/mcp` in your session to authenticate and skip the command below.
+If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Skip the command below and run `/mcp` in your session to authenticate.
 
 <Terminal cmd={['$ claude mcp add --transport http expo https://mcp.expo.dev/mcp']} />
 
@@ -155,7 +155,7 @@ Click the following link to install the MCP server for Cursor:
 
 <Tab label="Codex">
 
-If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Run `codex mcp login expo` to authenticate and skip the command below.
+If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Skip the command below and run `codex mcp login expo` to authenticate.
 
 <Terminal cmd={['$ codex mcp add expo --url https://mcp.expo.dev/mcp']} />
 

--- a/docs/pages/mcp.mdx
+++ b/docs/pages/mcp.mdx
@@ -115,6 +115,8 @@ On a Claude Team or Enterprise plan, the Expo connector can be enabled for the e
 
 **Claude Code**
 
+If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Run `/mcp` in your session to authenticate and skip the command below.
+
 <Terminal cmd={['$ claude mcp add --transport http expo https://mcp.expo.dev/mcp']} />
 
 After installation, run `/mcp` in your Claude Code session to authenticate.
@@ -152,6 +154,8 @@ Click the following link to install the MCP server for Cursor:
 </Tab>
 
 <Tab label="Codex">
+
+If you installed the [`expo` plugin](/skills/#install-expo-skills), it already registers this server. Run `codex mcp login expo` to authenticate and skip the command below.
 
 <Terminal cmd={['$ codex mcp add expo --url https://mcp.expo.dev/mcp']} />
 

--- a/docs/pages/skills.mdx
+++ b/docs/pages/skills.mdx
@@ -32,7 +32,9 @@ Expo Skills are structured instruction files that teach AI agents how to build, 
 
 Run the following command to install the official Expo plugin from the `claude-plugins-official` marketplace:
 
-<Terminal cmd={['$ /plugin install expo@claude-plugins-official']} />
+<Terminal cmd={['$ claude plugin install expo@claude-plugins-official']} />
+
+You can also run `/plugin install expo@claude-plugins-official` inside a Claude Code session.
 
 </Tab>
 
@@ -91,6 +93,8 @@ Use the [skills CLI](https://skills.sh/docs/cli) to add Expo Skills to any compa
 </Tab>
 
 </Tabs>
+
+> **info** For Claude Code and Codex, the plugin also registers the [Expo MCP Server](/mcp/), so you do not add it separately. The skills CLI installs skills only.
 
 ## Available Expo Skills
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26194

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update docs paths for AI agents with expo to use official plugins.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2428" height="1358" alt="CleanShot 2026-08-26 at 21 46 45@2x" src="https://github.com/user-attachments/assets/2b5cca8d-5ddd-4493-85aa-aef2aaff5420" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
