### PR TITLE
[expo-modules-core][expo] Fix expo-modules-core Platform.h UIApplication alias guard on macOS

### DIFF
--- a/packages/expo-modules-core/ios/Platform/Platform.h
+++ b/packages/expo-modules-core/ios/Platform/Platform.h
@@ -18,7 +18,12 @@
 @compatibility_alias UIImage NSImage;
 @compatibility_alias UIImageView NSImageView;
 
-#ifndef UIApplication
+// `@compatibility_alias` doesn't define a preprocessor macro, so `#ifndef
+// UIApplication` never detected that `React/RCTUIKit.h` (imported above)
+// already declares this same alias. Under Swift Explicit Modules, that
+// duplicate declaration becomes a real Clang conflict. Guard on the
+// header's presence instead.
+#if !__has_include(<React/RCTUIKit.h>)
 @compatibility_alias UIApplication NSApplication;
 #endif
 


### PR DESCRIPTION
Fixes the root cause reported in #49500.

### Problem

`Platform.h` and `React/RCTUIKit.h` both declare `@compatibility_alias UIApplication NSApplication;` on macOS. Under Xcode's Swift Explicit Modules build, Clang pulls both modules into the same precompiled-module build and reports:

```
conflicting types for alias 'UIApplication'
```

### Root cause

The existing guard is:

```objc
#ifndef UIApplication
@compatibility_alias UIApplication NSApplication;
#endif
```

`@compatibility_alias` does not define a preprocessor macro, so `#ifndef UIApplication` never detects `RCTUIKitCompat.h`'s alias. The guard silently does nothing.

### Fix

Guard on the header's actual presence instead:

```objc
#if !__has_include(<React/RCTUIKit.h>)
@compatibility_alias UIApplication NSApplication;
#endif
```

We've carried this as a local `patch-package` patch for a few months and confirmed it resolves the build cleanly (see #49500 for the version matrix checked — still unfixed through 57.0.14 and the 58.0.0 canary).