### PR TITLE
docs: document zero-config `metro.config.ts` compatibility

### DIFF
--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -268,7 +268,7 @@ For a more comprehensive TypeScript setup, install [`tsx`](https://tsx.is/) as a
 
 </Tabs>
 
-Then utilize its [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) to import TypeScript files within your JS configuration file. This hook allows TypeScript imports while keeping the root file as JavaScript.
+Then utilize its [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) in your app config to enable importing external TypeScript modules.
 
 ```ts app.config.ts
 import 'tsx/cjs'; // Add this to import TypeScript files

--- a/docs/pages/guides/typescript.mdx
+++ b/docs/pages/guides/typescript.mdx
@@ -220,9 +220,23 @@ Some Expo libraries provide both static types and type generation capabilities. 
 
 ## TypeScript for project's config files
 
-Additional setup is required to use TypeScript for configuration files such as **metro.config.js** or **app.config.js**.
+### metro.config.ts
 
-Install [`tsx`](https://tsx.is/) as a dev dependency and utilize its [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) to import TypeScript files within your JS configuration file. This hook allows TypeScript imports while keeping the root file as JavaScript. The command below adds `tsx` so `import 'tsx/cjs'` works in the following sub-section examples.
+Metro supports TypeScript configuration files directly:
+
+```ts metro.config.ts
+import { getDefaultConfig } from 'expo/metro-config.js';
+
+const config = getDefaultConfig(import.meta.dirname);
+
+export default config;
+```
+
+### app.config.ts
+
+**app.config.ts** is supported by default. However, it doesn't support external TypeScript modules, or **tsconfig.json** customization.
+
+For a more comprehensive TypeScript setup, install [`tsx`](https://tsx.is/) as a dev dependency:
 
 <Tabs>
 
@@ -254,23 +268,18 @@ Install [`tsx`](https://tsx.is/) as a dev dependency and utilize its [`tsx/cjs` 
 
 </Tabs>
 
-### metro.config.js
+Then utilize its [`tsx/cjs` require hook](https://tsx.is/dev-api/entry-point#commonjs-mode-only) to import TypeScript files within your JS configuration file. This hook allows TypeScript imports while keeping the root file as JavaScript.
 
-Update **metro.config.js** to require **metro.config.ts** file:
+```ts app.config.ts
+import 'tsx/cjs'; // Add this to import TypeScript files
+import { ExpoConfig } from 'expo/config';
 
-```js metro.config.js
-require('tsx/cjs'); // Add this to import TypeScript files
-module.exports = require('./metro.config.ts');
-```
+const config: ExpoConfig = {
+  name: 'my-app',
+  slug: 'my-app',
+};
 
-Update **metro.config.ts** file with your project's metro configuration:
-
-```ts metro.config.ts
-import { getDefaultConfig } from 'expo/metro-config';
-
-const config = getDefaultConfig(__dirname);
-
-module.exports = config;
+export default config;
 ```
 
 <Collapsible summary="Deprecated: webpack.config.js">
@@ -294,22 +303,6 @@ module.exports = async function (env: Environment, argv: Arguments) {
 ```
 
 </Collapsible>
-
-### app.config.js
-
-**app.config.ts** is supported by default. However, it doesn't support external TypeScript modules, or **tsconfig.json** customization. You can use the following approach to get a more comprehensive TypeScript setup:
-
-```ts app.config.ts
-import 'tsx/cjs'; // Add this to import TypeScript files
-import { ExpoConfig } from 'expo/config';
-
-const config: ExpoConfig = {
-  name: 'my-app',
-  slug: 'my-app',
-};
-
-export default config;
-```
 
 ## Other TypeScript features
 


### PR DESCRIPTION
# Why

Metro supports TypeScript configuration files directly. ESM and TypeScript config support [shipped in `metro@0.83.2`](https://github.com/react/metro/issues/916#issuecomment-5475959289) and was recently documented by @robhogan.

[Expo SDK 57.0.16 depends on `@expo/metro@56.0.2`](https://unpkg.com/expo@57.0.16/package.json), which [depends on `metro@0.84.5`](https://unpkg.com/@expo/metro@56.0.2/package.json) (newer than `metro@0.83.2`), so the documented `metro.config.js` wrapper and `tsx/cjs` hook are no longer needed for Metro configuration.

# How

Update the TypeScript guide to use `metro.config.ts` directly and keep the `tsx` setup with the `app.config.ts` configuration that still uses it.

# Test Plan

Create a new Expo SDK 57 project:

```bash
pnpm create expo-app metro-config-ts-repro --template blank-typescript@57.0.17
cd metro-config-ts-repro
pnpm why metro
```

```bash
metro@0.84.5
...
Found 1 version of metro
```

Create a `metro.config.ts`:

```ts
import { getDefaultConfig } from 'expo/metro-config.js';

const message: string = '✅ loaded metro.config.ts';
console.log(message);

const config = getDefaultConfig(import.meta.dirname);

export default config;
```

Then start Expo:

```sh
pnpm expo start
```

```text
Starting project at /Users/k/p/metro-config-ts-repro
✅ loaded metro.config.ts
Starting Metro Bundler
...
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
