### PR TITLE
[cli] Match --device by Android device serial and improve no-match error

### DIFF
--- a/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/android/AndroidDeviceManager.ts
@@ -24,12 +24,22 @@ import { promptForDeviceAsync } from './promptAndroidDevice';
 const EXPO_GO_APPLICATION_IDENTIFIER = 'host.exp.exponent';
 
 export class AndroidDeviceManager extends DeviceManager<AndroidDebugBridge.Device> {
-  static async resolveFromNameAsync(name: string): Promise<AndroidDeviceManager> {
+  static async resolveFromNameAsync(query: string): Promise<AndroidDeviceManager> {
     const devices = await getDevicesAsync();
-    const device = devices.find((device) => device.name === name);
+    const device =
+      devices.find((device) => device.pid === query) ??
+      devices.find((device) => device.name === query);
 
     if (!device) {
-      throw new CommandError('Could not find device with name: ' + name);
+      const message = [
+        `No connected Android device or emulator matched "${query}" by serial or name.`,
+        'Available devices:',
+        ...devices.map(
+          (device) => `  ${device.name} (${device.pid ?? 'not attached'}, ${device.type})`
+        ),
+        'Pass a device serial from `adb devices` or a name from the list above to --device.',
+      ].join('\n');
+      throw new CommandError('BAD_ARGS', message);
     }
     return AndroidDeviceManager.resolveAsync({ device, shouldPrompt: false });
   }

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/AndroidDeviceManager-test.ts
@@ -10,6 +10,7 @@ import {
   openUrlAsync,
 } from '../adb';
 import { startDeviceAsync } from '../emulator';
+import { getDevicesAsync } from '../getDevices';
 import { shellDumpsysPackage } from './fixtures/adb-output';
 
 jest.mock('../adbReverse', () => ({
@@ -26,6 +27,7 @@ jest.mock('../adb', () => ({
   logUnauthorized: jest.fn(),
 }));
 jest.mock('../emulator', () => ({ startDeviceAsync: jest.fn() }));
+jest.mock('../getDevices', () => ({ getDevicesAsync: jest.fn() }));
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
 
@@ -228,6 +230,87 @@ describe('device resolution', () => {
       /The device disconnected. Reconnect it and try again./
     );
     expect(installAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveFromNameAsync', () => {
+  it('resolves a physical device by serial', async () => {
+    const device = asDevice({
+      name: 'moto_g55_5G',
+      pid: 'ZY22KPLGQ9',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([device]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(device);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('ZY22KPLGQ9');
+    expect(manager.device.pid).toBe('ZY22KPLGQ9');
+  });
+
+  it('resolves a physical device by name', async () => {
+    const device = asDevice({
+      name: 'moto_g55_5G',
+      pid: 'ZY22KPLGQ9',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([device]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(device);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('moto_g55_5G');
+    expect(manager.device.pid).toBe('ZY22KPLGQ9');
+  });
+
+  it('prefers a serial match over a name match', async () => {
+    const deviceNamedX = asDevice({
+      name: 'X',
+      pid: 'other-serial',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    const deviceWithSerialX = asDevice({
+      name: 'other-name',
+      pid: 'X',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValueOnce([deviceNamedX, deviceWithSerialX]);
+    jest.mocked(isDeviceBootedAsync).mockResolvedValueOnce(deviceWithSerialX);
+
+    const manager = await AndroidDeviceManager.resolveFromNameAsync('X');
+    expect(manager.device.pid).toBe('X');
+    expect(manager.device.name).toBe('other-name');
+  });
+
+  it('rejects with an actionable error when no device matches', async () => {
+    const device = asDevice({
+      name: 'Pixel 5',
+      pid: '123',
+      type: 'device',
+      state: 'device',
+      isAuthorized: true,
+      isBooted: true,
+    });
+    jest.mocked(getDevicesAsync).mockResolvedValue([device]);
+
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /nonsense/s
+    );
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /Pixel 5.*123/s
+    );
+    await expect(AndroidDeviceManager.resolveFromNameAsync('nonsense')).rejects.toThrow(
+      /--device/s
+    );
   });
 });
 


### PR DESCRIPTION
# Why

Found while device-testing #49258 on a physical Moto G55 5G: `npx expo run:android --device ZY22KPLGQ9` (adb serial) fails with `Could not find device with name: ZY22KPLGQ9`.

`AndroidDeviceManager.resolveFromNameAsync` matches only `device.name`. For a physical device, `name` is the model string (`moto_g55_5G`) and the serial lives in `device.pid`. This conflicts with #49258's goal of serial-first device identification. Two more defects in the same lines: the old code passed the whole message as the `CommandError` *code* (the constructor is `(code, message)`), and the error listed no available devices.

# How

- Match the `--device` value against `device.pid` (serial) first, then fall back to `device.name`. This mirrors the iOS resolver, which matches UDID or name.
- On no match, throw `CommandError('BAD_ARGS', message)` where the message names the query, lists the available devices as `name (serial, type)`, and tells the user what to pass to `--device`.
- Written test-first: the new tests failed on the old code, then passed after the fix.

# Test Plan

- Unit: new `resolveFromNameAsync` tests (match by serial, match by name, serial wins over name, actionable no-match error). Full `src/start/platforms/android` + `src/run/android` suites pass (224 tests).
- On device (Moto G55 5G, Android 15, USB):
  - `npx expo run:android --device ZY22KPLGQ9` → resolves, builds, installs, and opens on the device.
  - `npx expo run:android --device nonsense` →
    ```
    CommandError: No connected Android device or emulator matched "nonsense" by serial or name.
    Available devices:
      moto_g55_5G (ZY22KPLGQ9, device)
      Pixel_8a_big (emulator-5554, emulator)
      TestingAVD (not attached, emulator)
    Pass a device serial from `adb devices` or a name from the list above to --device.
    ```

# Checklist

- [ ] Changelog entry intentionally omitted — this targets the #49258 branch, which already has its own entry.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (not relevant — CLI-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZFaHpuGLWSoYZhsvyQ1eU