### PR TITLE
[iOS][JSI] Use shared instances for the runtime-free undefined and null values

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - [iOS] `CppError::tryCatch` now takes a C++ callable instead of an Objective-C block. Every caller already passes a pure C++ body, so the block bridged no Swift closure and only added a non-inlinable indirect call and an Objective-C runtime dependency on the JS call/eval error-handling path. ([#48333](https://github.com/expo/expo/pull/48333) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptActor.assumeIsolated` no longer heap-allocates a closure box per call by keeping its `operation` non-escaping, making synchronous host calls ~1.6× faster. ([#47837](https://github.com/expo/expo/pull/47837) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `JavaScriptValue.undefined` and `JavaScriptValue.null` now return shared immortal instances instead of allocating a new value on each access, removing one allocation from every void-returning host call. ([#49545](https://github.com/expo/expo/pull/49545) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -602,18 +602,25 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
 
   // MARK: - Runtime-free initializers
 
+  // Shared immortal instances for the runtime-free `undefined`/`null` kinds. The class is fully
+  // immutable and these carry no runtime and a trivial `jsi::Value`, so one instance can be safely
+  // handed out from any isolation context. Every void-returning `@JS` function returns `.undefined`,
+  // so a computed getter here would allocate on every host call.
+  private static let sharedUndefined = JavaScriptValue(nil, facebook.jsi.Value.undefined())
+  private static let sharedNull = JavaScriptValue(nil, facebook.jsi.Value.null())
+
   /// This is a lightweight way to create an undefined value that can be used in contexts
   /// where a runtime is not available or needed. The resulting value can be passed to
   /// JavaScript functions or used in comparisons.
   public static var undefined: JavaScriptValue {
-    JavaScriptValue(nil, facebook.jsi.Value.undefined())
+    return sharedUndefined
   }
 
   /// This is a lightweight way to create a null value that can be used in contexts
   /// where a runtime is not available or needed. The resulting value represents
   /// JavaScript's `null`, which is distinct from `undefined`.
   public static var null: JavaScriptValue {
-    JavaScriptValue(nil, facebook.jsi.Value.null())
+    return sharedNull
   }
 
   /// This is a lightweight way to create a boolean true value that can be used in contexts


### PR DESCRIPTION
# Why

`JavaScriptValue.undefined` and `JavaScriptValue.null` allocated a fresh instance on every access. Every void-returning host function returns `.undefined`, so each such call paid one allocation for a value that is always the same.

# How

The getters now hand out two shared immortal instances. The class is immutable and `Sendable`, and these values carry no runtime, so a single instance is safe to share from any isolation context.

# Test Plan

`pnpm test:integration` in the package passes (617 tests in 33 suites).
