### PR TITLE
[router] Remove devtools related stackRef

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -81,6 +81,7 @@
 ### 💡 Others
 
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))
+- Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`.
 - Scope routing queues to each router root and bind `useRouter()` to its owning container. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Derive `useIsFocused` from context. ([#49390](https://github.com/expo/expo/pull/49390) by [@Ubax](https://github.com/Ubax))
 - Base `useNavigationState` on global state. ([#49381](https://github.com/expo/expo/pull/49381) by [@jakub-agent](https://github.com/jakub-agent))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -80,8 +80,8 @@
 
 ### 💡 Others
 
+- Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`. ([#49431](https://github.com/expo/expo/pull/49431) by [@Ubax](https://github.com/Ubax))
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))
-- Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`.
 - Scope routing queues to each router root and bind `useRouter()` to its owning container. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Derive `useIsFocused` from context. ([#49390](https://github.com/expo/expo/pull/49390) by [@Ubax](https://github.com/Ubax))
 - Base `useNavigationState` on global state. ([#49381](https://github.com/expo/expo/pull/49381) by [@jakub-agent](https://github.com/jakub-agent))

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -102,14 +102,13 @@ function BaseNavigationContainerInner({
 
   const registry = use(RouterRegistryContext)!;
   const emitter = useEventEmitter<NavigationContainerEventMap>();
-  // TODO(@ubax): investigate if this is really needed
-  const stackRef = React.useRef<string | undefined>(undefined);
   // TODO(@ubax): invoke this callback from global reducer dispatches.
   // https://linear.app/expo/issue/ENG-26123
   const onDispatchAction = useLatestCallback((action: NavigationAction, noop: boolean) => {
+    // TODO(@ubax): Capture dispatch stack traces in the expo-router devtools plugin. https://linear.app/expo/issue/ENG-20826
     emitter.emit({
       type: '__unsafe_action__',
-      data: { action, noop, stack: stackRef.current },
+      data: { action, noop },
     });
   });
 
@@ -243,7 +242,6 @@ function BaseNavigationContainerInner({
       resetNavigator,
       onDispatchAction,
       onOptionsChange,
-      stackRef,
     }),
     [addListener, addKeyedListener, handleAction, onDispatchAction, onOptionsChange, resetNavigator]
   );

--- a/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
@@ -42,7 +42,6 @@ export const NavigationBuilderContext = React.createContext<{
   addKeyedListener?: AddKeyedListener;
   onDispatchAction: (action: NavigationAction, noop: boolean) => void;
   onOptionsChange: (options: object, routeKey?: string) => void;
-  stackRef?: React.MutableRefObject<string | undefined>;
 }>({
   handleAction: () => undefined,
   resetNavigator: () => undefined,

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -754,10 +754,6 @@ export type NavigationContainerEventMap = {
        * Whether the action was a no-op, i.e. resulted in any state changes.
        */
       noop: boolean;
-      /**
-       * Stack trace of the action, this will only be available during development.
-       */
-      stack: string | undefined;
     };
   };
 };

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -108,7 +108,7 @@ export function useDescriptors<
 }: Options<State, ScreenOptions, EventMap>) {
   const theme = use(ThemeContext);
   const [options, setOptions] = React.useState<Record<string, ScreenOptions>>({});
-  const { handleAction, resetNavigator, onDispatchAction, onOptionsChange, stackRef } =
+  const { handleAction, resetNavigator, onDispatchAction, onOptionsChange } =
     use(NavigationBuilderContext);
 
   const context = React.useMemo(
@@ -120,7 +120,6 @@ export function useDescriptors<
       addKeyedListener,
       onDispatchAction,
       onOptionsChange,
-      stackRef,
     }),
     [
       navigation,
@@ -130,7 +129,6 @@ export function useDescriptors<
       addKeyedListener,
       onDispatchAction,
       onOptionsChange,
-      stackRef,
     ]
   );
 

--- a/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
@@ -1,6 +1,5 @@
 'use client';
 import * as React from 'react';
-import { use } from 'react';
 
 import {
   CommonActions,
@@ -9,7 +8,6 @@ import {
   type ParamListBase,
   type Router,
 } from '../routers';
-import { NavigationBuilderContext } from './NavigationBuilderContext';
 import type { NavigationHelpers, NavigationProp } from './types';
 import type { NavigationEventEmitter } from './useEventEmitter';
 
@@ -63,6 +61,7 @@ export function useNavigationCache<
   emitter,
 }: Options<State, ScreenOptions, EventMap>) {
   const { stackRef } = use(NavigationBuilderContext);
+  const getState = useLatestCallback(() => state);
 
   // Cache object which holds navigation objects for each screen
   // We use `React.useMemo` instead of `React.useRef` coz we want to invalidate it when deps change
@@ -108,24 +107,6 @@ export function useNavigationCache<
       navigation.dispatch({ source: route.key, ...action });
     };
 
-    const withStack = (callback: () => void) => {
-      let isStackSet = false;
-
-      try {
-        if (process.env.NODE_ENV !== 'production' && stackRef && !stackRef.current) {
-          // Capture the stack trace for devtools
-          stackRef.current = new Error().stack;
-          isStackSet = true;
-        }
-
-        callback();
-      } finally {
-        if (isStackSet && stackRef) {
-          stackRef.current = undefined;
-        }
-      }
-    };
-
     const actions = {
       ...router.actionCreators,
       ...CommonActions,
@@ -133,10 +114,8 @@ export function useNavigationCache<
 
     const helpers = Object.keys(actions).reduce<Record<string, () => void>>((acc, name) => {
       acc[name] = (...args: any) =>
-        withStack(() =>
-          // @ts-expect-error: name is a valid key, but TypeScript is dumb
-          dispatch(actions[name](...args))
-        );
+        // @ts-expect-error: name is a valid key, but TypeScript is dumb
+        dispatch(actions[name](...args));
 
       return acc;
     }, {});
@@ -149,8 +128,8 @@ export function useNavigationCache<
       ...helpers,
       // FIXME: too much work to fix the types for now
       ...(emitter.create(route.key) as any),
-      dispatch: (action: NavigationAction) => withStack(() => dispatch(action)),
-      dispatchSync: (action: NavigationAction) => withStack(() => dispatchSync(action)),
+      dispatch,
+      dispatchSync,
       getParent: (id?: string) => {
         if (id !== undefined && id === rest.getId()) {
           // If the passed id is the same as the current navigation id,

--- a/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
@@ -60,9 +60,6 @@ export function useNavigationCache<
   router,
   emitter,
 }: Options<State, ScreenOptions, EventMap>) {
-  const { stackRef } = use(NavigationBuilderContext);
-  const getState = useLatestCallback(() => state);
-
   // Cache object which holds navigation objects for each screen
   // We use `React.useMemo` instead of `React.useRef` coz we want to invalidate it when deps change
   // In reality, these deps will rarely change, if ever


### PR DESCRIPTION
## Why

The `stackRef` is one of the blockers for concurrent react migration. It is used only in react-navigation/devtools which will no longer work with expo-router anyway.

We will add our own devtools as part of https://linear.app/expo/issue/ENG-20826

## How

1. Remove `stackRef` and `withStack`
2. Remove `stack` param from `__unsafe_action__`