### PR TITLE
[docs] Round FileTree and project structure boxes to the card radius

### DIFF
--- a/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
+++ b/docs/scenes/get-started/start-developing/ProjectStructure/index.tsx
@@ -18,7 +18,7 @@ export function ProjectStructure() {
   const [selected, setSelected] = useState('app');
 
   return (
-    <div className="overflow-hidden rounded-md border border-default text-default">
+    <div className="overflow-hidden rounded-3xl border border-default text-default">
       <div className="flex border-b border-default bg-subtle p-3 pl-4">
         <HEADLINE>Files</HEADLINE>
       </div>

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/index.tsx
@@ -15,7 +15,7 @@ export function TemplateFeatures() {
   const [selected, setSelected] = useState('navigation');
 
   return (
-    <div className="overflow-hidden rounded-md border border-default text-default">
+    <div className="overflow-hidden rounded-3xl border border-default text-default">
       <div className="flex border-b border-default bg-subtle p-3 pl-4">
         <HEADLINE>Default project</HEADLINE>
       </div>

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -19,7 +19,7 @@ type FileObject = {
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
     <div
-      className="mb-4 overflow-x-auto rounded-md border border-default bg-default p-2 pr-4 pb-4 text-sm whitespace-nowrap"
+      className="mb-4 overflow-x-auto rounded-3xl border border-default bg-default p-2 pr-4 pb-4 text-sm whitespace-nowrap"
       {...rest}>
       {renderStructure(generateStructure(files))}
     </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of the radius migration from #49389.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the outer containers of `FileTree`, `ProjectStructure`, and `TemplateFeatures` from `rounded-md` to `rounded-3xl`, leaving their inner rows and tabs unchanged.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="2340" height="1102" alt="CleanShot 2026-08-27 at 22 42 33@2x" src="https://github.com/user-attachments/assets/e8d17758-7c4d-4d52-a56f-651e4c01e7b6" />


<img width="2332" height="994" alt="CleanShot 2026-08-27 at 22 41 33@2x" src="https://github.com/user-attachments/assets/fd5b8fe1-322e-4e05-899b-d4554923c5e7" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
