### PR TITLE
[docs] Round in-content boxes to match the new radius scale in multiple components

### DIFF
--- a/docs/.oxlintrc.json
+++ b/docs/.oxlintrc.json
@@ -255,6 +255,7 @@
       "error",
       {
         "allowlist": [
+          "code-block-wrapper",
           "dark-theme",
           "react-player",
           "table-wrapper",

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -166,7 +166,7 @@ export function Code({ className, children, title }: CodeProps) {
         maxHeight: collapseBound,
       }}
       className={mergeClasses(
-        'relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre',
+        'relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [&::-webkit-scrollbar-track]:mx-6',
         preferredTheme === Themes.DARK && 'dark-theme',
         commonClasses,
         '[p+&]:mt-0'

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -166,7 +166,7 @@ export function Code({ className, children, title }: CodeProps) {
         maxHeight: collapseBound,
       }}
       className={mergeClasses(
-        'relative my-4 overflow-x-auto rounded-md border border-secondary bg-subtle whitespace-pre',
+        'relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre',
         preferredTheme === Themes.DARK && 'dark-theme',
         commonClasses,
         '[p+&]:mt-0'

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -129,8 +129,9 @@ export function Code({ className, children, title }: CodeProps) {
 
   const forceWordWrap = params?.wrap === 'true';
   const commonClasses = mergeClasses(
+    '[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin',
     (wordWrap || forceWordWrap) && 'wrap-break-word! whitespace-pre-wrap!',
-    showExpand && !isExpanded && `overflow-y-hidden! [&::-webkit-scrollbar-track]:bg-default!`
+    showExpand && !isExpanded && 'overflow-y-hidden!'
   );
 
   return codeBlockTitle ? (
@@ -159,27 +160,29 @@ export function Code({ className, children, title }: CodeProps) {
       </SnippetContent>
     </Snippet>
   ) : (
-    <pre
-      ref={contentRef}
-      data-md-lang={language}
-      style={{
-        maxHeight: collapseBound,
-      }}
+    <div
       className={mergeClasses(
-        'relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [&::-webkit-scrollbar-track]:mx-6',
+        'code-block-wrapper my-4 overflow-clip rounded-3xl border border-secondary bg-subtle',
         preferredTheme === Themes.DARK && 'dark-theme',
-        commonClasses,
         '[p+&]:mt-0'
-      )}
-      {...attributes}>
-      <div className="w-fit p-4">
-        <code
-          className="text-xs text-default"
-          dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-        />
-      </div>
-      {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
-    </pre>
+      )}>
+      <pre
+        ref={contentRef}
+        data-md-lang={language}
+        style={{
+          maxHeight: collapseBound,
+        }}
+        className={mergeClasses('relative overflow-x-auto whitespace-pre', commonClasses)}
+        {...attributes}>
+        <div className="w-fit p-4">
+          <code
+            className="text-xs text-default"
+            dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+          />
+        </div>
+        {showExpand && <SnippetExpandOverlay onClick={expandCodeBlock} />}
+      </pre>
+    </div>
   );
 }
 

--- a/docs/components/plugins/CodeBlocksTable.tsx
+++ b/docs/components/plugins/CodeBlocksTable.tsx
@@ -43,9 +43,10 @@ export function CodeBlocksTable({ children, tabs, connected = true, ...rest }: P
         'grid grid-cols-2 gap-4',
         connected && 'lg:mb-4 lg:gap-0',
         connected &&
-          '[&>div:nth-child(odd)>div]:lg:rounded-r-none! [&>div:nth-child(odd)>div]:lg:border-r-0',
-        connected && '[&>div:nth-child(even)>div]:lg:rounded-l-none!',
-        '[&_pre]:m-0 [&_pre]:border-0',
+          '[&>div:nth-child(odd)]:lg:rounded-r-none! [&>div:nth-child(odd)>div]:lg:rounded-r-none! [&>div:nth-child(odd)>div]:lg:border-r-0',
+        connected &&
+          '[&>div:nth-child(even)]:lg:rounded-l-none! [&>div:nth-child(even)>div]:lg:rounded-l-none!',
+        '[&_.code-block-wrapper]:m-0 [&_.code-block-wrapper]:border-0',
         'max-lg:grid-cols-1'
       )}
       {...rest}>

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -266,7 +266,7 @@ button.
 not appear on the screen.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -1033,7 +1033,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1277,7 +1277,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1374,7 +1374,7 @@ This should come from the user field of an
       
 
       <blockquote
-        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="flex rounded-3xl border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -1723,7 +1723,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1977,7 +1977,7 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2282,7 +2282,7 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2610,7 +2610,7 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3106,7 +3106,7 @@ After calling this function, the listener will no longer receive any events from
 which contains all of the pertinent user and credential information.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4039,7 +4039,7 @@ may be
         A value to specify the style for formatting a name.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4231,7 +4231,7 @@ for more details.
 You must include the ID string of the user whose credentials you'd like to refresh.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4564,7 +4564,7 @@ OAuth 2.0 protocol
 None of these options are required.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -4917,7 +4917,7 @@ OAuth 2.0 protocol
 You must include the ID string of the user to sign out.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -5816,7 +5816,7 @@ OAuth 2.0 protocol
         .
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6511,7 +6511,7 @@ for more details.
       
 
       <blockquote
-        class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
+        class="flex rounded-3xl border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6558,7 +6558,7 @@ You will still need to handle null values for any fields you request.
         </div>
       </blockquote>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -6804,7 +6804,7 @@ for more details.
         An enum whose values specify the system's best guess for how likely the current user is a real person.
       </p>
       <blockquote
-        class="mb-4 flex rounded-md border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
+        class="mb-4 flex rounded-3xl border border-default gap-2 px-3 py-2.5 [table_&]:last:mb-0 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link bg-default [&_p]:mb-0! shadow-none mb-2.5! [table_&]:last:mb-0! [table_&]:mt-2"
         data-md="callout"
         data-testid="callout-container"
       >
@@ -7329,7 +7329,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7572,7 +7572,7 @@ exports[`APISection expo-pedometer 1`] = `
           
 
           <blockquote
-            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="flex rounded-3xl border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
             data-md="callout"
             data-testid="callout-container"
           >
@@ -7943,7 +7943,7 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8117,7 +8117,7 @@ provided with a single argument that is
           
 
           <blockquote
-            class="flex rounded-md border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
+            class="flex rounded-3xl border border-default bg-subtle gap-2 px-3 py-2.5 [&_code]:bg-element [&_a]:text-[#0c6ec4] [&_a:visited]:text-[#0c6ec4] dark:[&_a]:text-link dark:[&_a:visited]:text-link [&_p]:mb-0! shadow-none mb-2.5 [table_&]:last:mb-0"
             data-md="callout"
             data-testid="callout-container"
           >
@@ -8678,7 +8678,7 @@ After calling this function, the listener will no longer receive any events from
         class=""
       />
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs mx-4 mt-0.5"
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
       >
         <table
           class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1033,130 +1033,134 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                fullName
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationfullname"
-                >
-                  AppleAuthenticationFullName
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  The full name object with the tokenized portions
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+                  fullName
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                formatStyle
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
-              >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationfullnameformatstyle"
-                >
-                  AppleAuthenticationFullNameFormatStyle
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
                   data-text="true"
                 >
-                  The style in which the name should be formatted
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationfullname"
+                  >
+                    AppleAuthenticationFullName
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    The full name object with the tokenized portions
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
+                  data-text="true"
+                >
+                  formatStyle
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationfullnameformatstyle"
+                  >
+                    AppleAuthenticationFullNameFormatStyle
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    The style in which the name should be formatted
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -1277,89 +1281,93 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                user
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  The unique identifier for the user whose credential state you'd like to check.
-This should come from the user field of an 
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="#appleauthenticationcredentialstate"
+                  user
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
                   >
-                    <code
-                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                      data-text="true"
+                    The unique identifier for the user whose credential state you'd like to check.
+This should come from the user field of an 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#appleauthenticationcredentialstate"
                     >
-                      AppleAuthenticationCredential
-                    </code>
-                  </a>
-                   object.
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                      <code
+                        class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                        data-text="true"
+                      >
+                        AppleAuthenticationCredential
+                      </code>
+                    </a>
+                     object.
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -1723,93 +1731,97 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                options
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationrefreshoptions"
-                >
-                  AppleAuthenticationRefreshOptions
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  An 
+                  options
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
                   <a
                     class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationrefreshoptions"
                   >
-                    <code
-                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                      data-text="true"
-                    >
-                      AppleAuthenticationRefreshOptions
-                    </code>
+                    AppleAuthenticationRefreshOptions
                   </a>
-                   object
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#appleauthenticationrefreshoptions"
+                    >
+                      <code
+                        class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                        data-text="true"
+                      >
+                        AppleAuthenticationRefreshOptions
+                      </code>
+                    </a>
+                     object
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -1977,98 +1989,102 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                options
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
             >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationsigninoptions"
-                >
-                  AppleAuthenticationSignInOptions
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  An optional 
+                  options
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
                   <a
                     class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationsigninoptions"
                   >
-                    <code
-                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                      data-text="true"
-                    >
-                      AppleAuthenticationSignInOptions
-                    </code>
+                    AppleAuthenticationSignInOptions
                   </a>
-                   object
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An optional 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#appleauthenticationsigninoptions"
+                    >
+                      <code
+                        class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                        data-text="true"
+                      >
+                        AppleAuthenticationSignInOptions
+                      </code>
+                    </a>
+                     object
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -2282,93 +2298,97 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                options
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationsignoutoptions"
-                >
-                  AppleAuthenticationSignOutOptions
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  An 
+                  options
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
                   <a
                     class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
                     href="#appleauthenticationsignoutoptions"
                   >
-                    <code
-                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                      data-text="true"
-                    >
-                      AppleAuthenticationSignOutOptions
-                    </code>
+                    AppleAuthenticationSignOutOptions
                   </a>
-                   object
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#appleauthenticationsignoutoptions"
+                    >
+                      <code
+                        class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                        data-text="true"
+                      >
+                        AppleAuthenticationSignOutOptions
+                      </code>
+                    </a>
+                     object
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -2610,63 +2630,67 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                listener
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Type
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
             >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
                 <span
-                  class="text-quaternary"
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
+                  data-text="true"
                 >
-                  () =&gt;
+                  listener
                 </span>
-                 
-                void
-              </code>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span
+                    class="text-quaternary"
+                  >
+                    () =&gt;
+                  </span>
+                   
+                  void
+                </code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -3169,431 +3193,435 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                authorizationCode
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
-                  </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  A short-lived session token used by your app for proof of authorization when interacting with
+                  authorizationCode
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    user
-                  </code>
-                  , this is ephemeral and will change each session.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      user
+                    </code>
+                    , this is ephemeral and will change each session.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                email
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
-                  </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  The user's email address. Might not be present if you didn't request the 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                  email
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                     data-text="true"
                   >
-                    EMAIL
-                  </code>
-                   scope. May
+                    The user's email address. Might not be present if you didn't request the 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      EMAIL
+                    </code>
+                     scope. May
 also be null if this is not the first time the user has signed into your app. If the user chose
 to withhold their email address, this field will instead contain an obscured email address with
 an Apple domain.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                fullName
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="#appleauthenticationfullname"
-                  >
-                    AppleAuthenticationFullName
-                  </a>
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
-                  </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  The user's name. May be 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
+                  fullName
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#appleauthenticationfullname"
+                    >
+                      AppleAuthenticationFullName
+                    </a>
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
                     null
-                  </code>
-                   or contain 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                     data-text="true"
                   >
-                    null
-                  </code>
-                   values if you didn't request the 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    FULL_NAME
-                  </code>
-                  
+                    The user's name. May be 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                     or contain 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                     values if you didn't request the 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      FULL_NAME
+                    </code>
+                    
 scope, if the user denied access, or if this is not the first time the user has signed into
 your app.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                identityToken
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  identityToken
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-                  data-text="true"
-                >
-                  A JSON Web Token (JWT) that securely communicates information about the user to your app.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                realUserStatus
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationuserdetectionstatus"
-                >
-                  AppleAuthenticationUserDetectionStatus
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-                  data-text="true"
-                >
-                  A value that indicates whether the user appears to the system to be a real person.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                state
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                  <span>
+                    null
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-                  data-text="true"
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
                 >
-                  An arbitrary string that your app provided as 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
                     data-text="true"
                   >
-                    state
-                  </code>
-                   in the request that generated the
+                    A JSON Web Token (JWT) that securely communicates information about the user to your app.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  realUserStatus
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationuserdetectionstatus"
+                  >
+                    AppleAuthenticationUserDetectionStatus
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A value that indicates whether the user appears to the system to be a real person.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  state
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An arbitrary string that your app provided as 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      state
+                    </code>
+                     in the request that generated the
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    state
-                  </code>
-                   when making the sign-in request, this field
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      state
+                    </code>
+                     when making the sign-in request, this field
 will be 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    null
-                  </code>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                user
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  An identifier associated with the authenticated user. You can use this to check if the user is
+                  user
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An identifier associated with the authenticated user. You can use this to check if the user is
 still authenticated later. This is stable and can be shared across apps released under the same
 development team. The same user will have a different identifier for apps released by other
 developers.
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div
@@ -3670,295 +3698,299 @@ may be
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                familyName
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  familyName
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
-              >
-                -
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                givenName
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                  <span>
+                    null
                   </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  givenName
                 </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                -
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                middleName
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
-              >
-                -
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                namePrefix
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                  <span>
+                    null
                   </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  middleName
                 </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                -
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                nameSuffix
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
-              >
-                -
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
-              >
-                nickname
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <span>
-                  string
-                  <span
-                    class="text-quaternary"
-                  >
-                     | 
+                  <span>
+                    null
                   </span>
-                </span>
-                <span>
-                  null
-                </span>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                -
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  namePrefix
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  nameSuffix
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  nickname
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <span>
+                    string
+                    <span
+                      class="text-quaternary"
+                    >
+                       | 
+                    </span>
+                  </span>
+                  <span>
+                    null
+                  </span>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div
@@ -4294,199 +4326,203 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                requestedScopes
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
             >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationscope"
-                >
-                  AppleAuthenticationScope
-                  []
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  Array of user information scopes to which your app is requesting access. Note that the user can
+                  requestedScopes
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="#appleauthenticationscope"
+                  >
+                    AppleAuthenticationScope
+                    []
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    null
-                  </code>
-                   values for any scopes you request. Additionally, note that the requested scopes
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                     values for any scopes you request. Additionally, note that the requested scopes
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    null
-                  </code>
-                  . Defaults to 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    []
-                  </code>
-                   (no scopes).
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                    . Defaults to 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      []
+                    </code>
+                     (no scopes).
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                state
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
-              >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  An arbitrary string that is returned unmodified in the corresponding credential after a
+                  state
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    RFC6749
-                  </a>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      RFC6749
+                    </a>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                user
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  user
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                -
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div
@@ -4627,219 +4663,223 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                nonce
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
             >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  An arbitrary string that is used to prevent replay attacks. See more information on this in the
+                  nonce
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An arbitrary string that is used to prevent replay attacks. See more information on this in the
 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      OpenID Connect specification
+                    </a>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  requestedScopes
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
                   <a
                     class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="https://openid.net/specs/openid-connect-core-1_0.html#CodeFlowSteps"
-                    rel="noopener noreferrer"
-                    target="_blank"
+                    href="#appleauthenticationscope"
                   >
-                    OpenID Connect specification
+                    AppleAuthenticationScope
+                    []
                   </a>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                requestedScopes
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
-              >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="#appleauthenticationscope"
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
                 >
-                  AppleAuthenticationScope
-                  []
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
-                  data-text="true"
-                >
-                  Array of user information scopes to which your app is requesting access. Note that the user can
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Array of user information scopes to which your app is requesting access. Note that the user can
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    null
-                  </code>
-                   values for any scopes you request. Additionally, note that the requested scopes
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                     values for any scopes you request. Additionally, note that the requested scopes
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    null
-                  </code>
-                  . Defaults to 
-                  <code
-                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                    data-text="true"
-                  >
-                    []
-                  </code>
-                   (no scopes).
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      null
+                    </code>
+                    . Defaults to 
+                    <code
+                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                      data-text="true"
+                    >
+                      []
+                    </code>
+                     (no scopes).
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                state
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
-              >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  An arbitrary string that is returned unmodified in the corresponding credential after a
+                  state
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    RFC6749
-                  </a>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      RFC6749
+                    </a>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div
@@ -4980,125 +5020,129 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                state
-              </span>
-              <span
-                class="flex text-xs! text-tertiary"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                (optional)
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              >
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
             >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  An arbitrary string that is returned unmodified in the corresponding credential after a
+                  state
+                </span>
+                <span
+                  class="flex text-xs! text-tertiary"
+                >
+                  (optional)
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    An arbitrary string that is returned unmodified in the corresponding credential after a
 successful authentication. This can be used to verify that the response was from the request
 you made and avoid replay attacks. More information on this property is available in the
 OAuth 2.0 protocol 
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="https://tools.ietf.org/html/rfc6749#section-10.12"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    RFC6749
-                  </a>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="https://tools.ietf.org/html/rfc6749#section-10.12"
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      RFC6749
+                    </a>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                user
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  user
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                string
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="text-quaternary"
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  string
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                -
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                <div
+                  class="text-quaternary"
+                >
+                  -
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <h2
@@ -7329,129 +7373,133 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                start
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Date
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  A date indicating the start of the range over which to measure steps.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+                  start
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                end
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  Date
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
                   data-text="true"
                 >
-                  A date indicating the end of the range over which to measure steps.
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Date
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A date indicating the start of the range over which to measure steps.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
+                  data-text="true"
+                >
+                  end
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    Date
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A date indicating the end of the range over which to measure steps.
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -7943,94 +7991,98 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Parameter
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-md="api-param-name"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                callback
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Parameter
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="/versions/latest/sdk/pedometer#pedometerupdatecallbackresult"
-                >
-                  PedometerUpdateCallback
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-md="api-param-name"
                   data-text="true"
                 >
-                  A callback that is invoked when new step count data is available. The callback is
-provided with a single argument that is 
+                  callback
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
                   <a
                     class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="#pedometerresult"
+                    href="/versions/latest/sdk/pedometer#pedometerupdatecallbackresult"
                   >
-                    <code
-                      class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
-                      data-text="true"
-                    >
-                      PedometerResult
-                    </code>
+                    PedometerUpdateCallback
                   </a>
-                  .
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0 [&>*]:last:mb-0!"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A callback that is invoked when new step count data is available. The callback is
+provided with a single argument that is 
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#pedometerresult"
+                    >
+                      <code
+                        class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 inline! py-0 wrap-break-word"
+                        data-text="true"
+                      >
+                        PedometerResult
+                      </code>
+                    </a>
+                    .
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
     <br />
     <div
@@ -8540,75 +8592,79 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                steps
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                number
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  Number of steps taken between the given dates.
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                  steps
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  number
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Number of steps taken between the given dates.
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <div
@@ -8678,62 +8734,66 @@ After calling this function, the listener will no longer receive any events from
         class=""
       />
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
+        class="table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
       >
-        <table
-          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        <div
+          class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
         >
-          <thead
-            class="border-b border-b-default bg-subtle"
+          <table
+            class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
           >
-            <tr
-              class="even:bg-subtle"
+            <thead
+              class="border-b border-b-default bg-subtle"
             >
-              <th
-                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+              <tr
+                class="even:bg-subtle"
               >
-                Parameter
-              </th>
-              <th
-                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-              >
-                Type
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              class="even:bg-subtle"
-            >
-              <td
-                class="border-r border-secondary p-4 text-left last:border-r-0"
-              >
-                <span
-                  class="leading-[1.6154] text-inherit font-medium"
-                  data-md="api-param-name"
-                  data-text="true"
+                <th
+                  class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
                 >
-                  result
-                </span>
-              </td>
-              <td
-                class="border-r border-secondary p-4 text-left last:border-r-0"
-              >
-                <code
-                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                  data-text="true"
+                  Parameter
+                </th>
+                <th
+                  class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
                 >
-                  <a
-                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                    href="#pedometerresult"
+                  Type
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                class="even:bg-subtle"
+              >
+                <td
+                  class="border-r border-secondary p-4 text-left last:border-r-0"
+                >
+                  <span
+                    class="leading-[1.6154] text-inherit font-medium"
+                    data-md="api-param-name"
+                    data-text="true"
                   >
-                    PedometerResult
-                  </a>
-                </code>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                    result
+                  </span>
+                </td>
+                <td
+                  class="border-r border-secondary p-4 text-left last:border-r-0"
+                >
+                  <code
+                    class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                    data-text="true"
+                  >
+                    <a
+                      class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                      href="#pedometerresult"
+                    >
+                      PedometerResult
+                    </a>
+                  </code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
     <div
@@ -8950,196 +9010,200 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-clip border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
-      <table
-        class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+      <div
+        class="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden"
       >
-        <thead
-          class="border-b border-b-default bg-subtle"
+        <table
+          class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
-          <tr
-            class="even:bg-subtle"
+          <thead
+            class="border-b border-b-default bg-subtle"
           >
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
+            <tr
+              class="even:bg-subtle"
             >
-              Property
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Type
-            </th>
-            <th
-              class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
-            >
-              Description
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                canAskAgain
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
+                Property
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                boolean
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                Type
+              </th>
+              <th
+                class="border-r border-secondary px-4 font-medium text-secondary text-left py-2 text-xs [&_code]:text-xs [&_code]:text-secondary last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                Description
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  Indicates if user can be asked again for specific permission.
+                  canAskAgain
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  boolean
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Indicates if user can be asked again for specific permission.
 If not, one should be directed to the Settings app
 in order to enable/disable the permission.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                expires
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                PermissionExpiration
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  Determines time when the permission expires.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+                  expires
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                granted
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                boolean
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
-              >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
                   data-text="true"
                 >
-                  A convenience boolean that indicates if the permission is granted.
-                </p>
-              </div>
-            </td>
-          </tr>
-          <tr
-            class="even:bg-subtle"
-          >
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <span
-                class="leading-[1.6154] text-inherit font-medium"
-                data-text="true"
+                  PermissionExpiration
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                status
-              </span>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
-            >
-              <code
-                class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
-                data-text="true"
-              >
-                <a
-                  class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
-                  href="/versions/latest/sdk/expo#permissionstatus"
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
                 >
-                  PermissionStatus
-                </a>
-              </code>
-            </td>
-            <td
-              class="border-r border-secondary p-4 text-left last:border-r-0"
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Determines time when the permission expires.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
             >
-              <div
-                class="px-4 [table_&]:mb-0! [table_&]:px-0"
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
               >
-                <p
-                  class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
                   data-text="true"
                 >
-                  Determines the status of the permission.
-                </p>
-              </div>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+                  granted
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  boolean
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    A convenience boolean that indicates if the permission is granted.
+                  </p>
+                </div>
+              </td>
+            </tr>
+            <tr
+              class="even:bg-subtle"
+            >
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <span
+                  class="leading-[1.6154] text-inherit font-medium"
+                  data-text="true"
+                >
+                  status
+                </span>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <code
+                  class="text-inherit text-xs leading-[130%] font-normal inline-block rounded-md border border-secondary bg-subtle px-1 py-0.5 [&>span]:text-inherit!"
+                  data-text="true"
+                >
+                  <a
+                    class="cursor-pointer decoration-0 hocus:opacity-80 font-normal text-link visited:text-link hocus:underline [&_code]:hocus:underline [&_b]:text-link [&_code]:text-link [&_em]:text-link [&_i]:text-link [&_span]:text-link [&_strong]:text-link"
+                    href="/versions/latest/sdk/expo#permissionstatus"
+                  >
+                    PermissionStatus
+                  </a>
+                </code>
+              </td>
+              <td
+                class="border-r border-secondary p-4 text-left last:border-r-0"
+              >
+                <div
+                  class="px-4 [table_&]:mb-0! [table_&]:px-0"
+                >
+                  <p
+                    class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
+                    data-text="true"
+                  >
+                    Determines the status of the permission.
+                  </p>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
   <h2

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1033,7 +1033,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1277,7 +1277,7 @@ properties.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1723,7 +1723,7 @@ value depending on the state of the credential.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -1977,7 +1977,7 @@ refresh operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2282,7 +2282,7 @@ sign-in operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -2610,7 +2610,7 @@ sign-out operation.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3169,7 +3169,7 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -3670,7 +3670,7 @@ may be
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4294,7 +4294,7 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4627,7 +4627,7 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -4980,7 +4980,7 @@ for more details.
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7329,7 +7329,7 @@ exports[`APISection expo-pedometer 1`] = `
       </div>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -7943,7 +7943,7 @@ available on this device.
       </h3>
     </div>
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8540,7 +8540,7 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8678,7 +8678,7 @@ After calling this function, the listener will no longer receive any events from
         class=""
       />
       <div
-        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs mx-4 mt-0.5"
+        class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mx-4 mt-0.5"
       >
         <table
           class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
@@ -8950,7 +8950,7 @@ After calling this function, the listener will no longer receive any events from
       class=""
     />
     <div
-      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs mt-0.5 rounded-none border-0 border-t"
+      class="table-wrapper mb-4 overflow-x-auto overflow-y-hidden border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6 mt-0.5 rounded-none border-0 border-t"
     >
       <table
         class="w-full rounded-none border-0 text-sm text-default [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -113,7 +113,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
         </span>
       </p>
       <pre
-        class="relative my-4 overflow-x-auto rounded-md border border-secondary bg-subtle whitespace-pre [p+&]:mt-0"
+        class="relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [p+&]:mt-0"
         data-md-lang="ts"
         data-text="true"
       >

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -112,60 +112,64 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
           Example
         </span>
       </p>
-      <pre
-        class="relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [&::-webkit-scrollbar-track]:mx-6 [p+&]:mt-0"
-        data-md-lang="ts"
-        data-text="true"
+      <div
+        class="code-block-wrapper my-4 overflow-clip rounded-3xl border border-secondary bg-subtle [p+&]:mt-0"
       >
-        <div
-          class="w-fit p-4"
+        <pre
+          class="relative overflow-x-auto whitespace-pre [scrollbar-color:var(--slate-5)_transparent] scrollbar-thin"
+          data-md-lang="ts"
+          data-text="true"
         >
-          <code
-            class="text-xs text-default"
+          <div
+            class="w-fit p-4"
           >
-            <span
-              class="token keyword"
+            <code
+              class="text-xs text-default"
             >
-              await
-            </span>
-             Application
-            <span
-              class="token punctuation"
-            >
-              .
-            </span>
-            <span
-              class="token function"
-            >
-              getInstallReferrerAsync
-            </span>
-            <span
-              class="token punctuation"
-            >
-              (
-            </span>
-            <span
-              class="token punctuation"
-            >
-              )
-            </span>
-            <span
-              class="token punctuation"
-            >
-              ;
-            </span>
-            
+              <span
+                class="token keyword"
+              >
+                await
+              </span>
+               Application
+              <span
+                class="token punctuation"
+              >
+                .
+              </span>
+              <span
+                class="token function"
+              >
+                getInstallReferrerAsync
+              </span>
+              <span
+                class="token punctuation"
+              >
+                (
+              </span>
+              <span
+                class="token punctuation"
+              >
+                )
+              </span>
+              <span
+                class="token punctuation"
+              >
+                ;
+              </span>
+              
 
-            <span
-              class="token comment"
-            >
-              // "utm_source=google-play&utm_medium=organic"
-            </span>
-            
+              <span
+                class="token comment"
+              >
+                // "utm_source=google-play&utm_medium=organic"
+              </span>
+              
 
-          </code>
-        </div>
-      </pre>
+            </code>
+          </div>
+        </pre>
+      </div>
     </div>
   </div>
 </div>

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -113,7 +113,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
         </span>
       </p>
       <pre
-        class="relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [p+&]:mt-0"
+        class="relative my-4 overflow-x-auto rounded-3xl border border-secondary bg-subtle whitespace-pre [&::-webkit-scrollbar-track]:mx-6 [p+&]:mt-0"
         data-md-lang="ts"
         data-text="true"
       >

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -87,38 +87,26 @@ details::details-content {
 
 /* Scrollbars */
 
-div:not(#root) > ::-webkit-scrollbar,
-pre[data-text]::-webkit-scrollbar,
-.table-wrapper::-webkit-scrollbar {
+div:not(#root) > ::-webkit-scrollbar {
   width: 6px;
   height: 5px;
 }
 
-div:not(#root) > ::-webkit-scrollbar-track,
-pre[data-text]::-webkit-scrollbar-track,
-.table-wrapper::-webkit-scrollbar-track {
+div:not(#root) > ::-webkit-scrollbar-track {
   background-color: transparent;
   cursor: pointer;
 }
 
-div:not(#root) > ::-webkit-scrollbar-thumb,
-pre[data-text]::-webkit-scrollbar-thumb,
-.table-wrapper::-webkit-scrollbar-thumb {
+div:not(#root) > ::-webkit-scrollbar-thumb {
   @apply bg-palette-gray5 rounded-sm;
 }
 
-div:not(#root) > ::-webkit-scrollbar-thumb:hover,
-pre[data-text]::-webkit-scrollbar-thumb:hover,
-.table-wrapper::-webkit-scrollbar-thumb:hover {
+div:not(#root) > ::-webkit-scrollbar-thumb:hover {
   @apply bg-palette-gray6;
 }
 
-div[class*='terminal-snippet'] > ::-webkit-scrollbar-thumb {
-  @apply bg-palette-gray11;
-}
-
-div[class*='terminal-snippet'] > ::-webkit-scrollbar-thumb:hover {
-  @apply bg-palette-gray12;
+div[class*='terminal-snippet'] > * {
+  scrollbar-color: var(--slate-11) transparent;
 }
 
 details > summary::-webkit-details-marker {

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -87,21 +87,29 @@ details::details-content {
 
 /* Scrollbars */
 
-div:not(#root) > ::-webkit-scrollbar {
+div:not(#root) > ::-webkit-scrollbar,
+pre[data-text]::-webkit-scrollbar,
+.table-wrapper::-webkit-scrollbar {
   width: 6px;
   height: 5px;
 }
 
-div:not(#root) > ::-webkit-scrollbar-track {
+div:not(#root) > ::-webkit-scrollbar-track,
+pre[data-text]::-webkit-scrollbar-track,
+.table-wrapper::-webkit-scrollbar-track {
   background-color: transparent;
   cursor: pointer;
 }
 
-div:not(#root) > ::-webkit-scrollbar-thumb {
+div:not(#root) > ::-webkit-scrollbar-thumb,
+pre[data-text]::-webkit-scrollbar-thumb,
+.table-wrapper::-webkit-scrollbar-thumb {
   @apply bg-palette-gray5 rounded-sm;
 }
 
-div:not(#root) > ::-webkit-scrollbar-thumb:hover {
+div:not(#root) > ::-webkit-scrollbar-thumb:hover,
+pre[data-text]::-webkit-scrollbar-thumb:hover,
+.table-wrapper::-webkit-scrollbar-thumb:hover {
   @apply bg-palette-gray6;
 }
 

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -74,12 +74,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Name of your app.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-3xl border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-3xl bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="mt-1.25 mr-2 ml-1.5 self-baseline"
@@ -228,12 +228,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for loading and splash screen for standalone apps.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-3xl border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app-1"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-3xl bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="mt-1.25 mr-2 ml-1.5 self-baseline"
@@ -670,12 +670,12 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         Configuration for setting an array of custom intent filters in Android manifest.
       </p>
       <details
-        class="mb-3 scroll-m-4 rounded-md border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
+        class="mb-3 scroll-m-4 rounded-3xl border border-default bg-default p-0 [&[open]]:shadow-xs [h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3"
         data-md="collapsible"
         id="existing-react-native-app-2"
       >
         <summary
-          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
+          class="group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-3xl bg-subtle p-1.5 pr-3 [details[open]>&]:rounded-b-none [&_h4]:my-0 [&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug"
         >
           <div
             class="mt-1.25 mr-2 ml-1.5 self-baseline"

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -54,7 +54,7 @@ export function AppJSBanner() {
       <div className="min-h-0 overflow-hidden">
         <div
           className={mergeClasses(
-            'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg px-6 py-4',
+            'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-3xl px-6 py-4',
             'bg-[#eef0ff] dark:bg-[#494CFC22]',
             'border border-[#494CFC] dark:border-[#3133b0]',
             'max-md:flex-wrap'

--- a/docs/ui/components/Collapsible/index.tsx
+++ b/docs/ui/components/Collapsible/index.tsx
@@ -65,7 +65,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
           setIsOpen(event.currentTarget.open);
         }}
         className={mergeClasses(
-          'mb-3 scroll-m-4 rounded-md border border-default bg-default p-0',
+          'mb-3 scroll-m-4 rounded-3xl border border-default bg-default p-0',
           '[&[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
@@ -75,7 +75,7 @@ const Collapsible: ComponentType<CollapsibleProps> = withHeadingManager(
         data-md="collapsible">
         <summary
           className={mergeClasses(
-            'group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-md bg-subtle p-1.5 pr-3',
+            'group m-0 grid cursor-pointer grid-cols-[min-content_auto_min-content_1fr] items-center rounded-3xl bg-subtle p-1.5 pr-3',
             '[details[open]>&]:rounded-b-none',
             '[&_h4]:my-0',
             '[&_code]:mt-px [&_code]:inline [&_code]:bg-element [&_code]:pb-px [&_code]:text-[85%] [&_code]:leading-snug'

--- a/docs/ui/components/ComponentExample.tsx
+++ b/docs/ui/components/ComponentExample.tsx
@@ -98,7 +98,7 @@ export function ComponentExample({ title, src, darkSrc, alt, android, ios, child
   const device = active === 'android' ? DEVICE_FRAMES.android : DEVICE_FRAMES.ios;
 
   return (
-    <Snippet className="mb-4 flex flex-col prose-pre:m-0! prose-pre:rounded-none! prose-pre:border-0!">
+    <Snippet className="mb-4 flex flex-col [&_.code-block-wrapper]:m-0! [&_.code-block-wrapper]:rounded-none! [&_.code-block-wrapper]:border-0!">
       <div className="flex overflow-hidden rounded-3xl border border-default max-lg:flex-col">
         <div className="flex min-w-0 flex-1 flex-col [&>div:first-child]:rounded-none [&>div:first-child]:border-0 [&>div:first-child]:border-b [&>div:first-child]:border-default">
           <SnippetHeader title={title} Icon={FileCode01Icon}>

--- a/docs/ui/components/ComponentExample.tsx
+++ b/docs/ui/components/ComponentExample.tsx
@@ -99,7 +99,7 @@ export function ComponentExample({ title, src, darkSrc, alt, android, ios, child
 
   return (
     <Snippet className="mb-4 flex flex-col prose-pre:m-0! prose-pre:rounded-none! prose-pre:border-0!">
-      <div className="flex overflow-hidden rounded-md border border-default max-lg:flex-col">
+      <div className="flex overflow-hidden rounded-3xl border border-default max-lg:flex-col">
         <div className="flex min-w-0 flex-1 flex-col [&>div:first-child]:rounded-none [&>div:first-child]:border-0 [&>div:first-child]:border-b [&>div:first-child]:border-default">
           <SnippetHeader title={title} Icon={FileCode01Icon}>
             <CopyAction text={cleanCopyValue(value, context.version)} />

--- a/docs/ui/components/Home/sections/CommandLineTools.tsx
+++ b/docs/ui/components/Home/sections/CommandLineTools.tsx
@@ -29,7 +29,7 @@ export function CommandLineTools() {
               Deploy to TestFlight
             </h2>
             <div>
-              <Terminal cmd={['$ npx testflight']} className="rounded-md asset-shadow" />
+              <Terminal cmd={['$ npx testflight']} className="rounded-3xl asset-shadow" />
               <CALLOUT theme="secondary">
                 This is an iOS-only command that will upload your app to TestFlight.
               </CALLOUT>
@@ -54,7 +54,7 @@ export function CommandLineTools() {
               Deploy your web app
             </h2>
             <div>
-              <Terminal cmd={['$ npx eas-cli deploy']} className="rounded-md asset-shadow" />
+              <Terminal cmd={['$ npx eas-cli deploy']} className="rounded-3xl asset-shadow" />
               <CALLOUT theme="secondary">
                 For prerequisites and complete instructions, see{' '}
                 <A href="/deploy/web/#export-your-web-project">our guide</A>.

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -52,7 +52,7 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
   return (
     <blockquote
       className={mergeClasses(
-        'mb-4 flex gap-2.5 rounded-md border border-default bg-subtle py-3 pr-4 pl-3.5 shadow-xs',
+        'mb-4 flex gap-2.5 rounded-3xl border border-default bg-subtle py-3 pr-4 pl-3.5 shadow-xs',
         size === 'sm' && 'gap-2 px-3 py-2.5',
         '[table_&]:last:mb-0',
         '[&_code]:bg-element',

--- a/docs/ui/components/PlatformTabs/PlatformTabs.tsx
+++ b/docs/ui/components/PlatformTabs/PlatformTabs.tsx
@@ -46,7 +46,7 @@ export function PlatformTabs({ available, active, select, className }: Props) {
               select(platform);
             }}
             className={mergeClasses(
-              'flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 transition-colors',
+              'flex cursor-pointer items-center gap-1.5 rounded-lg border px-2 py-1 transition-colors',
               isActive
                 ? 'border-default bg-default shadow-xs dark:bg-subtle'
                 : 'border-transparent dark:hocus:bg-subtle hocus:bg-element'

--- a/docs/ui/components/PossibleRedirectNotification.tsx
+++ b/docs/ui/components/PossibleRedirectNotification.tsx
@@ -19,7 +19,7 @@ export default function PossibleRedirectNotification({ newUrl }: Props) {
 
   if (targetId) {
     return (
-      <div className="mt-1 rounded-sm border border-solid border-warning bg-warning p-4">
+      <div className="mt-1 rounded-3xl border border-solid border-warning bg-warning p-4">
         <P className="mb-0">
           ⚠️ The information you are looking for (addressed by <em>"{targetId}"</em>) has moved.{' '}
           <A href={`${newUrl}#${targetId}`}>Continue to the new location.</A>

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -69,7 +69,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
       <details
         id={heading.current.slug}
         className={mergeClasses(
-          'mb-3 scroll-m-4 rounded-md border border-default p-0',
+          'mb-3 scroll-m-4 rounded-3xl border border-default p-0',
           '[[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
@@ -82,7 +82,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
         data-md="prerequisites">
         <summary
           className={mergeClasses(
-            'group m-0 flex cursor-pointer items-center justify-between rounded-md p-1.5 py-3 pr-4',
+            'group m-0 flex cursor-pointer items-center justify-between rounded-3xl p-1.5 py-3 pr-4',
             '[details[open]>&]:rounded-b-none',
             'hocus:bg-subtle'
           )}>

--- a/docs/ui/components/Snippet/Snippet.tsx
+++ b/docs/ui/components/Snippet/Snippet.tsx
@@ -4,7 +4,9 @@ import type { HTMLAttributes } from 'react';
 type SnippetProps = HTMLAttributes<HTMLDivElement>;
 
 export const Snippet = ({ children, className, ...rest }: SnippetProps) => (
-  <div className={mergeClasses('mb-4 flex flex-col last:mb-0', className)} {...rest}>
+  <div
+    className={mergeClasses('mb-4 flex flex-col overflow-clip rounded-3xl last:mb-0', className)}
+    {...rest}>
     {children}
   </div>
 );

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -20,7 +20,7 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
           wordWrap && 'wrap-break-word! whitespace-pre-wrap!',
-          'relative overflow-x-auto rounded-b-3xl border border-default bg-subtle p-4 leading-4.5! text-default [&::-webkit-scrollbar-track]:mx-6',
+          '[scrollbar-color:var(--slate-5)_transparent] relative scrollbar-thin overflow-x-auto rounded-b-3xl border border-default bg-subtle p-4 leading-4.5! text-default',
           'prose-code:px-0!',
           alwaysDark && 'dark-theme border-transparent bg-palette-black whitespace-nowrap',
           hideOverflow && 'overflow-hidden prose-code:whitespace-nowrap!',

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -20,7 +20,7 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
           wordWrap && 'wrap-break-word! whitespace-pre-wrap!',
-          'relative overflow-x-auto rounded-b-3xl border border-default bg-subtle p-4 leading-4.5! text-default',
+          'relative overflow-x-auto rounded-b-3xl border border-default bg-subtle p-4 leading-4.5! text-default [&::-webkit-scrollbar-track]:mx-6',
           'prose-code:px-0!',
           alwaysDark && 'dark-theme border-transparent bg-palette-black whitespace-nowrap',
           hideOverflow && 'overflow-hidden prose-code:whitespace-nowrap!',

--- a/docs/ui/components/Snippet/SnippetContent.tsx
+++ b/docs/ui/components/Snippet/SnippetContent.tsx
@@ -20,7 +20,7 @@ export const SnippetContent = forwardRef<HTMLDivElement, SnippetContentProps>(
         className={mergeClasses(
           preferredTheme === Themes.DARK && 'dark-theme',
           wordWrap && 'wrap-break-word! whitespace-pre-wrap!',
-          'relative overflow-x-auto rounded-b-md border border-default bg-subtle p-4 leading-4.5! text-default',
+          'relative overflow-x-auto rounded-b-3xl border border-default bg-subtle p-4 leading-4.5! text-default',
           'prose-code:px-0!',
           alwaysDark && 'dark-theme border-transparent bg-palette-black whitespace-nowrap',
           hideOverflow && 'overflow-hidden prose-code:whitespace-nowrap!',

--- a/docs/ui/components/Snippet/SnippetHeader.tsx
+++ b/docs/ui/components/Snippet/SnippetHeader.tsx
@@ -29,8 +29,8 @@ export const SnippetHeader = ({
     data-md="snippet-header"
     className={mergeClasses(
       'flex min-h-10 justify-between overflow-hidden border border-default bg-default pl-4',
-      !float && 'rounded-t-md border-b-0',
-      float && 'rounded-md',
+      !float && 'rounded-t-3xl border-b-0',
+      float && 'rounded-3xl',
       Icon && 'pl-3',
       alwaysDark && 'dark-theme bg-palette-gray3! pr-2 dark:border-transparent'
     )}>

--- a/docs/ui/components/Snippet/blocks/SnackInline.tsx
+++ b/docs/ui/components/Snippet/blocks/SnackInline.tsx
@@ -72,7 +72,7 @@ export const SnackInline = ({
   const { language, value } = getCodeBlockDataFromChildren(children);
 
   return (
-    <Snippet className="mb-3 flex flex-col prose-pre:m-0! prose-pre:border-0!">
+    <Snippet className="mb-3 flex flex-col [&_.code-block-wrapper]:m-0! [&_.code-block-wrapper]:border-0!">
       <SnippetHeader title={label ?? 'Example'} Icon={SnackLogo}>
         <form action={SNACK_URL} method="POST" target="_blank" className="contents">
           <input type="hidden" name="platform" value={defaultPlatform ?? DEFAULT_PLATFORM} />

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -20,7 +20,7 @@ export const Table = ({
 }: TableProps) => (
   <div
     className={mergeClasses(
-      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs',
+      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6',
       containerClassName
     )}>
     <table

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -20,7 +20,7 @@ export const Table = ({
 }: TableProps) => (
   <div
     className={mergeClasses(
-      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-md border border-default shadow-xs',
+      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs',
       containerClassName
     )}>
     <table

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -20,29 +20,31 @@ export const Table = ({
 }: TableProps) => (
   <div
     className={mergeClasses(
-      'table-wrapper mb-4 overflow-x-auto overflow-y-hidden rounded-3xl border border-default shadow-xs [&::-webkit-scrollbar-track]:mx-6',
+      'table-wrapper mb-4 overflow-clip rounded-3xl border border-default shadow-xs',
       containerClassName
     )}>
-    <table
-      className={mergeClasses(
-        'w-full rounded-none border-0 text-sm text-default',
-        '[&_p]:text-sm',
-        '[&_li]:text-sm',
-        '[&_span]:text-sm',
-        '[&_code_span]:text-xs',
-        '[&_strong]:text-sm',
-        '[&_blockquote_div]:text-sm',
-        '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',
-        className
-      )}>
-      {headers.length > 0 ? (
-        <>
-          <TableHeaders headers={headers} headersAlign={headersAlign} />
-          <tbody>{children}</tbody>
-        </>
-      ) : (
-        children
-      )}
-    </table>
+    <div className="[scrollbar-color:var(--slate-5)_transparent] scrollbar-thin overflow-x-auto overflow-y-hidden">
+      <table
+        className={mergeClasses(
+          'w-full rounded-none border-0 text-sm text-default',
+          '[&_p]:text-sm',
+          '[&_li]:text-sm',
+          '[&_span]:text-sm',
+          '[&_code_span]:text-xs',
+          '[&_strong]:text-sm',
+          '[&_blockquote_div]:text-sm',
+          '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',
+          className
+        )}>
+        {headers.length > 0 ? (
+          <>
+            <TableHeaders headers={headers} headersAlign={headersAlign} />
+            <tbody>{children}</tbody>
+          </>
+        ) : (
+          children
+        )}
+      </table>
+    </div>
   </div>
 );

--- a/docs/ui/components/Tabs/TabButton.tsx
+++ b/docs/ui/components/Tabs/TabButton.tsx
@@ -45,7 +45,7 @@ export function TabButton({
             duration: shouldReduceMotion ? 0 : 0.2,
           }}
           className={mergeClasses(
-            'absolute inset-0 rounded-md border',
+            'absolute inset-0 rounded-lg border',
             theme === 'default' && 'border-secondary bg-screen dark:bg-hover dark:drop-shadow-none',
             theme === 'secondary' && 'border-default bg-default shadow-sm dark:bg-subtle'
           )}
@@ -55,7 +55,7 @@ export function TabButton({
         value={value}
         disabled={disabled}
         className={mergeClasses(
-          'relative z-10 rounded-md transition-colors',
+          'relative z-10 rounded-lg transition-colors',
           !active && theme === 'default' && 'dark:hocus:bg-element hocus:bg-selected',
           !active && theme === 'secondary' && 'dark:hocus:bg-subtle hocus:bg-element',
           className

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -78,7 +78,7 @@ const InnerTabs = ({
       onValueChange={value => {
         setIndex(Number(value));
       }}
-      className="my-4 rounded-md border border-default shadow-xs">
+      className="my-4 rounded-3xl border border-default shadow-xs">
       <TabsPrimitive.List className="flex flex-wrap gap-1 border-b border-secondary px-4 py-3">
         {tabTitles.map((title, index) => (
           <TabButton

--- a/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.tsx
+++ b/docs/ui/components/TemplateBareMinimumDiffViewer/NativeUpgradePromptCallout.tsx
@@ -37,7 +37,7 @@ export function NativeUpgradePromptCallout({
     <div
       data-md="skip"
       className={mergeClasses(
-        'mb-4 flex flex-col gap-3 rounded-md border border-info bg-info px-4 py-3 shadow-xs',
+        'mb-4 flex flex-col gap-3 rounded-3xl border border-info bg-info px-4 py-3 shadow-xs',
         'sm:flex-row sm:items-center sm:gap-4'
       )}>
       <div className="flex gap-3 sm:flex-1">


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/49466#pullrequestreview-5044562800

# How

<!--
How did you build this feature or fix this bug and why?
-->
Round in-content boxes to match the new radius scale in multiple components:
- Collapsible
- Prerequisites
- Tabs
- TabButton
- PlatformTabs
- Table
- SnippetHeader
- SnippetContent
- Code
- CommandLineTools
- InlineHelp
- NativeUpgradePromptCallout
- PossibleRedirectNotification
- ComponentExample
- AppJSBanner

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**Callouts**

<img width="2282" height="226" alt="CleanShot 2026-08-31 at 15 22 43@2x" src="https://github.com/user-attachments/assets/9c2dd65c-796b-4ba1-ba97-6166cf7c34fa" />

**Collapsibles**
<img width="2338" height="456" alt="CleanShot 2026-08-31 at 15 22 58@2x" src="https://github.com/user-attachments/assets/19968323-f631-4403-bb98-16ba64a72bab" />

**Table**

<img width="2314" height="702" alt="CleanShot 2026-08-31 at 15 22 54@2x" src="https://github.com/user-attachments/assets/af452834-f35f-4a98-9e27-180c3b1c7f9d" />

**Terminal**


<img width="2244" height="384" alt="CleanShot 2026-08-31 at 15 23 11@2x" src="https://github.com/user-attachments/assets/b4477db3-3582-4691-92e8-cb5c81e6ac9b" />

**Code blocks**

<img width="2252" height="672" alt="CleanShot 2026-08-31 at 15 23 33@2x" src="https://github.com/user-attachments/assets/18691c87-de9f-4b39-a7b9-6d3af35fe094" />

<img width="2198" height="1060" alt="CleanShot 2026-08-31 at 15 23 44@2x" src="https://github.com/user-attachments/assets/ecd47169-0423-431f-a9f9-df4d4e7935b1" />

**Prerequisites**

<img width="2226" height="1200" alt="CleanShot 2026-08-31 at 15 24 31@2x" src="https://github.com/user-attachments/assets/d68497a3-7da2-48f7-8c22-2a9cd23db9b6" />

**Tabs**

<img width="960" height="158" alt="CleanShot 2026-08-31 at 15 29 43@2x" src="https://github.com/user-attachments/assets/0b52f05c-774f-4376-88c8-c3a5ba6f1816" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
