### PR TITLE
[docs] Add /api and /developers redirects for agent discovery paths

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -646,3 +646,8 @@
 /llms-sdk-v54.0.0.txt /llms.txt 301
 /llms-sdk-v55.0.0.txt /llms.txt 301
 /llms-sdk-v56.0.0.txt /llms.txt 301
+# Agent discovery paths probed by AI-readiness checkers
+/api /versions/latest 301
+/api/ /versions/latest 301
+/developers / 301
+/developers/ / 301

--- a/docs/scripts/test-worker.ts
+++ b/docs/scripts/test-worker.ts
@@ -330,6 +330,33 @@ async function testDeletedPageRedirectsAsync(): Promise<void> {
   console.log('✓ expo-go-to-dev-build redirects to the introduction build locally section');
 }
 
+async function testAgentDiscoveryRedirectsAsync(): Promise<void> {
+  console.log('\n--- Testing agent discovery redirects ---');
+
+  const api = await fetch(`${BASE_URL}/api`, { redirect: 'manual' });
+  const apiLocation = api.headers.get('location') ?? '';
+
+  if (api.status !== 301 || !apiLocation.includes('/versions/latest')) {
+    throw new Error(
+      `Expected /api to redirect to /versions/latest, got: HTTP ${api.status} -> ${apiLocation}`
+    );
+  }
+  console.log('✓ /api redirects to the API reference');
+
+  const developers = await fetch(`${BASE_URL}/developers`, { redirect: 'manual' });
+  const developersLocation = developers.headers.get('location') ?? '';
+
+  if (
+    developers.status !== 301 ||
+    !(developersLocation === '/' || developersLocation === `${BASE_URL}/`)
+  ) {
+    throw new Error(
+      `Expected /developers to redirect to /, got: HTTP ${developers.status} -> ${developersLocation}`
+    );
+  }
+  console.log('✓ /developers redirects to the docs home');
+}
+
 async function testHtmlNotFoundAsync(): Promise<void> {
   console.log('\n--- Testing HTML 404 responses ---');
 
@@ -354,6 +381,7 @@ async function mainAsync(): Promise<void> {
     await testMarkdownNotFoundAsync();
     await testUpgradePairNegotiationAsync();
     await testDeletedPageRedirectsAsync();
+    await testAgentDiscoveryRedirectsAsync();
     await testHtmlNotFoundAsync();
 
     console.log('\n=== All tests passed! ===');


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26228 ENG-26235

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add /api and /developers redirects for agent discovery paths.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

`pnpm test:worker` should pass.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
