### PR TITLE
[observe] dispatch native crashes as logs

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [iOS] [Android] Dispatch attributed native crashes as fatal exception logs. ([#49489](https://github.com/expo/expo/pull/49489) by [@Ubax](https://github.com/Ubax))
 - Add an optional `displayName` to `logEvent` ([#47289](https://github.com/expo/expo/pull/47289) by [@Ubax](https://github.com/Ubax))
 - Capture React render-phase errors via `AppMetricsErrorBoundary`. ([#47341](https://github.com/expo/expo/pull/47341) by [@tsapeta](https://github.com/tsapeta))
 - Describe the network a launch ran on: connection cost, request throughput, and a `slowest.*` group replacing `expo.network.requests.slowestDuration` and `slowestHost`. ([#48518](https://github.com/expo/expo/pull/48518) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -168,13 +168,14 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
             exitInfoProvider = ExitInfoProviderImpl(context),
             lastProcessedExitStore = PreferencesLastProcessedExitStore(context),
             appVersion = metadata?.appVersion
-          ) { sessionId, origin, report ->
+          ) { sessionId, origin, report, logDetails ->
             attributeAndStoreCrashReport(
               sessionManager = sessionManager,
               currentSessionId = mainSession.sessionId,
               sessionId = sessionId,
               origin = origin,
-              report = report
+              report = report,
+              logDetails = logDetails
             )
           }.process()
         }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
@@ -48,7 +48,7 @@ data class CrashReport(
     return LogRecord(
       sessionId = sessionId,
       timestamp = timestampBegin,
-      name = "exception",
+      name = "native.exception",
       severity = Severity.FATAL.rawValue,
       attributes = JsonAny.encodeMapToJsonString(attributes)
     )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReport.kt
@@ -1,5 +1,9 @@
 package expo.modules.appmetrics.crashreporting
 
+import expo.modules.appmetrics.logevents.Severity
+import expo.modules.appmetrics.logevents.truncateToMaxLength
+import expo.modules.appmetrics.storage.LogRecord
+import expo.modules.appmetrics.utils.JsonAny
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -28,6 +32,51 @@ data class CrashReport(
    */
   val ingestedAt: String
 ) {
+  fun toLogRecord(sessionId: String, details: CrashLogDetails = CrashLogDetails()): LogRecord {
+    val attributes = buildMap<String, Any?> {
+      put("exception.type", details.exceptionType ?: signal?.let(::signalName) ?: "NativeCrash")
+      put("exception.message", terminationReason ?: exceptionReason ?: signal?.let(::signalName) ?: "Native crash")
+      put("exception.stacktrace", renderStacktrace(details.stackFrames))
+      put("expo.error.source", "nativeCrash")
+      put("expo.error.is_fatal", true)
+      signal?.let {
+        put("expo.crash.signal", signalName(it))
+        put("expo.crash.signal_number", it)
+      }
+      terminationReason?.let { put("expo.crash.termination_reason", it) }
+    }
+    return LogRecord(
+      sessionId = sessionId,
+      timestamp = timestampBegin,
+      name = "exception",
+      severity = Severity.FATAL.rawValue,
+      attributes = JsonAny.encodeMapToJsonString(attributes)
+    )
+  }
+
+  private fun renderStacktrace(stackFrames: List<String>?): String? {
+    val callStacks = callStackTree?.callStacks.orEmpty()
+    val attributedStacks = callStacks.filter { it.threadAttributed == true }
+    val selectedStacks = attributedStacks.ifEmpty { callStacks }
+    val frames = stackFrames ?: selectedStacks
+      .flatMap { it.callStackRootFrames.orEmpty() }
+      .map { it.symbol ?: "<unknown>" }
+    if (frames.isEmpty()) {
+      return null
+    }
+    val rendered = buildList {
+      addAll(frames.take(MAX_LOG_STACK_FRAMES))
+      if (frames.size > MAX_LOG_STACK_FRAMES) {
+        add("… +${frames.size - MAX_LOG_STACK_FRAMES} more frames")
+      }
+    }.joinToString("\n")
+    return truncateToMaxLength(
+      rendered,
+      MAX_LOG_STACKTRACE_LENGTH,
+      "Native crash stack trace exceeded the maximum length and was truncated."
+    )
+  }
+
   @Serializable
   data class CallStackTree(
     val callStacks: List<CallStack>? = null
@@ -93,5 +142,25 @@ data class CrashReport(
     }
 
     private const val MAX_CAUSE_DEPTH = 5
+    private const val MAX_LOG_STACK_FRAMES = 25
+    private const val MAX_LOG_STACKTRACE_LENGTH = 65_536
+
+    private fun signalName(signal: Int): String =
+      when (signal) {
+        4 -> "SIGILL"
+        5 -> "SIGTRAP"
+        6 -> "SIGABRT"
+        7 -> "SIGBUS"
+        8 -> "SIGFPE"
+        9 -> "SIGKILL"
+        11 -> "SIGSEGV"
+        15 -> "SIGTERM"
+        else -> "SIG$signal"
+      }
   }
 }
+
+data class CrashLogDetails(
+  val exceptionType: String? = null,
+  val stackFrames: List<String>? = null
+)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportAttribution.kt
@@ -13,7 +13,8 @@ suspend fun attributeAndStoreCrashReport(
   currentSessionId: String?,
   sessionId: String?,
   origin: CrashOrigin,
-  report: CrashReport
+  report: CrashReport,
+  logDetails: CrashLogDetails = CrashLogDetails()
 ) {
   runCatching {
     // A null target stores the report as an orphan.
@@ -29,7 +30,12 @@ suspend fun attributeAndStoreCrashReport(
       // id-less JVM file (a crash before the main session existed) → orphan.
       else -> null
     }
-    sessionManager.setCrashReport(target, report.encodeToJsonString())
+    val payload = report.encodeToJsonString()
+    if (target != null) {
+      sessionManager.storeCrashReportIfNew(target, payload, report.toLogRecord(target, logDetails))
+    } else {
+      sessionManager.setCrashReport(null, payload)
+    }
   }.onFailure {
     Log.e(TAG, "Failed to persist a crash report", it)
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/crashreporting/CrashReportProcessor.kt
@@ -46,7 +46,12 @@ class CrashReportProcessor(
   private val exitInfoProvider: ExitInfoProvider,
   private val lastProcessedExitStore: LastProcessedExitStore,
   private val appVersion: String?,
-  private val storeReport: suspend (sessionId: String?, origin: CrashOrigin, report: CrashReport) -> Unit
+  private val storeReport: suspend (
+    sessionId: String?,
+    origin: CrashOrigin,
+    report: CrashReport,
+    logDetails: CrashLogDetails
+  ) -> Unit
 ) {
   suspend fun process() {
     crashFileReader.deleteOrphanedTempFiles()
@@ -95,7 +100,8 @@ class CrashReportProcessor(
       storeReport(
         file.sessionId,
         CrashOrigin.JVM_FILE,
-        file.toCrashReport(ingestedAt, resolvedAppVersion)
+        file.toCrashReport(ingestedAt, resolvedAppVersion),
+        CrashLogDetails(exceptionType = file.exceptionClass, stackFrames = file.stackFrames)
       )
       crashFileReader.delete(file)
     }
@@ -111,7 +117,8 @@ class CrashReportProcessor(
       storeReport(
         null,
         CrashOrigin.EXIT_RECORD,
-        record.toCrashReport(ingestedAt, resolvedAppVersion)
+        record.toCrashReport(ingestedAt, resolvedAppVersion),
+        CrashLogDetails()
       )
     }
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -1,6 +1,7 @@
 package expo.modules.appmetrics.storage
 
 import android.content.Context
+import androidx.room.withTransaction
 import expo.modules.appmetrics.AppMetadata
 import expo.modules.appmetrics.AppMetricsPreferences
 import expo.modules.appmetrics.GlobalAttributes
@@ -99,6 +100,25 @@ class SessionManager(
     )
   }
 
+  /**
+   * Stores a crash report and its log for `sessionId`, but only when the session
+   * has no report yet. Reprocessing the same crash must not add a second log.
+   */
+  suspend fun storeCrashReportIfNew(sessionId: String, payload: String, log: LogRecord) {
+    database.withTransaction {
+      if (database.crashReportDao().getBySessionId(sessionId) == null) {
+        database.crashReportDao().upsert(
+          CrashReportEntity(
+            sessionId = sessionId,
+            payload = payload,
+            createdAt = TimeUtils.getCurrentTimestampInISOFormat()
+          )
+        )
+        database.logDao().insertAll(logsWithSession(listOf(log), sessionId))
+      }
+    }
+  }
+
   suspend fun getCrashReport(sessionId: String): String? =
     database.crashReportDao().getBySessionId(sessionId)?.payload
 
@@ -168,14 +188,16 @@ class SessionManager(
     logs: List<LogRecord>,
     sessionId: String
   ) {
-    val logsWithSession = logs.map { log ->
+    database.logDao().insertAll(logsWithSession(logs, sessionId))
+  }
+
+  private fun logsWithSession(logs: List<LogRecord>, sessionId: String): List<LogRecord> =
+    logs.map { log ->
       log.copy(
         sessionId = sessionId,
         attributes = mergeGlobalAttributesIntoJsonString(log.attributes)
       )
     }
-    database.logDao().insertAll(logsWithSession)
-  }
 
   suspend fun cleanupOldLogs() {
     val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
@@ -78,7 +78,7 @@ class CrashReportAttributionTest {
       attribute("crashed-session", CrashOrigin.JVM_FILE)
 
       assertEquals("java.lang.IllegalStateException: boom", storedMessage("crashed-session"))
-      assertEquals(listOf("exception"), sessionManager.getLogsForSession("crashed-session").map { it.name })
+      assertEquals(listOf("native.exception"), sessionManager.getLogsForSession("crashed-session").map { it.name })
     }
 
   @Test
@@ -128,7 +128,7 @@ class CrashReportAttributionTest {
 
       assertEquals("java.lang.IllegalStateException: native", storedMessage("previous"))
       assertNull(sessionManager.getCrashReport("older"))
-      assertEquals(listOf("exception"), sessionManager.getLogsForSession("previous").map { it.name })
+      assertEquals(listOf("native.exception"), sessionManager.getLogsForSession("previous").map { it.name })
     }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportAttributionTest.kt
@@ -78,6 +78,18 @@ class CrashReportAttributionTest {
       attribute("crashed-session", CrashOrigin.JVM_FILE)
 
       assertEquals("java.lang.IllegalStateException: boom", storedMessage("crashed-session"))
+      assertEquals(listOf("exception"), sessionManager.getLogsForSession("crashed-session").map { it.name })
+    }
+
+  @Test
+  fun `does not duplicate the crash log when a report is reprocessed`() =
+    runTest {
+      sessionManager.startSessionWithIdAt("crashed-session", "2023-11-14T22:00:00.000Z")
+
+      attribute("crashed-session", CrashOrigin.JVM_FILE)
+      attribute("crashed-session", CrashOrigin.JVM_FILE)
+
+      assertEquals(1, sessionManager.getLogsForSession("crashed-session").size)
     }
 
   @Test
@@ -89,6 +101,7 @@ class CrashReportAttributionTest {
 
       assertNull(sessionManager.getCrashReport("never-persisted"))
       assertEquals(1, orphanCount())
+      assertEquals(0, sessionManager.getLogsForSession("never-persisted").size)
     }
 
   @Test
@@ -98,6 +111,7 @@ class CrashReportAttributionTest {
       attribute(null, CrashOrigin.JVM_FILE)
 
       assertEquals(1, orphanCount())
+      assertEquals(0, sessionManager.getLogsForSession("current").size)
     }
 
   // endregion
@@ -114,6 +128,7 @@ class CrashReportAttributionTest {
 
       assertEquals("java.lang.IllegalStateException: native", storedMessage("previous"))
       assertNull(sessionManager.getCrashReport("older"))
+      assertEquals(listOf("exception"), sessionManager.getLogsForSession("previous").map { it.name })
     }
 
   @Test
@@ -126,6 +141,7 @@ class CrashReportAttributionTest {
       // Never blame the live session — stored unattributed instead.
       assertNull(sessionManager.getCrashReport("current"))
       assertEquals(1, orphanCount())
+      assertEquals(0, sessionManager.getLogsForSession("current").size)
     }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportProcessorTest.kt
@@ -44,13 +44,18 @@ class CrashReportProcessorTest {
     }
   }
 
-  data class StoreCall(val sessionId: String?, val origin: CrashOrigin, val report: CrashReport)
+  data class StoreCall(
+    val sessionId: String?,
+    val origin: CrashOrigin,
+    val report: CrashReport,
+    val logDetails: CrashLogDetails
+  )
 
   private val storeCalls = mutableListOf<StoreCall>()
 
-  private val storeReport: suspend (String?, CrashOrigin, CrashReport) -> Unit =
-    { sessionId, origin, report ->
-      storeCalls += StoreCall(sessionId, origin, report)
+  private val storeReport: suspend (String?, CrashOrigin, CrashReport, CrashLogDetails) -> Unit =
+    { sessionId, origin, report, logDetails ->
+      storeCalls += StoreCall(sessionId, origin, report, logDetails)
     }
 
   @Before
@@ -110,6 +115,8 @@ class CrashReportProcessorTest {
       assertEquals(CrashOrigin.JVM_FILE, call.origin)
       assertEquals("java.lang.IllegalStateException: boom", call.report.exceptionReason)
       assertEquals("1.2.3", call.report.appVersion)
+      assertEquals("java.lang.IllegalStateException", call.logDetails.exceptionType)
+      assertTrue(call.logDetails.stackFrames.orEmpty().isNotEmpty())
     }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
@@ -3,6 +3,7 @@ package expo.modules.appmetrics.crashreporting
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import expo.modules.appmetrics.utils.JsonAny
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -94,6 +95,87 @@ class CrashReportTest {
     assertTrue(frames!!.isNotEmpty())
     // The crash site (this test) must appear before JUnit infrastructure frames.
     assertTrue(frames.first().symbol!!.contains("CrashReportTest"))
+  }
+
+  @Test
+  fun `builds a fatal exception log for a JVM crash`() {
+    val report = reportFromThrowable(IllegalStateException("boom"))
+
+    val log = report.toLogRecord(
+      "session",
+      CrashLogDetails(exceptionType = "java.lang.IllegalStateException")
+    )
+    val attributes = requireNotNull(JsonAny.decodeJsonStringToMap(requireNotNull(log.attributes)))
+
+    assertEquals("session", log.sessionId)
+    assertEquals("exception", log.name)
+    assertEquals("fatal", log.severity)
+    assertEquals(crashTimestamp, log.timestamp)
+    assertEquals("java.lang.IllegalStateException", attributes["exception.type"])
+    assertEquals("java.lang.IllegalStateException: boom", attributes["exception.message"])
+    assertEquals("nativeCrash", attributes["expo.error.source"])
+    assertEquals(true, attributes["expo.error.is_fatal"])
+  }
+
+  @Test
+  fun `builds a fatal exception log for an exit record`() {
+    val report = CrashReport(
+      signal = 11,
+      terminationReason = "Native crash",
+      appVersion = "1.2.3",
+      timestampBegin = crashTimestamp,
+      ingestedAt = ingestedAt
+    )
+
+    val attributes = requireNotNull(
+      JsonAny.decodeJsonStringToMap(requireNotNull(report.toLogRecord("session").attributes))
+    )
+
+    assertEquals("SIGSEGV", attributes["exception.type"])
+    assertEquals("Native crash", attributes["exception.message"])
+    assertNull(attributes["exception.stacktrace"])
+    assertEquals("SIGSEGV", attributes["expo.crash.signal"])
+    assertEquals(11L, attributes["expo.crash.signal_number"])
+    assertEquals("Native crash", attributes["expo.crash.termination_reason"])
+  }
+
+  @Test
+  fun `renders at most twenty-five attributed stack frames and reports the omitted count`() {
+    val report = CrashReport(
+      exceptionReason = "boom",
+      callStackTree = CrashReport.CallStackTree(
+        callStacks = listOf(
+          CrashReport.CallStackTree.CallStack(
+            threadAttributed = true,
+            callStackRootFrames = (0 until 28).map { CrashReport.CallStackTree.Frame("frame$it") }
+          ),
+          CrashReport.CallStackTree.CallStack(
+            threadAttributed = false,
+            callStackRootFrames = listOf(CrashReport.CallStackTree.Frame("unattributed"))
+          )
+        )
+      ),
+      appVersion = "1.2.3",
+      timestampBegin = crashTimestamp,
+      ingestedAt = ingestedAt
+    )
+
+    val attributes = requireNotNull(
+      JsonAny.decodeJsonStringToMap(
+        requireNotNull(
+          report.toLogRecord(
+            "session",
+            CrashLogDetails(exceptionType = "java.lang.IllegalStateException")
+          ).attributes
+        )
+      )
+    )
+    val lines = requireNotNull(attributes["exception.stacktrace"] as? String).lines()
+    assertEquals(26, lines.size)
+    assertEquals("frame0", lines.first())
+    assertEquals("frame24", lines[24])
+    assertEquals("… +3 more frames", lines.last())
+    assertFalse(lines.contains("unattributed"))
   }
 
   // MARK: JSON encoding — the payload is the cross-platform contract with types.ts

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportTest.kt
@@ -108,7 +108,7 @@ class CrashReportTest {
     val attributes = requireNotNull(JsonAny.decodeJsonStringToMap(requireNotNull(log.attributes)))
 
     assertEquals("session", log.sessionId)
-    assertEquals("exception", log.name)
+    assertEquals("native.exception", log.name)
     assertEquals("fatal", log.severity)
     assertEquals(crashTimestamp, log.timestamp)
     assertEquals("java.lang.IllegalStateException", attributes["exception.type"])

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
@@ -101,13 +101,14 @@ class CrashReportingPipelineTest {
           }
         },
         appVersion = "3.1.4"
-      ) { sessionId, origin, report ->
+      ) { sessionId, origin, report, logDetails ->
         attributeAndStoreCrashReport(
           sessionManager = sessionManager,
           currentSessionId = currentSessionId,
           sessionId = sessionId,
           origin = origin,
-          report = report
+          report = report,
+          logDetails = logDetails
         )
       }.process()
 
@@ -117,6 +118,7 @@ class CrashReportingPipelineTest {
 
       val crashed = sessions.single { it.id == crashedSessionId }
       val crashReport = requireNotNull(crashed.crashReport)
+      assertEquals(listOf("exception"), crashed.logs.map { it.name })
       assertEquals("3.1.4", crashReport["appVersion"])
       assertEquals("java.lang.IllegalStateException: boom", crashReport["exceptionReason"])
       @Suppress("UNCHECKED_CAST")

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/crashreporting/CrashReportingPipelineTest.kt
@@ -118,7 +118,7 @@ class CrashReportingPipelineTest {
 
       val crashed = sessions.single { it.id == crashedSessionId }
       val crashReport = requireNotNull(crashed.crashReport)
-      assertEquals(listOf("exception"), crashed.logs.map { it.name })
+      assertEquals(listOf("native.exception"), crashed.logs.map { it.name })
       assertEquals("3.1.4", crashReport["appVersion"])
       assertEquals("java.lang.IllegalStateException: boom", crashReport["exceptionReason"])
       @Suppress("UNCHECKED_CAST")

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -6,6 +6,9 @@
 /// payload time window. Unhandled JavaScript errors are recorded separately as `exception` log
 /// events (see `ErrorReport`).
 public struct CrashReport: Codable, Sendable {
+  private static let maxLogStackFrames = 25
+  private static let maxLogStacktraceLength = 65_536
+
   /// Mach exception type (e.g. EXC_BAD_ACCESS, EXC_CRASH).
   public let exceptionType: Int?
 
@@ -85,6 +88,116 @@ public struct CrashReport: Codable, Sendable {
       return session
     }
     return candidates.max(by: { $0.startTimestamp < $1.startTimestamp })
+  }
+
+  func toLogRecord() -> LogRecord {
+    var attributes: [String: Any] = [
+      "exception.type": exceptionReason?.exceptionName
+        ?? exceptionType.map { exceptionName(for: $0) }
+        ?? signal.map { signalName(for: $0) }
+        ?? "NativeCrash",
+      "exception.message": exceptionMessage,
+      "exception.stacktrace": renderedStacktrace as Any,
+      "expo.error.source": "nativeCrash",
+      "expo.error.is_fatal": true,
+    ]
+    if let exceptionType {
+      attributes["expo.crash.exception_type"] = exceptionName(for: exceptionType)
+      attributes["expo.crash.exception_type_code"] = exceptionType
+    }
+    if let exceptionCode {
+      attributes["expo.crash.exception_code"] = exceptionCode
+    }
+    if let signal {
+      attributes["expo.crash.signal"] = signalName(for: signal)
+      attributes["expo.crash.signal_number"] = signal
+    }
+    if let terminationReason {
+      attributes["expo.crash.termination_reason"] = terminationReason
+    }
+    if let exceptionReason {
+      attributes["expo.crash.objc_exception_type"] = exceptionReason.exceptionType
+      attributes["expo.crash.objc_exception_message"] = exceptionReason.composedMessage
+    }
+    return LogRecord(
+      name: "exception",
+      attributes: attributes,
+      severity: .fatal,
+      // MetricKit gives a time window; its end is the tightest crash-time bound and matches Android.
+      timestamp: timestampEnd.ISO8601Format()
+    )
+  }
+
+  private var exceptionMessage: String {
+    let parts = [terminationReason, exceptionReason?.composedMessage].compactMap { value -> String? in
+      guard let value, !value.isEmpty else {
+        return nil
+      }
+      return value
+    }
+    if !parts.isEmpty {
+      return parts.joined(separator: "\n")
+    }
+    if let signal {
+      return signalName(for: signal)
+    }
+    if let exceptionType {
+      return exceptionName(for: exceptionType)
+    }
+    return "Native crash"
+  }
+
+  private var renderedStacktrace: String? {
+    guard let callStacks = callStackTree?.callStacks else {
+      return nil
+    }
+    let attributedStacks = callStacks.filter { $0.threadAttributed == true }
+    let selectedStacks = attributedStacks.isEmpty ? callStacks : attributedStacks
+    var frames: [CallStackTree.Frame] = []
+    var totalFrames = 0
+    var lines: [String] = []
+    for callStack in selectedStacks {
+      collectFrames(callStack.callStackRootFrames ?? [], into: &frames, total: &totalFrames)
+    }
+    lines.append(contentsOf: frames.map(renderFrame))
+    if totalFrames > frames.count {
+      lines.append("… +\(totalFrames - frames.count) more frames")
+    }
+    guard !lines.isEmpty else {
+      return nil
+    }
+    return truncateToMaxLength(
+      lines.joined(separator: "\n"),
+      maxLength: Self.maxLogStacktraceLength,
+      warningMessage: "[AppMetrics] Native crash stack trace exceeded the maximum length and was truncated."
+    )
+  }
+
+  private func collectFrames(
+    _ source: [CallStackTree.Frame],
+    into frames: inout [CallStackTree.Frame],
+    total: inout Int
+  ) {
+    for frame in source {
+      total += 1
+      if frames.count < Self.maxLogStackFrames {
+        frames.append(frame)
+      }
+      collectFrames(frame.subFrames ?? [], into: &frames, total: &total)
+    }
+  }
+
+  private func renderFrame(_ frame: CallStackTree.Frame) -> String {
+    if let symbol = frame.symbol {
+      return symbol
+    }
+    if let binaryName = frame.binaryName, let offset = frame.offsetIntoBinaryTextSegment {
+      return "\(binaryName) + \(offset)"
+    }
+    if let address = frame.address {
+      return "0x\(String(address, radix: 16))"
+    }
+    return frame.binaryName ?? "<unknown>"
   }
 
   /// Mirrors the shape of `MXCallStackTree.JSONRepresentation()`. Every field is optional so that

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -120,7 +120,7 @@ public struct CrashReport: Codable, Sendable {
       attributes["expo.crash.objc_exception_message"] = exceptionReason.composedMessage
     }
     return LogRecord(
-      name: "exception",
+      name: "native.exception",
       attributes: attributes,
       severity: .fatal,
       // MetricKit gives a time window; its end is the tightest crash-time bound and matches Android.

--- a/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
+++ b/packages/expo-app-metrics/ios/Database/MetricsDatabase.swift
@@ -542,6 +542,21 @@ final class MetricsDatabase: Sendable {
     try statement.run()
   }
 
+  /// Stores a crash report once and, when its session row exists, its dispatchable log atomically.
+  /// The crash report's primary key is the idempotence marker for MetricKit payload redelivery.
+  @AppMetricsActor
+  func storeCrashReportIfNew(sessionId: String, payload: String, log: LogRow) throws {
+    try database.transaction {
+      if try getCrashReport(sessionId: sessionId) != nil {
+        return
+      }
+      try setCrashReport(sessionId: sessionId, payload: payload)
+      if try getSession(id: sessionId) != nil {
+        try insert(log: log)
+      }
+    }
+  }
+
   @AppMetricsActor
   func getCrashReport(sessionId: String) throws -> String? {
     let statement = try database.prepare("SELECT payload FROM crash_reports WHERE sessionId = ?1")

--- a/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
+++ b/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
@@ -57,7 +57,8 @@ private func persistCrashReport(_ crashReport: CrashReport, sessionId: String) {
     return
   }
   do {
-    try AppMetrics.database?.setCrashReport(sessionId: sessionId, payload: payload)
+    let log = LogRow.from(log: crashReport.toLogRecord(), sessionId: sessionId)
+    try AppMetrics.database?.storeCrashReportIfNew(sessionId: sessionId, payload: payload, log: log)
   } catch {
     logger.warn("[AppMetrics] Failed to persist crash report for session \(sessionId): \(error.localizedDescription)")
   }

--- a/packages/expo-app-metrics/ios/Sessions/MainSession.swift
+++ b/packages/expo-app-metrics/ios/Sessions/MainSession.swift
@@ -33,21 +33,4 @@ public final class MainSession: Session, @unchecked Sendable {
   init(id: String, startDate: Date, endDate: Date?) {
     super.init(id: id, type: .main, startDate: startDate, endDate: endDate)
   }
-
-  // MARK: - Crash reports
-
-  /// Persists a crash report attributed to this session. Replaces any previously stored report for
-  /// this session id (only one crash per session is meaningful).
-  @AppMetricsActor
-  func storeCrashReport(_ crashReport: CrashReport) {
-    logger.warn("[AppMetrics] Received crash report:\n\(crashReport)")
-    guard let payload = encodeAsJSONString(crashReport) else {
-      return
-    }
-    do {
-      try AppMetrics.database?.setCrashReport(sessionId: self.id, payload: payload)
-    } catch {
-      logger.warn("[AppMetrics] Failed to persist crash report for session \(self.id): \(error.localizedDescription)")
-    }
-  }
 }

--- a/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
@@ -183,7 +183,7 @@ struct CrashReportTests {
       let log = report.toLogRecord()
       let attributes = try #require(log.attributes?.value as? [String: Any])
 
-      #expect(log.name == "exception")
+      #expect(log.name == "native.exception")
       #expect(log.severity == .fatal)
       #expect(log.timestamp == timestampEnd.ISO8601Format())
       #expect(attributes["exception.type"] as? String == "EXC_BAD_ACCESS")

--- a/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
@@ -163,6 +163,116 @@ struct CrashReportTests {
       #expect(report.findMatchingSession(in: []) == nil)
     }
   }
+
+  @Suite("toLogRecord")
+  struct ToLogRecordTests {
+    @Test
+    func `builds a fatal exception log for a Mach exception`() throws {
+      let timestampEnd = Date(timeIntervalSince1970: 1_699_999_000)
+      let ingestedAt = Date(timeIntervalSince1970: 1_700_000_000)
+      let report = makeCrashReport(
+        timestampBegin: timestampEnd.addingTimeInterval(-3600),
+        timestampEnd: timestampEnd,
+        ingestedAt: ingestedAt,
+        exceptionType: 1,
+        exceptionCode: 2,
+        signal: 11,
+        terminationReason: "Namespace SIGNAL, Code 11"
+      )
+
+      let log = report.toLogRecord()
+      let attributes = try #require(log.attributes?.value as? [String: Any])
+
+      #expect(log.name == "exception")
+      #expect(log.severity == .fatal)
+      #expect(log.timestamp == timestampEnd.ISO8601Format())
+      #expect(attributes["exception.type"] as? String == "EXC_BAD_ACCESS")
+      #expect(attributes["exception.message"] as? String == "Namespace SIGNAL, Code 11")
+      #expect(attributes["expo.error.source"] as? String == "nativeCrash")
+      #expect(attributes["expo.error.is_fatal"] as? Bool == true)
+      #expect(attributes["expo.crash.exception_type"] as? String == "EXC_BAD_ACCESS")
+      #expect(attributes["expo.crash.exception_type_code"] as? Int == 1)
+      #expect(attributes["expo.crash.exception_code"] as? Int == 2)
+      #expect(attributes["expo.crash.signal"] as? String == "SIGSEGV")
+      #expect(attributes["expo.crash.signal_number"] as? Int == 11)
+      #expect(attributes["expo.crash.termination_reason"] as? String == "Namespace SIGNAL, Code 11")
+    }
+
+    @Test
+    func `uses Objective-C exception details`() throws {
+      let report = makeCrashReport(
+        timestampBegin: Date.now,
+        timestampEnd: Date.now,
+        terminationReason: "Application Specific Information",
+        exceptionReason: CrashReport.ExceptionReason(
+          composedMessage: "-[NSNull length]: unrecognized selector",
+          formatString: "%@: unrecognized selector",
+          arguments: ["-[NSNull length]"],
+          exceptionType: "NSInvalidArgumentException",
+          className: "NSException",
+          exceptionName: "NSInvalidArgumentException"
+        )
+      )
+
+      let attributes = try #require(report.toLogRecord().attributes?.value as? [String: Any])
+      #expect(attributes["exception.type"] as? String == "NSInvalidArgumentException")
+      #expect(
+        attributes["exception.message"] as? String
+          == "Application Specific Information\n-[NSNull length]: unrecognized selector"
+      )
+      #expect(attributes["expo.crash.objc_exception_type"] as? String == "NSInvalidArgumentException")
+      #expect(
+        attributes["expo.crash.objc_exception_message"] as? String == "-[NSNull length]: unrecognized selector"
+      )
+    }
+
+    @Test
+    func `renders at most twenty-five attributed stack frames and reports the omitted count`() throws {
+      let attributedFrames = (0..<28).map { index in
+        CrashReport.CallStackTree.Frame(
+          binaryName: "TestApp",
+          binaryUUID: nil,
+          address: nil,
+          offsetIntoBinaryTextSegment: nil,
+          sampleCount: nil,
+          subFrames: nil,
+          symbol: "frame\(index)"
+        )
+      }
+      let unattributedFrame = CrashReport.CallStackTree.Frame(
+        binaryName: "TestApp",
+        binaryUUID: nil,
+        address: nil,
+        offsetIntoBinaryTextSegment: nil,
+        sampleCount: nil,
+        subFrames: nil,
+        symbol: "unattributed"
+      )
+      let report = makeCrashReport(
+        timestampBegin: Date.now,
+        timestampEnd: Date.now,
+        callStackTree: CrashReport.CallStackTree(callStacks: [
+          CrashReport.CallStackTree.CallStack(
+            threadAttributed: true,
+            callStackRootFrames: attributedFrames
+          ),
+          CrashReport.CallStackTree.CallStack(
+            threadAttributed: false,
+            callStackRootFrames: [unattributedFrame]
+          ),
+        ])
+      )
+
+      let attributes = try #require(report.toLogRecord().attributes?.value as? [String: Any])
+      let stacktrace = try #require(attributes["exception.stacktrace"] as? String)
+      let lines = stacktrace.split(separator: "\n")
+      #expect(lines.count == 26)
+      #expect(lines.first == "frame0")
+      #expect(lines[24] == "frame24")
+      #expect(lines.last == "… +3 more frames")
+      #expect(!stacktrace.contains("unattributed"))
+    }
+  }
 }
 
 private func makeMainSessionRow(id: String, startDate: Date, endDate: Date?) -> SessionRow {
@@ -175,18 +285,28 @@ private func makeMainSessionRow(id: String, startDate: Date, endDate: Date?) -> 
   )
 }
 
-private func makeCrashReport(timestampBegin: Date, timestampEnd: Date) -> CrashReport {
+private func makeCrashReport(
+  timestampBegin: Date,
+  timestampEnd: Date,
+  ingestedAt: Date = Date.now,
+  exceptionType: Int? = 1,
+  exceptionCode: Int? = 1,
+  signal: Int? = 11,
+  terminationReason: String? = nil,
+  exceptionReason: CrashReport.ExceptionReason? = nil,
+  callStackTree: CrashReport.CallStackTree? = nil
+) -> CrashReport {
   return CrashReport(
-    exceptionType: 1,
-    exceptionCode: 1,
-    signal: 11,
-    terminationReason: nil,
+    exceptionType: exceptionType,
+    exceptionCode: exceptionCode,
+    signal: signal,
+    terminationReason: terminationReason,
     virtualMemoryRegionInfo: nil,
-    exceptionReason: nil,
-    callStackTree: nil,
+    exceptionReason: exceptionReason,
+    callStackTree: callStackTree,
     appVersion: "1.0.0",
     timestampBegin: timestampBegin,
     timestampEnd: timestampEnd,
-    ingestedAt: Date.now
+    ingestedAt: ingestedAt
   )
 }

--- a/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsDatabaseTests.swift
@@ -549,6 +549,32 @@ struct MetricsDatabaseTests {
   }
 
   @Test
+  func `stores a crash report and log only once`() throws {
+    try withTemporaryDatabase { database in
+      try database.insert(session: makeSessionRow(id: "s"))
+      let log = makeLogRow(sessionId: "s", severity: "fatal", name: "exception")
+
+      try database.storeCrashReportIfNew(sessionId: "s", payload: "{\"v\":1}", log: log)
+      try database.storeCrashReportIfNew(sessionId: "s", payload: "{\"v\":2}", log: log)
+
+      #expect(try database.getCrashReport(sessionId: "s") == "{\"v\":1}")
+      #expect(try database.getLogs(sessionId: "s").map(\.name) == ["exception"])
+    }
+  }
+
+  @Test
+  func `stores the crash report without a log when the session does not exist`() throws {
+    try withTemporaryDatabase { database in
+      let log = makeLogRow(sessionId: "missing", severity: "fatal", name: "exception")
+
+      try database.storeCrashReportIfNew(sessionId: "missing", payload: "{}", log: log)
+
+      #expect(try database.getCrashReport(sessionId: "missing") == "{}")
+      #expect(try database.getLogs(sessionId: "missing").isEmpty)
+    }
+  }
+
+  @Test
   func `getCrashReport returns nil when there is no entry`() throws {
     try withTemporaryDatabase { database in
       try database.insert(session: makeSessionRow(id: "s"))


### PR DESCRIPTION
# Why

We are collecting crash reports locally, but we never dispatch them.

# How

Similar to JS errors dispatch crashes as logs. 

1. When crash is recorded add a new log for it
2. Trim stack trace to 50 frames, so that we don't make the log too big

The logs use following attributes:

* `event.name`: `"exception"`
* `session.id`: session associated with the crash
* `severity`: `"FATAL"`
* `exception.type`: native exception or signal name 
* `exception.message`: termination or exception reason
* `exception.stacktrace`: native call stack, when available
* `expo.error.source`: nativeCrash
* `expo.error.is_fatal`: true
* `expo.crash.signal`: signal name, such as SIGSEGV
* `expo.crash.signal_code`: numeric signal code
* `expo.crash.termination_reason`: OS-provided termination reason
* `expo.crash.exception_type`: iOS Mach exception name
* `expo.crash.exception_type_code`: iOS Mach exception type code
* `expo.crash.exception_code`: iOS processor-specific exception code
* `expo.crash.objc_exception_type`: Objective-C exception type
* `expo.crash.objc_exception_message`: Objective-C exception message

android example: 
```json
{
  "attributes": {
    "exception.message": "java.lang.ArithmeticException: divide by zero",
    "exception.stacktrace": "expo.modules.crashtester.CrashTriggers.throwFor(CrashTester.kt:76)\nexpo.modules.crashtester.CrashTriggers.trigger$lambda$0(CrashTester.kt:65)\nexpo.modules.crashtester.CrashTriggers$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)\nandroid.os.Handler.handleCallback(Handler.java:873)\nandroid.os.Handler.dispatchMessage(Handler.java:99)\nandroid.os.Looper.loop(Looper.java:193)\nandroid.app.ActivityThread.main(ActivityThread.java:6669)\njava.lang.reflect.Method.invoke(Native Method)\ncom.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)\ncom.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)",
    "exception.type": "java.lang.ArithmeticException",
    "expo.error.is_fatal": true,
    "expo.error.source": "nativeCrash"
  },
  "body": null,
  "name": "exception",
  "severity": "fatal",
  "timestamp": "2026-08-28T12:17:47.406Z"
}
```

# Test Plan

1. CI
2. Observe-tester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
