### PR TITLE
fix(log-box): Only enable Android WebView debugging for debuggable apps

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Only enable LogBox WebView debugging in debuggable apps. ([#49529](https://github.com/expo/expo/pull/49529) by [@KaminariOS](https://github.com/KaminariOS))
 - Fix the web overlay bundle printing a `Deep imports from the 'react-native' package are deprecated` warning on every load. ([#47772](https://github.com/expo/expo/pull/47772) by [@ramonclaudio](https://github.com/ramonclaudio))
 - Resolve development server requests from the URL the bundle was loaded from, instead of the default Metro address ([#48276](https://github.com/expo/expo/pull/48276) by [@kitten](https://github.com/kitten))
 - Stop the iOS webview wrapper printing `Unknown message type` for DOM runtime messages that LogBox does not handle, matching Android. ([#48813](https://github.com/expo/expo/pull/48813) by [@kudo](https://github.com/Kudo))

--- a/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxWebViewWrapper.kt
+++ b/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxWebViewWrapper.kt
@@ -3,6 +3,7 @@
 package expo.modules.logbox
 
 import android.app.Activity
+import android.content.pm.ApplicationInfo
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.webkit.JavascriptInterface
@@ -27,7 +28,9 @@ class ExpoLogBoxWebViewWrapper(
   val webView: WebView = WebView(context).apply {
     setBackgroundColor(Color.BLACK)
     settings.javaScriptEnabled = true
-    setWebContentsDebuggingEnabled(true)
+    if (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+      setWebContentsDebuggingEnabled(true)
+    }
     // This interface is defined by the Expo DOM Components WebView Wrapper
     // and must always be the same as [add link]
     addJavascriptInterface(


### PR DESCRIPTION
# Why

`ExpoLogBoxWebViewWrapper` unconditionally calls `WebView.setWebContentsDebuggingEnabled(true)`.

This setting applies to every WebView in the application. [Android documents](https://developer.android.com/reference/android/webkit/WebView#setWebContentsDebuggingEnabled(boolean)) that enabling it allows WebView state to be inspected and modified through ADB and should not normally be enabled in production builds.

We currently carry this guard as a [downstream patch in Whip](https://github.com/KaminariOS/whip/blob/main/patches/%40expo%2Blog-box%2B57.0.4.patch).

# How

Check the consuming application’s `ApplicationInfo.FLAG_DEBUGGABLE` flag before explicitly enabling WebView debugging.

This preserves the existing behavior for debuggable applications, including those using WebView versions older than 113, while non-debuggable applications retain WebView’s secure default. The release path does not explicitly disable debugging, so it does not override a host application that intentionally manages the process-wide setting itself.

# Test Plan

- [x] `git diff --check`
- [x] The equivalent downstream patch compiles in [Whip Android CI](https://github.com/KaminariOS/whip/actions/runs/33300430436/job/99227417959).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)