### PR TITLE
[tools] Upload the Expo Go device IPA to GitHub Releases

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -227,7 +227,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 **How:**
 
 - Run `et eas ios-simulator-build` to trigger building Expo Go for iOS simulators on EAS.
-- Run `GITHUB_TOKEN=${GITHUB_TOKEN} et eas ios-simulator-upload` to download the build artifact and upload it to [the expo-go-releases GitHub repo](https://github.com/expo/expo-go-releases/releases). The `GITHUB_TOKEN` environment variable should have contents read/write access to the repo.
+- Run `GITHUB_TOKEN=${GITHUB_TOKEN} et eas ios-simulator-upload` to download the simulator build artifact and the device IPA (built by `ios-client-build-and-submit`) and upload both to [the expo-go-releases GitHub repo](https://github.com/expo/expo-go-releases/releases). The `GITHUB_TOKEN` environment variable should have contents read/write access to the repo.
 - Run `et eas android-apk-build` to trigger building Expo Go for Android APK on EAS.
 - Run `GITHUB_TOKEN=${GITHUB_TOKEN} et eas android-apk-upload` to download the build artifact and upload it to [the expo-go-releases GitHub repo](https://github.com/expo/expo-go-releases/releases). The `GITHUB_TOKEN` environment variable should have contents read/write access to the repo.
 - Once the job is finished, test if this simulator build work as expected. You can install and launch it using expotools command `et client-install -p {ios,android}`.

--- a/tools/src/commands/EasDispatch.ts
+++ b/tools/src/commands/EasDispatch.ts
@@ -50,7 +50,7 @@ const CUSTOM_ACTIONS: Record<string, Action> = {
     action: iosSimulatorBuildAsync,
   },
   'ios-simulator-upload': {
-    name: '[internal] Upload a new iOS Client simulator to expo/expo-go-releases repo and updates www endpoint',
+    name: '[internal] Upload a new iOS Client simulator build and device IPA to expo/expo-go-releases repo and updates www endpoint',
     actionId: 'ios-simulator-upload',
     action: iosSimulatorUploadAsync,
   },
@@ -135,6 +135,10 @@ function getAndroidApkUrl(appVersion: string): string {
 
 function getIosSimulatorUrl(appVersion: string): string {
   return `https://github.com/${REPO_OWNER}/${RELEASES_REPO_NAME}/releases/download/${getAppName(appVersion)}/${getAppName(appVersion)}.tar.gz`;
+}
+
+function getIosIpaUrl(appVersion: string): string {
+  return `https://github.com/${REPO_OWNER}/${RELEASES_REPO_NAME}/releases/download/${getAppName(appVersion)}/${getAppName(appVersion)}.ipa`;
 }
 
 async function confirmPromptIfOverridingRemoteFileAsync(
@@ -582,6 +586,33 @@ async function iosSimulatorUploadAsync() {
       spinner.fail('Upload failed!');
       throw error;
     }
+
+    await confirmPromptIfOverridingRemoteFileAsync(getIosIpaUrl(appVersion), appVersion);
+    const ipaPath = await downloadBuildArtifactAsync(
+      projectDir,
+      'ios',
+      appVersion,
+      sdkVersion,
+      RELEASE_BUILD_PROFILE,
+      'ipa'
+    );
+
+    const ipaSpinner = ora(`Uploading to GitHub: ${path.basename(ipaPath)}...`).start();
+    try {
+      const ipaRes = await uploadReleaseAssetAsync(
+        repoOwner,
+        repoName,
+        release.data.id,
+        path.basename(ipaPath),
+        await fs.readFile(ipaPath)
+      );
+      ipaSpinner.succeed(`Upload completed successfully! ${ipaRes.data.browser_download_url}`);
+    } catch (error) {
+      ipaSpinner.fail('IPA upload failed!');
+      throw error;
+    } finally {
+      await fs.unlink(ipaPath);
+    }
   } catch (error: any) {
     logger.error(`Error creating release: ${error.message}`);
     throw error;
@@ -608,7 +639,9 @@ async function downloadBuildArtifactAsync(
   projectDir: string,
   platform: 'ios' | 'android',
   appVersion: string,
-  sdkVersion: string
+  sdkVersion: string,
+  buildProfile: string = PUBLISH_CLIENT_BUILD_PROFILE,
+  extension: string = platform === 'android' ? 'apk' : 'tar.gz'
 ) {
   const buildInfo = await spawnAsync(
     'eas',
@@ -623,7 +656,7 @@ async function downloadBuildArtifactAsync(
       '--status',
       'finished',
       '--profile',
-      PUBLISH_CLIENT_BUILD_PROFILE,
+      buildProfile,
       '--sdk-version',
       sdkVersion,
     ],
@@ -632,7 +665,7 @@ async function downloadBuildArtifactAsync(
       stdio: 'pipe',
       env: {
         ...process.env,
-        EAS_BUILD_PROFILE: PUBLISH_CLIENT_BUILD_PROFILE,
+        EAS_BUILD_PROFILE: buildProfile,
       },
     }
   );
@@ -690,10 +723,8 @@ async function downloadBuildArtifactAsync(
           if (!input.startsWith('http')) {
             return 'URL must start with http:// or https://';
           }
-          if (platform === 'android' && !input.endsWith('.apk')) {
-            return 'URL must end with .apk';
-          } else if (platform === 'ios' && !input.endsWith('.tar.gz')) {
-            return 'URL must end with .tar.gz';
+          if (!input.endsWith(`.${extension}`)) {
+            return `URL must end with .${extension}`;
           }
           return true;
         },
@@ -707,10 +738,7 @@ async function downloadBuildArtifactAsync(
     buildUrl = selectedBuild.artifacts.buildUrl;
   }
 
-  const archivePath = path.join(
-    projectDir,
-    `${getAppName(appVersion)}.${platform === 'android' ? 'apk' : 'tar.gz'}`
-  );
+  const archivePath = path.join(projectDir, `${getAppName(appVersion)}.${extension}`);
 
   logger.info(`Downloading build from: ${buildUrl}`);
   await spawnAsync('curl', ['-L', '-o', archivePath, buildUrl], {


### PR DESCRIPTION
# Why

In order to automate the process of updating Expo Go builds on `eas go` and sign.expo.dev automatically, we should publish the Expo Go IPA generated during the release flow to the same GitHub releases repo.

# How

This PR extends the `et eas ios-simulator-upload` action instead of adding a new release step. (Perhaps we should just rename it to `eas ios-upload` ? )

 After it uploads the simulator archive and updates the versions endpoint, it now also:

- downloads the device IPA from the `release-client` EAS build (the one produced by `ios-client-build-and-submit`), and
- uploads it as `Expo-Go-<version>.ipa` to the same GitHub release, reusing the release object already in scope.

The versions endpoint is unchanged for now: `iosClientUrl` still points to the simulator tarball. I'll add a dedicated field for the IPA in a follow-up PR 

# Test Plan

N / A