### PR TITLE
[ios][updates] Preserve the launcher failure as the emergency launch reason

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -26,10 +26,11 @@
 - [Android] Register the embedded update in a single transaction. An interrupted registration previously left an update row with no launch asset, which is treated as launchable and then fails every cold start with "Launch asset not found for update"; it now leaves no row, so the next launch registers it cleanly. ([#49130](https://github.com/expo/expo/pull/49130) by [@gwdp](https://github.com/gwdp))
 - [Android] Apply `reactNativeArchitectures` as a CMake ABI filter so single-ABI builds no longer compile the native code for unused ABIs. ([#49299](https://github.com/expo/expo/pull/49299) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Keep the Room-generated `UpdatesDatabase_Impl` constructor, so minified release builds no longer crash with `NoSuchMethodException` on first database access. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch.
+- [iOS] Propagate database failures from `addNewAssets` instead of swallowing them, which let an update be marked ready without its launch asset and then fail every launch. ([#49456](https://github.com/expo/expo/pull/49456) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Repair ready updates that are missing their launch asset by demoting them to pending during launcher selection, so a corrupted row is skipped and retried instead of failing every launch. ([#49457](https://github.com/expo/expo/pull/49457) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Register a downloaded update's assets, links, and ready status in a single transaction, so an interrupted or partially failed registration leaves no partial state behind. ([#49458](https://github.com/expo/expo/pull/49458) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Report a specific launch asset not found error when a launchable update has no linked launch asset, instead of failing silently or, for an update with no assets at all, hanging on the splash screen. ([#49459](https://github.com/expo/expo/pull/49459) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Preserve the cached update's launch failure as the emergency launch reason when the remote check finds no new update, instead of replacing it with the generic AppLoaderTask error. ([#49460](https://github.com/expo/expo/pull/49460) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/AppLoaderTask.swift
@@ -104,7 +104,7 @@ public enum BackgroundUpdateStatus: Int {
  */
 @objc(EXUpdatesAppLoaderTask)
 @objcMembers
-public final class AppLoaderTask: NSObject {
+public class AppLoaderTask: NSObject {
   public weak var delegate: AppLoaderTaskDelegate?
   public weak var swiftDelegate: AppLoaderTaskSwiftDelegate?
 
@@ -126,6 +126,7 @@ public final class AppLoaderTask: NSObject {
   private var isTimerFinished: Bool
   private var hasLaunched: Bool
   private var isUpToDate: Bool
+  private var fallbackLaunchError: UpdatesError = .appLoaderTaskUnexpectedErrorDuringLaunch
   private let loaderTaskQueue: DispatchQueue
 
   public required init(
@@ -166,10 +167,13 @@ public final class AppLoaderTask: NSObject {
     loadEmbeddedUpdate {
       self.launch { error, success in
         if !success {
+          // keep the cause so a launch that finishes without a specific error reports
+          // this failure instead of the generic error
+          let cause = UpdatesError.appLoaderTaskFailedToLaunch(cause: error)
+          self.fallbackLaunchError = cause
           if !shouldCheckForUpdate {
             self.finish(withError: error)
           }
-          let cause = UpdatesError.appLoaderTaskFailedToLaunch(cause: error)
           self.logger.error(
             cause: cause,
             code: .updateFailedToLoad
@@ -223,7 +227,7 @@ public final class AppLoaderTask: NSObject {
         } else {
           delegate.appLoaderTask(
             self,
-            didFinishWithError: error ?? UpdatesError.appLoaderTaskUnexpectedErrorDuringLaunch
+            didFinishWithError: error ?? self.fallbackLaunchError
           )
         }
       }
@@ -268,7 +272,7 @@ public final class AppLoaderTask: NSObject {
     }
   }
 
-  private func loadEmbeddedUpdate(withCompletion completion: @escaping () -> Void) {
+  func loadEmbeddedUpdate(withCompletion completion: @escaping () -> Void) {
     AppLauncherWithDatabase.launchableUpdate(
       withConfig: config,
       database: database,
@@ -325,13 +329,13 @@ public final class AppLoaderTask: NSObject {
     }
   }
 
-  private func launch(withCompletion completion: @escaping (_ error: UpdatesError?, _ success: Bool) -> Void) {
+  func launch(withCompletion completion: @escaping (_ error: UpdatesError?, _ success: Bool) -> Void) {
     let launcher = AppLauncherWithDatabase(config: config, database: database, directory: directory, completionQueue: loaderTaskQueue, logger: self.logger)
     candidateLauncher = launcher
     launcher.launchUpdate(withSelectionPolicy: selectionPolicy, completion: completion)
   }
 
-  private func loadRemoteUpdate(withCompletion completion: @escaping (_ remoteError: UpdatesError?, _ updateResponse: UpdateResponse?) -> Void) {
+  func loadRemoteUpdate(withCompletion completion: @escaping (_ remoteError: UpdatesError?, _ updateResponse: UpdateResponse?) -> Void) {
     remoteAppLoader = RemoteAppLoader(
       config: config,
       logger: logger,

--- a/packages/expo-updates/ios/Tests/AppLoaderTaskTests.swift
+++ b/packages/expo-updates/ios/Tests/AppLoaderTaskTests.swift
@@ -1,0 +1,136 @@
+//  Copyright (c) 2026 650 Industries, Inc. All rights reserved.
+
+import Testing
+import Foundation
+
+@testable import EXUpdates
+
+// Simulates a cold start where the cached update cannot launch and the
+// remote check finds nothing new, without touching the network.
+private final class FailingLaunchLoaderTask: AppLoaderTask {
+  static let brokenUpdateId = UUID()
+
+  override func loadEmbeddedUpdate(withCompletion completion: @escaping () -> Void) {
+    completion()
+  }
+
+  override func launch(withCompletion completion: @escaping (_ error: UpdatesError?, _ success: Bool) -> Void) {
+    completion(UpdatesError.appLauncherLaunchAssetNotFound(updateId: Self.brokenUpdateId), false)
+  }
+
+  override func loadRemoteUpdate(withCompletion completion: @escaping (_ remoteError: UpdatesError?, _ updateResponse: UpdateResponse?) -> Void) {
+    completion(nil, nil)
+  }
+}
+
+private final class ErrorRecordingDelegate: AppLoaderTaskDelegate {
+  private let onError: (Error) -> Void
+
+  init(onError: @escaping (Error) -> Void) {
+    self.onError = onError
+  }
+
+  func appLoaderTask(_: AppLoaderTask, didLoadCachedUpdate update: Update) -> Bool {
+    true
+  }
+  func appLoaderTask(_: AppLoaderTask, didStartLoadingUpdate update: Update?) {}
+  func appLoaderTask(_: AppLoaderTask, didFinishWithLauncher launcher: AppLauncher, isUpToDate: Bool) {}
+  func appLoaderTask(_: AppLoaderTask, didFinishWithError error: Error) {
+    onError(error)
+  }
+  func appLoaderTask(
+    _: AppLoaderTask,
+    didFinishBackgroundUpdateWithStatus status: BackgroundUpdateStatus,
+    update: Update?,
+    error: Error?
+  ) {}
+  func appLoaderTaskDidFinishAllLoading(_: AppLoaderTask) {}
+}
+
+@Suite("AppLoaderTask", .serialized)
+class AppLoaderTaskTests {
+  var testDatabaseDir: URL
+  var db: UpdatesDatabase
+
+  init() throws {
+    let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+    testDatabaseDir = applicationSupportDir!.appendingPathComponent("AppLoaderTaskTests")
+
+    try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+    if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+      try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+    }
+
+    db = UpdatesDatabase()
+    db.databaseQueue.sync {
+      try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+    }
+  }
+
+  deinit {
+    db.databaseQueue.sync {
+      db.closeDatabase()
+    }
+    try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+  }
+
+  @Test
+  func `reports the launcher failure instead of the generic error`() async throws {
+    let config = try UpdatesConfig.config(fromDictionary: [
+      UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://example.com",
+      UpdatesConfig.EXUpdatesConfigScopeKeyKey: "dummyScope",
+      UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      UpdatesConfig.EXUpdatesConfigHasEmbeddedUpdateKey: false,
+    ])
+
+    let task = FailingLaunchLoaderTask(
+      withConfig: config,
+      database: db,
+      directory: testDatabaseDir,
+      selectionPolicy: SelectionPolicyFactory.filterAwarePolicy(withRuntimeVersion: "1", config: config),
+      delegateQueue: DispatchQueue(label: "AppLoaderTaskTests.delegate"),
+      logger: UpdatesLogger()
+    )
+
+    final class Once: @unchecked Sendable {
+      private var done = false
+      private let lock = NSLock()
+      func run(_ block: () -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        if !done {
+          done = true
+          block()
+        }
+      }
+    }
+
+    let once = Once()
+    var strongDelegate: ErrorRecordingDelegate?
+    let receivedError: Error? = await withCheckedContinuation { continuation in
+      let delegate = ErrorRecordingDelegate { error in
+        once.run { continuation.resume(returning: error) }
+      }
+      strongDelegate = delegate
+      task.delegate = delegate
+      task.start()
+      DispatchQueue.global().asyncAfter(deadline: .now() + 10.0) {
+        once.run { continuation.resume(returning: nil) }
+      }
+    }
+    withExtendedLifetime(strongDelegate) {}
+
+    #expect(receivedError != nil, "the loader task never reported an error")
+
+    guard let updatesError = receivedError as? UpdatesError else {
+      Issue.record("Expected an UpdatesError but got \(String(describing: receivedError))")
+      return
+    }
+
+    guard case .appLoaderTaskFailedToLaunch = updatesError else {
+      Issue.record("Expected appLoaderTaskFailedToLaunch but got \(updatesError)")
+      return
+    }
+  }
+}


### PR DESCRIPTION
# Why
On a cold start where the cached update fails to launch and the remote check finds nothing new, AppLoaderTask logged the real failure and then reported the generic "unexpected error" to the delegate. Crash reporting therefore showed one indistinguishable message for completely different failure modes

# How
A fallbackLaunchError property defaults to the generic error and is upgraded to the wrapped launcher failure when the task defers to the remote check. finish reports the explicit error when there is one, then the fallback. The delegate, and therefore the emergency launch reason in crash reporting, now carries the real cause.

# Test Plan
A new AppLoaderTaskTests suite simulates the full cold-start
