### PR TITLE
docs: update expo-blur support on Android

### DIFF
--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -31,7 +31,7 @@ npx expo install expo-blur
 ### Configure for Android
 
 > [!note]
-> This package only supports iOS. On Android, a plain `View` with a translucent background will be rendered.
+> [From SDK 55 and later, it is stable on Android.](https://docs.expo.dev/versions/latest/sdk/blur-view/#android-support)
 
 ### Configure for iOS
 

--- a/packages/expo-blur/README.md
+++ b/packages/expo-blur/README.md
@@ -31,7 +31,7 @@ npx expo install expo-blur
 ### Configure for Android
 
 > [!note]
-> [From SDK 55 and later, it is stable on Android.](https://docs.expo.dev/versions/latest/sdk/blur-view/#android-support)
+> [The blurring feature is stable on Android from SDK 55](https://docs.expo.dev/versions/latest/sdk/blur-view/#android-support)
 
 ### Configure for iOS
 


### PR DESCRIPTION
# Why

`expo-blur` README.md is outdated

# Test Plan

Check https://docs.expo.dev/versions/latest/sdk/blur-view/#android-support

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
