### PR TITLE
[maps][ios] Add `animateAnnotations` to `AppleMaps.View`

### DIFF
--- a/apps/native-component-list/src/screens/ExpoMaps/apple/MapsAnnotationsScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoMaps/apple/MapsAnnotationsScreen.tsx
@@ -1,6 +1,6 @@
 import { AppleMaps } from 'expo-maps';
 import { useRef, useState } from 'react';
-import { View, Text, FlatList, Pressable, StyleSheet } from 'react-native';
+import { View, Text, FlatList, Pressable, StyleSheet, Switch } from 'react-native';
 
 const ANNOTATIONS: AppleMaps.Annotation[] = [
   {
@@ -48,6 +48,11 @@ const ANNOTATIONS: AppleMaps.Annotation[] = [
 export default function MapsAnnotationsScreen() {
   const mapRef = useRef<AppleMaps.MapView>(null);
   const [selectedAnnotationId, setSelectedAnnotationId] = useState<string>();
+  const [animateAnnotations, setAnimateAnnotations] = useState(true);
+  const [showEveryAnnotation, setShowEveryAnnotation] = useState(true);
+  const annotations = showEveryAnnotation
+    ? ANNOTATIONS
+    : ANNOTATIONS.filter((_, index) => index % 2 === 0);
 
   const handleAnnotationSelect = (annotationId: string) => {
     mapRef.current?.selectAnnotation(annotationId);
@@ -78,7 +83,8 @@ export default function MapsAnnotationsScreen() {
           },
           zoom: 7,
         }}
-        annotations={ANNOTATIONS}
+        annotations={annotations}
+        animateAnnotations={animateAnnotations}
         onAnnotationClick={onAnnotationClick}
         onMapClick={onMapClick}
         properties={{
@@ -87,6 +93,17 @@ export default function MapsAnnotationsScreen() {
       />
 
       <View style={styles.listContainer}>
+        <View style={styles.toggleRow}>
+          <Text style={styles.listTitle}>Animate annotations</Text>
+          <Switch value={animateAnnotations} onValueChange={setAnimateAnnotations} />
+          <Pressable
+            style={styles.toggleButton}
+            onPress={() => setShowEveryAnnotation((show) => !show)}>
+            <Text style={styles.toggleButtonText}>
+              {showEveryAnnotation ? 'Remove Reading and Oxford' : 'Add Reading and Oxford'}
+            </Text>
+          </Pressable>
+        </View>
         <Text style={styles.listTitle}>Select an annotation (via ref):</Text>
         <FlatList
           data={ANNOTATIONS}
@@ -138,6 +155,27 @@ const styles = StyleSheet.create({
     color: '#586069',
     marginLeft: 16,
     marginBottom: 8,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 8,
+    marginRight: 16,
+  },
+  toggleButton: {
+    marginLeft: 'auto',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: '#fff',
+    borderRadius: 16,
+    borderWidth: 2,
+    borderColor: '#e1e4e8',
+  },
+  toggleButtonText: {
+    fontSize: 13,
+    color: '#24292e',
+    fontWeight: '500',
   },
   listContent: {
     paddingHorizontal: 12,

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add `Circle` type to the `GoogleMaps` namespace. ([#49124](https://github.com/expo/expo/pull/49124) by [@CatLover01](https://github.com/CatLover01))
 - [iOS] Added `anchor` to `AppleMaps.View` annotations, so a pin-shaped icon can point at its coordinates instead of being centered on them. Matches the `anchor` that `GoogleMaps.View` markers already support. ([#49315](https://github.com/expo/expo/pull/49315) by [@jensdev](https://github.com/jensdev))
+- [iOS] Added `animateAnnotations` to `AppleMaps.View`, which fades and scales an annotation's content in when it first appears instead of popping it in. ([#49526](https://github.com/expo/expo/pull/49526) by [@moishinetzer](https://github.com/moishinetzer))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-maps/ios/AnnotationContent.swift
+++ b/packages/expo-maps/ios/AnnotationContent.swift
@@ -1,0 +1,63 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import SwiftUI
+
+/// Remembers which annotations have already been shown, so that with `animateAnnotations` an
+/// annotation animates in only the first time it appears: not when its content changes, and not
+/// when MapKit recreates its view after it was scrolled off screen and back.
+final class AnnotationAppearances {
+  private var shownIds = Set<String>()
+
+  func hasShown(_ id: String) -> Bool {
+    shownIds.contains(id)
+  }
+
+  func markShown(_ id: String) {
+    shownIds.insert(id)
+  }
+
+  /// Forgets annotations that are no longer on the map, so they animate in again if they come back.
+  func retain(_ ids: [String]) {
+    shownIds.formIntersection(ids)
+  }
+}
+
+/// The content of an `Annotation`: its icon, or a colored rounded rectangle, with the text on top.
+///
+/// With `appearances` set, the content fades and scales in the first time the annotation appears.
+/// Removal is not animated: MapKit's `MapContent` `ForEach` offers no transition for it.
+@available(iOS 17.0, *)
+struct AnnotationContent: View {
+  let annotation: MapAnnotation
+  let appearances: AnnotationAppearances?
+  @State private var isShown: Bool
+
+  init(annotation: MapAnnotation, appearances: AnnotationAppearances?) {
+    self.annotation = annotation
+    self.appearances = appearances
+    _isShown = State(initialValue: appearances?.hasShown(annotation.id) ?? true)
+  }
+
+  var body: some View {
+    ZStack {
+      if let icon = annotation.icon {
+        Image(uiImage: icon.ref)
+          .resizable()
+          .frame(width: 50, height: 50)
+      } else {
+        RoundedRectangle(cornerRadius: 5)
+          .fill(annotation.backgroundColor)
+      }
+      Text(annotation.text)
+        .foregroundStyle(annotation.textColor)
+        .padding(5)
+    }
+    .opacity(isShown ? 1 : 0)
+    .scaleEffect(isShown ? 1 : 0.6)
+    .animation(.easeInOut(duration: 0.22), value: isShown)
+    .onAppear {
+      appearances?.markShown(annotation.id)
+      isShown = true
+    }
+  }
+}

--- a/packages/expo-maps/ios/AppleMapsView.swift
+++ b/packages/expo-maps/ios/AppleMapsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 class AppleMapsViewProps: ExpoSwiftUI.ViewProps {
   @Field var markers: [MapMarker] = []
   @Field var annotations: [MapAnnotation] = []
+  @Field var animateAnnotations: Bool = false
   @Field var polylines: [ExpoAppleMapPolyline] = []
   @Field var polygons: [Polygon] = []
   @Field var circles: [Circle] = []

--- a/packages/expo-maps/ios/AppleMapsViewState.swift
+++ b/packages/expo-maps/ios/AppleMapsViewState.swift
@@ -10,6 +10,7 @@ public class AppleMapsViewiOS18State: ObservableObject {
   @Published var selection: MapSelection<MKMapItem>?
   @Published var lookAroundScene: MKLookAroundScene?
   @Published var lookAroundPresented: Bool = false
+  let annotationAppearances = AnnotationAppearances()
   var hasInitializedCamera: Bool = false
   var lastKnownDistance: Double?
   var lastKnownHeading: Double = 0
@@ -21,5 +22,6 @@ public class AppleMapsViewiOS17State: ObservableObject {
   @Published var mapCameraPosition: MapCameraPosition = .automatic
   @Published var lookAroundScene: MKLookAroundScene?
   @Published var lookAroundPresented: Bool = false
+  let annotationAppearances = AnnotationAppearances()
   var hasInitializedCamera: Bool = false
 }

--- a/packages/expo-maps/ios/AppleMapsViewiOS17.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS17.swift
@@ -81,19 +81,10 @@ struct AppleMapsViewiOS17: View, AppleMapsViewProtocol {
             coordinate: annotation.clLocationCoordinate2D,
             anchor: annotation.unitPoint
           ) {
-            ZStack {
-              if let icon = annotation.icon {
-                Image(uiImage: icon.ref)
-                  .resizable()
-                  .frame(width: 50, height: 50)
-              } else {
-                RoundedRectangle(cornerRadius: 5)
-                  .fill(annotation.backgroundColor)
-              }
-              Text(annotation.text)
-                .foregroundStyle(annotation.textColor)
-                .padding(5)
-            }
+            AnnotationContent(
+              annotation: annotation,
+              appearances: props.animateAnnotations ? state.annotationAppearances : nil
+            )
           }
         }
 
@@ -127,6 +118,9 @@ struct AppleMapsViewiOS17: View, AppleMapsViewProtocol {
       }
       .onChange(of: props.cameraPosition) { _, newValue in
         state.mapCameraPosition = convertToMapCamera(position: newValue)
+      }
+      .onChange(of: props.annotations.map(\.id)) { _, ids in
+        state.annotationAppearances.retain(ids)
       }
       .onMapCameraChange(frequency: .onEnd) { context in
         let cameraPosition = context.region.center

--- a/packages/expo-maps/ios/AppleMapsViewiOS18.swift
+++ b/packages/expo-maps/ios/AppleMapsViewiOS18.swift
@@ -167,19 +167,10 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
             coordinate: annotation.clLocationCoordinate2D,
             anchor: annotation.unitPoint
           ) {
-            ZStack {
-              if let icon = annotation.icon {
-                Image(uiImage: icon.ref)
-                  .resizable()
-                  .frame(width: 50, height: 50)
-              } else {
-                RoundedRectangle(cornerRadius: 5)
-                  .fill(annotation.backgroundColor)
-              }
-              Text(annotation.text)
-                .foregroundStyle(annotation.textColor)
-                .padding(5)
-            }
+            AnnotationContent(
+              annotation: annotation,
+              appearances: props.animateAnnotations ? state.annotationAppearances : nil
+            )
           }
           .tag(MapSelection(annotation.mapItem))
         }
@@ -288,6 +279,9 @@ struct AppleMapsViewiOS18: View, AppleMapsViewProtocol {
       }
       .onChange(of: props.cameraPosition) { _, newValue in
         state.mapCameraPosition = convertToMapCamera(position: newValue)
+      }
+      .onChange(of: props.annotations.map(\.id)) { _, ids in
+        state.annotationAppearances.retain(ids)
       }
       .onChange(of: state.selection, perform: handleSelectionChange)
       .onMapCameraChange(frequency: .onEnd) { context in

--- a/packages/expo-maps/src/apple/AppleMaps.types.ts
+++ b/packages/expo-maps/src/apple/AppleMaps.types.ts
@@ -514,6 +514,16 @@ export type AppleMapsViewProps = {
   annotations?: AppleMapsAnnotation[];
 
   /**
+   * Whether an annotation's content fades and scales in when the annotation first appears on the
+   * map, instead of appearing instantly. An annotation animates once per `id`: not again when its
+   * content changes, and only after it has been removed from `annotations` and added back. Useful
+   * when the set of annotations changes often, for example when annotations are clustered by zoom
+   * level. Removed annotations disappear instantly.
+   * @default false
+   */
+  animateAnnotations?: boolean;
+
+  /**
    * The `MapUiSettings` to be used for UI-specific settings on the map.
    */
   uiSettings?: AppleMapsUISettings;


### PR DESCRIPTION
# Why

When the `annotations` of `AppleMaps.View` change, the new ones pop onto the map on the next frame. For an annotation set that changes on every zoom step, such as clustered badges that split as the user zooms in, this flickers. This PR adds an opt-in `animateAnnotations` prop that fades and scales an annotation's content in the first time it appears. It is off by default, and with it off the rendered content is the same as today.

It is the iOS counterpart of #49525 (`animateMarkers` on `GoogleMaps.View`), and pairs with #49524 (continuous `onCameraMove`), which is what lets clusters regroup mid-pinch in the first place.

**Appear-only, on purpose.** MapKit's `MapContent` `ForEach` offers no transition for removal (`.transition` is a `View` modifier and does not apply to `MapContent`), so a removed annotation still disappears instantly. Animating removal would mean keeping removed annotations in the `ForEach` on a timer, which I don't think belongs in the library; the Android PR can do it because maps-compose keeps the marker composable alive.

# How

- `AppleMapsViewProps.animateAnnotations?: boolean` in TypeScript and `@Field var animateAnnotations: Bool = false` on the Swift props.
- The annotation content (`ZStack` with the icon or rounded rectangle plus the text), which was duplicated in `AppleMapsViewiOS17` and `AppleMapsViewiOS18`, moves into one `AnnotationContent` view (**ios/AnnotationContent.swift**). Both views render it in place of the `ZStack`; the iOS 18 view keeps its `.tag(MapSelection(...))`.
- `AnnotationContent` animates with `opacity` / `scaleEffect` driven by an `@State isShown` that flips to `true` in `onAppear`, under `.animation(.easeInOut(duration: 0.22), value: isShown)`. That is the modifier chain the appearance was verified with (see Test Plan).
- To make it animate exactly once per annotation, the view state holds an `AnnotationAppearances` set of ids that have been shown:
  - `AnnotationContent` initialises `isShown` from `hasShown(id)`, and marks the id shown in `onAppear`. So an annotation that already appeared starts at full opacity when its view is created again, whether that happens because MapKit recreated the view after it was scrolled off screen or because SwiftUI gave it a new identity. Content edits for an unchanged `id` repaint through the normal `ForEach` update and don't animate.
  - `.onChange(of: props.annotations.map(\.id))` drops ids that left `annotations`, so an annotation that is removed and later added back (a cluster that splits and re-merges) animates in again. This is keyed on ids only; the content itself is rendered straight from `props.annotations` as before, so nothing about an annotation's text, colour or icon is compared or cached.
- The set is a plain `let` on `AppleMapsViewiOS17State` / `AppleMapsViewiOS18State`; it is bookkeeping, not rendered state, so it is not `@Published`.
- Docs: TSDoc on the prop (the API section of the maps docs page is generated from it), CHANGELOG entry, and the NCL "Annotations" screen gets an "Animate annotations" switch plus a button that removes and re-adds two annotations.

Things I had to reason about rather than observe, called out so a reviewer with Xcode can check them:

1. **Whether `onAppear` fires again (and `@State` resets) when MapKit recreates an annotation view after it was scrolled off screen and back.** I believe it does, which is why the appearances set exists: without it, badges would replay their fade every time they scroll back into view. If MapKit turns out to keep the SwiftUI view alive instead, the set is harmless.
2. **Enabling `animateAnnotations` at runtime** for annotations that are already on the map: they are not in the set yet, so if MapKit later recreates their views (case 1) they would animate once, late. If that is observable, the fix is to seed the set with the current ids in `.onChange(of: props.animateAnnotations)`; I left it out to keep the diff small.
3. Annotations that are in the initial `annotations` also fade in on first render, same as the Android PR. Easy to change to "only annotations added later" if you'd prefer that default.

# Test Plan

I'm contributing this from a production app rather than from a checkout of this monorepo, so to be explicit about what was and wasn't run:

- The appearance animation (`opacity` + `scaleEffect` + `.animation(value:)`, flipped from `onAppear` inside `Annotation` content) is verified on an iPhone running iOS 26 (TestFlight build of the app, `pnpm patch` of `expo-maps@57.0.2`): when a cluster splits, the new badges fade and scale in. That patch tracked appearances differently (a synced copy of the annotations plus a departing list), which is what I replaced with the appearances set; the set, the id pruning, the prop plumbing and the `AppleMapsViewiOS17` path have **not** been compiled or run by me, as I don't have Xcode in the environment I'm contributing from. That's why this is a draft.
- TypeScript: `tsc --noEmit` over `packages/expo-maps/src` and the touched NCL screen passes with a local TypeScript 6 install; the touched TS files are formatted with `oxfmt` 0.55 using the repo's `.oxfmtrc.json`. The monorepo's own `pnpm typecheck` / `pnpm lint` were not run.
- To reproduce: NCL → Expo Maps → "Annotations" on iOS. With "Animate annotations" on, "Add Reading and Oxford" should fade and scale those two in and "Remove Reading and Oxford" should drop them instantly; toggling twice should animate them in again. Pan them off screen and back: they should not animate again (point 1 above). With the switch off nothing animates.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CjZscbH8PGw91XFY8rf3oz
