### PR TITLE
[docs] Move the AgentInstructions block below the H1 in generated markdown

### DIFF
--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -2,8 +2,8 @@
  * Agent feedback instructions appended into per-page .md files.
  *
  * Each page's generated markdown includes an <AgentInstructions> block (placed
- * right after the frontmatter) telling LLM-based agents how to submit feedback
- * with the Expo feedback CLI or direct HTTP fallback.
+ * directly below the page's first H1) telling LLM-based agents how to submit
+ * feedback with the Expo feedback CLI or direct HTTP fallback.
  *
  * Intentionally isolated in its own module so the experiment can be tweaked or
  * removed without touching the broader markdown generation utilities.
@@ -48,7 +48,7 @@ export function buildAgentInstructions(pathname: string): string {
 
 /**
  * Page-specific notes injected as bare blockquotes into per-page index.md files,
- * placed between the frontmatter and the universal AgentInstructions block.
+ * placed right after the frontmatter, before the page content.
  * Keys are URL paths matching urlPathFromHtmlPath output.
  *
  * These notes appear only in the markdown output served via Accept: text/markdown,

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -50,6 +50,39 @@ describe('insertAgentInstructionsAfterH1', () => {
 
     expect(result).toBe(`${block}\n${markdown}`);
   });
+
+  it('keeps the description paragraph attached to the title', () => {
+    const markdown = '# Create a project\n\nLearn how to create a new Expo project.\n\nBody.';
+    const result = insertAgentInstructionsAfterH1(
+      markdown,
+      block,
+      'Learn how to create a new Expo project.'
+    );
+
+    expect(result).toBe(
+      '# Create a project\n\nLearn how to create a new Expo project.\n\n<AgentInstructions>\n\n## Submitting Feedback\n\nReport it.\n\n</AgentInstructions>\n\nBody.'
+    );
+  });
+
+  it('matches a description paragraph that turndown escaped', () => {
+    const markdown = '# Page\n\nUse \\[brackets\\] carefully.\n\nBody.';
+    const result = insertAgentInstructionsAfterH1(markdown, block, 'Use [brackets] carefully.');
+
+    expect(result.indexOf('carefully.')).toBeLessThan(result.indexOf('<AgentInstructions>'));
+  });
+
+  it('inserts below the H1 when the next paragraph is not the description', () => {
+    const markdown = '# Page title\n\nRegular first paragraph.\n\nBody.';
+    const result = insertAgentInstructionsAfterH1(
+      markdown,
+      block,
+      'A description not on the page.'
+    );
+
+    expect(result.indexOf('<AgentInstructions>')).toBeLessThan(
+      result.indexOf('Regular first paragraph.')
+    );
+  });
 });
 
 describe('convertMdxInstructionToMarkdown', () => {

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -12,8 +12,45 @@ import {
   convertMdxInstructionToMarkdown,
   extractFrontmatter,
   findMdxSource,
+  insertAgentInstructionsAfterH1,
   stripCodeBlocks,
 } from './generate-markdown-pages-utils.ts';
+
+describe('insertAgentInstructionsAfterH1', () => {
+  const block =
+    '<AgentInstructions>\n\n## Submitting Feedback\n\nReport it.\n\n</AgentInstructions>\n';
+
+  it('inserts the block below the first H1', () => {
+    const markdown = '# Page title\n\nFirst paragraph.\n\n## First section\n\nMore.';
+    const result = insertAgentInstructionsAfterH1(markdown, block);
+
+    expect(result).toBe(
+      '# Page title\n\n<AgentInstructions>\n\n## Submitting Feedback\n\nReport it.\n\n</AgentInstructions>\n\nFirst paragraph.\n\n## First section\n\nMore.'
+    );
+  });
+
+  it('targets the first H1 even when content precedes it', () => {
+    const markdown = 'Intro line.\n\n# Page title\n\nBody.';
+    const result = insertAgentInstructionsAfterH1(markdown, block);
+
+    expect(result.indexOf('# Page title')).toBeLessThan(result.indexOf('<AgentInstructions>'));
+    expect(result.indexOf('<AgentInstructions>')).toBeLessThan(result.indexOf('Body.'));
+  });
+
+  it('prepends the block when no H1 exists', () => {
+    const markdown = 'This page redirects to another page.';
+    const result = insertAgentInstructionsAfterH1(markdown, block);
+
+    expect(result).toBe(`${block}\n${markdown}`);
+  });
+
+  it('does not treat an H2 as an H1', () => {
+    const markdown = '## Only a section heading\n\nBody.';
+    const result = insertAgentInstructionsAfterH1(markdown, block);
+
+    expect(result).toBe(`${block}\n${markdown}`);
+  });
+});
 
 describe('convertMdxInstructionToMarkdown', () => {
   it('converts scene JSX components and inlines helper MDX', () => {

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -890,13 +890,26 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   });
 }
 
-export function insertAgentInstructionsAfterH1(markdown: string, block: string): string {
+export function insertAgentInstructionsAfterH1(
+  markdown: string,
+  block: string,
+  description?: string | null
+): string {
   const h1 = markdown.match(/^# .*$/m);
   if (h1?.index === undefined) {
     return `${block}\n${markdown}`;
   }
 
-  const insertAt = h1.index + h1[0].length;
+  let insertAt = h1.index + h1[0].length;
+
+  if (description) {
+    const normalize = (text: string) => text.replace(/\\/g, '').replace(/\s+/g, ' ').trim();
+    const paragraph = markdown.slice(insertAt).match(/^\n+([^\n]+)/);
+    if (paragraph && normalize(paragraph[1]).startsWith(normalize(description).slice(0, 40))) {
+      insertAt += paragraph[0].length;
+    }
+  }
+
   return `${markdown.slice(0, insertAt)}\n\n${block.trimEnd()}${markdown.slice(insertAt)}`;
 }
 

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -890,6 +890,16 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   });
 }
 
+export function insertAgentInstructionsAfterH1(markdown: string, block: string): string {
+  const h1 = markdown.match(/^# .*$/m);
+  if (h1?.index === undefined) {
+    return `${block}\n${markdown}`;
+  }
+
+  const insertAt = h1.index + h1[0].length;
+  return `${markdown.slice(0, insertAt)}\n\n${block.trimEnd()}${markdown.slice(insertAt)}`;
+}
+
 /**
  * Post-process the markdown output to clean up common artifacts.
  */

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -152,7 +152,10 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
     const pageNote = buildPageSpecificNote(pathname);
 
     if (agentInstructions) {
-      markdown = insertAgentInstructionsAfterH1(markdown, agentInstructions);
+      const description = frontmatter
+        ?.match(/^description: (.*)$/m)?.[1]
+        ?.replace(/^["']|["']$/g, '');
+      markdown = insertAgentInstructionsAfterH1(markdown, agentInstructions, description);
     }
 
     const parts: string[] = [];

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -23,6 +23,7 @@ import {
   extractFrontmatter,
   findMdxSource,
   injectSceneVariants,
+  insertAgentInstructionsAfterH1,
   type ResolvedMdxImport,
 } from './generate-markdown-pages-utils.ts';
 import { SCENE_PAGES } from './scene-page-manifest.ts';
@@ -150,15 +151,16 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
       instructionSections.length > 0 ? wrapAgentInstructions(instructionSections) : null;
     const pageNote = buildPageSpecificNote(pathname);
 
+    if (agentInstructions) {
+      markdown = insertAgentInstructionsAfterH1(markdown, agentInstructions);
+    }
+
     const parts: string[] = [];
     if (frontmatter) {
       parts.push(frontmatter);
     }
     if (pageNote) {
       parts.push(pageNote);
-    }
-    if (agentInstructions) {
-      parts.push(agentInstructions);
     }
     parts.push(markdown);
     markdown = parts.join('\n');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26234

# How

<!--
How did you build this feature or fix this bug and why?
-->

Move the `AgentInstructions` block below the H1 in generated markdown so it stays within the boundaries of a Markdown page and passes the agentic tooling tests.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="3328" height="1680" alt="CleanShot 2026-08-27 at 18 20 49@2x" src="https://github.com/user-attachments/assets/f30c6caa-b5c3-45ac-aa69-656cefde991f" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
