### PR TITLE
[widgets] Add createContext/useContext to the widget bundle React stub

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add `createContext`/`useContext` to the widget bundle React stub, so widget layouts using `@expo/ui` stop failing with `createContext is not a function`. ([#49507](https://github.com/expo/expo/pull/49507) by [@usmsam](https://github.com/usmsam))
+
 ### 💡 Others
 
 ## 57.0.14 — 2026-08-28

--- a/packages/expo-widgets/bundle/react-stub.ts
+++ b/packages/expo-widgets/bundle/react-stub.ts
@@ -11,3 +11,18 @@ export const Children = {
 export const isValidElement = (value: unknown) => {
   return Boolean(value) && typeof value === 'object' && 'type' in (value as object);
 };
+
+// TODO(@jakex7): Make this a proper React reconciler in the future. For now, we just need a stub to allow the widget bundle to compile with @expo/ui/jetpack-compose.
+type StubContext<T> = {
+  Provider: string;
+  Consumer: string;
+  _currentValue: T;
+};
+
+export const createContext = <T>(defaultValue: T): StubContext<T> => ({
+  Provider: 'react.provider',
+  Consumer: 'react.consumer',
+  _currentValue: defaultValue,
+});
+
+export const useContext = <T>(context: StubContext<T>): T => context._currentValue;


### PR DESCRIPTION
# Why

`expo-widgets@57.0.14` shipped #49491, so deep `react-native/*` imports no longer drag the RN core into the widget bundle. But widgets on the released package still fail to render — the crash just moved one step further:

```
TypeError: (0,n.createContext) is not a function
```

`@expo/ui`'s swift-ui `Host` (re-exported from the barrel, so every widget pulls it) imports `../../keyboard`, whose `TextInputHostProvider` calls `React.createContext`. `bundle/react-stub.ts` on `sdk-57` doesn't have `createContext`/`useContext` — they were added on `main` in 22334f06 (#48454) but never made it onto the release branch, so they have not shipped in any published 57.x version.

This is a straight cherry-pick of that stub change onto `sdk-57`. No new code.

# How

Copies the `createContext`/`useContext` stubs from `main`'s `packages/expo-widgets/bundle/react-stub.ts` verbatim (including the original `TODO(@jakex7)` comment), plus a CHANGELOG entry under Unpublished.

Deliberately minimal: `main` also has `useColorScheme` in `react-native-stub.ts` and `getModulesRunBeforeMainModule: () => []` in `metro.config.js`, but neither is required to fix this crash — the widget bundle evaluates cleanly with just the React stub. Happy to widen the cherry-pick if you'd rather bring the release branch fully in sync.

# Test plan

On an unmodified `npx create-expo-app --example with-widgets` with `expo-widgets@57.0.14` installed from npm:

```sh
node node_modules/expo-widgets/scripts/build-bundle.mjs "$PWD"
/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc \
  node_modules/expo-widgets/bundle/build/ExpoWidgets.bundle
```

- **Before** (published 57.0.14): `TypeError: (0,n.createContext) is not a function` — 104 modules.
- **After** (this file dropped into `node_modules`): evaluates silently — 104 modules.

Also exercised earlier with these same stubs on 57.0.13 in a production app: 12 widget states × `systemSmall`/`systemMedium`/`accessoryRectangular` × light/dark, 72/72 render to the expected view trees, widgets render on an iOS 26.5 simulator.

Refs #49490, #49491.
