### PR TITLE
[android][updates] Reuse existing asset rows on key conflict instead of replacing them

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [iOS] Preserve the cached update's launch failure as the emergency launch reason when the remote check finds no new update, instead of replacing it with the generic AppLoaderTask error. ([#49460](https://github.com/expo/expo/pull/49460) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Skip and repair updates that are missing their launch asset instead of selecting them for launch, which previously failed every cold start with "Launch asset not found for update". ([#49470](https://github.com/expo/expo/pull/49470) by [@alanjhughes](https://github.com/alanjhughes), based on [#48733](https://github.com/expo/expo/pull/48733) by [@martintreurnicht](https://github.com/martintreurnicht))
 - [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49505](https://github.com/expo/expo/pull/49505) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
+++ b/packages/expo-updates/android/src/androidTest/java/expo/modules/updates/db/UpdatesDatabaseTest.kt
@@ -184,4 +184,50 @@ class UpdatesDatabaseTest {
     Assert.assertNotNull(assetDao.loadAssetWithKey("asset2"))
     Assert.assertNotNull(assetDao.loadAssetWithKey("asset3"))
   }
+
+  @Test
+  fun testInsertAssets_KeyConflict_AdoptsExistingAssetRow() {
+    val update1 = insertedUpdate(Date(1000))
+    assetDao.insertAssets(listOf(asset("shared-bundle", isLaunchAsset = true)), update1)
+    updateDao.markUpdateFinished(update1)
+
+    // a second update registers the same key as a new asset, as happens when
+    // two loaders classify it before either has inserted it
+    val update2 = insertedUpdate(Date(2000))
+    assetDao.insertAssets(listOf(asset("shared-bundle", isLaunchAsset = true)), update2)
+
+    Assert.assertNotNull(updateDao.loadUpdateWithId(update1.id))
+    Assert.assertNotNull(updateDao.loadLaunchAssetForUpdate(update1.id))
+    Assert.assertNotNull(updateDao.loadLaunchAssetForUpdate(update2.id))
+    Assert.assertEquals(1, assetDao.loadAllAssets().size)
+  }
+
+  @Test
+  fun testInsertAssets_KeyConflict_KeepsOtherUpdatesLinked() {
+    val update1 = insertedUpdate(Date(1000))
+    assetDao.insertAssets(listOf(asset("bundle-1", isLaunchAsset = true), asset("shared-image")), update1)
+    updateDao.markUpdateFinished(update1)
+
+    val update2 = insertedUpdate(Date(2000))
+    assetDao.insertAssets(listOf(asset("shared-image")), update2)
+
+    Assert.assertEquals(2, assetDao.loadAssetsForUpdate(update1.id).size)
+    Assert.assertEquals(1, assetDao.loadAssetsForUpdate(update2.id).size)
+    Assert.assertEquals(2, assetDao.loadAllAssets().size)
+  }
+
+  private fun insertedUpdate(commitTime: Date) = UpdateEntity(
+    UUID.randomUUID(),
+    commitTime,
+    "1.0",
+    "https://exp.host/@esamelson/test-project",
+    JSONObject("{}"),
+    null,
+    null
+  ).also { updateDao.insertUpdate(it) }
+
+  private fun asset(key: String, isLaunchAsset: Boolean = false) = AssetEntity(key, "js").apply {
+    relativePath = "$key.js"
+    this.isLaunchAsset = isLaunchAsset
+  }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/db/dao/AssetDao.kt
@@ -13,7 +13,7 @@ import java.util.*
  */
 @Dao
 abstract class AssetDao {
-  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  @Insert
   protected abstract fun insertAssetInternal(asset: AssetEntity): Long
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -80,6 +80,11 @@ abstract class AssetDao {
   @Transaction
   open fun insertAssets(assets: List<AssetEntity>, update: UpdateEntity) {
     for (asset in assets) {
+      // A row with this key may have appeared since the caller classified the asset as new.
+      // Adopt it: replacing it would cascade-delete every update that references it.
+      if (addExistingAssetToUpdate(update, asset, asset.isLaunchAsset)) {
+        continue
+      }
       val assetId = insertAssetInternal(asset)
       insertUpdateAssetInternal(UpdateAssetEntity(update.id, assetId))
       if (asset.isLaunchAsset) {


### PR DESCRIPTION
# Why
Same issue as the pr below but for android

# How
insertAssets already runs as a @Transaction, so it now calls the existing addExistingAssetToUpdate first, which adopts the row, links it, and sets the launch asset when flagged

# Test Plan
New tests in UpdatesDatabaseTest
