### PR TITLE
[ios][widgets] Avoid applying Text modifiers twice

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix widget and Live Activity `Text` modifiers being applied twice. ([#49534](https://github.com/expo/expo/issues/49534) by [@gee1k](https://github.com/gee1k))
+- [iOS] Fix widget and Live Activity `Text` modifiers being applied twice. ([#49535](https://github.com/expo/expo/pull/49535) by [@gee1k](https://github.com/gee1k))
 - Resolve deep `react-native/*` imports as empty modules when bundling widget layouts, fixing every widget failing with "Could not create context for layout evaluation" after `@expo/ui` 57.0.14 introduced such an import. ([#49491](https://github.com/expo/expo/pull/49491) by [@usmsam](https://github.com/usmsam))
 - [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1. ([#49076](https://github.com/expo/expo/pull/49076) by [@brentvatne](https://github.com/brentvatne))
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix widget and Live Activity `Text` modifiers being applied twice. ([#49534](https://github.com/expo/expo/issues/49534) by [@gee1k](https://github.com/gee1k))
 - Resolve deep `react-native/*` imports as empty modules when bundling widget layouts, fixing every widget failing with "Could not create context for layout evaluation" after `@expo/ui` 57.0.14 introduced such an import. ([#49491](https://github.com/expo/expo/pull/49491) by [@usmsam](https://github.com/usmsam))
 - [iOS] Fix XCFramework precompilation failing on the unguarded `ActivityViewContext` parameter of `getLiveActivityEnvironment`, which requires iOS 16.1. ([#49076](https://github.com/expo/expo/pull/49076) by [@brentvatne](https://github.com/brentvatne))
 - [iOS] Quote script-phase paths so iOS builds work from a project path containing a space. ([#48747](https://github.com/expo/expo/pull/48747) by [@expo-bot](https://github.com/expo-bot))

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -48,7 +48,9 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   public var body: some View {
     switch node["type"] as? String {
     case "TextView":
-      render(TextView.self, TextViewProps.self, updateProps: updateChildren)
+      // TextView applies common modifiers internally so concatenated text keeps
+      // its SwiftUI.Text representation. Avoid applying those modifiers again.
+      render(TextView.self, TextViewProps.self, updateProps: updateChildren, wrapInUIBaseView: false)
     case "HStackView":
       render(HStackView.self, HStackViewProps.self, updateProps: updateChildren)
     case "VStackView":
@@ -127,7 +129,12 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
   // MARK: - Render Method
 
   @ViewBuilder
-  private func render<P, V>(_ viewType: V.Type, _ propsType: P.Type, updateProps: ((_ initialProps: P) throws -> Void)? = nil) -> some View
+  private func render<P, V>(
+    _ viewType: V.Type,
+    _ propsType: P.Type,
+    updateProps: ((_ initialProps: P) throws -> Void)? = nil,
+    wrapInUIBaseView: Bool = true
+  ) -> some View
   where P: UIBaseViewProps, V: ExpoSwiftUI.View, V.Props == P {
     // immediately invoked closure {}() here because we can't use 'do-catch' inside @ViewBuilder
     {
@@ -136,7 +143,10 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
           let props = try propsType.init(rawProps: rawProps, context: WidgetsContext.shared.context)
           try updateProps?(props)
           // TODO(@jakex7): Prevent unwanted transition when view is updated with new props - we want to have the same view instance recreated with new props instead of creating a new view instance and transitioning to it
-          return AnyView(UIBaseView<P, V>(props: props).transition(.identity))
+          if wrapInUIBaseView {
+            return AnyView(UIBaseView<P, V>(props: props).transition(.identity))
+          }
+          return AnyView(V(props: props).transition(.identity))
         }
         return AnyView(EmptyView())
       } catch {


### PR DESCRIPTION
# Why

Fixes #49534.

`TextView` is one of the Expo UI views that applies common modifiers internally so that concatenated children remain a native `SwiftUI.Text`. The widget renderer currently wraps it in `UIBaseView`, which applies the same modifiers a second time. A modifier such as `padding` or `strokeBorder` therefore appears twice in iOS widgets. `WidgetsDynamicView` is also used by Live Activities, so they share the same behavior.

The public minimal reproduction is available at https://github.com/gee1k/expo-widgets-text-modifier-repro.

# How

Added an opt-out to `WidgetsDynamicView.render` for views that already handle common modifiers, and use it only for `TextView`. All other widget views continue to render through `UIBaseView` unchanged.

Also added the fix to the unpublished `expo-widgets` changelog.

# Test Plan

The reproduction renders the same `padding` and `strokeBorder` values in two ways: on an `HStack` (green) and directly on `Text` (red).

| Before | After |
| --- | --- |
| ![Before: the Text has two nested red borders](https://raw.githubusercontent.com/gee1k/expo-widgets-text-modifier-repro/main/screenshots/before.png) | ![After: the Text has one red border](https://raw.githubusercontent.com/gee1k/expo-widgets-text-modifier-repro/main/screenshots/after.png) |

Local verification on an iPhone 17 Pro Max Simulator running iOS 26.5:

- `npx expo-doctor@latest`: 21/21 checks passed.
- `./node_modules/.bin/tsc --noEmit`: passed in the reproduction.
- Built and installed the unmodified `expo-widgets@57.0.15` reproduction with `npx expo run:ios`; observed two nested red borders.
- Rebuilt the same project with this `DynamicView.swift`; build completed with 0 errors and 0 warnings, and the red `Text` rendered one border with the expected padding.
- `git diff --check`: passed.

There is currently no native `WidgetsDynamicView` test target; the package's existing automated tests cover the JavaScript bundle and configuration layer, so the regression is demonstrated with the minimal native reproduction and before/after Simulator evidence.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (not applicable; no documentation changes)
