### PR TITLE
fix(env): Keep internal config mode blocked

### DIFF
--- a/packages/@expo/env/CHANGELOG.md
+++ b/packages/@expo/env/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Block dotenv files from setting `__EXPO_CONFIG_MODE` through `EXPO_UNSAFE_DOTENV_KEYS`. ([#49417](https://github.com/expo/expo/pull/49417) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Set `NODE_ENV` when `loadProjectEnv` receives a development or production mode. ([#48554](https://github.com/expo/expo/pull/48554) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others

--- a/packages/@expo/env/src/__tests__/index.test.ts
+++ b/packages/@expo/env/src/__tests__/index.test.ts
@@ -527,6 +527,27 @@ describe(getOriginalEnv, () => {
     expect(getOriginalEnv(inheritedEnv)).toEqual({ PRE_EXISTING: 'original' });
   });
 
+  it('keeps inherited dotenv values listed in EXPO_UNSAFE_DOTENV_KEYS', () => {
+    const prev = process.env.EXPO_UNSAFE_DOTENV_KEYS;
+    process.env.EXPO_UNSAFE_DOTENV_KEYS = 'DOTENV_VALUE';
+    try {
+      jest.isolateModules(() => {
+        const mod = require('../');
+        const inheritedEnv = {
+          DOTENV_VALUE: 'from-parent-dotenv',
+          [LOADED_ENV_NAME]: JSON.stringify(['DOTENV_VALUE']),
+        };
+
+        expect(mod.getOriginalEnv(inheritedEnv)).toEqual({
+          DOTENV_VALUE: 'from-parent-dotenv',
+        });
+      });
+    } finally {
+      if (prev === undefined) delete process.env.EXPO_UNSAFE_DOTENV_KEYS;
+      else process.env.EXPO_UNSAFE_DOTENV_KEYS = prev;
+    }
+  });
+
   it('removes inherited dotenv values after a forced local load', () => {
     const inheritedEnv = {
       FOO: 'from-parent-dotenv',
@@ -817,6 +838,22 @@ describe('isLocalEnvKey policy', () => {
     vol.fromJSON({ '.env': '__EXPO_CONFIG_MODE=production' }, '/');
 
     expect(() => parseProjectEnv('/', { systemEnv: {} })).toThrow(/__EXPO_CONFIG_MODE/);
+  });
+
+  it('keeps __EXPO_CONFIG_MODE blocked when the unsafe list includes it', () => {
+    const prev = process.env.EXPO_UNSAFE_DOTENV_KEYS;
+    process.env.EXPO_UNSAFE_DOTENV_KEYS = '__EXPO_CONFIG_MODE';
+    try {
+      jest.isolateModules(() => {
+        const mod = require('../');
+        vol.fromJSON({ '.env': '__EXPO_CONFIG_MODE=production' }, '/');
+
+        expect(() => mod.parseProjectEnv('/', { systemEnv: {} })).toThrow(/__EXPO_CONFIG_MODE/);
+      });
+    } finally {
+      if (prev === undefined) delete process.env.EXPO_UNSAFE_DOTENV_KEYS;
+      else process.env.EXPO_UNSAFE_DOTENV_KEYS = prev;
+    }
   });
 
   it('combines both violation classes into a single thrown error', () => {

--- a/packages/@expo/env/src/constants.ts
+++ b/packages/@expo/env/src/constants.ts
@@ -6,7 +6,7 @@ const platform = os.platform();
 const safeKeys = new Set(process.env.EXPO_UNSAFE_DOTENV_KEYS?.split(',').filter((x) => !!x));
 
 export function isUnsafeAllowedEnvKey(name: string): boolean {
-  return safeKeys.has(name);
+  return name !== '__EXPO_CONFIG_MODE' && safeKeys.has(name);
 }
 
 export function isIgnoredEnvKey(name: string) {
@@ -14,7 +14,7 @@ export function isIgnoredEnvKey(name: string) {
     return true;
   } else if (platform === 'linux' && name.startsWith('LD_')) {
     return true;
-  } else if (safeKeys.has(name)) {
+  } else if (isUnsafeAllowedEnvKey(name)) {
     return false;
   }
 

--- a/packages/@expo/env/src/index.ts
+++ b/packages/@expo/env/src/index.ts
@@ -245,7 +245,7 @@ function formatViolationFiles(byFile: Record<string, string[]>): string {
 function formatBlockedViolation(byFile: Record<string, string[]>): string {
   return [
     'Refused to load dangerous environment variables from .env files.',
-    'Opt in via EXPO_UNSAFE_DOTENV_KEYS in your shell environment if you truly need them.',
+    'Use EXPO_UNSAFE_DOTENV_KEYS in your shell environment to allow a non-internal key.',
     '',
     formatViolationFiles(byFile),
   ].join('\n');


### PR DESCRIPTION
# Why

While backporting `@expo/env` to SDK 57, I realized that a dotenv file can add `__EXPO_CONFIG_MODE` back through `EXPO_UNSAFE_DOTENV_KEYS` after Expo removes the internal handoff.

# How

Now we check for `__EXPO_CONFIG_MODE` and throw if a dotenv file tries to add it back.

# Test Plan

All tests pass.
