### PR TITLE
 [docs] Fix markdown content negotiation headers, 404s, and q-values

### DIFF
--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -7,6 +7,35 @@ No markdown exists for this path. Useful starting points:
 - [Documentation home](https://docs.expo.dev/)
 `;
 
+function acceptsMarkdown(accept) {
+  let markdownListed = false;
+  let markdownQuality = 0;
+  let htmlQuality = 0;
+
+  for (const entry of accept.split(",")) {
+    const [type, ...params] = entry.split(";");
+    const name = type.trim().toLowerCase();
+
+    let quality = 1;
+    for (const param of params) {
+      const [key, value] = param.split("=");
+      if (key.trim().toLowerCase() === "q") {
+        quality = Number(value);
+        if (!Number.isFinite(quality)) quality = 0;
+      }
+    }
+
+    if (name === "text/markdown") {
+      markdownListed = true;
+      markdownQuality = Math.max(markdownQuality, quality);
+    } else if (name === "text/html" || name === "text/*" || name === "*/*") {
+      htmlQuality = Math.max(htmlQuality, quality);
+    }
+  }
+
+  return markdownListed && markdownQuality > 0 && markdownQuality >= htmlQuality;
+}
+
 function upgradeHelperPairPath(url) {
   if (!/^\/bare\/upgrade\/?$/.test(url.pathname)) return null;
 
@@ -27,7 +56,7 @@ export default {
     const pairPath = upgradeHelperPairPath(url);
 
     const wantsMarkdown =
-      accept.includes("text/markdown") ||
+      acceptsMarkdown(accept) ||
       (pairPath !== null && /\.md$/.test(url.searchParams.get("toSdk") || ""));
 
     if (wantsMarkdown) {

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -98,6 +98,9 @@ export default {
       });
     }
 
-    return env.ASSETS.fetch(request);
+    const htmlResponse = await env.ASSETS.fetch(request);
+    const response = new Response(htmlResponse.body, htmlResponse);
+    response.headers.append("Vary", "Accept");
+    return response;
   },
 };

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -55,6 +55,11 @@ export default {
         }
       }
 
+      const passthrough = await env.ASSETS.fetch(request);
+      if (passthrough.status >= 300 && passthrough.status < 400) {
+        return passthrough;
+      }
+
       return new Response(NOT_FOUND_MARKDOWN, {
         status: 404,
         headers: {

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -40,12 +40,13 @@ export default {
             status: 200,
             headers: {
               "Content-Type": "text/markdown; charset=utf-8",
+              Vary: "Accept",
             },
           });
         }
       }
 
-      return new Response("Not found\n", { status: 404 });
+      return new Response("Not found\n", { status: 404, headers: { Vary: "Accept" } });
     }
 
     return env.ASSETS.fetch(request);

--- a/docs/public/_worker.js
+++ b/docs/public/_worker.js
@@ -1,3 +1,12 @@
+const NOT_FOUND_MARKDOWN = `# Page not found
+
+No markdown exists for this path. Useful starting points:
+
+- [Documentation index](https://docs.expo.dev/llms.txt)
+- [Sitemap](https://docs.expo.dev/sitemap.xml)
+- [Documentation home](https://docs.expo.dev/)
+`;
+
 function upgradeHelperPairPath(url) {
   if (!/^\/bare\/upgrade\/?$/.test(url.pathname)) return null;
 
@@ -46,7 +55,13 @@ export default {
         }
       }
 
-      return new Response("Not found\n", { status: 404, headers: { Vary: "Accept" } });
+      return new Response(NOT_FOUND_MARKDOWN, {
+        status: 404,
+        headers: {
+          "Content-Type": "text/markdown; charset=utf-8",
+          Vary: "Accept",
+        },
+      });
     }
 
     return env.ASSETS.fetch(request);

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -144,6 +144,13 @@ async function testMarkdownContentNegotiationAsync(): Promise<void> {
   }
   console.log('✓ Normal request serves HTML');
 
+  if (!varyTokens(htmlResponse).includes('accept')) {
+    throw new Error(
+      `Expected Vary header listing Accept on the HTML variant, got: ${htmlResponse.headers.get('vary') ?? '(absent)'}`
+    );
+  }
+  console.log('✓ HTML variant of a negotiated page returns Vary: Accept');
+
   // With Accept: text/markdown, should serve markdown
   const mdResponse = await fetch(`${BASE_URL}/test-page`, {
     headers: { Accept: 'text/markdown' },

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -220,6 +220,46 @@ async function testMarkdownNotFoundAsync(): Promise<void> {
   console.log('✓ Nonexistent page returns 404');
 }
 
+async function testAcceptQualityValuesAsync(): Promise<void> {
+  console.log('\n--- Testing Accept header q-values ---');
+
+  const htmlPreferred = await fetch(`${BASE_URL}/test-page`, {
+    headers: { Accept: 'text/html;q=0.9, text/markdown;q=0.1' },
+  });
+  const htmlPreferredBody = await htmlPreferred.text();
+
+  if (!htmlPreferredBody.includes('Test Page HTML')) {
+    throw new Error(
+      'Expected HTML when it carries the higher q, got: ' + htmlPreferredBody.slice(0, 200)
+    );
+  }
+  console.log('✓ HTML with the higher q is served over markdown');
+
+  const markdownRejected = await fetch(`${BASE_URL}/test-page`, {
+    headers: { Accept: 'text/markdown;q=0, text/html' },
+  });
+  const markdownRejectedBody = await markdownRejected.text();
+
+  if (!markdownRejectedBody.includes('Test Page HTML')) {
+    throw new Error(
+      'Expected HTML when markdown has q=0, got: ' + markdownRejectedBody.slice(0, 200)
+    );
+  }
+  console.log('✓ Markdown with q=0 is never served');
+
+  const markdownPreferred = await fetch(`${BASE_URL}/test-page`, {
+    headers: { Accept: 'text/markdown;q=0.9, text/html;q=0.1' },
+  });
+  const markdownPreferredBody = await markdownPreferred.text();
+
+  if (!markdownPreferredBody.includes('Test Markdown Content')) {
+    throw new Error(
+      'Expected markdown when it carries the higher q, got: ' + markdownPreferredBody.slice(0, 200)
+    );
+  }
+  console.log('✓ Markdown with the higher q is served');
+}
+
 async function testUpgradePairNegotiationAsync(): Promise<void> {
   console.log('\n--- Testing upgrade helper version-pair negotiation ---');
 
@@ -398,6 +438,7 @@ async function mainAsync(): Promise<void> {
     await testDirectMarkdownAccessAsync();
     await testMarkdownContentNegotiationAsync();
     await testMarkdownNotFoundAsync();
+    await testAcceptQualityValuesAsync();
     await testUpgradePairNegotiationAsync();
     await testDeletedPageRedirectsAsync();
     await testHtmlNotFoundAsync();

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -194,6 +194,21 @@ async function testMarkdownNotFoundAsync(): Promise<void> {
   }
   console.log('✓ Markdown 404 response includes Vary: Accept');
 
+  const missingMdType = missingMd.headers.get('content-type') ?? '';
+
+  if (!missingMdType.includes('text/markdown')) {
+    throw new Error(`Expected markdown Content-Type on the 404, got: ${missingMdType}`);
+  }
+
+  const missingMdBody = await missingMd.text();
+
+  if (!missingMdBody.includes('/llms.txt') || !missingMdBody.includes('/sitemap.xml')) {
+    throw new Error(
+      `Expected recovery links on the markdown 404, got: ${missingMdBody.slice(0, 200)}`
+    );
+  }
+  console.log('✓ Markdown 404 responds with a markdown body and recovery links');
+
   // Nonexistent page should also 404
   const notFound = await fetch(`${BASE_URL}/nonexistent-page`, {
     headers: { Accept: 'text/markdown' },

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -361,6 +361,19 @@ async function testDeletedPageRedirectsAsync(): Promise<void> {
     );
   }
   console.log('✓ expo-go-to-dev-build redirects to the introduction build locally section');
+
+  const mdRedirect = await fetch(`${BASE_URL}/develop/development-builds/create-a-build`, {
+    headers: { Accept: 'text/markdown' },
+    redirect: 'manual',
+  });
+  const mdLocation = mdRedirect.headers.get('location') ?? '';
+
+  if (mdRedirect.status !== 301 || !mdLocation.includes('?buildenv=build-with-eas')) {
+    throw new Error(
+      `Expected the markdown request to pass through the page redirect, got: HTTP ${mdRedirect.status} -> ${mdLocation}`
+    );
+  }
+  console.log('✓ Accept: text/markdown request passes through page redirects');
 }
 
 async function testHtmlNotFoundAsync(): Promise<void> {

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -161,6 +161,17 @@ async function testMarkdownContentNegotiationAsync(): Promise<void> {
     throw new Error(`Expected Content-Type text/markdown, got: ${mdContentType}`);
   }
   console.log('✓ Accept: text/markdown request returns correct Content-Type');
+
+  if (!varyTokens(mdResponse).includes('accept')) {
+    throw new Error(
+      `Expected Vary header listing Accept, got: ${mdResponse.headers.get('vary') ?? '(absent)'}`
+    );
+  }
+  console.log('✓ Accept: text/markdown request returns Vary: Accept');
+}
+
+function varyTokens(response: Response): string[] {
+  return (response.headers.get('vary') ?? '').split(',').map(token => token.trim().toLowerCase());
 }
 
 async function testMarkdownNotFoundAsync(): Promise<void> {
@@ -175,6 +186,13 @@ async function testMarkdownNotFoundAsync(): Promise<void> {
     throw new Error(`Expected 404 for missing .md, got: HTTP ${missingMd.status}`);
   }
   console.log('✓ Missing .md file returns 404');
+
+  if (!varyTokens(missingMd).includes('accept')) {
+    throw new Error(
+      `Expected Vary header listing Accept on the markdown 404, got: ${missingMd.headers.get('vary') ?? '(absent)'}`
+    );
+  }
+  console.log('✓ Markdown 404 response includes Vary: Accept');
 
   // Nonexistent page should also 404
   const notFound = await fetch(`${BASE_URL}/nonexistent-page`, {


### PR DESCRIPTION
# Why

Fix ENG-26229 ENG-26230 ENG-26231 ENG-26236

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Add `Vary: Accept` to negotiated markdown responses in `public/_worker.js` so caches key on the `Accept` header (ENG-26229)
- Return a markdown 404 body linking `llms.txt`, `sitemap.xml`, and the docs home instead of a plain `Not found` (ENG-26230)
- Pass 3xx responses through to markdown requests so moved pages redirect instead of returning 404 (ENG-26231)
- Replace the `text/markdown` substring match with an `acceptsMarkdown` q-value parser: markdown is served only when explicitly listed, above zero, and at or above HTML's quality (ENG-26236)
- Cover all four behaviors in `scripts/test-worker.ts`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

`pnpm test:worker` should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
