### PR TITLE
[calendar][android] Expose extended properties on events

### DIFF
--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -151,11 +151,13 @@ const styles = StyleSheet.create({
 });
 ```
 
-## Storing your own metadata on an event
+## Storing your app's metadata with extended properties
 
-An event has no free-form field your app can write to on Android. To recognize the events your app created, and avoid deleting anyone else's, attach an extended property to them:
+On Android, an event has no field reserved for your app's own data. To recognize the events your app created, and avoid deleting anyone else's, attach an extended property to them:
 
 ```ts
+const [calendar] = await Calendar.getCalendars(Calendar.EntityTypes.EVENT);
+
 const event = await calendar.createEvent({
   title: 'Team sync',
   startDate: new Date(),
@@ -168,12 +170,12 @@ const properties = await event.getExtendedProperties();
 // [{ name: 'private:my-app-id', value: 'a4f1c2' }]
 ```
 
-These methods are backed by `CalendarContract.ExtendedProperties`, which comes with two constraints:
+These methods read and write `CalendarContract.ExtendedProperties`, which comes with two constraints:
 
-- On a calendar owned by an account, the name has to start with `private:`, which keeps the value readable by that account, or `shared:`, which shares it with the guests of the event. The sync adapter drops any other name on the next sync, so `setExtendedProperty` rejects it instead of letting the value disappear later. Calendars of the local account are never synced and accept any name.
-- The event has to belong to a calendar that has an account, since the calendar provider accepts writes to that table only from the sync adapter of that account.
+- On a calendar owned by an account, the name has to start with `private:` or `shared:`. The `private:` prefix keeps the value readable by that account, and the `shared:` prefix shares it with the guests of the event. Some sync adapters, including Google Calendar's, drop any other name on the next sync, so `setExtendedProperty` rejects it instead of letting the value disappear later. Calendars of the local account are never synced and accept any name.
+- `setExtendedProperty` and `deleteExtendedProperty` need the event to belong to a calendar that has an account. The calendar provider accepts writes to that table only from the sync adapter of that account. Reading with `getExtendedProperties` has no account requirement.
 
-> **Note:** Extended properties are Android-only. On iOS, write to the `url` property of the event instead.
+> **info** Extended properties are Android-only. On iOS, write to the `url` property of the event instead.
 
 ## API
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -172,7 +172,7 @@ const properties = await event.getExtendedProperties();
 
 These methods read and write `CalendarContract.ExtendedProperties`, which comes with two constraints:
 
-- On a calendar owned by an account, the name has to start with `private:` or `shared:`. The `private:` prefix keeps the value readable by that account, and the `shared:` prefix shares it with the guests of the event. Some sync adapters, including Google Calendar's, drop any other name on the next sync, so `setExtendedProperty` rejects it instead of letting the value disappear later. Calendars of the local account are never synced and accept any name.
+- On a calendar owned by a Google account, the name has to start with `private:` or `shared:`. The `private:` prefix keeps the value readable by that account, and the `shared:` prefix shares it with the guests of the event. Google Calendar's sync adapter drops any other name on the next sync, so `setExtendedProperty` rejects it instead of letting the value disappear later. This convention belongs to that adapter rather than to the calendar provider, so calendars of any other account accept any name.
 - `setExtendedProperty` and `deleteExtendedProperty` need the event to belong to a calendar that has an account. The calendar provider accepts writes to that table only from the sync adapter of that account. Reading with `getExtendedProperties` has no account requirement.
 
 > **info** Extended properties are Android-only. On iOS, write to the `url` property of the event instead.

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -151,6 +151,30 @@ const styles = StyleSheet.create({
 });
 ```
 
+## Storing your own metadata on an event
+
+An event has no free-form field your app can write to on Android. To recognize the events your app created, and avoid deleting anyone else's, attach an extended property to them:
+
+```ts
+const event = await calendar.createEvent({
+  title: 'Team sync',
+  startDate: new Date(),
+  endDate: new Date(),
+});
+
+await event.setExtendedProperty('private:my-app-id', 'a4f1c2');
+
+const properties = await event.getExtendedProperties();
+// [{ name: 'private:my-app-id', value: 'a4f1c2' }]
+```
+
+These methods are backed by `CalendarContract.ExtendedProperties`, which comes with two constraints:
+
+- On a calendar owned by an account, the name has to start with `private:`, which keeps the value readable by that account, or `shared:`, which shares it with the guests of the event. The sync adapter drops any other name on the next sync, so `setExtendedProperty` rejects it instead of letting the value disappear later. Calendars of the local account are never synced and accept any name.
+- The event has to belong to a calendar that has an account, since the calendar provider accepts writes to that table only from the sync adapter of that account.
+
+> **Note:** Extended properties are Android-only. On iOS, write to the `url` property of the event instead.
+
 ## API
 
 ```js

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [android] Add `getExtendedProperties()`, `setExtendedProperty()` and `deleteExtendedProperty()` to `ExpoCalendarEvent`, so that apps can recognize the events they created: Android has no `url` field to mark them with, and `CalendarContract.ExtendedProperties` — the mechanism meant for it — was not exposed. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@MoOx](https://github.com/MoOx))
+
 ### 🐛 Bug fixes
 
 - [ios] Fix a crash when reading `calendarId` on an event or reminder whose `EKCalendarItem.calendar` is nil. The property is `null_unspecified` in the EventKit headers, so the bare access was an implicit force-unwrap that trapped the JS thread. ([#48445](https://github.com/expo/expo/pull/48445) by [@cvburgess](https://github.com/cvburgess))

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [android] Add `getExtendedProperties()`, `setExtendedProperty()` and `deleteExtendedProperty()` to `ExpoCalendarEvent`, so that apps can recognize the events they created: Android has no `url` field to mark them with, and `CalendarContract.ExtendedProperties` — the mechanism meant for it — was not exposed. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@MoOx](https://github.com/MoOx))
+- [android] Add `getExtendedProperties()`, `setExtendedProperty()` and `deleteExtendedProperty()` to `ExpoCalendarEvent`, so that apps can recognize the events they created: Android has no `url` field to mark them with, and `CalendarContract.ExtendedProperties` — the mechanism meant for it — was not exposed. ([#49428](https://github.com/expo/expo/pull/49428) by [@MoOx](https://github.com/MoOx))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/CalendarNextModule.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/CalendarNextModule.kt
@@ -11,12 +11,14 @@ import expo.modules.calendar.next.domain.repositories.instance.InstanceRepositor
 import expo.modules.calendar.next.domain.repositories.attendee.AttendeeRepository
 import expo.modules.calendar.next.domain.repositories.reminder.ReminderRepository
 import expo.modules.calendar.next.domain.repositories.calendar.CalendarRepository
+import expo.modules.calendar.next.domain.repositories.extendedproperty.ExtendedPropertyRepository
 import expo.modules.calendar.next.exceptions.CalendarNotFoundException
 import expo.modules.calendar.next.mappers.AttendeeMapper
 import expo.modules.calendar.next.records.AttendeeRecord
 import expo.modules.calendar.next.records.AddEventWithFormOptionsRecord
 import expo.modules.calendar.next.mappers.CalendarMapper
 import expo.modules.calendar.next.mappers.EventMapper
+import expo.modules.calendar.next.mappers.ExtendedPropertyMapper
 import expo.modules.calendar.next.mappers.ReminderMapper
 import expo.modules.calendar.next.records.EventUpdateRecord
 import expo.modules.calendar.next.records.RecurringEventOptions
@@ -50,6 +52,7 @@ class CalendarNextModule : Module() {
   private val eventMapper = EventMapper()
   private val attendeeMapper = AttendeeMapper()
   private val reminderMapper = ReminderMapper()
+  private val extendedPropertyMapper = ExtendedPropertyMapper()
 
   private val calendarRepository by lazy {
     CalendarRepository(context.contentResolver)
@@ -71,6 +74,10 @@ class CalendarNextModule : Module() {
     ReminderRepository(context.contentResolver)
   }
 
+  private val extendedPropertyRepository by lazy {
+    ExtendedPropertyRepository(context.contentResolver)
+  }
+
   private val expoCalendarFactory by lazy {
     ExpoCalendarFactory(
       calendarRepository = calendarRepository,
@@ -89,9 +96,12 @@ class CalendarNextModule : Module() {
       eventRepository = eventRepository,
       instanceRepository = instanceRepository,
       attendeeRepository = attendeeRepository,
+      calendarRepository = calendarRepository,
+      extendedPropertyRepository = extendedPropertyRepository,
       eventMapper = eventMapper,
       attendeeMapper = attendeeMapper,
       reminderMapper = reminderMapper,
+      extendedPropertyMapper = extendedPropertyMapper,
       reminderRepository = reminderRepository
     )
   }
@@ -362,6 +372,21 @@ class CalendarNextModule : Module() {
       AsyncFunction("getAttendees") Coroutine { expoCalendarEvent: ExpoCalendarEvent ->
         permissionsDelegate.requireSystemPermissions(false)
         expoCalendarEvent.getAttendees()
+      }
+
+      AsyncFunction("getExtendedProperties") Coroutine { expoCalendarEvent: ExpoCalendarEvent ->
+        permissionsDelegate.requireSystemPermissions(false)
+        expoCalendarEvent.getExtendedProperties()
+      }
+
+      AsyncFunction("setExtendedProperty") Coroutine { expoCalendarEvent: ExpoCalendarEvent, name: String, value: String ->
+        permissionsDelegate.requireSystemPermissions(true)
+        expoCalendarEvent.setExtendedProperty(name, value)
+      }
+
+      AsyncFunction("deleteExtendedProperty") Coroutine { expoCalendarEvent: ExpoCalendarEvent, name: String ->
+        permissionsDelegate.requireSystemPermissions(true)
+        expoCalendarEvent.deleteExtendedProperty(name)
       }
 
       Function("getOccurrenceSync") { expoCalendarEvent: ExpoCalendarEvent, options: RecurringEventOptions? ->

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -161,10 +161,11 @@ class ExpoCalendarEvent(
       return
     }
     throw ExtendedPropertyNameNotSyncSafeException(
-      "Extended property name `$name` has no visibility prefix, and this event belongs to the `${account.type}` account `${account.name}`. " +
-        "The value would be stored on the device and dropped by the sync adapter on the next sync, without an error, " +
-        "because only names prefixed `${ExtendedPropertyName.PRIVATE_PREFIX}` or `${ExtendedPropertyName.SHARED_PREFIX}` survive a server round trip. " +
-        "Use `${ExtendedPropertyName.PRIVATE_PREFIX}$name` to keep the value readable by this account only, " +
+      "Extended property name `$name` has no visibility prefix, and this event belongs to an account of type `${account.type}`. " +
+        "Sync adapters such as Google Calendar's keep only names prefixed `${ExtendedPropertyName.PRIVATE_PREFIX}` or " +
+        "`${ExtendedPropertyName.SHARED_PREFIX}`, and drop the rest on the next sync without reporting an error, " +
+        "so the value would be stored on the device and disappear later. " +
+        "Use `${ExtendedPropertyName.PRIVATE_PREFIX}$name` to keep the value readable by the owning account only, " +
         "or `${ExtendedPropertyName.SHARED_PREFIX}$name` to share it with the guests of the event."
     )
   }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -1,6 +1,5 @@
 package expo.modules.calendar.next
 
-import android.provider.CalendarContract
 import expo.modules.calendar.next.utils.DateTimeInput
 import expo.modules.calendar.next.utils.getTimeInMillis
 import expo.modules.calendar.next.domain.dto.event.EventExceptionInput
@@ -154,16 +153,20 @@ class ExpoCalendarEvent(
   }
 
   /**
-   * Rejects names a sync adapter would drop, on the calendars where one is at work.
+   * Rejects names Google Calendar's sync adapter would drop.
+   *
+   * The prefix convention belongs to that adapter, not to the calendar provider, so it is enforced
+   * on Google accounts only. Another adapter may keep an unprefixed name, and refusing the write
+   * here would deny something that works.
    */
   private fun requireSyncSafeName(name: String, account: CalendarAccount) {
-    if (account.type == CalendarContract.ACCOUNT_TYPE_LOCAL || ExtendedPropertyName.isSyncSafe(name)) {
+    if (!account.isGoogle || ExtendedPropertyName.isSyncSafe(name)) {
       return
     }
     throw ExtendedPropertyNameNotSyncSafeException(
-      "Extended property name `$name` has no visibility prefix, and this event belongs to an account of type `${account.type}`. " +
-        "Sync adapters such as Google Calendar's keep only names prefixed `${ExtendedPropertyName.PRIVATE_PREFIX}` or " +
-        "`${ExtendedPropertyName.SHARED_PREFIX}`, and drop the rest on the next sync without reporting an error, " +
+      "Extended property name `$name` has no visibility prefix, and this event belongs to a Google account. " +
+        "Google Calendar's sync adapter keeps only names prefixed `${ExtendedPropertyName.PRIVATE_PREFIX}` or " +
+        "`${ExtendedPropertyName.SHARED_PREFIX}`, and drops the rest on the next sync without reporting an error, " +
         "so the value would be stored on the device and disappear later. " +
         "Use `${ExtendedPropertyName.PRIVATE_PREFIX}$name` to keep the value readable by the owning account only, " +
         "or `${ExtendedPropertyName.SHARED_PREFIX}$name` to share it with the guests of the event."

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -111,7 +111,7 @@ class ExpoCalendarEvent(
 
   suspend fun getExtendedProperties(): List<ExtendedPropertyRecord> =
     extendedPropertyRepository.findAllByEventId(eventId)
-      .map { extendedPropertyMapper.toRecord(it) }
+      .mapNotNull { extendedPropertyMapper.toRecord(it) }
 
   suspend fun setExtendedProperty(name: String, value: String) {
     val account = requireOwningAccount()

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -1,22 +1,33 @@
 package expo.modules.calendar.next
 
+import android.provider.CalendarContract
 import expo.modules.calendar.next.utils.DateTimeInput
 import expo.modules.calendar.next.utils.getTimeInMillis
 import expo.modules.calendar.next.domain.dto.event.EventExceptionInput
 import kotlin.time.Duration.Companion.milliseconds
+import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyName
 import expo.modules.calendar.next.domain.repositories.attendee.AttendeeRepository
+import expo.modules.calendar.next.domain.repositories.calendar.CalendarRepository
 import expo.modules.calendar.next.domain.repositories.event.EventRepository
+import expo.modules.calendar.next.domain.repositories.extendedproperty.ExtendedPropertyRepository
 import expo.modules.calendar.next.domain.repositories.instance.InstanceRepository
 import expo.modules.calendar.next.domain.repositories.reminder.ReminderRepository
 import expo.modules.calendar.next.domain.wrappers.CalendarId
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.exceptions.AttendeeNotFoundException
+import expo.modules.calendar.next.exceptions.CalendarNotFoundException
+import expo.modules.calendar.next.exceptions.EventNotFoundException
+import expo.modules.calendar.next.exceptions.ExtendedPropertyAccountMissingException
+import expo.modules.calendar.next.exceptions.ExtendedPropertyNameNotSyncSafeException
 import expo.modules.calendar.next.mappers.AttendeeMapper
 import expo.modules.calendar.next.mappers.EventMapper
 import expo.modules.calendar.next.mappers.ExpoCalendarEventMapper
+import expo.modules.calendar.next.mappers.ExtendedPropertyMapper
 import expo.modules.calendar.next.mappers.ReminderMapper
 import expo.modules.calendar.next.records.AttendeeRecord
 import expo.modules.calendar.next.records.EventUpdateRecord
+import expo.modules.calendar.next.records.ExtendedPropertyRecord
 import expo.modules.calendar.next.records.RecurringEventOptions
 import expo.modules.kotlin.sharedobjects.SharedObject
 import kotlinx.coroutines.Dispatchers
@@ -25,10 +36,13 @@ import kotlinx.coroutines.withContext
 class ExpoCalendarEvent(
   private val eventRepository: EventRepository,
   private val attendeeRepository: AttendeeRepository,
+  private val calendarRepository: CalendarRepository,
+  private val extendedPropertyRepository: ExtendedPropertyRepository,
   private val attendeeMapper: AttendeeMapper,
   private val eventMapper: EventMapper,
   private val reminderMapper: ReminderMapper,
   private val expoCalendarEventMapper: ExpoCalendarEventMapper,
+  private val extendedPropertyMapper: ExtendedPropertyMapper,
   private val instanceRepository: InstanceRepository,
   private val reminderRepository: ReminderRepository,
   private var data: ExpoCalendarEventData?,
@@ -96,6 +110,65 @@ class ExpoCalendarEvent(
     }.getOrElse { throw AttendeeNotFoundException("Attendees could not be found", it) }
   }
 
+  suspend fun getExtendedProperties(): List<ExtendedPropertyRecord> =
+    extendedPropertyRepository.findAllByEventId(eventId)
+      .map { extendedPropertyMapper.toRecord(it) }
+
+  suspend fun setExtendedProperty(name: String, value: String) {
+    val account = requireOwningAccount()
+    requireSyncSafeName(name, account)
+    extendedPropertyRepository.upsert(eventId, account, extendedPropertyMapper.toInput(name, value))
+    eventRepository.markDirty(eventId)
+  }
+
+  suspend fun deleteExtendedProperty(name: String): Boolean {
+    val account = requireOwningAccount()
+    val deleted = extendedPropertyRepository.deleteByName(eventId, account, name)
+    if (deleted) {
+      eventRepository.markDirty(eventId)
+    }
+    return deleted
+  }
+
+  /**
+   * Resolves the account owning this event, which every write to the extended properties table has
+   * to name.
+   */
+  private suspend fun requireOwningAccount(): CalendarAccount {
+    val calendarId = eventRepository.findById(eventId)?.calendarId
+      ?: throw EventNotFoundException(
+        "Event ${eventId.value} was not found, so the calendar owning it could not be resolved"
+      )
+    val calendar = calendarRepository.findById(calendarId)
+      ?: throw CalendarNotFoundException("Calendar ${calendarId.value} was not found")
+    val accountName = calendar.accountName
+    val accountType = calendar.accountType
+    if (accountName == null || accountType == null) {
+      throw ExtendedPropertyAccountMissingException(
+        "Extended properties can't be written on this event, because calendar ${calendarId.value} names no account. " +
+          "The calendar provider accepts writes to that table only from the sync adapter of the account owning the event, " +
+          "and the write has to name that account. Use an event of a calendar that has an account instead."
+      )
+    }
+    return CalendarAccount(name = accountName, type = accountType)
+  }
+
+  /**
+   * Rejects names a sync adapter would drop, on the calendars where one is at work.
+   */
+  private fun requireSyncSafeName(name: String, account: CalendarAccount) {
+    if (account.type == CalendarContract.ACCOUNT_TYPE_LOCAL || ExtendedPropertyName.isSyncSafe(name)) {
+      return
+    }
+    throw ExtendedPropertyNameNotSyncSafeException(
+      "Extended property name `$name` has no visibility prefix, and this event belongs to the `${account.type}` account `${account.name}`. " +
+        "The value would be stored on the device and dropped by the sync adapter on the next sync, without an error, " +
+        "because only names prefixed `${ExtendedPropertyName.PRIVATE_PREFIX}` or `${ExtendedPropertyName.SHARED_PREFIX}` survive a server round trip. " +
+        "Use `${ExtendedPropertyName.PRIVATE_PREFIX}$name` to keep the value readable by this account only, " +
+        "or `${ExtendedPropertyName.SHARED_PREFIX}$name` to share it with the guests of the event."
+    )
+  }
+
   fun getOccurrence(options: RecurringEventOptions?): ExpoCalendarEvent {
     if (options?.instanceStartDate == null) {
       return this
@@ -103,10 +176,13 @@ class ExpoCalendarEvent(
     return ExpoCalendarEvent(
       eventRepository = eventRepository,
       attendeeRepository = attendeeRepository,
+      calendarRepository = calendarRepository,
+      extendedPropertyRepository = extendedPropertyRepository,
       attendeeMapper = attendeeMapper,
       eventMapper = eventMapper,
       reminderMapper = reminderMapper,
       expoCalendarEventMapper = expoCalendarEventMapper,
+      extendedPropertyMapper = extendedPropertyMapper,
       instanceRepository = instanceRepository,
       reminderRepository = reminderRepository,
       data = data,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEvent.kt
@@ -117,16 +117,11 @@ class ExpoCalendarEvent(
     val account = requireOwningAccount()
     requireSyncSafeName(name, account)
     extendedPropertyRepository.upsert(eventId, account, extendedPropertyMapper.toInput(name, value))
-    eventRepository.markDirty(eventId)
   }
 
   suspend fun deleteExtendedProperty(name: String): Boolean {
     val account = requireOwningAccount()
-    val deleted = extendedPropertyRepository.deleteByName(eventId, account, name)
-    if (deleted) {
-      eventRepository.markDirty(eventId)
-    }
-    return deleted
+    return extendedPropertyRepository.deleteByName(eventId, account, name)
   }
 
   /**

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEventFactory.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/ExpoCalendarEventFactory.kt
@@ -4,21 +4,27 @@ import expo.modules.calendar.next.domain.model.event.EventEntity
 import expo.modules.calendar.next.domain.model.instance.InstanceEntity
 import expo.modules.calendar.next.domain.model.reminder.ReminderEntity
 import expo.modules.calendar.next.domain.repositories.attendee.AttendeeRepository
+import expo.modules.calendar.next.domain.repositories.calendar.CalendarRepository
 import expo.modules.calendar.next.domain.repositories.event.EventRepository
+import expo.modules.calendar.next.domain.repositories.extendedproperty.ExtendedPropertyRepository
 import expo.modules.calendar.next.domain.repositories.instance.InstanceRepository
 import expo.modules.calendar.next.domain.repositories.reminder.ReminderRepository
 import expo.modules.calendar.next.mappers.AttendeeMapper
 import expo.modules.calendar.next.mappers.EventMapper
 import expo.modules.calendar.next.mappers.ExpoCalendarEventMapper
+import expo.modules.calendar.next.mappers.ExtendedPropertyMapper
 import expo.modules.calendar.next.mappers.ReminderMapper
 
 class ExpoCalendarEventFactory(
   private val eventRepository: EventRepository,
   private val instanceRepository: InstanceRepository,
   private val attendeeRepository: AttendeeRepository,
+  private val calendarRepository: CalendarRepository,
+  private val extendedPropertyRepository: ExtendedPropertyRepository,
   private val eventMapper: EventMapper,
   private val attendeeMapper: AttendeeMapper,
   private val reminderMapper: ReminderMapper,
+  private val extendedPropertyMapper: ExtendedPropertyMapper,
   private val reminderRepository: ReminderRepository
 ) {
   private val expoCalendarEventMapper = ExpoCalendarEventMapper(reminderMapper)
@@ -29,9 +35,12 @@ class ExpoCalendarEventFactory(
   ) = ExpoCalendarEvent(
     eventRepository = eventRepository,
     attendeeRepository = attendeeRepository,
+    calendarRepository = calendarRepository,
+    extendedPropertyRepository = extendedPropertyRepository,
     eventMapper = eventMapper,
     reminderMapper = reminderMapper,
     expoCalendarEventMapper = expoCalendarEventMapper,
+    extendedPropertyMapper = extendedPropertyMapper,
     instanceRepository = instanceRepository,
     attendeeMapper = attendeeMapper,
     reminderRepository = reminderRepository,
@@ -45,9 +54,12 @@ class ExpoCalendarEventFactory(
   ) = ExpoCalendarEvent(
     eventRepository = eventRepository,
     attendeeRepository = attendeeRepository,
+    calendarRepository = calendarRepository,
+    extendedPropertyRepository = extendedPropertyRepository,
     eventMapper = eventMapper,
     reminderMapper = reminderMapper,
     expoCalendarEventMapper = expoCalendarEventMapper,
+    extendedPropertyMapper = extendedPropertyMapper,
     instanceRepository = instanceRepository,
     attendeeMapper = attendeeMapper,
     reminderRepository = reminderRepository,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/extendedproperty/ExtendedPropertyInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/dto/extendedproperty/ExtendedPropertyInput.kt
@@ -1,0 +1,6 @@
+package expo.modules.calendar.next.domain.dto.extendedproperty
+
+data class ExtendedPropertyInput(
+  val name: String,
+  val value: String
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/calendar/CalendarAccount.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/calendar/CalendarAccount.kt
@@ -1,0 +1,12 @@
+package expo.modules.calendar.next.domain.model.calendar
+
+/**
+ * Account a calendar belongs to, as stored in `CalendarContract.Calendars`.
+ *
+ * Writes to the tables that only sync adapters may touch have to name the account they act for,
+ * so this pair travels from the calendar down to those repositories.
+ */
+data class CalendarAccount(
+  val name: String,
+  val type: String
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/calendar/CalendarAccount.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/calendar/CalendarAccount.kt
@@ -9,4 +9,14 @@ package expo.modules.calendar.next.domain.model.calendar
 data class CalendarAccount(
   val name: String,
   val type: String
-)
+) {
+  /**
+   * Whether Google Calendar syncs this account, whose adapter brings naming rules of its own that
+   * the calendar provider does not impose.
+   */
+  val isGoogle get() = type == GOOGLE_TYPE
+
+  companion object {
+    const val GOOGLE_TYPE = "com.google"
+  }
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyEntity.kt
@@ -7,7 +7,10 @@ import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
  * Extended property entity mapped from the Android database cursor.
  *
  * Mapping Assumptions:
- * - [id], [eventId], [name] and [value] are non-nullable columns of `CalendarContract.ExtendedProperties`.
+ * - [id] and [eventId] identify the row and the event it hangs from.
+ * - [name] and [value] are nullable because no database constraint says otherwise. The entity
+ *   holds what the provider handed back, malformed rows included, and the layers above decide
+ *   what to do with them.
  * - [name] is stored verbatim, prefix included, because properties written by other apps
  *   (or by the platform itself) use conventions this module does not control.
  *
@@ -19,6 +22,6 @@ import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
 data class ExtendedPropertyEntity(
   val id: ExtendedPropertyId,
   val eventId: EventId,
-  val name: String,
-  val value: String
+  val name: String?,
+  val value: String?
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyEntity.kt
@@ -1,0 +1,24 @@
+package expo.modules.calendar.next.domain.model.extendedproperty
+
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
+
+/**
+ * Extended property entity mapped from the Android database cursor.
+ *
+ * Mapping Assumptions:
+ * - [id], [eventId], [name] and [value] are non-nullable columns of `CalendarContract.ExtendedProperties`.
+ * - [name] is stored verbatim, prefix included, because properties written by other apps
+ *   (or by the platform itself) use conventions this module does not control.
+ *
+ * Design Note:
+ * Default values are intentionally omitted to ensure compile-time safety.
+ * This forces the mapper to explicitly handle every field and prevents
+ * accidental omissions during cursor reading.
+ */
+data class ExtendedPropertyEntity(
+  val id: ExtendedPropertyId,
+  val eventId: EventId,
+  val name: String,
+  val value: String
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyName.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyName.kt
@@ -1,0 +1,23 @@
+package expo.modules.calendar.next.domain.model.extendedproperty
+
+/**
+ * Naming rules a property has to follow to survive a round trip through a sync adapter.
+ *
+ * Google Calendar's sync adapter maps `private:name` and `shared:name` onto
+ * `extendedProperties.private` and `extendedProperties.shared` in its API, and drops every other
+ * name on the next sync — silently, and only once the write has already been reported as
+ * successful locally. Names on calendars that no account syncs are unaffected.
+ */
+object ExtendedPropertyName {
+  /** Prefix for a property only the owning account can read. */
+  const val PRIVATE_PREFIX = "private:"
+
+  /** Prefix for a property shared with the guests of the event. */
+  const val SHARED_PREFIX = "shared:"
+
+  /**
+   * Whether [name] survives being pushed to a server and downloaded again.
+   */
+  fun isSyncSafe(name: String) =
+    name.startsWith(PRIVATE_PREFIX) || name.startsWith(SHARED_PREFIX)
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyName.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyName.kt
@@ -1,12 +1,14 @@
 package expo.modules.calendar.next.domain.model.extendedproperty
 
 /**
- * Naming rules a property has to follow to survive a round trip through a sync adapter.
+ * Naming rules a property has to follow to survive a round trip through Google Calendar.
  *
- * Google Calendar's sync adapter maps `private:name` and `shared:name` onto
- * `extendedProperties.private` and `extendedProperties.shared` in its API, and drops every other
- * name on the next sync — silently, and only once the write has already been reported as
- * successful locally. Names on calendars that no account syncs are unaffected.
+ * Its sync adapter maps `private:name` and `shared:name` onto `extendedProperties.private` and
+ * `extendedProperties.shared` in the Google Calendar API, and drops every other name on the next
+ * sync — silently, and only once the write has already been reported as successful locally.
+ *
+ * Nothing in the calendar provider imposes this: it is that one adapter's convention. Another
+ * adapter may well keep an unprefixed name, so these rules apply to Google accounts only.
  */
 object ExtendedPropertyName {
   /** Prefix for a property only the owning account can read. */
@@ -16,7 +18,7 @@ object ExtendedPropertyName {
   const val SHARED_PREFIX = "shared:"
 
   /**
-   * Whether [name] survives being pushed to a server and downloaded again.
+   * Whether [name] survives being pushed to Google Calendar and downloaded again.
    */
   fun isSyncSafe(name: String) =
     name.startsWith(PRIVATE_PREFIX) || name.startsWith(SHARED_PREFIX)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/ContentResolverExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/ContentResolverExtensions.kt
@@ -1,9 +1,14 @@
 package expo.modules.calendar.next.domain.repositories
 
 import android.Manifest
+import android.content.ContentProviderOperation
+import android.content.ContentProviderResult
 import android.content.ContentResolver
+import android.content.OperationApplicationException
 import android.database.Cursor
 import android.net.Uri
+import android.os.RemoteException
+import android.provider.CalendarContract
 import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
 import expo.modules.calendar.next.exceptions.PermissionException
 import kotlinx.coroutines.Dispatchers
@@ -58,5 +63,19 @@ suspend fun ContentResolver.safeInsert(
       ?: throw CouldNotExecuteQueryException("Couldn't insert content, returned URI is null")
   } catch (e: SecurityException) {
     throw PermissionException(Manifest.permission.WRITE_CALENDAR, e)
+  }
+}
+
+suspend fun ContentResolver.safeApplyBatch(
+  operations: ArrayList<ContentProviderOperation>
+): Array<ContentProviderResult> = withContext(Dispatchers.IO) {
+  try {
+    applyBatch(CalendarContract.AUTHORITY, operations)
+  } catch (e: SecurityException) {
+    throw PermissionException(Manifest.permission.WRITE_CALENDAR, e)
+  } catch (e: OperationApplicationException) {
+    throw CouldNotExecuteQueryException("Couldn't apply the batch of calendar operations", e)
+  } catch (e: RemoteException) {
+    throw CouldNotExecuteQueryException("Couldn't reach the calendar provider to apply a batch", e)
   }
 }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/SyncAdapterUri.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/SyncAdapterUri.kt
@@ -1,0 +1,22 @@
+package expo.modules.calendar.next.domain.repositories
+
+import android.net.Uri
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
+
+/**
+ * Marks [this] URI as coming from the sync adapter of [account].
+ *
+ * `CalendarProvider2` reserves some tables and columns for sync adapters, and decides who is one
+ * by reading these query parameters — there is no signature check behind them. Reads never need
+ * them; only the writes the provider would otherwise reject.
+ *
+ * Writing through this URI also tells the provider that the row is already in sync with the
+ * server, so the affected event has to be marked dirty afterwards for the change to be pushed.
+ * See [expo.modules.calendar.next.domain.repositories.event.EventRepository.markDirty].
+ */
+internal fun Uri.asSyncAdapter(account: CalendarAccount): Uri = buildUpon()
+  .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+  .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, account.name)
+  .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE, account.type)
+  .build()

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/SyncAdapterUri.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/SyncAdapterUri.kt
@@ -12,8 +12,8 @@ import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
  * them; only the writes the provider would otherwise reject.
  *
  * Writing through this URI also tells the provider that the row is already in sync with the
- * server, so the affected event has to be marked dirty afterwards for the change to be pushed.
- * See [expo.modules.calendar.next.domain.repositories.event.EventRepository.markDirty].
+ * server, so the affected event has to be flagged as dirty for the change to be pushed. See
+ * [expo.modules.calendar.next.domain.repositories.extendedproperty.ExtendedPropertyRepository].
  */
 internal fun Uri.asSyncAdapter(account: CalendarAccount): Uri = buildUpon()
   .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
@@ -9,7 +9,6 @@ import expo.modules.calendar.next.domain.dto.event.EventExceptionInput
 import expo.modules.calendar.next.domain.model.event.EventEntity
 import expo.modules.calendar.next.domain.dto.event.EventInput
 import expo.modules.calendar.next.domain.dto.event.EventUpdate
-import expo.modules.calendar.next.domain.repositories.getOptionalLong
 import expo.modules.calendar.next.domain.repositories.safeDelete
 import expo.modules.calendar.next.domain.repositories.safeInsert
 import expo.modules.calendar.next.domain.repositories.safeQuery
@@ -61,28 +60,17 @@ class EventRepository(private val contentResolver: ContentResolver) {
    * Flags the event as carrying local changes that still have to be pushed.
    *
    * Rows written through a sync adapter URI are recorded as already in sync, so a change made that
-   * way — an extended property, for instance — never leaves the device on its own. Writing any
-   * column back through the plain URI makes `CalendarProvider2` set `dirty`, and the pending change
-   * then travels with the next sync. The start date is the column written back, unchanged, because
-   * it is the one an event is guaranteed to have.
+   * way — an extended property, for instance — never leaves the device on its own. Updating the
+   * event through the plain URI is enough: the provider sets `dirty` itself on any update it did
+   * not attribute to a sync adapter, whatever the values carry, so an empty set flags the event
+   * without touching a single column of it.
    *
    * @return whether the event was found and flagged.
    */
   suspend fun markDirty(id: EventId): Boolean = withContext(Dispatchers.IO) {
-    val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id.value)
-    val dtStart = contentResolver.safeQuery(
-      uri = uri,
-      projection = arrayOf(CalendarContract.Events.DTSTART)
-    ).use { cursor ->
-      cursor.takeIf { it.moveToFirst() }
-        ?.getOptionalLong(CalendarContract.Events.DTSTART)
-    } ?: return@withContext false
-
     contentResolver.safeUpdate(
-      uri = uri,
-      values = ContentValues().apply {
-        put(CalendarContract.Events.DTSTART, dtStart)
-      }
+      uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id.value),
+      values = ContentValues()
     ) > 0
   }
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
@@ -9,6 +9,7 @@ import expo.modules.calendar.next.domain.dto.event.EventExceptionInput
 import expo.modules.calendar.next.domain.model.event.EventEntity
 import expo.modules.calendar.next.domain.dto.event.EventInput
 import expo.modules.calendar.next.domain.dto.event.EventUpdate
+import expo.modules.calendar.next.domain.repositories.getOptionalLong
 import expo.modules.calendar.next.domain.repositories.safeDelete
 import expo.modules.calendar.next.domain.repositories.safeInsert
 import expo.modules.calendar.next.domain.repositories.safeQuery
@@ -53,6 +54,35 @@ class EventRepository(private val contentResolver: ContentResolver) {
   suspend fun remove(id: EventId): Boolean = withContext(Dispatchers.IO) {
     contentResolver.safeDelete(
       uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id.value)
+    ) > 0
+  }
+
+  /**
+   * Flags the event as carrying local changes that still have to be pushed.
+   *
+   * Rows written through a sync adapter URI are recorded as already in sync, so a change made that
+   * way — an extended property, for instance — never leaves the device on its own. Writing any
+   * column back through the plain URI makes `CalendarProvider2` set `dirty`, and the pending change
+   * then travels with the next sync. The start date is the column written back, unchanged, because
+   * it is the one an event is guaranteed to have.
+   *
+   * @return whether the event was found and flagged.
+   */
+  suspend fun markDirty(id: EventId): Boolean = withContext(Dispatchers.IO) {
+    val uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id.value)
+    val dtStart = contentResolver.safeQuery(
+      uri = uri,
+      projection = arrayOf(CalendarContract.Events.DTSTART)
+    ).use { cursor ->
+      cursor.takeIf { it.moveToFirst() }
+        ?.getOptionalLong(CalendarContract.Events.DTSTART)
+    } ?: return@withContext false
+
+    contentResolver.safeUpdate(
+      uri = uri,
+      values = ContentValues().apply {
+        put(CalendarContract.Events.DTSTART, dtStart)
+      }
     ) > 0
   }
 

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/event/EventRepository.kt
@@ -56,24 +56,6 @@ class EventRepository(private val contentResolver: ContentResolver) {
     ) > 0
   }
 
-  /**
-   * Flags the event as carrying local changes that still have to be pushed.
-   *
-   * Rows written through a sync adapter URI are recorded as already in sync, so a change made that
-   * way — an extended property, for instance — never leaves the device on its own. Updating the
-   * event through the plain URI is enough: the provider sets `dirty` itself on any update it did
-   * not attribute to a sync adapter, whatever the values carry, so an empty set flags the event
-   * without touching a single column of it.
-   *
-   * @return whether the event was found and flagged.
-   */
-  suspend fun markDirty(id: EventId): Boolean = withContext(Dispatchers.IO) {
-    contentResolver.safeUpdate(
-      uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, id.value),
-      values = ContentValues()
-    ) > 0
-  }
-
   suspend fun insertException(id: EventId, eventExceptionInput: EventExceptionInput) = withContext(Dispatchers.IO) {
     contentResolver.safeInsert(
       uri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_EXCEPTION_URI, id.value),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyCursorExtensions.kt
@@ -4,7 +4,7 @@ import android.database.Cursor
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
 import expo.modules.calendar.next.domain.repositories.getOptionalLong
-import expo.modules.calendar.next.domain.repositories.getRequiredString
+import expo.modules.calendar.next.domain.repositories.getOptionalString
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
 
@@ -14,6 +14,6 @@ fun Cursor.toExtendedPropertyEntity(eventId: EventId) = ExtendedPropertyEntity(
       ?: throw IllegalStateException("extended property ID must not be null")
   ),
   eventId = eventId,
-  name = getRequiredString(CalendarContract.ExtendedProperties.NAME),
-  value = getRequiredString(CalendarContract.ExtendedProperties.VALUE)
+  name = getOptionalString(CalendarContract.ExtendedProperties.NAME),
+  value = getOptionalString(CalendarContract.ExtendedProperties.VALUE)
 )

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyCursorExtensions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyCursorExtensions.kt
@@ -1,0 +1,19 @@
+package expo.modules.calendar.next.domain.repositories.extendedproperty
+
+import android.database.Cursor
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
+import expo.modules.calendar.next.domain.repositories.getOptionalLong
+import expo.modules.calendar.next.domain.repositories.getRequiredString
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
+
+fun Cursor.toExtendedPropertyEntity(eventId: EventId) = ExtendedPropertyEntity(
+  id = ExtendedPropertyId(
+    getOptionalLong(CalendarContract.ExtendedProperties._ID)
+      ?: throw IllegalStateException("extended property ID must not be null")
+  ),
+  eventId = eventId,
+  name = getRequiredString(CalendarContract.ExtendedProperties.NAME),
+  value = getRequiredString(CalendarContract.ExtendedProperties.VALUE)
+)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
@@ -1,7 +1,7 @@
 package expo.modules.calendar.next.domain.repositories.extendedproperty
 
+import android.content.ContentProviderOperation
 import android.content.ContentResolver
-import android.content.ContentUris
 import android.content.ContentValues
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.dto.extendedproperty.ExtendedPropertyInput
@@ -9,10 +9,9 @@ import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
 import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
 import expo.modules.calendar.next.domain.repositories.asSequence
 import expo.modules.calendar.next.domain.repositories.asSyncAdapter
+import expo.modules.calendar.next.domain.repositories.safeApplyBatch
 import expo.modules.calendar.next.domain.repositories.safeDelete
-import expo.modules.calendar.next.domain.repositories.safeInsert
 import expo.modules.calendar.next.domain.repositories.safeQuery
-import expo.modules.calendar.next.domain.repositories.safeUpdate
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
 import kotlinx.coroutines.Dispatchers
@@ -22,8 +21,7 @@ import kotlinx.coroutines.withContext
  * Access to `CalendarContract.ExtendedProperties`, the per-event key/value table.
  *
  * Reads go through the plain URI. Writes go through [asSyncAdapter], because the provider rejects
- * every other caller, and are addressed to a single row, because the provider only understands
- * updates and deletes that carry a row id in their path.
+ * every other caller.
  */
 class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
   suspend fun findAllByEventId(eventId: EventId): List<ExtendedPropertyEntity> = withContext(Dispatchers.IO) {
@@ -40,60 +38,31 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
   }
 
   /**
-   * Every row stored under [name] on the event. The table has no unique constraint on
-   * (`EVENT_ID`, `NAME`), so a name can carry more than one row: two concurrent writes, or another
-   * app writing the same name, both produce duplicates.
-   */
-  suspend fun findAllByName(eventId: EventId, name: String): List<ExtendedPropertyEntity> = withContext(Dispatchers.IO) {
-    contentResolver.safeQuery(
-      uri = CalendarContract.ExtendedProperties.CONTENT_URI,
-      projection = FULL_PROJECTION,
-      selection = "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
-      selectionArgs = arrayOf(eventId.value.toString(), name)
-    ).use { cursor ->
-      cursor.asSequence()
-        .map { it.toExtendedPropertyEntity(eventId) }
-        .toList()
-    }
-  }
-
-  /**
    * Writes [input] on the event, leaving exactly one row under that name.
    *
-   * Any duplicate the table already holds under the same name is removed, so a name that ended up
-   * with several rows converges back to one on the next write rather than staying ambiguous.
+   * The table has no unique constraint on (`EVENT_ID`, `NAME`), so the write removes what is
+   * already stored under the name before inserting. Both operations travel in one batch, which the
+   * provider applies as a single transaction: no window in which a concurrent write sees no row
+   * and inserts a second one, and no half-applied state to repair.
    */
   suspend fun upsert(
     eventId: EventId,
     account: CalendarAccount,
     input: ExtendedPropertyInput
   ): ExtendedPropertyId = withContext(Dispatchers.IO) {
-    val existing = findAllByName(eventId, input.name)
-    existing.drop(1).forEach { duplicate ->
-      deleteById(duplicate.id, account)
-    }
-
-    val kept = existing.firstOrNull()
-    if (kept != null) {
-      val updated = contentResolver.safeUpdate(
-        uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, kept.id.value)
-          .asSyncAdapter(account),
-        values = ContentValues().apply {
-          put(CalendarContract.ExtendedProperties.VALUE, input.value)
-        }
-      ) > 0
-      if (updated) {
-        return@withContext kept.id
-      }
-      // The row was removed between the two calls, so it is written again below.
-    }
-
-    val uri = contentResolver.safeInsert(
-      uri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account),
-      values = input.toContentValues(eventId)
+    val syncAdapterUri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account)
+    val results = contentResolver.safeApplyBatch(
+      arrayListOf(
+        ContentProviderOperation.newDelete(syncAdapterUri)
+          .withSelection(SELECTION_BY_NAME, selectionArgsByName(eventId, input.name))
+          .build(),
+        ContentProviderOperation.newInsert(syncAdapterUri)
+          .withValues(input.toContentValues(eventId))
+          .build()
+      )
     )
     ExtendedPropertyId(
-      uri.lastPathSegment?.toLongOrNull()
+      results.last().uri?.lastPathSegment?.toLongOrNull()
         ?: throw IllegalStateException("Couldn't decode extended property ID from inserted content URI")
     )
   }
@@ -108,15 +77,15 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
     account: CalendarAccount,
     name: String
   ): Boolean = withContext(Dispatchers.IO) {
-    findAllByName(eventId, name)
-      .sumOf { deleteById(it.id, account) } > 0
+    contentResolver.safeDelete(
+      uri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account),
+      where = SELECTION_BY_NAME,
+      selectionArgs = selectionArgsByName(eventId, name)
+    ) > 0
   }
 
-  private suspend fun deleteById(id: ExtendedPropertyId, account: CalendarAccount): Int =
-    contentResolver.safeDelete(
-      uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, id.value)
-        .asSyncAdapter(account)
-    )
+  private fun selectionArgsByName(eventId: EventId, name: String) =
+    arrayOf(eventId.value.toString(), name)
 
   private fun ExtendedPropertyInput.toContentValues(eventId: EventId) = ContentValues().apply {
     put(CalendarContract.ExtendedProperties.EVENT_ID, eventId.value)
@@ -130,5 +99,8 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
       CalendarContract.ExtendedProperties.NAME,
       CalendarContract.ExtendedProperties.VALUE
     )
+
+    private const val SELECTION_BY_NAME =
+      "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?"
   }
 }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
@@ -39,38 +39,51 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
     }
   }
 
-  suspend fun findByName(eventId: EventId, name: String): ExtendedPropertyEntity? = withContext(Dispatchers.IO) {
+  /**
+   * Every row stored under [name] on the event. The table has no unique constraint on
+   * (`EVENT_ID`, `NAME`), so a name can carry more than one row: two concurrent writes, or another
+   * app writing the same name, both produce duplicates.
+   */
+  suspend fun findAllByName(eventId: EventId, name: String): List<ExtendedPropertyEntity> = withContext(Dispatchers.IO) {
     contentResolver.safeQuery(
       uri = CalendarContract.ExtendedProperties.CONTENT_URI,
       projection = FULL_PROJECTION,
       selection = "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
       selectionArgs = arrayOf(eventId.value.toString(), name)
     ).use { cursor ->
-      cursor.takeIf { it.moveToFirst() }
-        ?.toExtendedPropertyEntity(eventId)
+      cursor.asSequence()
+        .map { it.toExtendedPropertyEntity(eventId) }
+        .toList()
     }
   }
 
   /**
-   * Writes [input] on the event, replacing the value of a property of the same name if there is
-   * one — the table itself does not constrain names to be unique per event.
+   * Writes [input] on the event, leaving exactly one row under that name.
+   *
+   * Any duplicate the table already holds under the same name is removed, so a name that ended up
+   * with several rows converges back to one on the next write rather than staying ambiguous.
    */
   suspend fun upsert(
     eventId: EventId,
     account: CalendarAccount,
     input: ExtendedPropertyInput
   ): ExtendedPropertyId = withContext(Dispatchers.IO) {
-    val existing = findByName(eventId, input.name)
-    if (existing != null) {
+    val existing = findAllByName(eventId, input.name)
+    existing.drop(1).forEach { duplicate ->
+      deleteById(duplicate.id, account)
+    }
+
+    val kept = existing.firstOrNull()
+    if (kept != null) {
       val updated = contentResolver.safeUpdate(
-        uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, existing.id.value)
+        uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, kept.id.value)
           .asSyncAdapter(account),
         values = ContentValues().apply {
           put(CalendarContract.ExtendedProperties.VALUE, input.value)
         }
       ) > 0
       if (updated) {
-        return@withContext existing.id
+        return@withContext kept.id
       }
       // The row was removed between the two calls, so it is written again below.
     }
@@ -85,18 +98,25 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
     )
   }
 
+  /**
+   * Removes every row stored under [name] on the event.
+   *
+   * @return whether at least one row was removed.
+   */
   suspend fun deleteByName(
     eventId: EventId,
     account: CalendarAccount,
     name: String
   ): Boolean = withContext(Dispatchers.IO) {
-    val existing = findByName(eventId, name)
-      ?: return@withContext false
-    contentResolver.safeDelete(
-      uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, existing.id.value)
-        .asSyncAdapter(account)
-    ) > 0
+    findAllByName(eventId, name)
+      .sumOf { deleteById(it.id, account) } > 0
   }
+
+  private suspend fun deleteById(id: ExtendedPropertyId, account: CalendarAccount): Int =
+    contentResolver.safeDelete(
+      uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, id.value)
+        .asSyncAdapter(account)
+    )
 
   private fun ExtendedPropertyInput.toContentValues(eventId: EventId) = ContentValues().apply {
     put(CalendarContract.ExtendedProperties.EVENT_ID, eventId.value)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
@@ -1,0 +1,114 @@
+package expo.modules.calendar.next.domain.repositories.extendedproperty
+
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.content.ContentValues
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.extendedproperty.ExtendedPropertyInput
+import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
+import expo.modules.calendar.next.domain.repositories.asSequence
+import expo.modules.calendar.next.domain.repositories.asSyncAdapter
+import expo.modules.calendar.next.domain.repositories.safeDelete
+import expo.modules.calendar.next.domain.repositories.safeInsert
+import expo.modules.calendar.next.domain.repositories.safeQuery
+import expo.modules.calendar.next.domain.repositories.safeUpdate
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Access to `CalendarContract.ExtendedProperties`, the per-event key/value table.
+ *
+ * Reads go through the plain URI. Writes go through [asSyncAdapter], because the provider rejects
+ * every other caller, and are addressed to a single row, because the provider only understands
+ * updates and deletes that carry a row id in their path.
+ */
+class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
+  suspend fun findAllByEventId(eventId: EventId): List<ExtendedPropertyEntity> = withContext(Dispatchers.IO) {
+    contentResolver.safeQuery(
+      uri = CalendarContract.ExtendedProperties.CONTENT_URI,
+      projection = FULL_PROJECTION,
+      selection = "${CalendarContract.ExtendedProperties.EVENT_ID} = ?",
+      selectionArgs = arrayOf(eventId.value.toString())
+    ).use { cursor ->
+      cursor.asSequence()
+        .map { it.toExtendedPropertyEntity(eventId) }
+        .toList()
+    }
+  }
+
+  suspend fun findByName(eventId: EventId, name: String): ExtendedPropertyEntity? = withContext(Dispatchers.IO) {
+    contentResolver.safeQuery(
+      uri = CalendarContract.ExtendedProperties.CONTENT_URI,
+      projection = FULL_PROJECTION,
+      selection = "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
+      selectionArgs = arrayOf(eventId.value.toString(), name)
+    ).use { cursor ->
+      cursor.takeIf { it.moveToFirst() }
+        ?.toExtendedPropertyEntity(eventId)
+    }
+  }
+
+  /**
+   * Writes [input] on the event, replacing the value of a property of the same name if there is
+   * one — the table itself does not constrain names to be unique per event.
+   */
+  suspend fun upsert(
+    eventId: EventId,
+    account: CalendarAccount,
+    input: ExtendedPropertyInput
+  ): ExtendedPropertyId = withContext(Dispatchers.IO) {
+    val existing = findByName(eventId, input.name)
+    if (existing != null) {
+      val updated = contentResolver.safeUpdate(
+        uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, existing.id.value)
+          .asSyncAdapter(account),
+        values = ContentValues().apply {
+          put(CalendarContract.ExtendedProperties.VALUE, input.value)
+        }
+      ) > 0
+      if (updated) {
+        return@withContext existing.id
+      }
+      // The row was removed between the two calls, so it is written again below.
+    }
+
+    val uri = contentResolver.safeInsert(
+      uri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account),
+      values = input.toContentValues(eventId)
+    )
+    ExtendedPropertyId(
+      uri.lastPathSegment?.toLongOrNull()
+        ?: throw IllegalStateException("Couldn't decode extended property ID from inserted content URI")
+    )
+  }
+
+  suspend fun deleteByName(
+    eventId: EventId,
+    account: CalendarAccount,
+    name: String
+  ): Boolean = withContext(Dispatchers.IO) {
+    val existing = findByName(eventId, name)
+      ?: return@withContext false
+    contentResolver.safeDelete(
+      uri = ContentUris.withAppendedId(CalendarContract.ExtendedProperties.CONTENT_URI, existing.id.value)
+        .asSyncAdapter(account)
+    ) > 0
+  }
+
+  private fun ExtendedPropertyInput.toContentValues(eventId: EventId) = ContentValues().apply {
+    put(CalendarContract.ExtendedProperties.EVENT_ID, eventId.value)
+    put(CalendarContract.ExtendedProperties.NAME, name)
+    put(CalendarContract.ExtendedProperties.VALUE, value)
+  }
+
+  companion object {
+    val FULL_PROJECTION = arrayOf(
+      CalendarContract.ExtendedProperties._ID,
+      CalendarContract.ExtendedProperties.NAME,
+      CalendarContract.ExtendedProperties.VALUE
+    )
+  }
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepository.kt
@@ -2,6 +2,7 @@ package expo.modules.calendar.next.domain.repositories.extendedproperty
 
 import android.content.ContentProviderOperation
 import android.content.ContentResolver
+import android.content.ContentUris
 import android.content.ContentValues
 import android.provider.CalendarContract
 import expo.modules.calendar.next.domain.dto.extendedproperty.ExtendedPropertyInput
@@ -10,7 +11,6 @@ import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedProperty
 import expo.modules.calendar.next.domain.repositories.asSequence
 import expo.modules.calendar.next.domain.repositories.asSyncAdapter
 import expo.modules.calendar.next.domain.repositories.safeApplyBatch
-import expo.modules.calendar.next.domain.repositories.safeDelete
 import expo.modules.calendar.next.domain.repositories.safeQuery
 import expo.modules.calendar.next.domain.wrappers.EventId
 import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
@@ -21,7 +21,7 @@ import kotlinx.coroutines.withContext
  * Access to `CalendarContract.ExtendedProperties`, the per-event key/value table.
  *
  * Reads go through the plain URI. Writes go through [asSyncAdapter], because the provider rejects
- * every other caller.
+ * every other caller, and travel in a batch headed by [flagEventOperation].
  */
 class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
   suspend fun findAllByEventId(eventId: EventId): List<ExtendedPropertyEntity> = withContext(Dispatchers.IO) {
@@ -41,9 +41,10 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
    * Writes [input] on the event, leaving exactly one row under that name.
    *
    * The table has no unique constraint on (`EVENT_ID`, `NAME`), so the write removes what is
-   * already stored under the name before inserting. Both operations travel in one batch, which the
-   * provider applies as a single transaction: no window in which a concurrent write sees no row
-   * and inserts a second one, and no half-applied state to repair.
+   * already stored under the name before inserting. Everything travels in one batch, which the
+   * provider applies as a single transaction: the event is flagged before the rows it covers move,
+   * there is no window in which a concurrent write sees no row and inserts a second one, and no
+   * half-applied state to repair.
    */
   suspend fun upsert(
     eventId: EventId,
@@ -53,6 +54,7 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
     val syncAdapterUri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account)
     val results = contentResolver.safeApplyBatch(
       arrayListOf(
+        flagEventOperation(eventId),
         ContentProviderOperation.newDelete(syncAdapterUri)
           .withSelection(SELECTION_BY_NAME, selectionArgsByName(eventId, input.name))
           .build(),
@@ -68,7 +70,8 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
   }
 
   /**
-   * Removes every row stored under [name] on the event.
+   * Removes every row stored under [name] on the event, in a batch headed by the same flag as
+   * [upsert]: what the sync adapter has to push here is the absence of the rows.
    *
    * @return whether at least one row was removed.
    */
@@ -77,11 +80,36 @@ class ExtendedPropertyRepository(private val contentResolver: ContentResolver) {
     account: CalendarAccount,
     name: String
   ): Boolean = withContext(Dispatchers.IO) {
-    contentResolver.safeDelete(
-      uri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account),
-      where = SELECTION_BY_NAME,
-      selectionArgs = selectionArgsByName(eventId, name)
-    ) > 0
+    val syncAdapterUri = CalendarContract.ExtendedProperties.CONTENT_URI.asSyncAdapter(account)
+    val results = contentResolver.safeApplyBatch(
+      arrayListOf(
+        flagEventOperation(eventId),
+        ContentProviderOperation.newDelete(syncAdapterUri)
+          .withSelection(SELECTION_BY_NAME, selectionArgsByName(eventId, name))
+          .build()
+      )
+    )
+    (results.last().count ?: 0) > 0
+  }
+
+  /**
+   * Builds the update every batch of this repository starts with.
+   *
+   * The event goes through the plain URI, which buys two things the rows need to reach the server.
+   * The provider flags as dirty any event it did not attribute to a sync adapter, so the change
+   * made on the sync adapter URI stops looking like one already in sync; and
+   * `HAS_EXTENDED_PROPERTIES` tells the sync adapter that the event carries properties worth
+   * looking at, without which Google's drops them on the next sync. The flag stays at 1 after a
+   * deletion, so the sync adapter still looks at an event whose last property just went away.
+   *
+   * It is also what makes the operation legal: a batch refuses to carry an update with no value,
+   * where [android.content.ContentResolver.update] takes an empty set to flag the event alone.
+   */
+  private fun flagEventOperation(eventId: EventId): ContentProviderOperation {
+    val eventUri = ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId.value)
+    return ContentProviderOperation.newUpdate(eventUri)
+      .withValue(CalendarContract.Events.HAS_EXTENDED_PROPERTIES, 1)
+      .build()
   }
 
   private fun selectionArgsByName(eventId: EventId, name: String) =

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/ExtendedPropertyId.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/domain/wrappers/ExtendedPropertyId.kt
@@ -1,0 +1,4 @@
+package expo.modules.calendar.next.domain.wrappers
+
+@JvmInline
+value class ExtendedPropertyId(val value: Long)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/exceptions/ExtendedPropertiesExceptions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/exceptions/ExtendedPropertiesExceptions.kt
@@ -1,0 +1,9 @@
+package expo.modules.calendar.next.exceptions
+
+import expo.modules.kotlin.exception.CodedException
+
+class ExtendedPropertyNameNotSyncSafeException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)
+
+class ExtendedPropertyAccountMissingException(message: String, cause: Throwable? = null) :
+  CodedException(message, cause)

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapper.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapper.kt
@@ -1,0 +1,17 @@
+package expo.modules.calendar.next.mappers
+
+import expo.modules.calendar.next.domain.dto.extendedproperty.ExtendedPropertyInput
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
+import expo.modules.calendar.next.records.ExtendedPropertyRecord
+
+class ExtendedPropertyMapper {
+  fun toRecord(entity: ExtendedPropertyEntity) = ExtendedPropertyRecord(
+    name = entity.name,
+    value = entity.value
+  )
+
+  fun toInput(name: String, value: String) = ExtendedPropertyInput(
+    name = name,
+    value = value
+  )
+}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapper.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapper.kt
@@ -5,10 +5,16 @@ import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedProperty
 import expo.modules.calendar.next.records.ExtendedPropertyRecord
 
 class ExtendedPropertyMapper {
-  fun toRecord(entity: ExtendedPropertyEntity) = ExtendedPropertyRecord(
-    name = entity.name,
-    value = entity.value
-  )
+  /**
+   * Maps [entity] for the JS surface, or returns null for a row the provider handed back without a
+   * name or without a value. No constraint forbids either, and a property carrying no name can be
+   * neither read back nor deleted by one, so it is left out rather than surfaced as a null.
+   */
+  fun toRecord(entity: ExtendedPropertyEntity): ExtendedPropertyRecord? {
+    val name = entity.name ?: return null
+    val value = entity.value ?: return null
+    return ExtendedPropertyRecord(name = name, value = value)
+  }
 
   fun toInput(name: String, value: String) = ExtendedPropertyInput(
     name = name,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/ExtendedPropertyRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/ExtendedPropertyRecord.kt
@@ -1,0 +1,11 @@
+package expo.modules.calendar.next.records
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
+
+@OptimizedRecord
+data class ExtendedPropertyRecord(
+  @Field val name: String,
+  @Field val value: String
+) : Record

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyNameTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/model/extendedproperty/ExtendedPropertyNameTest.kt
@@ -1,0 +1,32 @@
+package expo.modules.calendar.next.domain.model.extendedproperty
+
+import org.junit.Assert
+import org.junit.Test
+
+class ExtendedPropertyNameTest {
+  @Test
+  fun `given a private name, when isSyncSafe, then returns true`() {
+    Assert.assertTrue(ExtendedPropertyName.isSyncSafe("private:x-owner"))
+  }
+
+  @Test
+  fun `given a shared name, when isSyncSafe, then returns true`() {
+    Assert.assertTrue(ExtendedPropertyName.isSyncSafe("shared:x-owner"))
+  }
+
+  @Test
+  fun `given an unprefixed name, when isSyncSafe, then returns false`() {
+    // A name a sync adapter drops on the next sync, without reporting an error.
+    Assert.assertFalse(ExtendedPropertyName.isSyncSafe("x-owner"))
+  }
+
+  @Test
+  fun `given a name with an unrelated prefix, when isSyncSafe, then returns false`() {
+    Assert.assertFalse(ExtendedPropertyName.isSyncSafe("public:x-owner"))
+  }
+
+  @Test
+  fun `given a name where the prefix is not at the start, when isSyncSafe, then returns false`() {
+    Assert.assertFalse(ExtendedPropertyName.isSyncSafe("x-private:owner"))
+  }
+}

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
@@ -23,6 +23,7 @@ import expo.modules.kotlin.types.ValueOrUndefined
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
@@ -657,6 +658,61 @@ class EventRepositoryTest {
 
     // Then
     Assert.assertFalse(result)
+  }
+
+  // endregion
+
+  // region markDirty
+
+  @Test
+  fun `given an event, when markDirty, then rewrites its start date through the plain URI`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    val valuesSlot = slot<ContentValues>()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(CalendarContract.Events.DTSTART to 1_000_000L)
+    )
+    every { contentResolver.update(capture(uriSlot), capture(valuesSlot), any(), any()) } returns 1
+
+    // When
+    val result = repository.markDirty(EventId(42L))
+
+    // Then
+    // Writing the start date back unchanged is what makes the provider set `dirty`; the update
+    // must not claim to come from a sync adapter, or the flag would stay at 0.
+    Assert.assertTrue(result)
+    Assert.assertEquals("42", uriSlot.captured.lastPathSegment)
+    Assert.assertNull(uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals(1_000_000L, valuesSlot.captured.getAsLong(CalendarContract.Events.DTSTART).toLong())
+    Assert.assertEquals(1, valuesSlot.captured.size())
+  }
+
+  @Test
+  fun `given a missing event, when markDirty, then returns false without updating`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.markDirty(EventId(42L))
+
+    // Then
+    Assert.assertFalse(result)
+    verify(exactly = 0) { contentResolver.update(any(), any(), any(), any()) }
+  }
+
+  @Test
+  fun `given an event without a start date, when markDirty, then returns false without updating`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(CalendarContract.Events.DTSTART to null)
+    )
+
+    // When
+    val result = repository.markDirty(EventId(42L))
+
+    // Then
+    Assert.assertFalse(result)
+    verify(exactly = 0) { contentResolver.update(any(), any(), any(), any()) }
   }
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
@@ -23,7 +23,6 @@ import expo.modules.kotlin.types.ValueOrUndefined
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
@@ -665,54 +664,34 @@ class EventRepositoryTest {
   // region markDirty
 
   @Test
-  fun `given an event, when markDirty, then rewrites its start date through the plain URI`() = runTest {
+  fun `given an event, when markDirty, then updates it through the plain URI with no values`() = runTest {
     // Given
     val uriSlot = slot<Uri>()
     val valuesSlot = slot<ContentValues>()
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(CalendarContract.Events.DTSTART to 1_000_000L)
-    )
     every { contentResolver.update(capture(uriSlot), capture(valuesSlot), any(), any()) } returns 1
 
     // When
     val result = repository.markDirty(EventId(42L))
 
     // Then
-    // Writing the start date back unchanged is what makes the provider set `dirty`; the update
-    // must not claim to come from a sync adapter, or the flag would stay at 0.
+    // The provider sets `dirty` on any update it does not attribute to a sync adapter, so the
+    // update has to carry neither the sync adapter parameters nor a single column of the event.
     Assert.assertTrue(result)
     Assert.assertEquals("42", uriSlot.captured.lastPathSegment)
     Assert.assertNull(uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-    Assert.assertEquals(1_000_000L, valuesSlot.captured.getAsLong(CalendarContract.Events.DTSTART).toLong())
-    Assert.assertEquals(1, valuesSlot.captured.size())
+    Assert.assertEquals(0, valuesSlot.captured.size())
   }
 
   @Test
-  fun `given a missing event, when markDirty, then returns false without updating`() = runTest {
+  fun `given no row was updated, when markDirty, then returns false`() = runTest {
     // Given
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+    every { contentResolver.update(any(), any(), any(), any()) } returns 0
 
     // When
     val result = repository.markDirty(EventId(42L))
 
     // Then
     Assert.assertFalse(result)
-    verify(exactly = 0) { contentResolver.update(any(), any(), any(), any()) }
-  }
-
-  @Test
-  fun `given an event without a start date, when markDirty, then returns false without updating`() = runTest {
-    // Given
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(CalendarContract.Events.DTSTART to null)
-    )
-
-    // When
-    val result = repository.markDirty(EventId(42L))
-
-    // Then
-    Assert.assertFalse(result)
-    verify(exactly = 0) { contentResolver.update(any(), any(), any(), any()) }
   }
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/event/EventRepositoryTest.kt
@@ -661,41 +661,6 @@ class EventRepositoryTest {
 
   // endregion
 
-  // region markDirty
-
-  @Test
-  fun `given an event, when markDirty, then updates it through the plain URI with no values`() = runTest {
-    // Given
-    val uriSlot = slot<Uri>()
-    val valuesSlot = slot<ContentValues>()
-    every { contentResolver.update(capture(uriSlot), capture(valuesSlot), any(), any()) } returns 1
-
-    // When
-    val result = repository.markDirty(EventId(42L))
-
-    // Then
-    // The provider sets `dirty` on any update it does not attribute to a sync adapter, so the
-    // update has to carry neither the sync adapter parameters nor a single column of the event.
-    Assert.assertTrue(result)
-    Assert.assertEquals("42", uriSlot.captured.lastPathSegment)
-    Assert.assertNull(uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-    Assert.assertEquals(0, valuesSlot.captured.size())
-  }
-
-  @Test
-  fun `given no row was updated, when markDirty, then returns false`() = runTest {
-    // Given
-    every { contentResolver.update(any(), any(), any(), any()) } returns 0
-
-    // When
-    val result = repository.markDirty(EventId(42L))
-
-    // Then
-    Assert.assertFalse(result)
-  }
-
-  // endregion
-
   // region helpers
 
   private fun emptyCursor(): Cursor {

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
@@ -1,0 +1,279 @@
+package expo.modules.calendar.next.domain.repositories.extendedproperty
+
+import android.content.ContentResolver
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.net.Uri
+import android.provider.CalendarContract
+import expo.modules.calendar.next.domain.dto.extendedproperty.ExtendedPropertyInput
+import expo.modules.calendar.next.domain.model.calendar.CalendarAccount
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
+import expo.modules.calendar.next.exceptions.CouldNotExecuteQueryException
+import expo.modules.calendar.next.exceptions.PermissionException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ExtendedPropertyRepositoryTest {
+  private val contentResolver = mockk<ContentResolver>()
+  private val repository = ExtendedPropertyRepository(contentResolver)
+  private val account = CalendarAccount(name = "user@example.com", type = "com.google")
+
+  // region findAllByEventId
+
+  @Test
+  fun `given cursor has no rows, when findAllByEventId, then returns empty list`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.findAllByEventId(EventId(1L))
+
+    // Then
+    Assert.assertEquals(emptyList<ExtendedPropertyEntity>(), result)
+  }
+
+  @Test
+  fun `given cursor with data, when findAllByEventId, then maps cursor rows to ExtendedPropertyEntity`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-42"
+      ),
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 6L,
+        CalendarContract.ExtendedProperties.NAME to "shared:x-topic",
+        CalendarContract.ExtendedProperties.VALUE to "standup"
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(99L))
+
+    // Then
+    Assert.assertEquals(2, result.size)
+    Assert.assertEquals(ExtendedPropertyId(5L), result[0].id)
+    Assert.assertEquals(EventId(99L), result[0].eventId)
+    Assert.assertEquals("private:x-owner", result[0].name)
+    Assert.assertEquals("mirror-42", result[0].value)
+    Assert.assertEquals(ExtendedPropertyId(6L), result[1].id)
+    Assert.assertEquals("shared:x-topic", result[1].name)
+    Assert.assertEquals("standup", result[1].value)
+  }
+
+  @Test
+  fun `given event id, when findAllByEventId, then reads through the plain URI selecting on EVENT_ID`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.query(capture(uriSlot), any(), capture(selectionSlot), capture(selectionArgsSlot), any())
+    } returns emptyCursor()
+
+    // When
+    repository.findAllByEventId(EventId(42L))
+
+    // Then
+    // Reading is allowed for ordinary callers, so the sync adapter parameters must not be added here.
+    Assert.assertEquals(CalendarContract.ExtendedProperties.CONTENT_URI, uriSlot.captured)
+    Assert.assertNull(uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals("${CalendarContract.ExtendedProperties.EVENT_ID} = ?", selectionSlot.captured)
+    Assert.assertArrayEquals(arrayOf("42"), selectionArgsSlot.captured)
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when findAllByEventId, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given null cursor, when findAllByEventId, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns null
+
+    // When / Then
+    repository.findAllByEventId(EventId(1L))
+  }
+
+  // endregion
+
+  // region findByName
+
+  @Test
+  fun `given a name, when findByName, then selects on both EVENT_ID and NAME`() = runTest {
+    // Given
+    val selectionSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.query(any(), any(), capture(selectionSlot), capture(selectionArgsSlot), any())
+    } returns emptyCursor()
+
+    // When
+    val result = repository.findByName(EventId(42L), "private:x-owner")
+
+    // Then
+    Assert.assertNull(result)
+    Assert.assertEquals(
+      "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
+      selectionSlot.captured
+    )
+    Assert.assertArrayEquals(arrayOf("42", "private:x-owner"), selectionArgsSlot.captured)
+  }
+
+  // endregion
+
+  // region upsert
+
+  @Test
+  fun `given no existing property, when upsert, then inserts through the sync adapter URI`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    val valuesSlot = slot<ContentValues>()
+    val insertedUri = mockk<Uri>()
+    every { insertedUri.lastPathSegment } returns "7"
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+    every { contentResolver.insert(capture(uriSlot), capture(valuesSlot)) } returns insertedUri
+
+    // When
+    val result = repository.upsert(
+      EventId(42L),
+      account,
+      ExtendedPropertyInput(name = "private:x-owner", value = "mirror-42")
+    )
+
+    // Then
+    // CalendarProvider2 refuses writes to this table unless the caller declares itself
+    // the sync adapter of the owning account.
+    Assert.assertEquals(ExtendedPropertyId(7L), result)
+    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals("user@example.com", uriSlot.captured.getQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME))
+    Assert.assertEquals("com.google", uriSlot.captured.getQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE))
+    Assert.assertEquals(42L, valuesSlot.captured.getAsLong(CalendarContract.ExtendedProperties.EVENT_ID).toLong())
+    Assert.assertEquals("private:x-owner", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.NAME))
+    Assert.assertEquals("mirror-42", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.VALUE))
+  }
+
+  @Test
+  fun `given an existing property, when upsert, then updates that row instead of inserting a duplicate`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    val valuesSlot = slot<ContentValues>()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-1"
+      )
+    )
+    every { contentResolver.update(capture(uriSlot), capture(valuesSlot), any(), any()) } returns 1
+
+    // When
+    val result = repository.upsert(
+      EventId(42L),
+      account,
+      ExtendedPropertyInput(name = "private:x-owner", value = "mirror-2")
+    )
+
+    // Then
+    // The provider only understands updates addressed to a single row, hence the id in the path.
+    Assert.assertEquals(ExtendedPropertyId(5L), result)
+    Assert.assertEquals("5", uriSlot.captured.lastPathSegment)
+    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals("mirror-2", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.VALUE))
+    verify(exactly = 0) { contentResolver.insert(any(), any()) }
+  }
+
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when upsert, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+    every { contentResolver.insert(any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.upsert(EventId(42L), account, ExtendedPropertyInput("private:x-owner", "mirror-42"))
+  }
+
+  // endregion
+
+  // region deleteByName
+
+  @Test
+  fun `given an existing property, when deleteByName, then deletes that row through the sync adapter URI`() = runTest {
+    // Given
+    val uriSlot = slot<Uri>()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-42"
+      )
+    )
+    every { contentResolver.delete(capture(uriSlot), any(), any()) } returns 1
+
+    // When
+    val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
+
+    // Then
+    Assert.assertTrue(result)
+    Assert.assertEquals("5", uriSlot.captured.lastPathSegment)
+    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+  }
+
+  @Test
+  fun `given no such property, when deleteByName, then returns false without touching the provider`() = runTest {
+    // Given
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+
+    // When
+    val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
+
+    // Then
+    Assert.assertFalse(result)
+    verify(exactly = 0) { contentResolver.delete(any(), any(), any()) }
+  }
+
+  // endregion
+
+  // region helpers
+
+  private fun emptyCursor(): Cursor {
+    // Empty cursor requires at least one column for MatrixCursor
+    return MatrixCursor(arrayOf(CalendarContract.ExtendedProperties._ID))
+  }
+
+  private fun cursorWithRows(vararg rows: Map<String, Any?>): Cursor {
+    if (rows.isEmpty()) {
+      return emptyCursor()
+    }
+
+    val columnNames = rows.first().keys.toTypedArray()
+    val cursor = MatrixCursor(columnNames)
+
+    for (row in rows) {
+      val rowValues = columnNames.map { columnName -> row[columnName] }.toTypedArray()
+      cursor.addRow(rowValues)
+    }
+
+    return cursor
+  }
+
+  // endregion
+}

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
@@ -1,7 +1,9 @@
 package expo.modules.calendar.next.domain.repositories.extendedproperty
 
+import android.content.ContentProviderOperation
+import android.content.ContentProviderResult
 import android.content.ContentResolver
-import android.content.ContentValues
+import android.content.OperationApplicationException
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
@@ -16,7 +18,6 @@ import expo.modules.calendar.next.exceptions.PermissionException
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
@@ -138,42 +139,17 @@ class ExtendedPropertyRepositoryTest {
 
   // endregion
 
-  // region findAllByName
-
-  @Test
-  fun `given a name, when findAllByName, then selects on both EVENT_ID and NAME`() = runTest {
-    // Given
-    val selectionSlot = slot<String>()
-    val selectionArgsSlot = slot<Array<String>>()
-    every {
-      contentResolver.query(any(), any(), capture(selectionSlot), capture(selectionArgsSlot), any())
-    } returns emptyCursor()
-
-    // When
-    val result = repository.findAllByName(EventId(42L), "private:x-owner")
-
-    // Then
-    Assert.assertEquals(emptyList<ExtendedPropertyEntity>(), result)
-    Assert.assertEquals(
-      "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
-      selectionSlot.captured
-    )
-    Assert.assertArrayEquals(arrayOf("42", "private:x-owner"), selectionArgsSlot.captured)
-  }
-
-  // endregion
-
   // region upsert
 
   @Test
-  fun `given no existing property, when upsert, then inserts through the sync adapter URI`() = runTest {
+  fun `given a name and a value, when upsert, then deletes and inserts in one batch through the sync adapter URI`() = runTest {
     // Given
-    val uriSlot = slot<Uri>()
-    val valuesSlot = slot<ContentValues>()
-    val insertedUri = mockk<Uri>()
-    every { insertedUri.lastPathSegment } returns "7"
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
-    every { contentResolver.insert(capture(uriSlot), capture(valuesSlot)) } returns insertedUri
+    val authoritySlot = slot<String>()
+    val operationsSlot = slot<ArrayList<ContentProviderOperation>>()
+    every { contentResolver.applyBatch(capture(authoritySlot), capture(operationsSlot)) } returns arrayOf(
+      ContentProviderResult(1),
+      ContentProviderResult(Uri.parse("content://com.android.calendar/extendedproperties/7"))
+    )
 
     // When
     val result = repository.upsert(
@@ -183,90 +159,45 @@ class ExtendedPropertyRepositoryTest {
     )
 
     // Then
-    // CalendarProvider2 refuses writes to this table unless the caller declares itself
-    // the sync adapter of the owning account.
+    // The provider applies a batch as one transaction, so the row a concurrent write could have
+    // left behind is gone and the new one is in place without a window between the two.
     Assert.assertEquals(ExtendedPropertyId(7L), result)
-    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-    Assert.assertEquals("user@example.com", uriSlot.captured.getQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME))
-    Assert.assertEquals("com.google", uriSlot.captured.getQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE))
-    Assert.assertEquals(42L, valuesSlot.captured.getAsLong(CalendarContract.ExtendedProperties.EVENT_ID).toLong())
-    Assert.assertEquals("private:x-owner", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.NAME))
-    Assert.assertEquals("mirror-42", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.VALUE))
+    Assert.assertEquals(CalendarContract.AUTHORITY, authoritySlot.captured)
+    Assert.assertEquals(2, operationsSlot.captured.size)
+    Assert.assertTrue(operationsSlot.captured[0].isDelete)
+    Assert.assertTrue(operationsSlot.captured[1].isInsert)
+    operationsSlot.captured.forEach { operation ->
+      Assert.assertEquals("true", operation.uri.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+      Assert.assertEquals("user@example.com", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME))
+      Assert.assertEquals("com.google", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE))
+    }
   }
 
-  @Test
-  fun `given an existing property, when upsert, then updates that row instead of inserting a duplicate`() = runTest {
+  @Test(expected = IllegalStateException::class)
+  fun `given a batch result without a URI, when upsert, then throws IllegalStateException`() = runTest {
     // Given
-    val uriSlot = slot<Uri>()
-    val valuesSlot = slot<ContentValues>()
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 5L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-1"
-      )
-    )
-    every { contentResolver.update(capture(uriSlot), capture(valuesSlot), any(), any()) } returns 1
-
-    // When
-    val result = repository.upsert(
-      EventId(42L),
-      account,
-      ExtendedPropertyInput(name = "private:x-owner", value = "mirror-2")
-    )
-
-    // Then
-    // The provider only understands updates addressed to a single row, hence the id in the path.
-    Assert.assertEquals(ExtendedPropertyId(5L), result)
-    Assert.assertEquals("5", uriSlot.captured.lastPathSegment)
-    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-    Assert.assertEquals("mirror-2", valuesSlot.captured.getAsString(CalendarContract.ExtendedProperties.VALUE))
-    verify(exactly = 0) { contentResolver.insert(any(), any()) }
-  }
-
-  @Test(expected = PermissionException::class)
-  fun `given SecurityException, when upsert, then throws PermissionException`() = runTest {
-    // Given
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
-    every { contentResolver.insert(any(), any()) } throws SecurityException()
+    every { contentResolver.applyBatch(any(), any()) } returns arrayOf(ContentProviderResult(1))
 
     // When / Then
     repository.upsert(EventId(42L), account, ExtendedPropertyInput("private:x-owner", "mirror-42"))
   }
 
-  @Test
-  fun `given duplicate rows under one name, when upsert, then updates the first and removes the rest`() = runTest {
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when upsert, then throws PermissionException`() = runTest {
     // Given
-    // The table has no unique constraint on (EVENT_ID, NAME), so a name can carry several rows.
-    val updatedUriSlot = slot<Uri>()
-    val deletedUris = mutableListOf<Uri>()
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 5L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-1"
-      ),
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 6L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-1-duplicate"
-      )
-    )
-    every { contentResolver.update(capture(updatedUriSlot), any(), any(), any()) } returns 1
-    every { contentResolver.delete(capture(deletedUris), any(), any()) } returns 1
+    every { contentResolver.applyBatch(any(), any()) } throws SecurityException()
 
-    // When
-    val result = repository.upsert(
-      EventId(42L),
-      account,
-      ExtendedPropertyInput(name = "private:x-owner", value = "mirror-2")
-    )
+    // When / Then
+    repository.upsert(EventId(42L), account, ExtendedPropertyInput("private:x-owner", "mirror-42"))
+  }
 
-    // Then
-    Assert.assertEquals(ExtendedPropertyId(5L), result)
-    Assert.assertEquals("5", updatedUriSlot.captured.lastPathSegment)
-    Assert.assertEquals(listOf("6"), deletedUris.map { it.lastPathSegment })
-    verify(exactly = 0) { contentResolver.insert(any(), any()) }
+  @Test(expected = CouldNotExecuteQueryException::class)
+  fun `given a rejected batch, when upsert, then throws CouldNotExecuteQueryException`() = runTest {
+    // Given
+    every { contentResolver.applyBatch(any(), any()) } throws OperationApplicationException()
+
+    // When / Then
+    repository.upsert(EventId(42L), account, ExtendedPropertyInput("private:x-owner", "mirror-42"))
   }
 
   // endregion
@@ -274,65 +205,39 @@ class ExtendedPropertyRepositoryTest {
   // region deleteByName
 
   @Test
-  fun `given an existing property, when deleteByName, then deletes that row through the sync adapter URI`() = runTest {
+  fun `given a name, when deleteByName, then removes every matching row through the sync adapter URI`() = runTest {
     // Given
     val uriSlot = slot<Uri>()
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 5L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-42"
-      )
-    )
-    every { contentResolver.delete(capture(uriSlot), any(), any()) } returns 1
+    val whereSlot = slot<String>()
+    val selectionArgsSlot = slot<Array<String>>()
+    every {
+      contentResolver.delete(capture(uriSlot), capture(whereSlot), capture(selectionArgsSlot))
+    } returns 2
 
     // When
     val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
 
     // Then
+    // Selecting on the name rather than on a row id removes the duplicates the table allows.
     Assert.assertTrue(result)
-    Assert.assertEquals("5", uriSlot.captured.lastPathSegment)
     Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals(
+      "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
+      whereSlot.captured
+    )
+    Assert.assertArrayEquals(arrayOf("42", "private:x-owner"), selectionArgsSlot.captured)
   }
 
   @Test
-  fun `given no such property, when deleteByName, then returns false without touching the provider`() = runTest {
+  fun `given no matching row, when deleteByName, then returns false`() = runTest {
     // Given
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns emptyCursor()
+    every { contentResolver.delete(any(), any(), any()) } returns 0
 
     // When
     val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
 
     // Then
     Assert.assertFalse(result)
-    verify(exactly = 0) { contentResolver.delete(any(), any(), any()) }
-  }
-
-  @Test
-  fun `given duplicate rows under one name, when deleteByName, then removes every row`() = runTest {
-    // Given
-    val deletedUris = mutableListOf<Uri>()
-    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 5L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-42"
-      ),
-      mapOf(
-        CalendarContract.ExtendedProperties._ID to 6L,
-        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
-        CalendarContract.ExtendedProperties.VALUE to "mirror-42-duplicate"
-      )
-    )
-    every { contentResolver.delete(capture(deletedUris), any(), any()) } returns 1
-
-    // When
-    val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
-
-    // Then
-    // Leaving a duplicate behind would make the delete report a success it did not deliver.
-    Assert.assertTrue(result)
-    Assert.assertEquals(listOf("5", "6"), deletedUris.map { it.lastPathSegment })
   }
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
@@ -115,10 +115,10 @@ class ExtendedPropertyRepositoryTest {
 
   // endregion
 
-  // region findByName
+  // region findAllByName
 
   @Test
-  fun `given a name, when findByName, then selects on both EVENT_ID and NAME`() = runTest {
+  fun `given a name, when findAllByName, then selects on both EVENT_ID and NAME`() = runTest {
     // Given
     val selectionSlot = slot<String>()
     val selectionArgsSlot = slot<Array<String>>()
@@ -127,10 +127,10 @@ class ExtendedPropertyRepositoryTest {
     } returns emptyCursor()
 
     // When
-    val result = repository.findByName(EventId(42L), "private:x-owner")
+    val result = repository.findAllByName(EventId(42L), "private:x-owner")
 
     // Then
-    Assert.assertNull(result)
+    Assert.assertEquals(emptyList<ExtendedPropertyEntity>(), result)
     Assert.assertEquals(
       "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
       selectionSlot.captured
@@ -211,6 +211,41 @@ class ExtendedPropertyRepositoryTest {
     repository.upsert(EventId(42L), account, ExtendedPropertyInput("private:x-owner", "mirror-42"))
   }
 
+  @Test
+  fun `given duplicate rows under one name, when upsert, then updates the first and removes the rest`() = runTest {
+    // Given
+    // The table has no unique constraint on (EVENT_ID, NAME), so a name can carry several rows.
+    val updatedUriSlot = slot<Uri>()
+    val deletedUris = mutableListOf<Uri>()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-1"
+      ),
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 6L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-1-duplicate"
+      )
+    )
+    every { contentResolver.update(capture(updatedUriSlot), any(), any(), any()) } returns 1
+    every { contentResolver.delete(capture(deletedUris), any(), any()) } returns 1
+
+    // When
+    val result = repository.upsert(
+      EventId(42L),
+      account,
+      ExtendedPropertyInput(name = "private:x-owner", value = "mirror-2")
+    )
+
+    // Then
+    Assert.assertEquals(ExtendedPropertyId(5L), result)
+    Assert.assertEquals("5", updatedUriSlot.captured.lastPathSegment)
+    Assert.assertEquals(listOf("6"), deletedUris.map { it.lastPathSegment })
+    verify(exactly = 0) { contentResolver.insert(any(), any()) }
+  }
+
   // endregion
 
   // region deleteByName
@@ -248,6 +283,33 @@ class ExtendedPropertyRepositoryTest {
     // Then
     Assert.assertFalse(result)
     verify(exactly = 0) { contentResolver.delete(any(), any(), any()) }
+  }
+
+  @Test
+  fun `given duplicate rows under one name, when deleteByName, then removes every row`() = runTest {
+    // Given
+    val deletedUris = mutableListOf<Uri>()
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-42"
+      ),
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 6L,
+        CalendarContract.ExtendedProperties.NAME to "private:x-owner",
+        CalendarContract.ExtendedProperties.VALUE to "mirror-42-duplicate"
+      )
+    )
+    every { contentResolver.delete(capture(deletedUris), any(), any()) } returns 1
+
+    // When
+    val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
+
+    // Then
+    // Leaving a duplicate behind would make the delete report a success it did not deliver.
+    Assert.assertTrue(result)
+    Assert.assertEquals(listOf("5", "6"), deletedUris.map { it.lastPathSegment })
   }
 
   // endregion

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
@@ -75,6 +75,29 @@ class ExtendedPropertyRepositoryTest {
   }
 
   @Test
+  fun `given a row without a name or a value, when findAllByEventId, then keeps the nulls`() = runTest {
+    // Given
+    // No database constraint forbids either column being null, so the entity has to carry what is
+    // there rather than refuse to map the row.
+    val cursor = cursorWithRows(
+      mapOf(
+        CalendarContract.ExtendedProperties._ID to 5L,
+        CalendarContract.ExtendedProperties.NAME to null,
+        CalendarContract.ExtendedProperties.VALUE to null
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.findAllByEventId(EventId(99L))
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    Assert.assertNull(result[0].name)
+    Assert.assertNull(result[0].value)
+  }
+
+  @Test
   fun `given event id, when findAllByEventId, then reads through the plain URI selecting on EVENT_ID`() = runTest {
     // Given
     val uriSlot = slot<Uri>()

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/domain/repositories/extendedproperty/ExtendedPropertyRepositoryTest.kt
@@ -142,11 +142,12 @@ class ExtendedPropertyRepositoryTest {
   // region upsert
 
   @Test
-  fun `given a name and a value, when upsert, then deletes and inserts in one batch through the sync adapter URI`() = runTest {
+  fun `given a name and a value, when upsert, then flags the event, deletes and inserts in one batch`() = runTest {
     // Given
     val authoritySlot = slot<String>()
     val operationsSlot = slot<ArrayList<ContentProviderOperation>>()
     every { contentResolver.applyBatch(capture(authoritySlot), capture(operationsSlot)) } returns arrayOf(
+      ContentProviderResult(1),
       ContentProviderResult(1),
       ContentProviderResult(Uri.parse("content://com.android.calendar/extendedproperties/7"))
     )
@@ -159,17 +160,17 @@ class ExtendedPropertyRepositoryTest {
     )
 
     // Then
-    // The provider applies a batch as one transaction, so the row a concurrent write could have
-    // left behind is gone and the new one is in place without a window between the two.
+    // The provider applies a batch as one transaction, so the event is flagged before the rows it
+    // covers move, the row a concurrent write could have left behind is gone, and the new one is
+    // in place without a window between the two.
     Assert.assertEquals(ExtendedPropertyId(7L), result)
     Assert.assertEquals(CalendarContract.AUTHORITY, authoritySlot.captured)
-    Assert.assertEquals(2, operationsSlot.captured.size)
-    Assert.assertTrue(operationsSlot.captured[0].isDelete)
-    Assert.assertTrue(operationsSlot.captured[1].isInsert)
-    operationsSlot.captured.forEach { operation ->
-      Assert.assertEquals("true", operation.uri.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-      Assert.assertEquals("user@example.com", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME))
-      Assert.assertEquals("com.google", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE))
+    Assert.assertEquals(3, operationsSlot.captured.size)
+    assertFlagsTheEvent(operationsSlot.captured.first())
+    Assert.assertTrue(operationsSlot.captured[1].isDelete)
+    Assert.assertTrue(operationsSlot.captured[2].isInsert)
+    operationsSlot.captured.drop(1).forEach { operation ->
+      assertRunsAsSyncAdapter(operation)
     }
   }
 
@@ -205,33 +206,35 @@ class ExtendedPropertyRepositoryTest {
   // region deleteByName
 
   @Test
-  fun `given a name, when deleteByName, then removes every matching row through the sync adapter URI`() = runTest {
+  fun `given a name, when deleteByName, then flags the event and removes every matching row in one batch`() = runTest {
     // Given
-    val uriSlot = slot<Uri>()
-    val whereSlot = slot<String>()
-    val selectionArgsSlot = slot<Array<String>>()
-    every {
-      contentResolver.delete(capture(uriSlot), capture(whereSlot), capture(selectionArgsSlot))
-    } returns 2
+    val operationsSlot = slot<ArrayList<ContentProviderOperation>>()
+    every { contentResolver.applyBatch(any(), capture(operationsSlot)) } returns arrayOf(
+      ContentProviderResult(1),
+      ContentProviderResult(2)
+    )
 
     // When
     val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
 
     // Then
-    // Selecting on the name rather than on a row id removes the duplicates the table allows.
+    // The deletion is what the batch is for, the flag travels with it so the event carries it
+    // before the rows go away.
     Assert.assertTrue(result)
-    Assert.assertEquals("true", uriSlot.captured.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
-    Assert.assertEquals(
-      "${CalendarContract.ExtendedProperties.EVENT_ID} = ? AND ${CalendarContract.ExtendedProperties.NAME} = ?",
-      whereSlot.captured
-    )
-    Assert.assertArrayEquals(arrayOf("42", "private:x-owner"), selectionArgsSlot.captured)
+    Assert.assertEquals(2, operationsSlot.captured.size)
+    assertFlagsTheEvent(operationsSlot.captured.first())
+    val deletion = operationsSlot.captured.last()
+    Assert.assertTrue(deletion.isDelete)
+    assertRunsAsSyncAdapter(deletion)
   }
 
   @Test
   fun `given no matching row, when deleteByName, then returns false`() = runTest {
     // Given
-    every { contentResolver.delete(any(), any(), any()) } returns 0
+    every { contentResolver.applyBatch(any(), any()) } returns arrayOf(
+      ContentProviderResult(1),
+      ContentProviderResult(0)
+    )
 
     // When
     val result = repository.deleteByName(EventId(42L), account, "private:x-owner")
@@ -240,9 +243,36 @@ class ExtendedPropertyRepositoryTest {
     Assert.assertFalse(result)
   }
 
+  @Test(expected = PermissionException::class)
+  fun `given SecurityException, when deleteByName, then throws PermissionException`() = runTest {
+    // Given
+    every { contentResolver.applyBatch(any(), any()) } throws SecurityException()
+
+    // When / Then
+    repository.deleteByName(EventId(42L), account, "private:x-owner")
+  }
+
   // endregion
 
   // region helpers
+
+  private fun assertFlagsTheEvent(operation: ContentProviderOperation) {
+    // The provider sets `dirty` on any update it does not attribute to a sync adapter, so the
+    // event goes through the plain URI, and `HAS_EXTENDED_PROPERTIES` is what keeps Google's sync
+    // adapter from dropping the rows on the next sync.
+    Assert.assertTrue(operation.isUpdate)
+    Assert.assertEquals("42", operation.uri.lastPathSegment)
+    Assert.assertNull(operation.uri.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    val values = requireNotNull(operation.resolveValueBackReferences(emptyArray(), 0))
+    Assert.assertEquals(1, values.size())
+    Assert.assertEquals(1, values.getAsInteger(CalendarContract.Events.HAS_EXTENDED_PROPERTIES))
+  }
+
+  private fun assertRunsAsSyncAdapter(operation: ContentProviderOperation) {
+    Assert.assertEquals("true", operation.uri.getQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER))
+    Assert.assertEquals("user@example.com", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME))
+    Assert.assertEquals("com.google", operation.uri.getQueryParameter(CalendarContract.Calendars.ACCOUNT_TYPE))
+  }
 
   private fun emptyCursor(): Cursor {
     // Empty cursor requires at least one column for MatrixCursor

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapperTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapperTest.kt
@@ -1,0 +1,40 @@
+package expo.modules.calendar.next.mappers
+
+import expo.modules.calendar.next.domain.model.extendedproperty.ExtendedPropertyEntity
+import expo.modules.calendar.next.domain.wrappers.EventId
+import expo.modules.calendar.next.domain.wrappers.ExtendedPropertyId
+import org.junit.Assert
+import org.junit.Test
+
+class ExtendedPropertyMapperTest {
+  private val mapper = ExtendedPropertyMapper()
+
+  @Test
+  fun `given ExtendedPropertyEntity, when toRecord, then maps name and value`() {
+    // Given
+    val entity = ExtendedPropertyEntity(
+      id = ExtendedPropertyId(5L),
+      eventId = EventId(9L),
+      name = "private:x-owner",
+      value = "mirror-42"
+    )
+
+    // When
+    val result = mapper.toRecord(entity)
+
+    // Then
+    Assert.assertEquals("private:x-owner", result.name)
+    Assert.assertEquals("mirror-42", result.value)
+  }
+
+  @Test
+  fun `given a name and a value, when toInput, then keeps the name verbatim`() {
+    // Given / When
+    val result = mapper.toInput("shared:x-owner", "mirror-42")
+
+    // Then
+    // The prefix is part of the name the provider stores, so nothing is stripped or added here.
+    Assert.assertEquals("shared:x-owner", result.name)
+    Assert.assertEquals("mirror-42", result.value)
+  }
+}

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapperTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/next/mappers/ExtendedPropertyMapperTest.kt
@@ -23,8 +23,37 @@ class ExtendedPropertyMapperTest {
     val result = mapper.toRecord(entity)
 
     // Then
-    Assert.assertEquals("private:x-owner", result.name)
-    Assert.assertEquals("mirror-42", result.value)
+    Assert.assertEquals("private:x-owner", result?.name)
+    Assert.assertEquals("mirror-42", result?.value)
+  }
+
+  @Test
+  fun `given an entity without a name, when toRecord, then returns null`() {
+    // Given
+    // Nothing constrains the column, so the provider can hand back a row with no name.
+    val entity = ExtendedPropertyEntity(
+      id = ExtendedPropertyId(5L),
+      eventId = EventId(9L),
+      name = null,
+      value = "mirror-42"
+    )
+
+    // When / Then
+    Assert.assertNull(mapper.toRecord(entity))
+  }
+
+  @Test
+  fun `given an entity without a value, when toRecord, then returns null`() {
+    // Given
+    val entity = ExtendedPropertyEntity(
+      id = ExtendedPropertyId(5L),
+      eventId = EventId(9L),
+      name = "private:x-owner",
+      value = null
+    )
+
+    // When / Then
+    Assert.assertNull(mapper.toRecord(entity))
   }
 
   @Test

--- a/packages/expo-calendar/src/Calendar.ts
+++ b/packages/expo-calendar/src/Calendar.ts
@@ -8,6 +8,7 @@ import { Platform, processColor } from 'react-native';
 
 import InternalExpoCalendar from './ExpoCalendar';
 import type {
+  ExtendedProperty,
   ModifiableEventProperties,
   ModifiableReminderProperties,
   ModifiableCalendarProperties,
@@ -73,6 +74,27 @@ export class ExpoCalendarEvent extends InternalExpoCalendar.ExpoCalendarEvent {
     const newAttendee = await super.createAttendee(attendee);
     Object.setPrototypeOf(newAttendee, ExpoCalendarAttendee.prototype);
     return newAttendee;
+  }
+
+  override async getExtendedProperties(): Promise<ExtendedProperty[]> {
+    if (Platform.OS !== 'android') {
+      throw new UnavailabilityError('ExpoCalendarEvent', 'getExtendedProperties');
+    }
+    return await super.getExtendedProperties();
+  }
+
+  override async setExtendedProperty(name: string, value: string): Promise<void> {
+    if (Platform.OS !== 'android') {
+      throw new UnavailabilityError('ExpoCalendarEvent', 'setExtendedProperty');
+    }
+    await super.setExtendedProperty(name, value);
+  }
+
+  override async deleteExtendedProperty(name: string): Promise<boolean> {
+    if (Platform.OS !== 'android') {
+      throw new UnavailabilityError('ExpoCalendarEvent', 'deleteExtendedProperty');
+    }
+    return await super.deleteExtendedProperty(name);
   }
 
   override async update(details: Partial<ModifiableEventProperties>): Promise<void> {
@@ -355,6 +377,7 @@ export function getSourcesSync(): Source[] {
 }
 
 export type {
+  ExtendedProperty,
   ModifiableEventProperties,
   ModifiableReminderProperties,
   ModifiableCalendarProperties,

--- a/packages/expo-calendar/src/ExpoCalendar.types.ts
+++ b/packages/expo-calendar/src/ExpoCalendar.types.ts
@@ -89,8 +89,8 @@ export type ExtendedProperty = {
   /**
    * Name the property is stored under, visibility prefix included. Names prefixed with `private:`
    * are readable by the account owning the event, names prefixed with `shared:` by the guests of
-   * the event. On Google Calendar both prefixes survive a round trip to the server, while a name
-   * carrying neither may be stored on the device and dropped by the sync adapter on the next sync.
+   * the event. Both survive a round trip through Google Calendar, while a name carrying neither is
+   * stored on the device and dropped by that sync adapter on the next sync.
    */
   name: string;
   /**
@@ -435,10 +435,10 @@ export declare class ExpoCalendarEvent {
    * row as already synced, so the event is flagged as locally modified afterwards, and that flag
    * is what carries the property to the server on the next sync.
    *
-   * > **Note:** On an event of a calendar owned by an account, `name` has to start with `private:`
-   * > or `shared:`. Sync adapters such as Google Calendar's drop any other name on the next sync,
-   * > without an error, so this method rejects it instead of letting the value disappear later.
-   * > Calendars of the local account are never synced and accept any name.
+   * > **Note:** On an event of a calendar owned by a Google account, `name` has to start with
+   * > `private:` or `shared:`. Google Calendar's sync adapter drops any other name on the next
+   * > sync, without an error, so this method rejects it instead of letting the value disappear
+   * > later. The convention is that adapter's, so calendars of any other account accept any name.
    *
    * @param name Name to store the value under, visibility prefix included.
    * @param value Value to store.

--- a/packages/expo-calendar/src/ExpoCalendar.types.ts
+++ b/packages/expo-calendar/src/ExpoCalendar.types.ts
@@ -81,16 +81,16 @@ export type ModifiableAttendeeProperties = ExpoCalendarAttendee;
 
 /**
  * Key/value pair attached to an event, stored in Android's `CalendarContract.ExtendedProperties`
- * table. Apps use it to keep metadata of their own on an event, such as an identifier tying the
- * event back to one of their own records, which the event itself has no field for.
+ * table. Android events have no field reserved for an app's own data, so apps use this one to keep
+ * theirs, such as an identifier tying the event back to one of their own records.
  * @platform android
  */
 export type ExtendedProperty = {
   /**
-   * Name the property is stored under, visibility prefix included. Names prefixed `private:` are
-   * readable by the account owning the event, names prefixed `shared:` by the guests of the event,
-   * and both survive a round trip to the server the calendar syncs with. A name carrying neither
-   * prefix stays on the device: the sync adapter drops it on the next sync.
+   * Name the property is stored under, visibility prefix included. Names prefixed with `private:`
+   * are readable by the account owning the event, names prefixed with `shared:` by the guests of
+   * the event. On Google Calendar both prefixes survive a round trip to the server, while a name
+   * carrying neither may be stored on the device and dropped by the sync adapter on the next sync.
    */
   name: string;
   /**
@@ -430,14 +430,15 @@ export declare class ExpoCalendarEvent {
    * Attaches a key/value pair to this event, replacing the value already stored under the same name.
    *
    * The property is written as the sync adapter of the account owning the event, because the
-   * calendar provider accepts writes to that table from no one else. Writing that way records the
+   * calendar provider accepts writes to that table from no one else. Any duplicate already stored
+   * under the same name is removed, so the name is left carrying exactly one value. Writing that way records the
    * row as already synced, so the event is flagged as locally modified afterwards, and that flag
    * is what carries the property to the server on the next sync.
    *
-   * > **Note:** on an event of a calendar owned by an account, `name` has to start with `private:`
-   * > or `shared:`. Any other name is stored on the device and dropped by the sync adapter on the
-   * > next sync, without an error, so this method rejects it instead. Calendars of the local
-   * > account are never synced and accept any name.
+   * > **Note:** On an event of a calendar owned by an account, `name` has to start with `private:`
+   * > or `shared:`. Sync adapters such as Google Calendar's drop any other name on the next sync,
+   * > without an error, so this method rejects it instead of letting the value disappear later.
+   * > Calendars of the local account are never synced and accept any name.
    *
    * @param name Name to store the value under, visibility prefix included.
    * @param value Value to store.
@@ -452,11 +453,11 @@ export declare class ExpoCalendarEvent {
   setExtendedProperty(name: string, value: string): Promise<void>;
 
   /**
-   * Removes the property stored under `name` on this event, and flags the event so that the removal
-   * reaches the server on the next sync.
+   * Removes every property stored under `name` on this event, and flags the event so that the
+   * removal reaches the server on the next sync.
    * @param name Name of the property to remove, visibility prefix included.
-   * @return A promise that resolves to `true` when a property was removed, and to `false` when the
-   * event carried none under that name.
+   * @return A promise that resolves to `true` when at least one property was removed, and to
+   * `false` when the event carried none under that name.
    * @platform android
    */
   deleteExtendedProperty(name: string): Promise<boolean>;

--- a/packages/expo-calendar/src/ExpoCalendar.types.ts
+++ b/packages/expo-calendar/src/ExpoCalendar.types.ts
@@ -79,6 +79,27 @@ export type ModifiableReminderProperties = Pick<
 
 export type ModifiableAttendeeProperties = ExpoCalendarAttendee;
 
+/**
+ * Key/value pair attached to an event, stored in Android's `CalendarContract.ExtendedProperties`
+ * table. Apps use it to keep metadata of their own on an event, such as an identifier tying the
+ * event back to one of their own records, which the event itself has no field for.
+ * @platform android
+ */
+export type ExtendedProperty = {
+  /**
+   * Name the property is stored under, visibility prefix included. Names prefixed `private:` are
+   * readable by the account owning the event, names prefixed `shared:` by the guests of the event,
+   * and both survive a round trip to the server the calendar syncs with. A name carrying neither
+   * prefix stays on the device: the sync adapter drops it on the next sync.
+   */
+  name: string;
+  /**
+   * Value stored under `name`. It is stored verbatim, so anything structured has to be serialized
+   * by the caller.
+   */
+  value: string;
+};
+
 export declare class ExpoCalendar {
   constructor(id: string);
 
@@ -396,6 +417,49 @@ export declare class ExpoCalendarEvent {
    * @return An array of [`Attendee`](#attendee) associated with the specified event.
    */
   getAttendees(): Promise<ExpoCalendarAttendee[]>;
+
+  /**
+   * Gets the extended properties attached to this event, including the ones written by other apps
+   * or by the calendar's own sync adapter.
+   * @return A promise that resolves to the properties stored on the event.
+   * @platform android
+   */
+  getExtendedProperties(): Promise<ExtendedProperty[]>;
+
+  /**
+   * Attaches a key/value pair to this event, replacing the value already stored under the same name.
+   *
+   * The property is written as the sync adapter of the account owning the event, because the
+   * calendar provider accepts writes to that table from no one else. Writing that way records the
+   * row as already synced, so the event is flagged as locally modified afterwards, and that flag
+   * is what carries the property to the server on the next sync.
+   *
+   * > **Note:** on an event of a calendar owned by an account, `name` has to start with `private:`
+   * > or `shared:`. Any other name is stored on the device and dropped by the sync adapter on the
+   * > next sync, without an error, so this method rejects it instead. Calendars of the local
+   * > account are never synced and accept any name.
+   *
+   * @param name Name to store the value under, visibility prefix included.
+   * @param value Value to store.
+   *
+   * @example
+   * ```ts
+   * await event.setExtendedProperty('private:my-app-id', 'a4f1c2');
+   * ```
+   *
+   * @platform android
+   */
+  setExtendedProperty(name: string, value: string): Promise<void>;
+
+  /**
+   * Removes the property stored under `name` on this event, and flags the event so that the removal
+   * reaches the server on the next sync.
+   * @param name Name of the property to remove, visibility prefix included.
+   * @return A promise that resolves to `true` when a property was removed, and to `false` when the
+   * event carried none under that name.
+   * @platform android
+   */
+  deleteExtendedProperty(name: string): Promise<boolean>;
 
   /**
    * Updates the provided details of an existing calendar stored on the device. To remove a property,

--- a/packages/expo-calendar/src/__tests__/Calendar-test.native.ts
+++ b/packages/expo-calendar/src/__tests__/Calendar-test.native.ts
@@ -2,7 +2,15 @@ jest.mock('../ExpoCalendar', () => ({
   __esModule: true,
   default: {
     ExpoCalendar: class {},
-    ExpoCalendarEvent: class {},
+    ExpoCalendarEvent: class {
+      async getExtendedProperties() {
+        return [{ name: 'private:x-owner', value: 'mirror-42' }];
+      }
+      async setExtendedProperty() {}
+      async deleteExtendedProperty() {
+        return true;
+      }
+    },
     ExpoCalendarReminder: class {},
     ExpoCalendarAttendee: class {},
     getSourcesSync: jest.fn(),
@@ -54,5 +62,32 @@ describe('entrypoints', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('expo-calendar/legacy'));
 
     warn.mockRestore();
+  });
+});
+
+describe('extended properties', () => {
+  const properties = [{ name: 'private:x-owner', value: 'mirror-42' }];
+
+  it('are reachable on Android and unavailable everywhere else', async () => {
+    const { Platform } = require('react-native');
+    const { ExpoCalendarEvent } = require('../index');
+    const event = Object.create(ExpoCalendarEvent.prototype);
+
+    if (Platform.OS === 'android') {
+      await expect(event.getExtendedProperties()).resolves.toEqual(properties);
+      await expect(
+        event.setExtendedProperty('private:x-owner', 'mirror-42')
+      ).resolves.toBeUndefined();
+      await expect(event.deleteExtendedProperty('private:x-owner')).resolves.toBe(true);
+    } else {
+      // The table backing them exists only in Android's calendar provider.
+      await expect(event.getExtendedProperties()).rejects.toThrow(/not available/);
+      await expect(event.setExtendedProperty('private:x-owner', 'mirror-42')).rejects.toThrow(
+        /not available/
+      );
+      await expect(event.deleteExtendedProperty('private:x-owner')).rejects.toThrow(
+        /not available/
+      );
+    }
   });
 });


### PR DESCRIPTION
# Why

I am building an app that writes and manages its own events inside a user's calendar, so it has to know which events are its own. Without a per-event marker there is no safe way to tell: the app either risks deleting events the user created, or has to keep a side database mapping its ids to calendar ids, which drifts as soon as the calendar is edited elsewhere, does not survive a reinstall, and cannot be shared across devices.

iOS has `url` for exactly this, documented as iOS-only. Android has `CalendarContract.ExtendedProperties`, the platform mechanism meant for it, which `expo-calendar` does not expose. So the guard "never delete an event I did not create" can be written on one platform and not on the other.

## The one thing to agree on first

`CalendarProvider2` refuses writes to that table from ordinary callers:

    IllegalArgumentException: Only sync adapters may write using
    content://com.android.calendar/extendedproperties

The way through is `?caller_is_syncadapter=true&account_name=...&account_type=...`. Four things make that a smaller step than it sounds:

- `CalendarContract.CALLER_IS_SYNCADAPTER` is public, documented API. No permission gates it, and it needs no manifest entry, no `SyncAdapter` service and no account authenticator. It is a per-request write mode, not a status the app registers with the system.
- **`expo-calendar` already uses it**, in both implementations, to create calendars: `domain/calendar/CalendarRepository.kt:52` and `next/domain/repositories/calendar/CalendarRepository.kt:44`. This PR does not introduce the practice, it reuses it for a second table.
- The scope stays that one table. Events keep going through the plain URI, so the two provider behaviours that matter for them are untouched: a deletion still leaves the tombstone a sync adapter needs to propagate it, and `dirty` is still set on every write.
- What the provider does not do is verify the claim. It never checks that the caller really is that account's sync adapter. That is the part which is a convention being leaned on rather than an API used as intended, and it is why this deserves an explicit yes rather than being assumed.

**So the question is narrow: you already declare `expo-calendar` a sync adapter to create calendars, is there a reason for a key/value write on an event to be treated differently?**

If extended properties should not go through that door, I am curious to know more about the reason. Everything below follows from that decision.

# How

Measured on a physical device (Huawei P30, EMUI, real Google account) rather than assumed. Three findings shaped the API.

**1. Only prefixed names survive a server round trip.** Three names were written to one event, pushed to Google, then the local database was wiped (`pm clear com.android.providers.calendar`) and rebuilt from Google's servers:

| Name written | Survived a full server round trip | |---|---|
| `x-hide-my-cal` | **no** |
| `private:x-hide-my-cal` | **yes** |
| `shared:x-hide-my-cal` | **yes** |

The prefixes map onto `extendedProperties.private` and `extendedProperties.shared` in the Google Calendar API. Unprefixed names are dropped by the sync adapter — silently, after the local write has already reported success.

Corroborating evidence from the same wipe: EMUI's own `private:categories = "Come From :com.android.shell"` came back too. Its value encodes how the event was created, which no local process could reconstruct after a wipe, so it came from the server.

**2. The sync-adapter write marks the row as already synced.** The event stays at `dirty=0` and nothing is ever pushed. A normal write to any column afterwards sets `dirty=1`, and the properties travel with the next sync (confirmed: back to `dirty=0` within 15 seconds).

**3. Reads need none of this.** Ordinary callers may read the table.

So the API deliberately is not a thin wrapper over the table. A wrapper would let callers write an unprefixed name, read it back locally, watch it work, and lose it at the first sync without ever seeing an error. Instead:

- writes go through the sync adapter URI, with the account resolved from the event's calendar, handled internally;
- the event is marked dirty after every write and every delete, so the change actually leaves the device;
- unprefixed names are rejected on calendars owned by an account, with an error explaining the prefixes, and accepted on local-account calendars, which no adapter syncs.

The change follows the layering already in `next`: `ExtendedPropertyEntity` / `ExtendedPropertyInput` / `ExtendedPropertyRepository` (a separate table, so its own URI and lifecycle, not a column on Events) → `ExtendedPropertyRecord` / `ExtendedPropertyMapper` → `ExpoCalendarEvent` → TypeScript. `EventRepository.markDirty()` is the one addition to an existing repository.

Public surface, Android only:

```ts
await event.setExtendedProperty('private:my-app-id', 'a4f1c2');
await event.getExtendedProperties(); // [{ name: 'private:my-app-id', value: 'a4f1c2' }]
await event.deleteExtendedProperty('private:my-app-id');
```

On other platforms the three methods throw `UnavailabilityError`, following the existing pattern for the iOS-only reminder APIs.

## Open questions

- **The sync-adapter declaration above.** Everything else is downstream of it.
- **Prefix enforcement.** Rejecting unprefixed names on synced calendars trades a compile-free footgun for a runtime error. The alternative (accept anything and document the trap) is one comment away.
- **Recurring events.** `setExtendedProperty` on an occurrence writes to the parent event, since extended properties belong to the event row. iOS `url` behaves the same way, so this does not change it, but it is worth naming.

# Test Plan

Unit tests, matching the conventions of `EventRepositoryTest` (mockk + Robolectric + `MatrixCursor`):

- `ExtendedPropertyRepositoryTest`: reads go through the plain URI and select on `EVENT_ID`; writes carry the sync adapter parameters; an existing property is updated in place through its row URI rather than duplicated; a missing one is not deleted; `SecurityException` surfaces as `PermissionException`.
- `EventRepositoryTest`: `markDirty` rewrites the start date through the plain URI, writes exactly one column, and no-ops on an event that is gone.
- `ExtendedPropertyNameTest`, `ExtendedPropertyMapperTest`: the prefix rule and the mapping.
- `Calendar-test.native.ts`: the methods resolve on Android and throw `UnavailabilityError` elsewhere.

Run with `et check-packages expo-calendar` and `et native-unit-tests -p android --packages expo-calendar`.

Device check to reproduce the findings above (around half a day, physical device with a real Google account; an emulator cannot answer this):

1. `setExtendedProperty('private:x-test', 'v1')` on an event of a Google calendar.
2. Force a sync, confirm the event is visible on calendar.google.com.
3. Settings → Apps → show system apps → Calendar Storage → Clear data. This wipes the local database without removing the account, forcing a full resync from the server.
4. `getExtendedProperties()` on the event once it comes back. Note the trap: the resync rebuilds the database, so the event returns under a different row id. Querying the pre-wipe id reports a false negative.
5. Repeat with an unprefixed name: it is now rejected upfront, which is the behaviour this change is arguing for.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). Note: n/a, no plugin change
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
