### PR TITLE
[ios][updates] Repair ready updates that are missing their launch asset

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [Android] Apply `reactNativeArchitectures` as a CMake ABI filter so single-ABI builds no longer compile the native code for unused ABIs. ([#49299](https://github.com/expo/expo/pull/49299) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Keep the Room-generated `UpdatesDatabase_Impl` constructor, so minified release builds no longer crash with `NoSuchMethodException` on first database access. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch.
+- [iOS] Repair ready updates that are missing their launch asset by demoting them to pending during launcher selection, so a corrupted row is skipped and retried instead of failing every launch. ([#49457](https://github.com/expo/expo/pull/49457) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -444,7 +444,23 @@ public final class UpdatesDatabase: NSObject {
     )
 
     let rows = try execute(sql: sql, withArgs: [config.scopeKey])
-    return rows.map { row in
+
+    // A ready row with no launch asset is corrupt (e.g. from an interrupted registration) and
+    // would fail every launch. Demote it for the loader to retry instead of offering it.
+    var launchableRows: [[String: Any?]] = []
+    for row in rows {
+      let status: NSNumber = row.requiredValue(forKey: "status")
+      let launchAssetId: NSNumber? = row.optionalValue(forKey: "launch_asset_id")
+      if status.intValue == UpdateStatus.StatusReady.rawValue && launchAssetId == nil {
+        let updateId: UUID = row.requiredValue(forKey: "id")
+        let demoteSql = "UPDATE updates SET status = ?1 WHERE id = ?2;"
+        _ = try execute(sql: demoteSql, withArgs: [UpdateStatus.StatusPending.rawValue, updateId])
+      } else {
+        launchableRows.append(row)
+      }
+    }
+
+    return launchableRows.map { row in
       update(withRow: row, config: config)
     }
   }

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
@@ -185,6 +185,92 @@ class UpdatesDatabaseTests {
     }
   }
 
+  // MARK: - repair updates missing launch asset
+
+  @Suite("repair updates missing launch asset", .serialized)
+  struct RepairMissingLaunchAssetTests {
+    var testDatabaseDir: URL
+    var db: UpdatesDatabase
+    var config: UpdatesConfig
+
+    init() throws {
+      let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+      testDatabaseDir = applicationSupportDir!.appendingPathComponent("RepairMissingLaunchAssetTests")
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+      if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+        try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+      }
+
+      db = UpdatesDatabase()
+
+      config = try UpdatesConfig.config(fromDictionary: [
+        UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      ])
+
+      db.databaseQueue.sync {
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+      }
+    }
+
+    private func makeUpdate(id: String) -> Update {
+      let manifest = ExpoUpdatesManifest(rawManifestJSON: [
+        "runtimeVersion": "1",
+        "id": id,
+        "createdAt": "2020-11-11T00:17:54.797Z",
+        "launchAsset": ["url": "https://url.to/bundle.js", "contentType": "application/javascript"]
+      ])
+      return ExpoUpdatesUpdate.update(
+        withExpoUpdatesManifest: manifest,
+        extensions: [:],
+        config: config,
+        database: db
+      )
+    }
+
+    @Test
+    func `demotes ready updates without a launch asset during selection`() throws {
+      let update = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f196")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update, config: config)
+        // simulate the broken end state: finished without any assets linked
+        try! db.markUpdateFinished(update)
+
+        let launchable = try! db.launchableUpdates(withConfig: config)
+        #expect(launchable.isEmpty)
+
+        let reloaded = try! db.update(withId: update.updateId, config: config)
+        #expect(reloaded?.status == .StatusPending)
+      }
+    }
+
+    @Test
+    func `returns ready updates with a launch asset untouched`() throws {
+      let update = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f197")
+
+      let launchAsset = UpdateAsset(key: "bundle-key", type: "js")
+      launchAsset.downloadTime = Date()
+      launchAsset.contentHash = "hash"
+      launchAsset.filename = "bundle.js"
+      launchAsset.isLaunchAsset = true
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update, config: config)
+        try! db.addNewAssets([launchAsset], toUpdateWithId: update.updateId)
+        try! db.markUpdateFinished(update)
+
+        let launchable = try! db.launchableUpdates(withConfig: config)
+        #expect(launchable.map(\.updateId) == [update.updateId])
+
+        let reloaded = try! db.update(withId: update.updateId, config: config)
+        #expect(reloaded?.status == .StatusReady)
+      }
+    }
+  }
+
   // MARK: - setExtraClientParams
 
   @Suite("setExtraClientParams", .serialized)


### PR DESCRIPTION
# Why
The previous PR stops inserting bad row, but devices that already have a ready update row with no launch asset stay broken forever. The row is selected on every launch, the launch fails, and nothing ever fixes it

# How
launchableUpdates already reads every candidate row on launch, so the repair lives there at no extra cost to healthy devices. A ready row with no launch asset is demoted to pending and excluded from the candidates in the same pass. The launcher then falls back to the embedded update cleanly on that boot, and the existing loader path re-registers the demoted row in the background.

# Test Plan
Two tests: selection demotes a broken ready row to pending and excludes it, and a healthy ready row passes through untouched.
