### PR TITLE
fix(metro-config): Keep side-effectful initializers of unused exports

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
 - Seal web worker chunks to prevent common chunk splitting from applying to them ([#49227](https://github.com/expo/expo/pull/49227) by [@kitten](https://github.com/kitten))
+- Keep side-effectful initializers when removing unused exports during tree shaking ([#49492](https://github.com/expo/expo/pull/49492) by [@hknakn](https://github.com/hknakn))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
@@ -198,6 +198,73 @@ export class Math {
   expect(artifacts[0].source).toMatch('gravity');
 });
 
+describe('unused exports with initializers', () => {
+  it(`preserves an initializer that has side effects`, async () => {
+    const [, artifacts] = await serializeShakingAsync({
+      'index.js': `
+import { getModes } from "./culori";
+console.log(getModes());
+            `,
+      // Registration-by-side-effect, as used by `culori`. `rgb` is never imported, but dropping its
+      // declaration would also drop the `useMode` call that populates `modes`.
+      'culori.js': `
+const modes = {};
+
+function useMode(mode) {
+	modes[mode.id] = mode;
+	return mode;
+}
+
+export const rgb = useMode({ id: 'rgb' });
+
+export function getModes() {
+	return modes;
+}
+`,
+    });
+
+    expect(artifacts[0].source).toMatch('useMode(');
+  });
+
+  it(`removes an initializer that is side-effect free`, async () => {
+    const [, artifacts] = await serializeShakingAsync({
+      'index.js': `
+import { gravity } from "./b";
+console.log(gravity);
+            `,
+      'b.js': `
+export const gravity = 7;
+export const unusedNumber = 42;
+export const unusedObject = { value: 1 };
+`,
+    });
+
+    expect(artifacts[0].source).toMatch('gravity');
+    expect(artifacts[0].source).not.toMatch('unusedNumber');
+    expect(artifacts[0].source).not.toMatch('unusedObject');
+  });
+
+  it(`removes an initializer that is annotated as pure`, async () => {
+    const [, artifacts] = await serializeShakingAsync({
+      'index.js': `
+import { gravity } from "./b";
+console.log(gravity);
+            `,
+      'b.js': `
+function createValue(value) {
+	return value;
+}
+
+export const gravity = 7;
+export const unusedValue = /*#__PURE__*/ createValue(42);
+`,
+    });
+
+    expect(artifacts[0].source).toMatch('gravity');
+    expect(artifacts[0].source).not.toMatch('unusedValue');
+  });
+});
+
 // TODO: We could possibly use a special transform to convert `import "./foo"` to something like `IMPORT_SIDE_EFFECT("./foo")` but we'd need to ensure the import order is preserved.
 describe('side-effecty imports', () => {
   // TODO: Fix this...

--- a/packages/@expo/metro-config/src/serializer/treeShakeSerializerPlugin.ts
+++ b/packages/@expo/metro-config/src/serializer/treeShakeSerializerPlugin.ts
@@ -157,6 +157,85 @@ function populateModuleWithImportUsage(value: Module<AdvancedMixedOutput>) {
   }
 }
 
+const PURE_ANNOTATION = /[@#]__PURE__/;
+
+function hasPureAnnotation(node: types.Node): boolean {
+  return node.leadingComments?.some((comment) => PURE_ANNOTATION.test(comment.value)) ?? false;
+}
+
+function hasDecorators(node: types.Node): boolean {
+  return 'decorators' in node && Array.isArray(node.decorators) && node.decorators.length > 0;
+}
+
+function canRemoveClass(node: types.Class): boolean {
+  if (hasDecorators(node) || (node.superClass && !canRemoveInitializer(node.superClass))) {
+    return false;
+  }
+  return node.body.body.every((member) => {
+    if (types.isStaticBlock(member) || hasDecorators(member)) {
+      return false;
+    }
+    if ('computed' in member && member.computed) {
+      return false;
+    }
+    if (types.isClassProperty(member) && member.static) {
+      return canRemoveInitializer(member.value);
+    }
+    return true;
+  });
+}
+
+/**
+ * Removing an unused export also removes its initializer, so it may only be dropped when
+ * evaluating that initializer cannot be observed. Rollup and webpack require an explicit
+ * `#__PURE__` annotation before dropping a call for the same reason -- e.g. `culori` registers
+ * its color spaces with `export const rgb = useMode(modeRgb)`.
+ */
+function canRemoveInitializer(node?: types.Node | null): boolean {
+  if (node == null || hasPureAnnotation(node)) {
+    return true;
+  }
+  if (types.isPureish(node) || types.isIdentifier(node)) {
+    return true;
+  }
+  if (types.isClass(node)) {
+    return canRemoveClass(node);
+  }
+  if (types.isTemplateLiteral(node)) {
+    return node.expressions.every((expression) => canRemoveInitializer(expression));
+  }
+  if (types.isArrayExpression(node)) {
+    return node.elements.every(
+      (element) => !types.isSpreadElement(element) && canRemoveInitializer(element)
+    );
+  }
+  if (types.isObjectExpression(node)) {
+    return node.properties.every(
+      (property) =>
+        types.isObjectProperty(property) &&
+        !property.computed &&
+        canRemoveInitializer(property.value)
+    );
+  }
+  if (types.isMemberExpression(node)) {
+    return !node.computed && canRemoveInitializer(node.object);
+  }
+  if (types.isUnaryExpression(node)) {
+    return node.operator !== 'delete' && canRemoveInitializer(node.argument);
+  }
+  if (types.isBinaryExpression(node) || types.isLogicalExpression(node)) {
+    return canRemoveInitializer(node.left) && canRemoveInitializer(node.right);
+  }
+  if (types.isConditionalExpression(node)) {
+    return (
+      canRemoveInitializer(node.test) &&
+      canRemoveInitializer(node.consequent) &&
+      canRemoveInitializer(node.alternate)
+    );
+  }
+  return false;
+}
+
 function markUnused(path: NodePath) {
   path.remove();
 }
@@ -566,7 +645,11 @@ export async function treeShakeSerializer(
       // Traverse exports and mark them as used or unused based on if inverse dependencies are importing them.
       traverse(ast, {
         ExportDefaultDeclaration(path) {
-          if (possibleUnusedExports.includes('default') && !isExportUsed('default')) {
+          if (
+            possibleUnusedExports.includes('default') &&
+            !isExportUsed('default') &&
+            canRemoveInitializer(path.node.declaration)
+          ) {
             // TODO: Update source maps
             markUnused(path);
           }
@@ -602,7 +685,11 @@ export async function treeShakeSerializer(
           if (types.isVariableDeclaration(declaration)) {
             declaration.declarations = declaration.declarations.filter((decl) => {
               if (decl.id.type === 'Identifier') {
-                if (possibleUnusedExports.includes(decl.id.name) && !isExportUsed(decl.id.name)) {
+                if (
+                  possibleUnusedExports.includes(decl.id.name) &&
+                  !isExportUsed(decl.id.name) &&
+                  canRemoveInitializer(decl.init)
+                ) {
                   // TODO: Update source maps
                   // Account for variables, and classes which may contain references to other exports.
                   shouldRecurseUnusedExports = true;


### PR DESCRIPTION
# Why

`treeShakeSerializerPlugin` deletes an unused `export const` without inspecting its initializer, so a side-effectful initializer is dropped along with the binding.

`culori` registers its color spaces exactly this way:

```js
// culori/src/index.js
export const rgb = useMode(modeRgb); // useMode() writes to a shared mode registry
```

Nothing imports `rgb`, so the declarator is removed, the registry stays empty, and a later `interpolate()` throws `TypeError: Cannot read property 'channels' of undefined`.

It reached our app through `uniwind` → `heroui-native`, which use culori to resolve `color-mix()` CSS variables. Every themed `<Button>` threw during render, the root error boundary unmounted the tree, and the splash screen was never hidden — so the app looked frozen rather than crashed, which made it hard to trace back to tree shaking.

Rollup and webpack only drop such an initializer when it carries a `#__PURE__` annotation; culori has none. No Babel plugin is involved — plain ESM in `node_modules` is enough to reproduce.

Same "side effect dropped by the shaker" family as #41620, though this PR does not fix that one.

# How

Adds `canRemoveInitializer()` and gates both removal branches (`export const …` and `export default …`) on it.

An unused export is still removed when its initializer is observably inert: literals, functions and arrows, identifiers, `#__PURE__`-annotated calls, and structurally pure object/array/member/unary/binary/conditional expressions. Anything else — most importantly a bare call — is kept.

Deliberately conservative: it can retain slightly more than strictly necessary, but it never drops an observable side effect.

# Test Plan

Three tests added to `tree-shaking.test.ts`:

- a side-effectful initializer is preserved (fails without this change)
- a side-effect-free initializer is still removed
- a `#__PURE__`-annotated initializer is still removed

`pnpm exec jest` in `packages/@expo/metro-config`:

| | Tests |
|---|---|
| `main` | 57 failed, 4 skipped, 1291 passed, 1352 total |
| this PR | 57 failed, 4 skipped, 1294 passed, 1355 total |

Identical failures on both — they come from `babel-preset-expo` not building in my checkout (a type-only `expo-splash-screen/plugin` import) and are unrelated to this change. The only delta is the 3 added tests.

Also verified against a real SDK 57 app, iOS release build on device, with `EXPO_UNSTABLE_TREE_SHAKING=1 EXPO_UNSTABLE_METRO_OPTIMIZE_GRAPH=1`: it now boots instead of hanging on the splash screen, and the bundle still shrinks (11.80 MB → 10.07 MB of Hermes bytecode).

# Checklist

- [x] I added a `changelog.md` entry
- [ ] Not applicable — no prebuild/module plugin changes
- [ ] Not applicable — no documentation changes

cc @kitten @EvanBacon
