### PR TITLE
[core] add ExpoModulesProviderModuleName lookup for repack

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [iOS] Added `SceneGeometry.foregroundScene()`, which returns nil when no scene is on screen so callers can avoid presenting UI into a background scene. ([#48318](https://github.com/expo/expo/pull/48318) by [@alanjhughes](https://github.com/alanjhughes))
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
 - Migrated from deprecated react-native-worklets WorkletRuntime API `executeSync` to up-to-date `runSync`. `runSync` is available since 0.7.0. ([#48691](https://github.com/expo/expo/pull/48691) by [@tjzel](https://github.com/tjzel))
+- Added internal `ExpoModulesProviderModuleName` lookup key for `ExpoModulesProvider` class. ([#49539](https://github.com/expo/expo/pull/49539) by [@kudo](https://github.com/kudo))
 
 ## 57.0.8 - 2026-07-29
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -724,12 +724,14 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
    */
   @objc
   public static func modulesProvider(withName providerName: String = "ExpoModulesProvider") -> ModulesProvider {
-    // [0] When ExpoModulesCore is built as separated framework/module,
-    // we should explicitly load main bundle's `ExpoModulesProvider` class.
-    // CFBundleExecutable is tried first: it is the product name, from which the Swift module
-    // name is derived. CFBundleName is kept as a fallback for the uncommon case where both
-    // values are identical valid identifiers.
+    // [0] When ExpoModulesCore is built as a separate framework/module,
+    // explicitly load the main bundle's `ExpoModulesProvider` class.
+    // `ExpoModulesProviderModuleName` is an internal key that allows repack-app to
+    // preserve the original Swift module name. Try `CFBundleExecutable` next because
+    // it usually matches the Swift module name. Keep `CFBundleName` as a final fallback
+    // for cases where it is also a valid module identifier.
     let mainBundleNames = [
+      Bundle.main.infoDictionary?["ExpoModulesProviderModuleName"],
       Bundle.main.infoDictionary?["CFBundleExecutable"],
       Bundle.main.infoDictionary?["CFBundleName"]
     ].compactMap { $0 as? String }


### PR DESCRIPTION
# Why

repacked build will fail to run when precompile is enabled.

# How

repack will rename both CFBundleExecutable and CFBundleName in Info.plist while keep native code untouched. in this case we won't able to find the ExpoModulesProvider class. this pr tries to add an internal `ExpoModulesProviderModuleName` lookup key. repack will add the property in info.plist as the original native class name.

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
