### PR TITLE
[fingerprint] Resolve the git root from the project root instead of the process cwd

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve the git root from the project root instead of the process working directory during project workflow detection, so fingerprinting a project (for example a git worktree) while the working directory is inside another repository no longer flips the workflow from `managed` to `generic` and silently changes the hash. ([#49435](https://github.com/expo/expo/pull/49435) by [@janicduplessis](https://github.com/janicduplessis))
 - Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fixed ignore patterns (built-in and `.fingerprintignore`) not matching on Windows, which made fingerprints differ between Windows machines and EAS builds ("Runtime version mismatch"). ([#46816](https://github.com/expo/expo/pull/46816) by [@blurbyte](https://github.com/blurbyte))
 

--- a/packages/@expo/fingerprint/src/ProjectWorkflow.ts
+++ b/packages/@expo/fingerprint/src/ProjectWorkflow.ts
@@ -74,16 +74,20 @@ interface VCSClient {
 }
 
 async function getVCSClientAsync(projectRoot: string): Promise<VCSClient> {
-  if (await isGitInstalledAndConfiguredAsync()) {
-    return new GitClient();
+  if (await isGitInstalledAndConfiguredAsync(projectRoot)) {
+    return new GitClient(projectRoot);
   } else {
     return new NoVCSClient(projectRoot);
   }
 }
 
 class GitClient implements VCSClient {
+  constructor(private readonly projectRoot: string) {}
+
   public async getRootPathAsync(): Promise<string> {
-    return (await spawnAsync('git', ['rev-parse', '--show-toplevel'])).stdout.trim();
+    return (
+      await spawnAsync('git', ['rev-parse', '--show-toplevel'], { cwd: this.projectRoot })
+    ).stdout.trim();
   }
 
   async isFileIgnoredAsync(filePath: string): Promise<boolean> {
@@ -112,7 +116,7 @@ class NoVCSClient implements VCSClient {
   }
 }
 
-async function isGitInstalledAndConfiguredAsync(): Promise<boolean> {
+async function isGitInstalledAndConfiguredAsync(projectRoot: string): Promise<boolean> {
   try {
     await spawnAsync('git', ['--help']);
   } catch (error: any) {
@@ -123,7 +127,7 @@ async function isGitInstalledAndConfiguredAsync(): Promise<boolean> {
   }
 
   try {
-    await spawnAsync('git', ['rev-parse', '--show-toplevel']);
+    await spawnAsync('git', ['rev-parse', '--show-toplevel'], { cwd: projectRoot });
   } catch {
     return false;
   }

--- a/packages/@expo/fingerprint/src/__tests__/ProjectWorkflow-git-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/ProjectWorkflow-git-test.ts
@@ -1,0 +1,61 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { resolveProjectWorkflowAsync } from '../ProjectWorkflow';
+
+// This is an integration test against real git repositories on disk, so opt out of the
+// automatic `resolve-from` mock from `__mocks__/` and use the real module resolution.
+jest.unmock('resolve-from');
+
+// Path to the `expo` package inside this monorepo, symlinked into the temporary project so
+// `expo/config-plugins` is resolvable from the project root.
+const EXPO_PACKAGE_ROOT = path.resolve(__dirname, '..', '..', '..', '..', 'expo');
+
+describe('resolveProjectWorkflowAsync - resolves the git root of the project, not of the caller cwd', () => {
+  let tmpDir: string;
+  let projectRoot: string;
+  let otherRepoRoot: string;
+  let originalCwd: string;
+
+  beforeAll(async () => {
+    originalCwd = process.cwd();
+    // Use the realpath so that symlinked temp dirs (e.g. /var -> /private/var on macOS)
+    // don't interfere with path comparisons.
+    tmpDir = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), 'fingerprint-git-'));
+    projectRoot = path.join(tmpDir, 'project');
+    otherRepoRoot = path.join(tmpDir, 'other-repo');
+
+    // The project we fingerprint: a git repo whose native ios directory is gitignored,
+    // which makes it a managed workflow project.
+    await fs.mkdir(path.join(projectRoot, 'ios', 'app.xcodeproj'), { recursive: true });
+    await fs.writeFile(path.join(projectRoot, 'ios', 'app.xcodeproj', 'project.pbxproj'), '');
+    await fs.writeFile(path.join(projectRoot, '.gitignore'), 'ios\n');
+    await fs.mkdir(path.join(projectRoot, 'node_modules'), { recursive: true });
+    await fs.symlink(EXPO_PACKAGE_ROOT, path.join(projectRoot, 'node_modules', 'expo'));
+    execFileSync('git', ['init'], { cwd: projectRoot });
+
+    // An unrelated git repo where the caller's cwd sits, e.g. running a tool from another
+    // project or from the main checkout while fingerprinting a git worktree.
+    await fs.mkdir(otherRepoRoot, { recursive: true });
+    execFileSync('git', ['init'], { cwd: otherRepoRoot });
+  });
+
+  afterAll(async () => {
+    process.chdir(originalCwd);
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns managed workflow when cwd is inside another git repo', async () => {
+    // The bug: the git root was resolved from the caller's cwd instead of the project root,
+    // so the gitignored ios directory was not detected and the workflow flipped to generic.
+    process.chdir(otherRepoRoot);
+    await expect(resolveProjectWorkflowAsync(projectRoot, 'ios', [])).resolves.toBe('managed');
+  });
+
+  it('returns managed workflow when cwd is the project root', async () => {
+    process.chdir(projectRoot);
+    await expect(resolveProjectWorkflowAsync(projectRoot, 'ios', [])).resolves.toBe('managed');
+  });
+});


### PR DESCRIPTION
# Why

`@expo/fingerprint` resolves a project's workflow (`managed` vs `generic`) by asking git for the repository root, but `ProjectWorkflow.ts` spawned `git rev-parse --show-toplevel` without a `cwd` — so the answer came from wherever the calling process happened to be, not from the project being fingerprinted.

Concrete repro: fingerprinting a git worktree while the process cwd sat in the main checkout. The git root resolved to the caller's repo, so `git check-ignore` ran against the wrong repository and missed the project's `.gitignore` — the workflow flipped from `managed` to `generic` and the fingerprint hash silently changed for the same project.

# How

- `GitClient` now receives the project root and runs `git rev-parse --show-toplevel` with `cwd: projectRoot`.
- `isGitInstalledAndConfiguredAsync()` had the same latent issue: it decided whether the *project* is inside a git repo from the caller's cwd, which picks `GitClient` vs `NoVCSClient` wrongly when only one of the two locations is a git repo. It now runs its `rev-parse` probe with `cwd: projectRoot` too.

The `git check-ignore` call already used the resolved root as `cwd`, so it is fixed transitively. These are the only git spawns in the package.

# Test Plan

New test `src/__tests__/ProjectWorkflow-git-test.ts` (real temp git repos, no mocks): a project whose `ios` directory is gitignored (managed workflow) plus an unrelated git repo; the test `process.chdir`s into the unrelated repo and asserts the project still resolves as `managed`.

Written red-first — before the fix:

```
✕ returns managed workflow when cwd is inside another git repo
    Expected: "managed"
    Received: "generic"
✓ returns managed workflow when cwd is the project root
```

After the fix, the whole package suite passes (26 suites, 221 tests), and `et check-packages @expo/fingerprint` (run as `node ./tools/bin/expotools.js check-packages @expo/fingerprint`) passes build, typecheck, depscheck, test, lint, and format.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
