### PR TITLE
[docs] document observe memory warning

### DIFF
--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -33,7 +33,7 @@ The dashboard groups data into five pages:
 
 - **App startup**: startup performance metrics (cold launch, warm launch, bundle load time, time to first render, time to interactive). See the [Metrics reference](/eas/observe/reference/metrics/) for full descriptions.
 - **EAS Update**: download time for OTA updates and a per-update table. See [EAS Update download performance](/eas/observe/eas-update/) for details.
-- **Events** (requires SDK 56 and later): user-defined events logged with [`Observe.logEvent`](/eas/observe/events/) and events emitted by the SDK and its integrations, such as `expo.memory.warning` and `expo-image.oversized`, with counts and links to drill into each event.
+- **Events** (requires SDK 56 and later): user-defined events logged with [`Observe.logEvent`](/eas/observe/events/) and events emitted by the SDK and its integrations (such as `expo.memory.warning` and `expo-image.oversized`), with counts and links to drill into each event.
 - **Navigation** (requires SDK 56 and later): per-route navigation timings with cold vs warm time to first render and time to interactive. Requires [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/).
 - **Errors** (in preview, requires SDK 57 and later): JavaScript errors recorded by the app, with symbolicated stack traces. See [Error reporting](/eas/observe/errors/) for details.
 

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -33,7 +33,7 @@ The dashboard groups data into five pages:
 
 - **App startup**: startup performance metrics (cold launch, warm launch, bundle load time, time to first render, time to interactive). See the [Metrics reference](/eas/observe/reference/metrics/) for full descriptions.
 - **EAS Update**: download time for OTA updates and a per-update table. See [EAS Update download performance](/eas/observe/eas-update/) for details.
-- **Events** (requires SDK 56 and later): user-defined events logged with [`Observe.logEvent`](/eas/observe/events/), with counts and links to drill into each event.
+- **Events** (requires SDK 56 and later): user-defined events logged with [`Observe.logEvent`](/eas/observe/events/) and events emitted by the SDK and its integrations, such as `expo.memory.warning` and `expo-image.oversized`, with counts and links to drill into each event.
 - **Navigation** (requires SDK 56 and later): per-route navigation timings with cold vs warm time to first render and time to interactive. Requires [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigation](/eas/observe/integrations/react-navigation/).
 - **Errors** (in preview, requires SDK 57 and later): JavaScript errors recorded by the app, with symbolicated stack traces. See [Error reporting](/eas/observe/errors/) for details.
 

--- a/docs/pages/eas/observe/eas-cli.mdx
+++ b/docs/pages/eas/observe/eas-cli.mdx
@@ -188,7 +188,7 @@ Command flags:
 
 ## `eas observe:events`
 
-Shows [user-defined events](/eas/observe/events/) logged with `Observe.logEvent`. With no arguments, it lists event names and their counts.
+Shows [user-defined events](/eas/observe/events/) logged with `Observe.logEvent`, as well as [events emitted by the SDK and its integrations](/eas/observe/events/#events-emitted-by-the-sdk-and-integrations), such as `expo.memory.warning` and `expo-image.oversized`. With no arguments, it lists event names and their counts.
 
 <Terminal
   cmd={[

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -91,6 +91,13 @@ Observe.logEvent('onboarding.completed', {
   darkSrc="/static/images/expo-observe/observe-log-event-display-name-dark.webp"
 />
 
+## Events emitted by the SDK and integrations
+
+Alongside your own events, you may see events that EAS Observe and its integrations emit:
+
+- Event names that start with `expo.` are reserved for events emitted by EAS Observe itself. For example, `expo.memory.warning` is recorded when iOS delivers a low-memory warning to the app. See [Memory warnings](/eas/observe/reference/metrics/#memory-warnings). `logEvent` drops an event that uses the reserved prefix, and drops attribute keys in the `expo.` namespace, logging a warning in development.
+- Enabled integrations log their own events. For example, the [`expo-image` integration](/eas/observe/integrations/expo-image/) logs `expo-image.oversized` when an image is decoded at a much larger size than the screen can display.
+
 ## View events
 
 In the dashboard: open your project and navigate to [**Observe > Events**](https://expo.dev/accounts/[account]/projects/[project]/observe/events). The default view lists distinct event names with their counts in the selected time range. Click an event name to see individual events with their timestamps, attributes, and the session they belong to.

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -296,6 +296,30 @@ When the [Expo Router](/eas/observe/integrations/expo-router/) or [React Navigat
 
 For setup instructions and the full event params for each metric, see the integration page for [Expo Router](/eas/observe/integrations/expo-router/#metrics) or [React Navigation](/eas/observe/integrations/react-navigation/#metrics).
 
+## Memory warnings
+
+> **info** Memory warnings require SDK 57 and later, and are recorded on iOS only.
+
+When iOS delivers a low-memory warning to the app, EAS Observe records an `expo.memory.warning` event with `warn` severity. The event marks the moment the system came under memory pressure. It carries a memory usage snapshot taken as the warning is received, before other parts of the app react to it and free memory.
+
+A memory warning means the OS is running low on memory and may terminate the app to reclaim it. A session that ends shortly after this event is likely an out-of-memory termination, which is not reported as a crash.
+
+This event is recorded automatically. No instrumentation is needed. It appears in the session timeline and in [`eas observe:events`](/eas/observe/eas-cli/#eas-observeevents), alongside your user-defined events.
+
+### Event params
+
+- **`expo.memory.allocated`** (bytes): The memory footprint charged to the app process. This is the value the system compares against the app's memory limit, so it is the number to watch.
+- **`expo.memory.physical`** (bytes): Resident memory, that is, the app's pages currently held in physical RAM.
+- **`expo.memory.available`** (bytes): The memory the app can still allocate before it reaches its limit. Omitted on the iOS Simulator, which enforces no limit.
+- **`expo.memory.warningsCount`** (count): The number of warnings recorded in the session so far, including this one. A count that climbs within a single session points to a leak or a cache that never releases memory.
+
+**How to improve:**
+
+- Downscale large images to the size they are displayed at before decoding them. Full-resolution assets held in memory are a common cause of memory pressure.
+- Release caches and other non-visible resources when the app moves to the background.
+- Avoid holding entire network responses or file contents in memory. Stream or paginate them instead.
+- Check for retain cycles and event listeners that are never removed.
+
 ## Data handling
 
 ### Offline collection


### PR DESCRIPTION
# Why

Resolves ENG-26210

We [added](https://github.com/expo/expo/pull/47108) memory warning logs for iOS, which is published in SDK 57, but not documented.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Document the memory warning event.

Additionally, clarify that events can be sent by `logEvent`, the SDK and integrations.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Review the new copy for correctness and style.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
