### PR TITLE
[router] Wrap all actions from queue in transitions

### DIFF
--- a/apps/router-e2e/__e2e__/native-navigation/app/index.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/index.tsx
@@ -31,6 +31,7 @@ const HomeIndex = () => {
       <CaseLink href="/composition-rerenders" text="Composition Rerenders" />
       <CaseLink href="/modals" text="Modals" />
       <CaseLink href="/params" text="Params" />
+      <CaseLink href="/suspense" text="Suspense" />
       <CaseLink href="/js-stack" text="JS Stack" />
       <CaseLink href="/js-tabs" text="JS Tabs" />
       <CaseLink href="/top-tabs" text="JS Top Tabs" />

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/_layout.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/_layout.tsx
@@ -1,0 +1,20 @@
+import { Stack } from 'expo-router';
+import { Text, View } from 'react-native';
+
+export default function Layout() {
+  return <Stack />;
+}
+
+export function SuspenseFallback() {
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: 'red',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Text style={{ color: '#fff', fontSize: 24 }}>fallback</Text>
+    </View>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/index.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/index.tsx
@@ -1,0 +1,18 @@
+import { usePathname } from 'expo-router';
+import { ScrollView, Text } from 'react-native';
+
+import { SuspenseLinks } from '../../components/suspense';
+
+export default function SuspenseIndex() {
+  const pathname = usePathname();
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: '#fff' }}
+      contentContainerStyle={{ padding: 16, gap: 12 }}
+      contentInsetAdjustmentBehavior="automatic">
+      <Text>Suspense</Text>
+      <Text>Current Path: {pathname}</Text>
+      <SuspenseLinks />
+    </ScrollView>
+  );
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms-consecutive-200ms.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms-consecutive-200ms.tsx
@@ -1,0 +1,5 @@
+import { SuspenseScreen } from '../../components/suspense';
+
+export default function Screen() {
+  return <SuspenseScreen initial={200} consecutive={200} />;
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms-consecutive-5s.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms-consecutive-5s.tsx
@@ -1,0 +1,5 @@
+import { SuspenseScreen } from '../../components/suspense';
+
+export default function Screen() {
+  return <SuspenseScreen initial={200} consecutive={5000} />;
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-200ms.tsx
@@ -1,0 +1,5 @@
+import { SuspenseScreen } from '../../components/suspense';
+
+export default function Screen() {
+  return <SuspenseScreen initial={200} consecutive={0} />;
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-5s-consecutive-5s.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-5s-consecutive-5s.tsx
@@ -1,0 +1,5 @@
+import { SuspenseScreen } from '../../components/suspense';
+
+export default function Screen() {
+  return <SuspenseScreen initial={5000} consecutive={5000} />;
+}

--- a/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-5s.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/app/suspense/initial-5s.tsx
@@ -1,0 +1,5 @@
+import { SuspenseScreen } from '../../components/suspense';
+
+export default function Screen() {
+  return <SuspenseScreen initial={5000} consecutive={0} />;
+}

--- a/apps/router-e2e/__e2e__/native-navigation/components/suspense.tsx
+++ b/apps/router-e2e/__e2e__/native-navigation/components/suspense.tsx
@@ -1,0 +1,199 @@
+import {
+  Link,
+  unstable_useIsNavigating,
+  useIsFocused,
+  usePathname,
+  useRoute,
+  useRouter,
+  type Href,
+} from 'expo-router';
+import React, { use } from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+
+type SuspenseScreenConfig = {
+  href: Href;
+  title: string;
+  /** Delay of the first render of a given route key, in milliseconds. */
+  initial: number;
+  /** Delay of every focus after the first one, in milliseconds. `0` never suspends again. */
+  consecutive: number;
+};
+
+export const SUSPENSE_SCREENS: SuspenseScreenConfig[] = [
+  {
+    href: '/suspense/initial-5s',
+    title: 'initial: 5s, consecutive: 0',
+    initial: 5000,
+    consecutive: 0,
+  },
+  {
+    href: '/suspense/initial-200ms',
+    title: 'initial: 200ms, consecutive: 0',
+    initial: 200,
+    consecutive: 0,
+  },
+  {
+    href: '/suspense/initial-200ms-consecutive-200ms',
+    title: 'initial: 200ms, consecutive: 200ms',
+    initial: 200,
+    consecutive: 200,
+  },
+  {
+    href: '/suspense/initial-5s-consecutive-5s',
+    title: 'initial: 5s, consecutive: 5s',
+    initial: 5000,
+    consecutive: 5000,
+  },
+  {
+    href: '/suspense/initial-200ms-consecutive-5s',
+    title: 'initial: 200ms, consecutive: 5s',
+    initial: 200,
+    consecutive: 5000,
+  },
+];
+
+type SuspenseRecord = {
+  /**
+   * The promise the screen waits on. It stays the same instance once resolved, so `use` returns
+   * right away until a new focus replaces it.
+   */
+  promise: Promise<void>;
+  focusCount: number;
+  isFocused: boolean;
+};
+
+/** Keyed by navigation route key, so a new push of the same route suspends again. */
+const records = new Map<string, SuspenseRecord>();
+
+function delay(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function getRecord(routeKey: string, initial: number): SuspenseRecord {
+  let record = records.get(routeKey);
+  if (!record) {
+    record = { promise: delay(initial), focusCount: 0, isFocused: false };
+    records.set(routeKey, record);
+  }
+  return record;
+}
+
+/**
+ * Suspends on the first render of a route key for `initial` ms, and on every focus after that for
+ * `consecutive` ms.
+ */
+function useSuspendOnFocus(initial: number, consecutive: number): SuspenseRecord {
+  const routeKey = useRoute().key;
+  // Re-renders the screen on focus and on blur, which is what drives the logic below.
+  const isFocused = useIsFocused();
+  const record = getRecord(routeKey, initial);
+
+  // A screen also re-renders for reasons other than focus, so only the blurred -> focused
+  // transition starts a new delay. Without that guard the render after the promise resolves would
+  // start another one and the screen would never settle.
+  if (isFocused !== record.isFocused) {
+    record.isFocused = isFocused;
+    if (isFocused) {
+      record.focusCount += 1;
+      if (record.focusCount > 1 && consecutive > 0) {
+        record.promise = delay(consecutive);
+      }
+    }
+  }
+
+  use(record.promise);
+  return record;
+}
+
+function formatDelay(delay: number) {
+  if (delay === 0) return '0';
+  return delay >= 1000 ? `${delay / 1000}s` : `${delay}ms`;
+}
+
+export function SuspenseScreen({ initial, consecutive }: { initial: number; consecutive: number }) {
+  const record = useSuspendOnFocus(initial, consecutive);
+  const pathname = usePathname();
+
+  return (
+    <ScrollView
+      style={{ flex: 1, backgroundColor: '#fff' }}
+      contentContainerStyle={{ padding: 16, gap: 12 }}
+      contentInsetAdjustmentBehavior="automatic">
+      <Text>Current Path: {pathname}</Text>
+      <Text style={{ fontSize: 28, fontWeight: 'bold' }}>Initial: {formatDelay(initial)}</Text>
+      <Text style={{ fontSize: 28, fontWeight: 'bold' }}>
+        Consecutive: {formatDelay(consecutive)}
+      </Text>
+      <Text>Focus count: {record.focusCount}</Text>
+      <SuspenseLinks />
+    </ScrollView>
+  );
+}
+
+export function SuspenseLinks() {
+  // True while a navigation is queued or its state update is pending. The screen that started the
+  // navigation stays visible while the destination suspends, so this is where it shows up.
+  const isNavigating = unstable_useIsNavigating();
+
+  return (
+    <View style={{ gap: 12 }}>
+      {/* Rendered even when idle so the list below does not jump. */}
+      <Text style={{ fontSize: 12, minHeight: 16 }}>{isNavigating ? 'Loading...' : ''}</Text>
+      {SUSPENSE_SCREENS.map((screen) => (
+        <View key={String(screen.href)} style={{ gap: 4 }}>
+          <Text>{screen.title}</Text>
+          <View style={{ flexDirection: 'row', gap: 8 }}>
+            <LinkButton href={screen.href} text="navigate" />
+            <PreloadButton href={screen.href} />
+          </View>
+        </View>
+      ))}
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <BackButton />
+        <LinkButton href="/suspense" text="Suspense index" />
+      </View>
+    </View>
+  );
+}
+
+function LinkButton({ href, text }: { href: Href; text: string }) {
+  return (
+    <Link
+      href={href}
+      style={{
+        backgroundColor: 'rgb(11, 103, 175)',
+        color: '#fff',
+        padding: 12,
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}>
+      {text}
+    </Link>
+  );
+}
+
+function BackButton() {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="back"
+      onPress={() => router.back()}
+      style={{ backgroundColor: 'rgb(66, 66, 66)', padding: 12, borderRadius: 8 }}>
+      <Text style={{ color: '#fff' }}>back</Text>
+    </Pressable>
+  );
+}
+
+function PreloadButton({ href }: { href: Href }) {
+  const router = useRouter();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="preload"
+      onPress={() => router.prefetch(href)}
+      style={{ backgroundColor: 'rgb(94, 53, 177)', padding: 12, borderRadius: 8 }}>
+      <Text style={{ color: '#fff' }}>preload</Text>
+    </Pressable>
+  );
+}

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))
 - Generate deterministic navigation states and route keys. Complete states from custom routers or persisted state must include `routeKeySeq`. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))
@@ -45,6 +46,7 @@
 
 ### 🎉 New features
 
+- Add `unstable_useIsNavigating` for observing queued or pending navigation. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Add unstable `NavigationAwareActivity` component. ([#49164](https://github.com/expo/expo/pull/49164) by [@Ubax](https://github.com/Ubax))
 - Add screen error boundaries ([#49174](https://github.com/expo/expo/pull/49174) by [@Ubax](https://github.com/Ubax))
 - Export `NativeStackView` for custom navigator implementations on web. ([#49204](https://github.com/expo/expo/pull/49204) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/exports.ts
+++ b/packages/expo-router/src/exports.ts
@@ -16,6 +16,7 @@ export {
 } from './hooks';
 
 export { router, type ImperativeRouter } from './imperative-api';
+export { useIsNavigating as unstable_useIsNavigating } from './global-state/useIsNavigating';
 
 export { withLayoutContext } from './layouts/withLayoutContext';
 export { Navigator, Slot };

--- a/packages/expo-router/src/global-state/RoutingQueueDrainer.tsx
+++ b/packages/expo-router/src/global-state/RoutingQueueDrainer.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export function RoutingQueueDrainer({ ready, processIntent }: Props) {
   const intents = React.use(PendingIntentsContext);
-  const { dequeue } = React.use(RoutingQueueApiContext)!;
+  const { dequeue, startTransition } = React.use(RoutingQueueApiContext)!;
   const lastProcessed = React.useRef<RoutingIntent[] | undefined>(undefined);
 
   React.useEffect(() => {
@@ -21,22 +21,33 @@ export function RoutingQueueDrainer({ ready, processIntent }: Props) {
     }
     // Strict Mode re-runs the mount effect with the same array before `dequeue` updates state.
     lastProcessed.current = intents;
+    // TODO(@ubax): Navigation runs in a transition, so a destination that suspends keeps the
+    // current screen visible and never renders `SuspenseFallback` (including the web dev
+    // "Bundling..." toast for async routes). Design a fallback UX for pending navigation.
+    // Dequeue urgently so a later enqueue is not rebased on a stale queue.
     dequeue(intents);
-    for (const intent of intents) {
-      // Only catches errors thrown while dispatching. The navigation reducer runs
-      // during the next render, so errors from it surface there, not here.
-      try {
-        intent.onDispatch?.(intent.metadata);
-        processIntent(intent);
-      } catch (error) {
-        const message =
-          typeof error === 'object' && error != null && 'message' in error ? error.message : error;
-        console.warn(
-          `An error occurred when trying to handle navigation action ${JSON.stringify(intent)}: ${message}`
-        );
+    startTransition(() => {
+      for (const intent of intents) {
+        // Only catches errors thrown while dispatching. The navigation reducer runs
+        // during the next render, so errors from it surface there, not here.
+        try {
+          // TODO(@ubax): `onDispatch` records the web history operation now, but the commit that
+          // consumes it is deferred by the transition and an urgent `dispatchSync` can land in between.
+          // https://linear.app/expo/issue/ENG-22046
+          intent.onDispatch?.(intent.metadata);
+          processIntent(intent);
+        } catch (error) {
+          const message =
+            typeof error === 'object' && error != null && 'message' in error
+              ? error.message
+              : error;
+          console.warn(
+            `An error occurred when trying to handle navigation action ${JSON.stringify(intent)}: ${message}`
+          );
+        }
       }
-    }
-  }, [dequeue, intents, processIntent, ready]);
+    });
+  }, [dequeue, intents, processIntent, ready, startTransition]);
 
   return null;
 }

--- a/packages/expo-router/src/global-state/__tests__/navigationTransition.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/navigationTransition.test.ios.tsx
@@ -1,0 +1,164 @@
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react-native';
+import { use } from 'react';
+import { Text } from 'react-native';
+
+import { unstable_useIsNavigating, usePathname } from '../../exports';
+import Stack from '../../layouts/StackClient';
+import { unstable_navigationEvents } from '../../navigationEvents';
+import { CommonActions } from '../../react-navigation/routers';
+import { renderRouter } from '../../testing-library';
+import { navigationRef } from '../navigationRef';
+import { router } from '../router';
+
+afterEach(cleanup);
+
+function createDeferred() {
+  let resolve!: (value: string) => void;
+  const promise = new Promise<string>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function PendingStackLayout() {
+  const isNavigating = unstable_useIsNavigating();
+  return (
+    <>
+      <Text testID="is-navigating">{String(isNavigating)}</Text>
+      <Stack />
+    </>
+  );
+}
+
+it('keeps the current screen visible and reports pending while a navigation suspends', async () => {
+  const deferred = createDeferred();
+
+  function SlowScreen() {
+    const content = use(deferred.promise);
+    return <Text testID="slow">{content}</Text>;
+  }
+
+  renderRouter({
+    _layout: PendingStackLayout,
+    index: () => <Text testID="index">Index</Text>,
+    slow: {
+      default: SlowScreen,
+      SuspenseFallback: () => <Text testID="fallback">Fallback</Text>,
+    },
+  });
+
+  expect(screen.getByTestId('is-navigating')).toHaveTextContent('false');
+  expect(screen.getByTestId('index')).toBeVisible();
+
+  const navigationAct = act(() => router.push('/slow'));
+
+  expect(screen.getByTestId('is-navigating')).toHaveTextContent('true');
+  expect(screen.getByTestId('index')).toBeVisible();
+  expect(screen.queryByTestId('fallback')).toBeNull();
+
+  deferred.resolve('Slow');
+  await navigationAct;
+
+  await waitFor(() => expect(screen.getByTestId('is-navigating')).toHaveTextContent('false'));
+  expect(screen.getByTestId('slow')).toBeVisible();
+});
+
+it('commits two queued navigations in one transition', async () => {
+  const committedPaths: string[] = [];
+
+  function Layout() {
+    committedPaths.push(usePathname());
+    return <Stack />;
+  }
+
+  renderRouter({
+    _layout: Layout,
+    index: () => <Text>Index</Text>,
+    first: () => <Text>First</Text>,
+    second: () => <Text>Second</Text>,
+  });
+
+  await act(async () => {
+    router.push('/first');
+    router.push('/second');
+  });
+
+  expect(screen).toHavePathname('/second');
+  expect(committedPaths).not.toContain('/first');
+});
+
+it('processes each intent once when one is queued during a pending transition', async () => {
+  const deferred = createDeferred();
+  const dispatchedActions: string[] = [];
+
+  function SlowScreen() {
+    const content = use(deferred.promise);
+    return <Text testID="slow">{content}</Text>;
+  }
+
+  renderRouter({
+    _layout: PendingStackLayout,
+    index: () => <Text testID="index">Index</Text>,
+    slow: SlowScreen,
+    sync: () => <Text testID="sync">Sync</Text>,
+  });
+  const unsubscribe = unstable_navigationEvents.addListener('actionDispatched', (event) =>
+    dispatchedActions.push(event.actionType)
+  );
+
+  try {
+    const navigationAct = act(() => router.push('/slow'));
+    expect(screen.getByTestId('is-navigating')).toHaveTextContent('true');
+    expect(screen.getByTestId('index')).toBeVisible();
+
+    await act(async () => {
+      router.push('/sync');
+    });
+
+    deferred.resolve('Slow');
+    await navigationAct;
+
+    expect(screen.getByTestId('sync')).toBeVisible();
+    expect(screen).toHavePathname('/sync');
+    expect(dispatchedActions).toHaveLength(2);
+  } finally {
+    unsubscribe();
+  }
+});
+
+it('preserves action order when a synchronous dispatch interrupts a transition', async () => {
+  const deferred = createDeferred();
+
+  function SlowScreen() {
+    const content = use(deferred.promise);
+    return <Text testID="slow">{content}</Text>;
+  }
+
+  renderRouter({
+    _layout: PendingStackLayout,
+    index: () => <Text testID="index">Index</Text>,
+    sync: () => <Text testID="sync">Sync</Text>,
+    slow: SlowScreen,
+  });
+
+  const navigationAct = act(() => router.push('/slow'));
+  expect(screen.getByTestId('is-navigating')).toHaveTextContent('true');
+
+  act(() => navigationRef.current?.dispatchSync(CommonActions.navigate('sync')));
+
+  deferred.resolve('Slow');
+  await navigationAct;
+
+  expect(screen.getByTestId('sync')).toBeVisible();
+  expect(screen).toHavePathname('/sync');
+});
+
+it('reports no pending navigation outside ExpoRoot', () => {
+  function Consumer() {
+    return <Text testID="is-navigating">{String(unstable_useIsNavigating())}</Text>;
+  }
+
+  const { getByTestId } = render(<Consumer />);
+
+  expect(getByTestId('is-navigating')).toHaveTextContent('false');
+});

--- a/packages/expo-router/src/global-state/__tests__/routingQueueContext.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routingQueueContext.test.ios.tsx
@@ -4,6 +4,7 @@ import { use, type ContextType } from 'react';
 import { router } from '../router';
 import type { RoutingIntent } from '../routingQueue';
 import {
+  NavigationPendingContext,
   PendingIntentsContext,
   RoutingQueueApiContext,
   RoutingQueueProvider,
@@ -64,11 +65,13 @@ it('warns when a second root binds the imperative router', () => {
 
 it('preserves enqueue order and drains on the following render', () => {
   const snapshots: RoutingIntent[][] = [];
+  const pendingSnapshots: boolean[] = [];
   let enqueue: ReturnType<typeof useEnqueueRoutingIntent>;
 
   function Consumer() {
     enqueue = useEnqueueRoutingIntent();
     snapshots.push(use(PendingIntentsContext));
+    pendingSnapshots.push(use(NavigationPendingContext));
     return null;
   }
 
@@ -84,6 +87,7 @@ it('preserves enqueue order and drains on the following render', () => {
   });
 
   expect(snapshots).toEqual([[], [actionIntent('FIRST'), actionIntent('SECOND')]]);
+  expect(pendingSnapshots).toEqual([false, true]);
 });
 
 it('keeps intents added while a batch is being dequeued', () => {

--- a/packages/expo-router/src/global-state/routingQueueContext.tsx
+++ b/packages/expo-router/src/global-state/routingQueueContext.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { createContext, use, useMemo, useState, type PropsWithChildren } from 'react';
+import {
+  createContext,
+  use,
+  useMemo,
+  useState,
+  useTransition,
+  type PropsWithChildren,
+  type TransitionStartFunction,
+} from 'react';
 
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
 import { createImperativeRouter, router, unboundRouter } from './router';
@@ -17,29 +25,35 @@ const throwMissingRoutingQueue = () => {
 export type RoutingQueueApi = {
   enqueue: (intent: RoutingIntent) => void;
   dequeue: (processed: RoutingIntent[]) => void;
+  startTransition: TransitionStartFunction;
 };
 
 export const RoutingQueueApiContext = createContext<RoutingQueueApi | undefined>(undefined);
 export const PendingIntentsContext = createContext<RoutingIntent[]>(EMPTY);
+export const NavigationPendingContext = createContext(false);
 
 export function RoutingQueueProvider({ children }: PropsWithChildren) {
   const [queue, setQueue] = useState(EMPTY);
+  const [isPending, startTransition] = useTransition();
   const api = useMemo<RoutingQueueApi>(
     () => ({
       enqueue: (intent) => setQueue((previous) => [...previous, intent]),
       // Keep intents added between the drained render and this state update.
       dequeue: (processed) =>
         setQueue((previous) => (previous === processed ? EMPTY : previous.slice(processed.length))),
+      startTransition,
     }),
-    []
+    [startTransition]
   );
 
   return (
     <RoutingQueueApiContext.Provider value={api}>
-      <PendingIntentsContext.Provider value={queue}>
-        {children}
-        <ImperativeRoutingQueueBridge enqueue={api.enqueue} />
-      </PendingIntentsContext.Provider>
+      <NavigationPendingContext.Provider value={isPending || queue.length > 0}>
+        <PendingIntentsContext.Provider value={queue}>
+          {children}
+          <ImperativeRoutingQueueBridge enqueue={api.enqueue} />
+        </PendingIntentsContext.Provider>
+      </NavigationPendingContext.Provider>
     </RoutingQueueApiContext.Provider>
   );
 }

--- a/packages/expo-router/src/global-state/useIsNavigating.ts
+++ b/packages/expo-router/src/global-state/useIsNavigating.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { use } from 'react';
+
+import { NavigationPendingContext } from './routingQueueContext';
+
+/**
+ * Returns whether a navigation is queued or its state update is pending.
+ *
+ * The current screen can remain visible while this returns `true` if the destination suspends.
+ * `navigation.dispatchSync` bypasses the queue, and native back gestures never enter it, so this
+ * hook does not report navigation triggered by either one.
+ * Returns `false` when called outside an Expo Router root.
+ *
+ * @experimental
+ */
+export function useIsNavigating(): boolean {
+  return use(NavigationPendingContext);
+}

--- a/packages/expo-router/src/imperative-api.tsx
+++ b/packages/expo-router/src/imperative-api.tsx
@@ -3,4 +3,5 @@ import { router as internalRouter } from './global-state/router';
 
 export type { ImperativeRouter };
 // Hide internal `goBack` and `linkTo` methods from the public API and typedoc.
+// TODO(@ubax): Return promises from navigation methods that resolve when their transitions commit.
 export const router: ImperativeRouter = internalRouter;

--- a/packages/expo-router/src/link/Link.tsx
+++ b/packages/expo-router/src/link/Link.tsx
@@ -32,6 +32,7 @@ export const Link = Object.assign(
    *}
    * ```
    */
+  // TODO(@ubax): Expose pending status scoped to this link's navigation.
   function Link(props: LinkProps) {
     // Re-exporting ExpoLink here so that Link.* can be used in server components.
     return <ExpoLink {...props} />;

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -33,10 +33,6 @@ describe('Native Bottom Tabs Navigation', () => {
     expect(TabsScreen).toHaveBeenCalledTimes(2);
   }
 
-  function expectTwoRenders() {
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
-  }
-
   function lastHostSelectedKey() {
     const calls = TabsHost.mock.calls;
     return calls[calls.length - 1][0].navStateRequest.selectedScreenKey;
@@ -89,25 +85,23 @@ describe('Native Bottom Tabs Navigation', () => {
 
   it('can navigate using router.push', () => {
     act(() => router.push('/second'));
-    expectTwoRenders();
-    expectSecondTabFocused(2);
+    expectOneRender();
+    expectSecondTabFocused();
     TabsScreen.mockClear();
     act(() => router.push('/'));
-    expectTwoRenders();
-    expectIndexTabFocused(2);
+    expectOneRender();
+    expectIndexTabFocused();
   });
 
   it('can navigate using Link', () => {
     act(() => fireEvent.press(screen.getByTestId('index-second-link')));
 
-    // First render is deferred index=0, index =1
-    // Second one is deferred index=1, index =1
-    expectTwoRenders();
-    expectSecondTabFocused(2);
+    expectOneRender();
+    expectSecondTabFocused();
     TabsScreen.mockClear();
     act(() => fireEvent.press(screen.getByTestId('second-index-link')));
-    expectTwoRenders();
-    expectIndexTabFocused(2);
+    expectOneRender();
+    expectIndexTabFocused();
   });
 
   it('does not re-render when router.push is called to the same tab', () => {
@@ -123,7 +117,7 @@ describe('Native Bottom Tabs Navigation', () => {
 
     TabsScreen.mockClear();
     act(() => router.push('/second'));
-    expectSecondTabFocused(2);
+    expectSecondTabFocused();
 
     TabsScreen.mockClear();
     act(() => fireEvent.press(screen.getByTestId('second-second-link'))); // link to same tab
@@ -138,7 +132,7 @@ describe('Native Bottom Tabs Navigation', () => {
 
     TabsScreen.mockClear();
     act(() => router.push('/second'));
-    expectSecondTabFocused(2);
+    expectSecondTabFocused();
 
     act(() => fireEvent.press(screen.getByTestId('second-hidden-link')));
     expect(lastHostSelectedKey()).toBe('index');

--- a/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/render.test.ios.tsx
@@ -393,12 +393,11 @@ describe('First focused tab', () => {
 
     expect(screen.getByTestId('index')).toBeVisible();
     expect(screen.getByTestId('second')).toBeVisible();
-    expect(TabsScreen).toHaveBeenCalledTimes(4);
-    expect(TabsScreen.mock.calls[2][0].screenKey).toBe('index');
-    expect(TabsScreen.mock.calls[3][0].screenKey).toBe('second');
-    expect(TabsHost).toHaveBeenCalledTimes(2);
-    expect(TabsHost.mock.calls[0][0].navStateRequest.selectedScreenKey).toBe('index');
-    expect(TabsHost.mock.calls[1][0].navStateRequest.selectedScreenKey).toBe('second');
+    expect(TabsScreen).toHaveBeenCalledTimes(2);
+    expect(TabsScreen.mock.calls[0][0].screenKey).toBe('index');
+    expect(TabsScreen.mock.calls[1][0].screenKey).toBe('second');
+    expect(TabsHost).toHaveBeenCalledTimes(1);
+    expect(TabsHost.mock.calls[0][0].navStateRequest.selectedScreenKey).toBe('second');
 
     TabsScreen.mockClear();
     TabsHost.mockClear();

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -133,6 +133,8 @@ function BaseNavigationContainerInner({
 
   const dispatchSync = useLatestCallback((action: NavigationAction) => {
     // TODO(@ubax): Throw if this is called from a `removePrevented` callback.
+    // TODO(@ubax): Review urgent dispatches interleaved with pending navigation transitions. React
+    // rebases the queued actions, but intermediate state can reflect only the urgent action.
     handleAction(action);
   });
 


### PR DESCRIPTION
# Why

At the moment all actions are dispatched synchronously. Add support for transitions.

This is only an initial implementation and we still need to clarify the best DX/UX.

# How

1. Wrap all queue actions into transition

# Test Plan

1. CI
2. Router e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
