### PR TITLE
[location][iOS] Exclude CoreMotion code from build if motion permission is disabled in config plugin

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Exclude the CoreMotion features from the build when `motionUsagePermission: false` is set in `app.json`.
 - [iOS] Add `scope` and `accuracy` under `ios` to the responses from `getBackgroundPermissionsAsync` and `requestBackgroundPermissionsAsync`, matching the `LocationPermissionResponse` type. ([#48926](https://github.com/expo/expo/pull/48926) by [@vonovak](https://github.com/vonovak))
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))

--- a/packages/expo-location/ios/ExpoLocation.podspec
+++ b/packages/expo-location/ios/ExpoLocation.podspec
@@ -1,6 +1,7 @@
 require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoLocation'
@@ -19,9 +20,13 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   # Swift/Objective-C compatibility
-  s.pod_target_xcconfig = {
+  pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
   }
+  if podfile_properties['expo.location.motionActivityEnabled'] == 'false'
+    pod_target_xcconfig['OTHER_SWIFT_FLAGS'] = '$(inherited) -DEXPO_LOCATION_DISABLE_MOTION'
+  end
+  s.pod_target_xcconfig = pod_target_xcconfig
 
   s.source_files = "**/*.{h,m,swift}"
 end

--- a/packages/expo-location/ios/LocationExceptions.swift
+++ b/packages/expo-location/ios/LocationExceptions.swift
@@ -77,6 +77,13 @@ extension Exceptions {
     }
   }
 
+  internal final class MotionActivityDisabled: Exception {
+    override var reason: String {
+      "Motion activity was disabled by setting 'motionUsagePermission' to false in the config plugin. " +
+      "Remove the option and run 'npx expo prebuild' again to enable it"
+    }
+  }
+
   internal final class MotionActivityUnauthorized: Exception {
     override var reason: String {
       "Motion activity access has been denied. Add NSMotionUsageDescription to Info.plist, " +

--- a/packages/expo-location/ios/LocationModule.swift
+++ b/packages/expo-location/ios/LocationModule.swift
@@ -1,7 +1,9 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 import CoreLocation
+#if !EXPO_LOCATION_DISABLE_MOTION
 import CoreMotion
+#endif
 import ExpoModulesCore
 
 private let EVENT_LOCATION_CHANGED = "Expo.locationChanged"
@@ -11,7 +13,9 @@ private let EVENT_MOTION_ACTIVITY_CHANGED = "Expo.motionActivityChanged"
 
 public final class LocationModule: Module {
   private lazy var locationStreamers = [Int: BaseStreamer]()
+  #if !EXPO_LOCATION_DISABLE_MOTION
   private lazy var motionActivityStreamers = [Int: MotionActivityStreamer]()
+  #endif
 
   private var taskManager: EXTaskManagerInterface {
     get throws {
@@ -29,15 +33,15 @@ public final class LocationModule: Module {
 
     OnCreate {
       let permissionsManager = self.appContext?.permissions
-      EXPermissionsMethodsDelegate.register(
-        [
-          EXLocationPermissionRequester(),
-          EXForegroundPermissionRequester(),
-          EXBackgroundLocationPermissionRequester(),
-          MotionActivityPermissionRequester()
-        ],
-        withPermissionsManager: permissionsManager
-      )
+      var requesters: [EXPermissionsRequester] = [
+        EXLocationPermissionRequester(),
+        EXForegroundPermissionRequester(),
+        EXBackgroundLocationPermissionRequester()
+      ]
+      #if !EXPO_LOCATION_DISABLE_MOTION
+      requesters.append(MotionActivityPermissionRequester())
+      #endif
+      EXPermissionsMethodsDelegate.register(requesters, withPermissionsManager: permissionsManager)
     }
 
     AsyncFunction("getProviderStatusAsync") {
@@ -122,6 +126,9 @@ public final class LocationModule: Module {
     }
 
     AsyncFunction("watchMotionActivityImplAsync") { (watchId: Int) in
+      #if EXPO_LOCATION_DISABLE_MOTION
+      throw Exceptions.MotionActivityDisabled()
+      #else
       guard CMMotionActivityManager.isActivityAvailable() else {
         throw Exceptions.MotionActivityUnavailable()
       }
@@ -164,6 +171,7 @@ public final class LocationModule: Module {
           sendEvent(EVENT_LOCATION_ERROR, ["watchId": watchId, "reason": error.localizedDescription])
         }
       }
+      #endif
     }
 
     AsyncFunction("removeWatchAsync") { (watchId: Int) in
@@ -172,10 +180,12 @@ public final class LocationModule: Module {
       }
       locationStreamers[watchId] = nil
 
+      #if !EXPO_LOCATION_DISABLE_MOTION
       if let streamer = motionActivityStreamers[watchId] {
         streamer.stopStreaming()
       }
       motionActivityStreamers[watchId] = nil
+      #endif
     }
 
     AsyncFunction("geocodeAsync") { (address: String) in
@@ -187,11 +197,29 @@ public final class LocationModule: Module {
     }
 
     AsyncFunction("getMotionActivityPermissionsAsync") { (promise: Promise) in
+      #if EXPO_LOCATION_DISABLE_MOTION
+      promise.resolve([
+        "status": "denied",
+        "expires": "never",
+        "granted": false,
+        "canAskAgain": false
+      ])
+      #else
       try getPermissionUsingRequester(MotionActivityPermissionRequester.self, appContext: appContext, promise: promise)
+      #endif
     }
 
     AsyncFunction("requestMotionActivityPermissionsAsync") { (promise: Promise) in
+      #if EXPO_LOCATION_DISABLE_MOTION
+      promise.resolve([
+        "status": "denied",
+        "expires": "never",
+        "granted": false,
+        "canAskAgain": false
+      ])
+      #else
       try askForPermissionUsingRequester(MotionActivityPermissionRequester.self, appContext: appContext, promise: promise)
+      #endif
     }
 
     AsyncFunction("getPermissionsAsync") { (promise: Promise) in

--- a/packages/expo-location/ios/Providers/MotionActivityStreamer.swift
+++ b/packages/expo-location/ios/Providers/MotionActivityStreamer.swift
@@ -1,5 +1,6 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
+#if !EXPO_LOCATION_DISABLE_MOTION
 import CoreMotion
 import ExpoModulesCore
 
@@ -47,3 +48,4 @@ internal final class MotionActivityStreamer {
     continuation = nil
   }
 }
+#endif

--- a/packages/expo-location/ios/Requesters/MotionActivityPermissionRequester.swift
+++ b/packages/expo-location/ios/Requesters/MotionActivityPermissionRequester.swift
@@ -1,3 +1,4 @@
+#if !EXPO_LOCATION_DISABLE_MOTION
 import CoreMotion
 import ExpoModulesCore
 
@@ -45,3 +46,4 @@ class MotionActivityPermissionRequester: NSObject, EXPermissionsRequester {
     }
   }
 }
+#endif

--- a/packages/expo-location/jest.config.js
+++ b/packages/expo-location/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('expo-module-scripts/createCompositeJestPreset')(__dirname, ['plugin']);

--- a/packages/expo-location/package.json
+++ b/packages/expo-location/package.json
@@ -49,8 +49,5 @@
   },
   "peerDependencies": {
     "expo": "*"
-  },
-  "jest": {
-    "preset": "expo-module-scripts"
   }
 }

--- a/packages/expo-location/plugin/src/__tests__/withLocation-test.ts
+++ b/packages/expo-location/plugin/src/__tests__/withLocation-test.ts
@@ -1,0 +1,84 @@
+import type { ExpoConfig } from 'expo/config';
+import type { ExportedConfig, Mod } from 'expo/config-plugins';
+
+import withLocation from '../withLocation';
+
+function fakeConfig(): ExpoConfig {
+  return { name: 'test', slug: 'test' };
+}
+
+async function evalIosModAsync<T>(
+  config: ExportedConfig,
+  mod: Mod<T> | undefined,
+  modResults: T
+): Promise<T> {
+  if (!mod) {
+    throw new Error('Expected the mod to be registered');
+  }
+  const result = await mod({
+    ...config,
+    modResults,
+    modRequest: {
+      projectRoot: '/app',
+      platformProjectRoot: '/app/ios',
+      modName: 'test',
+      platform: 'ios',
+      introspect: true,
+    },
+    modRawConfig: config,
+  });
+  return result.modResults;
+}
+
+describe('withLocation iOS motion configuration', () => {
+  it('sets expo.location.motionActivityEnabled in podfile properties when motionUsagePermission is false', async () => {
+    const config: ExportedConfig = withLocation(fakeConfig(), { motionUsagePermission: false });
+    const properties = await evalIosModAsync(config, config.mods?.ios?.podfileProperties, {});
+    expect(properties['expo.location.motionActivityEnabled']).toBe('false');
+  });
+
+  it('removes a stale expo.location.motionActivityEnabled left by a previous prebuild without --clean when motionUsagePermission is a string', async () => {
+    const config: ExportedConfig = withLocation(fakeConfig(), {
+      motionUsagePermission: 'Allow motion',
+    });
+    const properties = await evalIosModAsync(config, config.mods?.ios?.podfileProperties, {
+      'expo.location.motionActivityEnabled': 'false',
+    });
+    expect(properties['expo.location.motionActivityEnabled']).toBeUndefined();
+  });
+
+  it('removes a stale expo.location.motionActivityEnabled left by a previous prebuild without --clean when motionUsagePermission is not provided', async () => {
+    const config: ExportedConfig = withLocation(fakeConfig(), {});
+    const properties = await evalIosModAsync(config, config.mods?.ios?.podfileProperties, {
+      'expo.location.motionActivityEnabled': 'false',
+    });
+    expect(properties['expo.location.motionActivityEnabled']).toBeUndefined();
+  });
+
+  it('sets NSMotionUsageDescription to the provided message', async () => {
+    const config: ExportedConfig = withLocation(fakeConfig(), {
+      motionUsagePermission: 'Allow motion',
+    });
+    const infoPlist = await evalIosModAsync(config, config.mods?.ios?.infoPlist, {});
+    expect(infoPlist.NSMotionUsageDescription).toBe('Allow motion');
+  });
+
+  it('sets the default NSMotionUsageDescription when not provided', async () => {
+    const config: ExportedConfig = withLocation(fakeConfig(), {});
+    const infoPlist = await evalIosModAsync(config, config.mods?.ios?.infoPlist, {});
+    expect(infoPlist.NSMotionUsageDescription).toBe(
+      'Allow $(PRODUCT_NAME) to detect your current motion activity'
+    );
+  });
+
+  it('deletes NSMotionUsageDescription when motionUsagePermission is false, even when supplied through ios.infoPlist', async () => {
+    const config: ExportedConfig = withLocation(
+      { ...fakeConfig(), ios: { infoPlist: { NSMotionUsageDescription: 'My own message' } } },
+      { motionUsagePermission: false }
+    );
+    const infoPlist = await evalIosModAsync(config, config.mods?.ios?.infoPlist, {
+      NSMotionUsageDescription: 'My own message',
+    });
+    expect(infoPlist.NSMotionUsageDescription).toBeUndefined();
+  });
+});

--- a/packages/expo-location/plugin/src/withLocation.ts
+++ b/packages/expo-location/plugin/src/withLocation.ts
@@ -7,6 +7,7 @@ import {
   withInfoPlist,
   withDangerousMod,
   withAndroidManifest,
+  withPodfileProperties,
 } from 'expo/config-plugins';
 import { writeFileSync, unlinkSync, existsSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
@@ -161,9 +162,9 @@ export type Props = {
   /**
    * A string to set the `NSMotionUsageDescription` permission message shown when
    * `getMotionActivityAsync` or `watchMotionActivityAsync` is called for the first time.
-   * Set to `false` to omit the key. In that case, the app must add `NSMotionUsageDescription`
-   * manually to its `Info.plist`, for example via the `infoPlist` key in `app.json`.
-   * Without this key, calling motion activity APIs on iOS will throw an exception.
+   * Set to `false` to disable the motion activity feature: the key is removed from `Info.plist`,
+   * the CoreMotion features are excluded from the iOS build, motion permission methods resolve
+   * with a denied response, and calling motion activity APIs throws an exception.
    * @default "Allow $(PRODUCT_NAME) to detect your current motion activity"
    * @platform ios
    */
@@ -217,6 +218,15 @@ const withLocation: ConfigPlugin<Props | void> = (
   if (isIosBackgroundLocationEnabled) {
     config = withBackgroundLocation(config);
   }
+
+  config = withPodfileProperties(config, (config) => {
+    if (motionUsagePermission === false) {
+      config.modResults['expo.location.motionActivityEnabled'] = 'false';
+    } else {
+      delete config.modResults['expo.location.motionActivityEnabled'];
+    }
+    return config;
+  });
 
   config = withForegroundServiceIcon(config, { icon: androidForegroundServiceIcon ?? null });
 

--- a/tools/src/prebuilds/Utils.test.ts
+++ b/tools/src/prebuilds/Utils.test.ts
@@ -94,8 +94,8 @@ describe('selectDistributedPackages', () => {
     assert.equal(result, fakePackages);
   });
 
-  it('IOS_PREBUILD_PACKAGES lists the 15 distributed packages', () => {
-    assert.equal(IOS_PREBUILD_PACKAGES.length, 15);
+  it('IOS_PREBUILD_PACKAGES lists the 14 distributed packages', () => {
+    assert.equal(IOS_PREBUILD_PACKAGES.length, 14);
     assert.ok(IOS_PREBUILD_PACKAGES.includes('expo-modules-core'));
     assert.ok(!IOS_PREBUILD_PACKAGES.includes('expo-age-range'));
   });

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -159,7 +159,6 @@ export const IOS_PREBUILD_PACKAGES = [
   'expo-image',
   'expo-image-manipulator',
   'expo-live-photo',
-  'expo-location',
   'expo-maps',
   'expo-media-library',
   'expo-modules-core',


### PR DESCRIPTION
# Why

fixes: https://github.com/expo/expo/issues/49319

On iOS, even when an app doesn't use the motion APIs, the App Store still rejects the submission if the app lacks `NSMotionUsageDescription`

# How

Modified the config plugin to add a flag to the Podfile to exclude CoreMotion code. The flag is read by the podspec, and the `EXPO_LOCATION_DISABLE_MOTION` compilation flag is set (we do the same in `expo-sensors` #29845).

Since we exclude the code using the compiler flag, the package can't be precompiled - I excluded `expo-location` from the list of precompiled packages.

Also:
- I made permission requests reject instead of throwing just as in `expo-sensors`
- Moved the Jest config to `jest.config.js` - the same pattern as in expo-media-library to enable config plugin tests

Worth noting that the config plugin docs said that the permission could be modified manually. In practice, this didn't work because `IOSConfig.Permissions.createPermissionsPlugin` cleared the manually set permission. This is important here, since otherwise the change in this PR would be breaking for users who had set the permission manually

# Test Plan

Added config plugin tests
