### PR TITLE
[router] Layout routes don't receive query parameters when using `useLocalSearchParams()`

### DIFF
--- a/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
+++ b/packages/expo-router/src/hooks/__tests__/useLocalSearchParams.test.ios.tsx
@@ -59,6 +59,30 @@ describe(useLocalSearchParams, () => {
     expect(results2).toEqual([{ id: '3', fruit: 'apple' }]);
   });
 
+  it.only('returns route and query params from layouts and routes in the same render', () => {
+    let layoutParams;
+    let routeParams;
+
+    renderRouter(
+      {
+        'app/[id]/_layout': function Layout() {
+          layoutParams = useLocalSearchParams();
+          return <Slot />;
+        },
+        'app/[id]/index': function Route() {
+          routeParams = useLocalSearchParams();
+          return null;
+        },
+      },
+      {
+        initialUrl: '/app/123?query=hello',
+      }
+    );
+
+    expect(layoutParams).toEqual({ id: '123', query: 'hello' });
+    expect(routeParams).toEqual({ id: '123', query: 'hello' });
+  });
+
   it(`defaults abstract types`, () => {
     const params = renderHookOnce(() => useLocalSearchParams());
     expectTypeOf(params).toExtend<Record<string, string | string[] | undefined>>();


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
