### PR TITLE
[android][updates] Repair launchable updates that are missing their launch asset

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [iOS] Register a downloaded update's assets, links, and ready status in a single transaction, so an interrupted or partially failed registration leaves no partial state behind. ([#49458](https://github.com/expo/expo/pull/49458) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Report a specific launch asset not found error when a launchable update has no linked launch asset, instead of failing silently or, for an update with no assets at all, hanging on the splash screen. ([#49459](https://github.com/expo/expo/pull/49459) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Preserve the cached update's launch failure as the emergency launch reason when the remote check finds no new update, instead of replacing it with the generic AppLoaderTask error. ([#49460](https://github.com/expo/expo/pull/49460) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Skip and repair updates that are missing their launch asset instead of selecting them for launch, which previously failed every cold start with "Launch asset not found for update". ([#49470](https://github.com/expo/expo/pull/49470) by [@alanjhughes](https://github.com/alanjhughes), based on [#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/launcher/DatabaseLauncherTest.kt
@@ -10,8 +10,10 @@ import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.UpdatesDatabase
 import expo.modules.updates.db.entity.AssetEntity
 import expo.modules.updates.db.entity.UpdateEntity
+import expo.modules.updates.db.enums.UpdateStatus
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.selectionpolicy.SelectionPolicy
+import expo.modules.updates.selectionpolicy.SelectionPolicyFactory
 import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.spyk
@@ -89,5 +91,66 @@ class DatabaseLauncherTest {
       "new lastAccessed date should be within 1000 ms of now",
       Date().time - sameUpdate.lastAccessed.time < 1000
     )
+  }
+
+  @Test
+  fun testGetLaunchableUpdate_SkipsUpdateWithMissingLaunchAsset() = runTest {
+    val configuration = testConfiguration()
+
+    val completeUpdate = readyUpdate(configuration.scopeKey, Date(1000))
+    db.updateDao().insertUpdate(completeUpdate)
+    db.assetDao().insertAssets(listOf(launchAssetEntity()), completeUpdate)
+
+    // newer, but its launch asset was never registered -- launching it would throw
+    val incompleteUpdate = readyUpdate(configuration.scopeKey, Date(2000))
+    db.updateDao().insertUpdate(incompleteUpdate)
+
+    val launchableUpdate = databaseLauncher(configuration).getLaunchableUpdate(db)
+
+    Assert.assertEquals(completeUpdate.id, launchableUpdate?.id)
+  }
+
+  @Test
+  fun testGetLaunchableUpdate_NullWhenEveryUpdateIsMissingItsLaunchAsset() = runTest {
+    val configuration = testConfiguration()
+
+    val incompleteUpdate = readyUpdate(configuration.scopeKey, Date(1000))
+    db.updateDao().insertUpdate(incompleteUpdate)
+
+    Assert.assertNull(databaseLauncher(configuration).getLaunchableUpdate(db))
+  }
+
+  private fun testConfiguration() = UpdatesConfiguration(
+    null,
+    mapOf(
+      "updateUrl" to Uri.parse("https://example.com"),
+      "runtimeVersion" to "1.0",
+      "hasEmbeddedUpdate" to false
+    )
+  )
+
+  private fun databaseLauncher(configuration: UpdatesConfiguration) = DatabaseLauncher(
+    context,
+    configuration,
+    File("test"),
+    mockk(),
+    SelectionPolicyFactory.createFilterAwarePolicy("1.0", configuration),
+    UpdatesLogger(context.filesDir),
+    TestScope()
+  )
+
+  private fun readyUpdate(scopeKey: String, commitTime: Date) = UpdateEntity(
+    UUID.randomUUID(),
+    commitTime,
+    "1.0",
+    scopeKey,
+    JSONObject("{}"),
+    null,
+    null
+  ).apply { status = UpdateStatus.READY }
+
+  private fun launchAssetEntity() = AssetEntity("bundle-1234", "js").apply {
+    relativePath = "bundle-1234"
+    isLaunchAsset = true
   }
 }

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/EmbeddedLoaderTest.kt
@@ -292,6 +292,11 @@ class EmbeddedLoaderTest {
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
 
+    val launchAsset = AssetEntity("bundle-1234", "js")
+    launchAsset.relativePath = "bundle-1234"
+    launchAsset.isLaunchAsset = true
+    db.assetDao().insertAssets(listOf(launchAsset), update)
+
     val result = loader.load { _ ->
       Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
     }
@@ -302,6 +307,80 @@ class EmbeddedLoaderTest {
     val updates = db.updateDao().loadAllUpdates()
     Assert.assertEquals(1, updates.size.toLong())
     Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+
+    // short-circuited, so the manifest's assets were never registered
+    Assert.assertEquals(1, db.assetDao().loadAllAssets().size.toLong())
+  }
+
+  @Test
+  @Throws(IOException::class, NoSuchAlgorithmException::class)
+  fun testEmbeddedLoader_UpdateExists_ReadyButMissingLaunchAsset() = runTest {
+    val update = UpdateEntity(
+      manifest.updateEntity!!.id,
+      manifest.updateEntity!!.commitTime,
+      manifest.updateEntity!!.runtimeVersion,
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest,
+      null,
+      null
+    )
+    update.status = UpdateStatus.READY
+    db.updateDao().insertUpdate(update)
+
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
+
+    val updates = db.updateDao().loadAllUpdates()
+    Assert.assertEquals(1, updates.size.toLong())
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+
+    // the incomplete row is repaired rather than short-circuited
+    Assert.assertNotNull(db.updateDao().loadLaunchAssetForUpdate(update.id))
+    Assert.assertEquals(2, db.assetDao().loadAllAssets().size.toLong())
+  }
+
+  @Test
+  @Throws(IOException::class, NoSuchAlgorithmException::class)
+  fun testEmbeddedLoader_UpdateExists_ReadyWithOrphanedLaunchAssetRow() = runTest {
+    val update = UpdateEntity(
+      manifest.updateEntity!!.id,
+      manifest.updateEntity!!.commitTime,
+      manifest.updateEntity!!.runtimeVersion,
+      manifest.updateEntity!!.scopeKey,
+      manifest.updateEntity!!.manifest,
+      null,
+      null
+    )
+    update.status = UpdateStatus.READY
+    db.updateDao().insertUpdate(update)
+
+    // the launch asset row and join row exist on disk and in the database, but the registration
+    // was interrupted before launch_asset_id was set on the update
+    val orphanedLaunchAsset = AssetEntity("bundle-${update.id}", "js")
+    orphanedLaunchAsset.relativePath = "bundle-1234"
+    db.assetDao().insertAssets(listOf(orphanedLaunchAsset), update)
+    Assert.assertNull(db.updateDao().loadLaunchAssetForUpdate(update.id))
+
+    every { mockLoaderFiles.fileExists(any(), any(), any()) } answers {
+      thirdArg<String>().contains("bundle-1234")
+    }
+
+    val result = loader.load { _ ->
+      Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+    }
+
+    Assert.assertNotNull(result.updateEntity)
+
+    val updates = db.updateDao().loadAllUpdates()
+    Assert.assertEquals(1, updates.size.toLong())
+    Assert.assertEquals(UpdateStatus.READY, updates[0].status)
+
+    // repaired through the existing-asset branch: the orphaned row is reused, not re-registered
+    Assert.assertNotNull(db.updateDao().loadLaunchAssetForUpdate(update.id))
+    Assert.assertEquals(2, db.assetDao().loadAllAssets().size.toLong())
   }
 
   @Test

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/loader/RemoteLoaderTest.kt
@@ -195,6 +195,11 @@ class RemoteLoaderTest {
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
 
+    val launchAsset = AssetEntity("bundle-1234", "js")
+    launchAsset.relativePath = "bundle-1234"
+    launchAsset.isLaunchAsset = true
+    db.assetDao().insertAssets(listOf(launchAsset), update)
+
     val result = loader.load { _ ->
       Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
     }
@@ -250,6 +255,11 @@ class RemoteLoaderTest {
     )
     update.status = UpdateStatus.READY
     db.updateDao().insertUpdate(update)
+
+    val launchAsset = AssetEntity("bundle-1234", "js")
+    launchAsset.relativePath = "bundle-1234"
+    launchAsset.isLaunchAsset = true
+    db.assetDao().insertAssets(listOf(launchAsset), update)
 
     val result = loader.load { _ ->
       Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -161,6 +161,15 @@ class DatabaseLauncher(
       if (!configuration.hasEmbeddedUpdate && embeddedUpdate?.updateEntity?.id == update.id) {
         continue
       }
+
+      // An update with no launch asset can never launch. Excluding it here lets the loader
+      // re-run and repair the row instead of failing every cold start.
+      if (update.status != UpdateStatus.DEVELOPMENT &&
+        database.updateDao().loadLaunchAssetForUpdate(update.id) == null
+      ) {
+        logger.warn("Skipping launchable update with no launch asset. Debug info: ${update.debugInfo()}")
+        continue
+      }
       filteredLaunchableUpdates.add(update)
     }
     val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/Loader.kt
@@ -166,7 +166,11 @@ abstract class Loader protected constructor(
       database.updateDao().setUpdateScopeKey(existingUpdateEntity, newUpdateEntity.scopeKey)
     }
 
-    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY) {
+    // A READY update with no launch asset is not actually ready. Fall through to
+    // downloadAllAssets so its assets are re-registered instead of staying broken forever.
+    if (existingUpdateEntity != null && existingUpdateEntity.status == UpdateStatus.READY &&
+      database.updateDao().loadLaunchAssetForUpdate(existingUpdateEntity.id) != null
+    ) {
       // hooray, we already have this update downloaded and ready to go!
       updateEntity = existingUpdateEntity
       return finish()


### PR DESCRIPTION
# Why
An update row can end up with status READY but no launch asset row. Registration is now transactional (#49130) so new rows can no longer be committed in this state, but rows corrupted on older SDKs persist through library upgrades, and any future cause would land in the same state. Today such a row is selected for launch, fails with "Launch asset not found for update" on every cold start, and never heals: the loader short-circuits on READY so it never re-registers the assets, and the launcher keeps selecting the same broken row.

This brings back the changes in #48733 by @martintreurnicht, which was closed in favor of #49130. 

# How
- DatabaseLauncher.getLaunchableUpdate skips any non-DEVELOPMENT update whose launch asset row is missing and logs a warning. Selection can then fall back to an older complete update, the embedded update, or nothing, instead of a row that can never launch.
- Loader.processUpdate's READY short-circuit now also requires the launch asset to exist. A broken row falls through to downloadAllAssets, which re-registers the assets and repairs it on the next load pass

The launcher guard is the safety net until repair happens, and the loader guard is the repair path. DEVELOPMENT rows are exempt because they legitimately have no asset rows.

# Test Plan
Added new tests
