### PR TITLE
[ios][updates] Reuse existing asset rows on key conflict instead of replacing them

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [iOS] Report a specific launch asset not found error when a launchable update has no linked launch asset, instead of failing silently or, for an update with no assets at all, hanging on the splash screen. ([#49459](https://github.com/expo/expo/pull/49459) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Preserve the cached update's launch failure as the emergency launch reason when the remote check finds no new update, instead of replacing it with the generic AppLoaderTask error. ([#49460](https://github.com/expo/expo/pull/49460) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Skip and repair updates that are missing their launch asset instead of selecting them for launch, which previously failed every cold start with "Launch asset not found for update". ([#49470](https://github.com/expo/expo/pull/49470) by [@alanjhughes](https://github.com/alanjhughes), based on [#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
+- [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/Database/UpdatesDatabase.swift
@@ -168,10 +168,16 @@ public final class UpdatesDatabase: NSObject {
 
   private func addNewAssetsInternal(_ assets: [UpdateAsset], toUpdateWithId updateId: UUID) throws {
     let assetInsertSql = """
-      INSERT OR REPLACE INTO "assets" ("key", "url", "headers", "extra_request_headers", "type", "metadata", "download_time", "relative_path", "hash", "hash_type", "expected_hash", "marked_for_deletion")
+      INSERT INTO "assets" ("key", "url", "headers", "extra_request_headers", "type", "metadata", "download_time", "relative_path", "hash", "hash_type", "expected_hash", "marked_for_deletion")
       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 0);
     """
     for asset in assets {
+      // A row with this key may have appeared since the caller classified the asset as new.
+      // Adopt it: replacing it would cascade-delete every update that references it.
+      if try addExistingAsset(asset, toUpdateWithId: updateId) {
+        continue
+      }
+
       _ = try execute(
         sql: assetInsertSql,
         withArgs: [

--- a/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/UpdatesDatabaseTests.swift
@@ -459,6 +459,157 @@ class UpdatesDatabaseTests {
     }
   }
 
+  @Suite("asset key conflicts", .serialized)
+  struct AssetKeyConflictTests {
+    var testDatabaseDir: URL
+    var db: UpdatesDatabase
+    var config: UpdatesConfig
+
+    init() throws {
+      let applicationSupportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).last
+      testDatabaseDir = applicationSupportDir!.appendingPathComponent("AssetKeyConflictTests")
+
+      try? FileManager.default.removeItem(atPath: testDatabaseDir.path)
+
+      if !FileManager.default.fileExists(atPath: testDatabaseDir.path) {
+        try FileManager.default.createDirectory(atPath: testDatabaseDir.path, withIntermediateDirectories: true)
+      }
+
+      db = UpdatesDatabase()
+
+      config = try UpdatesConfig.config(fromDictionary: [
+        UpdatesConfig.EXUpdatesConfigUpdateUrlKey: "https://exp.host/@test/test",
+        UpdatesConfig.EXUpdatesConfigRuntimeVersionKey: "1",
+      ])
+
+      db.databaseQueue.sync {
+        try! db.openDatabase(inDirectory: testDatabaseDir, logger: UpdatesLogger())
+      }
+    }
+
+    private func makeUpdate(id: String, createdAt: String) -> Update {
+      let manifest = ExpoUpdatesManifest(rawManifestJSON: [
+        "runtimeVersion": "1",
+        "id": id,
+        "createdAt": createdAt,
+        "launchAsset": ["url": "https://url.to/bundle.js", "contentType": "application/javascript"]
+      ])
+      return ExpoUpdatesUpdate.update(
+        withExpoUpdatesManifest: manifest,
+        extensions: [:],
+        config: config,
+        database: db
+      )
+    }
+
+    private func makeAsset(key: String, isLaunchAsset: Bool = false) -> UpdateAsset {
+      let asset = UpdateAsset(key: key, type: "js")
+      asset.downloadTime = Date()
+      asset.contentHash = key
+      asset.filename = "\(key).js"
+      asset.isLaunchAsset = isLaunchAsset
+      return asset
+    }
+
+    private func joinRowCount(forUpdateId updateId: UUID) -> Int {
+      db.databaseQueue.sync {
+        try! db.execute(sql: "SELECT asset_id FROM updates_assets WHERE update_id = ?1;", withArgs: [updateId]).count
+      }
+    }
+
+    private func assetRowCount(forKey key: String) -> Int {
+      db.databaseQueue.sync {
+        try! db.execute(sql: "SELECT id FROM assets WHERE \"key\" = ?1;", withArgs: [key]).count
+      }
+    }
+
+    private func assetId(forKey key: String) -> NSNumber? {
+      db.databaseQueue.sync {
+        let rows = try! db.execute(sql: "SELECT id FROM assets WHERE \"key\" = ?1;", withArgs: [key])
+        guard let row = rows.first else {
+          return nil
+        }
+        let id: NSNumber = row.requiredValue(forKey: "id")
+        return id
+      }
+    }
+
+    private func launchAssetId(forUpdateId updateId: UUID) -> NSNumber? {
+      db.databaseQueue.sync {
+        let rows = try! db.execute(sql: "SELECT launch_asset_id FROM updates WHERE id = ?1;", withArgs: [updateId])
+        guard let row = rows.first else {
+          return nil
+        }
+        let launchAssetId: NSNumber? = row.optionalValue(forKey: "launch_asset_id")
+        return launchAssetId
+      }
+    }
+
+    @Test
+    func `adopts the existing asset row instead of cascade-deleting its update`() throws {
+      let update1 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f1a0", createdAt: "2020-11-11T00:18:00.797Z")
+      let update2 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f1a1", createdAt: "2020-11-11T00:18:01.797Z")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update1, config: config)
+        try! db.finishUpdateRegistration(
+          update1,
+          newAssets: [makeAsset(key: "shared-bundle", isLaunchAsset: true)],
+          existingAssets: [],
+          markFinished: true
+        )
+
+        // a second update registers the same key as a new asset, as happens when
+        // two loaders classify it before either has inserted it
+        try! db.addUpdate(update2, config: config)
+        try! db.addNewAssets([makeAsset(key: "shared-bundle", isLaunchAsset: true)], toUpdateWithId: update2.updateId)
+      }
+
+      db.databaseQueue.sync {
+        let survivor = try! db.update(withId: update1.updateId, config: config)
+        #expect(survivor != nil)
+        #expect(survivor?.status == .StatusReady)
+      }
+      #expect(assetRowCount(forKey: "shared-bundle") == 1)
+      #expect(joinRowCount(forUpdateId: update1.updateId) == 1)
+      #expect(joinRowCount(forUpdateId: update2.updateId) == 1)
+
+      // both updates must launch from the one surviving asset row
+      let sharedAssetId = assetId(forKey: "shared-bundle")
+      #expect(sharedAssetId != nil)
+      #expect(launchAssetId(forUpdateId: update1.updateId) == sharedAssetId)
+      #expect(launchAssetId(forUpdateId: update2.updateId) == sharedAssetId)
+    }
+
+    @Test
+    func `keeps other updates linked to the conflicting asset`() throws {
+      let update1 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f1a2", createdAt: "2020-11-11T00:18:02.797Z")
+      let update2 = makeUpdate(id: "0eef8214-4833-4089-9dff-b4138a14f1a3", createdAt: "2020-11-11T00:18:03.797Z")
+
+      db.databaseQueue.sync {
+        try! db.addUpdate(update1, config: config)
+        try! db.finishUpdateRegistration(
+          update1,
+          newAssets: [makeAsset(key: "bundle-1", isLaunchAsset: true), makeAsset(key: "shared-image")],
+          existingAssets: [],
+          markFinished: true
+        )
+
+        try! db.addUpdate(update2, config: config)
+        try! db.addNewAssets([makeAsset(key: "shared-image")], toUpdateWithId: update2.updateId)
+      }
+
+      // update1 must keep both of its asset links and its launch asset
+      #expect(joinRowCount(forUpdateId: update1.updateId) == 2)
+      #expect(assetRowCount(forKey: "shared-image") == 1)
+      #expect(joinRowCount(forUpdateId: update2.updateId) == 1)
+      #expect(launchAssetId(forUpdateId: update1.updateId) == assetId(forKey: "bundle-1"))
+
+      // adopting a non-launch asset must not set the new update's launch asset
+      #expect(launchAssetId(forUpdateId: update2.updateId) == nil)
+    }
+  }
+
   // MARK: - setExtraClientParams
 
   @Suite("setExtraClientParams", .serialized)


### PR DESCRIPTION
# Why
Follow up from the review of #49458 

assets.key is unique, and addNewAssets inserted with INSERT OR REPLACE. On a key conflict, the REPLACE deletes the existing row before inserting, and we run with foreign keys enforced, so the delete cascades. Any update using that asset as its launch asset is deleted through updates.launch_asset_id ON DELETE CASCADE, and every other update sharing the asset loses its updates_assets rows. One registration can silently erase or gut updates it has nothing to do with.

# How
When registering a new asset whose key already exists, adopt the existing row instead of replacing it. addNewAssetsInternal now calls the existing addExistingAsset first, which links the join row and sets launch_asset_id when flagged, and only falls through to the insert when the key is absent. The check runs inside the registration transaction, so it cannot race. The insert itself drops OR REPLACE, so any conflict that could still occur aborts the transaction rather than deleting rows.

# Test Plan
New tests in UpdatesDatabaseTests

