### PR TITLE
[core][iOS] Bind each host runtime callback to the app context it creates

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a Hermes JSI crash during reloads where two overlapping `RCTHost` runtime callbacks shared `EXReactNativeFactory`'s app context ivar, letting one callback decorate objects against the other callback's runtime. ([#48576](https://github.com/expo/expo/issues/48576) by [@LizunovSergey](https://github.com/LizunovSergey))
 - [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))
 - Fix `expo/fetch` body-stream teardown races: aborting via an `AbortSignal` now rejects the in-flight read with an `AbortError` instead of hanging forever, and late native events no longer throw `The stream is not in a state that permits enqueue`/`close` from outside any consumer `try`/`catch`. ([#47573](https://github.com/expo/expo/pull/47573) by [@idoyana](https://github.com/idoyana))
 - [iOS] Fix `expo/fetch` `Response.text()` and `.arrayBuffer()` never settling when the request fails (network drop, `abort()`) after the response was already delivered. ([#48230](https://github.com/expo/expo/pull/48230) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -39,7 +39,15 @@
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {
-  _appContext = [[EXAppContext alloc] init];
+  // Bind this callback to the context it creates. The factory is created once in
+  // `application:didFinishLaunchingWithOptions:` and outlives any single `RCTHost`,
+  // so a reload can run this callback for the incoming host while the outgoing
+  // host's callback is still in flight on its own JS thread. Reading the shared ivar
+  // back after that point can hand this callback the other callback's context, and
+  // decorating objects created for one Hermes runtime against another runtime's
+  // `AppContext.runtime` faults inside JSI.
+  EXAppContext *appContext = [[EXAppContext alloc] init];
+  _appContext = appContext;
 
   // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto
   // the JS thread. Doing it here (rather than inside the xcframework) keeps
@@ -59,12 +67,12 @@
   auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
   void *schedulerHandle = expo::createReactSchedulerHandle(scheduler);
 
-  [_appContext setRuntime:&runtime
-                scheduler:schedulerHandle
-                 dispatch:schedulerHandle ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
-  [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
+  [appContext setRuntime:&runtime
+               scheduler:schedulerHandle
+                dispatch:schedulerHandle ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
+  [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
-  [_appContext registerNativeModules];
+  [appContext registerNativeModules];
 }
 
 @end


### PR DESCRIPTION
# Why

Fixes #48576.

`EXReactNativeFactory` stores the `EXAppContext` it builds in an instance variable, then reads that ivar back three times in the same callback ([`ExpoReactNativeFactory.mm#L42-L67`](https://github.com/expo/expo/blob/main/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm#L42-L67)) for `setRuntime:`, `setHostWrapper:` and `registerNativeModules`.

The factory is created once in `application:didFinishLaunchingWithOptions:` and held by the app delegate for the process lifetime (`ExpoReactNativeFactoryProvider.reactNativeFactory`), while `RCTHost` is recreated on every reload. One factory instance therefore serves several host generations, and `host:didInitializeRuntime:` runs on the host's own JS thread — so the callback for an incoming host can overlap the outgoing host's callback with nothing serializing the two:

```
callback A: _appContext = contextA
callback B: _appContext = contextB
callback A: [_appContext setRuntime:&runtimeA]   // lands on contextB
callback B: [_appContext setRuntime:&runtimeB]   // overwrites it
```

Callback A then keeps decorating objects it created for `runtimeA` while `AppContext.runtime` already points at `runtimeB`. That is cross-runtime JSI access, and it faults inside Hermes with the stack from the issue (`ObjectDefinition.decorateWithConstants` → `expo::setProperty` → `HermesRuntimeImpl::setPropertyValue`).

# How

Hold the context in a method-local strong reference and use it for the whole callback, so a callback can only ever touch the context it created.

The ivar assignment stays. I did look at dropping it, as the issue suggests, and the ownership argument holds: `AppContext.setRuntime` assigns `_runtime`, whose `didSet` synchronously runs `prepareRuntime()` (`JavaScriptActor.assumeIsolated` asserts isolation rather than hopping threads), and that installs `AppContext.NativeState` on `global.expo` holding the context strongly — the intentional `AppContext -> runtime -> global.expo -> NativeState -> AppContext` cycle documented on `NativeState`. By the time `setRuntime:` returns, the runtime heap owns the context.

The path where it does not hold is `try? prepareRuntime()` swallowing a throw: no `NativeState` is installed, and a method-local would then release the context when the callback returns, running `deinit` and posting `.appContextDestroys` to the module registry in the middle of a failed init. Keeping the assignment leaves lifetime exactly as it is today and keeps this diff to the race itself. The ivar is write-only as a result — glad to drop it in a follow-up commit if you would rather have that.

# Test Plan

Compiled from source. `apps/minimal-tester` was installed with `EXPO_USE_PRECOMPILED_MODULES=0`, so the workspace builds `packages/expo/ios` directly instead of resolving a prebuilt xcframework — without that flag this file is not compiled at all and a green build would prove nothing.

```
xcodebuild -workspace minimaltester.xcworkspace -scheme Expo \
  -destination 'generic/platform=iOS Simulator' -configuration Debug build
```

`** BUILD SUCCEEDED **`, 0 errors. `ExpoReactNativeFactory.mm` compiled in both the `arm64` and `x86_64` simulator slices. The only warning pointing at the file is the pre-existing `class 'EXReactNativeFactory' does not conform to protocol 'RCTHostDelegate'` at line 25, which comes from `RCTHostDelegate` having no definition in that translation unit; no warning lands on a changed line.

What this does **not** include: I did not reproduce the crash. It needs two `didInitializeRuntime` callbacks to overlap during a reload, which is timing-dependent — the issue reports it as intermittent, captured twice from the same reload sequence. Nothing in the change is observable when the callbacks do not overlap, so a passing manual reload demonstrates no regression rather than a fix. The argument for the fix is the ordering above plus the ownership analysis; both are checkable by reading `ExpoReactNativeFactory.mm` and `AppContext.swift` and I have tried to make them falsifiable rather than assertive.

# Checklist

- [x] `CHANGELOG.md` entry added — it links the issue, since the pull request number is not known while writing.
- [ ] Not applicable: no module plugin or prebuild behaviour is touched.
- [ ] Not applicable: no documentation changes.
