### PR TITLE
fix(metro-config): Reconcile CSS modules that a transformer replaced with JS

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
 - Seal web worker chunks to prevent common chunk splitting from applying to them ([#49227](https://github.com/expo/expo/pull/49227) by [@kitten](https://github.com/kitten))
+- Reconcile CSS modules that a transformer replaced with JS instead of skipping them by file extension ([#49493](https://github.com/expo/expo/pull/49493) by [@hknakn](https://github.com/hknakn))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/reconcileTransformSerializerPlugin.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/reconcileTransformSerializerPlugin.test.ts
@@ -1,0 +1,37 @@
+import type { ExpoJsOutput } from '../jsOutput';
+import { shouldSkipReconcile } from '../reconcileTransformSerializerPlugin';
+
+function createOutput(data: Partial<ExpoJsOutput['data']> = {}): ExpoJsOutput {
+  return {
+    type: 'js/module',
+    data: { code: '', lineCount: 1, map: [], ...data },
+  } as ExpoJsOutput;
+}
+
+const reconcileSettings = { inlineRequires: false } as ExpoJsOutput['data']['reconcile'];
+
+it(`skips non-js modules`, () => {
+  expect(shouldSkipReconcile('/app/asset.png', { ...createOutput(), type: 'js/script' })).toBe(
+    true
+  );
+  expect(shouldSkipReconcile('/app/data.json', createOutput())).toBe(true);
+});
+
+it(`skips css modules emitted by the CSS pipeline`, () => {
+  // `transformShim` wraps these itself and attaches no reconcile settings.
+  expect(shouldSkipReconcile('/app/styles.css', createOutput())).toBe(true);
+  expect(shouldSkipReconcile('/app/styles.scss', createOutput())).toBe(true);
+  expect(shouldSkipReconcile('/app/styles.sass', createOutput())).toBe(true);
+});
+
+it(`reconciles css modules that a transformer replaced with JS`, () => {
+  expect(
+    shouldSkipReconcile('/app/global.css', createOutput({ reconcile: reconcileSettings }))
+  ).toBe(false);
+});
+
+it(`reconciles regular js modules`, () => {
+  expect(shouldSkipReconcile('/app/index.js', createOutput({ reconcile: reconcileSettings }))).toBe(
+    false
+  );
+});

--- a/packages/@expo/metro-config/src/serializer/reconcileTransformSerializerPlugin.ts
+++ b/packages/@expo/metro-config/src/serializer/reconcileTransformSerializerPlugin.ts
@@ -137,6 +137,21 @@ export function isEnvBoolean(graph: ReadOnlyGraph, name: string): boolean {
 }
 
 // This is the insane step which reconciles the second half of the transformation process but it does it uncached at the end of the bundling process when we have tree shaking completed.
+/**
+ * CSS modules emitted by Expo's own CSS pipeline are synthesized by `transformShim`, which already
+ * wraps them and attaches no reconcile settings, so they must not be transformed again.
+ *
+ * A third-party transformer may instead replace a `.css` file's contents with a regular JS module
+ * (e.g. `uniwind`). Those carry reconcile settings and are not wrapped yet, so skipping them by
+ * file extension alone leaves `require` unbound at the top level of the bundle.
+ */
+export function shouldSkipReconcile(path: string, outputItem: ExpoJsOutput): boolean {
+  if (outputItem.type !== 'js/module' || path.endsWith('.json')) {
+    return true;
+  }
+  return /\.(s?css|sass)$/.test(path) && outputItem.data.reconcile == null;
+}
+
 export async function reconcileTransformSerializerPlugin(
   entryPoint: string,
   preModules: readonly Module<MixedOutput>[],
@@ -167,11 +182,7 @@ export async function reconcileTransformSerializerPlugin(
     value: Module<MixedOutput>,
     outputItem: ExpoJsOutput
   ): Promise<ExpoJsOutput> {
-    if (
-      outputItem.type !== 'js/module' ||
-      value.path.endsWith('.json') ||
-      value.path.match(/\.(s?css|sass)$/)
-    ) {
+    if (shouldSkipReconcile(value.path, outputItem)) {
       return outputItem;
     }
 


### PR DESCRIPTION
# Why

`transformDependencyOutput` skips any module whose path ends in `.css`/`.scss`/`.sass` (added in #31304 to support Expo's CSS pipeline under tree shaking).

That check is by file extension only, but not every `.css` path is a CSS module. A transformer can replace a `.css` file's contents with a regular JS module — `uniwind` does exactly this on native, handing the file to the JS worker as `<path>.js`:

```js
// uniwind/src/bundler/adapters/metro/transformer.ts
const transform = await worker.transform(config, projectRoot, `${filePath}${isWeb ? '' : '.js'}`, data, options);
```

The module keeps its `.css` path in the graph, so reconcile is skipped — but reconcile is what wraps it via `JsFileWrapping.wrapModule`. The module is emitted unwrapped, and its `require` calls end up at the top level of the bundle, where `require` is not defined. With `EXPO_UNSTABLE_TREE_SHAKING=1` this crashes at startup.

Expo's own CSS modules are unaffected: they are synthesized by `transformShim`, which wraps them itself and attaches no reconcile settings.

# How

Extracts the condition into `shouldSkipReconcile()` and narrows the CSS case to modules that carry no reconcile settings:

```ts
return /\.(s?css|sass)$/.test(path) && outputItem.data.reconcile == null;
```

- CSS pipeline output (no reconcile settings, already wrapped) → still skipped, behaviour unchanged
- A `.css` path that was transformed into a real JS module (has reconcile settings, not wrapped) → now reconciled

Since `transformShim` never sets `reconcile`, this cannot change how #31304's CSS modules are handled.

# Test Plan

New `reconcileTransformSerializerPlugin.test.ts` covers non-JS modules, JSON, CSS-pipeline output, a `.css` module transformed to JS, and ordinary JS. Reverting the predicate to the extension-only check fails exactly one — `reconciles css modules that a transformer replaced with JS` — while the CSS-pipeline case stays green.

`pnpm exec jest` in `packages/@expo/metro-config`:

| | Tests |
|---|---|
| `main` | 57 failed, 4 skipped, 1291 passed, 1352 total |
| this PR | 57 failed, 4 skipped, 1295 passed, 1356 total |

Identical failures on both — they come from `babel-preset-expo` not building in my checkout (a type-only `expo-splash-screen/plugin` import), unrelated to this change.

Also verified on a real SDK 57 app (iOS release build on device, uniwind + tree shaking enabled): without this the bundle throws `Property 'require' doesn't exist` at startup; with it the app boots.

Found while enabling tree shaking alongside #49492 (independent fix, same feature flag).

# Checklist

- [x] I added a `changelog.md` entry
- [ ] Not applicable — no prebuild/module plugin changes
- [ ] Not applicable — no documentation changes

cc @kitten @EvanBacon
