### PR TITLE
[cli] Invalidate transforms when Expo config changes

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Invalidate Metro transforms when the Expo config embedded in client bundles changes.
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.
 - Show the Xcode build log path when `run:ios` fails. ([#48624](https://github.com/expo/expo/pull/48624) by [@ramonclaudio](https://github.com/ramonclaudio))

--- a/packages/@expo/cli/src/export/exportDomComponents.ts
+++ b/packages/@expo/cli/src/export/exportDomComponents.ts
@@ -56,7 +56,7 @@ export async function exportDomComponentAsync({
   const relativeImport =
     './' + toPosixPath(path.relative(path.dirname(virtualEntry), generatedEntryPath));
   // Run metro bundler and create the JS bundles/source maps.
-  const bundle = await devServer.legacySinglePageExportBundleAsync({
+  const bundle = await devServer.legacySinglePageExportBundleAsync(exp, {
     platform: 'web',
     domRoot: encodeURI(relativeImport),
     splitChunks: !env.EXPO_NO_BUNDLE_SPLITTING,

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -67,6 +67,7 @@ import {
   createBundleOsPath,
   getAsyncRoutesFromExpoConfig,
   getBaseUrlFromExpoConfig,
+  getExpoConfigHash,
   getMetroDirectBundleOptions,
 } from '../middleware/metroOptions';
 import { prependMiddleware } from '../middleware/mutations';
@@ -986,7 +987,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       return this.singlePageReactServerComponentExportAsync(exp, options, files, extraOptions);
     }
 
-    return this.legacySinglePageExportBundleAsync(options, extraOptions);
+    return this.legacySinglePageExportBundleAsync(exp, options, extraOptions);
   }
 
   private async singlePageReactServerComponentExportAsync(
@@ -1044,6 +1045,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
 
       // Run metro bundler and create the JS bundles/source maps.
       const bundle = await this.legacySinglePageExportBundleAsync(
+        exp,
         {
           ...options,
           clientBoundaries,
@@ -1170,6 +1172,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
   }
 
   async legacySinglePageExportBundleAsync(
+    exp: ExpoConfig,
     options: Omit<
       ExpoMetroOptions,
       'routerRoot' | 'asyncRoutes' | 'isExporting' | 'serializerOutput' | 'environment' | 'hosted'
@@ -1194,6 +1197,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       ...options,
       environment: 'client',
       serializerOutput: 'static',
+      expoConfigHash: getExpoConfigHash(exp),
     };
 
     // https://github.com/facebook/metro/blob/2405f2f6c37a1b641cc379b9c733b1eff0c1c2a1/packages/metro/src/lib/parseOptionsFromUrl.js#L55-L87

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/metroOptions.test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/metroOptions.test.ts
@@ -1,6 +1,10 @@
 import { env } from 'node:process';
 
-import { createBundleUrlPath, getMetroDirectBundleOptions } from '../metroOptions';
+import {
+  createBundleUrlPath,
+  getMetroDirectBundleOptions,
+  getMetroDirectBundleOptionsForExpoConfig,
+} from '../metroOptions';
 
 describe(getMetroDirectBundleOptions, () => {
   it(`asserts unsupported options: using bytecode on web`, () => {
@@ -100,6 +104,32 @@ describe(getMetroDirectBundleOptions, () => {
         'false'
       );
     });
+  });
+});
+describe(getMetroDirectBundleOptionsForExpoConfig, () => {
+  it('changes transform cache options when the public Expo config changes', () => {
+    const options = {
+      mainModuleName: '/index.js',
+      mode: 'production' as const,
+      platform: 'web',
+      isExporting: true,
+    };
+
+    const first = getMetroDirectBundleOptionsForExpoConfig(
+      '/app',
+      { name: 'app', slug: 'app', extra: { API_BASE_URL: 'http://localhost:3000' } },
+      options
+    );
+    const second = getMetroDirectBundleOptionsForExpoConfig(
+      '/app',
+      { name: 'app', slug: 'app', extra: { API_BASE_URL: 'https://api.example.com' } },
+      options
+    );
+
+    expect(first.customTransformOptions?.expoConfigHash).toEqual(expect.any(String));
+    expect(first.customTransformOptions?.expoConfigHash).not.toBe(
+      second.customTransformOptions?.expoConfigHash
+    );
   });
 });
 describe(createBundleUrlPath, () => {

--- a/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
+++ b/packages/@expo/cli/src/start/server/middleware/metroOptions.ts
@@ -1,6 +1,7 @@
 import type { ExpoConfig } from '@expo/config';
 import Server from '@expo/metro/metro/Server';
 import type { BundleOptions as MetroBundleOptions } from '@expo/metro/metro/shared/types';
+import crypto from 'crypto';
 
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
@@ -62,6 +63,8 @@ export type ExpoMetroOptions = {
   liveBindings?: boolean;
   /** When true, indicates this bundle should contain only the loader export. */
   isLoaderBundle?: boolean;
+  /** Hash of the Expo config embedded in client bundles. */
+  expoConfigHash?: string;
 };
 
 // See: @expo/metro-config/src/serializer/fork/baseJSBundle.ts `ExpoSerializerOptions`
@@ -150,7 +153,12 @@ export function getMetroDirectBundleOptionsForExpoConfig(
     baseUrl: getBaseUrlFromExpoConfig(exp),
     routerRoot: getRouterDirectoryModuleIdWithManifest(projectRoot, exp),
     asyncRoutes: getAsyncRoutesFromExpoConfig(exp, options.mode, options.platform),
+    expoConfigHash: getExpoConfigHash(exp),
   });
+}
+
+export function getExpoConfigHash(exp: ExpoConfig): string {
+  return crypto.createHash('sha1').update(JSON.stringify(exp)).digest('hex');
 }
 
 export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
@@ -184,6 +192,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     liveBindings,
     isLoaderBundle,
     excludeSource,
+    expoConfigHash,
   } = withDefaults(options);
 
   const dev = mode !== 'production';
@@ -226,6 +235,7 @@ export function getMetroDirectBundleOptions(options: ExpoMetroOptions) {
     useMd5Filename: useMd5Filename || undefined,
     liveBindings: !liveBindings ? toBoolStr(!!liveBindings) : undefined,
     isLoaderBundle: isLoaderBundle ? toBoolStr(isLoaderBundle) : undefined,
+    expoConfigHash,
   };
 
   // Iterate and delete undefined values


### PR DESCRIPTION
## Summary

`expo export` previously reused Metro transforms containing the Expo config from an earlier invocation. Dynamic config changes therefore reached `expo config` but not the exported client bundle unless users passed `--clear`.

This adds a SHA-1 fingerprint of the public Expo config to Metro `customTransformOptions` for legacy client bundles. Metro can keep its normal cache, while transforms that inline `APP_MANIFEST` are separated whenever the config changes. The same fingerprint is applied to SPA/native exports, RSC client-boundary bundles, and DOM component bundles.

Closes #39619.

## Test Plan

- Added a focused regression that creates two public Expo configs with different `extra.API_BASE_URL` values.
  - RED: both bundle option sets had no config cache discriminator.
  - GREEN: both contain string fingerprints and the fingerprints differ.
- `pnpm test -- src/start/server/middleware/__tests__/metroOptions.test.ts --runInBand` — 11/11 pass.
- `pnpm lint` in `packages/@expo/cli` — pass.
- `pnpm format --check` in `packages/@expo/cli` — pass across 831 files.
- `git diff --check` — pass.

I used a sparse checkout limited to `.github`, `packages/@expo/*`, and the direct CLI workspace dependencies to avoid downloading/building the full Expo monorepo. Full package typecheck/build could not complete because workspace build outputs outside that sparse checkout were absent (for example `@expo/metro-config/build`, `@expo/router-server/build`, and Expo Router native dependencies). The focused regression, lint, and format gates above are green; CI should run the complete workspace graph.