### PR TITLE
[ios][updates] Propagate addNewAssets database failures instead of swallowing them

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [Android] Register the embedded update in a single transaction. An interrupted registration previously left an update row with no launch asset, which is treated as launchable and then fails every cold start with "Launch asset not found for update"; it now leaves no row, so the next launch registers it cleanly. ([#49130](https://github.com/expo/expo/pull/49130) by [@gwdp](https://github.com/gwdp))
 - [Android] Apply `reactNativeArchitectures` as a CMake ABI filter so single-ABI builds no longer compile the native code for unused ABIs. ([#49299](https://github.com/expo/expo/pull/49299) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Keep the Room-generated `UpdatesDatabase_Impl` constructor, so minified release builds no longer crash with `NoSuchMethodException` on first database access. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch.
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -160,7 +160,7 @@ public final class UpdatesDatabase: NSObject {
         )
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        return
+        throw error
       }
 
       // statements must stay in precisely this order for last_insert_rowid() to work correctly
@@ -170,7 +170,7 @@ public final class UpdatesDatabase: NSObject {
           _ = try execute(sql: updateSql, withArgs: [updateId])
         } catch {
           sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-          return
+          throw error
         }
       }
 
@@ -181,7 +181,7 @@ public final class UpdatesDatabase: NSObject {
         _ = try execute(sql: updateInsertSql, withArgs: [updateId])
       } catch {
         sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        return
+        throw error
       }
     }
 

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
@@ -115,6 +115,76 @@ class UpdatesDatabaseTests {
     }
   }
 
+  // MARK: - addNewAssets failure handling
+
+  @Suite("addNewAssets failure handling", .serialized)
+  struct AddNewAssetsFailureTests {
+    var testDatabaseDir: URL
+    var db: UpdatesDatabase
+    var manifest: ExpoUpdatesManifest
+    var config: UpdatesConfig
+
+    init() throws {
+      let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+      testDatabaseDir = applicationSupportDir!.appendingPathComponent("AddNewAssetsFailureTests")
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+      if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+        try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+      }
+
+      db = UpdatesDatabase()
+
+      manifest = ExpoUpdatesManifest(rawManifestJSON: [
+        "runtimeVersion": "1",
+        "id": "0eef8214-4833-4089-9dff-b4138a14f196",
+        "createdAt": "2020-11-11T00:17:54.797Z",
+        "launchAsset": ["url": "https://url.to/bundle.js", "contentType": "application/javascript"]
+      ])
+
+      config = try UpdatesConfig.config(fromDictionary: [
+        UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      ])
+
+      db.databaseQueue.sync {
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+      }
+    }
+
+    @Test
+    func `throws and rolls back when a statement fails`() throws {
+      let update = ExpoUpdatesUpdate.update(
+        withExpoUpdatesManifest: manifest,
+        extensions: [:],
+        config: config,
+        database: db
+      )
+
+      let asset = UpdateAsset(key: "bundle-key", type: "js")
+      asset.downloadTime = Date()
+      asset.contentHash = "hash"
+      asset.filename = "bundle.js"
+      asset.isLaunchAsset = true
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update, config: config)
+
+        // force the per-asset join insert to fail
+        _ = try! db.execute(sql: "DROP TABLE updates_assets", withArgs: nil)
+
+        do {
+          try db.addNewAssets([asset], toUpdateWithId: update.updateId)
+          Issue.record("Expected addNewAssets to throw when a statement fails")
+        } catch {}
+
+        // the whole batch must have been rolled back
+        #expect(try! db.asset(withKey: "bundle-key") == nil)
+      }
+    }
+  }
+
   // MARK: - setExtraClientParams
 
   @Suite("setExtraClientParams", .serialized)


### PR DESCRIPTION
# Why
addNewAssets is declared throws but never threw. All three failure paths rolled the transaction back and returned silently. A single SQLite error while registering a downloaded update meant the asset rows, and the launch_asset_id write were rolled back, while the caller saw success and still marked the update ready. The result is an update row that is selected as launchable on every cold start but can never launch.

# How
Rethrow after each rollback. The caller in AppLoader.finish() already has correct handling for a thrown error, so the update row stays pending and the next update check retries it cleanly. This is deliberately the smallest possible change so it can be cherry-picked to SDK 55.

# Test Plan
Added UpdatesDatabaseTests that forces a mid-batch statement failure by dropping the updates_assets table, then asserts addNewAssets throws and the whole batch rolled back
