### PR TITLE
[inline-modules][prebuild-config] Resolve the main Xcode target from the pbxproj by product type

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### 🐛 Bug fixes
 
 - Stop writing DOM component source maps into the app binary during `expo export:embed`, so Android release builds no longer ship `www.bundle` source maps with the original app source. ([#49480](https://github.com/expo/expo/pull/49480) by [@expo-bot](https://github.com/expo-bot))
+- Derive sanitized project identifiers in the prebuild template from the raw app name in XML and plist files too (e.g. 'A & B' produced 'AampB' in plists but 'AB' elsewhere), and lowercase identifiers from the sanitized name, so file paths and contents always agree. Escape display names for Android resources and plists, and insert names containing replacement patterns (e.g. '$&') literally. ([#49143](https://github.com/expo/expo/pull/49143) by [@vonovak](https://github.com/vonovak))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -58,6 +58,7 @@
 
 ### 💡 Others
 
+- [Internal] Pass the app name to `updateXcodeProject` only as a tiebreak fallback — `@expo/inline-modules` now resolves the main target from the pbxproj. ([#49413](https://github.com/expo/expo/pull/49413) by [@vonovak](https://github.com/vonovak))
 - [Internal] Use `@expo/env` to read the EAS config mode and keep older EAS Build versions in production mode. ([#48938](https://github.com/expo/expo/pull/48938) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Add sandbox detection to telemetry context ([#47928](https://github.com/expo/expo/pull/47928) by [@davidmokos](https://github.com/davidmokos))
 - [Internal] Remove the unreachable port fallbacks and increase consistency in port selection logic ([#47771](https://github.com/expo/expo/pull/47771) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/prebuild/__tests__/renameTemplateAppName-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/renameTemplateAppName-test.ts
@@ -173,13 +173,49 @@ describe('renameTemplateAppNameAsync', () => {
       expect(spyWriteFile).toHaveBeenCalledTimes(1);
     });
 
-    // Whether the expected behaviour is a bug or not is up for discussion. This
-    // test is partially for the purpose of characterising the current behaviour.
-    //
-    // To be precise, this quirk originally existed only in Expo CLI (because XML
-    // escaping was only performed there), but now Create Expo has been made
-    // consistent with that behaviour as well.
-    it('sanitizes XML-unsafe characters in XML and Plist files when renaming', async () => {
+    it('derives the lowercase identifier from the sanitized name, matching path renames', async () => {
+      // Lowercasing happens after sanitizing ('Ǉubljana' -> 'LJubljana' ->
+      // 'ljubljana'), like in file-path renames.
+      jest.spyOn(fs.promises, 'readFile').mockImplementation(async () => 'package com.helloworld;');
+      let written = '';
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation(async (_filePath, data) => {
+        written = data as string;
+      });
+
+      await renameTemplateAppNameAsync(cwd, { files: ['Main.kt'], expName: 'Ǉubljana' });
+      expect(written).toBe('package com.ljubljana;');
+    });
+
+    it.each([
+      // XML-unsafe characters use entities in generic XML/plist files; Android
+      // resource files (.xml) use backslash escapes for quotes
+      ['A & B & C', 'strings.xml', '<string>A &amp; B &amp; C</string>'],
+      ["Bob's App", 'strings.xml', "<string>Bob\\'s App</string>"],
+      ['A "B" C', 'strings.xml', '<string>A \\"B\\" C</string>'],
+      ['@string/foo', 'strings.xml', '<string>\\@string/foo</string>'],
+      ['?attr', 'strings.xml', '<string>\\?attr</string>'],
+      ['C:\\Temp', 'strings.xml', '<string>C:\\\\Temp</string>'],
+      [' Padded ', 'strings.xml', '<string>" Padded "</string>'],
+      ["Bob's App", 'app.plist', '<string>Bob&apos;s App</string>'],
+      ['A "B" C', 'app.plist', '<string>A &quot;B&quot; C</string>'],
+      // replacement patterns in the name are inserted literally, not expanded
+      ['Cost $& Fees', 'app.json', '<string>Cost $& Fees</string>'],
+    ])('renders the display name %j in %s as %j', async (expName, file, expected) => {
+      jest
+        .spyOn(fs.promises, 'readFile')
+        .mockImplementation(async () => '<string>Hello App Display Name</string>');
+      let written = '';
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation(async (_filePath, data) => {
+        written = data as string;
+      });
+
+      await renameTemplateAppNameAsync(cwd, { files: [file], expName });
+      expect(written).toBe(expected);
+    });
+
+    // XML escaping applies only to the display name; the sanitized project
+    // identifiers derive from the raw name so they match across all files.
+    it('derives the same sanitized identifier in XML and non-XML files', async () => {
       // There is probably a more Jesty way to spy this, but I am tired
       const filesRead: string[] = [];
       const filesWritten: string[] = [];
@@ -194,15 +230,8 @@ describe('renameTemplateAppNameAsync', () => {
       const spyWriteFile = jest
         .spyOn(fs.promises, 'writeFile')
         .mockImplementation(async (filePath, data) => {
-          if (['.plist', '.xml'].includes(path.extname(filePath as string))) {
-            // XML escaping followed by sanitization:
-            // Bye<World -> Bye&lt;World -> ByeltWorld
-            expect(data).toMatch('ByeltWorld');
-          } else {
-            // Sanitization:
-            // Bye<World -> ByeWorld
-            expect(data).toMatch('ByeWorld');
-          }
+          // Sanitization: Bye<World -> ByeWorld
+          expect(data).toMatch('ByeWorld');
 
           filesWritten.push(filePath as string);
         });

--- a/packages/@expo/cli/src/prebuild/prebuildAsync.ts
+++ b/packages/@expo/cli/src/prebuild/prebuildAsync.ts
@@ -198,7 +198,7 @@ export async function prebuildAsync(
     await updateXcodeProject(projectRoot, {
       watchedDirectories: inlineModules.watchedDirectories ?? [],
       xcodeProjectTargets: inlineModules.xcodeProjectTargets,
-      name: exp.name,
+      appName: exp.name,
     });
   }
 

--- a/packages/@expo/cli/src/prebuild/renameTemplateAppName.ts
+++ b/packages/@expo/cli/src/prebuild/renameTemplateAppName.ts
@@ -1,16 +1,26 @@
-import { IOSConfig } from '@expo/config-plugins';
+import { IOSConfig, XML } from '@expo/config-plugins';
 import fs from 'fs';
 import { glob } from 'glob';
 import path from 'path';
 
 import { debugEvent } from './events';
 
+// Android resource XML (strings.xml): aapt2 resolves XML entities before its
+// own escape rules, so only &, <, > take entities; the rest (quotes, @, ?,
+// whitespace) needs Android's backslash escapes from `escapeAndroidString`.
+function escapeAndroidResourceValue(original: string): string {
+  const noAmps = original.replace(/&/g, '&amp;');
+  const noLt = noAmps.replace(/</g, '&lt;');
+  const noGt = noLt.replace(/>/g, '&gt;');
+  return XML.escapeAndroidString(noGt);
+}
+
 function escapeXMLCharacters(original: string): string {
-  const noAmps = original.replace('&', '&amp;');
-  const noLt = noAmps.replace('<', '&lt;');
-  const noGt = noLt.replace('>', '&gt;');
-  const noApos = noGt.replace('"', '\\"');
-  return noApos.replace("'", "\\'");
+  const noAmps = original.replace(/&/g, '&amp;');
+  const noLt = noAmps.replace(/</g, '&lt;');
+  const noGt = noLt.replace(/>/g, '&gt;');
+  const noQuots = noGt.replace(/"/g, '&quot;');
+  return noQuots.replace(/'/g, '&apos;');
 }
 
 /**
@@ -147,15 +157,28 @@ export async function renameTemplateAppNameAsync(
 
       debugEvent('rename_file', { path: debugEvent.path(absoluteFilePath) });
 
-      const safeName = ['.xml', '.plist'].includes(path.extname(file))
-        ? escapeXMLCharacters(name)
-        : name;
+      const extension = path.extname(file);
+      // Escaping applies only to the display name; the sanitized project
+      // identifiers derive from the raw name so they match across all files.
+      // `.xml` files in the rename config are Android resources; `.plist` is
+      // generic XML.
+      // Under `expo prebuild`, `AndroidConfig.Name.withName` later overwrites
+      // `app_name` from the raw config name, escaped by the same
+      // `escapeAndroidString`. This escaping keeps the file valid until the
+      // mods run, and is the final output for custom rename configs and for
+      // `create-expo`, which runs no mods.
+      const safeName =
+        extension === '.xml'
+          ? escapeAndroidResourceValue(name)
+          : extension === '.plist'
+            ? escapeXMLCharacters(name)
+            : name;
 
       try {
         const replacement = contents
-          .replace(/Hello App Display Name/g, safeName)
-          .replace(/HelloWorld/g, IOSConfig.XcodeUtils.sanitizedName(safeName))
-          .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(safeName.toLowerCase()));
+          .replace(/Hello App Display Name/g, () => safeName)
+          .replace(/HelloWorld/g, IOSConfig.XcodeUtils.sanitizedName(name))
+          .replace(/helloworld/g, IOSConfig.XcodeUtils.sanitizedName(name).toLowerCase());
 
         if (replacement === contents) {
           return;

--- a/packages/@expo/cli/src/utils/npm.ts
+++ b/packages/@expo/cli/src/utils/npm.ts
@@ -104,12 +104,13 @@ function renameNpmTarballEntries(expName: string | undefined) {
     }
   };
   if (expName) {
-    const androidName = IOSConfig.XcodeUtils.sanitizedName(expName.toLowerCase());
     const iosName = IOSConfig.XcodeUtils.sanitizedName(expName);
+    // Lowercase after sanitizing so the result always matches content renames
+    // (slugify's charmap is case-asymmetric).
     const lowerCaseName = iosName.toLowerCase();
     return (input: string, typeflag: TarTypeFlag) => {
       input = input
-        .replace(/HelloWorld/g, input.includes('android') ? androidName : iosName)
+        .replace(/HelloWorld/g, input.includes('android') ? lowerCaseName : iosName)
         .replace(/helloworld/g, lowerCaseName);
       return renameConfigs(input, typeflag);
     };

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### 🐛 Bug fixes
 
+- Normalize accented and compatibility characters instead of stripping them when deriving iOS project names from the app name ('Árbók' now becomes 'Arbok', not 'rbk'; 'ﬁre' becomes 'fire'), and transliterate letters that normalization cannot decompose ('Bjørn' becomes 'Bjorn'). ([#49143](https://github.com/expo/expo/pull/49143) by [@vonovak](https://github.com/vonovak))
+- Escape `?` and `\` in `XML.escapeAndroidString` so values are not compiled as attribute references or aapt2 escape sequences. ([#49143](https://github.com/expo/expo/pull/49143) by [@vonovak](https://github.com/vonovak))
 - Fix `getApplicationIdAsync` and `setPackageInBuildGradle` failing with the Gradle assignment syntax (`applicationId = '...'`). ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
 - [iOS] Quote and escape keys and values written to `.strings` files. ([#49605](https://github.com/expo/expo/pull/49605) by [@jakex7](https://github.com/jakex7))
 - [iOS] Keep writing `locales` after one that has no `Info.plist` keys. ([#49777](https://github.com/expo/expo/pull/49777) by [@giaBaoJS](https://github.com/giaBaoJS))

--- a/packages/@expo/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -58,15 +58,29 @@ export function resolvePathOrProject(
 
 // TODO: come up with a better solution for using app.json expo.name in various places
 export function sanitizedName(name: string) {
-  // Default to the name `app` when every safe character has been sanitized
-  return sanitizedNameForProjects(name) || sanitizedNameForProjects(slugify(name)) || 'app';
+  // Symbols carry no name information: drop them so 'A & B' stays 'AB' and 'Expo®'
+  // stays 'Expo'. Then strip diacritics via NFKD before slugify, because slugify
+  // deletes letters absent from its charmap ('Ċ' would vanish instead of becoming
+  // 'C'). NFKD also decomposes compatibility letters and numbers ('ﬁ' becomes 'fi',
+  // 'Ǉ' becomes 'LJ', fullwidth 'Ｅ' becomes 'E'); symbols like '™' are already
+  // dropped, so they do not turn into letters. slugify then transliterates letters
+  // that NFKD cannot decompose (ø, æ, ł, ß). Symbol-only names fall back to a
+  // slugify of the full name ('♥' becomes 'love'), then to the name `app`.
+  const lettersAndNumbers = name
+    .replace(/[^\p{L}\p{N}]+/gu, '')
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '');
+  return (
+    sanitizedNameForProjects(slugify(lettersAndNumbers)) ||
+    sanitizedNameForProjects(slugify(name)) ||
+    'app'
+  );
 }
 
+// Normalize before stripping so diacritics decompose into combining marks that
+// `\W` removes, keeping the base letters ("Árbók" -> "Arbok", not "rbk").
 function sanitizedNameForProjects(name: string) {
-  return name
-    .replace(/[\W_]+/g, '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+  return name.normalize('NFKD').replace(/[\W_]+/g, '');
 }
 
 // TODO: it's silly and kind of fragile that we look at app config to determine

--- a/packages/@expo/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
@@ -1,14 +1,36 @@
 import { resolveXcodeBuildSetting, sanitizedName } from '../Xcodeproj';
 
 describe(sanitizedName, () => {
-  it(`formats basic name`, () => {
-    expect(sanitizedName('bacon')).toBe('bacon');
-  });
-  it(`formats android/xcode unsupported name`, () => {
-    expect(sanitizedName('あいう')).toBe('app');
-  });
-  it(`uses slugify for better name support`, () => {
-    expect(sanitizedName('\u2665')).toBe('love');
+  it.each([
+    // plain names pass through
+    ['bacon', 'bacon'],
+    // diacritics decompose via NFKD and keep their base letters
+    ['Árbók', 'Arbok'],
+    ['Pěkná applikačka', 'Peknaapplikacka'],
+    // letters that slugify has no charmap entry for survive via NFKD
+    ['Ċittadin', 'Cittadin'],
+    ['Ǻpp', 'App'],
+    // compatibility letters and numbers decompose via NFKD
+    ['Ǉubljana', 'LJubljana'],
+    ['ﬁre', 'fire'],
+    ['Ｅｘｐｏ', 'Expo'],
+    ['x² app', 'x2app'],
+    // letters that NFKD cannot decompose are transliterated by slugify
+    ['Æøå', 'AEoa'],
+    ['Łódź', 'Lodz'],
+    ['Straße', 'Strasse'],
+    ['Привет', 'Privet'],
+    // symbols are stripped, not transliterated
+    ['A & B', 'AB'],
+    ['Expo®', 'Expo'],
+    ['Priçe €10', 'Price10'],
+    ['h"&<world/>🚀', 'hworld'],
+    // symbol-only names fall back to a slugify of the full name
+    ['♥', 'love'],
+    // nothing usable remains
+    ['あいう', 'app'],
+  ])(`sanitizes %j to %j`, (name, expected) => {
+    expect(sanitizedName(name)).toBe(expected);
   });
 });
 

--- a/packages/@expo/config-plugins/src/utils/XML.ts
+++ b/packages/@expo/config-plugins/src/utils/XML.ts
@@ -116,16 +116,18 @@ export function format(manifest: any, { indentLevel = 2, newline = EOL } = {}): 
 }
 
 /**
- * Escapes Android string literals, specifically characters `"`, `'`, `\`, `\n`, `\r`, `\t`
+ * Escapes Android string literals, specifically characters `"`, `'`, `\`, `\n`, `\r`, `\t`, `@`, `?`
  *
  * @param value unescaped Android XML string literal.
  */
 export function escapeAndroidString(value: string): string {
-  value = value.replace(/[\n\r\t'"@]/g, (m) => {
+  value = value.replace(/[\n\r\t'"@?\\]/g, (m) => {
     switch (m) {
       case '"':
       case "'":
       case '@':
+      case '?':
+      case '\\':
         return '\\' + m;
       case '\n':
         return '\\n';

--- a/packages/@expo/config-plugins/src/utils/__tests__/XML-test.ts
+++ b/packages/@expo/config-plugins/src/utils/__tests__/XML-test.ts
@@ -104,6 +104,8 @@ describe(escapeAndroidString, () => {
     expect(escapeAndroidString(`@`)).toBe(`\\@`);
     expect(escapeAndroidString(`'''`)).toBe(`\\'\\'\\'`);
     expect(escapeAndroidString('"E&x<p>o"@\n\r\t')).toBe(`\\"E&x<p>o\\"\\@\\n\\r\\t`);
+    expect(escapeAndroidString('?attr/foo')).toBe('\\?attr/foo');
+    expect(escapeAndroidString('C:\\Temp')).toBe('C:\\\\Temp');
   });
 });
 

--- a/packages/@expo/inline-modules/CHANGELOG.md
+++ b/packages/@expo/inline-modules/CHANGELOG.md
@@ -4,9 +4,13 @@
 
 ### 🛠 Breaking changes
 
+- Replace the required `name` field of `InlineModulesXcodeParams` with the optional `appName`, used only as a tiebreak fallback when several application targets exist. ([#49413](https://github.com/expo/expo/pull/49413) by [@vonovak](https://github.com/vonovak))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
+
+- Resolve the main Xcode target by its application product type instead of the app name, so renamed and `--no-clean` projects match. Skip aggregate and legacy targets, prefer the target named after the on-disk project when several exist (warn when none matches), and match quoted target names in `xcodeProjectTargets`. ([#49413](https://github.com/expo/expo/pull/49413) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/@expo/inline-modules/src/__tests__/fixtures/bare-project/ios/bare-project.xcodeproj/project.pbxproj
+++ b/packages/@expo/inline-modules/src/__tests__/fixtures/bare-project/ios/bare-project.xcodeproj/project.pbxproj
@@ -35,9 +35,26 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				F43ABE372F2366380051AD1C /* HelloWorld */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXNativeTarget section */
+		F43ABE372F2366380051AD1C /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F43ABE392F2366380051AD1C /* Build configuration list for PBXNativeTarget "bare-project" */;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
 
 /* Begin XCBuildConfiguration section */
 		F43ABE352F2366380051AD1C /* Debug */ = {
@@ -56,6 +73,15 @@
 
 /* Begin XCConfigurationList section */
 		F43ABE342F2366380051AD1C /* Build configuration list for PBXProject "bare-project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F43ABE352F2366380051AD1C /* Debug */,
+				F43ABE362F2366380051AD1C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F43ABE392F2366380051AD1C /* Build configuration list for PBXNativeTarget "bare-project" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F43ABE352F2366380051AD1C /* Debug */,

--- a/packages/@expo/inline-modules/src/__tests__/xcodeUpdates.test.ts
+++ b/packages/@expo/inline-modules/src/__tests__/xcodeUpdates.test.ts
@@ -5,43 +5,117 @@ import * as path from 'path';
 
 import { updateXcodeProject } from '../xcodeProjectUpdates';
 
+// A second application target ("WatchApp"), listed before the fixture's
+// "HelloWorld" target — a paired watchOS app also uses the application
+// product type.
+const addWatchAppTarget = (content: string) =>
+  content
+    .replace('targets = (', 'targets = (\n\t\t\t\tBBBBBBBBBBBBBBBBBBBBBBBB /* WatchApp */,')
+    .replace(
+      '/* Begin PBXNativeTarget section */',
+      '/* Begin PBXNativeTarget section */\n' +
+        '\t\tBBBBBBBBBBBBBBBBBBBBBBBB /* WatchApp */ = {\n' +
+        '\t\t\tisa = PBXNativeTarget;\n' +
+        '\t\t\tbuildConfigurationList = F43ABE392F2366380051AD1C;\n' +
+        '\t\t\tbuildPhases = (\n' +
+        '\t\t\t);\n' +
+        '\t\t\tbuildRules = (\n' +
+        '\t\t\t);\n' +
+        '\t\t\tdependencies = (\n' +
+        '\t\t\t);\n' +
+        '\t\t\tname = WatchApp;\n' +
+        '\t\t\tproductName = WatchApp;\n' +
+        '\t\t\tproductType = "com.apple.product-type.application";\n' +
+        '\t\t};'
+    );
+
+// An aggregate target ("Scripts"), listed before the fixture's application
+// target. Aggregate targets are not part of the PBXNativeTarget section.
+const addAggregateTarget = (content: string) =>
+  content
+    .replace('targets = (', 'targets = (\n\t\t\t\tAAAAAAAAAAAAAAAAAAAAAAAA /* Scripts */,')
+    .replace(
+      '/* Begin PBXNativeTarget section */',
+      '/* Begin PBXAggregateTarget section */\n' +
+        '\t\tAAAAAAAAAAAAAAAAAAAAAAAA /* Scripts */ = {\n' +
+        '\t\t\tisa = PBXAggregateTarget;\n' +
+        '\t\t\tbuildConfigurationList = F43ABE392F2366380051AD1C;\n' +
+        '\t\t\tbuildPhases = (\n' +
+        '\t\t\t);\n' +
+        '\t\t\tdependencies = (\n' +
+        '\t\t\t);\n' +
+        '\t\t\tname = Scripts;\n' +
+        '\t\t};\n' +
+        '/* End PBXAggregateTarget section */\n\n' +
+        '/* Begin PBXNativeTarget section */'
+    );
+
+// Replaces the whole PBXNativeTarget section with an aggregate target, so no
+// PBXNativeTarget section exists at all.
+const replaceNativeTargetsWithAggregate = (content: string) =>
+  content.replace(
+    /\/\* Begin PBXNativeTarget section \*\/[\s\S]*?\/\* End PBXNativeTarget section \*\//,
+    '/* Begin PBXAggregateTarget section */\n' +
+      '\t\tF43ABE372F2366380051AD1C /* Scripts */ = {\n' +
+      '\t\t\tisa = PBXAggregateTarget;\n' +
+      '\t\t\tbuildConfigurationList = F43ABE392F2366380051AD1C;\n' +
+      '\t\t\tbuildPhases = (\n' +
+      '\t\t\t);\n' +
+      '\t\t\tdependencies = (\n' +
+      '\t\t\t);\n' +
+      '\t\t\tname = Scripts;\n' +
+      '\t\t};\n' +
+      '/* End PBXAggregateTarget section */'
+  );
+
 describe('updateXcodeProject', () => {
-  let tempProjectRoot: string | null = null;
+  let tempProjectRoot: string;
   const FIXTURE_PATH = path.resolve(__dirname, 'fixtures/bare-project');
 
+  const pbxProjPath = () =>
+    path.join(tempProjectRoot, 'ios', 'bare-project.xcodeproj', 'project.pbxproj');
+
+  const mutatePbxproj = async (mutate: (content: string) => string) => {
+    const content = await fs.promises.readFile(pbxProjPath(), 'utf8');
+    await fs.promises.writeFile(pbxProjPath(), mutate(content));
+  };
+
+  const getTargetByName = (name: string) => {
+    const nativeTargets =
+      IOSConfig.XcodeUtils.getPbxproj(tempProjectRoot).hash.project.objects.PBXNativeTarget;
+    return Object.values(nativeTargets).find(
+      (target) => typeof target === 'object' && target?.name === name
+    ) as { fileSystemSynchronizedGroups?: { value: string; comment?: string }[] } | undefined;
+  };
+
+  const expectAppGroupOnTarget = (name: string) => {
+    expect(getTargetByName(name)?.fileSystemSynchronizedGroups).toEqual(
+      expect.arrayContaining([expect.objectContaining({ comment: 'app' })])
+    );
+  };
+
   beforeEach(async () => {
-    const tempDir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'xcode-updates-test-'));
-    await fs.promises.cp(FIXTURE_PATH, tempDir, { recursive: true });
-    tempProjectRoot = tempDir;
+    tempProjectRoot = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'xcode-updates-test-'));
+    await fs.promises.cp(FIXTURE_PATH, tempProjectRoot, { recursive: true });
   });
 
   afterEach(async () => {
-    if (tempProjectRoot && fs.existsSync(tempProjectRoot)) {
+    if (fs.existsSync(tempProjectRoot)) {
       await fs.promises.rm(tempProjectRoot, { recursive: true, force: true });
     }
     jest.resetAllMocks();
   });
 
   it('adds watched directories to the PBX project', async () => {
-    expect(tempProjectRoot).toBeTruthy();
-    expect(tempProjectRoot).toBeDefined();
-    tempProjectRoot = tempProjectRoot as string;
+    await updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] });
 
-    await updateXcodeProject(tempProjectRoot, {
-      watchedDirectories: ['app'],
-      name: 'bare-project',
-    });
-
-    const pbxProject = IOSConfig.XcodeUtils.getPbxproj(tempProjectRoot);
-    const objects = pbxProject.hash.project.objects;
+    const objects = IOSConfig.XcodeUtils.getPbxproj(tempProjectRoot).hash.project.objects;
     const rootGroups = objects.PBXFileSystemSynchronizedRootGroup;
     expect(rootGroups).toBeDefined();
 
     const rootGroupKeys = Object.keys(rootGroups).filter((key) => !key.endsWith('_comment'));
     expect(rootGroupKeys).toHaveLength(1);
-
-    const rootGroupUUID = rootGroupKeys[0]!;
-    expect(rootGroups[rootGroupUUID]).toEqual(
+    expect(rootGroups[rootGroupKeys[0]!]).toEqual(
       expect.objectContaining({
         isa: 'PBXFileSystemSynchronizedRootGroup',
         name: 'app',
@@ -49,25 +123,127 @@ describe('updateXcodeProject', () => {
     );
   });
 
-  it('does nothing if watchedDirectories is empty', async () => {
-    expect(tempProjectRoot).toBeTruthy();
-    expect(tempProjectRoot).toBeDefined();
-    tempProjectRoot = tempProjectRoot as string;
+  it('resolves the main target by its application product type', async () => {
+    // The fixture's main target "HelloWorld" matches neither the .xcodeproj name
+    // nor any app name; only its product type identifies it.
+    await updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] });
 
-    const pbxProjPath = path.join(
-      tempProjectRoot,
-      'ios',
-      'bare-project.xcodeproj',
-      'project.pbxproj'
+    expectAppGroupOnTarget('HelloWorld');
+  });
+
+  it('ignores aggregate targets when resolving the main target', async () => {
+    // Aggregate targets are not in the PBXNativeTarget section; resolving the
+    // main target must not crash on them.
+    await mutatePbxproj(addAggregateTarget);
+
+    await updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] });
+
+    expectAppGroupOnTarget('HelloWorld');
+  });
+
+  it('prefers the application target named after the project when there are several', async () => {
+    // The watch app comes first in target order; the on-disk project name must win.
+    await mutatePbxproj(addWatchAppTarget);
+    // `getProjectName` resolves "HelloWorld" from the AppDelegate location.
+    const sourceRoot = path.join(tempProjectRoot, 'ios', 'HelloWorld');
+    await fs.promises.mkdir(sourceRoot, { recursive: true });
+    await fs.promises.writeFile(path.join(sourceRoot, 'AppDelegate.swift'), '// placeholder\n');
+
+    await updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] });
+
+    expectAppGroupOnTarget('HelloWorld');
+    expect(getTargetByName('WatchApp')?.fileSystemSynchronizedGroups).toBeUndefined();
+  });
+
+  it('warns and uses the first application target when the name tiebreak fails', async () => {
+    // Two application targets, no AppDelegate on disk to break the tie.
+    await mutatePbxproj(addWatchAppTarget);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] });
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('multiple application targets'));
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('WatchApp'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expectAppGroupOnTarget('WatchApp');
+  });
+
+  it('uses the sanitized app name as tiebreak when no source folder is on disk', async () => {
+    // Two application targets, no AppDelegate on disk. 'Hello World!' sanitizes
+    // to 'HelloWorld', proving the app name is sanitized before comparison.
+    await mutatePbxproj(addWatchAppTarget);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await updateXcodeProject(tempProjectRoot, {
+        watchedDirectories: ['app'],
+        appName: 'Hello World!',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expectAppGroupOnTarget('HelloWorld');
+    expect(getTargetByName('WatchApp')?.fileSystemSynchronizedGroups).toBeUndefined();
+  });
+
+  it('prefers the on-disk project name over the app name for the tiebreak', async () => {
+    await mutatePbxproj(addWatchAppTarget);
+    // `getProjectName` resolves "HelloWorld" from the AppDelegate location.
+    const sourceRoot = path.join(tempProjectRoot, 'ios', 'HelloWorld');
+    await fs.promises.mkdir(sourceRoot, { recursive: true });
+    await fs.promises.writeFile(path.join(sourceRoot, 'AppDelegate.swift'), '// placeholder\n');
+
+    await updateXcodeProject(tempProjectRoot, {
+      watchedDirectories: ['app'],
+      appName: 'WatchApp',
+    });
+
+    expectAppGroupOnTarget('HelloWorld');
+  });
+
+  it('matches explicit xcodeProjectTargets against quoted target names', async () => {
+    // pbxproj quotes names containing spaces; the user config value is unquoted.
+    await mutatePbxproj((content) =>
+      content.replace('name = HelloWorld;', 'name = "Hello World";')
     );
-    const contentBefore = await fs.promises.readFile(pbxProjPath, 'utf8');
+
+    await updateXcodeProject(tempProjectRoot, {
+      watchedDirectories: ['app'],
+      xcodeProjectTargets: ['Hello World'],
+    });
+
+    expectAppGroupOnTarget('"Hello World"');
+  });
+
+  it('throws a descriptive error when no target has the application product type', async () => {
+    await mutatePbxproj((content) => content.replace(/^.*productType.*\n/m, ''));
+
+    await expect(
+      updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] })
+    ).rejects.toThrow('could not find an application target');
+  });
+
+  it('throws the descriptive error for a project with only aggregate targets', async () => {
+    // No PBXNativeTarget section at all; must reach the descriptive error, not a TypeError.
+    await mutatePbxproj(replaceNativeTargetsWithAggregate);
+
+    await expect(
+      updateXcodeProject(tempProjectRoot, { watchedDirectories: ['app'] })
+    ).rejects.toThrow('could not find an application target');
+  });
+
+  it('does nothing if watchedDirectories is empty', async () => {
+    const contentBefore = await fs.promises.readFile(pbxProjPath(), 'utf8');
     expect(contentBefore).toBeTruthy();
 
-    await updateXcodeProject(tempProjectRoot, { watchedDirectories: [], name: 'bare-project' });
+    await updateXcodeProject(tempProjectRoot, { watchedDirectories: [] });
 
-    const contentAfter = await fs.promises.readFile(pbxProjPath, 'utf8');
-
-    // We shouldn't change the pbxproj if there are no watchedDirectories
+    const contentAfter = await fs.promises.readFile(pbxProjPath(), 'utf8');
     expect(contentAfter).toEqual(contentBefore);
   });
 });

--- a/packages/@expo/inline-modules/src/xcodeProjectUpdates.ts
+++ b/packages/@expo/inline-modules/src/xcodeProjectUpdates.ts
@@ -8,8 +8,11 @@ export interface InlineModulesXcodeParams {
    * List of targets to which inline modules files are added. If undefined defaults to the main target only.
    */
   xcodeProjectTargets?: string[];
-  /** app config name */
-  name: string;
+  /**
+   * The app name from the Expo config. Used as the tiebreak fallback when the
+   * project has several application targets and no source folder is on disk.
+   */
+  appName?: string;
 }
 
 type UUID = string;
@@ -24,20 +27,62 @@ type NativeTarget = NonNullable<
   fileSystemSynchronizedGroups?: { value: string; comment?: string }[];
 };
 
-function escapeXMLCharacters(original: string): string {
-  const noAmps = original.replace('&', '&amp;');
-  const noLt = noAmps.replace('<', '&lt;');
-  const noGt = noLt.replace('>', '&gt;');
-  const noApos = noGt.replace('"', '\\"');
-  return noApos.replace("'", "\\'");
-}
+const APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
 
-// Note that this main target name is based on how `@expo/cli/src/prebuild/renameTemplateAppNameAsync.ts` preprocesses the ios project template.
-// It is necessary to match the target name in the path to ExpoModulesProvider.swift for the main target as is used when generating it.
-function getMainTargetName(config: InlineModulesXcodeParams): string {
-  const name = config.name;
-  const safeName = escapeXMLCharacters(name);
-  return IOSConfig.XcodeUtils.sanitizedName(safeName);
+const unquote = (value: string) => value.replace(/^"(.*)"$/, '$1');
+
+// The pbxproj is the source of truth for the main target: names derived from the
+// app config can drift from it (older sanitizer output, or a manual rename).
+// Iterated by hand because `pbxProject.getTarget` crashes on aggregate and legacy
+// targets, which are absent from the PBXNativeTarget section.
+// Keep in sync with `resolveMainTargetName` in `@expo/prebuild-config`.
+function getMainApplicationTargetUuid(
+  pbxProject: XcodeProject,
+  projectRoot: string,
+  appName: string | undefined
+): UUID {
+  // The section is absent when the project holds only aggregate/legacy targets.
+  const nativeTargets = pbxProject.hash.project.objects.PBXNativeTarget ?? {};
+  const applicationTargetUuids = pbxProject
+    .getFirstProject()
+    .firstProject.targets.map((target: { value: UUID }) => target.value)
+    .filter((uuid: UUID) => {
+      const productType = (nativeTargets[uuid] as NativeTarget | undefined)?.productType;
+      return typeof productType === 'string' && unquote(productType) === APPLICATION_PRODUCT_TYPE;
+    });
+
+  if (applicationTargetUuids.length === 0) {
+    throw new Error(
+      'Inline modules could not find an application target (product type "com.apple.product-type.application") in your iOS Xcode project. ' +
+        'Inline module directories are attached to the main application target by default. ' +
+        'Check that the project builds in Xcode, or list the targets explicitly in `expo.experiments.inlineModules.xcodeProjectTargets` in your app config.'
+    );
+  }
+  if (applicationTargetUuids.length > 1) {
+    // A paired watchOS app also uses the application product type; prefer the
+    // target named after the on-disk project.
+    const targetName = (uuid: UUID) => unquote(String((nativeTargets[uuid] as NativeTarget).name));
+    let projectName: string | null;
+    try {
+      projectName = IOSConfig.XcodeUtils.getProjectName(projectRoot);
+    } catch {
+      // No source folder on disk; fall back to the config-derived name, the
+      // same tiebreak `resolveMainTargetName` in @expo/prebuild-config uses.
+      projectName = appName ? IOSConfig.XcodeUtils.sanitizedName(appName) : null;
+    }
+    const named = applicationTargetUuids.find((uuid: UUID) => targetName(uuid) === projectName);
+    if (named) {
+      return named;
+    }
+    console.warn(
+      `Inline modules found multiple application targets (${applicationTargetUuids
+        .map(targetName)
+        .join(', ')}) and none matches the project name. ` +
+        `Using the first one, "${targetName(applicationTargetUuids[0]!)}". ` +
+        'Set `expo.experiments.inlineModules.xcodeProjectTargets` in your app config to pick the targets explicitly.'
+    );
+  }
+  return applicationTargetUuids[0]!;
 }
 
 function getNativeTargetSynchronizedGroupsMap(pbxProject: XcodeProject) {
@@ -45,7 +90,9 @@ function getNativeTargetSynchronizedGroupsMap(pbxProject: XcodeProject) {
   const nativeTargetSynchronizedGroups = new Map<UUID, Set<UUID>>();
 
   for (const target of pbxProject.getFirstProject().firstProject.targets) {
-    const nativeTargetGroup = objects.PBXNativeTarget[target.value] as NativeTarget | undefined;
+    const nativeTargetGroup = (objects.PBXNativeTarget ?? {})[target.value] as
+      | NativeTarget
+      | undefined;
     const synchronizedGroups = new Set<UUID>();
 
     if (nativeTargetGroup?.fileSystemSynchronizedGroups) {
@@ -98,7 +145,7 @@ export async function updateXcodeProject(
   const mainGroupUUID = pbxProject.getFirstProject().firstProject.mainGroup;
   const objects = pbxProject.hash.project.objects;
   const projectRootRelativeToIos = '..';
-  const pbxNativeTarget = pbxProject.hash.project.objects.PBXNativeTarget;
+  const pbxNativeTarget = pbxProject.hash.project.objects.PBXNativeTarget ?? {};
 
   const nativeTargetSynchronizedGroups = getNativeTargetSynchronizedGroupsMap(pbxProject);
   const addWatchedDirectoryToTarget = (
@@ -148,6 +195,10 @@ export async function updateXcodeProject(
     return newUUID;
   };
 
+  // If the xcodeProjectTargets are not provided, default to the main target
+  const mainTargetUuid = xcodeProjectTargets
+    ? null
+    : getMainApplicationTargetUuid(pbxProject, projectRoot, inlineModulesXcodeParams.appName);
   const targetsToUpdate = pbxProject
     .getFirstProject()
     .firstProject.targets.filter((target: { value: UUID; comment: string }) => {
@@ -157,10 +208,10 @@ export async function updateXcodeProject(
         return false;
       }
       if (!xcodeProjectTargets) {
-        // If the xcodeProjectTargets are not provided, default to the main target
-        return targetName === getMainTargetName(inlineModulesXcodeParams);
+        return targetUuid === mainTargetUuid;
       }
-      return xcodeProjectTargets.has(targetName);
+      // pbxproj quotes names containing spaces; the user config value is unquoted.
+      return xcodeProjectTargets.has(unquote(targetName));
     });
 
   for (const watchedDirectory of swiftWatchedDirectories) {

--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [inline modules] Resolve the `mainTarget` in Podfile.properties.json from the Xcode project (application product type) instead of the app name, falling back to the folder-derived name when no iOS project exists. This keeps autolinking's target matching in sync with the pbxproj. Projects without inline modules skip the pbxproj parse. ([#49413](https://github.com/expo/expo/pull/49413) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 ## 58.0.0 — 2026-09-10

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -955,7 +955,7 @@ exports[`built-in plugins introspects mods 1`] = `
         "podfileProperties": {
           "EX_DEV_CLIENT_NETWORK_INSPECTOR": "true",
           "expo.inlineModules.watchedDirectories": "[]",
-          "expo.inlineModules.xcodeProjectTargets": "{"mainTarget":"mycoolapp","targets":[]}",
+          "expo.inlineModules.xcodeProjectTargets": "{"targets":[]}",
           "expo.jsEngine": "hermes",
           "ios.deploymentTarget": "15.1",
         },
@@ -1596,7 +1596,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
         },
         "podfileProperties": {
           "expo.inlineModules.watchedDirectories": "[]",
-          "expo.inlineModules.xcodeProjectTargets": "{"mainTarget":"mycoolapp","targets":[]}",
+          "expo.inlineModules.xcodeProjectTargets": "{"targets":[]}",
           "ios.deploymentTarget": "15.1",
         },
       },

--- a/packages/@expo/prebuild-config/src/plugins/unversioned/expo-inline-modules/__tests__/withInlineModules-test.ts
+++ b/packages/@expo/prebuild-config/src/plugins/unversioned/expo-inline-modules/__tests__/withInlineModules-test.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { resolveMainTargetName } from '../withInlineModules';
+
+// Minimal pbxproj with one application target whose name differs from the
+// ios/<dir> folder name.
+const PBXPROJ = `// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXGroup section */
+		F43ABE302F2366380051AD1C = {
+			isa = PBXGroup;
+			children = (
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		F43ABE312F2366380051AD1C /* Project object */ = {
+			isa = PBXProject;
+			buildConfigurationList = F43ABE342F2366380051AD1C;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = F43ABE302F2366380051AD1C;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				F43ABE372F2366380051AD1C /* Real Target */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXNativeTarget section */
+		F43ABE372F2366380051AD1C /* Real Target */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F43ABE392F2366380051AD1C;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Real Target";
+			productName = "Real Target";
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin XCBuildConfiguration section */
+		F43ABE352F2366380051AD1C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F43ABE342F2366380051AD1C /* Build configuration list */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F43ABE352F2366380051AD1C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		F43ABE392F2366380051AD1C /* Build configuration list */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F43ABE352F2366380051AD1C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F43ABE312F2366380051AD1C /* Project object */;
+}
+`;
+
+describe(resolveMainTargetName, () => {
+  let tempProjectRoot: string;
+
+  beforeEach(async () => {
+    tempProjectRoot = await fs.promises.mkdtemp(
+      path.resolve(os.tmpdir(), 'with-inline-modules-test-')
+    );
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempProjectRoot, { recursive: true, force: true });
+  });
+
+  it('resolves the application target name from the pbxproj, unquoted', async () => {
+    const projPath = path.join(tempProjectRoot, 'ios', 'HelloWorld.xcodeproj');
+    await fs.promises.mkdir(projPath, { recursive: true });
+    await fs.promises.writeFile(path.join(projPath, 'project.pbxproj'), PBXPROJ);
+
+    // The folder-derived name says HelloWorld; the pbxproj target name wins.
+    expect(resolveMainTargetName(tempProjectRoot, 'HelloWorld')).toBe('Real Target');
+  });
+
+  it('surfaces the parse error for a corrupt pbxproj instead of the fallback', async () => {
+    const projPath = path.join(tempProjectRoot, 'ios', 'HelloWorld.xcodeproj');
+    await fs.promises.mkdir(projPath, { recursive: true });
+    await fs.promises.writeFile(path.join(projPath, 'project.pbxproj'), 'not a pbxproj');
+
+    expect(() => resolveMainTargetName(tempProjectRoot, 'HelloWorld')).toThrow();
+  });
+
+  it('falls back to the folder-derived name when there is no ios project', () => {
+    expect(resolveMainTargetName(tempProjectRoot, 'HelloWorld')).toBe('HelloWorld');
+  });
+
+  it('throws when neither source resolves a name', () => {
+    expect(() => resolveMainTargetName(tempProjectRoot, undefined)).toThrow(
+      'could not resolve the main Xcode target'
+    );
+  });
+});

--- a/packages/@expo/prebuild-config/src/plugins/unversioned/expo-inline-modules/withInlineModules.ts
+++ b/packages/@expo/prebuild-config/src/plugins/unversioned/expo-inline-modules/withInlineModules.ts
@@ -1,23 +1,61 @@
-import { AndroidConfig, IOSConfig } from '@expo/config-plugins';
+import { AndroidConfig, IOSConfig, type ExportedConfigWithProps } from '@expo/config-plugins';
 import type { ExpoConfig } from '@expo/config-types';
 
 const { createBuildGradlePropsConfigPlugin } = AndroidConfig.BuildProperties;
 const { createBuildPodfilePropsConfigPlugin } = IOSConfig.BuildProperties;
 
-function escapeXMLCharacters(original: string): string {
-  const noAmps = original.replace('&', '&amp;');
-  const noLt = noAmps.replace('<', '&lt;');
-  const noGt = noLt.replace('>', '&gt;');
-  const noApos = noGt.replace('"', '\\"');
-  return noApos.replace("'", "\\'");
-}
+const APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
 
-// Note that this main target name is based on how `@expo/cli/src/prebuild/renameTemplateAppNameAsync.ts` preprocesses the ios project template.
-// It is necessary to match the target name in the path to ExpoModulesProvider.swift for the main target as is used when generating it.
-function getMainTargetName(config: ExpoConfig): string {
-  const name = config.name;
-  const safeName = escapeXMLCharacters(name);
-  return IOSConfig.XcodeUtils.sanitizedName(safeName);
+const unquote = (value: string) => value.replace(/^"(.*)"$/, '$1');
+
+// The Xcode target name is the source of truth: autolinking matches this value
+// against the CocoaPods target name (`Pods-<TargetName>`), which follows the
+// target, not the `ios/<dir>` folder that `modRequest.projectName` derives from.
+// Keep in sync with `getMainApplicationTargetUuid` in `@expo/inline-modules`:
+// both resolvers use the same tiebreak when several application targets exist
+// — the on-disk project name first, then the sanitized app name.
+export function resolveMainTargetName(
+  projectRoot: string,
+  fallbackName: string | undefined
+): string {
+  let projectPath: string | null = null;
+  try {
+    projectPath = IOSConfig.Paths.getPBXProjectPath(projectRoot);
+  } catch {
+    // No ios project on disk (e.g. introspection); use the folder-derived name.
+  }
+  if (projectPath) {
+    // Parse errors surface: a corrupt pbxproj must not silently fall back to a
+    // name that may match no target.
+    const pbxProject = IOSConfig.XcodeUtils.getPbxproj(projectRoot);
+    const nativeTargets = pbxProject.hash.project.objects.PBXNativeTarget ?? {};
+    const applicationTargetNames = pbxProject
+      .getFirstProject()
+      .firstProject.targets.map((target: { value: string }) => {
+        const nativeTarget = nativeTargets[target.value] as
+          | { productType?: string; name?: string }
+          | undefined;
+        return typeof nativeTarget?.productType === 'string' &&
+          unquote(nativeTarget.productType) === APPLICATION_PRODUCT_TYPE
+          ? unquote(String(nativeTarget.name))
+          : null;
+      })
+      .filter((name): name is string => name !== null);
+    if (applicationTargetNames.length) {
+      // When several application targets exist (e.g. a paired watchOS app),
+      // prefer the one named after the source folder.
+      return (
+        applicationTargetNames.find((name) => name === fallbackName) ?? applicationTargetNames[0]!
+      );
+    }
+  }
+  if (!fallbackName) {
+    throw new Error(
+      'Inline modules could not resolve the main Xcode target to write into Podfile.properties.json. ' +
+        'Set `expo.experiments.inlineModules.xcodeProjectTargets` in your app config to name the targets explicitly.'
+    );
+  }
+  return fallbackName;
 }
 
 export const withInlineModules = (config: ExpoConfig, props: any) => {
@@ -50,9 +88,21 @@ export const withInlineModules = (config: ExpoConfig, props: any) => {
       {
         propName: 'expo.inlineModules.xcodeProjectTargets',
         propValueGetter: (conf) => {
+          if (!conf.experiments?.inlineModules) {
+            // Skip the pbxproj parse in `resolveMainTargetName` for projects
+            // that don't use inline modules.
+            return JSON.stringify({ targets: [] });
+          }
           const xcodeProjectTargets = conf.experiments?.inlineModules?.xcodeProjectTargets;
           if (!xcodeProjectTargets) {
-            return JSON.stringify({ mainTarget: getMainTargetName(config), targets: [] });
+            const modRequest = (conf as ExportedConfigWithProps).modRequest;
+            return JSON.stringify({
+              mainTarget: resolveMainTargetName(
+                modRequest?.projectRoot ?? '',
+                modRequest?.projectName
+              ),
+              targets: [],
+            });
           }
           return JSON.stringify({ targets: xcodeProjectTargets });
         },

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Derive project names from the app name the same way as `@expo/config-plugins`: normalize accented and compatibility characters ('Árbók' now becomes 'Arbok', not 'rbk'; 'ﬁre' becomes 'fire'), transliterate letters that normalization cannot decompose ('Bjørn' becomes 'Bjorn'), and fall back to 'app'. Derive sanitized identifiers from the raw app name in XML and plist files too, and escape display names for Android resources and plists. ([#49143](https://github.com/expo/expo/pull/49143) by [@vonovak](https://github.com/vonovak))
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Print the "make sure you have modules installed" warning when the dependency install fails ([#48929](https://github.com/expo/expo/issues/48929)) ([#48946](https://github.com/expo/expo/pull/48946) by [@expo-bot](https://github.com/expo-bot))
 - [Internal] Fix sporadic `ncc` build failures ([#49615](https://github.com/expo/expo/pull/49615) by [@kitten](https://github.com/kitten))

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -66,6 +66,7 @@
     "picomatch": "^2.3.2",
     "prompts": "^2.4.2",
     "resolve-workspace-root": "^2.0.0",
+    "slugify": "^1.6.8",
     "update-check": "^1.5.4"
   },
   "engines": {

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -168,12 +168,42 @@ export async function extractAndPrepareTemplateAppAsync(
   return projectRoot;
 }
 
+// Android resource XML (strings.xml): aapt2 resolves XML entities before its
+// own escape rules, so only &, <, > take entities; the rest (quotes, @, ?,
+// whitespace) needs Android's backslash escapes. The backslash escaping is a
+// copy of `XML.escapeAndroidString` from `@expo/config-plugins`, which this
+// package does not depend on.
+function escapeAndroidResourceValue(original: string): string {
+  const noAmps = original.replace(/&/g, '&amp;');
+  const noLt = noAmps.replace(/</g, '&lt;');
+  const noGt = noLt.replace(/>/g, '&gt;');
+  const escaped = noGt.replace(/[\n\r\t'"@?\\]/g, (m) => {
+    switch (m) {
+      case '"':
+      case "'":
+      case '@':
+      case '?':
+      case '\\':
+        return '\\' + m;
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '\t':
+        return '\\t';
+      default:
+        throw new Error(`Cannot escape unhandled XML character: ${m}`);
+    }
+  });
+  return escaped.match(/(^\s|\s$)/) ? `"${escaped}"` : escaped;
+}
+
 function escapeXMLCharacters(original: string): string {
-  const noAmps = original.replace('&', '&amp;');
-  const noLt = noAmps.replace('<', '&lt;');
-  const noGt = noLt.replace('>', '&gt;');
-  const noApos = noGt.replace('"', '\\"');
-  return noApos.replace("'", "\\'");
+  const noAmps = original.replace(/&/g, '&amp;');
+  const noLt = noAmps.replace(/</g, '&lt;');
+  const noGt = noLt.replace(/>/g, '&gt;');
+  const noQuots = noGt.replace(/"/g, '&quot;');
+  return noQuots.replace(/'/g, '&apos;');
 }
 
 /**
@@ -307,15 +337,25 @@ export async function renameTemplateAppNameAsync({
 
       debug(`Renaming app name in file: ${absoluteFilePath}`);
 
-      const safeName = ['.xml', '.plist'].includes(path.extname(file))
-        ? escapeXMLCharacters(name)
-        : name;
+      const extension = path.extname(file);
+      // Escaping applies only to the display name; the sanitized project
+      // identifiers derive from the raw name so they match across all files.
+      // `.xml` files in the rename config are Android resources; `.plist` is
+      // generic XML.
+      // This is the final output here: unlike `expo prebuild`, `create-expo`
+      // runs no config mods that would rewrite `app_name` afterwards.
+      const safeName =
+        extension === '.xml'
+          ? escapeAndroidResourceValue(name)
+          : extension === '.plist'
+            ? escapeXMLCharacters(name)
+            : name;
 
       try {
         const replacement = contents
-          .replace(/Hello App Display Name/g, safeName)
-          .replace(/HelloWorld/g, sanitizedName(safeName))
-          .replace(/helloworld/g, sanitizedName(safeName.toLowerCase()));
+          .replace(/Hello App Display Name/g, () => safeName)
+          .replace(/HelloWorld/g, sanitizedName(name))
+          .replace(/helloworld/g, sanitizedName(name).toLowerCase());
 
         if (replacement === contents) {
           return;

--- a/packages/create-expo/src/__tests__/Template.test.ts
+++ b/packages/create-expo/src/__tests__/Template.test.ts
@@ -274,13 +274,49 @@ describe('renameTemplateAppNameAsync', () => {
       expect(spyWriteFile).toHaveBeenCalledTimes(1);
     });
 
-    // Whether the expected behaviour is a bug or not is up for discussion. This
-    // test is partially for the purpose of characterising the current behaviour.
-    //
-    // To be precise, this quirk originally existed only in Expo CLI (because XML
-    // escaping was only performed there), but now Create Expo has been made
-    // consistent with that behaviour as well.
-    it('sanitizes XML-unsafe characters in XML and Plist files when renaming', async () => {
+    it('derives the lowercase identifier from the sanitized name, matching path renames', async () => {
+      // Lowercasing happens after sanitizing ('Ǉubljana' -> 'LJubljana' ->
+      // 'ljubljana'), like in file-path renames.
+      jest.spyOn(fs.promises, 'readFile').mockImplementation(async () => 'package com.helloworld;');
+      let written = '';
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation(async (_filePath, data) => {
+        written = data as string;
+      });
+
+      await renameTemplateAppNameAsync({ cwd, files: ['Main.kt'], name: 'Ǉubljana' });
+      expect(written).toBe('package com.ljubljana;');
+    });
+
+    it.each([
+      // XML-unsafe characters use entities in generic XML/plist files; Android
+      // resource files (.xml) use backslash escapes for quotes
+      ['A & B & C', 'strings.xml', '<string>A &amp; B &amp; C</string>'],
+      ["Bob's App", 'strings.xml', "<string>Bob\\'s App</string>"],
+      ['A "B" C', 'strings.xml', '<string>A \\"B\\" C</string>'],
+      ['@string/foo', 'strings.xml', '<string>\\@string/foo</string>'],
+      ['?attr', 'strings.xml', '<string>\\?attr</string>'],
+      ['C:\\Temp', 'strings.xml', '<string>C:\\\\Temp</string>'],
+      [' Padded ', 'strings.xml', '<string>" Padded "</string>'],
+      ["Bob's App", 'app.plist', '<string>Bob&apos;s App</string>'],
+      ['A "B" C', 'app.plist', '<string>A &quot;B&quot; C</string>'],
+      // replacement patterns in the name are inserted literally, not expanded
+      ['Cost $& Fees', 'app.json', '<string>Cost $& Fees</string>'],
+    ])('renders the display name %j in %s as %j', async (name, file, expected) => {
+      jest
+        .spyOn(fs.promises, 'readFile')
+        .mockImplementation(async () => '<string>Hello App Display Name</string>');
+      let written = '';
+      jest.spyOn(fs.promises, 'writeFile').mockImplementation(async (_filePath, data) => {
+        written = data as string;
+      });
+
+      await renameTemplateAppNameAsync({ cwd, files: [file], name });
+      expect(written).toBe(expected);
+    });
+
+    // XML escaping applies only to the display name; the sanitized project
+    // identifiers derive from the raw name so they match across all files.
+    it('derives the same sanitized identifier in XML and non-XML files', async () => {
       // There is probably a more Jesty way to spy this, but I am tired
       const filesRead: string[] = [];
       const filesWritten: string[] = [];
@@ -295,15 +331,8 @@ describe('renameTemplateAppNameAsync', () => {
       const spyWriteFile = jest
         .spyOn(fs.promises, 'writeFile')
         .mockImplementation(async (filePath, data) => {
-          if (['.plist', '.xml'].includes(path.extname(filePath as string))) {
-            // XML escaping followed by sanitization:
-            // Bye<World -> Bye&lt;World -> ByeltWorld
-            expect(data).toMatch('ByeltWorld');
-          } else {
-            // Sanitization:
-            // Bye<World -> ByeWorld
-            expect(data).toMatch('ByeWorld');
-          }
+          // Sanitization: Bye<World -> ByeWorld
+          expect(data).toMatch('ByeWorld');
 
           filesWritten.push(filePath as string);
         });

--- a/packages/create-expo/src/__tests__/createFileTransformer.test.ts
+++ b/packages/create-expo/src/__tests__/createFileTransformer.test.ts
@@ -1,9 +1,55 @@
 import { TarTypeFlag } from 'multitars';
 
-import { createEntryRenamer, createGlobFilter } from '../createFileTransform';
+import { createEntryRenamer, createGlobFilter, sanitizedName } from '../createFileTransform';
+
+describe(sanitizedName, () => {
+  // The same table as in `@expo/config-plugins` (ios/utils/__tests__/Xcodeproj-test.ts):
+  // the two implementations must stay in sync.
+  it.each([
+    // plain names pass through
+    ['bacon', 'bacon'],
+    // diacritics decompose via NFKD and keep their base letters
+    ['Árbók', 'Arbok'],
+    ['Pěkná applikačka', 'Peknaapplikacka'],
+    // letters that slugify has no charmap entry for survive via NFKD
+    ['Ċittadin', 'Cittadin'],
+    ['Ǻpp', 'App'],
+    // compatibility letters and numbers decompose via NFKD
+    ['Ǉubljana', 'LJubljana'],
+    ['ﬁre', 'fire'],
+    ['Ｅｘｐｏ', 'Expo'],
+    ['x² app', 'x2app'],
+    // letters that NFKD cannot decompose are transliterated by slugify
+    ['Æøå', 'AEoa'],
+    ['Łódź', 'Lodz'],
+    ['Straße', 'Strasse'],
+    ['Привет', 'Privet'],
+    // symbols are stripped, not transliterated
+    ['A & B', 'AB'],
+    ['Expo®', 'Expo'],
+    ['Priçe €10', 'Price10'],
+    ['h"&<world/>🚀', 'hworld'],
+    // symbol-only names fall back to a slugify of the full name
+    ['♥', 'love'],
+    // nothing usable remains
+    ['あいう', 'app'],
+  ])(`sanitizes %j to %j`, (name, expected) => {
+    expect(sanitizedName(name)).toBe(expected);
+  });
+});
 
 describe(createEntryRenamer, () => {
   const rename = createEntryRenamer('');
+
+  it(`lowercases android paths after sanitizing, matching content renames`, () => {
+    const renameApp = createEntryRenamer('Ǉubljana');
+    expect(renameApp('android/app/src/main/java/com/HelloWorld/x.kt', TarTypeFlag.FILE)).toEqual(
+      'android/app/src/main/java/com/ljubljana/x.kt'
+    );
+    expect(renameApp('android/app/src/main/java/com/helloworld/x.kt', TarTypeFlag.FILE)).toEqual(
+      'android/app/src/main/java/com/ljubljana/x.kt'
+    );
+  });
 
   it(`renames _vscode to .vscode`, () => {
     expect(rename('package/_vscode/', TarTypeFlag.FILE)).toEqual('package/.vscode/');

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -1,14 +1,36 @@
 import { TarTypeFlag } from 'multitars';
 import path from 'path';
 import picomatch from 'picomatch';
+import slugify from 'slugify';
 
 const debug = require('debug')('expo:init:fileTransform') as typeof console.log;
 
+// Keep in sync with `sanitizedName` in `@expo/config-plugins` (src/ios/utils/Xcodeproj.ts)
+// so create-expo and prebuild derive the same project name.
+// Symbols are dropped so 'A & B' stays 'AB' and 'Expo®' stays 'Expo'. Diacritics
+// are stripped via NFKD before slugify, because slugify deletes letters absent from
+// its charmap ('Ċ' would vanish instead of becoming 'C'). NFKD also decomposes
+// compatibility letters and numbers ('ﬁ' becomes 'fi', 'Ǉ' becomes 'LJ', fullwidth
+// 'Ｅ' becomes 'E'); symbols like '™' are already dropped, so they do not turn into
+// letters. slugify then transliterates letters that NFKD cannot decompose
+// (ø, æ, ł, ß). Symbol-only names fall back to a slugify of the full name
+// ('♥' becomes 'love').
 export function sanitizedName(name: string) {
-  return name
-    .replace(/[\W_]+/g, '')
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '');
+  const lettersAndNumbers = name
+    .replace(/[^\p{L}\p{N}]+/gu, '')
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '');
+  return (
+    sanitizedNameForProjects(slugify(lettersAndNumbers)) ||
+    sanitizedNameForProjects(slugify(name)) ||
+    'app'
+  );
+}
+
+// Normalize before stripping so diacritics decompose into combining marks that `\W` removes,
+// keeping the base letters ("\u00c1rb\u00f3k" -> "Arbok", not "rbk").
+function sanitizedNameForProjects(name: string) {
+  return name.normalize('NFKD').replace(/[\W_]+/g, '');
 }
 
 // Directories that can be added to the template with an underscore instead of a dot, e.g. `.vscode` and be added with `_vscode`.
@@ -39,11 +61,12 @@ function renameConfigs(input: string, typeflag: TarTypeFlag): string {
 export function createEntryRenamer(name: string) {
   return (input: string, typeflag: TarTypeFlag): string => {
     if (name) {
-      // Rewrite paths for bare workflow
+      // Rewrite paths for bare workflow. Lowercase after sanitizing so the result
+      // always matches content renames (slugify's charmap is case-asymmetric).
       input = input
         .replace(
           /HelloWorld/g,
-          input.includes('android') ? sanitizedName(name.toLowerCase()) : sanitizedName(name)
+          input.includes('android') ? sanitizedName(name).toLowerCase() : sanitizedName(name)
         )
         .replace(/helloworld/g, sanitizedName(name).toLowerCase());
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3513,6 +3513,9 @@ importers:
       resolve-workspace-root:
         specifier: ^2.0.0
         version: 2.0.1
+      slugify:
+        specifier: ^1.6.8
+        version: 1.6.8
       update-check:
         specifier: ^1.5.4
         version: 1.5.4


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)