### PR TITLE
[location][android] Survive foreground-service eligibility rejection instead of crashing

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Survive the foreground-service eligibility rejection that Android 14+ can raise inside `onServiceConnected` instead of crashing, and retry the foreground service on the next task registration. ([#TBD](https://github.com/expo/expo/pull/TBD) by [@steve-rodri](https://github.com/steve-rodri))
 - [iOS] Add `scope` and `accuracy` under `ios` to the responses from `getBackgroundPermissionsAsync` and `requestBackgroundPermissionsAsync`, matching the `LocationPermissionResponse` type. ([#48926](https://github.com/expo/expo/pull/48926) by [@vonovak](https://github.com/vonovak))
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))

--- a/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/taskConsumers/LocationTaskConsumer.kt
@@ -211,7 +211,26 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
       extras.putString("taskName", task.name)
       extras.putBoolean("killService", serviceOptions.getBoolean("killServiceOnDestroy", false))
       serviceIntent.putExtras(extras)
-      context.startForegroundService(serviceIntent)
+      try {
+        // startService, not startForegroundService: startForegroundService
+        // attaches a promise that the service WILL reach startForeground, and
+        // Android 14+ kills the app with ForegroundServiceDidNotStartInTime-
+        // Exception whenever that promise breaks - including when the
+        // eligibility rejection below makes keeping it impossible, and even
+        // when the service is torn down cleanly. The isForegrounded check
+        // above makes startService legal here, and the startForeground call
+        // in onServiceConnected promotes the service all the same.
+        context.startService(serviceIntent)
+      } catch (e: IllegalStateException) {
+        // BackgroundServiceStartNotAllowedException (API 31+): the app left
+        // the foreground after the check above. Skip binding; the next task
+        // (re)registration retries the foreground service.
+        Log.e(TAG, "Location service start not allowed; skipping the foreground service.", e)
+        return
+      } catch (e: SecurityException) {
+        Log.e(TAG, "Location service start rejected; skipping the foreground service.", e)
+        return
+      }
       context.bindService(
         serviceIntent,
         object : ServiceConnection {
@@ -219,7 +238,13 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
             mService = (service as? ServiceBinder)?.service
             mService?.let {
               it.setParentContext(context)
-              it.startForeground(serviceOptions)
+              try {
+                it.startForeground(serviceOptions)
+              } catch (e: SecurityException) {
+                abortForegroundServiceStart(context, this, e)
+              } catch (e: IllegalStateException) {
+                abortForegroundServiceStart(context, this, e)
+              }
             }
           }
 
@@ -232,12 +257,44 @@ class LocationTaskConsumer(context: Context, taskManagerUtils: TaskManagerUtilsI
       )
     } else {
       // Restart the service with new service options.
-      mService?.startForeground(options.getArguments(FOREGROUND_SERVICE_KEY).toBundle())
+      try {
+        mService?.startForeground(options.getArguments(FOREGROUND_SERVICE_KEY).toBundle())
+      } catch (e: SecurityException) {
+        Log.e(TAG, "Foreground service restart rejected; stopping the service.", e)
+        stopForegroundService()
+      } catch (e: IllegalStateException) {
+        Log.e(TAG, "Foreground service restart rejected; stopping the service.", e)
+        stopForegroundService()
+      }
     }
   }
 
   private fun stopForegroundService() {
     mService?.stop()
+  }
+
+  /**
+   * Android 14+ evaluates foreground-service-type eligibility when
+   * startForeground() runs; this call arrives asynchronously via
+   * onServiceConnected, so the app may have left the eligible state after
+   * the isForegrounded check above passed. Uncaught, the SecurityException
+   * (or ForegroundServiceStartNotAllowedException) is fatal on the main
+   * looper. The service must also be fully torn down, stop + unbind, so the
+   * started-service record is destroyed: stopSelf() alone leaves the
+   * "did not call startForeground" deadline armed while the binding keeps
+   * the service alive, and that deadline kills the app once it backgrounds.
+   * The task stays registered, so the next (re)registration retries the
+   * foreground service start.
+   */
+  private fun abortForegroundServiceStart(context: Context, connection: ServiceConnection, error: Exception) {
+    Log.e(TAG, "Foreground service start rejected; shutting the service down.", error)
+    mService?.stop()
+    mService = null
+    try {
+      context.unbindService(connection)
+    } catch (ignored: IllegalArgumentException) {
+      // The binding may already have been released.
+    }
   }
 
   /**


### PR DESCRIPTION
## Why

Fixes #49424.

`LocationTaskConsumer.maybeStartForegroundService` starts `LocationTaskService` with `startForegroundService` + `bindService`, and only calls `Service.startForeground` later, inside `onServiceConnected`. Android 14+ checks foreground-service-type eligibility at `startForeground` time, so if the app leaves the eligible state during the bind (user backgrounds or locks right after `startLocationUpdatesAsync`), the system throws `SecurityException` on the main looper, after the JS promise has resolved. Nothing can catch it and the process dies. Neither the existing `isForegrounded` check nor a JS-level `AppState` guard can close the race, because both run before the async bind.

## How

Two coordinated changes in `LocationTaskConsumer`, both verified on an Android 16 (targetSDK 36) emulator:

1. `context.startService(serviceIntent)` instead of `context.startForegroundService(serviceIntent)`. The `startForegroundService` promise (the service MUST reach `startForeground`) cannot be kept when Android rejects the foreground start for eligibility, and any way of breaking it, including tearing the service down cleanly, kills the app with `ForegroundServiceDidNotStartInTimeException` (both verified). The `isForegrounded` check directly above makes `startService` legal at that point, no promise is armed, and the `startForeground` call in `onServiceConnected` promotes the service to a fully-typed location FGS exactly as before. If the app leaves the foreground before the call, `startService` throws a synchronous, catchable `IllegalStateException` instead of scheduling a delayed crash.
2. Catch `SecurityException` / `IllegalStateException` (parent of `ForegroundServiceStartNotAllowedException`, API 31+) around both `startForeground` call sites. On rejection in `onServiceConnected`: log, `stop()` the service, null `mService`, and `unbindService` so the service is destroyed. On rejection in the restart branch: log and stop.

The task stays registered, so tracking degrades gracefully and the next (re)registration while the app is foreground retries the foreground service and recovers.

## Test Plan

On an Android 16 (targetSDK 36) emulator, with a production app that registers a location task with `foregroundService` options, and `LocationTaskService.startForeground` locally instrumented to throw `SecurityException` on its first invocation (simulating the OS rejection at the exact production callsite):

- Without this change: the first attempt kills the app (in production as the uncatchable `SecurityException`; with intermediate catch-only variants as `ForegroundServiceDidNotStartInTimeException`).
- With this change: the rejection is caught and logged, the service record is destroyed, and the process survives the catch, 15s in foreground, and 90s in background with zero FATALs/ANRs. On the next app resume the task re-registers and the foreground service comes up (`isForeground=true`, `foregroundServiceType` location, notification shown).
- Happy path unchanged: with no simulated rejection, starting tracking brings the FGS up on the first attempt via `startService` + `startForeground` (`types=0x00000008`), and it survives background/foreground cycles.
- Real-timing repro attempts (start tracking + immediately background/lock at several delays): no crash.

## Checklist

- CHANGELOG entry added under expo-location "Unpublished > Bug fixes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
