### PR TITLE
[widgets][iOS] Resolve autolinking relative to `expo`

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [Android] Fix modifiers type cast. ([#47616](https://github.com/expo/expo/pull/47721) by [@jakex7](https://github.com/jakex7))
 - Fix blank widget when JSX children mix a `.map()` array with sibling elements. ([#47888](https://github.com/expo/expo/pull/47888) by [@jakex7](https://github.com/jakex7))
 - [iOS] Restore push token observation when retrieving existing Live Activities. ([#48589](https://github.com/expo/expo/pull/48589) by [@developwithJB](https://github.com/developwithJB))
+- [iOS] Resolve autolinking relative to expo. ([#49453](https://github.com/expo/expo/pull/49453) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/scripts/autolinking.rb
+++ b/packages/expo-widgets/scripts/autolinking.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'pathname'
 require 'colored2' # dependency of CocoaPods
 
-require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: ['#{__dir__}'] })"`), "scripts/ios/autolinking_manager")
+require File.join(File.dirname(`node --print "require.resolve('expo-modules-autolinking/package.json', { paths: [require.resolve('expo/package.json')] })"`), "scripts/ios/autolinking_manager")
 require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
 
 def use_expo_modules_widgets!(options = {})


### PR DESCRIPTION
# Why

`expo-modules-autolinking` is not a direct dependency of `expo-widgets`, but it is to `expo`. In some setups it may cause issues.

# How

Resolve `expo-modules-autolinking` relative to `expo` like we do in other packages/template.

# Test Plan

`expo-widgets` should link properly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
