### PR TITLE
[ios][updates] Fail with a launch asset not found error instead of silently or hanging

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch.
 - [iOS] Repair ready updates that are missing their launch asset by demoting them to pending during launcher selection, so a corrupted row is skipped and retried instead of failing every launch. ([#49457](https://github.com/expo/expo/pull/49457) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Register a downloaded update's assets, links, and ready status in a single transaction, so an interrupted or partially failed registration leaves no partial state behind. ([#49458](https://github.com/expo/expo/pull/49458) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Report a specific launch asset not found error when a launchable update has no linked launch asset, instead of failing silently or, for an update with no assets at all, hanging on the splash screen. ([#49459](https://github.com/expo/expo/pull/49459) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -193,7 +193,11 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
       )
 
       completionQueue.async {
-        self.completion!(self.launchAssetError, self.launchAssetUrl != nil)
+        var error = self.launchAssetError
+        if error == nil && self.launchAssetUrl == nil {
+          error = UpdatesError.appLauncherLaunchAssetNotFound(updateId: launchedUpdate.updateId)
+        }
+        self.completion!(error, self.launchAssetUrl != nil)
         self.completion = nil
       }
       return
@@ -211,6 +215,16 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
     self.assetFilesMap = UpdatesUtils.embeddedAssetsMap(withConfig: config, database: database, logger: logger)
 
     let assets = launchedUpdate.assets()!
+    if assets.isEmpty {
+      // a ready update with no assets cannot launch, and an empty loop below would never
+      // invoke the completion
+      completionQueue.async {
+        self.completion!(UpdatesError.appLauncherLaunchAssetNotFound(updateId: launchedUpdate.updateId), false)
+        self.completion = nil
+      }
+      return
+    }
+
     let totalAssetCount = assets.count
     for asset in assets {
       let assetLocalUrl = directory.appendingPathComponent(asset.filename)
@@ -230,7 +244,12 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
 
         if self.completedAssets == totalAssetCount {
           self.completionQueue.async {
-            self.completion!(self.launchAssetError, self.launchAssetUrl != nil)
+            var error = self.launchAssetError
+            if error == nil && self.launchAssetUrl == nil {
+              // completing without an error and without a launch asset would fail the launch silently
+              error = UpdatesError.appLauncherLaunchAssetNotFound(updateId: launchedUpdate.updateId)
+            }
+            self.completion!(error, self.launchAssetUrl != nil)
             self.completion = nil
           }
         }

--- a/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesError.swift
@@ -43,6 +43,7 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
   case appLauncherWithDatabaseAssetCopyFailed
   case appLauncherWithDatabaseUnknownError(cause: Error)
   case appLauncherNoLaunchableUpdates(cause: Error?)
+  case appLauncherLaunchAssetNotFound(updateId: UUID)
   case embeddedAppLoaderEmbeddedManifestLoadFailed
   case startupProcedureDidFinishWithError(cause: Error)
   case startupProcedureDidFinishBackgroundUpdateWithStatusWithError(cause: Error)
@@ -128,6 +129,8 @@ public enum UpdatesError: Error, Sendable, LocalizedError {
       return "Unknown error: \(cause.localizedDescription)"
     case let .appLauncherNoLaunchableUpdates(cause):
       return "No launchable updates found in database: \(cause?.localizedDescription ?? "Unknown error")"
+    case let .appLauncherLaunchAssetNotFound(updateId):
+      return "Launch asset not found for update \(updateId). The update cannot launch and will be repaired at the next app launch."
     case .embeddedAppLoaderEmbeddedManifestLoadFailed:
       return "Failed to load embedded manifest. Make sure you have configured expo-updates correctly."
     case let .startupProcedureDidFinishWithError(cause):

--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
@@ -39,6 +39,15 @@ class AppLauncherWithDatabaseMock: AppLauncherWithDatabase {
   }
 }
 
+// Overrides only the update selection so ensureAllAssetsExist runs for real.
+class AppLauncherRealAssetsMock: AppLauncherWithDatabase {
+  static var updateToLaunch: Update?
+
+  override func launchableUpdate(selectionPolicy: SelectionPolicy, completion: @escaping AppLauncherUpdateCompletionBlock) {
+    completion(nil, AppLauncherRealAssetsMock.updateToLaunch)
+  }
+}
+
 @Suite("AppLauncherWithDatabase", .serialized)
 @MainActor
 class AppLauncherWithDatabaseTests {
@@ -114,6 +123,152 @@ class AppLauncherWithDatabaseTests {
       // `lastAccessed` should have been bumped from yesterday to launch time. Bounding from
       // `beforeLaunch` keeps the assertion valid however long the launch takes on CI.
       #expect(sameUpdate!.lastAccessed >= beforeLaunch)
+    }
+  }
+
+  // MARK: - missing launch asset
+
+  private func makeConfig() throws -> UpdatesConfig {
+    try UpdatesConfig.config(fromDictionary: [
+      UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://example.com",
+      UpdatesConfig.EXUpdatesConfigScopeKeyKey: "dummyScope",
+      UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      UpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: false,
+    ])
+  }
+
+  private func makeUpdate(config: UpdatesConfig, status: UpdateStatus = .StatusPending) -> Update {
+    Update(
+      manifest: ManifestFactory.manifest(forManifestJSON: [:]),
+      config: config,
+      database: db,
+      updateId: UUID(),
+      scopeKey: "dummyScope",
+      commitTime: Date(timeIntervalSince1970: 1608667851),
+      runtimeVersion: "1",
+      keep: true,
+      status: status,
+      isDevelopmentMode: false,
+      assetsFromManifest: nil,
+      url: URL(string: "https://example.com"),
+      requestHeaders: [:]
+    )
+  }
+
+  // resolves nil if the launcher never calls its completion within the timeout
+  private func launchOutcome(launcher: AppLauncherWithDatabase, config: UpdatesConfig) async -> (error: UpdatesError?, success: Bool)? {
+    final class Once: @unchecked Sendable {
+      private var done = false
+      private let lock = NSLock()
+      func run(_ block: () -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        if !done {
+          done = true
+          block()
+        }
+      }
+    }
+
+    let once = Once()
+    return await withCheckedContinuation { continuation in
+      launcher.launchUpdate(withSelectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config)) { error, success in
+        once.run { continuation.resume(returning: (error, success)) }
+      }
+      DispatchQueue.global().asyncAfter(deadline: .now() + 10.0) {
+        once.run { continuation.resume(returning: nil) }
+      }
+    }
+  }
+
+  @Test
+  func `fails with launch asset not found when the update has no assets`() async throws {
+    let config = try makeConfig()
+    let update = makeUpdate(config: config)
+
+    db.databaseQueue.sync {
+      try! db.addUpdate(update, config: config)
+      try! db.markUpdateFinished(update)
+    }
+
+    AppLauncherRealAssetsMock.updateToLaunch = update
+    let launcher = AppLauncherRealAssetsMock(
+      config: config,
+      database: db,
+      directory: testDatabaseDir,
+      completionQueue: DispatchQueue.global(qos: .default),
+      logger: UpdatesLogger()
+    )
+
+    let outcome = await launchOutcome(launcher: launcher, config: config)
+
+    #expect(outcome != nil, "the launcher never invoked its completion")
+    #expect(outcome?.success == false)
+    if case .appLauncherLaunchAssetNotFound = outcome?.error {
+    } else {
+      Issue.record("Expected appLauncherLaunchAssetNotFound but got \(String(describing: outcome?.error))")
+    }
+  }
+
+  @Test
+  func `fails with launch asset not found when the launch asset is not linked`() async throws {
+    let config = try makeConfig()
+    let update = makeUpdate(config: config)
+
+    let imageAsset = UpdateAsset(key: "image-1", type: "png")
+    imageAsset.isLaunchAsset = false
+    imageAsset.downloadTime = Date()
+    imageAsset.contentHash = "imagehash"
+    imageAsset.filename = "image-1.png"
+    try Data("fake image".utf8).write(to: testDatabaseDir.appendingPathComponent("image-1.png"))
+
+    db.databaseQueue.sync {
+      try! db.addUpdate(update, config: config)
+      try! db.addNewAssets([imageAsset], toUpdateWithId: update.updateId)
+      try! db.markUpdateFinished(update)
+    }
+
+    AppLauncherRealAssetsMock.updateToLaunch = update
+    let launcher = AppLauncherRealAssetsMock(
+      config: config,
+      database: db,
+      directory: testDatabaseDir,
+      completionQueue: DispatchQueue.global(qos: .default),
+      logger: UpdatesLogger()
+    )
+
+    let outcome = await launchOutcome(launcher: launcher, config: config)
+
+    #expect(outcome != nil, "the launcher never invoked its completion")
+    #expect(outcome?.success == false)
+    if case .appLauncherLaunchAssetNotFound = outcome?.error {
+    } else {
+      Issue.record("Expected appLauncherLaunchAssetNotFound but got \(String(describing: outcome?.error))")
+    }
+  }
+
+  @Test
+  func `fails with launch asset not found when the embedded bundle is missing`() async throws {
+    let config = try makeConfig()
+    // the test bundle contains no embedded bundle resource, so the lookup returns nil
+    let update = makeUpdate(config: config, status: .StatusEmbedded)
+
+    AppLauncherRealAssetsMock.updateToLaunch = update
+    let launcher = AppLauncherRealAssetsMock(
+      config: config,
+      database: db,
+      directory: testDatabaseDir,
+      completionQueue: DispatchQueue.global(qos: .default),
+      logger: UpdatesLogger()
+    )
+
+    let outcome = await launchOutcome(launcher: launcher, config: config)
+
+    #expect(outcome != nil, "the launcher never invoked its completion")
+    #expect(outcome?.success == false)
+    if case .appLauncherLaunchAssetNotFound = outcome?.error {
+    } else {
+      Issue.record("Expected appLauncherLaunchAssetNotFound but got \(String(describing: outcome?.error))")
     }
   }
 }


### PR DESCRIPTION
# Why
iOS had no equivalent of Android's "Launch asset not found" error. A launchable update with no linked launch asset completed with a nil error and a false success flag, and an update with zero linked assets never invoked its completion at all, leaving the app on the splash screen forever. In production this surfaced as a generic message that pointed at nothing.

# How
Both paths now produce appLauncherLaunchAssetNotFound carrying the update id: the empty asset list completes immediately with the error, and a completed pass with no launch asset URL substitutes it for the nil error. The new checks sit after the embedded and development early returns, so no-copy embedded launches are unaffected, per the iOS caveat raised on #48733. With the repair in the previous PR filtering broken rows at selection, this guard is the backstop for states that arise after selection.

# Test Plan
Two launcher tests run the real ensureAllAssetsExist against a seeded database, one for the hang and one for the silent failure
