### PR TITLE
[ios][updates] Register a downloaded update's assets and ready status in a single transaction

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Android] Keep the Room-generated `UpdatesDatabase_Impl` constructor, so minified release builds no longer crash with `NoSuchMethodException` on first database access. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch.
 - [iOS] Repair ready updates that are missing their launch asset by demoting them to pending during launcher selection, so a corrupted row is skipped and retried instead of failing every launch. ([#49457](https://github.com/expo/expo/pull/49457) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Register a downloaded update's assets, links, and ready status in a single transaction, so an interrupted or partially failed registration leaves no partial state behind. ([#49458](https://github.com/expo/expo/pull/49458) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoader.swift
@@ -358,18 +358,29 @@ open class AppLoader: NSObject {
     database.databaseQueue.async {
       self.arrayLock.lock()
 
+      guard let updateResponse = self.updateResponseContainingManifest,
+        let updateManifest = updateResponse.manifestUpdateResponsePart?.updateManifest else {
+        self.arrayLock.unlock()
+        self.finish(withError: UpdatesError.appLoaderFinishedWithoutManifest)
+        return
+      }
+
+      var assetsToLink: [UpdateAsset] = []
       for existingAsset in self.existingAssets {
-        var existingAssetFound: Bool = false
+        let existingAssetFound: Bool
         do {
-          existingAssetFound = try self.database.addExistingAsset(
-            existingAsset,
-            toUpdateWithId: self.updateResponseContainingManifest!.manifestUpdateResponsePart!.updateManifest.updateId
-          )
+          existingAssetFound = try self.database.asset(withKey: existingAsset.key) != nil
         } catch {
-          self.logger.warn(message: "Error searching for existing asset in DB: \(error.localizedDescription)")
+          // treating a failed check as "not found" would re-insert an existing asset, and the
+          // key-conflicting replace cascade-deletes every update that uses the old row
+          self.arrayLock.unlock()
+          self.finish(withError: UpdatesError.appLoaderUnknownError(cause: error))
+          return
         }
 
-        if !existingAssetFound {
+        if existingAssetFound {
+          assetsToLink.append(existingAsset)
+        } else {
           // the database and filesystem have gotten out of sync
           // do our best to create a new entry for this file even though it already existed on disk
           // TODO: we should probably get rid of this assumption that if an asset exists on disk with the same filename, it's the same asset
@@ -392,25 +403,16 @@ open class AppLoader: NSObject {
       }
 
       do {
-        try self.database.addNewAssets(
-          self.finishedAssets,
-          toUpdateWithId: self.updateResponseContainingManifest!.manifestUpdateResponsePart!.updateManifest.updateId
+        try self.database.finishUpdateRegistration(
+          updateManifest,
+          newAssets: self.finishedAssets,
+          existingAssets: assetsToLink,
+          markFinished: self.erroredAssets.isEmpty
         )
       } catch {
         self.arrayLock.unlock()
         self.finish(withError: UpdatesError.appLoaderUnknownError(cause: error))
         return
-      }
-
-      if self.erroredAssets.isEmpty {
-        do {
-          let updateManifest = self.updateResponseContainingManifest!.manifestUpdateResponsePart!.updateManifest
-          try self.database.markUpdateFinished(updateManifest)
-        } catch {
-          self.arrayLock.unlock()
-          self.finish(withError: UpdatesError.appLoaderUnknownError(cause: error))
-          return
-        }
       }
 
       var successBlock: AppLoaderSuccessBlock?
@@ -432,7 +434,7 @@ open class AppLoader: NSObject {
         if let errorBlock = errorBlock {
           errorBlock(UpdatesError.appLoaderFailedToLoadAllAssets)
         } else if let successBlock = successBlock {
-          successBlock(self.updateResponseContainingManifest!)
+          successBlock(updateResponse)
         }
       }
     }

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -23,6 +23,9 @@ internal enum UpdatesDatabaseError: Error, Sendable, LocalizedError {
   case deleteUpdatesError(cause: Error)
   case deleteUnusedAssetsError(cause: Error)
   case setJsonDataError(cause: Error)
+  case transactionBeginError(resultCode: Int32)
+  case transactionCommitError(resultCode: Int32)
+  case finishedUpdateMissingLaunchAsset
 
   var errorDescription: String? {
     switch self {
@@ -38,6 +41,12 @@ internal enum UpdatesDatabaseError: Error, Sendable, LocalizedError {
       return "Database error while deleting unused assets: \(cause.localizedDescription)"
     case let .setJsonDataError(cause):
       return "Database error while setting JSON data: \(cause.localizedDescription)"
+    case let .transactionBeginError(resultCode):
+      return "Database error while starting a transaction. SQLite result code: \(resultCode)"
+    case let .transactionCommitError(resultCode):
+      return "Database error while committing a transaction. SQLite result code: \(resultCode)"
+    case .finishedUpdateMissingLaunchAsset:
+      return "The update finished registration without a launch asset. Refusing to mark it as ready."
     }
   }
 }
@@ -106,6 +115,24 @@ public final class UpdatesDatabase: NSObject {
     return try UpdatesDatabaseUtils.execute(sql: sql, withArgs: args, onDatabase: db.require("Missing database handle"))
   }
 
+  private func withTransaction(_ block: () throws -> Void) throws {
+    let beginResult = sqlite3_exec(db, "BEGIN;", nil, nil, nil)
+    guard beginResult == SQLITE_OK else {
+      throw UpdatesDatabaseError.transactionBeginError(resultCode: beginResult)
+    }
+    do {
+      try block()
+    } catch {
+      sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
+      throw error
+    }
+    let commitResult = sqlite3_exec(db, "COMMIT;", nil, nil, nil)
+    guard commitResult == SQLITE_OK else {
+      sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
+      throw UpdatesDatabaseError.transactionCommitError(resultCode: commitResult)
+    }
+  }
+
   public func executeForObjC(sql: String, withArgs args: [Any]?) throws -> [Any] {
     return try execute(sql: sql, withArgs: args)
   }
@@ -134,98 +161,100 @@ public final class UpdatesDatabase: NSObject {
   }
 
   public func addNewAssets(_ assets: [UpdateAsset], toUpdateWithId updateId: UUID) throws {
-    sqlite3_exec(db, "BEGIN;", nil, nil, nil)
+    try withTransaction {
+      try addNewAssetsInternal(assets, toUpdateWithId: updateId)
+    }
+  }
 
+  private func addNewAssetsInternal(_ assets: [UpdateAsset], toUpdateWithId updateId: UUID) throws {
     let assetInsertSql = """
       INSERT OR REPLACE INTO "assets" ("key", "url", "headers", "extra_request_headers", "type", "metadata", "download_time", "relative_path", "hash", "hash_type", "expected_hash", "marked_for_deletion")
       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 0);
     """
     for asset in assets {
-      do {
-        _ = try execute(
-          sql: assetInsertSql,
-          withArgs: [
-            asset.key,
-            asset.url,
-            asset.headers,
-            asset.extraRequestHeaders,
-            asset.type,
-            asset.metadata,
-            asset.downloadTime.require("asset downloadTime should be nonnull"),
-            asset.filename,
-            asset.contentHash,
-            UpdatesDatabaseHashType.Sha1.rawValue,
-            asset.expectedHash
-          ]
-        )
-      } catch {
-        sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw error
-      }
+      _ = try execute(
+        sql: assetInsertSql,
+        withArgs: [
+          asset.key,
+          asset.url,
+          asset.headers,
+          asset.extraRequestHeaders,
+          asset.type,
+          asset.metadata,
+          asset.downloadTime.require("asset downloadTime should be nonnull"),
+          asset.filename,
+          asset.contentHash,
+          UpdatesDatabaseHashType.Sha1.rawValue,
+          asset.expectedHash
+        ]
+      )
 
       // statements must stay in precisely this order for last_insert_rowid() to work correctly
       if asset.isLaunchAsset {
         let updateSql = "UPDATE updates SET launch_asset_id = last_insert_rowid() WHERE id = ?1;"
-        do {
-          _ = try execute(sql: updateSql, withArgs: [updateId])
-        } catch {
-          sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-          throw error
-        }
+        _ = try execute(sql: updateSql, withArgs: [updateId])
       }
 
       let updateInsertSql = """
         INSERT OR REPLACE INTO updates_assets ("update_id", "asset_id") VALUES (?1, last_insert_rowid());
       """
-      do {
-        _ = try execute(sql: updateInsertSql, withArgs: [updateId])
-      } catch {
-        sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw error
-      }
+      _ = try execute(sql: updateInsertSql, withArgs: [updateId])
     }
-
-    sqlite3_exec(db, "COMMIT;", nil, nil, nil)
   }
 
-  public func addExistingAsset(_ asset: UpdateAsset, toUpdateWithId updateId: UUID) throws -> Bool {
+  public func finishUpdateRegistration(_ update: Update, newAssets: [UpdateAsset], existingAssets: [UpdateAsset], markFinished: Bool) throws {
+    try withTransaction {
+      for asset in existingAssets {
+        _ = try addExistingAsset(asset, toUpdateWithId: update.updateId)
+      }
+      try addNewAssetsInternal(newAssets, toUpdateWithId: update.updateId)
+      if markFinished {
+        try markUpdateFinished(update)
+
+        // a ready update that cannot launch must never be committed
+        if update.status == UpdateStatus.StatusReady {
+          let launchAssetRows = try execute(
+            sql: "SELECT 1 FROM updates WHERE id = ?1 AND launch_asset_id IS NOT NULL;",
+            withArgs: [update.updateId]
+          )
+          if launchAssetRows.isEmpty {
+            throw UpdatesDatabaseError.finishedUpdateMissingLaunchAsset
+          }
+        }
+      }
+    }
+  }
+
+  private func addExistingAsset(_ asset: UpdateAsset, toUpdateWithId updateId: UUID) throws -> Bool {
     guard let key = asset.key else {
       return false
     }
-
-    sqlite3_exec(db, "BEGIN;", nil, nil, nil)
 
     let assetSelectSql = """
       SELECT id FROM assets WHERE "key" = ?1 LIMIT 1;
     """
     let rows = try execute(sql: assetSelectSql, withArgs: [key])
-    if !rows.isEmpty {
-      let assetId: NSNumber = rows[0].requiredValue(forKey: "id")
-      let insertSql = """
-        INSERT OR REPLACE INTO updates_assets ("update_id", "asset_id") VALUES (?1, ?2);
-      """
-      do {
-        _ = try execute(sql: insertSql, withArgs: [updateId, assetId.intValue])
-      } catch {
-        sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-        throw UpdatesDatabaseError.addExistingAssetInsertOrReplaceIntoError(cause: error)
-      }
-
-      if asset.isLaunchAsset {
-        let updateSql = "UPDATE updates SET launch_asset_id = ?1 WHERE id = ?2;"
-        do {
-          _ = try execute(sql: updateSql, withArgs: [assetId.intValue, updateId])
-        } catch {
-          sqlite3_exec(db, "ROLLBACK;", nil, nil, nil)
-          throw UpdatesDatabaseError.addExistingAssetUpdateLaunchAssetError(cause: error)
-        }
-      }
-    }
-
-    sqlite3_exec(db, "COMMIT;", nil, nil, nil)
-
     if rows.isEmpty {
       return false
+    }
+
+    let assetId: NSNumber = rows[0].requiredValue(forKey: "id")
+    let insertSql = """
+      INSERT OR REPLACE INTO updates_assets ("update_id", "asset_id") VALUES (?1, ?2);
+    """
+    do {
+      _ = try execute(sql: insertSql, withArgs: [updateId, assetId.intValue])
+    } catch {
+      throw UpdatesDatabaseError.addExistingAssetInsertOrReplaceIntoError(cause: error)
+    }
+
+    if asset.isLaunchAsset {
+      let updateSql = "UPDATE updates SET launch_asset_id = ?1 WHERE id = ?2;"
+      do {
+        _ = try execute(sql: updateSql, withArgs: [assetId.intValue, updateId])
+      } catch {
+        throw UpdatesDatabaseError.addExistingAssetUpdateLaunchAssetError(cause: error)
+      }
     }
 
     return true

--- a/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
@@ -30,6 +30,7 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
   case remoteAppLoaderHeaderDataError(cause: Error)
   case remoteAppLoaderUnknownError(cause: Error)
   case appLoaderFailedToLoadAllAssets
+  case appLoaderFinishedWithoutManifest
   case appLoaderUnknownError(cause: Error)
   case appLoaderTaskFailedToLaunch(cause: Error?)
   case appLoaderTaskUnexpectedErrorDuringLaunch
@@ -99,6 +100,8 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
       return "Error persisting header data to disk: \(cause.localizedDescription)"
     case .appLoaderFailedToLoadAllAssets:
       return "Failed to load all assets"
+    case .appLoaderFinishedWithoutManifest:
+      return "AppLoader finished without a processed update manifest. This is an internal error."
     case let .remoteAppLoaderUnknownError(cause):
       return "Unknown error: \(cause.localizedDescription)"
     case let .appLoaderUnknownError(cause):

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
@@ -183,6 +183,38 @@ class UpdatesDatabaseTests {
         #expect(try! db.asset(withKey: "bundle-key") == nil)
       }
     }
+
+    @Test
+    func `throws when a transaction is already open`() throws {
+      let update = ExpoUpdatesUpdate.update(
+        withExpoUpdatesManifest: manifest,
+        extensions: [:],
+        config: config,
+        database: db
+      )
+
+      let asset = UpdateAsset(key: "bundle-key", type: "js")
+      asset.downloadTime = Date()
+      asset.contentHash = "hash"
+      asset.filename = "bundle.js"
+      asset.isLaunchAsset = true
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update, config: config)
+
+        // an already-open transaction makes the internal BEGIN fail
+        _ = try! db.execute(sql: "BEGIN;", withArgs: nil)
+        defer { _ = try? db.execute(sql: "ROLLBACK;", withArgs: nil) }
+
+        do {
+          try db.addNewAssets([asset], toUpdateWithId: update.updateId)
+          Issue.record("Expected addNewAssets to throw when its transaction cannot start")
+        } catch UpdatesDatabaseError.transactionBeginError {
+        } catch {
+          Issue.record("Expected transactionBeginError but got \(error)")
+        }
+      }
+    }
   }
 
   // MARK: - repair updates missing launch asset
@@ -268,6 +300,162 @@ class UpdatesDatabaseTests {
         let reloaded = try! db.update(withId: update.updateId, config: config)
         #expect(reloaded?.status == .StatusReady)
       }
+    }
+  }
+
+  // MARK: - finishUpdateRegistration
+
+  @Suite("finishUpdateRegistration", .serialized)
+  struct FinishUpdateRegistrationTests {
+    var testDatabaseDir: URL
+    var db: UpdatesDatabase
+    var config: UpdatesConfig
+
+    init() throws {
+      let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+      testDatabaseDir = applicationSupportDir!.appendingPathComponent("FinishUpdateRegistrationTests")
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+      if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+        try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+      }
+
+      db = UpdatesDatabase()
+
+      config = try UpdatesConfig.config(fromDictionary: [
+        UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      ])
+
+      db.databaseQueue.sync {
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+      }
+    }
+
+    private func makeUpdate(id: String, createdAt: String) -> Update {
+      let manifest = ExpoUpdatesManifest(rawManifestJSON: [
+        "runtimeVersion": "1",
+        "id": id,
+        "createdAt": createdAt,
+        "launchAsset": ["url": "https://url.to/bundle.js", "contentType": "application/javascript"]
+      ])
+      return ExpoUpdatesUpdate.update(
+        withExpoUpdatesManifest: manifest,
+        extensions: [:],
+        config: config,
+        database: db
+      )
+    }
+
+    private func makeAsset(key: String, isLaunchAsset: Bool = false) -> UpdateAsset {
+      let asset = UpdateAsset(key: key, type: "js")
+      asset.downloadTime = Date()
+      asset.contentHash = key
+      asset.filename = "\(key).js"
+      asset.isLaunchAsset = isLaunchAsset
+      return asset
+    }
+
+    private func joinRowCount(forUpdateId updateId: UUID) -> Int {
+      db.databaseQueue.sync {
+        try! db.execute(sql: "SELECT asset_id FROM updates_assets WHERE update_id = ?1;", withArgs: [updateId]).count
+      }
+    }
+
+    @Test
+    func `registers assets and marks the update finished`() throws {
+      let update1 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f196", createdAt: "2020-11-11T00:17:54.797Z")
+      let update2 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f197", createdAt: "2020-11-11T00:17:55.797Z")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update1, config: config)
+        try! db.addNewAssets([makeAsset(key: "asset-a")], toUpdateWithId: update1.updateId)
+
+        try! db.addUpdate(update2, config: config)
+        try! db.finishUpdateRegistration(
+          update2,
+          newAssets: [makeAsset(key: "asset-b", isLaunchAsset: true)],
+          existingAssets: [makeAsset(key: "asset-a")],
+          markFinished: true
+        )
+      }
+
+      db.databaseQueue.sync {
+        let reloaded = try! db.update(withId: update2.updateId, config: config)
+        #expect(reloaded?.status == .StatusReady)
+      }
+      #expect(joinRowCount(forUpdateId: update2.updateId) == 2)
+    }
+
+    @Test
+    func `persists nothing when any statement fails`() throws {
+      let update1 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f198", createdAt: "2020-11-11T00:17:56.797Z")
+      let update2 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f199", createdAt: "2020-11-11T00:17:57.797Z")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update1, config: config)
+        try! db.addNewAssets([makeAsset(key: "asset-a")], toUpdateWithId: update1.updateId)
+
+        try! db.addUpdate(update2, config: config)
+
+        // fail the insert of the new asset, after the existing asset was linked
+        _ = try! db.execute(
+          sql: """
+            CREATE TRIGGER fail_asset_b BEFORE INSERT ON assets WHEN NEW."key" = 'asset-b'
+            BEGIN SELECT RAISE(ABORT, 'injected failure'); END;
+          """,
+          withArgs: nil
+        )
+
+        do {
+          try db.finishUpdateRegistration(
+            update2,
+            newAssets: [makeAsset(key: "asset-b", isLaunchAsset: true)],
+            existingAssets: [makeAsset(key: "asset-a")],
+            markFinished: true
+          )
+          Issue.record("Expected finishUpdateRegistration to throw when a statement fails")
+        } catch let error as UpdatesDatabaseUtilsError {
+          #expect(error.info?.message.contains("injected failure") == true)
+        } catch {
+          Issue.record("Expected the injected statement failure but got \(error)")
+        }
+      }
+
+      db.databaseQueue.sync {
+        let reloaded = try! db.update(withId: update2.updateId, config: config)
+        #expect(reloaded?.status == .StatusPending)
+      }
+      #expect(joinRowCount(forUpdateId: update2.updateId) == 0)
+    }
+
+    @Test
+    func `throws when marking finished without a launch asset`() throws {
+      let update = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f19a", createdAt: "2020-11-11T00:17:58.797Z")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update, config: config)
+
+        do {
+          try db.finishUpdateRegistration(
+            update,
+            newAssets: [makeAsset(key: "image-a")],
+            existingAssets: [],
+            markFinished: true
+          )
+          Issue.record("Expected finishUpdateRegistration to throw when no launch asset was linked")
+        } catch UpdatesDatabaseError.finishedUpdateMissingLaunchAsset {
+        } catch {
+          Issue.record("Expected finishedUpdateMissingLaunchAsset but got \(error)")
+        }
+      }
+
+      db.databaseQueue.sync {
+        let reloaded = try! db.update(withId: update.updateId, config: config)
+        #expect(reloaded?.status == .StatusPending)
+      }
+      #expect(joinRowCount(forUpdateId: update.updateId) == 0)
     }
   }
 


### PR DESCRIPTION
# Why
Registration used to be three separate commits: one per existing asset link, one batch for new assets, and one for the ready status. Any interruption between them left partial state behind. Worse, a failed existing-asset link was logged and swallowed, and an unreadable asset file was dropped by a release-mode no-op assert, so an update could still be marked ready without its launch asset. This mirrors what #49130 fixed for embedded registration on Android.

# How
 A new finishUpdateRegistration runs the existing links, the new asset batch, and the finished status in one transaction. The transaction helper checks the result codes of BEGIN and COMMIT, which the old inline code ignored, so a failed commit can no longer report success. Before committing, a guard verifies the update actually has a launch asset and refuses to mark it ready otherwise.

# Test Plan
Three tests on the new method
