### PR TITLE
[docs] Round media and diagram containers to the card radius

### DIFF
--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalExpoGo.mdx
@@ -4,7 +4,7 @@ import QRCodeReact from 'react-qr-code';
 
 Scan the QR code to download the app from the Google Play Store, or visit the Expo Go page on the [Google Play Store](https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs).
 
-<div className="border-default bg-palette-white inline-block rounded-lg border p-4">
+<div className="border-default bg-palette-white inline-block rounded-3xl border p-4">
   <QRCodeReact
     value="https://play.google.com/store/apps/details?id=host.exp.exponent&referrer=docs"
     size={228}

--- a/docs/scenes/guides/controlled-components/UpdateLoopDiagram.tsx
+++ b/docs/scenes/guides/controlled-components/UpdateLoopDiagram.tsx
@@ -62,7 +62,7 @@ const CONNECTORS = [
 export function UpdateLoopDiagram() {
   return (
     <div
-      className="my-5 rounded-lg border border-default bg-default p-4"
+      className="my-5 rounded-3xl border border-default bg-default p-4"
       data-md="diagram"
       data-md-alt={DIAGRAM_ALT}>
       <div className="flex gap-3">

--- a/docs/scenes/guides/controlled-components/WorkletPathDiagram.tsx
+++ b/docs/scenes/guides/controlled-components/WorkletPathDiagram.tsx
@@ -40,7 +40,7 @@ const DIAGRAM_ALT = [
 export function WorkletPathDiagram() {
   return (
     <div
-      className="my-5 rounded-lg border border-default bg-default p-4"
+      className="my-5 rounded-3xl border border-default bg-default p-4"
       data-md="diagram"
       data-md-alt={DIAGRAM_ALT}>
       <div className="flex items-center gap-3">

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -171,7 +171,7 @@ export const ConfigPluginHierarchy: React.FC<ConfigPluginHierarchyProps> = ({
 
   return (
     <div
-      className="mb-4 h-75 w-full overflow-hidden rounded-lg border border-default bg-default"
+      className="mb-4 h-75 w-full overflow-hidden rounded-3xl border border-default bg-default"
       data-md="diagram"
       data-md-alt={diagramAlt}>
       <style dangerouslySetInnerHTML={{ __html: nodeHandleStyles }} />

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -80,7 +80,7 @@ export function ContentSpotlight({
   return (
     <figure
       className={mergeClasses(
-        'my-5 cursor-pointer rounded-lg py-2.5 text-center',
+        'my-5 cursor-pointer overflow-hidden rounded-3xl py-2.5 text-center',
         containerClassName,
         !isVideo && !isComponentVariant && 'bg-subtle',
         isComponentVariant &&
@@ -119,7 +119,7 @@ export function ContentSpotlight({
       ) : isVideo ? (
         <div
           className={mergeClasses(
-            'relative overflow-hidden rounded-lg bg-palette-black',
+            'relative overflow-hidden rounded-3xl bg-palette-black',
             hasCustomPlayerSize ? 'mx-auto' : 'aspect-video'
           )}
           ref={playerRef}

--- a/docs/ui/components/Diagram/Diagram.tsx
+++ b/docs/ui/components/Diagram/Diagram.tsx
@@ -36,7 +36,7 @@ export const Diagram = ({ source, darkSource, disableSrcSet, alt }: Props) => {
   const withFormats = source.endsWith('.png') && !disableSrcSet;
 
   return (
-    <div className="relative m-auto my-6 max-w-187.5 overflow-hidden rounded-md border border-default bg-default">
+    <div className="relative m-auto my-6 max-w-187.5 overflow-hidden rounded-3xl border border-default bg-default">
       <DotGrid />
       <DiagramPicture
         src={source}

--- a/docs/ui/components/FlowDiagram/index.tsx
+++ b/docs/ui/components/FlowDiagram/index.tsx
@@ -85,7 +85,7 @@ export function FlowDiagram({ nodes, edges, height = 320, minWidth = 700, alt }:
   return (
     <div
       className={mergeClasses(
-        'mb-4 w-full overflow-x-auto overflow-y-hidden rounded-lg border border-default bg-default'
+        'mb-4 w-full overflow-x-auto overflow-y-hidden rounded-3xl border border-default bg-default'
       )}
       data-md="diagram"
       data-md-alt={alt}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26255

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the `ContentSpotlight` image figure wrapper to `rounded-3xl` and add `overflow-hidden` so full-width screenshots clip into the curve; the inline video container follows.
- Change the outer containers of `Diagram`, `FlowDiagram`, `ConfigPluginHierarchy`, and the two controlled-components diagrams to `rounded-3xl`, leaving their inner nodes unchanged.
- Round the QR code box in the set-up-your-environment flow (`androidPhysicalExpoGo.mdx`) to `rounded-3xl`.
- Leave the fullscreen lightbox untouched (no shell to round) and the `component` variant on its existing `rounded-md` override.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2328" height="1262" alt="CleanShot 2026-08-27 at 22 11 41@2x" src="https://github.com/user-attachments/assets/3f042699-51ac-4264-baef-d5f547cae552" />

<img width="2294" height="1052" alt="CleanShot 2026-08-27 at 22 11 47@2x" src="https://github.com/user-attachments/assets/c22fc33d-cc84-4a2b-b70c-6b00272555a3" />

<img width="2094" height="1778" alt="CleanShot 2026-08-27 at 22 19 51@2x" src="https://github.com/user-attachments/assets/ae0474a7-0449-4b54-909d-6ddab65ce8de" />

<img width="688" height="554" alt="CleanShot 2026-08-27 at 22 30 42@2x" src="https://github.com/user-attachments/assets/f733e12b-5366-49e0-856a-546ce01b164f" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
