### PR TITLE
[ios][widgets] Expose Live Activity content state on instances

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] Expose content state on Live Activity instances. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@coffee-cup](https://github.com/coffee-cup))
 - [iOS] Expose stable ActivityKit identifiers on Live Activity instances. ([#48589](https://github.com/expo/expo/pull/48589) by [@developwithJB](https://github.com/developwithJB))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [iOS] Expose content state on Live Activity instances. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@coffee-cup](https://github.com/coffee-cup))
+- [iOS] Expose content state on Live Activity instances. ([#49475](https://github.com/expo/expo/pull/49475) by [@coffee-cup](https://github.com/coffee-cup))
 - [iOS] Expose stable ActivityKit identifiers on Live Activity instances. ([#48589](https://github.com/expo/expo/pull/48589) by [@developwithJB](https://github.com/developwithJB))
 - [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 - [iOS] Expose ActivityKit's `staleDate` on `LiveActivity.start()` and `LiveActivity.update()`. ([#46343](https://github.com/expo/expo/pull/46343) by [@KyleAsaff](https://github.com/KyleAsaff))

--- a/packages/expo-widgets/ios/LiveActivity.swift
+++ b/packages/expo-widgets/ios/LiveActivity.swift
@@ -12,17 +12,12 @@ final class LiveActivity: SharedObject {
     super.init()
   }
 
-  func getContentState() -> [String: Any]? {
+  func getContentState() throws -> String? {
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
-      return nil
+      throw LiveActivityNotFoundException(id)
     }
 
-    let state = activity.content.state
-    var contentState: [String: Any] = ["name": state.name]
-    if let props = state.props {
-      contentState["props"] = props
-    }
-    return contentState
+    return activity.content.state.props
   }
 
   func update(props: String?, staleDate: Date?) async throws {

--- a/packages/expo-widgets/ios/LiveActivity.swift
+++ b/packages/expo-widgets/ios/LiveActivity.swift
@@ -12,6 +12,19 @@ final class LiveActivity: SharedObject {
     super.init()
   }
 
+  func getContentState() -> [String: Any]? {
+    guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
+      return nil
+    }
+
+    let state = activity.content.state
+    var contentState: [String: Any] = ["name": state.name]
+    if let props = state.props {
+      contentState["props"] = props
+    }
+    return contentState
+  }
+
   func update(props: String?, staleDate: Date?) async throws {
     guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
       throw LiveActivityNotFoundException(id)

--- a/packages/expo-widgets/ios/WidgetsModule.swift
+++ b/packages/expo-widgets/ios/WidgetsModule.swift
@@ -105,7 +105,7 @@ public final class WidgetsModule: Module {
       }
 
       Function("getContentState") { (instance: LiveActivity) in
-        instance.getContentState()
+        try instance.getContentState()
       }
 
       AsyncFunction("update") { (instance: LiveActivity, props: String?, staleDate: Date?) in

--- a/packages/expo-widgets/ios/WidgetsModule.swift
+++ b/packages/expo-widgets/ios/WidgetsModule.swift
@@ -104,6 +104,10 @@ public final class WidgetsModule: Module {
         instance.id
       }
 
+      Function("getContentState") { (instance: LiveActivity) in
+        instance.getContentState()
+      }
+
       AsyncFunction("update") { (instance: LiveActivity, props: String?, staleDate: Date?) in
         try await instance.update(props: props, staleDate: staleDate)
       }

--- a/packages/expo-widgets/src/ExpoWidgets.ts
+++ b/packages/expo-widgets/src/ExpoWidgets.ts
@@ -30,7 +30,7 @@ class LiveActivityStub {
   getId(): string {
     return '';
   }
-  getContentState(): { name: string; props?: string } | null {
+  getContentState(): string | null {
     return null;
   }
   async update(_props?: string): Promise<void> {}

--- a/packages/expo-widgets/src/ExpoWidgets.ts
+++ b/packages/expo-widgets/src/ExpoWidgets.ts
@@ -30,6 +30,9 @@ class LiveActivityStub {
   getId(): string {
     return '';
   }
+  getContentState(): { name: string; props?: string } | null {
+    return null;
+  }
   async update(_props?: string): Promise<void> {}
   async end(
     _dismissalPolicy?: string,

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -5,6 +5,7 @@ import ExpoWidgetsModule from './ExpoWidgets';
 import type {
   ExpoWidgetsEvents,
   LiveActivityComponent,
+  LiveActivityContentState,
   LiveActivityDismissalPolicy,
   NativeLiveActivity,
   NativeLiveActivityFactory,
@@ -108,6 +109,20 @@ export class LiveActivity<T extends object = object> {
    */
   getId(): string {
     return this.nativeLiveActivity.getId();
+  }
+
+  /**
+   * Returns the content state the Live Activity was started with or last updated to display.
+   * This also works for activities started remotely via push-to-start, whose content the app
+   * has not otherwise seen.
+   * @returns The current content state, or `null` if the activity is no longer active.
+   */
+  getContentState(): LiveActivityContentState<T> | null {
+    const state = this.nativeLiveActivity.getContentState();
+    if (!state) {
+      return null;
+    }
+    return { name: state.name, props: state.props ? (JSON.parse(state.props) as T) : null };
   }
 
   /**

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -114,11 +114,19 @@ export class LiveActivity<T extends object = object> {
    * Returns the props the Live Activity was started with or last updated to display.
    * This also works for activities started remotely via push-to-start, whose content the app
    * has not otherwise seen.
-   * @returns The current content props, or `null` if the activity was started without props.
+   * @returns The current content props, or `null` if the activity was started without props
+   * or they are not valid JSON.
    */
   getContentState(): T | null {
     const props = this.nativeLiveActivity.getContentState();
-    return props ? (JSON.parse(props) as T) : null;
+    if (!props) {
+      return null;
+    }
+    try {
+      return JSON.parse(props) as T;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -5,7 +5,6 @@ import ExpoWidgetsModule from './ExpoWidgets';
 import type {
   ExpoWidgetsEvents,
   LiveActivityComponent,
-  LiveActivityContentState,
   LiveActivityDismissalPolicy,
   NativeLiveActivity,
   NativeLiveActivityFactory,
@@ -112,17 +111,14 @@ export class LiveActivity<T extends object = object> {
   }
 
   /**
-   * Returns the content state the Live Activity was started with or last updated to display.
+   * Returns the props the Live Activity was started with or last updated to display.
    * This also works for activities started remotely via push-to-start, whose content the app
    * has not otherwise seen.
-   * @returns The current content state, or `null` if the activity is no longer active.
+   * @returns The current content props, or `null` if the activity was started without props.
    */
-  getContentState(): LiveActivityContentState<T> | null {
-    const state = this.nativeLiveActivity.getContentState();
-    if (!state) {
-      return null;
-    }
-    return { name: state.name, props: state.props ? (JSON.parse(state.props) as T) : null };
+  getContentState(): T | null {
+    const props = this.nativeLiveActivity.getContentState();
+    return props ? (JSON.parse(props) as T) : null;
   }
 
   /**

--- a/packages/expo-widgets/src/Widgets.types.ts
+++ b/packages/expo-widgets/src/Widgets.types.ts
@@ -272,21 +272,6 @@ export type PushToStartTokenEvent = {
 };
 
 /**
- * The content state of a Live Activity: its name and the props it currently displays.
- */
-export type LiveActivityContentState<T extends object = object> = {
-  /**
-   * The Live Activity name. Matches the `'name'` field in the widget configuration in the app config.
-   */
-  name: string;
-  /**
-   * The props the Live Activity was started with or last updated to display,
-   * or `null` if the activity has no props.
-   */
-  props: T | null;
-};
-
-/**
  * Dismissal policy for ending a live activity.
  * - `'default'` - The system’s default dismissal policy for the Live Activity.
  * - `'immediate'` - The system immediately removes the Live Activity that ended.
@@ -332,7 +317,7 @@ export declare class NativeLiveActivityFactory extends SharedObject {
 
 export declare class NativeLiveActivity extends SharedObject<LiveActivityEvents> {
   getId(): string;
-  getContentState(): { name: string; props?: string } | null;
+  getContentState(): string | null;
   update(props?: string, staleDate?: number): Promise<void>;
   end(
     dismissalPolicy?: string,

--- a/packages/expo-widgets/src/Widgets.types.ts
+++ b/packages/expo-widgets/src/Widgets.types.ts
@@ -272,6 +272,21 @@ export type PushToStartTokenEvent = {
 };
 
 /**
+ * The content state of a Live Activity: its name and the props it currently displays.
+ */
+export type LiveActivityContentState<T extends object = object> = {
+  /**
+   * The Live Activity name. Matches the `'name'` field in the widget configuration in the app config.
+   */
+  name: string;
+  /**
+   * The props the Live Activity was started with or last updated to display,
+   * or `null` if the activity has no props.
+   */
+  props: T | null;
+};
+
+/**
  * Dismissal policy for ending a live activity.
  * - `'default'` - The system’s default dismissal policy for the Live Activity.
  * - `'immediate'` - The system immediately removes the Live Activity that ended.
@@ -317,6 +332,7 @@ export declare class NativeLiveActivityFactory extends SharedObject {
 
 export declare class NativeLiveActivity extends SharedObject<LiveActivityEvents> {
   getId(): string;
+  getContentState(): { name: string; props?: string } | null;
   update(props?: string, staleDate?: number): Promise<void>;
   end(
     dismissalPolicy?: string,

--- a/packages/expo-widgets/src/index.ts
+++ b/packages/expo-widgets/src/index.ts
@@ -3,6 +3,7 @@ export type {
   ExpoWidgetsEvents,
   LevelOfDetail,
   LiveActivityComponent,
+  LiveActivityContentState,
   LiveActivityDismissalPolicy,
   LiveActivityEnvironment,
   LiveActivityEvents,

--- a/packages/expo-widgets/src/index.ts
+++ b/packages/expo-widgets/src/index.ts
@@ -3,7 +3,6 @@ export type {
   ExpoWidgetsEvents,
   LevelOfDetail,
   LiveActivityComponent,
-  LiveActivityContentState,
   LiveActivityDismissalPolicy,
   LiveActivityEnvironment,
   LiveActivityEvents,


### PR DESCRIPTION
# Why

I'm using push-to-start Live Activities. A server starts activities remotely and puts identifying data in the props, in my case a session id. Since #48589 the app can enumerate these server-started activities with `getInstances()` and read their ids and push tokens, but not the content they were started with. Props are write-only from JS: `start` and `update` take them, but nothing reads them back. So the app holds a handle to an activity and still has to ask the server what that activity is for.

# How

Adds `getContentState()` to `LiveActivity`. Same lookup as the other instance methods: find the ActivityKit activity by id, then read `activity.content.state`. It returns `null` when the activity is no longer running instead of throwing, because a read that races an ending activity is normal during reconciliation.

```swift
func getContentState() -> [String: Any]? {
  guard let activity = Activity<LiveActivityAttributes>.activities.first(where: { $0.id == id }) else {
    return nil
  }

  let state = activity.content.state
  var contentState: [String: Any] = ["name": state.name]
  if let props = state.props {
    contentState["props"] = props
  }
  return contentState
}
```

`update(props: T)` stringifies props on the way in, so the wrapper parses them on the way out:

```ts
const state = activity.getContentState();
// LiveActivityContentState<T> | null, i.e. { name: string; props: T | null } | null
```

The non-native stub returns `null` like the other stubbed methods.

# Test Plan

- `xcrun swiftc -parse ios/LiveActivity.swift ios/LiveActivityFactory.swift ios/WidgetsModule.swift`
- `pnpm run build && pnpm run typecheck && pnpm run lint && pnpm run test --runInBand` in `packages/expo-widgets` (all pass, 13 existing tests)
- Manually in an app that renders Live Activities with expo-widgets, on an iOS simulator with this diff applied to the installed package:
  1. `factory.start(props)`, then `getContentState()` returns the activity name and the same props.
  2. Force-quit and relaunch, then `getInstances()[0].getContentState()` reads the full content state of an activity the current JS runtime never started. That's the push-to-start situation this method is for.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
