### PR TITLE
[docs] Round sidebar and nav hover shapes to match the dashboard

### DIFF
--- a/docs/ui/components/Navigation/PageLink.tsx
+++ b/docs/ui/components/Navigation/PageLink.tsx
@@ -12,7 +12,7 @@ export function PageLink({ route, isActive }: NavigationRenderProps) {
   return (
     <A
       className={mergeClasses(
-        'mx-1 my-4 flex items-center rounded-md bg-default px-1.5 py-2 shadow-xs',
+        'mx-1 my-4 flex items-center rounded-lg bg-default px-1.5 py-2 shadow-xs',
         'dark:bg-element'
       )}
       href={route.href}>

--- a/docs/ui/components/Sidebar/SidebarCollapsible.tsx
+++ b/docs/ui/components/Sidebar/SidebarCollapsible.tsx
@@ -76,7 +76,7 @@ export function SidebarCollapsible({ info, children }: Props) {
       <ButtonBase
         ref={ref}
         className={mergeClasses(
-          'relative flex w-full cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 transition duration-150 select-none',
+          'relative flex w-full cursor-pointer items-center gap-2 rounded-lg px-3 py-1.5 transition duration-150 select-none',
           'hocus:bg-element'
         )}
         aria-expanded={isOpen ? 'true' : 'false'}

--- a/docs/ui/components/Sidebar/SidebarHead.tsx
+++ b/docs/ui/components/Sidebar/SidebarHead.tsx
@@ -39,7 +39,7 @@ export const SidebarHead = ({ sidebarActiveGroup }: SidebarHeadProps) => {
       <div className="flex flex-col gap-0.5 border-b border-default bg-default p-1.5">
         <LinkBase
           href="/"
-          className="flex items-center gap-3 rounded-md p-2.5 text-secondary hocus:bg-element">
+          className="flex items-center gap-3 rounded-lg p-2.5 text-secondary hocus:bg-element">
           <ArrowLeftIcon aria-hidden="true" className="text-icon-secondary" />
           Back
         </LinkBase>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -39,7 +39,7 @@ export const SidebarSingleEntry = ({
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
             secondary && 'text-sm',
             isActive &&
-              'bg-palette-blue3! font-medium text-link hocus:bg-palette-blue4! hocus:text-link'
+              'bg-selected! font-medium text-default hocus:bg-selected! hocus:text-default'
           )}
           {...(shouldLeakReferrer && { target: '_blank', referrerPolicy: 'origin' })}
           {...(isActive && mainSection && { 'data-main-section': mainSection })}>
@@ -48,7 +48,7 @@ export const SidebarSingleEntry = ({
             className={mergeClasses(
               'shrink-0',
               secondary ? 'icon-xs' : 'icon-sm',
-              isActive ? 'text-palette-blue11' : 'text-icon-tertiary'
+              isActive ? 'text-icon-default' : 'text-icon-tertiary'
             )}
           />
           <span className={mergeClasses(allowCompactDisplay && 'compact-height:hidden')}>

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -33,7 +33,7 @@ export const SidebarSingleEntry = ({
         <LinkBase
           href={href}
           className={mergeClasses(
-            'flex min-h-8 items-center gap-3 rounded-md px-2 py-1 text-sm leading-[100%]! text-secondary',
+            'flex min-h-8 items-center gap-3 rounded-lg px-2 py-1 text-sm leading-[100%]! text-secondary',
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Sidebar hover shapes still use the 6px default; the EAS dashboard's sidebar nav items measure 8px. Part of ENG-26237.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Change the hover shapes of `SidebarSingleEntry`, `SidebarCollapsible` headers, the `SidebarHead` back link, and the mobile `PageLink` from `rounded-md` to `rounded-lg`. Dots, version pills, and the collapse chevron box stay unchanged.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="558" height="338" alt="CleanShot 2026-08-27 at 23 42 08@2x" src="https://github.com/user-attachments/assets/88b524c6-379f-4e64-9806-a63cb035c1bb" />

<img width="562" height="392" alt="CleanShot 2026-08-27 at 23 44 18@2x" src="https://github.com/user-attachments/assets/28b13c4c-946e-42e6-9419-a44b7633f2a8" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
