### PR TITLE
[android][ui][router] add `cornerRadius` support to dropdown menu

### DIFF
--- a/apps/native-component-list/src/screens/UI/DropdownMenuScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/DropdownMenuScreen.android.tsx
@@ -44,6 +44,7 @@ export default function DropdownMenuScreen() {
   const [longPressTapCount, setLongPressTapCount] = React.useState(0);
   const [rnTriggerMenuExpanded, setRnTriggerMenuExpanded] = React.useState(false);
   const [rnTriggerTapCount, setRnTriggerTapCount] = React.useState(0);
+  const [roundedMenuExpanded, setRoundedMenuExpanded] = React.useState(false);
 
   React.useEffect(() => {
     if (sectionsMenuExpanded === false) {
@@ -402,6 +403,27 @@ export default function DropdownMenuScreen() {
                 onClick={() => setRnTriggerMenuExpanded(false)}>
                 <DropdownMenuItem.Text>
                   <ComposeText>Destructive item</ComposeText>
+                </DropdownMenuItem.Text>
+              </DropdownMenuItem>
+            </DropdownMenu.Items>
+          </DropdownMenu>
+        </Host>
+      </Section>
+      <Section title="Custom cornerRadius">
+        <Host matchContents>
+          <DropdownMenu
+            expanded={roundedMenuExpanded}
+            onDismissRequest={() => setRoundedMenuExpanded(false)}
+            cornerRadius={16}>
+            <DropdownMenu.Trigger>
+              <Button onClick={() => setRoundedMenuExpanded(true)}>
+                <ComposeText>Open rounded menu</ComposeText>
+              </Button>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Items>
+              <DropdownMenuItem onClick={() => setRoundedMenuExpanded(false)}>
+                <DropdownMenuItem.Text>
+                  <ComposeText>Item 1</ComposeText>
                 </DropdownMenuItem.Text>
               </DropdownMenuItem>
             </DropdownMenu.Items>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -211,6 +211,52 @@ export default function LongPressDropdownMenuExample() {
 
 </ComponentExample>
 
+### Rounded corners
+
+Use `cornerRadius` to override the default Material3 menu shape with a custom corner radius (in dp).
+
+<ComponentExample
+  title="RoundedDropdownMenuExample.tsx"
+  alt="A menu with rounded corners opened below a Show menu button">
+
+```tsx
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  OutlinedButton,
+  Text,
+} from '@expo/ui/jetpack-compose';
+import { useState } from 'react';
+
+export default function RoundedDropdownMenuExample() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Host matchContents>
+      <DropdownMenu
+        expanded={isExpanded}
+        onDismissRequest={() => setIsExpanded(false)}
+        cornerRadius={16}>
+        <DropdownMenu.Trigger>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>
+            <Text>Show menu</Text>
+          </OutlinedButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Items>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <Text>Item 1</Text>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+        </DropdownMenu.Items>
+      </DropdownMenu>
+    </Host>
+  );
+}
+```
+
+</ComponentExample>
+
 ## API
 
 ```tsx

--- a/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v57.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -211,6 +211,52 @@ export default function LongPressDropdownMenuExample() {
 
 </ComponentExample>
 
+### Rounded corners
+
+Use `cornerRadius` to override the default Material3 menu shape with a custom corner radius (in dp).
+
+<ComponentExample
+  title="RoundedDropdownMenuExample.tsx"
+  alt="A menu with rounded corners opened below a Show menu button">
+
+```tsx
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  OutlinedButton,
+  Text,
+} from '@expo/ui/jetpack-compose';
+import { useState } from 'react';
+
+export default function RoundedDropdownMenuExample() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Host matchContents>
+      <DropdownMenu
+        expanded={isExpanded}
+        onDismissRequest={() => setIsExpanded(false)}
+        cornerRadius={16}>
+        <DropdownMenu.Trigger>
+          <OutlinedButton onClick={() => setIsExpanded(true)}>
+            <Text>Show menu</Text>
+          </OutlinedButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Items>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <Text>Item 1</Text>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+        </DropdownMenu.Items>
+      </DropdownMenu>
+    </Host>
+  );
+}
+```
+
+</ComponentExample>
+
 ## API
 
 ```tsx

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ### 🎉 New features
 
+- [Android] Add `cornerRadius` support to dropdown menu
 - Add `unstable_useIsNavigating` for observing queued or pending navigation. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Add unstable `NavigationAwareActivity` component. ([#49164](https://github.com/expo/expo/pull/49164) by [@Ubax](https://github.com/Ubax))
 - Add screen error boundaries ([#49174](https://github.com/expo/expo/pull/49174) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
@@ -89,7 +89,8 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
       <DropdownMenu
         expanded={expanded}
         onDismissRequest={() => setExpanded(false)}
-        color={backgroundColor}>
+        color={backgroundColor}
+        cornerRadius={props.cornerRadius}>
         <DropdownMenu.Trigger>
           <DropdownMenuItem
             onClick={() => {
@@ -147,7 +148,8 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
       <DropdownMenu
         expanded={expanded}
         onDismissRequest={() => setExpanded(false)}
-        color={backgroundColor}>
+        color={backgroundColor}
+        cornerRadius={props.cornerRadius}>
         <DropdownMenu.Trigger>
           <ToolbarItemBadge badge={props.badge} disabled={props.disabled}>
             {iconButton}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/types.ts
@@ -166,6 +166,13 @@ export interface StackToolbarMenuProps {
    */
   title?: string;
   /**
+   * Corner radius in dp for the dropdown menu container. Defaults to the Material3
+   * `MenuDefaults.shape` corner radius.
+   *
+   * @platform android
+   */
+  cornerRadius?: number;
+  /**
    * @default 'plain'
    *
    * @platform ios
@@ -195,6 +202,8 @@ export interface NativeToolbarMenuProps {
   hidesSharedBackground?: boolean;
   icon?: SFSymbol;
   xcassetName?: string;
+  /** @platform android */
+  cornerRadius?: number;
   // TODO(@ubax): Add useImage support in a follow-up PR.
   /**
    * Image to display for the menu item.

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🎉 New features
 
+- [Android] Add `cornerRadius` support to dropdown menu
 - [iOS] Added `'default'` as a value for every edge of the `padding` modifier, so a single edge can use the system default padding while the other edges use explicit lengths. ([#48903](https://github.com/expo/expo/pull/48903) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [iOS] Added the `Background` component, which draws any view behind another view with an optional `alignment`, matching SwiftUI's `background(alignment:content:)`. ([#48904](https://github.com/expo/expo/pull/48904) by [@Den1Marshall](https://github.com/Den1Marshall))
 - [android] Added `maskClip` modifier, exposing Compose's `CarouselItemScope.maskClip` so carousel items keep their shape while the carousel masks them. ([#48852](https://github.com/expo/expo/pull/48852) by [@SchroederNathan](https://github.com/SchroederNathan))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
@@ -1,9 +1,11 @@
 package expo.modules.ui.menu
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.UIComposableScope
 import expo.modules.ui.ModifierRegistry
@@ -24,6 +26,7 @@ fun FunctionalComposableScope.DropdownMenuContent(
 
     DropdownMenu(
       containerColor = props.color?.composeOrNull ?: MenuDefaults.containerColor,
+      shape = props.cornerRadius?.let { RoundedCornerShape(it.dp) } ?: MenuDefaults.shape,
       expanded = props.expanded,
       onDismissRequest = onDismissRequest
     ) {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
@@ -16,5 +16,6 @@ data class DropdownMenuProps(
   val activationMethod: ActivationMethod = ActivationMethod.SINGLE_PRESS,
   val expanded: Boolean = false,
   val color: Color? = null,
+  val cornerRadius: Float? = null,
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/src/jetpack-compose/DropdownMenu/index.tsx
+++ b/packages/expo-ui/src/jetpack-compose/DropdownMenu/index.tsx
@@ -44,6 +44,14 @@ export interface DropdownMenuProps {
   color?: ColorValue;
 
   /**
+   * Corner radius in dp for the dropdown menu container. Defaults to the Material3
+   * `MenuDefaults.shape` corner radius.
+   *
+   * @platform android
+   */
+  cornerRadius?: number;
+
+  /**
    * Optional styles to apply to the `DropdownMenu`.
    */
   style?: StyleProp<ViewStyle>;
@@ -58,6 +66,7 @@ type NativeMenuProps = {
   expanded?: boolean;
   onDismissRequest?: () => void;
   color?: ColorValue;
+  cornerRadius?: number;
   style?: StyleProp<ViewStyle>;
   modifiers?: ModifierConfig[];
   children?: ReactNode;


### PR DESCRIPTION
# Why

👋 I've been really loving the direction of expo-ui and expo-router, and in particular the newer toolbar api, but have found the Android parts lacking in how I can style. iOS gets past this, at least imo, because out of the box it looks better. I've added `cornerRadius` to the menu since I think it goes a long way in making it look better without adding a bunch of options that may or may not be accepted.

I did not see a mention of requiring an issue before contributing, but apologies if I missed that somewhere.

# How

I started by manually editing installed versions of expo-ui and expo-router and creating a patch from that. Once I confirmed it worked as expected [in my app](https://github.com/stumpapp/stump/pull/1355), I just manually copied it over to my fork.

I also added small blurbs/examples in the relevant docs sections (mostly copying existing ones and tweaking for the change).

# Test Plan

I added a new section to and ran the `native-component-list` app. If the standard for this small of a change is different, please let me know and I can definitely try to align with that.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
