### PR TITLE
[docs] Update content-page cards to the 24px card radius

### DIFF
--- a/docs/scenes/develop/development-builds/MethodSelectCard.tsx
+++ b/docs/scenes/develop/development-builds/MethodSelectCard.tsx
@@ -16,7 +16,7 @@ export function MethodSelectCard({ Icon, title, description, isSelected, onClick
     <ButtonBase onClick={onClick}>
       <div
         className={mergeClasses(
-          'flex h-full w-68 flex-col overflow-hidden rounded-lg border border-default shadow-xs transition-all',
+          'flex h-full w-68 flex-col overflow-hidden rounded-3xl border border-default shadow-xs transition-all',
           'hocus:scale-[102%] hocus:shadow-sm'
         )}>
         <div

--- a/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/BuildEnvironmentSwitch.tsx
@@ -50,7 +50,7 @@ export function BuildEnvironmentSwitch() {
   }
 
   return (
-    <div className="flex items-start gap-3 rounded-lg border border-default bg-subtle px-4 py-3">
+    <div className="flex items-start gap-3 rounded-3xl border border-default bg-subtle px-4 py-3">
       <div className="mt-1">
         <Switch onChange={onSwitchChange} value={!buildEnv} />{' '}
       </div>

--- a/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
+++ b/docs/scenes/get-started/set-up-your-environment/SelectCard.tsx
@@ -27,7 +27,7 @@ export function SelectCard({
     <ButtonBase onClick={onClick}>
       <div
         className={mergeClasses(
-          'flex w-62.5 flex-col overflow-hidden rounded-lg border border-default shadow-xs transition-all',
+          'flex w-62.5 flex-col overflow-hidden rounded-3xl border border-default shadow-xs transition-all',
           'hocus:scale-[102%] hocus:shadow-sm'
         )}>
         <div

--- a/docs/ui/components/Authentication/Box.tsx
+++ b/docs/ui/components/Authentication/Box.tsx
@@ -14,7 +14,7 @@ type BoxProps = PropsWithChildren<{
 }>;
 
 export const Box = ({ name, image, createUrl, children }: BoxProps) => (
-  <APIBox className={mergeClasses('mt-6 px-4 pt-3', '[&_.table-wrapper]:mb-4')}>
+  <APIBox className={mergeClasses('mt-6 rounded-3xl px-4 pt-3', '[&_.table-wrapper]:mb-4')}>
     <div className="inline-flex w-full flex-row items-center gap-4 pb-4 max-md:flex-col max-md:gap-3">
       <div className="flex w-[inherit] flex-row items-center gap-3 [&>h3]:mb-0!">
         <Icon title={name} image={image} className="size-12" />

--- a/docs/ui/components/BoxLink/index.tsx
+++ b/docs/ui/components/BoxLink/index.tsx
@@ -22,14 +22,14 @@ export function BoxLink({ title, description, href, testID, Icon, imageUrl }: Bo
       // Used by scripts/generate-markdown-pages-utils.js to extract card link title/description
       data-md="card-link"
       className={mergeClasses(
-        'group mb-3 flex flex-row justify-between rounded-md border border-solid border-default px-4 py-3 transition',
+        'group mb-3 flex flex-row justify-between rounded-3xl border border-solid border-default px-4 py-3 transition',
         'hocus:bg-subtle hocus:shadow-xs'
       )}
       data-testid={testID}
       openInNewTab={isExternal}>
       <div className="flex flex-row gap-4">
         {Icon && (
-          <div className="flex h-9 min-w-9 items-center justify-center self-center rounded-md bg-element transition group-hover:bg-hover">
+          <div className="flex h-9 min-w-9 items-center justify-center self-center rounded-lg bg-element transition group-hover:bg-hover">
             <Icon aria-hidden="true" className="icon-lg text-icon-default" />
           </div>
         )}

--- a/docs/ui/components/DownloadSlide/index.tsx
+++ b/docs/ui/components/DownloadSlide/index.tsx
@@ -15,7 +15,7 @@ export function DownloadSlide({ title, description, imageUrl, className }: Props
       download
       href={imageUrl}
       className={mergeClasses(
-        'relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+        'relative flex items-stretch overflow-hidden rounded-3xl border border-default bg-default shadow-xs transition',
         'hocus:opacity-80 hocus:shadow-sm',
         'max-sm:flex-col',
         '[&+hr]:mt-6!',

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -58,7 +58,7 @@ export const Footer = ({
             <LinkBase
               href={previousPage.href}
               className={mergeClasses(
-                'flex w-full items-center gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'flex w-full items-center gap-3 rounded-3xl border border-solid border-default px-4 py-3 transition',
                 'hocus:bg-subtle hocus:shadow-xs'
               )}>
               <ArrowLeftIcon aria-hidden="true" className="shrink-0 text-icon-secondary" />
@@ -77,7 +77,7 @@ export const Footer = ({
             <LinkBase
               href={nextPage.href}
               className={mergeClasses(
-                'flex w-full items-center justify-between gap-3 rounded-md border border-solid border-default px-4 py-3 transition',
+                'flex w-full items-center justify-between gap-3 rounded-3xl border border-solid border-default px-4 py-3 transition',
                 'hocus:bg-subtle hocus:shadow-xs'
               )}>
               <div>

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -62,7 +62,7 @@ export function ProgressTracker({
 
   return (
     <>
-      <div className="mx-auto flex w-full flex-col gap-4 rounded-lg border-2 border-palette-gray4 px-4 py-5">
+      <div className="mx-auto flex w-full flex-col gap-4 rounded-3xl border-2 border-palette-gray4 px-4 py-5">
         <SuccessCheckmark
           size="sm"
           className={mergeClasses(

--- a/docs/ui/components/UIComponentGrid/index.tsx
+++ b/docs/ui/components/UIComponentGrid/index.tsx
@@ -184,7 +184,7 @@ export function UIComponentCard({
       href={resolvedHref}
       data-md-description={description}
       className={mergeClasses(
-        'group flex flex-col overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+        'group flex flex-col overflow-hidden rounded-3xl border border-default bg-default shadow-xs transition',
         'hocus:shadow-sm'
       )}
       isStyled>

--- a/docs/ui/components/VideoBoxLink/index.tsx
+++ b/docs/ui/components/VideoBoxLink/index.tsx
@@ -43,7 +43,7 @@ export function VideoBoxLink({
         openInNewTab
         href={`https://www.youtube.com/watch?v=${videoId}${time ? `&t=${time}` : ''}`}
         className={mergeClasses(
-          'group relative flex items-stretch overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+          'group relative flex items-stretch overflow-hidden rounded-3xl border border-default bg-default shadow-xs transition',
           'hocus:bg-subtle hocus:shadow-sm',
           'max-sm:flex-col',
           '[&+hr]:mt-6!',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26254

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the card shells of `BoxLink`,`Box` (used on authentication page) the footer Previous/Next cards, `VideoBoxLink`, `DownloadSlide`, `UIComponentGrid`, `SelectCard`, `MethodSelectCard`, `BuildEnvironmentSwitch`, and `ProgressTracker` from `rounded-md`/`rounded-lg` to `rounded-3xl`.
- Set the `BoxLink` icon tile to `rounded-lg`, the concentric radius for its 16px inset.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2314" height="798" alt="CleanShot 2026-08-27 at 21 55 18@2x" src="https://github.com/user-attachments/assets/bc09f1d2-8412-43a8-b623-c0a9d6a7304b" />

<img width="2294" height="306" alt="CleanShot 2026-08-27 at 21 55 24@2x" src="https://github.com/user-attachments/assets/7f522a40-67f9-46e2-8d21-4641a3213ba7" />

<img width="1890" height="590" alt="CleanShot 2026-08-27 at 21 55 28@2x" src="https://github.com/user-attachments/assets/2d203dd6-ae31-4b66-9a4e-1cbdfbfdee12" />

<img width="2350" height="2114" alt="CleanShot 2026-08-27 at 21 55 41@2x" src="https://github.com/user-attachments/assets/5c3367b1-401b-4c9e-8eb1-d59512f06edd" />

<img width="2438" height="902" alt="CleanShot 2026-08-27 at 21 56 10@2x" src="https://github.com/user-attachments/assets/1f55e1ca-05c7-4640-98c6-3d7603356ba4" />

<img width="2358" height="1510" alt="CleanShot 2026-08-27 at 22 00 23@2x" src="https://github.com/user-attachments/assets/13c685c3-85b5-48cd-9bc9-39918f5d223f" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
