### PR TITLE
[router] Replace imperative state reads with in-tree context

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -80,6 +80,7 @@
 
 ### 💡 Others
 
+- Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))
 - Scope routing queues to each router root and bind `useRouter()` to its owning container. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Derive `useIsFocused` from context. ([#49390](https://github.com/expo/expo/pull/49390) by [@Ubax](https://github.com/Ubax))
 - Base `useNavigationState` on global state. ([#49381](https://github.com/expo/expo/pull/49381) by [@jakub-agent](https://github.com/jakub-agent))

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -1190,6 +1190,14 @@ it('can reference a parent trigger from nested tabs', () => {
   expect(screen.getByTestId('current-parent')).toHaveProp('isFocused', true);
   expect(screen.getByTestId('goto-parent')).toHaveProp('isFocused', false);
   fireEvent.press(screen.getByTestId('goto-parent'));
+  expect(screen.getByTestId('current-parent', { includeHiddenElements: true })).toHaveProp(
+    'isFocused',
+    false
+  );
+  expect(screen.getByTestId('goto-parent', { includeHiddenElements: true })).toHaveProp(
+    'isFocused',
+    true
+  );
   expect(screen.getByTestId('index')).toBeVisible();
 });
 

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -147,21 +147,6 @@ function NavigationContainerInner(
   });
 
   const [isResolved, initialState] = useThenable(getInitialState);
-  if (
-    store &&
-    // Linking state remains the initial state forever. Once navigation is ready,
-    // `onStateChange` owns the store and this must not restore stale state.
-    !refContainer.current?.isReady() &&
-    // Async linking may not have produced its initial state yet.
-    initialState &&
-    // Avoid recalculating route info when the store already has this exact state.
-    initialState !== store.state
-  ) {
-    // TODO(@ubax): remove this render-phase global write with store ownership teardown.
-    // https://linear.app/expo/issue/ENG-26124
-    // Children read route info during this render, so an effect would update the store too late.
-    syncStoreNavigationState(initialState);
-  }
 
   React.useImperativeHandle(ref, () => refContainer.current!);
 

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -303,23 +303,3 @@ it('throws for an incomplete initial state', () => {
     )
   ).toThrow('incomplete initial state');
 });
-
-it('reads the latest root state by key', () => {
-  const result = renderReducer({
-    registry: new Map([
-      [
-        'root',
-        entry((state) => ({
-          state: { ...state, index: 1 },
-          affectedRouteKey: state.routes[1]!.key,
-        })),
-      ],
-    ]),
-  });
-
-  act(() => result.result.current.handleAction({ type: 'NEXT' }));
-
-  expect(result.result.current.getState()).toBe(result.result.current.state);
-  expect(result.result.current.getStateForKey('root')).toBe(result.result.current.state);
-  expect(result.result.current.getStateForKey('missing')).toBeUndefined();
-});

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -221,7 +221,6 @@ export function useNavigationTreeReducer({
     () => ({ registry, routeNode, linking, redirects }),
     [registry, routeNode, linking, redirects]
   );
-  const stateRef = React.useRef(state);
   const previousRegistryRef = React.useRef(registry);
 
   const processAction = React.useCallback(
@@ -246,17 +245,12 @@ export function useNavigationTreeReducer({
     warnIfScreenParam(params);
     process({ type: 'ACTION', payload: { action, originKey } });
   });
-  const getState = React.useCallback(() => stateRef.current, []);
-  const getStateForKey = React.useCallback(
-    (key: string) => findStateByKey(stateRef.current, key),
-    []
-  );
   const resetNavigator = useLatestCallback((stateKey: string, routerType: string | undefined) => {
     process({ type: 'NAVIGATOR_CHANGED', stateKey, routerType });
   });
 
   React.useInsertionEffect(() => {
-    stateRef.current = state;
+    // TODO(@ubax): Check if this is still needed
     onStateChangeInsertion?.(state);
   }, [onStateChangeInsertion, state]);
 
@@ -272,8 +266,6 @@ export function useNavigationTreeReducer({
 
   return {
     state,
-    getState,
-    getStateForKey,
     resetNavigator,
     handleAction,
     processIntent,

--- a/packages/expo-router/src/hooks/__tests__/useRootNavigationState.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useRootNavigationState.test.ios.tsx
@@ -1,5 +1,7 @@
+import { act, renderHook as renderNativeHook } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
+import { router } from '../../imperative-api';
 import Stack from '../../layouts/Stack';
 import Tabs from '../../layouts/Tabs';
 import { renderRouter } from '../../testing-library';
@@ -7,6 +9,32 @@ import { useRootNavigationState } from '../useRootNavigationState';
 import { renderHook } from './renderHook';
 
 describe(useRootNavigationState, () => {
+  it('throws outside a navigation container', () => {
+    expect(() => renderNativeHook(() => useRootNavigationState())).toThrow(
+      'useRootNavigationState was called from a generated route. This is likely a bug in Expo Router.'
+    );
+  });
+
+  it('returns the updated root state after navigation', () => {
+    const states: ReturnType<typeof useRootNavigationState>[] = [];
+
+    renderRouter({
+      _layout: () => <Stack />,
+      index: function Index() {
+        states.push(useRootNavigationState());
+        return <Text>Index</Text>;
+      },
+      second: () => <Text>Second</Text>,
+    });
+
+    const initialState = states[states.length - 1];
+
+    act(() => router.push('/second'));
+
+    expect(states[states.length - 1]).not.toBe(initialState);
+    expect(states[states.length - 1]?.routes[0]?.state?.routes.at(-1)?.name).toBe('second');
+  });
+
   it('returns the root navigation state', () => {
     const { result } = renderHook(() => useRootNavigationState(), ['index'], {
       initialUrl: '/?test=1&test=2',

--- a/packages/expo-router/src/hooks/useRootNavigationState.ts
+++ b/packages/expo-router/src/hooks/useRootNavigationState.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import { INTERNAL_SLOT_NAME } from '../constants';
-import type { NavigationProp, NavigationState } from '../react-navigation/native';
-import { useNavigation } from '../react-navigation/native';
+import { use } from 'react';
+
+import { RootNavigationStateContext } from '../react-navigation/core/RootNavigationStateContext';
+import type { NavigationState } from '../react-navigation/native';
 
 /**
  * Returns the navigation state of the root navigator — the top-level navigator that
@@ -25,14 +26,11 @@ import { useNavigation } from '../react-navigation/native';
  * reference for the shape of the returned object.
  */
 export function useRootNavigationState(): NavigationState {
-  const parent =
-    // We assume that this is called from routes in __root
-    // Users cannot customize the generated Sitemap or NotFound routes, so we should be safe
-    useNavigation<NavigationProp<object, never, string>>().getParent(INTERNAL_SLOT_NAME);
-  if (!parent) {
+  const state = use(RootNavigationStateContext);
+  if (state === undefined) {
     throw new Error(
       'useRootNavigationState was called from a generated route. This is likely a bug in Expo Router.'
     );
   }
-  return parent.getState();
+  return state;
 }

--- a/packages/expo-router/src/link/preview/HrefPreview.tsx
+++ b/packages/expo-router/src/link/preview/HrefPreview.tsx
@@ -7,11 +7,12 @@ import { findRouteNodeAndParamsForState, type RouteNode } from '../../Route';
 import { INTERNAL_SLOT_NAME } from '../../constants';
 import type { ResultState } from '../../exports';
 import { CompositionContext } from '../../fork/native-stack/composition-options';
-import { store } from '../../global-state/router-store';
 import { StoreContext } from '../../global-state/storeContext';
+import type { ReactNavigationState } from '../../global-state/types';
 import { useRouteInfo } from '../../global-state/useRouteInfo';
 import { getRootStackRouteNames } from '../../global-state/utils';
 import { usePathname } from '../../hooks';
+import { RootNavigationStateContext } from '../../react-navigation/core/RootNavigationStateContext';
 import {
   NavigationContext,
   type NavigationProp,
@@ -28,6 +29,7 @@ export function HrefPreview({ href }: { href: Href }) {
   // TODO(@ubax): Extract `linking` and `routeNode` into separate contexts to avoid unrelated rerenders.
   const { segments: routeSegments } = useRouteInfo();
   const { linking, routeNode } = use(StoreContext) ?? {};
+  const rootNavigationState = use(RootNavigationStateContext);
   const hrefState = useMemo(
     () => getStateForHref(href, { segments: routeSegments }, linking),
     [href, routeSegments, linking]
@@ -37,7 +39,7 @@ export function HrefPreview({ href }: { href: Href }) {
   let isProtected = false;
   if (hrefState?.routes[index]?.name === INTERNAL_SLOT_NAME) {
     let routerState: typeof hrefState | undefined = hrefState;
-    let rnState = store.state;
+    let rnState: ReactNavigationState | undefined = rootNavigationState;
     while (routerState && rnState) {
       const routerRoute: ResultState['routes'][number] = routerState.routes[0]!;
       // When the route we want to show is not present in react-navigation state

--- a/packages/expo-router/src/link/zoom/usePreventZoomTransitionDismissal.ios.tsx
+++ b/packages/expo-router/src/link/zoom/usePreventZoomTransitionDismissal.ios.tsx
@@ -4,6 +4,7 @@ import { use } from 'react';
 
 import { DescriptorsContext } from '../../fork/native-stack/descriptors-context';
 import { INTERNAL_EXPO_ROUTER_GESTURE_ENABLED_OPTION_NAME } from '../../navigationParams';
+import { NavigatorStateContext } from '../../react-navigation/core/useNavigationState';
 import { useRoute } from '../../react-navigation/native';
 import { useNavigation } from '../../useNavigation';
 import { isRoutePreloadedInStack } from '../../utils/stack';
@@ -19,9 +20,10 @@ export function usePreventZoomTransitionDismissal(
   const context = use(ZoomTransitionTargetContext);
   const route = useRoute();
   const navigation = useNavigation();
+  const navigatorState = use(NavigatorStateContext);
   const isPreview = useIsPreview();
   const isFocused = navigation.isFocused();
-  const isPreloaded = isPreview ? false : isRoutePreloadedInStack(navigation.getState(), route);
+  const isPreloaded = isPreview ? false : isRoutePreloadedInStack(navigatorState, route);
 
   const descriptorsMap = use(DescriptorsContext);
   const currentDescriptor = descriptorsMap[route.key];

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -27,6 +27,7 @@ import { EnsureSingleNavigator } from './EnsureSingleNavigator';
 import { NavigationBuilderContext } from './NavigationBuilderContext';
 import { NavigationContainerRefContext } from './NavigationContainerRefContext';
 import { NavigationStateContext } from './NavigationStateContext';
+import { RootNavigationStateContext } from './RootNavigationStateContext';
 import { checkDuplicateRouteNames } from './checkDuplicateRouteNames';
 import { checkSerializable } from './checkSerializable';
 import { NOT_INITIALIZED_ERROR } from './createNavigationContainerRef';
@@ -113,15 +114,14 @@ function BaseNavigationContainerInner({
   });
 
   // TODO(@ubax): consider moving this state to ExpoRoot.
-  const { state, getState, getStateForKey, resetNavigator, handleAction, processIntent } =
-    useNavigationTreeReducer({
-      initialState,
-      routeNode: UNSTABLE_routeNode,
-      registry,
-      linking: store?.linking,
-      redirects: store?.redirects,
-      onStateChangeInsertion: UNSTABLE_onStateChangeInsertion,
-    });
+  const { state, resetNavigator, handleAction, processIntent } = useNavigationTreeReducer({
+    initialState,
+    routeNode: UNSTABLE_routeNode,
+    registry,
+    linking: store?.linking,
+    redirects: store?.redirects,
+    onStateChangeInsertion: UNSTABLE_onStateChangeInsertion,
+  });
 
   const hasNotifiedInitialStateRef = React.useRef(false);
   const lastNotifiedStateRef = React.useRef<NavigationState | undefined>(undefined);
@@ -156,9 +156,7 @@ function BaseNavigationContainerInner({
     }
   });
 
-  const getRootState = useLatestCallback(() => {
-    return getState();
-  });
+  const getRootState = useLatestCallback(() => state);
 
   const getCurrentRoute = useLatestCallback(() => {
     const state = getRootState();
@@ -172,9 +170,8 @@ function BaseNavigationContainerInner({
     return route as Route<string> | undefined;
   });
 
-  const isReady = useLatestCallback(
-    () => listeners.focus[0] != null && registry.has(getState().key)
-  );
+  // TODO(@ubax): check if this is still needed anywhere
+  const isReady = useLatestCallback(() => listeners.focus[0] != null && registry.has(state.key));
 
   const { addOptionsGetter, getCurrentOptions } = useOptionsGetters({});
 
@@ -192,7 +189,7 @@ function BaseNavigationContainerInner({
       isFocused: () => true,
       canGoBack,
       getParent: () => undefined,
-      getState,
+      getState: getRootState,
       getRootState,
       getCurrentRoute,
       getCurrentOptions,
@@ -209,7 +206,6 @@ function BaseNavigationContainerInner({
       getCurrentOptions,
       getCurrentRoute,
       getRootState,
-      getState,
       isReady,
     ]
   );
@@ -244,21 +240,12 @@ function BaseNavigationContainerInner({
       addListener,
       addKeyedListener,
       handleAction,
-      getStateForKey,
       resetNavigator,
       onDispatchAction,
       onOptionsChange,
       stackRef,
     }),
-    [
-      addListener,
-      addKeyedListener,
-      getStateForKey,
-      handleAction,
-      onDispatchAction,
-      onOptionsChange,
-      resetNavigator,
-    ]
+    [addListener, addKeyedListener, handleAction, onDispatchAction, onOptionsChange, resetNavigator]
   );
 
   const context = React.useMemo(
@@ -388,10 +375,12 @@ function BaseNavigationContainerInner({
       <NavigationBuilderContext.Provider value={builderContext}>
         <NavigationStateContext.Provider value={context}>
           <RouteInfoContext.Provider value={routeInfo}>
-            <EnsureSingleNavigator>
-              <ThemeProvider value={theme}>{children}</ThemeProvider>
-            </EnsureSingleNavigator>
-            <RoutingQueueDrainer ready={registry.has(state.key)} processIntent={processIntent} />
+            <RootNavigationStateContext.Provider value={state}>
+              <EnsureSingleNavigator>
+                <ThemeProvider value={theme}>{children}</ThemeProvider>
+              </EnsureSingleNavigator>
+              <RoutingQueueDrainer ready={registry.has(state.key)} processIntent={processIntent} />
+            </RootNavigationStateContext.Provider>
           </RouteInfoContext.Provider>
         </NavigationStateContext.Provider>
       </NavigationBuilderContext.Provider>

--- a/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 
-import type { NavigationAction, NavigationState, ParamListBase } from '../routers';
+import type { NavigationAction, ParamListBase } from '../routers';
 import type { NavigationHelpers } from './types';
 
 export type ListenerMap = {
@@ -37,7 +37,6 @@ export type ChildBeforeRemoveListener = (action: NavigationAction) => void;
  */
 export const NavigationBuilderContext = React.createContext<{
   handleAction: (action: NavigationAction, originKey?: string) => void;
-  getStateForKey: (key: string) => NavigationState | undefined;
   resetNavigator: (stateKey: string, routerType: string | undefined) => void;
   addListener?: AddListener;
   addKeyedListener?: AddKeyedListener;
@@ -46,7 +45,6 @@ export const NavigationBuilderContext = React.createContext<{
   stackRef?: React.MutableRefObject<string | undefined>;
 }>({
   handleAction: () => undefined,
-  getStateForKey: () => undefined,
   resetNavigator: () => undefined,
   onDispatchAction: () => undefined,
   onOptionsChange: () => undefined,

--- a/packages/expo-router/src/react-navigation/core/NavigationProvider.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigationProvider.tsx
@@ -1,11 +1,10 @@
 'use client';
 import * as React from 'react';
-import { use } from 'react';
 
 import type { ParamListBase, Route } from '../routers';
 import { NavigationContext } from './NavigationContext';
 import type { NavigationProp } from './types';
-import { FocusedRouteKeyContext, IsFocusedContext } from './useIsFocused';
+import { IsFocusedContext, useIsRouteFocused } from './useIsFocused';
 
 /**
  * Context which holds the route prop for a screen.
@@ -26,14 +25,7 @@ export const NamedRouteContextListContext = React.createContext<
 >(undefined);
 
 export function NavigationProvider({ route, navigation, children }: Props) {
-  const parentIsFocused = use(IsFocusedContext);
-  const focusedRouteKey = use(FocusedRouteKeyContext);
-
-  // Mark route as focused only if:
-  // - It doesn't have a parent navigator
-  // - Parent navigator is focused
-  const isFocused =
-    parentIsFocused == null || parentIsFocused ? focusedRouteKey === route.key : false;
+  const isFocused = useIsRouteFocused(route.key);
 
   return (
     <NavigationRouteContext.Provider value={route}>

--- a/packages/expo-router/src/react-navigation/core/RootNavigationStateContext.tsx
+++ b/packages/expo-router/src/react-navigation/core/RootNavigationStateContext.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { createContext } from 'react';
+
+import type { NavigationState } from '../routers';
+
+export const RootNavigationStateContext = createContext<NavigationState | undefined>(undefined);

--- a/packages/expo-router/src/react-navigation/core/SceneView.tsx
+++ b/packages/expo-router/src/react-navigation/core/SceneView.tsx
@@ -37,7 +37,6 @@ export function SceneView<State extends NavigationState, ScreenOptions extends o
   const { addOptionsGetter } = useOptionsGetters({
     key: route.key,
     options,
-    navigation,
   });
 
   // Clear options set by this screen when it is unmounted

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -732,6 +732,66 @@ test('emits option events when options change with tab router', () => {
   expect(ref.current?.getCurrentOptions()).toEqual({ h: 9 });
 });
 
+test('does not emit options from an unfocused nested navigator', () => {
+  const NoFocusMockRouter = (options: DefaultRouterOptions) => ({
+    ...MockRouter(options),
+    shouldActionChangeFocus: () => false,
+  });
+  const TestNavigator = React.forwardRef(function TestNavigator(props: any, ref: any): any {
+    const { state, navigation, descriptors, NavigationContent } = useNavigationBuilder(
+      NoFocusMockRouter,
+      props
+    );
+
+    React.useImperativeHandle(ref, () => navigation, [navigation]);
+
+    return (
+      <NavigationContent>
+        {state.routes.map((route) => descriptors[route.key]!.render())}
+      </NavigationContent>
+    );
+  });
+  const child = React.createRef<any>();
+  const ref = createNavigationContainerRef<ParamListBase>();
+  const listener = jest.fn();
+
+  render(
+    <BaseNavigationContainer
+      ref={ref}
+      initialState={{
+        routes: [
+          { name: 'first' },
+          { name: 'nested', state: { routes: [{ name: 'third' }, { name: 'fourth' }] } },
+        ],
+      }}>
+      <TestNavigator>
+        <Screen name="first" options={{ x: 1 }}>
+          {() => null}
+        </Screen>
+        <Screen name="nested">
+          {() => (
+            <TestNavigator ref={child}>
+              <Screen name="third" options={{ g: 5 }}>
+                {() => null}
+              </Screen>
+              <Screen name="fourth" options={{ h: 9 }}>
+                {() => null}
+              </Screen>
+            </TestNavigator>
+          )}
+        </Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+  ref.current?.addListener('options', listener);
+
+  act(() => child.current.navigate('fourth'));
+
+  expect(ref.current?.getCurrentRoute()?.name).toBe('first');
+  expect(listener).not.toHaveBeenCalled();
+  expect(ref.current?.getCurrentOptions()).toEqual({ x: 1 });
+});
+
 test('emits option events when options change with stack router', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, props);

--- a/packages/expo-router/src/react-navigation/core/__tests__/useEventEmitter.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useEventEmitter.test.ios.tsx
@@ -274,7 +274,7 @@ test('fires focus and blur events in nested navigator', () => {
   act(() => parent.current.navigate('first'));
 
   expect(firstFocusCallback).toHaveBeenCalledTimes(2);
-  expect(thirdBlurCallback).toHaveBeenCalledTimes(2);
+  expect(thirdBlurCallback).toHaveBeenCalledTimes(1);
 
   act(() => {
     child.current.navigate('fourth');
@@ -282,7 +282,7 @@ test('fires focus and blur events in nested navigator', () => {
   });
 
   expect(fourthFocusCallback).toHaveBeenCalledTimes(3);
-  expect(thirdBlurCallback).toHaveBeenCalledTimes(2);
+  expect(thirdBlurCallback).toHaveBeenCalledTimes(1);
   expect(firstBlurCallback).toHaveBeenCalledTimes(2);
 
   act(() => child.current.navigate('third'));
@@ -298,7 +298,7 @@ test('fires focus and blur events in nested navigator', () => {
   expect(secondBlurCallback).toHaveBeenCalledTimes(1);
 
   expect(thirdFocusCallback).toHaveBeenCalledTimes(2);
-  expect(thirdBlurCallback).toHaveBeenCalledTimes(2);
+  expect(thirdBlurCallback).toHaveBeenCalledTimes(1);
 
   expect(fourthFocusCallback).toHaveBeenCalledTimes(3);
   expect(fourthBlurCallback).toHaveBeenCalledTimes(3);

--- a/packages/expo-router/src/react-navigation/core/__tests__/useIsFocused.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useIsFocused.test.ios.tsx
@@ -1,10 +1,15 @@
-import { act, render } from '@testing-library/react-native';
+import { act, render, renderHook } from '@testing-library/react-native';
 import * as React from 'react';
 
 import type { ParamListBase } from '../../routers';
 import { Screen } from '../Screen';
 import { createNavigationContainerRef } from '../createNavigationContainerRef';
-import { IsFocusedContext, useIsFocused } from '../useIsFocused';
+import {
+  FocusedRouteKeyContext,
+  IsFocusedContext,
+  useIsFocused,
+  useIsRouteFocused,
+} from '../useIsFocused';
 import { useNavigationBuilder } from '../useNavigationBuilder';
 import { useRoute } from '../useRoute';
 import { BaseNavigationContainer } from './__fixtures__/BaseNavigationContainer';
@@ -40,6 +45,30 @@ test('throws without a focus context', () => {
     "Couldn't find a focus context. Make sure the component is rendered inside your app's route tree. This is most likely a bug in expo-router. Please report it at https://github.com/expo/expo/issues."
   );
 });
+
+test.each([
+  { routeKey: undefined, parentIsFocused: undefined, focusedRouteKey: 'route', expected: true },
+  { routeKey: undefined, parentIsFocused: false, focusedRouteKey: 'route', expected: false },
+  { routeKey: undefined, parentIsFocused: true, focusedRouteKey: 'route', expected: true },
+  { routeKey: 'route', parentIsFocused: undefined, focusedRouteKey: 'route', expected: true },
+  { routeKey: 'route', parentIsFocused: true, focusedRouteKey: 'other', expected: false },
+  { routeKey: 'route', parentIsFocused: false, focusedRouteKey: 'route', expected: false },
+])(
+  'returns $expected for route $routeKey with parent focus $parentIsFocused and focused route $focusedRouteKey',
+  ({ routeKey, parentIsFocused, focusedRouteKey, expected }) => {
+    const wrapper = ({ children }: React.PropsWithChildren) => (
+      <IsFocusedContext.Provider value={parentIsFocused}>
+        <FocusedRouteKeyContext.Provider value={focusedRouteKey}>
+          {children}
+        </FocusedRouteKeyContext.Provider>
+      </IsFocusedContext.Provider>
+    );
+
+    const { result } = renderHook(() => useIsRouteFocused(routeKey), { wrapper });
+
+    expect(result.current).toBe(expected);
+  }
+);
 
 test('renders correct focus state', () => {
   const TestNavigator = (props: any): any => {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 test('preserves reference for navigation objects', () => {
-  expect.assertions(2);
+  expect.assertions(4);
 
   const state: NavigationState = {
     type: 'tab',
@@ -41,7 +41,6 @@ test('preserves reference for navigation objects', () => {
     ],
   };
 
-  const getState = () => state;
   const navigation = {} as any;
   const setOptions = (() => {}) as any;
   const router = MockRouter({});
@@ -53,14 +52,16 @@ test('preserves reference for navigation objects', () => {
     const getNavigation = useNavigationCache({
       routes: state.routes,
       routeNames: state.routeNames,
-      getState,
       navigation,
       setOptions,
       router,
       emitter,
     });
 
-    const navigations = state.routes.map((route) => getNavigation(route));
+    const navigations = state.routes.flatMap((route) => [
+      getNavigation(route, false),
+      getNavigation(route, true),
+    ]);
     if (previous.current !== undefined) {
       navigations.forEach((navigation, index) => {
         expect(navigation).toBe(previous.current[index]);
@@ -82,15 +83,6 @@ test('preserves reference for navigation objects', () => {
 test('preserves placeholder navigation after the route is created', () => {
   let routeNames = ['Foo', 'Bar'];
   let routes = [{ key: 'Foo-key', name: 'Foo' }];
-  const getState = (): NavigationState => ({
-    type: 'tab',
-    stale: false as const,
-    routeKeySeq: 0,
-    index: 0,
-    key: 'State',
-    routeNames,
-    routes,
-  });
   const navigation = {
     getId: () => 'State',
     getParent: jest.fn(),
@@ -104,7 +96,6 @@ test('preserves placeholder navigation after the route is created', () => {
     getNavigation = useNavigationCache({
       routes,
       routeNames,
-      getState,
       navigation,
       setOptions,
       router,
@@ -114,12 +105,12 @@ test('preserves placeholder navigation after the route is created', () => {
   };
 
   const root = render(<Test />);
-  const placeholderNavigation = getNavigation!({ key: 'Bar', name: 'Bar' });
+  const placeholderNavigation = getNavigation!({ key: 'Bar', name: 'Bar' }, false);
 
   routes = [...routes, { key: 'Bar-key', name: 'Bar' }];
   root.update(<Test />);
 
-  expect(getNavigation!({ key: 'Bar', name: 'Bar' })).toBe(placeholderNavigation);
+  expect(getNavigation!({ key: 'Bar', name: 'Bar' }, false)).toBe(placeholderNavigation);
 
   routeNames = ['Foo'];
   routes = routes.filter((route) => route.name !== 'Bar');
@@ -283,7 +274,7 @@ test('returns correct value for isFocused after changing screens', () => {
   expect(navigation.isFocused()).toBe(false);
 });
 
-test('ignores dispatches from a preloaded stack screen until it is promoted', () => {
+test('uses a no-op navigation object for a preloaded stack screen', () => {
   const TestNavigator = (props: any) => {
     const { state, descriptors, NavigationContent } = useNavigationBuilder(StackRouter, props);
 
@@ -346,10 +337,11 @@ test('ignores dispatches from a preloaded stack screen until it is promoted', ()
 
   act(() => ref.current?.navigate('second'));
 
-  expect(navigation).toBe(preloadedNavigation);
+  expect(navigation).not.toBe(preloadedNavigation);
+  const activeNavigation = navigation;
   enqueue.mockClear();
 
-  act(() => preloadedNavigation.dispatch(CommonActions.goBack()));
+  act(() => activeNavigation.dispatch(CommonActions.goBack()));
 
   expect(enqueue).toHaveBeenCalledTimes(1);
   expect(enqueue).toHaveBeenCalledWith({

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { use } from 'react';
 
+import { isRoutePreloadedInStack } from '../../utils/stack';
 import type {
   NavigationAction,
   NavigationState,
@@ -71,7 +72,7 @@ type Options<
   navigation: NavigationHelpers<ParamListBase>;
   screenOptions: ScreenOptionsOrCallback<ScreenOptions> | undefined;
   screenLayout: ScreenLayout<ScreenOptions> | undefined;
-  getState: () => State;
+  state: State;
   addListener: AddListener;
   addKeyedListener: AddKeyedListener;
   router: Router<State, NavigationAction>;
@@ -99,7 +100,7 @@ export function useDescriptors<
   navigation,
   screenOptions,
   screenLayout,
-  getState,
+  state,
   addListener,
   addKeyedListener,
   router,
@@ -107,20 +108,13 @@ export function useDescriptors<
 }: Options<State, ScreenOptions, EventMap>) {
   const theme = use(ThemeContext);
   const [options, setOptions] = React.useState<Record<string, ScreenOptions>>({});
-  const {
-    handleAction,
-    getStateForKey,
-    resetNavigator,
-    onDispatchAction,
-    onOptionsChange,
-    stackRef,
-  } = use(NavigationBuilderContext);
+  const { handleAction, resetNavigator, onDispatchAction, onOptionsChange, stackRef } =
+    use(NavigationBuilderContext);
 
   const context = React.useMemo(
     () => ({
       navigation,
       handleAction,
-      getStateForKey,
       resetNavigator,
       addListener,
       addKeyedListener,
@@ -131,7 +125,6 @@ export function useDescriptors<
     [
       navigation,
       handleAction,
-      getStateForKey,
       resetNavigator,
       addListener,
       addKeyedListener,
@@ -144,7 +137,6 @@ export function useDescriptors<
   const getNavigation = useNavigationCache<State, ScreenOptions, EventMap, ActionHelpers>({
     routes,
     routeNames,
-    getState,
     navigation,
     setOptions,
     router,
@@ -270,7 +262,7 @@ export function useDescriptors<
   >;
 
   const descriptors = cachedRoutes.reduce<DescriptorMap>((acc, route, i) => {
-    const navigation = getNavigation(route);
+    const navigation = getNavigation(route, isRoutePreloadedInStack(state, route));
 
     if (screens[route.name] === undefined) {
       acc[route.key] = {
@@ -318,13 +310,13 @@ export function useDescriptors<
     if (!config) {
       return {
         route,
-        navigation: getNavigation({ key: route.name, name: route.name }),
+        navigation: getNavigation({ key: route.name, name: route.name }, false),
         options: {} as ScreenOptions,
         render: () => null,
       } as DescriptorMap[string];
     }
 
-    const navigation = getNavigation({ key: route.name, name: route.name });
+    const navigation = getNavigation({ key: route.name, name: route.name }, false);
     return {
       route,
       navigation,

--- a/packages/expo-router/src/react-navigation/core/useIsFocused.tsx
+++ b/packages/expo-router/src/react-navigation/core/useIsFocused.tsx
@@ -6,6 +6,17 @@ export const FocusedRouteKeyContext = React.createContext<string | undefined>(un
 
 export const IsFocusedContext = React.createContext<boolean | undefined>(undefined);
 
+export function useIsRouteFocused(routeKey: string | undefined): boolean {
+  const parentIsFocused = use(IsFocusedContext);
+  const focusedRouteKey = use(FocusedRouteKeyContext);
+
+  if (routeKey === undefined) {
+    return parentIsFocused ?? true;
+  }
+
+  return parentIsFocused == null || parentIsFocused ? focusedRouteKey === routeKey : false;
+}
+
 /**
  * Hook to get the current focus state of the screen. Returns a `true` if screen is focused, otherwise `false`.
  * This can be used if a component needs to render something based on the focus state.

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -9,7 +9,6 @@ import { useComponent } from '../../fork/useComponent';
 import { type RouterRegistryEntry, useRegisterRouter } from '../../global-state/routerRegistry';
 import { useEnqueueRoutingIntent } from '../../global-state/routingQueueContext';
 import { resetNavigatorState } from '../../global-state/stateUtils';
-import useLatestCallback from '../../utils/useLatestCallback';
 import {
   type DefaultRouterOptions,
   type NavigationAction,
@@ -263,7 +262,6 @@ export function useNavigationBuilder<
   useRegisterNavigator();
   const routeNode = useRouteNode();
   const enqueue = useEnqueueRoutingIntent();
-
   const {
     children,
     layout,
@@ -333,7 +331,7 @@ export function useNavigationBuilder<
 
   const { state: currentState } = use(NavigationStateContext);
 
-  const { getStateForKey, resetNavigator, handleAction } = use(NavigationBuilderContext);
+  const { resetNavigator, handleAction } = use(NavigationBuilderContext);
   if (
     currentState === undefined ||
     currentState.stale !== false ||
@@ -375,22 +373,6 @@ export function useNavigationBuilder<
       }),
     [routeNamesKey, router]
   );
-  const getState = useLatestCallback((): State => {
-    const currentState = getStateForKey(stateKeyRef.current);
-    if (currentState === undefined) {
-      return committedState;
-    }
-    if (currentState.stale !== false) {
-      throw new Error(
-        'The mounted navigator no longer has complete state in the global navigation tree.'
-      );
-    }
-    if (currentState.type !== undefined && currentState.type !== router.type) {
-      // The reset keeps the complete fields required by every navigator state.
-      return resetNavigatorState(currentState, router.type) as State;
-    }
-    return currentState as State;
-  });
   const emitter = useEventEmitter<EventMapCore<State>>((e) => {
     const routeNames = [];
 
@@ -463,12 +445,11 @@ export function useNavigationBuilder<
   const { keyedListeners, addKeyedListener } = useKeyedChildListeners();
 
   const { isRoutePrevented, preventRemoveContextValue } = usePreventRemoveState({
-    getState,
-    state,
+    state: committedState,
   });
 
   useOnPreventRemove({
-    getState,
+    state: committedState,
     isRoutePrevented,
     emitter,
     preventRemoveListeners: keyedListeners.preventRemove,
@@ -525,9 +506,7 @@ export function useNavigationBuilder<
     if (isForeignType) {
       return;
     }
-    const committed = getState();
-
-    if (isArrayEqual(committed.routeNames, routeNames)) {
+    if (isArrayEqual(committedState.routeNames, routeNames)) {
       pendingRouteNamesRef.current = undefined;
     } else if (!isArrayEqual(pendingRouteNamesRef.current ?? [], routeNames)) {
       pendingRouteNamesRef.current = routeNames;
@@ -537,9 +516,9 @@ export function useNavigationBuilder<
           action: {
             type: 'ROUTE_NAMES_CHANGED',
             payload: { routeNames },
-            target: committed.key,
+            target: committedState.key,
           },
-          originKey: committed.key,
+          originKey: committedState.key,
         },
       });
     }
@@ -548,7 +527,7 @@ export function useNavigationBuilder<
   const navigation = useNavigationHelpers<State, ActionHelpers, NavigationAction, EventMap>({
     id: options.id,
     handleAction: onAction,
-    getState,
+    state: committedState,
     emitter,
     router,
   });
@@ -565,7 +544,7 @@ export function useNavigationBuilder<
     navigation,
     screenOptions,
     screenLayout,
-    getState,
+    state: committedState,
     addListener,
     addKeyedListener,
     router,

--- a/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationCache.tsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { use } from 'react';
 
-import { isRoutePreloadedInStack } from '../../utils/stack';
 import {
   CommonActions,
   type NavigationAction,
@@ -21,7 +20,6 @@ type Options<
 > = {
   routes: State['routes'];
   routeNames: State['routeNames'];
-  getState: () => State;
   navigation: NavigationHelpers<ParamListBase> &
     Partial<NavigationProp<ParamListBase, string, any, any, any>>;
   setOptions: (
@@ -47,6 +45,9 @@ type NavigationCache<
  * Hook to cache navigation objects for each screen in the navigator.
  * It's important to cache them to make sure navigation objects don't change between renders.
  * This lets us apply optimizations like `React.memo` to minimize re-rendering screens.
+ * Exception: a route's navigation object changes identity once when the route is promoted from
+ * preloaded to active.
+ * TODO(@ubax): consider resolving `isPreloaded` at call time to keep one object per route.
  */
 export function useNavigationCache<
   State extends NavigationState,
@@ -56,7 +57,6 @@ export function useNavigationCache<
 >({
   routes,
   routeNames,
-  getState,
   navigation,
   setOptions,
   router,
@@ -70,20 +70,19 @@ export function useNavigationCache<
   const cache = React.useMemo(
     () => ({ current: {} as NavigationCache<State, ScreenOptions, EventMap> }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getState, navigation, setOptions, emitter]
+    [navigation, setOptions, emitter]
   );
 
   // Keep name-keyed placeholders stable after their real route keys are created.
-  const validKeys = new Set([...routes.map((route) => route.key), ...routeNames]);
+  const routeKeys = [...routes.map((route) => route.key), ...routeNames];
+  const validKeys = new Set(routeKeys.flatMap((key) => [key, `p\0${key}`]));
   cache.current = Object.fromEntries(
     Object.entries(cache.current).filter(([key]) => validKeys.has(key))
   );
 
-  const createNavigation = (route: { key: string; name: string }) => {
+  const createNavigation = (route: { key: string; name: string }, isPreloaded: boolean) => {
     const dispatchSync = (action: NavigationAction) => {
-      const state = getState();
-
-      if (isRoutePreloadedInStack(state, route)) {
+      if (isPreloaded) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(
             `Ignored a navigation action dispatched from the preloaded screen '${route.name}'. The screen is rendered for preloading and is not focused, so its actions would unexpectedly modify the visible stack. Wait until the screen is focused before dispatching.`
@@ -97,8 +96,7 @@ export function useNavigationCache<
     };
 
     const dispatch = (action: NavigationAction) => {
-      const state = getState();
-      if (isRoutePreloadedInStack(state, route)) {
+      if (isPreloaded) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(
             `Ignored a navigation action dispatched from the preloaded screen '${route.name}'. The screen is rendered for preloading and is not focused, so its actions would unexpectedly modify the visible stack. Wait until the screen is focused before dispatching.`
@@ -171,7 +169,7 @@ export function useNavigationCache<
       isFocused: () => {
         const state = rest.getState();
 
-        if (state.routes[state.index]!.key !== route.key) {
+        if (state.routes[state.index]?.key !== route.key) {
           return false;
         }
 
@@ -184,14 +182,15 @@ export function useNavigationCache<
     return navigationItem;
   };
 
-  return (route: { key: string; name: string }) => {
-    const cachedNavigation = cache.current[route.key];
+  return (route: { key: string; name: string }, isPreloaded: boolean) => {
+    const key = `${isPreloaded ? 'p\0' : ''}${route.key}`;
+    const cachedNavigation = cache.current[key];
     if (cachedNavigation) {
       return cachedNavigation;
     }
 
-    const navigation = createNavigation(route);
-    cache.current[route.key] = navigation;
+    const navigation = createNavigation(route, isPreloaded);
+    cache.current[key] = navigation;
     return navigation;
   };
 }

--- a/packages/expo-router/src/react-navigation/core/useNavigationHelpers.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationHelpers.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { use } from 'react';
 
 import { useEnqueueRoutingIntent } from '../../global-state/routingQueueContext';
+import useLatestCallback from '../../utils/useLatestCallback';
 import {
   CommonActions,
   type NavigationAction,
@@ -21,7 +22,7 @@ PrivateValueStore;
 type Options<State extends NavigationState, Action extends NavigationAction> = {
   id: string | undefined;
   handleAction: (action: NavigationAction) => void;
-  getState: () => State;
+  state: State;
   emitter: NavigationEventEmitter<any>;
   router: Router<State, Action>;
 };
@@ -35,9 +36,11 @@ export function useNavigationHelpers<
   ActionHelpers extends Record<string, () => void>,
   Action extends NavigationAction,
   EventMap extends Record<string, any>,
->({ id: navigatorId, handleAction, getState, emitter, router }: Options<State, Action>) {
+>({ id: navigatorId, handleAction, state, emitter, router }: Options<State, Action>) {
   const parentNavigationHelpers = use(NavigationContext);
   const enqueue = useEnqueueRoutingIntent();
+  // Unlike handler-only Effect Events, the public accessor can be called during render.
+  const getState = useLatestCallback(() => state);
 
   return React.useMemo(() => {
     const dispatchSync = (action: Action) => {
@@ -105,5 +108,5 @@ export function useNavigationHelpers<
     } as NavigationHelpers<ParamListBase, EventMap> & ActionHelpers;
 
     return navigationHelpers;
-  }, [enqueue, router, parentNavigationHelpers, emitter.emit, getState, handleAction, navigatorId]);
+  }, [enqueue, router, parentNavigationHelpers, emitter.emit, handleAction, navigatorId]);
 }

--- a/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
+++ b/packages/expo-router/src/react-navigation/core/useOnPreventRemove.tsx
@@ -14,7 +14,7 @@ import type { NavigationEventEmitter } from './useEventEmitter';
 import type { IsRoutePrevented } from './usePreventRemoveState';
 
 type Options = {
-  getState: () => NavigationState;
+  state: NavigationState;
   isRoutePrevented: IsRoutePrevented;
   emitter: NavigationEventEmitter<EventMapCore<any>>;
   preventRemoveListeners: Record<string, ChildPreventRemoveListener | undefined>;
@@ -120,7 +120,7 @@ export const emitBeforeRemove = (
 };
 
 export function useOnPreventRemove({
-  getState,
+  state,
   isRoutePrevented,
   emitter,
   preventRemoveListeners,
@@ -135,7 +135,6 @@ export function useOnPreventRemove({
     }
 
     return addKeyedListener?.('preventRemove', routeKey, (action) => {
-      const state = getState();
       return shouldPreventRemove(
         emitter,
         preventRemoveListeners,
@@ -145,7 +144,7 @@ export function useOnPreventRemove({
         action
       );
     });
-  }, [addKeyedListener, emitter, getState, isRoutePrevented, preventRemoveListeners, routeKey]);
+  }, [addKeyedListener, emitter, isRoutePrevented, preventRemoveListeners, routeKey, state]);
 
   React.useEffect(() => {
     if (!routeKey) {
@@ -154,8 +153,7 @@ export function useOnPreventRemove({
 
     // Forward beforeRemove into nested navigators when an ancestor removes their route.
     return addKeyedListener?.('beforeRemove', routeKey, (action) => {
-      const state = getState();
       emitBeforeRemove(emitter, beforeRemoveListeners, getPreventableRoutes(state), [], action);
     });
-  }, [addKeyedListener, beforeRemoveListeners, emitter, getState, routeKey]);
+  }, [addKeyedListener, beforeRemoveListeners, emitter, routeKey, state]);
 }

--- a/packages/expo-router/src/react-navigation/core/useOptionsGetters.tsx
+++ b/packages/expo-router/src/react-navigation/core/useOptionsGetters.tsx
@@ -2,18 +2,17 @@
 import * as React from 'react';
 import { use } from 'react';
 
-import type { ParamListBase } from '../routers';
+import useLatestCallback from '../../utils/useLatestCallback';
 import { NavigationBuilderContext } from './NavigationBuilderContext';
 import { NavigationStateContext } from './NavigationStateContext';
-import type { NavigationProp } from './types';
+import { useIsRouteFocused } from './useIsFocused';
 
 type Options = {
   key?: string;
-  navigation?: NavigationProp<ParamListBase>;
   options?: object | undefined;
 };
 
-export function useOptionsGetters({ key, options, navigation }: Options) {
+export function useOptionsGetters({ key, options }: Options) {
   const optionsRef = React.useRef<object | undefined>(options);
   const optionsGettersFromChildRef = React.useRef<Record<string, () => object | undefined | null>>(
     {}
@@ -21,22 +20,20 @@ export function useOptionsGetters({ key, options, navigation }: Options) {
 
   const { onOptionsChange } = use(NavigationBuilderContext);
   const { addOptionsGetter: parentAddOptionsGetter } = use(NavigationStateContext);
+  const isFocused = useIsRouteFocused(key);
 
   const optionsChangeListener = React.useCallback(() => {
-    const isFocused = navigation?.isFocused() ?? true;
     const hasChildren = Object.keys(optionsGettersFromChildRef.current).length;
 
     if (isFocused && !hasChildren) {
       onOptionsChange(optionsRef.current ?? {}, key);
     }
-  }, [key, navigation, onOptionsChange]);
+  }, [isFocused, key, onOptionsChange]);
 
   React.useEffect(() => {
     optionsRef.current = options;
     optionsChangeListener();
-
-    return navigation?.addListener('focus', optionsChangeListener);
-  }, [navigation, options, optionsChangeListener]);
+  }, [options, optionsChangeListener]);
 
   const getOptionsFromListener = React.useCallback(() => {
     for (const key in optionsGettersFromChildRef.current) {
@@ -53,9 +50,7 @@ export function useOptionsGetters({ key, options, navigation }: Options) {
     return null;
   }, []);
 
-  const getCurrentOptions = React.useCallback(() => {
-    const isFocused = navigation?.isFocused() ?? true;
-
+  const getCurrentOptions = useLatestCallback(() => {
     if (!isFocused) {
       return null;
     }
@@ -67,7 +62,7 @@ export function useOptionsGetters({ key, options, navigation }: Options) {
     }
 
     return optionsRef.current;
-  }, [navigation, getOptionsFromListener]);
+  });
 
   React.useEffect(() => {
     return parentAddOptionsGetter?.(key!, getCurrentOptions);

--- a/packages/expo-router/src/react-navigation/core/usePreventRemoveState.tsx
+++ b/packages/expo-router/src/react-navigation/core/usePreventRemoveState.tsx
@@ -10,7 +10,6 @@ import { NavigationRouteContext } from './NavigationProvider';
 import { type PreventedRoutes, PreventRemoveContext } from './PreventRemoveContext';
 
 type Props = {
-  getState: () => NavigationState;
   state: NavigationState;
 };
 
@@ -33,7 +32,7 @@ const transformPreventedRoutes = (entries: PreventedRouteEntry[]): PreventedRout
 /**
  * Hook used for exposing removal prevention state to navigator views.
  */
-export function usePreventRemoveState({ getState, state }: Props) {
+export function usePreventRemoveState({ state }: Props) {
   'use no memo';
   const [parentId] = React.useState(() => nanoid());
   const entriesRef = React.useRef(new Map<string, PreventedRouteEntry>());
@@ -43,9 +42,9 @@ export function usePreventRemoveState({ getState, state }: Props) {
   const parentContext = use(PreventRemoveContext);
   const setParentPrevented = parentContext?.setPreventRemove;
 
-  const setPreventRemove = useLatestCallback(
+  const setPreventRemove = React.useCallback(
     (id: string, routeKey: string, preventRemove: boolean): void => {
-      if (preventRemove && getState().routes.every((route) => route.key !== routeKey)) {
+      if (preventRemove && state.routes.every((route) => route.key !== routeKey)) {
         throw new Error(
           `Couldn't find a route with the key ${routeKey}. Is your component inside NavigationContent?`
         );
@@ -70,13 +69,13 @@ export function usePreventRemoveState({ getState, state }: Props) {
       setEntries(next);
 
       if (route?.key !== undefined && setParentPrevented !== undefined) {
-        const state = getState();
         const hasActiveEntry = [...next.values()].some(
           (entry) => entry.preventRemove && !isRoutePreloadedInStack(state, { key: entry.routeKey })
         );
         setParentPrevented(parentId, route.key, hasActiveEntry);
       }
-    }
+    },
+    [parentId, route?.key, setParentPrevented, state]
   );
 
   const activeEntries = React.useMemo(
@@ -93,7 +92,7 @@ export function usePreventRemoveState({ getState, state }: Props) {
       (entry) =>
         entry.routeKey === routeKey &&
         entry.preventRemove &&
-        !isRoutePreloadedInStack(getState(), { key: routeKey })
+        !isRoutePreloadedInStack(state, { key: routeKey })
     )
   );
 

--- a/packages/expo-router/src/react-navigation/native/__tests__/useLinkBuilder.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native/__tests__/useLinkBuilder.test.ios.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react-native';
 
-import { NavigationRouteContext } from '../../core';
+import { NavigationHelpersContext, NavigationRouteContext } from '../../core';
+import type { NavigationHelpers, ParamListBase } from '../../core';
 import { NavigationContainer } from '../../core/__tests__/__fixtures__/NavigationContainer';
 import {
   createTestState,
@@ -104,10 +105,10 @@ test('builds href in route context', () => {
   );
 });
 
-test('builds href in stack navigator screen', () => {
+test('builds href in stack navigator screen without reading navigation state imperatively', () => {
   expect.assertions(2);
 
-  const Test = () => {
+  const HrefProbe = () => {
     const { buildHref } = useLinkBuilder();
 
     const href = buildHref('Foo');
@@ -116,6 +117,18 @@ test('builds href in stack navigator screen', () => {
 
     return null;
   };
+
+  const Test = ({ navigation }: { navigation: NavigationHelpers<ParamListBase> }) => (
+    <NavigationHelpersContext.Provider
+      value={{
+        ...navigation,
+        getState() {
+          throw new Error('navigation.getState must not be read');
+        },
+      }}>
+      <HrefProbe />
+    </NavigationHelpersContext.Provider>
+  );
 
   const StackA = createStackNavigator<{ Foo: undefined }>();
 

--- a/packages/expo-router/src/react-navigation/native/__tests__/useScrollToTop.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native/__tests__/useScrollToTop.test.ios.tsx
@@ -1,0 +1,138 @@
+import { userEvent } from '@testing-library/react-native';
+import { Pressable, View } from 'react-native';
+
+import { router } from '../../../imperative-api';
+import { Stack } from '../../../layouts/Stack';
+import { Tabs } from '../../../layouts/Tabs';
+import { act, renderRouter, screen } from '../../../testing-library';
+import { useScrollToTop } from '../useScrollToTop';
+
+function createScrollableScreen(scrollTo: jest.Mock) {
+  const ref = { current: { scrollTo } };
+
+  return function ScrollableScreen() {
+    useScrollToTop(ref);
+    return <View />;
+  };
+}
+
+function flushAnimationFrame() {
+  act(() => jest.runAllTimers());
+}
+
+test('scrolls a screen directly in the focused tab to the top', async () => {
+  const scrollTo = jest.fn();
+
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+      </Tabs>
+    ),
+    index: createScrollableScreen(scrollTo),
+    second: () => <View />,
+  });
+
+  await userEvent.press(screen.getByRole('button', { name: 'index, tab, 1 of 2' }));
+  flushAnimationFrame();
+
+  expect(scrollTo).toHaveBeenCalledWith({ y: 0, animated: true });
+});
+
+test('does not scroll a screen in an unfocused tab', async () => {
+  const scrollTo = jest.fn();
+
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" options={{ lazy: false }} />
+      </Tabs>
+    ),
+    index: () => <View />,
+    second: createScrollableScreen(scrollTo),
+  });
+
+  await userEvent.press(screen.getByRole('button', { name: 'index, tab, 1 of 2' }));
+  flushAnimationFrame();
+
+  expect(scrollTo).not.toHaveBeenCalled();
+});
+
+test('scrolls the first screen of a stack nested in a tab to the top', async () => {
+  const scrollTo = jest.fn();
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+        </Tabs>
+      ),
+      'one/_layout': () => <Stack screenOptions={{ headerShown: false }} />,
+      'one/index': createScrollableScreen(scrollTo),
+      'one/details': () => <View />,
+      two: () => <View />,
+    },
+    { initialUrl: '/one' }
+  );
+
+  await userEvent.press(screen.getByRole('button', { name: 'one, tab, 1 of 2' }));
+  flushAnimationFrame();
+
+  expect(scrollTo).toHaveBeenCalledWith({ y: 0, animated: true });
+});
+
+test('does not scroll a non-first screen of a stack nested in a tab', async () => {
+  const scrollTo = jest.fn();
+
+  renderRouter(
+    {
+      _layout: () => (
+        <Tabs>
+          <Tabs.Screen name="one" />
+          <Tabs.Screen name="two" />
+        </Tabs>
+      ),
+      'one/_layout': () => <Stack screenOptions={{ headerShown: false }} />,
+      'one/index': () => (
+        <Pressable
+          accessibilityLabel="Details"
+          accessibilityRole="button"
+          onPress={() => router.push('/one/details')}
+        />
+      ),
+      'one/details': createScrollableScreen(scrollTo),
+      two: () => <View />,
+    },
+    { initialUrl: '/one' }
+  );
+  await userEvent.press(screen.getByRole('button', { name: 'Details' }));
+
+  await userEvent.press(screen.getByRole('button', { name: 'one, tab, 1 of 2' }));
+  flushAnimationFrame();
+
+  expect(scrollTo).not.toHaveBeenCalled();
+});
+
+test('does not scroll when another tabPress listener prevents the default action', async () => {
+  const scrollTo = jest.fn();
+
+  renderRouter({
+    _layout: () => (
+      <Tabs>
+        <Tabs.Screen name="index" listeners={{ tabPress: (event) => event.preventDefault() }} />
+        <Tabs.Screen name="second" />
+      </Tabs>
+    ),
+    index: createScrollableScreen(scrollTo),
+    second: () => <View />,
+  });
+
+  await userEvent.press(screen.getByRole('button', { name: 'index, tab, 1 of 2' }));
+  flushAnimationFrame();
+
+  expect(scrollTo).not.toHaveBeenCalled();
+});

--- a/packages/expo-router/src/react-navigation/native/useLinkBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/native/useLinkBuilder.tsx
@@ -10,6 +10,7 @@ import {
   NavigationRouteContext,
   useStateForPath,
 } from '../core';
+import { NavigatorStateContext } from '../core/useNavigationState';
 import type { NavigationState, PartialState } from '../routers';
 import { LinkingContext } from './LinkingContext';
 
@@ -29,6 +30,7 @@ type ConfigItem = {
 export function useBuildHref() {
   const navigation = use(NavigationHelpersContext);
   const route = use(NavigationRouteContext);
+  const navigatorState = use(NavigatorStateContext);
 
   const { options } = use(LinkingContext);
 
@@ -46,7 +48,7 @@ export function useBuildHref() {
       const isScreen =
         navigation && route?.key && focusedRouteState
           ? route.key === findFocusedRoute(focusedRouteState)?.key &&
-            navigation.getState().routes.some((r) => r.key === route.key)
+            navigatorState?.routes.some((r) => r.key === route.key)
           : false;
 
       const stateForRoute: MinimalState = {
@@ -87,7 +89,14 @@ export function useBuildHref() {
 
       return path;
     },
-    [options?.config, route?.key, navigation, focusedRouteState, getPathFromStateHelper]
+    [
+      options?.config,
+      route?.key,
+      navigation,
+      navigatorState,
+      focusedRouteState,
+      getPathFromStateHelper,
+    ]
   );
 
   return buildHref;

--- a/packages/expo-router/src/react-navigation/native/useScrollToTop.tsx
+++ b/packages/expo-router/src/react-navigation/native/useScrollToTop.tsx
@@ -3,13 +3,8 @@ import * as React from 'react';
 import { use } from 'react';
 import type { ScrollView } from 'react-native';
 
-import {
-  type EventArg,
-  NavigationContext,
-  type NavigationProp,
-  type ParamListBase,
-  useRoute,
-} from '../core';
+import { type EventArg, NavigationContext, useRoute } from '../core';
+import { NavigatorStateContext } from '../core/useNavigationState';
 
 type ScrollOptions = { x?: number; y?: number; animated?: boolean };
 
@@ -55,7 +50,10 @@ function getScrollableNode(ref: React.RefObject<ScrollableWrapper>) {
 
 export function useScrollToTop(ref: React.RefObject<ScrollableWrapper>) {
   const navigation = use(NavigationContext);
+  const navigatorState = use(NavigatorStateContext);
   const route = useRoute();
+  const isDirectlyInTabNavigator = navigatorState?.type === 'tab';
+  const firstRouteKey = navigatorState?.routes[0]?.key;
 
   if (navigation === undefined) {
     throw new Error(
@@ -64,63 +62,44 @@ export function useScrollToTop(ref: React.RefObject<ScrollableWrapper>) {
   }
 
   React.useEffect(() => {
-    const tabNavigations: NavigationProp<ParamListBase>[] = [];
-    let currentNavigation = navigation;
-    // If the screen is nested inside multiple tab navigators, we should scroll to top for any of them
-    // So we need to find all the parent tab navigators and add the listeners there
-    while (currentNavigation) {
-      // TODO: Resolve every ancestor's navigator type at render time, as NavigatorTypeContext does
-      // for the nearest navigator.
-      if (currentNavigation.getState().type === 'tab') {
-        tabNavigations.push(currentNavigation);
-      }
+    const handler = (e: EventArg<'tabPress', true>) => {
+      // We should scroll to top only when the screen is focused
+      const isFocused = navigation.isFocused();
 
+      // In a nested stack navigator, tab press resets the stack to first screen
+      // So we should scroll to top only when we are on first screen
+      const isFirst = isDirectlyInTabNavigator || firstRouteKey === route.key;
+
+      // Run the operation in the next frame so we're sure all listeners have been run
+      // This is necessary to know if preventDefault() has been called
+      requestAnimationFrame(() => {
+        const scrollable = getScrollableNode(ref) as ScrollableWrapper;
+
+        if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
+          if ('scrollToTop' in scrollable) {
+            scrollable.scrollToTop();
+          } else if ('scrollTo' in scrollable) {
+            scrollable.scrollTo({ y: 0, animated: true });
+          } else if ('scrollToOffset' in scrollable) {
+            scrollable.scrollToOffset({ offset: 0, animated: true });
+          } else if ('scrollResponderScrollTo' in scrollable) {
+            scrollable.scrollResponderScrollTo({ y: 0, animated: true });
+          }
+        }
+      });
+    };
+
+    const unsubscribers: (() => void)[] = [];
+    let currentNavigation: typeof navigation | undefined = navigation;
+    while (currentNavigation) {
+      // Non-tab navigators never emit `tabPress`, so these listeners are inert.
+      // @ts-expect-error: `tabPress` is emitted only by tab navigators.
+      unsubscribers.push(currentNavigation.addListener('tabPress', handler));
       currentNavigation = currentNavigation.getParent();
     }
-
-    if (tabNavigations.length === 0) {
-      return;
-    }
-
-    const unsubscribers = tabNavigations.map((tab) => {
-      return tab.addListener(
-        // We don't wanna import tab types here to avoid extra deps
-        // in addition, there are multiple tab implementations
-        // @ts-expect-error the `tabPress` event is only available when navigation type is tab
-        'tabPress',
-        (e: EventArg<'tabPress', true>) => {
-          // We should scroll to top only when the screen is focused
-          const isFocused = navigation.isFocused();
-
-          // In a nested stack navigator, tab press resets the stack to first screen
-          // So we should scroll to top only when we are on first screen
-          const isFirst =
-            tabNavigations.includes(navigation) ||
-            navigation.getState().routes[0]!.key === route.key;
-
-          // Run the operation in the next frame so we're sure all listeners have been run
-          // This is necessary to know if preventDefault() has been called
-          requestAnimationFrame(() => {
-            const scrollable = getScrollableNode(ref) as ScrollableWrapper;
-
-            if (isFocused && isFirst && scrollable && !e.defaultPrevented) {
-              if ('scrollToTop' in scrollable) {
-                scrollable.scrollToTop();
-              } else if ('scrollTo' in scrollable) {
-                scrollable.scrollTo({ y: 0, animated: true });
-              } else if ('scrollToOffset' in scrollable) {
-                scrollable.scrollToOffset({ offset: 0, animated: true });
-              } else if ('scrollResponderScrollTo' in scrollable) {
-                scrollable.scrollResponderScrollTo({ y: 0, animated: true });
-              }
-            }
-          });
-        }
-      );
-    });
 
     return () => {
       unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
-  }, [navigation, ref, route.key]);
+  }, [firstRouteKey, isDirectlyInTabNavigator, navigation, ref, route.key]);
 }

--- a/packages/expo-router/src/ui/TabContext.tsx
+++ b/packages/expo-router/src/ui/TabContext.tsx
@@ -99,6 +99,10 @@ export const TabTriggerMapContext = createContext<TriggerMap>({});
 /**
  * @hidden
  */
+export const TabNavigatorStatesContext = createContext<Record<string, TabNavigationState<any>>>({});
+/**
+ * @hidden
+ */
 export const TabsDescriptorsContext = createContext<TabsContextValue['descriptors']>({});
 /**
  * @hidden

--- a/packages/expo-router/src/ui/TabTrigger.tsx
+++ b/packages/expo-router/src/ui/TabTrigger.tsx
@@ -12,7 +12,7 @@ import { stripGroupSegmentsFromPath } from '../matchers';
 import type { TabNavigationState } from '../react-navigation/native';
 import type { Href } from '../types';
 import { useNavigatorContext } from '../views/Navigator';
-import { TabTriggerMapContext } from './TabContext';
+import { TabNavigatorStatesContext, TabTriggerMapContext } from './TabContext';
 import { buildTabAction, type TriggerMap } from './common';
 
 type PressablePropsWithoutFunctionChildren = Omit<PressableProps, 'children'> & {
@@ -149,6 +149,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
   const { state, navigation, contextKey, descriptors } = useNavigatorContext();
   const { name, resetOnFocus, onPress, onLongPress } = options;
   const triggerMap = use(TabTriggerMapContext);
+  const navigatorStates = use(TabNavigatorStatesContext);
   const registry = use(RouterRegistryContext);
 
   const getTrigger = useCallback(
@@ -172,9 +173,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
 
       // Parent triggers are inherited, so read the state of the navigator that registered them.
       const owningState =
-        config.type === 'internal' && config.contextKey !== contextKey
-          ? navigation?.getParent(config.contextKey)?.getState()
-          : state;
+        config.type === 'internal' ? navigatorStates[config.contextKey] : undefined;
       const routeIndex =
         config.type === 'internal'
           ? (owningState?.routes.findIndex((route) => route.name === config.routeNode.route) ?? -1)
@@ -188,7 +187,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         ...config,
       };
     },
-    [contextKey, descriptors, navigation, state, triggerMap]
+    [descriptors, navigatorStates, state, triggerMap]
   );
 
   const trigger = name !== undefined ? getTrigger(name) : undefined;
@@ -204,10 +203,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
           if (!registry) {
             throw new Error('Router registry is unavailable. This is likely a bug in expo-router.');
           }
-          const owningState =
-            config.contextKey !== contextKey
-              ? navigation?.getParent(config.contextKey)?.getState()
-              : state;
+          const owningState = navigatorStates[config.contextKey];
           if (!owningState) {
             return;
           }
@@ -227,7 +223,7 @@ export function useTabTrigger(options: TabTriggerProps): UseTabTriggerResult {
         });
       }
     },
-    [contextKey, navigation, registry, state, triggerMap]
+    [contextKey, navigation, navigatorStates, registry, triggerMap]
   );
 
   const handleOnPress = useCallback<NonNullable<PressableProps['onPress']>>(

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -26,7 +26,7 @@ import { shouldLinkExternally } from '../utils/url';
 import type { NavigatorContextValue } from '../views/Navigator';
 import { NavigatorContext } from '../views/Navigator';
 import type { ExpoTabsScreenOptions, TabNavigationEventMap, TabsContextValue } from './TabContext';
-import { TabTriggerMapContext } from './TabContext';
+import { TabNavigatorStatesContext, TabTriggerMapContext } from './TabContext';
 import { isTabList } from './TabList';
 import type { ExpoTabRouterOptions } from './TabRouter';
 import { ExpoTabRouter } from './TabRouter';
@@ -151,6 +151,7 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
   const { triggers, ...rest } = options;
   // Ensure we extend the parent triggers, so we can trigger them as well
   const parentTriggerMap = use(TabTriggerMapContext);
+  const parentNavigatorStates = use(TabNavigatorStatesContext);
   const routeNode = useRouteNode();
   const contextKey = useContextKey();
   const linking = use(LinkingContext).options;
@@ -202,6 +203,10 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
       ) as typeof sparseDescriptors,
     [describe, sparseDescriptors, state]
   );
+  const navigatorStates = useMemo(
+    () => ({ ...parentNavigatorStates, [contextKey]: state }),
+    [contextKey, parentNavigatorStates, state]
+  );
 
   const navigatorContextValue = useMemo<NavigatorContextValue>(
     () => ({
@@ -218,9 +223,11 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     <GuardContextProvider node={routeNode} guardedRedirects={emptyGuardedRedirects}>
       <TabVisibilityRedirect state={state} descriptors={descriptors} />
       <TabTriggerMapContext.Provider value={triggerMap}>
-        <NavigatorContext.Provider value={navigatorContextValue}>
-          <RNNavigationContent>{children}</RNNavigationContent>
-        </NavigatorContext.Provider>
+        <TabNavigatorStatesContext.Provider value={navigatorStates}>
+          <NavigatorContext.Provider value={navigatorContextValue}>
+            <RNNavigationContent>{children}</RNNavigationContent>
+          </NavigatorContext.Provider>
+        </TabNavigatorStatesContext.Provider>
       </TabTriggerMapContext.Provider>
     </GuardContextProvider>
   )) as TabsContextValue['NavigationContent'];


### PR DESCRIPTION
# Why

In many places we still read `getState` or `store.state` instead of relying on the global state passed to navigators. 

# How

1. Remove `getState` and `getStateForKey`, and use `RootNavigationStateContext` and `NavigatorStateContext` instead
2. Replace usages of `store.state` by `RootNavigationStateContext`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
