### PR TITLE
[ios][expo-modules-core][expo] Survive a null URLSessionTask instead of aborting on launch

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [iOS] Measure hosted React Native views where SwiftUI placed them, instead of at their Yoga box. ([#48969](https://github.com/expo/expo/pull/48969) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Measure hosted React Native views where Jetpack Compose placed them, instead of at their Yoga box. ([#48970](https://github.com/expo/expo/pull/48970) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Bump the Gradle plugin's Kotlin version to 2.2.21. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fixed an abort during app launch when `URLSession` returns a task whose Objective-C pointer is null: `URLSessionSessionDelegateProxy` bridged it into an `AnyHashable` key and trapped. ([#49499](https://github.com/expo/expo/pull/49499) by [@spsaucier](https://github.com/spsaucier))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
+++ b/packages/expo-modules-core/ios/DevTools/URLSessionSessionDelegateProxy.swift
@@ -12,19 +12,36 @@ public final class URLSessionSessionDelegateProxy: NSObject, URLSessionDataDeleg
     super.init()
   }
 
+  /**
+   `URLSession`'s `nonnull`-audited factories can still return a null task, and bridging one into
+   an `AnyHashable` key aborts. Only a raw-pointer compare survives optimization.
+   */
+  private static func isNonNull(_ task: URLSessionTask) -> Bool {
+    return unsafeBitCast(task, to: UnsafeRawPointer?.self) != nil
+  }
+
   public func addDelegate(task: URLSessionTask, delegate: URLSessionDataDelegate) {
+    guard Self.isNonNull(task) else {
+      return
+    }
     self.dispatchQueue.async {
       self.delegateMap[task] = delegate
     }
   }
 
   public func removeDelegate(task: URLSessionTask) {
+    guard Self.isNonNull(task) else {
+      return
+    }
     self.dispatchQueue.async {
       self.delegateMap.removeValue(forKey: task)
     }
   }
 
   public func getDelegate(task: URLSessionTask) -> URLSessionDataDelegate? {
+    guard Self.isNonNull(task) else {
+      return nil
+    }
     return self.dispatchQueue.sync {
       return self.delegateMap[task]
     }

--- a/packages/expo-modules-core/ios/Tests/URLSessionSessionDelegateProxyTests.swift
+++ b/packages/expo-modules-core/ios/Tests/URLSessionSessionDelegateProxyTests.swift
@@ -1,0 +1,71 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import Testing
+
+@testable import ExpoModulesCore
+
+private final class MockSessionDataDelegate: NSObject, URLSessionDataDelegate {
+  let tag: String
+
+  init(tag: String) {
+    self.tag = tag
+    super.init()
+  }
+}
+
+@Suite("URLSessionSessionDelegateProxy")
+struct URLSessionSessionDelegateProxyTests {
+  private let session = URLSession(configuration: .default)
+  private let request = URLRequest(url: URL(string: "https://expo.dev/")!)
+  private let proxy = URLSessionSessionDelegateProxy(
+    dispatchQueue: DispatchQueue(label: "expo.test.URLSessionSessionDelegateProxy")
+  )
+
+  /// A null Objective-C pointer inside a non-optional task, as a `nonnull`-audited factory can return.
+  private func nullTask() -> URLSessionDataTask {
+    let nullPointer: UnsafeRawPointer? = nil
+    return unsafeBitCast(nullPointer, to: URLSessionDataTask.self)
+  }
+
+  @Test("resolves each task to its own delegate")
+  func resolvesDelegatePerTask() async throws {
+    let first = session.dataTask(with: request)
+    let second = session.dataTask(with: request)
+    let firstDelegate = MockSessionDataDelegate(tag: "first")
+    let secondDelegate = MockSessionDataDelegate(tag: "second")
+
+    proxy.addDelegate(task: first, delegate: firstDelegate)
+    proxy.addDelegate(task: second, delegate: secondDelegate)
+
+    #expect((proxy.getDelegate(task: first) as? MockSessionDataDelegate)?.tag == "first")
+    #expect((proxy.getDelegate(task: second) as? MockSessionDataDelegate)?.tag == "second")
+
+    proxy.removeDelegate(task: first)
+
+    #expect(proxy.getDelegate(task: first) == nil)
+    #expect((proxy.getDelegate(task: second) as? MockSessionDataDelegate)?.tag == "second")
+
+    proxy.removeDelegate(task: second)
+  }
+
+  @Test("returns nil for a task that was never registered")
+  func returnsNilForUnknownTask() async throws {
+    #expect(proxy.getDelegate(task: session.dataTask(with: request)) == nil)
+  }
+
+  @Test("ignores a task whose Objective-C pointer is null instead of aborting")
+  func ignoresNullTask() async throws {
+    let task = nullTask()
+
+    proxy.addDelegate(task: task, delegate: MockSessionDataDelegate(tag: "null"))
+    #expect(proxy.getDelegate(task: task) == nil)
+
+    proxy.removeDelegate(task: task)
+    #expect(proxy.getDelegate(task: task) == nil)
+
+    let real = session.dataTask(with: request)
+    proxy.addDelegate(task: real, delegate: MockSessionDataDelegate(tag: "real"))
+    #expect((proxy.getDelegate(task: real) as? MockSessionDataDelegate)?.tag == "real")
+    proxy.removeDelegate(task: real)
+  }
+}

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix `import.meta.url` being `null` on web when `transform.inlineRequires` is enabled. ([#49045](https://github.com/expo/expo/pull/49045) by [@expo-bot](https://github.com/expo-bot))
 - Fix platform resolution of the `expo/dom` and `expo/dom/internal` subpath exports ([#49056](https://github.com/expo/expo/pull/49056) by [@hassankhan](https://github.com/hassankhan))
 - [iOS] Remove a duplicated `ExpoModulesCore-Swift.h` import block in `ExpoReactNativeFactory.mm` whose `#else` branch imported the header unconditionally, breaking builds where neither form is on the header search path. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fixed `expo/fetch` registering a null `URLSessionDataTask`, which aborted the app on launch and left the promise pending; the request now rejects instead. ([#49499](https://github.com/expo/expo/pull/49499) by [@spsaucier](https://github.com/spsaucier))
 
 ### 💡 Others
 

--- a/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
+++ b/packages/expo/ios/Fetch/ExpoURLSessionTask.swift
@@ -39,6 +39,12 @@ internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSe
     request.httpBody = requestBody
 
     let task = urlSession.dataTask(with: request as URLRequest)
+    // A null task would abort in the delegate proxy and leave this promise pending forever.
+    // The raw-pointer compare is deliberate: an `Optional` test is folded away when optimized.
+    guard unsafeBitCast(task, to: UnsafeRawPointer?.self) != nil else {
+      self.delegate.urlSessionDidFailToStart(self, error: FetchTaskUnavailableException())
+      return
+    }
     urlSessionDelegate.addDelegate(task: task, delegate: self)
     self.task = task
     task.resume()
@@ -90,6 +96,7 @@ internal final class ExpoURLSessionTask: NSObject, URLSessionTaskDelegate, URLSe
 
 internal protocol ExpoURLSessionTaskDelegate: AnyObject, Sendable {
   func urlSessionDidStart(_ session: ExpoURLSessionTask)
+  func urlSessionDidFailToStart(_ session: ExpoURLSessionTask, error: Error)
   func urlSession(_ session: ExpoURLSessionTask, didReceive response: URLResponse)
   func urlSession(_ session: ExpoURLSessionTask, didReceive data: Data)
   func urlSession(

--- a/packages/expo/ios/Fetch/FetchExceptions.swift
+++ b/packages/expo/ios/Fetch/FetchExceptions.swift
@@ -8,6 +8,12 @@ internal final class FetchUnknownException: Exception {
   }
 }
 
+internal final class FetchTaskUnavailableException: Exception {
+  override var reason: String {
+    "Unable to create a network task for this request"
+  }
+}
+
 internal final class FetchRequestCanceledException: Exception {
   override var reason: String {
     "Fetch request has been canceled"

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -59,6 +59,12 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
     state = .bodyStreamingCanceled
   }
 
+  func urlSessionDidFailToStart(_ session: ExpoURLSessionTask, error: Error) {
+    self.error = error
+    state = .errorReceived
+    emit(event: "readyForJSFinalization")
+  }
+
   func emitRequestCanceled() {
     let error = FetchRequestCanceledException()
     self.error = error


### PR DESCRIPTION
# Why

`URLSession`'s task factories are `nonnull`-audited in Objective-C, so Swift imports them as returning a non-optional task — but they can still hand back a null pointer. Swift keeps that null inside the non-optional value, so nothing fails at the call site. The app aborts later, on the first cast that actually inspects the object, which is the `AnyHashable` key conversion in `URLSessionSessionDelegateProxy.addDelegate`:

```
Found a null pointer in a value of type 'NSURLSessionTask'.
Non-Optional values are not allowed to hold null pointers.
(Detected while casting to 'Swift._HasCustomAnyHashableRepresentation')
abort() called
```

Because the insert is queued (`dispatchQueue.async`), the trap surfaces as `closure #1 in URLSessionSessionDelegateProxy.addDelegate` under `_dispatch_call_block_and_release`, detached from whoever created the task. Both in-tree callers register tasks unguarded: `ExpoURLSessionTask.start` (`expo/fetch`, compiled into release apps) and `ExpoRequestInterceptorProtocol.init`. The `init` caller has nothing it can reject, so the proxy itself needs to tolerate the null.

On our fleet this is the #1 fatal on the two most recent iOS builds — 221 events over 2026-08-20..27, ~1.5–2.2 per 100 daily-active iOS users, 91–100% of them inside the first second of the session. #49482 is an independent report of the same frame and the same message; it was auto-closed for lacking a minimal reproducible example, which this PR provides.

Two things worth flagging, because they shaped the fix:

- **We cannot make Foundation return a null task on demand, and this PR does not claim a trigger.** #49482 proposes session invalidation. That does not hold: `-dataTaskWithRequest:` after `invalidateAndCancel()` or `finishTasksAndInvalidate()` **throws** `NSGenericException: Task created in a session that has been invalidated` — verified both sequentially and with creation raced against invalidation across 8 concurrent queues. A thrown `NSException` is a different crash signature, so invalidation cannot be producing these reports. Requests with a nil `URL`, `gopher://`/`data:` schemes, and `background`/`ephemeral` configurations all return real tasks too. Remaining candidates we can't test locally are allocation failure under memory pressure and OS-specific CFNetwork behaviour (our cohort skews iOS 26.x).
- **The null is survivable.** Today's code converts it into an unconditional abort during launch, which is the part worth fixing regardless of where the null comes from.

# How

- `URLSessionSessionDelegateProxy` drops null tasks in `addDelegate`, `removeDelegate` and `getDelegate`. The map type and every existing behaviour are unchanged.
- `ExpoURLSessionTask.start` fails the request instead of registering a null task. Without this, the crash fix alone would leave the `fetch()` promise pending forever, since a null task never resumes and never calls back. The failure travels through a new `urlSessionDidFailToStart` on the existing `ExpoURLSessionTaskDelegate`; `NativeResponse` moves to `.errorReceived`, which the `waitFor` in `ExpoFetchModule` already turns into a promise rejection.
- New swift-testing suite for the proxy, including the null-task case.

**On the shape of the guard:** it compares the raw pointer (`unsafeBitCast(task, to: UnsafeRawPointer?.self) != nil`) rather than wrapping the task in an `Optional` and testing for `nil`. The `Optional` form — the fix suggested in #49482 — is not reliable: the compiler is entitled to assume a non-optional class reference is never null and folds the check away. In the harness below that variant failed to detect the null at `-Onone`, `-O` **and** `-Osize`. Storing a null in a `struct` or dictionary is similarly unreliable (insertion silently succeeded at `-O`, silently did nothing at `-Onone`), which is why the guards reject rather than store.

The two halves are separable if you'd prefer them as separate PRs — `expo-modules-core` stops the crash, `expo` stops the hang.

# Test Plan

Added `packages/expo-modules-core/ios/Tests/URLSessionSessionDelegateProxyTests.swift`: per-task delegate routing, isolated removal, unknown-task lookup, and a null task that must not abort. The null-task case aborts the test run without this patch. I have not been able to execute your test target locally (no full checkout/pod install), so please treat CI as the source of truth on that file.

Standalone harness that embeds the two code shapes verbatim, so it needs no Expo checkout. Before — current `addDelegate` body, given a null task:

```
$ xcrun -sdk macosx swiftc -O current.swift -o current && ./current
about to addDelegate with a null task
Found a null pointer in a value of type 'NSURLSessionTask' (0x1fb3f74f8). Non-Optional values are not
allowed to hold null pointers. (Detected while casting to 'Swift._HasCustomAnyHashableRepresentation')
Abort trap: 6                    # exit 134
```

After — the guards in this PR, plus 11 behavioural assertions (null task ignored, per-task routing preserved, isolated removal, unknown-task lookup nil, fetch-side rejection, real task still starts):

```
$ for opt in -Onone -O -Osize; do xcrun -sdk macosx swiftc $opt patched.swift -o p && ./p; done
   -Onone  -> ALL CHECKS PASSED
   -O      -> ALL CHECKS PASSED
   -Osize  -> ALL CHECKS PASSED
```

And the invalidation probe referenced above:

```
$ ./invalidated-session
threw NSGenericException: Task created in a session that has been invalidated
```

Environment: macOS 26.2, Xcode 26, Swift 6.2.4. Happy to attach the harness files or fold them into the PR if you'd like them in-tree.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no plugin or config surface touched)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
