### PR TITLE
[docs] Clarify remotely acknowledged actions in local-first guide

### DIFF
--- a/docs/pages/guides/local-first.mdx
+++ b/docs/pages/guides/local-first.mdx
@@ -30,6 +30,8 @@ Another characteristic of local-first software is that it is collaborative — m
 
 You no longer have to manage various states of your app for each network request — "loaded", "loading", "error", and so on, with their corresponding UI states and other logic. Write to a local database, and the app will automatically sync the changes to the server. This means that you can focus on building the app, and not worry as much about the networking and offline states.
 
+Local-first architecture does not remove every network-dependent state. Some actions, such as sending an email, are complete only when a remote service accepts them. Write those actions to the local database first. Then track their state, such as "queued", "sending", "accepted", and "failed".
+
 Your server availability may still be important, but in the event of an outage your users can still access the app and continue working. You may even provide a mechanism to sync the data without going through your server.
 
 ## Challenges in building local-first apps


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26211 https://github.com/expo/expo/issues/49303


# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add a qualification paragraph to the Developer experience benefits section: remotely acknowledged actions still carry "queued", "sending", "accepted", and "failed" states.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
