### PR TITLE
[ios][audio] Resolve microphone permission requests from the system callback's result

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Android] Fix `createAudioPlayer`/`useAudioPlayer` throwing "Received 5 arguments, but 4 was expected" due to the native `AudioPlayer` constructor missing the iOS-only `allowsExternalPlayback` parameter. ([#48655](https://github.com/expo/expo/pull/48655) by [@RasmusKard](https://github.com/RasmusKard))
 - [iOS] Report `denied` instead of crashing the app when `NSMicrophoneUsageDescription` is missing. ([#48840](https://github.com/expo/expo/pull/48840) by [@ahmadaccino](https://github.com/ahmadaccino))
 - [iOS] Resolve permission requests with `denied` and reject recording calls instead of letting the OS terminate the app when `NSMicrophoneUsageDescription` is missing. ([#49162](https://github.com/expo/expo/pull/49162) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Resolve `requestRecordingPermissionsAsync` from the system callback's result instead of re-reading the audio session, which could still report `undetermined` and return `granted: false` for a permission the user just granted. ([#49438](https://github.com/expo/expo/pull/49438) by [@lux-in-tenebris-lucet](https://github.com/lux-in-tenebris-lucet))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/AudioRecordingRequester.swift
+++ b/packages/expo-audio/ios/AudioRecordingRequester.swift
@@ -3,6 +3,8 @@ import ExpoModulesCore
 private let selector = ["request", "Record", "Permission", ":"]
 
 public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
+  typealias SystemPermissionRequest = (@escaping (Bool) -> Void) -> Void
+
   public static func permissionType() -> String {
     return "audioRecording"
   }
@@ -59,30 +61,44 @@ public class AudioRecordingRequester: NSObject, EXPermissionsRequester {
     requestPermissions(usageDescription: Self.microphoneUsageDescription, resolver: resolve, rejecter: reject)
   }
 
-  func requestPermissions(usageDescription: Any?, resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock) {
+  func requestPermissions(
+    usageDescription: Any?,
+    requestSystemPermission: SystemPermissionRequest? = nil,
+    resolver resolve: @escaping EXPromiseResolveBlock,
+    rejecter reject: @escaping EXPromiseRejectBlock
+  ) {
     guard usageDescription != nil else {
       resolve(Self.permissions(systemStatus: AVAudioSession.sharedInstance().recordPermission, usageDescription: nil))
       return
     }
 
+    guard let requestSystemPermission = requestSystemPermission ?? Self.systemPermissionRequest() else {
+      reject("AudioRecordingRequester", "Failed to request audio recording permission", nil)
+      return
+    }
+
+    // The system reports the outcome through this callback. Reading `recordPermission` from inside
+    // it can still return `.undetermined`, which resolves a permission the user just granted as
+    // not granted.
+    requestSystemPermission { granted in
+      resolve(Self.permissions(systemStatus: granted ? .granted : .denied, usageDescription: usageDescription))
+    }
+  }
+
+  private static func systemPermissionRequest() -> SystemPermissionRequest? {
     typealias PermissionRequestFunction = @convention(c) (AnyObject, Selector, @escaping (Bool) -> Void) -> Void
     let recordPermissionSelector = NSSelectorFromString(selector.joined())
 
     let session = AVAudioSession.sharedInstance()
     guard let method = class_getInstanceMethod(type(of: session), recordPermissionSelector) else {
-      reject("AudioRecordingRequester", "Failed to request audio recording permission", nil)
-      return
+      return nil
     }
 
     let imp = method_getImplementation(method)
 
     let requestPermission = unsafeBitCast(imp, to: PermissionRequestFunction.self)
-    requestPermission(session, recordPermissionSelector) { [weak self] _ in
-      guard let self else {
-        reject("AudioRecordingRequester", "Failed to request audio recording permission", nil)
-        return
-      }
-      resolve(self.getPermissions())
+    return { handler in
+      requestPermission(session, recordPermissionSelector, handler)
     }
   }
 }

--- a/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
+++ b/packages/expo-audio/ios/Tests/AudioRecordingRequesterTests.swift
@@ -45,6 +45,32 @@ struct AudioRecordingRequesterTests {
     #expect(resolved?["status"] as? UInt32 == EXPermissionStatusDenied.rawValue)
   }
 
+  // The system only guarantees the outcome it hands to the request callback. Re-reading
+  // `AVAudioSession.recordPermission` from inside that callback can still return `.undetermined`,
+  // which used to resolve a permission the user just granted as `granted: false`.
+  @Test(arguments: [
+    (true, EXPermissionStatusGranted),
+    (false, EXPermissionStatusDenied),
+  ] as [(Bool, EXPermissionStatus)])
+  func `resolves from the request callback rather than the session status`(
+    granted: Bool,
+    expected: EXPermissionStatus
+  ) {
+    let requester = AudioRecordingRequester()
+    var resolved: [AnyHashable: Any]?
+
+    requester.requestPermissions(
+      usageDescription: "Allow $(PRODUCT_NAME) to access your microphone",
+      requestSystemPermission: { handler in handler(granted) }
+    ) { result in
+      resolved = result as? [AnyHashable: Any]
+    } rejecter: { _, _, _ in
+      Issue.record("requestPermissions rejected instead of resolving")
+    }
+
+    #expect(resolved?["status"] as? UInt32 == expected.rawValue)
+  }
+
   @Test
   func `requireUsageDescription throws when the usage description is missing`() {
     #expect(throws: MicrophoneUsageDescriptionException.self) {


### PR DESCRIPTION
# Why

`requestRecordingPermissionsAsync()` can resolve `granted: false` right after the user taps allow.

the requester drops the bool its callback delivers and re-reads the session instead:

```swift
requestPermission(session, recordPermissionSelector) { [weak self] _ in  // granted bool, dropped
  resolve(self.getPermissions())  // re-reads AVAudioSession.recordPermission
}
```

inside its own grant callback that property can still read `.undetermined`, so the response falls through to `undetermined`.

what that looks like in an app: user taps record, ios prompts, they allow, and the app tells them mic permission was denied. tapping again works. so every first-time user eats one dead tap, and the ones who don't retry look like they refused.

apple only guarantees the answer handed to the callback, not when the property catches up. react-native-permissions resolves this case from the callback bool ([RNPermissionHandlerMicrophone.mm](https://github.com/zoontek/react-native-permissions/blob/master/ios/Microphone/RNPermissionHandlerMicrophone.mm)).

same bug and same fix merged yesterday in jamsch/expo-speech-recognition [#168](https://github.com/jamsch/expo-speech-recognition/pull/168). hit it in production there on a real device, and expo-audio asks for the same `AVAudioSession` permission the same way.

# How

- resolve from the callback's bool. `getPermissions()` still reads live state, and both paths keep using the same `permissions(systemStatus:usageDescription:)` mapping.
- the `requestRecordPermission:` lookup moves into `systemPermissionRequest()` unchanged, so a test can stub it. split selector stays split.
- `[weak self]` goes with the `self` capture. it used to reject the promise if the requester was deallocated before the user answered.

no api change. when the property is fresh both paths agree, so only the broken state changes.

# Test Plan

- two new cases in `AudioRecordingRequesterTests`: the callback's result decides the response, granted and denied. putting `resolve(self.getPermissions())` back behind the same seam fails the granted case.
- couldn't run `expotools native-unit-tests --platform ios` here, it fails to build `expo-modules-jsi` on xcode 26.3 (`SWIFT_RETURNS_RETAINED` on a constructor). same on a clean `main`, and ci pins 26.4.1. ran the two cases against the same source in the harness below instead.
- the race needs real-device timing, so: spm harness swizzling `AVAudioSession` so the callback delivers `true` while `recordPermission` still reads `.undetermined`, running the requester copied byte-identical from `main` next to the patched one. stock resolves `undetermined`, patched resolves `granted`, both agree when the property is fresh. 5/5 on the iphone 16e simulator, ios 26.3.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<details>
<summary>spm harness (xcodebuild test on an ios simulator)</summary>

`Sources/StockRequester/AudioRecordingRequester.swift` is `packages/expo-audio/ios/AudioRecordingRequester.swift` from `main`, unmodified. `Sources/FixedRequester/AudioRecordingRequester.swift` is the same file from this branch. `Tests/PackageTests/` is the two cases this PR adds. Run with `xcodebuild test -scheme AudioProof-Package -destination "platform=iOS Simulator,name=iPhone 16e"`.

### Package.swift

```swift
// swift-tools-version:5.9
import PackageDescription

let package = Package(
  name: "AudioProof",
  platforms: [.iOS(.v16)],
  targets: [
    .target(name: "ExpoModulesCore", path: "Sources/ExpoModulesCore"),
    .target(name: "StockRequester", dependencies: ["ExpoModulesCore"], path: "Sources/StockRequester"),
    .target(name: "FixedRequester", dependencies: ["ExpoModulesCore"], path: "Sources/FixedRequester"),
    .testTarget(name: "ProofTests", dependencies: ["StockRequester", "FixedRequester"], path: "Tests/ProofTests"),
    .testTarget(name: "PackageTests", dependencies: ["FixedRequester"], path: "Tests/PackageTests"),
  ]
)
```

### Sources/ExpoModulesCore/Shim.swift

minimal stand-in so both requester files compile verbatim outside the monorepo.

```swift
@_exported import AVFoundation
import Foundation

public typealias EXPromiseResolveBlock = (Any?) -> Void
public typealias EXPromiseRejectBlock = (String?, String?, Error?) -> Void

public struct EXPermissionStatus: RawRepresentable, Equatable {
  public let rawValue: UInt32
  public init(rawValue: UInt32) { self.rawValue = rawValue }
}

public let EXPermissionStatusDenied = EXPermissionStatus(rawValue: 0)
public let EXPermissionStatusGranted = EXPermissionStatus(rawValue: 1)
public let EXPermissionStatusUndetermined = EXPermissionStatus(rawValue: 2)

public protocol EXPermissionsRequester {
  static func permissionType() -> String
  func getPermissions() -> [AnyHashable: Any]
  func requestPermissions(resolver resolve: @escaping EXPromiseResolveBlock, rejecter reject: @escaping EXPromiseRejectBlock)
}

public struct ExpoLog {
  public func error(_ message: String) {
    print("[error] \(message)")
  }
}

public let log = ExpoLog()

public final class MicrophoneUsageDescriptionException: NSObject, Error {}
```

### Tests/ProofTests/ProofTests.swift

```swift
import XCTest
import AVFoundation
import ExpoModulesCore
@testable import StockRequester
@testable import FixedRequester

private let usageDescription = "Allow $(PRODUCT_NAME) to access your microphone"

/// Puts the process into the state the bug needs:
///  - `NSMicrophoneUsageDescription` is present, like a real app that records audio
///  - the record-permission request callback delivers `true` (the user just granted)
///  - the `recordPermission` property still reads `.undetermined` (it has not caught up)
final class ProofTests: XCTestCase {
  static var bundlePatched = false

  override class func setUp() {
    super.setUp()
    guard !bundlePatched else { return }
    bundlePatched = true
    addMicrophoneUsageDescriptionToMainBundle()
  }

  static func setInstanceImp(_ cls: AnyClass, _ sel: Selector, _ imp: IMP) {
    guard let method = class_getInstanceMethod(cls, sel) else { fatalError("no method \(sel)") }
    method_setImplementation(method, imp)
  }

  /// What `AVAudioSession.recordPermission` reads right now.
  static func stubRecordPermission(_ permission: AVAudioSession.RecordPermission) {
    setInstanceImp(
      AVAudioSession.self, #selector(getter: AVAudioSession.recordPermission),
      imp_implementationWithBlock({ (_: AnyObject) -> UInt in
        permission.rawValue
      } as @convention(block) (AnyObject) -> UInt))
  }

  /// What the record-permission request callback delivers.
  static func stubRequestRecordPermission(delivering granted: Bool) {
    setInstanceImp(
      AVAudioSession.self, NSSelectorFromString("requestRecordPermission:"),
      imp_implementationWithBlock({ (_: AnyObject, response: @escaping (Bool) -> Void) in
        response(granted)
      } as @convention(block) (AnyObject, @escaping (Bool) -> Void) -> Void))
  }

  /// Leaves every other bundle and every other key alone; only adds the one Info.plist entry
  /// a recording app would ship, so `getPermissions()` reaches its status mapping.
  static func addMicrophoneUsageDescriptionToMainBundle() {
    let sel = #selector(getter: Bundle.infoDictionary)
    guard let method = class_getInstanceMethod(Bundle.self, sel) else { fatalError("no infoDictionary") }

    typealias InfoDictionaryFunction = @convention(c) (AnyObject, Selector) -> [String: Any]?
    let original = unsafeBitCast(method_getImplementation(method), to: InfoDictionaryFunction.self)

    let block: @convention(block) (AnyObject) -> [String: Any]? = { bundle in
      var info = original(bundle, sel) ?? [:]
      if (bundle as? Bundle) === Bundle.main {
        info["NSMicrophoneUsageDescription"] = usageDescription
      }
      return info
    }
    method_setImplementation(method, imp_implementationWithBlock(block))
  }

  private func resolve(
    _ request: (@escaping EXPromiseResolveBlock, @escaping EXPromiseRejectBlock) -> Void
  ) -> [AnyHashable: Any] {
    var result: [AnyHashable: Any] = [:]
    let resolved = expectation(description: "resolved")
    request({ value in
      result = value as? [AnyHashable: Any] ?? [:]
      resolved.fulfill()
    }, { _, _, _ in
      XCTFail("rejected")
      resolved.fulfill()
    })
    wait(for: [resolved], timeout: 2)
    return result
  }

  private func stockStatus() -> UInt32? {
    let requester = StockRequester.AudioRecordingRequester()
    return resolve { resolve, reject in
      requester.requestPermissions(usageDescription: usageDescription, resolver: resolve, rejecter: reject)
    }["status"] as? UInt32
  }

  private func fixedStatus() -> UInt32? {
    let requester = FixedRequester.AudioRecordingRequester()
    return resolve { resolve, reject in
      requester.requestPermissions(usageDescription: usageDescription, resolver: resolve, rejecter: reject)
    }["status"] as? UInt32
  }

  // MARK: - the state under test

  func testTheStubbedStateIsWhatWeThinkItIs() {
    ProofTests.stubRecordPermission(.undetermined)
    ProofTests.stubRequestRecordPermission(delivering: true)

    XCTAssertNotNil(Bundle.main.infoDictionary?["NSMicrophoneUsageDescription"])
    XCTAssertEqual(AVAudioSession.sharedInstance().recordPermission, .undetermined)

    var delivered: Bool?
    let called = expectation(description: "called")
    AVAudioSession.sharedInstance().requestRecordPermission { granted in
      delivered = granted
      called.fulfill()
    }
    wait(for: [called], timeout: 2)
    XCTAssertEqual(delivered, true)
  }

  // MARK: - the bug: callback says granted, property has not caught up

  func testStockResolvesUndeterminedOnTheGrantItsCallbackJustDelivered() {
    ProofTests.stubRecordPermission(.undetermined)
    ProofTests.stubRequestRecordPermission(delivering: true)

    XCTAssertEqual(stockStatus(), EXPermissionStatusUndetermined.rawValue)
  }

  func testFixedResolvesGrantedUnderTheIdenticalState() {
    ProofTests.stubRecordPermission(.undetermined)
    ProofTests.stubRequestRecordPermission(delivering: true)

    XCTAssertEqual(fixedStatus(), EXPermissionStatusGranted.rawValue)
  }

  // MARK: - the states where the property is already fresh: both agree

  func testBothResolveGrantedWhenThePropertyHasCaughtUp() {
    ProofTests.stubRecordPermission(.granted)
    ProofTests.stubRequestRecordPermission(delivering: true)

    XCTAssertEqual(stockStatus(), EXPermissionStatusGranted.rawValue)
    XCTAssertEqual(fixedStatus(), EXPermissionStatusGranted.rawValue)
  }

  func testBothResolveDeniedWhenTheUserRefuses() {
    ProofTests.stubRecordPermission(.denied)
    ProofTests.stubRequestRecordPermission(delivering: false)

    XCTAssertEqual(stockStatus(), EXPermissionStatusDenied.rawValue)
    XCTAssertEqual(fixedStatus(), EXPermissionStatusDenied.rawValue)
  }
}
```

</details>
