### PR TITLE
[docs] Round home page cards to the card radius

### DIFF
--- a/docs/ui/components/Home/components/GridBox.tsx
+++ b/docs/ui/components/Home/components/GridBox.tsx
@@ -18,7 +18,7 @@ export function GridBox({ icon, title, link, className }: GridBoxProps) {
     <A
       href={link}
       className={mergeClasses(
-        'group relative flex min-h-50 flex-col overflow-hidden rounded-lg border border-default bg-subtle shadow-xs transition',
+        'group relative flex min-h-50 flex-col overflow-hidden rounded-3xl border border-default bg-subtle shadow-xs transition',
         '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className

--- a/docs/ui/components/Home/components/GridCell.tsx
+++ b/docs/ui/components/Home/components/GridCell.tsx
@@ -8,7 +8,7 @@ type GridCellProps = PropsWithChildren<{
 export const GridCell = ({ children, className }: GridCellProps) => (
   <div
     className={mergeClasses(
-      'relative min-h-46.5 overflow-hidden rounded-lg border border-default px-6 py-5 shadow-xs',
+      'relative min-h-46.5 overflow-hidden rounded-3xl border border-default px-6 py-5 shadow-xs',
       '[&_h2]:my-0! [&_h3]:mt-0!',
       className
     )}>

--- a/docs/ui/components/Home/sections/ExploreAPIs.tsx
+++ b/docs/ui/components/Home/sections/ExploreAPIs.tsx
@@ -60,7 +60,7 @@ function APIGridCell({ icon, title, link, className }: APIGridCellProps) {
     <A
       href={link}
       className={mergeClasses(
-        'group relative block min-h-50 overflow-hidden rounded-lg border border-default bg-subtle shadow-xs transition',
+        'group relative block min-h-50 overflow-hidden rounded-3xl border border-default bg-subtle shadow-xs transition',
         '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className

--- a/docs/ui/components/Home/sections/JoinTheCommunity.tsx
+++ b/docs/ui/components/Home/sections/JoinTheCommunity.tsx
@@ -23,7 +23,7 @@ export function JoinTheCommunity() {
       <div
         className={mergeClasses(
           'my-4 inline-grid w-full grid-cols-2 gap-x-8 gap-y-1.5',
-          'rounded-lg border border-default p-3 shadow-xs',
+          'rounded-3xl border border-default p-3 shadow-xs',
           'max-xl:grid-cols-1',
           'max-lg:grid-cols-2',
           'max-md:grid-cols-1'

--- a/docs/ui/components/Home/sections/QuickStart.tsx
+++ b/docs/ui/components/Home/sections/QuickStart.tsx
@@ -24,7 +24,7 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-linear-to-b from-subtle from-15% to-[#21262d00]',
+              'absolute inset-0 size-full rounded-3xl bg-linear-to-b from-subtle from-15% to-[#21262d00]',
               'dark:from-[#181a1b]'
             )}
           />
@@ -51,7 +51,7 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-linear-to-b from-palette-blue3 from-15% to-[#201d5200]',
+              'absolute inset-0 size-full rounded-3xl bg-linear-to-b from-palette-blue3 from-15% to-[#201d5200]',
               'dark:from-palette-blue3 dark:to-transparent'
             )}
           />
@@ -74,7 +74,7 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-linear-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-5',
+              'absolute inset-0 size-full rounded-3xl bg-linear-to-br from-palette-blue3 via-palette-purple3 to-palette-blue3 opacity-5',
               'dark:from-palette-blue3 dark:via-palette-purple3 dark:to-palette-blue3 dark:opacity-20'
             )}
           />
@@ -121,7 +121,7 @@ export function QuickStart() {
           )}>
           <div
             className={mergeClasses(
-              'absolute inset-0 size-full rounded-lg bg-linear-to-b from-palette-green3 from-15% to-transparent',
+              'absolute inset-0 size-full rounded-3xl bg-linear-to-b from-palette-green3 from-15% to-transparent',
               'dark:from-palette-green3 dark:to-transparent'
             )}
           />

--- a/docs/ui/components/Home/sections/Talks.tsx
+++ b/docs/ui/components/Home/sections/Talks.tsx
@@ -67,7 +67,7 @@ export function TalkGridCell({
       openInNewTab
       href={link ?? `https://www.youtube.com/watch?v=${videoId}`}
       className={mergeClasses(
-        'relative flex h-full min-h-66.5 flex-col justify-between overflow-hidden rounded-lg border border-default bg-default shadow-xs transition',
+        'relative flex h-full min-h-66.5 flex-col justify-between overflow-hidden rounded-3xl border border-default bg-default shadow-xs transition',
         '[&_h2]:my-0! [&_h3]:mt-0!',
         'hocus:shadow-sm',
         className

--- a/docs/ui/components/StateOfRNBanner/index.tsx
+++ b/docs/ui/components/StateOfRNBanner/index.tsx
@@ -20,7 +20,7 @@ export function StateOfRNBanner() {
   return (
     <div
       className={mergeClasses(
-        'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg px-6 py-4',
+        'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-3xl px-6 py-4',
         'border-[#001a72] border-2 bg-[#b1dfd0]',
         'dark:border-[#b1dfd0] dark:bg-[#001a72]',
         'max-md:flex-wrap'


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Part of the radius migration from #49389

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the card shells of `GridBox`, `GridCell`, the Explore APIs cells, the Talks cards, the Join the community card, and `StateOfRNBanner` from `rounded-lg` to `rounded-3xl`.
- Match the four Quick Start gradient overlays to their parent cells, since they mirror the card radius by design.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="2546" height="1864" alt="CleanShot 2026-08-27 at 22 50 13@2x" src="https://github.com/user-attachments/assets/c0fcfed2-eb5e-4efd-bf70-405c82da7e85" />


<img width="2568" height="1646" alt="CleanShot 2026-08-27 at 22 50 08@2x" src="https://github.com/user-attachments/assets/88e641cc-baab-418d-b6fb-7074cea067fe" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
