### PR TITLE
[docs] Match form input and textarea radii

### DIFF
--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 
 import { Input, Textarea } from '~/ui/components/Form';
 import { InlineHelp } from '~/ui/components/InlineHelp';
-import { CALLOUT, LABEL, RawH2 } from '~/ui/components/Text';
+import { CALLOUT, LABEL, RawH3 } from '~/ui/components/Text';
 
 const isDev = process.env.NODE_ENV === 'development';
 const URL = isDev
@@ -74,14 +74,16 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                   <div className="flex size-18 items-center justify-center rounded-full border-2 border-success bg-success">
                     <CheckIcon aria-hidden="true" className="icon-2xl text-icon-success" />
                   </div>
-                  <RawH2 className="mt-5! mb-2!">Feedback received</RawH2>
+                  <RawH3 className="mt-5! mb-2!">Feedback received</RawH3>
                   <CALLOUT theme="secondary">
                     Your feedback will help us make our docs better. Thanks for sharing!
                   </CALLOUT>
                 </div>
-                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-6">
+                <div className="flex items-center gap-4 px-6 pb-6">
                   <Dialog.Close asChild>
-                    <Button type="submit">Done</Button>
+                    <Button type="submit" className="flex-1 justify-center">
+                      Done
+                    </Button>
                   </Dialog.Close>
                 </div>
               </>
@@ -93,11 +95,12 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                 }}>
                 <div className="p-6">
                   <div className="flex justify-between">
-                    <RawH2 className="my-0!">Share your feedback</RawH2>
+                    <RawH3 className="my-0!">Share your feedback</RawH3>
                     <Dialog.Close asChild>
                       <Button
                         aria-label="Close"
                         theme="quaternary"
+                        className="bg-element"
                         leftSlot={<XIcon aria-hidden="true" className="icon-md" />}
                       />
                     </Dialog.Close>
@@ -144,11 +147,15 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     </InlineHelp>
                   )}
                 </div>
-                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-6">
+                <div className="flex items-center gap-4 px-6 pb-6">
                   <Dialog.Close asChild>
-                    <Button theme="quaternary">No thanks</Button>
+                    <Button theme="secondary" className="flex-1 justify-center">
+                      No thanks
+                    </Button>
                   </Dialog.Close>
-                  <Button type="submit">Submit</Button>
+                  <Button type="submit" className="flex-1 justify-center">
+                    Submit
+                  </Button>
                 </div>
               </form>
             )}

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -110,7 +110,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                       <LABEL>Feedback</LABEL>
                       <Textarea
                         autoFocus
-                        className="h-45 resize-none rounded-2xl"
+                        className="h-45 resize-none"
                         characterLimit={1000}
                         value={feedback}
                         onChange={event => {
@@ -125,7 +125,6 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                       </CALLOUT>
                       <Input
                         type="email"
-                        className="rounded-3xl"
                         placeholder="your@email.com"
                         value={email}
                         onChange={event => {

--- a/docs/ui/components/Footer/FeedbackDialog.tsx
+++ b/docs/ui/components/Footer/FeedbackDialog.tsx
@@ -79,7 +79,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     Your feedback will help us make our docs better. Thanks for sharing!
                   </CALLOUT>
                 </div>
-                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-3">
+                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-6">
                   <Dialog.Close asChild>
                     <Button type="submit">Done</Button>
                   </Dialog.Close>
@@ -91,7 +91,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                   event.preventDefault();
                   sendFeedback();
                 }}>
-                <div className="px-6 py-5">
+                <div className="p-6">
                   <div className="flex justify-between">
                     <RawH2 className="my-0!">Share your feedback</RawH2>
                     <Dialog.Close asChild>
@@ -144,7 +144,7 @@ export const FeedbackDialog = ({ pathname }: Props) => {
                     </InlineHelp>
                   )}
                 </div>
-                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-3">
+                <div className="flex min-h-14 items-center justify-end gap-2 bg-subtle px-6">
                   <Dialog.Close asChild>
                     <Button theme="quaternary">No thanks</Button>
                   </Dialog.Close>

--- a/docs/ui/components/Form/Input.tsx
+++ b/docs/ui/components/Form/Input.tsx
@@ -7,7 +7,7 @@ export function Input({ className, ...rest }: Props) {
   return (
     <input
       className={mergeClasses(
-        'my-2.5 block h-12 w-full rounded-md border border-default bg-default px-4 text-default shadow-xs placeholder:text-icon-quaternary',
+        'my-2.5 block h-12 w-full rounded-3xl border border-default bg-default px-4 text-default shadow-xs placeholder:text-icon-quaternary',
         className
       )}
       {...rest}

--- a/docs/ui/components/Form/Textarea.tsx
+++ b/docs/ui/components/Form/Textarea.tsx
@@ -20,7 +20,7 @@ export function Textarea({ characterLimit, className, onChange, ...rest }: Props
           }
         }}
         className={mergeClasses(
-          'my-2.5 block h-12 w-full rounded-sm border border-default bg-default p-4 leading-5 text-default shadow-xs placeholder:text-icon-tertiary',
+          'my-2.5 block h-12 w-full rounded-2xl border border-default bg-default p-4 leading-5 text-default shadow-xs placeholder:text-icon-tertiary',
           className
         )}
         {...rest}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26253

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the `Form/Input` default radius from `rounded-md` to `rounded-3xl` (24px, the EAS dashboard input value) and `Form/Textarea` from `rounded-sm` to `rounded-2xl` (20px, the expo.dev contact form value).
- Remove the now-redundant radius overrides in `FeedbackDialog`.
- The footer newsletter input picks up the pill from the default; the embedded Sign Up button needed no adjustment.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="942" height="302" alt="CleanShot 2026-08-27 at 21 31 18@2x" src="https://github.com/user-attachments/assets/2984bd01-1880-4496-a998-6efc2faff6a2" />
<img width="844" height="302" alt="CleanShot 2026-08-27 at 21 31 23@2x" src="https://github.com/user-attachments/assets/f6af8493-85e4-4dd4-ba72-2c12a3889001" />

<img width="1350" height="1242" alt="CleanShot 2026-08-27 at 21 31 27@2x" src="https://github.com/user-attachments/assets/63a2446c-e2ce-48b3-817f-ec3a8fd1e34f" />


<img width="1184" height="1164" alt="CleanShot 2026-08-27 at 21 31 35@2x" src="https://github.com/user-attachments/assets/941b4ec7-267f-43f0-b8fb-7293906ce6c9" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
