### PR TITLE
[ios][notifications] Guard NotificationCenterManager's delegate list against concurrent access

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3913,7 +3913,7 @@ SPEC CHECKSUMS:
   ExpoModulesWorklets: 6b240031daa3de4df791588fc78236637ff602f6
   ExpoModulesWorkletsAdapter: add08a40add90b989d4f399e49508e34c6cf0334
   ExpoNetwork: 973d523fe9b1f99223dd945fed9ad1226ae64920
-  ExpoNotifications: 0f253ad90f108c1c4045b541294164865c6aadc8
+  ExpoNotifications: 2cb244d406414754b7159f1c7a9fd2d4754e7f47
   ExpoObserve: aa4fcbe7ed0a7ba387984a38e24c2ecaa8895fd0
   ExpoPrint: 7e7a9bc7c12b9b336f34c4458d0c9ba14f243759
   ExpoRouter: 224087330cc8f5a39700e6f4d7a55f55ecb2f90d

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. ([#49549](https://github.com/expo/expo/issues/49549), [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Prevented `onUserLeaveHint` from firing when a notification tap opens the app, which made picture-in-picture implementations enter PiP unexpectedly. ([#48471](https://github.com/expo/expo/pull/48471) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. ([#49549](https://github.com/expo/expo/issues/49549), [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
+- [iOS] Fix a data race on `NotificationCenterManager`'s delegate list that crashed the app with `SIGSEGV` when one app context registered its modules while another tore its own down, such as on a dev-client reload or `Updates.reloadAsync()`. [#49554](https://github.com/expo/expo/pull/49554) by [@dennytosp](https://github.com/dennytosp))
 - [Android] Prevented `onUserLeaveHint` from firing when a notification tap opens the app, which made picture-in-picture implementations enter PiP unexpectedly. ([#48471](https://github.com/expo/expo/pull/48471) by [@stareezy-1](https://github.com/stareezy-1))
 - [iOS] Avoid warning when an aborted push token registration request rejects with a native fetch cancellation error. ([#48547](https://github.com/expo/expo/pull/48547) by [@JoaoPauloCMarra](https://github.com/JoaoPauloCMarra))
 - [Android] Prevent a crash on notification tap when `getLaunchIntentForPackage` throws on some OEM ROMs. ([#47889](https://github.com/expo/expo/pull/47889) by [@nunocaseiro](https://github.com/nunocaseiro))

--- a/packages/expo-notifications/ios/ExpoNotifications.podspec
+++ b/packages/expo-notifications/ios/ExpoNotifications.podspec
@@ -31,5 +31,9 @@ Pod::Spec.new do |s|
     test_spec.dependency 'ExpoModulesTestCore'
 
     test_spec.source_files = "Tests/**/*.{m,mm,swift}"
+
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
   end
 end

--- a/packages/expo-notifications/ios/ExpoNotifications/Notifications/NotificationCenterManager.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Notifications/NotificationCenterManager.swift
@@ -39,6 +39,59 @@ public extension NotificationDelegate {
 private let discardPresentationOptions: (UNNotificationPresentationOptions) -> Void = { _ in }
 
 /**
+ The delegates of `NotificationCenterManager`, and the responses that arrived before any delegate
+ could handle them.
+
+ The manager is a process-wide singleton, but app contexts are not: the modules of an incoming
+ context register themselves while an outgoing context tears its own down, which happens on every
+ dev-client reload and on `Updates.reloadAsync()`. Both arrays are therefore written from more than
+ one thread at a time, so they live behind a lock.
+ */
+internal final class NotificationDelegateRegistry {
+  private let state = Mutex(State())
+
+  private struct State {
+    var delegates: [NotificationDelegate] = []
+    var pendingResponses: [UNNotificationResponse] = []
+  }
+
+  /**
+   A snapshot of the delegates. Callers iterate the snapshot instead of holding the lock across a
+   delegate callback: `add` hands back the pending responses so that the caller can offer them to
+   the delegate it just added, and a delegate is free to add or remove delegates from there.
+   */
+  var delegates: [NotificationDelegate] {
+    state.withLock { $0.delegates }
+  }
+
+  var pendingResponses: [UNNotificationResponse] {
+    state.withLock { $0.pendingResponses }
+  }
+
+  /**
+   Adds the delegate, and returns the responses that it still has to be offered.
+   */
+  func add(_ delegate: NotificationDelegate) -> [UNNotificationResponse] {
+    state.withLock { state in
+      state.delegates.append(delegate)
+      return state.pendingResponses
+    }
+  }
+
+  func remove(_ delegate: AnyObject) {
+    state.withLock { $0.delegates.removeAll { $0 === delegate } }
+  }
+
+  func appendPendingResponse(_ response: UNNotificationResponse) {
+    state.withLock { $0.pendingResponses.append(response) }
+  }
+
+  func removeAllPendingResponses() {
+    state.withLock { $0.pendingResponses.removeAll() }
+  }
+}
+
+/**
  Singleton that sets itself as the UserNotificationCenter delegate,
  and calls its own delegates in response to notification center calls.
  The notification center keeps a single delegate, so a delegate that another library set before
@@ -50,8 +103,15 @@ public class NotificationCenterManager: NSObject,
   @objc
   public static let shared = NotificationCenterManager()
 
-  var delegates: [NotificationDelegate] = []
-  var pendingResponses: [UNNotificationResponse] = []
+  private let registry = NotificationDelegateRegistry()
+
+  var delegates: [NotificationDelegate] {
+    registry.delegates
+  }
+
+  var pendingResponses: [UNNotificationResponse] {
+    registry.pendingResponses
+  }
 
   /**
    Delegate of the notification center that another library set before us. We forward every
@@ -102,18 +162,17 @@ public class NotificationCenterManager: NSObject,
   }
 
   public func addDelegate(_ delegate: NotificationDelegate) {
-    delegates.append(delegate)
     var handled = false
-    for pendingResponse in pendingResponses {
+    for pendingResponse in registry.add(delegate) {
       handled = delegate.didReceive(pendingResponse, completionHandler: {}) || handled
     }
     if handled {
-      pendingResponses.removeAll()
+      registry.removeAllPendingResponses()
     }
   }
 
   public func removeDelegate(_ delegate: AnyObject) {
-    delegates.removeAll { $0 === delegate }
+    registry.remove(delegate)
   }
 
   // MARK: - Called by PushTokenAppDelegateSubscriber
@@ -173,7 +232,7 @@ public class NotificationCenterManager: NSObject,
       handled = delegate.didReceive(response, completionHandler: completionHandler) || handled
     }
     if !handled {
-      pendingResponses.append(response)
+      registry.appendPendingResponse(response)
     }
     chainedDelegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
     completionHandler()

--- a/packages/expo-notifications/ios/Tests/NotificationDelegateRegistryTests.swift
+++ b/packages/expo-notifications/ios/Tests/NotificationDelegateRegistryTests.swift
@@ -1,0 +1,93 @@
+import Testing
+import Foundation
+
+@testable import ExpoNotifications
+
+/// A delegate that only needs an identity, which is all the registry uses.
+private final class StubDelegate: NotificationDelegate {}
+
+/// Runs `body` once per index, concurrently, and returns once every call has finished.
+private func concurrently(_ count: Int, _ body: @escaping (Int) -> Void) {
+  DispatchQueue.concurrentPerform(iterations: count) { index in
+    body(index)
+  }
+}
+
+// An incoming app context registers its modules while an outgoing one tears its modules down, so
+// the registry is written from more than one thread. Unsynchronized, concurrent `append`s lose
+// entries and corrupt the array's buffer, which crashes the process with SIGSEGV.
+@Suite("NotificationDelegateRegistry")
+struct NotificationDelegateRegistryTests {
+  @Test
+  func `keeps every delegate added from several threads at once`() {
+    let registry = NotificationDelegateRegistry()
+    let added = (0..<500).map { _ in StubDelegate() }
+
+    concurrently(added.count) { index in
+      _ = registry.add(added[index])
+    }
+
+    #expect(registry.delegates.count == added.count)
+    for delegate in added {
+      #expect(registry.delegates.contains { $0 === delegate })
+    }
+  }
+
+  @Test
+  func `removes every delegate removed from several threads at once`() {
+    let registry = NotificationDelegateRegistry()
+    let added = (0..<500).map { _ in StubDelegate() }
+    for delegate in added {
+      _ = registry.add(delegate)
+    }
+
+    concurrently(added.count) { index in
+      registry.remove(added[index])
+    }
+
+    #expect(registry.delegates.isEmpty)
+  }
+
+  @Test
+  func `keeps the survivors when adds and removes interleave across threads`() {
+    let registry = NotificationDelegateRegistry()
+    let survivors = (0..<250).map { _ in StubDelegate() }
+    let transients = (0..<250).map { _ in StubDelegate() }
+
+    concurrently(survivors.count + transients.count) { index in
+      if index < survivors.count {
+        _ = registry.add(survivors[index])
+      } else {
+        let transient = transients[index - survivors.count]
+        _ = registry.add(transient)
+        registry.remove(transient)
+      }
+    }
+
+    #expect(registry.delegates.count == survivors.count)
+    for delegate in survivors {
+      #expect(registry.delegates.contains { $0 === delegate })
+    }
+  }
+
+  @Test
+  func `add returns the responses the new delegate still has to be offered`() {
+    let registry = NotificationDelegateRegistry()
+    let first = StubDelegate()
+
+    #expect(registry.add(first).isEmpty)
+    #expect(registry.pendingResponses.isEmpty)
+  }
+
+  @Test
+  func `removing a delegate that was never added leaves the others in place`() {
+    let registry = NotificationDelegateRegistry()
+    let kept = StubDelegate()
+    _ = registry.add(kept)
+
+    registry.remove(StubDelegate())
+
+    #expect(registry.delegates.count == 1)
+    #expect(registry.delegates.first === kept)
+  }
+}


### PR DESCRIPTION
# Why

Fixes #49549. Previously reported as #47702, #48202 and #48992, each auto-closed for lacking a reproduction.

`NotificationCenterManager` is a process-wide singleton whose `delegates` and `pendingResponses` were unsynchronized stored properties. They are mutated by `addDelegate`, `removeDelegate` and the `pendingResponses.append` in `userNotificationCenter(_:didReceive:withCompletionHandler:)`, and read by every `for delegate in delegates` callback — from whichever thread happens to be creating or destroying an app context.

App contexts are not singletons. `PushTokenModule`, `HandlerModule` and `EmitterModule` each call `addDelegate` from `OnCreate` and `removeDelegate` from `OnDestroy`, so an incoming context registering its modules overlaps a departing context removing its own. That overlap is routine: every `expo-dev-client` reload, and `Updates.reloadAsync()` in a release build. Concurrent `Array.append` then corrupts the buffer and the process dies with `SIGSEGV` inside module registration.

# How

Both arrays move into a `NotificationDelegateRegistry` that keeps them behind `Mutex`, the backport in `ExpoModulesCore` that `expo-app-metrics` and `expo-app-intents` already use (`Synchronization.Mutex` is iOS 18+, this package targets 16.4).

Readers take a snapshot instead of holding the lock across a delegate callback. That matters: `addDelegate` calls `didReceive` on the delegate it just added, and a delegate is free to add or remove delegates from there — holding the lock across that would deadlock. `add` therefore returns the pending responses rather than exposing them separately.

Extracting the registry is what makes the synchronization testable. The manager is a singleton whose `init` calls `install()`, which reaches `UNUserNotificationCenter.current()` and crashes in a unit test bundle — I hit exactly that (`Crash: xctest at NotificationCenterManager.install()`) with a first version of these tests written against `.shared`. The registry has no such dependency.

`chainedDelegate` is left alone. It is written only from `install()` and is a separate concern from the reported crash.

# Test Plan

## The reporter's standalone repro

Their harness needs no Expo project, simulator or Xcode project. I re-ran it with the storage and the bodies of `addDelegate`, `removeDelegate` and `didRegister` copied verbatim from `main` — including `removeDelegate`'s current `removeAll { $0 === delegate }`, not the older `firstIndex` form quoted in the issue.

| build | ThreadSanitizer | 12 unsanitized runs |
| --- | --- | --- |
| `main` | race reported in `addDelegate` | **10–12 of 12 died with SIGSEGV** |
| this PR | **0 warnings** | **0 of 12** |

TSan on `main`'s logic:

```
WARNING: ThreadSanitizer: Swift access race
    #0 NotificationCenterManager.addDelegate(_:)
    #1 PushTokenModule.onCreate()
  Previous read:
    #0 NotificationCenterManager.didRegister(_:)
SUMMARY: ThreadSanitizer: Swift access race in NotificationCenterManager.addDelegate(_:)+0x10c
```

## Unit tests

Five new tests in `ios/Tests/NotificationDelegateRegistryTests.swift`. `et native-unit-tests -p ios --packages expo-notifications`:

```
NotificationDelegateRegistryTests
  ✓ keeps every delegate added from several threads at once
  ✓ removes every delegate removed from several threads at once
  ✓ keeps the survivors when adds and removes interleave across threads
  ✓ add returns the responses the new delegate still has to be offered
  ✓ removing a delegate that was never added leaves the others in place

BackgroundEventTransformerTests (existing, 5 tests)  ✓
** TEST SUCCEEDED **
```

Mutation check — reverting the registry to plain unsynchronized arrays and keeping everything else:

```
✕ keeps every delegate added from several threads at once      (0.000s)
✕ removes every delegate removed from several threads at once  (0.000s)
✕ keeps the survivors when adds and removes interleave across threads (0.000s)
✓ add returns the responses the new delegate still has to be offered
✓ removing a delegate that was never added leaves the others in place
** TEST FAILED **

Crash: xctest at closure #2 in NotificationDelegateRegistryTests.
  `removes every delegate removed from several threads at once`()
```

Exactly the three concurrency tests fail, and the two single-threaded ones still pass, so the tests are measuring the synchronization rather than passing by construction.

## One thing I had to add to run any of this

`test_spec` gains `'OTHER_LDFLAGS' => '$(inherited) -lc++'`. Without it the test target fails to link:

```
Undefined symbol: std::runtime_error::what() const
Undefined symbol: std::logic_error::logic_error(char const*)
  ... in libExpoModulesCore.a[3](EventEmitter-....o)
ExpoNotifications-Unit-Tests: clang: error: linker command failed with exit code 1
```

This is not caused by anything here — it is the same flag the test specs of `expo-maps`, `expo-camera`, `expo-audio`, `expo-updates`, `expo-image-picker`, `expo-observe`, `expo-app-metrics` and `expo-dev-launcher` already carry. Without it no test can run for this package at all, so the existing `BackgroundEventTransformerTests` could not have been running locally either. Happy to split it out if you would rather have it separately.

`Podfile.lock` carries the resulting `ExpoNotifications` checksum change, the same way the RN 0.87 upgrade PRs updated it.

## Not covered

I did not reproduce the crash in a running app on a device or simulator — the reporter's own trace does that, from a real build under Maestro relaunch cycles. Everything above is TSan output, crash counts and test results from this machine.

`et check-packages expo-notifications` reports `expo-notifications#lint` failing, but that reproduces unchanged on `main` (`Rule 'globals' not found in plugin 'react'`, an oxlint config/version mismatch). This PR touches no JavaScript or TypeScript.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [x] Added unit tests that fail without the fix.
- [x] Conforms to the [documentation writing style guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
