### PR TITLE
Hold the application context in TaskService

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `TaskService` losing its `Context` (it held a `WeakReference` to the creating `ReactContext`), after which registering or unregistering a task threw a `NullPointerException` from `SharedPreferences.getAll()`. ([#PR](https://github.com/expo/expo/pull/PR) by [@retu2libc](https://github.com/retu2libc))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `TaskService` losing its `Context` (it held a `WeakReference` to the creating `ReactContext`), after which registering or unregistering a task threw a `NullPointerException` from `SharedPreferences.getAll()`. ([#PR](https://github.com/expo/expo/pull/PR) by [@retu2libc](https://github.com/retu2libc))
+- [Android] Fix `TaskService` losing its `Context` (it held a `WeakReference` to the creating `ReactContext`), after which registering or unregistering a task threw a `NullPointerException` from `SharedPreferences.getAll()`. ([#49498](https://github.com/expo/expo/pull/49498) by [@retu2libc](https://github.com/retu2libc))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -82,7 +82,7 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
 
   public TaskService(Context context) {
     super();
-    mContextRef = new WeakReference<>(context);
+    mContextRef = new WeakReference<>(context.getApplicationContext());
     mTasksAndEventsRepository = TasksAndEventsRepository.create(context);
 
     if (!mTasksAndEventsRepository.tasksExist()) {


### PR DESCRIPTION
# Why

`TaskService` is a process-wide static (created once by `TaskManagerPackage.getTaskServiceImpl`) but only held a `WeakReference` to whatever `Context` first constructed it (`ReactContext`). Once that context is collected, `getSharedPreferences()` returns `null` and every task registration/unregistration throws:

See #48936 and #49495.

# Repro

Hold the application context instead of the constructing context. It lives as long as the process so the `WeakReference` never clears.