### PR TITLE
[fingerprint] Normalize the project root to its realpath so path spelling never changes the hash

### DIFF
--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- Normalize the project root to its realpath when creating a fingerprint, so spelling the same project through a symlink (for example `/tmp` vs `/private/tmp` on macOS) no longer leaks `../`-style traversal paths into config-plugin sources and changes the hash. ([#49436](https://github.com/expo/expo/pull/49436) by [@janicduplessis](https://github.com/janicduplessis))
 - Set development mode before loading Expo config and `.env` files. ([#48839](https://github.com/expo/expo/pull/48839) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Fixed ignore patterns (built-in and `.fingerprintignore`) not matching on Windows, which made fingerprints differ between Windows machines and EAS builds ("Runtime version mismatch"). ([#46816](https://github.com/expo/expo/pull/46816) by [@blurbyte](https://github.com/blurbyte))
 

--- a/packages/@expo/fingerprint/src/Fingerprint.ts
+++ b/packages/@expo/fingerprint/src/Fingerprint.ts
@@ -4,6 +4,7 @@ import { normalizeOptionsAsync } from './Options';
 import { compareSource, sortSources } from './Sort';
 import { createFingerprintFromSourcesAsync } from './hash/Hash';
 import { getHashSourcesAsync } from './sourcer/Sourcer';
+import { maybeGetRealPathAsync } from './sourcer/Utils';
 
 /**
  * Create a fingerprint for a project.
@@ -17,6 +18,10 @@ export async function createFingerprintAsync(
   projectRoot: string,
   options?: Options
 ): Promise<Fingerprint> {
+  // Use the realpath of the project root so that relative source paths - and with them the
+  // resulting hash - do not change with how the caller spelled the path (e.g. through a
+  // symlink like `/tmp` -> `/private/tmp` on macOS).
+  projectRoot = await maybeGetRealPathAsync(projectRoot);
   const opts = await normalizeOptionsAsync(projectRoot, options);
   const sources = await getHashSourcesAsync(projectRoot, opts);
   const normalizedSources = sortSources(dedupSources(sources, projectRoot));

--- a/packages/@expo/fingerprint/src/__tests__/Fingerprint-symlink-test.ts
+++ b/packages/@expo/fingerprint/src/__tests__/Fingerprint-symlink-test.ts
@@ -1,0 +1,89 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { createFingerprintAsync } from '../Fingerprint';
+
+// This is an integration test against a real project on disk, so opt out of the automatic
+// `resolve-from` mock from `__mocks__/` and use the real module resolution.
+jest.unmock('resolve-from');
+
+jest.mock('../ExpoConfigLoader', () => ({
+  // Mock the getExpoConfigLoaderPath to use the built version rather than the typescript version from src
+  getExpoConfigLoaderPath: jest.fn(() =>
+    jest.requireActual('path').resolve(__dirname, '..', '..', 'build', 'ExpoConfigLoader.js')
+  ),
+}));
+
+// Path to the `expo` package inside this monorepo, symlinked into the temporary project so
+// `expo/config` is resolvable from the project root.
+const EXPO_PACKAGE_ROOT = path.resolve(__dirname, '..', '..', '..', '..', 'expo');
+
+describe('createFingerprintAsync - projectRoot spelled through a symlink', () => {
+  jest.setTimeout(120000);
+
+  let tmpDir: string;
+  let projectRoot: string;
+  let symlinkedProjectRoot: string;
+  let symlinkSupported = false;
+
+  beforeAll(async () => {
+    // Use the realpath so that symlinked temp dirs (e.g. /var -> /private/var on macOS)
+    // don't hide or double up the behavior under test.
+    tmpDir = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), 'fingerprint-symlink-'));
+    projectRoot = path.join(tmpDir, 'project');
+    symlinkedProjectRoot = path.join(tmpDir, 'project-link');
+
+    await fs.mkdir(path.join(projectRoot, 'plugins'), { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, 'package.json'),
+      JSON.stringify({ name: 'symlink-app', version: '1.0.0', dependencies: { expo: '*' } })
+    );
+    await fs.writeFile(
+      path.join(projectRoot, 'app.json'),
+      JSON.stringify({
+        expo: { name: 'symlink-app', slug: 'symlink-app', plugins: ['./plugins/withNoop.js'] },
+      })
+    );
+    await fs.writeFile(
+      path.join(projectRoot, 'plugins', 'withNoop.js'),
+      'module.exports = (config) => config;\n'
+    );
+    await fs.mkdir(path.join(projectRoot, 'node_modules'), { recursive: true });
+
+    try {
+      await fs.symlink(EXPO_PACKAGE_ROOT, path.join(projectRoot, 'node_modules', 'expo'));
+      await fs.symlink(projectRoot, symlinkedProjectRoot);
+      symlinkSupported = true;
+    } catch {
+      // Symlink creation is unsupported on this platform (e.g. Windows without privileges).
+      symlinkSupported = false;
+    }
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('produces the same hash for the realpath and a symlinked spelling of the same project', async () => {
+    if (!symlinkSupported) {
+      console.warn('Skipping - cannot create symlinks on this platform.');
+      return;
+    }
+
+    const realFingerprint = await createFingerprintAsync(projectRoot);
+    // Guard that the out-of-process config loader actually ran and captured the local
+    // config plugin - otherwise this test would pass vacuously.
+    expect(
+      realFingerprint.sources.some(
+        (source) =>
+          source.type === 'file' &&
+          source.filePath === 'plugins/withNoop.js' &&
+          source.reasons.includes('expoConfigPlugins')
+      )
+    ).toBe(true);
+
+    const symlinkedFingerprint = await createFingerprintAsync(symlinkedProjectRoot);
+    expect(symlinkedFingerprint.hash).toBe(realFingerprint.hash);
+  });
+});


### PR DESCRIPTION
# Why

The same project produces a different fingerprint hash depending on how its path is spelled. Observed on macOS where `/tmp` is a symlink to `/private/tmp`: fingerprinting a project as `/tmp/app` vs `/private/tmp/app` gives two different hashes; spelling the root as its realpath restores agreement.

The cause: Node resolves loaded modules to their real paths, so when `projectRoot` is a symlinked spelling, the config loader's `path.relative(projectRoot, filename)` escapes the project and leaks tree-specific traversal paths into the `expoConfigPlugins` file sources. From the repro, the same local plugin becomes:

```
realpath root:  plugins/withNoop.js
symlinked root: ../project/plugins/withNoop.js
```

# How

Normalize `projectRoot` with `fs.realpath` (the existing `maybeGetRealPathAsync` helper, which falls back to the given path on error) once at the top of `createFingerprintAsync`. Everything downstream — options, sourcers, dedup, hashing, and the out-of-process config loader, which receives the root from the parent — then sees the canonical spelling. `createProjectHashAsync`, `diffFingerprintChangesAsync`, and the CLI all route through `createFingerprintAsync`, so this is the single choke point; a few sourcers already realpathed locally for the same reason (e.g. autolinking results in `Expo.ts`).

# Test Plan

New test `src/__tests__/Fingerprint-symlink-test.ts`: builds a minimal Expo project with a local config plugin in a temp dir, creates a sibling symlink to it (skips if the platform can't create symlinks), and fingerprints the project through both spellings, asserting equal hashes. It also asserts the local plugin was actually captured as an `expoConfigPlugins` source, so the test can't pass vacuously if the out-of-process config loader fails. Like the e2e suites, it points `getExpoConfigLoaderPath` at the built `build/ExpoConfigLoader.js` for the child process.

Written red-first — before the fix:

```
✕ produces the same hash for the realpath and a symlinked spelling of the same project
    Expected: "f12db3ad79da3de02e5b563e2410b5e507a34b39"
    Received: "0c1bedfc288b4cefa284bd160f09868c1d7c50dc"
```

After the fix, the whole package suite passes (26 suites, 220 tests), and `et check-packages @expo/fingerprint` (run as `node ./tools/bin/expotools.js check-packages @expo/fingerprint`) passes build, typecheck, depscheck, test, lint, and format.

Note for reviewers: for a project whose root was previously passed as a non-realpath spelling, the fingerprint changes once to the realpath-based (correct) value.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
