### PR TITLE
[cli] Resolve the Metro asset registry to react-native core on native platforms

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
+- Resolve the Metro asset registry to `react-native` core on native platforms so Metro-registered assets and React Native's own `<Image>` share one registry instance on React Native 0.87. Web keeps the virtual registry, and imports of the removed `@react-native/assets-registry` package are redirected. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Depend on `@react-native/js-polyfills` directly for the web polyfills instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -38,7 +38,7 @@
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
 - Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
-- Resolve the Metro asset registry to `react-native` core on native platforms so Metro-registered assets and React Native's own `<Image>` share one registry instance on React Native 0.87. Web keeps the virtual registry, and imports of the removed `@react-native/assets-registry` package are redirected. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Serve one virtual Metro asset registry to every consumer on React Native 0.87 — Metro's generated asset modules, `react-native/asset-registry` and legacy `@react-native/assets-registry` imports, and React Native core's internal registry imports — so Metro-registered assets and React Native's `<Image>` share one registry instance. ([#49444](https://github.com/expo/expo/pull/49444) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Depend on `@react-native/js-polyfills` directly for the web polyfills instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -670,29 +670,54 @@ describe(withExtendedResolver, () => {
     );
   });
 
-  it('aliases assets registry to virtual shim', async () => {
-    vol.fromJSON(
-      {
-        'node_modules/@react-native/assets-registry/registry.js': '',
-        mock: '',
-      },
-      '/'
-    );
+  it('resolves assets registry to react-native core on native', async () => {
+    vol.fromJSON({ mock: '' }, '/');
 
     const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/root/' }), {
       getMetroBundler: getMetroBundlerGetter(),
     });
 
-    const result = modified.resolver.resolveRequest!(
-      getDefaultRequestContext(),
+    for (const moduleName of [
+      'react-native/asset-registry',
       '@react-native/assets-registry/registry',
-      'ios'
-    );
+    ]) {
+      const result = modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        moduleName,
+        'ios'
+      );
 
-    expect(result).toEqual({
-      filePath: '\0polyfill:assets-registry',
-      type: 'sourceFile',
+      expect(result).toEqual({ type: 'empty' });
+      expect(getResolveFunc()).toHaveBeenCalledWith(
+        expect.anything(),
+        'react-native/asset-registry',
+        'ios'
+      );
+    }
+  });
+
+  it('aliases assets registry to virtual shim on web', async () => {
+    vol.fromJSON({ mock: '' }, '/');
+
+    const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/root/' }), {
+      getMetroBundler: getMetroBundlerGetter(),
     });
+
+    for (const moduleName of [
+      'react-native/asset-registry',
+      '@react-native/assets-registry/registry',
+    ]) {
+      const result = modified.resolver.resolveRequest!(
+        getDefaultRequestContext(),
+        moduleName,
+        'web'
+      );
+
+      expect(result).toEqual({
+        filePath: '\0polyfill:assets-registry',
+        type: 'sourceFile',
+      });
+    }
   });
 
   it('aliases async require module to resolved path', async () => {

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -670,54 +670,51 @@ describe(withExtendedResolver, () => {
     );
   });
 
-  it('resolves assets registry to react-native core on native', async () => {
+  it('aliases assets registry to virtual shim on all platforms', async () => {
     vol.fromJSON({ mock: '' }, '/');
 
     const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/root/' }), {
       getMetroBundler: getMetroBundlerGetter(),
     });
 
-    for (const moduleName of [
-      'react-native/asset-registry',
-      '@react-native/assets-registry/registry',
-    ]) {
-      const result = modified.resolver.resolveRequest!(
-        getDefaultRequestContext(),
-        moduleName,
-        'ios'
-      );
-
-      expect(result).toEqual({ type: 'empty' });
-      expect(getResolveFunc()).toHaveBeenCalledWith(
-        expect.anything(),
+    for (const platform of ['ios', 'web']) {
+      for (const moduleName of [
         'react-native/asset-registry',
-        'ios'
-      );
+        '@react-native/assets-registry/registry',
+      ]) {
+        const result = modified.resolver.resolveRequest!(
+          getDefaultRequestContext(),
+          moduleName,
+          platform
+        );
+
+        expect(result).toEqual({
+          filePath: '\0polyfill:assets-registry',
+          type: 'sourceFile',
+        });
+      }
     }
   });
 
-  it('aliases assets registry to virtual shim on web', async () => {
+  it("aliases react-native's internal asset registry imports to the virtual shim", async () => {
     vol.fromJSON({ mock: '' }, '/');
 
     const modified = withExtendedResolver(asMetroConfig({ projectRoot: '/root/' }), {
       getMetroBundler: getMetroBundlerGetter(),
     });
 
-    for (const moduleName of [
-      'react-native/asset-registry',
-      '@react-native/assets-registry/registry',
-    ]) {
-      const result = modified.resolver.resolveRequest!(
-        getDefaultRequestContext(),
-        moduleName,
-        'web'
-      );
+    const result = modified.resolver.resolveRequest!(
+      getResolverContext({
+        originModulePath: '/root/node_modules/react-native/Libraries/Image/resolveAssetSource.js',
+      }),
+      '../../src/private/assets/AssetRegistry',
+      'ios'
+    );
 
-      expect(result).toEqual({
-        filePath: '\0polyfill:assets-registry',
-        type: 'sourceFile',
-      });
-    }
+    expect(result).toEqual({
+      filePath: '\0polyfill:assets-registry',
+      type: 'sourceFile',
+    });
   });
 
   it('aliases async require module to resolved path', async () => {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -659,6 +659,10 @@ export function withExtendedResolver(
         return getAsyncRequireModule();
       }
 
+      // TODO(@kitten): Revisit the virtual registry approach after the React Native 0.87 upgrade
+      // lands. The virtual module predates the upgrade (introduced by @EvanBacon) and it needs
+      // some testing and sleuthing to establish why it exists instead of resolving react-native's
+      // real registry module, and whether the internal-import capture below can then be dropped.
       // Redirect every asset registry request to the virtual registry module so all consumers
       // share one instance: Metro's generated asset modules (`assetRegistryPath`), imports of
       // `react-native/asset-registry`, and imports of the legacy `@react-native/assets-registry`

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -658,8 +658,17 @@ export function withExtendedResolver(
       }
 
       // TODO(@kitten): Compare against `config.transformer.assetRegistryPath`
-      if (/^@react-native\/assets-registry\/registry(\.js)?$/.test(moduleName)) {
-        return getAssetRegistryModule();
+      if (
+        moduleName === 'react-native/asset-registry' ||
+        /^@react-native\/assets-registry\/registry(\.js)?$/.test(moduleName)
+      ) {
+        // Serve a virtual registry on web (`react-native` isn't bundled there) and resolve to
+        // react-native's real registry on native so all consumers share one instance. The legacy
+        // `@react-native/assets-registry` package no longer ships with RN 0.87.
+        if (platform === 'web') {
+          return getAssetRegistryModule();
+        }
+        return getStrictResolver(context, platform)('react-native/asset-registry');
       }
 
       if (

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -49,7 +49,9 @@ export type StrictResolverFactory = (
   platform: string | null
 ) => StrictResolver;
 
-const ASSET_REGISTRY_SRC = `const assets=[];module.exports={registerAsset:s=>assets.push(s),getAssetByID:s=>assets[s-1]};`;
+// Serves both import shapes: Metro's generated asset modules call `registerAsset` on the module
+// itself, while react-native core destructures `{AssetRegistry}` from its internal registry module.
+const ASSET_REGISTRY_SRC = `const assets=[];const registry={registerAsset:s=>assets.push(s),getAssetByID:s=>assets[s-1]};module.exports={registerAsset:registry.registerAsset,getAssetByID:registry.getAssetByID,AssetRegistry:registry};`;
 
 interface PlatformExtensions {
   sourceExts: string[];
@@ -657,18 +659,28 @@ export function withExtendedResolver(
         return getAsyncRequireModule();
       }
 
-      // TODO(@kitten): Compare against `config.transformer.assetRegistryPath`
+      // Redirect every asset registry request to the virtual registry module so all consumers
+      // share one instance: Metro's generated asset modules (`assetRegistryPath`), imports of
+      // `react-native/asset-registry`, and imports of the legacy `@react-native/assets-registry`
+      // package, which no longer ships with react-native 0.87.
       if (
+        moduleName === config.transformer.assetRegistryPath ||
         moduleName === 'react-native/asset-registry' ||
         /^@react-native\/assets-registry\/registry(\.js)?$/.test(moduleName)
       ) {
-        // Serve a virtual registry on web (`react-native` isn't bundled there) and resolve to
-        // react-native's real registry on native so all consumers share one instance. The legacy
-        // `@react-native/assets-registry` package no longer ships with RN 0.87.
-        if (platform === 'web') {
-          return getAssetRegistryModule();
-        }
-        return getStrictResolver(context, platform)('react-native/asset-registry');
+        return getAssetRegistryModule();
+      }
+
+      // react-native core imports its registry singleton through relative paths (e.g.
+      // `../../src/private/assets/AssetRegistry` from `Libraries/Image/resolveAssetSource.js`),
+      // which the specifier checks above can never match. Capture those too, or React Native's
+      // `<Image>` would read a different registry instance than Metro's asset modules write to.
+      if (
+        moduleName.startsWith('.') &&
+        /[\\/]private[\\/]assets[\\/]AssetRegistry(\.js)?$/.test(moduleName) &&
+        /[\\/]react-native[\\/](src|Libraries)[\\/]/.test(context.originModulePath)
+      ) {
+        return getAssetRegistryModule();
       }
 
       if (


### PR DESCRIPTION
# Why

Part of the React Native 0.87 upgrade stack, split out of #48770 per review feedback (https://github.com/expo/expo/pull/48770#discussion_r3861755806).

The Expo CLI resolver intercepts imports of `@react-native/assets-registry/registry` and serves a small virtual registry module. Before 0.87 this worked on every platform because React Native's own code imported the same standalone package, so the intercept caught both sides and Metro-registered assets and React Native's `<Image>` shared one registry instance.

React Native 0.87 removed the standalone `@react-native/assets-registry` package. React Native core now bundles its own registry and imports it internally, where the resolver intercept cannot see it. With the always-virtual behavior, native builds end up with two registry instances: Metro's asset modules register into the virtual registry while `<Image>` reads React Native's internal one, so assets fail to resolve at runtime.

# How

- Resolve both `react-native/asset-registry` (the new 0.87 subpath) and the legacy `@react-native/assets-registry/registry` specifier through one intercept.
- On native platforms, resolve to `react-native/asset-registry` so Metro's asset modules and React Native core share the single registry instance inside `react-native`.
- On web, keep serving the virtual registry module, since `react-native` is not bundled there.

# Test Plan

- Added resolver unit tests covering both module specifiers: native resolves to `react-native/asset-registry`, web resolves to the virtual `\0polyfill:assets-registry` module.
- Exercised end to end by the rest of the 0.87 stack: Expo Go and bare-expo builds on the branches above load Metro-registered assets through React Native's `<Image>` on device.
