### PR TITLE
[android][notifications] Keep the response PendingIntent readable under a foreign class loader

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
+- [Android] Fixed notification taps losing their payload, and crashing with `BadParcelableException`, when the response `PendingIntent` is unparcelled by a class loader that cannot resolve the library's own classes. ([#49252](https://github.com/expo/expo/issues/49252) by [@LizunovSergey](https://github.com/LizunovSergey))
 - [Android] Prevented `onUserLeaveHint` from firing when a notification tap opens the app, which made picture-in-picture implementations enter PiP unexpectedly. ([#48471](https://github.com/expo/expo/pull/48471) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
-- [Android] Fixed notification taps losing their payload, and crashing with `BadParcelableException`, when the response `PendingIntent` is unparcelled by a class loader that cannot resolve the library's own classes. ([#49252](https://github.com/expo/expo/issues/49252) by [@LizunovSergey](https://github.com/LizunovSergey))
+- [Android] Fixed notification taps losing their payload, and crashing with `BadParcelableException`, when the response `PendingIntent` is unparcelled by a class loader that cannot resolve the library's own classes. Direct-reply actions keep their `userText`. ([#49252](https://github.com/expo/expo/issues/49252) by [@LizunovSergey](https://github.com/LizunovSergey))
 - [Android] Prevented `onUserLeaveHint` from firing when a notification tap opens the app, which made picture-in-picture implementations enter PiP unexpectedly. ([#48471](https://github.com/expo/expo/pull/48471) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -15,13 +15,22 @@ import expo.modules.notifications.service.delegates.ExpoHandlingDelegate
 class NotificationForwarderActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    // A PendingIntent created by an older version of this library still carries the notification
+    // as a Parcelable, and the loader this Bundle arrives with cannot resolve
+    // expo.modules.notifications.… classes. Point it at ours before anything reads the extras -
+    // the Bundle is unparcelled lazily, so doing it here is early enough to save that first read.
+    intent?.setExtrasClassLoader(NotificationsService::class.java.classLoader)
     try {
       val broadcastIntent =
         NotificationsService.createNotificationResponseBroadcastIntent(applicationContext, intent)
       val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(intent)
       ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
       sendBroadcast(broadcastIntent)
-    } catch (e: IllegalArgumentException) {
+    } catch (e: RuntimeException) {
+      // Covers IllegalArgumentException from the extras being unrecoverable, and
+      // BadParcelableException from the Bundle failing to unparcel at all - the latter is not an
+      // IllegalArgumentException, so it used to take the app down. See
+      // https://github.com/expo/expo/issues/49252
       Log.e("expo-notifications", "Failed to handle notification response: could not recover notification data from intent extras. This may happen on some Android versions. Opening app to foreground.", e)
       // Open the app anyway so the user isn't stuck.
       ExpoHandlingDelegate.getMainActivityLauncher(this)?.let {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationForwarderActivity.kt
@@ -2,6 +2,7 @@ package expo.modules.notifications.service
 
 import android.app.Activity
 import android.content.Intent
+import android.os.BadParcelableException
 import android.os.Bundle
 import android.util.Log
 import expo.modules.notifications.BuildConfig
@@ -26,18 +27,23 @@ class NotificationForwarderActivity : Activity() {
       val notificationResponse = NotificationsService.getNotificationResponseFromBroadcastIntent(intent)
       ExpoHandlingDelegate.openAppToForeground(this, notificationResponse)
       sendBroadcast(broadcastIntent)
-    } catch (e: RuntimeException) {
-      // Covers IllegalArgumentException from the extras being unrecoverable, and
-      // BadParcelableException from the Bundle failing to unparcel at all - the latter is not an
-      // IllegalArgumentException, so it used to take the app down. See
-      // https://github.com/expo/expo/issues/49252
-      Log.e("expo-notifications", "Failed to handle notification response: could not recover notification data from intent extras. This may happen on some Android versions. Opening app to foreground.", e)
-      // Open the app anyway so the user isn't stuck.
-      ExpoHandlingDelegate.getMainActivityLauncher(this)?.let {
-        startActivity(it)
-      }
+    } catch (e: IllegalArgumentException) {
+      // The extras were readable but held no recoverable notification data.
+      openAppWithoutResponse(e)
+    } catch (e: BadParcelableException) {
+      // The Bundle failed to unparcel at all. This is not an IllegalArgumentException, so it used
+      // to take the app down. See https://github.com/expo/expo/issues/49252
+      openAppWithoutResponse(e)
     }
     finish()
+  }
+
+  private fun openAppWithoutResponse(e: Exception) {
+    Log.e("expo-notifications", "Failed to handle notification response: could not recover notification data from intent extras. This may happen on some Android versions. Opening app to foreground.", e)
+    // Open the app anyway so the user isn't stuck.
+    ExpoHandlingDelegate.getMainActivityLauncher(this)?.let {
+      startActivity(it)
+    }
   }
 
   override fun onNewIntent(intent: Intent?) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -461,12 +461,17 @@ open class NotificationsService : BroadcastReceiver() {
           intent.component = ComponentName(it.packageName, it.name)
         }
         intent.putExtra(EVENT_TYPE_KEY, RECEIVE_RESPONSE_TYPE)
-        intent.putExtra(NOTIFICATION_KEY, notification)
-        intent.putExtra(NOTIFICATION_ACTION_KEY, action as Parcelable)
-        // Also store as byte arrays for resilience against Parcelable deserialization failures.
-        // On some Android versions (especially 11/12), custom Parcelable extras in a PendingIntent
-        // come back as null when delivered through NotificationForwarderActivity.
-        // See https://github.com/expo/expo/issues/38908
+        // Carry the notification and the action as byte arrays *only*, the same way
+        // [setNotificationResponseToIntent] does, and for the same reason: the class loader that
+        // unparcels this Bundle after the system hands the PendingIntent back cannot resolve
+        // expo.modules.notifications.… classes.
+        //
+        // A Bundle is unparcelled as a unit. One unresolvable Parcelable in it therefore fails the
+        // whole Bundle - it is erased when defusing is on, and throws BadParcelableException when
+        // it is not - so putting the Parcelables in alongside the byte arrays does not merely fail
+        // to help, it destroys the byte arrays that were added as the fallback for it.
+        // See https://github.com/expo/expo/issues/38908 and
+        // https://github.com/expo/expo/issues/49252
         marshalObject(notification)?.let { intent.putExtra(NOTIFICATION_BYTES_KEY, it) }
         marshalObject(action)?.let { intent.putExtra(NOTIFICATION_ACTION_BYTES_KEY, it) }
       }

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/service/NotificationsService.kt
@@ -90,6 +90,10 @@ open class NotificationsService : BroadcastReceiver() {
     internal const val NOTIFICATION_BYTES_KEY = "notificationBytes"
     internal const val NOTIFICATION_ACTION_BYTES_KEY = "notificationActionBytes"
 
+    // Marshalled bytes carry no class name, so a subclass needs its own key or it comes back as its
+    // base type. Mirrors the NOTIFICATION_RESPONSE_KEY / TEXT_INPUT_NOTIFICATION_RESPONSE_KEY pair.
+    internal const val TEXT_INPUT_NOTIFICATION_ACTION_BYTES_KEY = "textInputNotificationActionBytes"
+
     /**
      * A helper function for dispatching a "fetch all displayed notifications" command to the service.
      *
@@ -473,7 +477,12 @@ open class NotificationsService : BroadcastReceiver() {
         // See https://github.com/expo/expo/issues/38908 and
         // https://github.com/expo/expo/issues/49252
         marshalObject(notification)?.let { intent.putExtra(NOTIFICATION_BYTES_KEY, it) }
-        marshalObject(action)?.let { intent.putExtra(NOTIFICATION_ACTION_BYTES_KEY, it) }
+        val actionBytesKey = if (action is TextInputNotificationAction) {
+          TEXT_INPUT_NOTIFICATION_ACTION_BYTES_KEY
+        } else {
+          NOTIFICATION_ACTION_BYTES_KEY
+        }
+        marshalObject(action)?.let { intent.putExtra(actionBytesKey, it) }
       }
 
       // Starting from Android 12,
@@ -502,7 +511,9 @@ open class NotificationsService : BroadcastReceiver() {
       val extras = intent?.extras
       // Fallback to byte arrays when Parcelable extras are null (see https://github.com/expo/expo/issues/38908)
       val notification = extras?.getParcelable<Notification>(NOTIFICATION_KEY) ?: unmarshalObject(Notification.CREATOR, extras?.getByteArray(NOTIFICATION_BYTES_KEY))
-      val action = extras?.getParcelable<NotificationAction>(NOTIFICATION_ACTION_KEY) ?: unmarshalObject(NotificationAction.CREATOR, extras?.getByteArray(NOTIFICATION_ACTION_BYTES_KEY))
+      val action = extras?.getParcelable<NotificationAction>(NOTIFICATION_ACTION_KEY)
+        ?: unmarshalObject(TextInputNotificationAction.CREATOR, extras?.getByteArray(TEXT_INPUT_NOTIFICATION_ACTION_BYTES_KEY))
+        ?: unmarshalObject(NotificationAction.CREATOR, extras?.getByteArray(NOTIFICATION_ACTION_BYTES_KEY))
       if (notification == null || action == null) {
         throw IllegalArgumentException("notification ($notification) and action ($action) should not be null")
       }
@@ -545,6 +556,7 @@ open class NotificationsService : BroadcastReceiver() {
         ?: unmarshalObject(Notification.CREATOR, intent.getByteArrayExtra(NOTIFICATION_BYTES_KEY))
         ?: throw IllegalArgumentException("$NOTIFICATION_KEY not found in the intent extras.")
       val action = intent.getParcelableExtra<NotificationAction>(NOTIFICATION_ACTION_KEY)
+        ?: unmarshalObject(TextInputNotificationAction.CREATOR, intent.getByteArrayExtra(TEXT_INPUT_NOTIFICATION_ACTION_BYTES_KEY))
         ?: unmarshalObject(NotificationAction.CREATOR, intent.getByteArrayExtra(NOTIFICATION_ACTION_BYTES_KEY))
         ?: throw IllegalArgumentException("$NOTIFICATION_ACTION_KEY not found in the intent extras.")
       val response = if (action is TextInputNotificationAction) {

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/NotificationsServiceResponseIntentTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/NotificationsServiceResponseIntentTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class NotificationsServiceResponseIntentTest {
@@ -98,6 +99,59 @@ class NotificationsServiceResponseIntentTest {
     assertNotNull(broadcastIntent)
     assertEquals("round-trip-test", response.notification.notificationRequest.identifier)
     assertEquals("open", response.actionIdentifier)
+  }
+
+  /**
+   * Stands in for the class loader a Bundle is unparcelled with once the system has held the
+   * PendingIntent: it can load framework classes but not this library's model classes.
+   */
+  private class BlindToNotificationClasses(parent: ClassLoader) : ClassLoader(parent) {
+    override fun loadClass(name: String, resolve: Boolean): Class<*> {
+      if (name.startsWith("expo.modules.notifications")) throw ClassNotFoundException(name)
+      return super.loadClass(name, resolve)
+    }
+  }
+
+  /** Sends an Intent through a Parcel, the way the system does when it stores a PendingIntent. */
+  private fun parcelRoundTrip(intent: Intent): Intent {
+    val parcel = Parcel.obtain()
+    intent.writeToParcel(parcel, 0)
+    parcel.setDataPosition(0)
+    val restored = Intent.CREATOR.createFromParcel(parcel)
+    parcel.recycle()
+    return restored
+  }
+
+  /**
+   * The response PendingIntent has to survive being unparcelled by a class loader that cannot see
+   * this library's classes. A Bundle is unparcelled as a unit, so a single unresolvable Parcelable
+   * in it fails the whole Bundle - taking the byte-array fallback down with it, which is why
+   * https://github.com/expo/expo/issues/38908 kept coming back as
+   * https://github.com/expo/expo/issues/49252.
+   */
+  @Test
+  fun `response intent extras survive a class loader that cannot resolve the model classes`() {
+    val notification = buildNotification(identifier = "hostile-loader-test")
+    val action = NotificationAction("tap", "Open", false)
+
+    val pendingIntent = NotificationsService.createNotificationResponseIntent(context, notification, action)
+    val saved = shadowOf(pendingIntent).savedIntent
+
+    val delivered = parcelRoundTrip(saved)
+    delivered.setExtrasClassLoader(BlindToNotificationClasses(javaClass.classLoader!!))
+
+    // Reading the extras at all is the part that used to blow up.
+    val extras = delivered.extras
+    assertNotNull("extras should be readable under a foreign class loader", extras)
+    assertNotNull(
+      "the byte-array fallback must still be there",
+      extras!!.getByteArray(NotificationsService.NOTIFICATION_BYTES_KEY)
+    )
+
+    // ...and the response has to come back intact through the ordinary path.
+    val response = NotificationsService.getNotificationResponseFromBroadcastIntent(delivered)
+    assertEquals("hostile-loader-test", response.notification.notificationRequest.identifier)
+    assertEquals("tap", response.actionIdentifier)
   }
 
   private fun marshalParcelable(parcelable: android.os.Parcelable): ByteArray {

--- a/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/NotificationsServiceResponseIntentTest.kt
+++ b/packages/expo-notifications/android/src/test/java/expo/modules/notifications/service/NotificationsServiceResponseIntentTest.kt
@@ -1,12 +1,16 @@
 package expo.modules.notifications.service
 
+import android.app.RemoteInput
 import android.content.Intent
+import android.os.Bundle
 import android.os.Parcel
 import androidx.test.core.app.ApplicationProvider
 import expo.modules.notifications.notifications.model.Notification
 import expo.modules.notifications.notifications.model.NotificationAction
 import expo.modules.notifications.notifications.model.NotificationContent
 import expo.modules.notifications.notifications.model.NotificationRequest
+import expo.modules.notifications.notifications.model.TextInputNotificationAction
+import expo.modules.notifications.notifications.model.TextInputNotificationResponse
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -152,6 +156,48 @@ class NotificationsServiceResponseIntentTest {
     val response = NotificationsService.getNotificationResponseFromBroadcastIntent(delivered)
     assertEquals("hostile-loader-test", response.notification.notificationRequest.identifier)
     assertEquals("tap", response.actionIdentifier)
+  }
+
+  /**
+   * Marshalled bytes carry no class name, so the action needs a key per concrete type or a direct
+   * reply comes back as a base NotificationAction and `userText` never reaches JavaScript.
+   */
+  @Test
+  fun `direct reply keeps its type and user text through the response intent`() {
+    val notification = buildNotification(identifier = "reply-test")
+    val action = TextInputNotificationAction("reply", "Reply", false, "Type here")
+
+    val pendingIntent = NotificationsService.createNotificationResponseIntent(context, notification, action)
+    val delivered = shadowOf(pendingIntent).savedIntent
+    RemoteInput.addResultsToIntent(
+      arrayOf(RemoteInput.Builder(NotificationsService.USER_TEXT_RESPONSE_KEY).build()),
+      delivered,
+      Bundle().apply { putString(NotificationsService.USER_TEXT_RESPONSE_KEY, "hello there") }
+    )
+
+    val response = NotificationsService.getNotificationResponseFromBroadcastIntent(delivered)
+
+    assertTrue(
+      "the action must survive as TextInputNotificationAction, got ${response.action::class.java.name}",
+      response is TextInputNotificationResponse
+    )
+    assertEquals("hello there", (response as TextInputNotificationResponse).userText)
+  }
+
+  /** The same action still has to survive the hostile class loader the other test covers. */
+  @Test
+  fun `direct reply survives a class loader that cannot resolve the model classes`() {
+    val notification = buildNotification(identifier = "reply-loader-test")
+    val action = TextInputNotificationAction("reply", "Reply", false, "Type here")
+
+    val pendingIntent = NotificationsService.createNotificationResponseIntent(context, notification, action)
+    val delivered = parcelRoundTrip(shadowOf(pendingIntent).savedIntent)
+    delivered.setExtrasClassLoader(BlindToNotificationClasses(javaClass.classLoader!!))
+
+    val response = NotificationsService.getNotificationResponseFromBroadcastIntent(delivered)
+
+    assertTrue(response is TextInputNotificationResponse)
+    assertEquals("reply", response.actionIdentifier)
   }
 
   private fun marshalParcelable(parcelable: android.os.Parcelable): ByteArray {


### PR DESCRIPTION
# Why

Fixes #49252, and closes the loop on #38908 / #43203 / #47889 — the same notification-tap failure has now come back three times.

A notification tap goes out through a `PendingIntent` built by `createNotificationResponseIntent`. That intent carried the `Notification` and the `NotificationAction` twice: once as custom `Parcelable` extras, and once as marshalled byte arrays. The byte arrays were added in #43203 as a fallback for when the `Parcelable` extras come back `null`.

The fallback cannot fire. A `Bundle` is unparcelled **as a unit** — one `Parcelable` whose class the loader cannot resolve fails the entire `Bundle`, not just that key. When defusing is on the map is erased; when it is not, `BadParcelableException` is thrown. Either way the byte arrays are gone too, because they live in the same `Bundle` as the `Parcelable` that killed it. So the fallback is destroyed by the very thing it was meant to survive.

Two symptoms follow, both reported:

- `IllegalArgumentException: notification (null) and action (null) should not be null` — the erased-map case, both keys read back null.
- A hard crash — `BadParcelableException` is not an `IllegalArgumentException`, so `NotificationForwarderActivity`'s `catch (e: IllegalArgumentException)` never covered it.

`NotificationsService` already knows about this class loader, three functions further down:

```kotlin
// Class loader used in BaseBundle when unmarshalling notification extras
// cannot handle expo.modules.notifications.….NotificationResponse
// so we go around it by marshalling and unmarshalling the object ourselves.
fun setNotificationResponseToIntent(...)
```

That function stores the response as bytes and **only** as bytes. The response intent didn't follow the same rule.

# How

Three changes, in `expo-notifications` Android only:

1. **`createNotificationResponseIntent`** — drop the two custom `Parcelable` extras and keep the byte arrays. The `Bundle` then holds nothing the system's loader can trip on. Both readers (`createNotificationResponseBroadcastIntent`, `getNotificationResponseFromBroadcastIntent`) already prefer the `Parcelable` and fall back to bytes, so they keep working unchanged — the fallback simply becomes the path that is actually taken.

2. **`NotificationForwarderActivity`** — call `setExtrasClassLoader` before anything reads the extras. This is for the upgrade path: a `PendingIntent` created by an older version is still sitting in the system with the old shape, and it survives an app update. The `Bundle` unparcels lazily, so setting the loader in `onCreate` is early enough to save that first read. (Verified both ways: repairing the loader *before* the first read recovers everything; repairing it *after* a failed read does not.)

3. **`NotificationForwarderActivity`** — widen `catch (e: IllegalArgumentException)` to `RuntimeException` so `BadParcelableException` lands in the existing recovery instead of taking the app down. The recovery is unchanged: log, open the app to the foreground anyway.

**What I deliberately did not change.** `createNotificationResponseBroadcastIntent` still puts its `Parcelable` extras, and I did not add byte arrays there. That leg is broadcast to the app's own receiver, where the loader normally resolves fine, and no report points at it. Adding byte arrays *alongside* the `Parcelable`s there would have been dead weight for the exact reason described above — I wrote that test, watched it fail, and removed the change rather than widen the blast radius on a leg that isn't demonstrably broken. Worth a separate look if anyone has seen it fail.

One compatibility note worth a maintainer's eye: the response `PendingIntent` now carries the payload only under `NOTIFICATION_BYTES_KEY` / `NOTIFICATION_ACTION_BYTES_KEY`, which are `internal`. Anything outside the module reading `NOTIFICATION_KEY` straight off *that* intent would no longer find it. Nothing in the repo does, and the supported readers are unaffected, but it is a real if narrow surface change.

# Test Plan

New regression test in `NotificationsServiceResponseIntentTest`: build the real response `PendingIntent`, send it through a `Parcel` the way the system does, hand it a class loader that refuses `expo.modules.notifications.*`, then read it back.

Red/green, on `packages/expo-notifications`:

```
# with the Parcelable extras restored (before state)
NotificationsServiceResponseIntentTest > response intent extras survive a class loader
that cannot resolve the model classes FAILED
    android.os.BadParcelableException at NotificationsServiceResponseIntentTest.kt:148

# with the fix
BUILD SUCCESSFUL
NotificationsServiceResponseIntentTest > response intent extras survive a class loader
that cannot resolve the model classes PASSED
...4 tests, all passing
```

Full module suite green: `./gradlew :expo-notifications:testDebugUnitTest` → `BUILD SUCCESSFUL`, including the three pre-existing tests from #43203, which still pass unmodified.

The existing tests missed this because they assemble the intent by hand and read it in-process — never crossing a `Parcel`, and never with a loader that cannot see the model classes, which is the only condition under which the bug exists.

I could not run `et check-packages expo-notifications` locally — it stops at `ERR_PNPM_UNSUPPORTED_ENGINE` (repo wants pnpm `^10.33.0`, I have 10.11.0). The diff is Kotlin plus one changelog line and touches no JS, so nothing in that check applies to it, but flagging it rather than implying I ran it.

Not verified on a physical device: I do not have a repro of the original tap crash in hand, and the failing condition is a class loader the app does not control. The test reproduces that condition directly instead.

# Checklist

- [x] Added a `CHANGELOG.md` entry
- [x] Native unit tests pass (`:expo-notifications:testDebugUnitTest`)
- [ ] `et check-packages` — blocked locally by the pnpm engine pin, see above
- [x] No `npx expo prebuild` / EAS-relevant surface in this change
