### PR TITLE
[widgets] Stub deep react-native imports in the widget bundle resolver

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve deep `react-native/*` imports as empty modules when bundling widget layouts, fixing every widget failing with "Could not create context for layout evaluation" after `@expo/ui` 57.0.14 introduced such an import. ([#49491](https://github.com/expo/expo/pull/49491) by [@usmsam](https://github.com/usmsam))
 - [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1. ([#49076](https://github.com/expo/expo/pull/49076) by [@brentvatne](https://github.com/brentvatne))
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))
 - [iOS] Fix `LiveActivityFactory.getInstances()` returning live activities that belong to other factories or that have already ended. ([#48489](https://github.com/expo/expo/pull/48489) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -40,6 +40,17 @@ const buildConfig = {
       if (fileSpecifierRe.test(moduleName)) {
         return context.resolveRequest(context, moduleName, platform);
       }
+      // Deep imports into React Native internals (e.g.
+      // 'react-native/Libraries/Components/TextInput/TextInputState' pulled in
+      // via the @expo/ui barrel) slip past the exact-match stubs below and drag
+      // the whole RN core, including InitializeCore, into the widget bundle.
+      // The bundle runs in a bare JS context without the native bridge, where
+      // requiring RN's NativeModules throws "__fbBatchedBridgeConfig is not
+      // set" and every widget renders the "Could not create context for layout
+      // evaluation" placeholder. Resolve such deep imports as empty modules.
+      if (moduleName.startsWith('react-native/')) {
+        return { type: 'empty' };
+      }
       switch (moduleName) {
         case 'expo':
           return { type: 'sourceFile', filePath: expoStubPath };

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -40,14 +40,6 @@ const buildConfig = {
       if (fileSpecifierRe.test(moduleName)) {
         return context.resolveRequest(context, moduleName, platform);
       }
-      // Deep imports into React Native internals (e.g.
-      // 'react-native/Libraries/Components/TextInput/TextInputState' pulled in
-      // via the @expo/ui barrel) slip past the exact-match stubs below and drag
-      // the whole RN core, including InitializeCore, into the widget bundle.
-      // The bundle runs in a bare JS context without the native bridge, where
-      // requiring RN's NativeModules throws "__fbBatchedBridgeConfig is not
-      // set" and every widget renders the "Could not create context for layout
-      // evaluation" placeholder. Resolve such deep imports as empty modules.
       if (moduleName.startsWith('react-native/')) {
         return { type: 'empty' };
       }


### PR DESCRIPTION
# Why

Fixes #49490.

Since `@expo/ui@57.0.14` (2026-08-26), every widget built with `expo-widgets` renders the red **"Could not create context for layout evaluation."** placeholder — including the unmodified `with-widgets` example. `@expo/ui@57.0.14` added `src/keyboard/textInputState.ts` with a deep import of `react-native/Libraries/Components/TextInput/TextInputState`. The stub resolver in `expo-widgets/metro.config.js` only intercepts the exact `'react-native'` specifier, so the deep import resolves to the real react-native and drags the RN core (incl. `InitializeCore`) into the widget bundle. In the extension's bare JS context, the first require of `Libraries/BatchedBridge/NativeModules.js` throws `Invariant Violation: __fbBatchedBridgeConfig is not set` at module-init time, so `WidgetsJSRuntime` fails to create the JS context.

Full analysis (import chain from the module graph, bisection over published tarballs, crash path) is in #49490.

# How

Resolve any `react-native/*` deep import as an empty module in `resolveRequest`, right before the exact-name stubs. This also hardens the widget bundler against any future deep imports into RN internals — none of them can work in a bridge-less JS context anyway.

Added a CHANGELOG entry under **Unpublished → Bug fixes**.

# Test plan

- Repro without a simulator, on an unmodified `npx create-expo-app --example with-widgets` (repro repo: https://github.com/usmsam/expo-widgets-context-error-repro):
  ```sh
  node node_modules/expo-widgets/scripts/build-bundle.mjs "$PWD"
  /System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc \
    node_modules/expo-widgets/bundle/build/ExpoWidgets.bundle
  ```
  Before: `Invariant Violation: __fbBatchedBridgeConfig is not set` (346 modules, 543 KB). After (this change applied to the installed package): bundle evaluates silently (104 modules, 147 KB). Control experiment confirmed causality in both directions.
- `__expoWidgetRender` exercised over a real app's layout: 12 widget states × `systemSmall`/`systemMedium`/`accessoryRectangular` × light/dark — 72/72 render to the expected view trees; widgets render on an iOS 26.5 simulator.
- Note: I could not run the monorepo toolchain (`et check-packages`) from a sparse clone; the change is config-only and mirrors the existing `react-native-worklets`/`react-native-reanimated` `{ type: 'empty' }` handling one switch-case below.

# Notes for reviewers

- On current `main` the crash reproduces the same way (verified against `main`'s `metro.config.js` — it has `getModulesRunBeforeMainModule: () => []` and the `createContext`/`useContext` stubs already, but not the deep-import handling; with the prelude removed the entry still crashes via `TextInputState → Platform.ios → NativePlatformConstantsIOS → TurboModuleRegistry`).
- An alternative/complementary fix is lazy-importing `TextInputState` inside `@expo/ui/src/keyboard` — but the resolver hardening protects the widget bundle from the whole class of deep-import regressions, so it seems worth having regardless.
- A related but separate issue observed while debugging (not addressed here): `bundle/index.ts` spreads `...ReactNative` after `...swiftUI` into `globalThis`, so the `Image` stub added on `main` shadows the `Image` component from `@expo/ui`, making `<Image systemName=... />` render as `{"resolveAssetSource":{}}`. Details in #49490.
