### PR TITLE
[metro-config] Emit default imports as importDefault calls

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Expand `skipCache` flag to data and support `prewarm` custom transform option ([#48836](https://github.com/expo/expo/pull/48836) by [@kitten](https://github.com/kitten))
 - Bump to `@expo/metro@56.0.2` and `metro@0.84.5` ([#49161](https://github.com/expo/expo/pull/49161) by [@kitten](https://github.com/kitten))
 - Point Metro's `assetRegistryPath` at `react-native/asset-registry`, which replaces the `@react-native/assets-registry` package as of React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Compile default imports to `importDefault` calls so that `inlineRequires` can defer them. ([#49556](https://github.com/expo/expo/pull/49556) by [@emma-syb](https://github.com/emma-syb))
 
 ## 57.0.7 - 2026-07-22
 

--- a/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/bundle-workers.test.ts
@@ -264,9 +264,6 @@ it(`supports worker bundle with shared deps`, async () => {
   );
 
   expectImports(graph, '/app/index.js').toEqual([
-    expect.objectContaining({
-      absolutePath: '/app/c.js',
-    }),
     {
       absolutePath: '/app/b.js',
       data: expect.objectContaining({
@@ -280,6 +277,9 @@ it(`supports worker bundle with shared deps`, async () => {
       data: expect.objectContaining({
         name: 'expo-mock/async-require',
       }),
+    }),
+    expect.objectContaining({
+      absolutePath: '/app/c.js',
     }),
   ]);
   expectImports(graph, '/app/b.js').toEqual([

--- a/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
+++ b/packages/@expo/metro-config/src/serializer/__tests__/tree-shaking.test.ts
@@ -674,19 +674,12 @@ it(`export var with trailing exports`, async () => {
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
       Object.defineProperty(exports, "add", {
         enumerable: true,
         get: function () {
-          return add;
+          return _$$_IMPORT_DEFAULT(_dependencyMap[0]).add;
         }
       });
-      var client = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
-      var add = client.default.add;
     },"/app/lib.js",["/app/b.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
@@ -1060,18 +1053,12 @@ export { Worm as default };
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
       Object.defineProperty(exports, "AArrowDown", {
         enumerable: true,
         get: function () {
-          return _aArrowDownJs2.default;
+          return _$$_IMPORT_DEFAULT(_dependencyMap[0]);
         }
       });
-      var _aArrowDownJs2 = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
     },"/app/lucide.js",["/app/a-arrow-down.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
@@ -1079,19 +1066,13 @@ export { Worm as default };
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
       Object.defineProperty(exports, "default", {
         enumerable: true,
         get: function () {
           return AArrowDown;
         }
       });
-      var createLucideIcon = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
-      const AArrowDown = (0, createLucideIcon.default)();
+      const AArrowDown = (0, _$$_IMPORT_DEFAULT(_dependencyMap[0]))();
     },"/app/a-arrow-down.js",["/app/createLucideIcon.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
@@ -1473,13 +1454,7 @@ it(`recursively expands unused with overlapping exports`, async () => {
     "__d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
 
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
-      var m = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
-      console.log(m.default.z1, DDD);
+      console.log(_$$_IMPORT_DEFAULT(_dependencyMap[0]).z1, DDD);
     },"/app/index.js",["/app/x0.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
@@ -1487,19 +1462,12 @@ it(`recursively expands unused with overlapping exports`, async () => {
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
       Object.defineProperty(exports, "default", {
         enumerable: true,
         get: function () {
-          return _default;
+          return _$$_IMPORT_DEFAULT(_dependencyMap[0]);
         }
       });
-      var X = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
-      var _default = X.default;
     },"/app/x0.js",["/app/x1.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";
@@ -1576,11 +1544,6 @@ it(`TODO: removes default export with overlapping exports (export-all and defaul
       Object.defineProperty(exports, '__esModule', {
         value: true
       });
-      function _interopDefault(e) {
-        return e && e.__esModule ? e : {
-          default: e
-        };
-      }
       Object.defineProperty(exports, "z1", {
         enumerable: true,
         get: function () {
@@ -1590,11 +1553,9 @@ it(`TODO: removes default export with overlapping exports (export-all and defaul
       Object.defineProperty(exports, "default", {
         enumerable: true,
         get: function () {
-          return _default;
+          return _$$_IMPORT_DEFAULT(_dependencyMap[0]);
         }
       });
-      var X = _interopDefault(_$$_REQUIRE(_dependencyMap[0]));
-      var _default = X.default;
     },"/app/x0.js",["/app/x1.js"]);
     __d(function (global, _$$_REQUIRE, _$$_IMPORT_DEFAULT, _$$_IMPORT_ALL, module, exports, _dependencyMap) {
       "use strict";

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-babel-snapshots.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-babel-snapshots.test.ts.snap
@@ -57,30 +57,18 @@ exports[`importInterop-none export-from 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _foo2.default;
+    return _foo2;
   }
 });
-var _foo = require('foo');
-var _foo2 = _interopDefault(_foo);"
+var _foo2 = _$$_IMPORT_DEFAULT('foo');"
 `;
 
 exports[`importInterop-none import-default-only 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _foo = require("foo");
-var foo = _interopDefault(_foo);
-(0, foo.default)();"
+"var foo = _$$_IMPORT_DEFAULT("foo");
+(0, foo)();"
 `;
 
 exports[`importInterop-none import-wildcard 1`] = `
@@ -109,11 +97,6 @@ exports[`interop export-all 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
@@ -131,12 +114,12 @@ Object.keys(_react).forEach(function (k) {
     });
   }
 });
-var _default = _interopDefault(_react);
+var _default = _$$_IMPORT_DEFAULT('react');
 // The fact that this exports both a normal default, and all of the names via
 // re-export is an edge case that is important not to miss. See
 // https://github.com/babel/babel/issues/8306 as an example.
 
-var _default2 = _default.default;"
+var _default2 = _default;"
 `;
 
 exports[`interop export-default 1`] = `
@@ -430,19 +413,13 @@ exports[`interop export-from-7 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "foo", {
   enumerable: true,
   get: function () {
-    return _foo2.default;
+    return _foo2;
   }
 });
-var _foo = require("foo");
-var _foo2 = _interopDefault(_foo);"
+var _foo2 = _$$_IMPORT_DEFAULT("foo");"
 `;
 
 exports[`interop export-from-8 1`] = `
@@ -1303,15 +1280,9 @@ require("./directory/foo-bar");"
 `;
 
 exports[`interop imports-default 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _foo = require("foo");
-var foo = _interopDefault(_foo);
-foo.default;
-foo.default;"
+"var foo = _$$_IMPORT_DEFAULT("foo");
+foo;
+foo;"
 `;
 
 exports[`interop imports-glob 1`] = `"require("foo");"`;
@@ -1319,14 +1290,9 @@ exports[`interop imports-glob 1`] = `"require("foo");"`;
 exports[`interop imports-hoisting 1`] = `"tag\`foo\`;"`;
 
 exports[`interop imports-mixing 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _foo = require("foo");
-var foo = _interopDefault(_foo);
-foo.default;
+"var _foo = require("foo");
+var foo = _$$_IMPORT_DEFAULT("foo");
+foo;
 _foo.baz;"
 `;
 
@@ -1366,11 +1332,6 @@ exports[`interop overview 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "test", {
   enumerable: true,
   get: function () {
@@ -1386,8 +1347,7 @@ Object.defineProperty(exports, "test2", {
 require("foo");
 require("foo-bar");
 require("./directory/foo-bar");
-var _foo2 = require("foo2");
-var foo = _interopDefault(_foo2);
+var foo = _$$_IMPORT_DEFAULT("foo2");
 require("foo3");
 var _foo4 = require("foo4");
 var _foo5 = require("foo5");
@@ -1395,7 +1355,7 @@ var test;
 var test2 = 5;
 _foo4.bar;
 _foo5.foo;
-foo.default;"
+foo;"
 `;
 
 exports[`interop remap 1`] = `
@@ -1468,15 +1428,10 @@ exports[`misc copy-getters-setters 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "Foo", {
   enumerable: true,
   get: function () {
-    return Foo.default;
+    return Foo;
   }
 });
 Object.defineProperty(exports, "baz", {
@@ -1486,7 +1441,7 @@ Object.defineProperty(exports, "baz", {
   }
 });
 var _moduleWithGetter = require("./moduleWithGetter");
-var Foo = _interopDefault(_moduleWithGetter);"
+var Foo = _$$_IMPORT_DEFAULT("./moduleWithGetter");"
 `;
 
 exports[`misc copy-getters-setters-star 1`] = `
@@ -1689,12 +1644,7 @@ for (foo of []);
 `;
 
 exports[`misc import-const-throw 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-function _interopNamespace(e) {
+"function _interopNamespace(e) {
   if (e && e.__esModule) return e;
   var n = {};
   if (e) Object.keys(e).forEach(function (k) {
@@ -1709,8 +1659,7 @@ function _interopNamespace(e) {
   n.default = e;
   return n;
 }
-var _foo = require("foo");
-var Foo = _interopDefault(_foo);
+var Foo = _$$_IMPORT_DEFAULT("foo");
 var _bar = require("bar");
 var Bar = _interopNamespace(_bar);
 var _baz = require("baz");
@@ -1744,13 +1693,13 @@ Baz >>>= 3;
 Foo &&= 4;
 Bar &&= 4;
 Baz &&= 4;
---Foo.default;
+--Foo;
 --Bar;
 --_baz.Baz;
-Foo.default++;
+Foo++;
 Bar++;
 _baz.Baz++;
-for (Foo.default in {});
+for (Foo in {});
 for (Bar in {}) {}
 for (_baz.Baz of []) {
   let Baz;
@@ -1935,12 +1884,7 @@ module.prop = "";"
 `;
 
 exports[`misc reference-source-map 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-function _interopNamespace(e) {
+"function _interopNamespace(e) {
   if (e && e.__esModule) return e;
   var n = {};
   if (e) Object.keys(e).forEach(function (k) {
@@ -1955,33 +1899,26 @@ function _interopNamespace(e) {
   n.default = e;
   return n;
 }
-var _one = require("one");
-var aDefault = _interopDefault(_one);
+var aDefault = _$$_IMPORT_DEFAULT("one");
 var _two = require("two");
 var _three = require("three");
 var _four = require("four");
 var aNamespace = _interopNamespace(_four);
-console.log(aDefault.default);
+console.log(aDefault);
 console.log(_two.aNamed);
 console.log(_three.orig);
 console.log(aNamespace);
-console.log((0, aDefault.default)());
+console.log((0, aDefault)());
 console.log((0, _two.aNamed)());
 console.log((0, _three.orig)());
 console.log((0, aNamespace)());"
 `;
 
 exports[`shadowed-namespace-import transformed-name 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _mod = require("mod");
-var t = _interopDefault(_mod);
+"var t = _$$_IMPORT_DEFAULT("mod");
 const foo = e => {
   return {
-    amount: t.default.format(1)
+    amount: t.format(1)
   };
 };"
 `;

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-interop-fallback-snapshots.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-interop-fallback-snapshots.test.ts.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`1. import default 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+test(AppleIcons.default);"
+`;
+
+exports[`2. import namespace 1`] = `
+"function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () {
+        return e[k];
+      }
+    });
+  });
+  n.default = e;
+  return n;
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopNamespace(_appleIcons);
+test(AppleIcons);"
+`;
+
+exports[`3. import default + namespace 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () {
+        return e[k];
+      }
+    });
+  });
+  n.default = e;
+  return n;
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+var AllAppleIcons = _interopNamespace(_appleIcons);
+test(AppleIcons.default, AllAppleIcons);"
+`;
+
+exports[`4. import default + named 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+test(AppleIcons.default, _appleIcons.Apple);"
+`;
+
+exports[`5. import default from multiple modules (single wrapper helper) 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+var _androidIcons = require('android-icons');
+var AndroidIcons = _interopDefault(_androidIcons);
+test(AppleIcons.default, AndroidIcons.default);"
+`;
+
+exports[`6. import namespace from multiple modules (single wrapper helper) 1`] = `
+"function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () {
+        return e[k];
+      }
+    });
+  });
+  n.default = e;
+  return n;
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopNamespace(_appleIcons);
+var _androidIcons = require('android-icons');
+var AndroidIcons = _interopNamespace(_androidIcons);
+test(AppleIcons, AndroidIcons);"
+`;
+
+exports[`7. import default unused (wrapper eliminated) 1`] = `"require('apple-icons');"`;
+
+exports[`8. import side effect + default import of same module 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+test(AppleIcons.default);"
+`;
+
+exports[`9. import side effect ordered before an unrelated side effect 1`] = `
+"function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+var _appleIcons = require('apple-icons');
+require('android-icons');
+var AppleIcons = _interopDefault(_appleIcons);
+test(AppleIcons.default);"
+`;
+
+exports[`10. export namespace by specifier 1`] = `
+"Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () {
+        return e[k];
+      }
+    });
+  });
+  n.default = e;
+  return n;
+}
+Object.defineProperty(exports, "AppleIcons", {
+  enumerable: true,
+  get: function () {
+    return _appleIcons2;
+  }
+});
+var _appleIcons = require('apple-icons');
+var _appleIcons2 = _interopNamespace(_appleIcons);"
+`;
+
+exports[`11. export default by specifier 1`] = `
+"Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+function _interopDefault(e) {
+  return e && e.__esModule ? e : {
+    default: e
+  };
+}
+Object.defineProperty(exports, "default", {
+  enumerable: true,
+  get: function () {
+    return _appleIcons2.default;
+  }
+});
+var _appleIcons = require('apple-icons');
+var _appleIcons2 = _interopDefault(_appleIcons);"
+`;

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-snapshots.test.ts.snap
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/__snapshots__/import-export-plugin-snapshots.test.ts.snap
@@ -108,20 +108,14 @@ exports[`with live bindings 5. export default + import default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
     return _default;
   }
 });
-var _test = require('test');
-var Test = _interopDefault(_test);
-test(Test.default);
+var Test = _$$_IMPORT_DEFAULT('test');
+test(Test);
 const local = 'local';
 var _default = local;"
 `;
@@ -384,59 +378,42 @@ exports[`with live bindings 14. re-export default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
-var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 15. re-export default as local 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "local", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
-var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 16. re-export combined cases (1) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "test", {
@@ -446,22 +423,17 @@ Object.defineProperty(exports, "test", {
   }
 });
 var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 17. re-export combined cases (2) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "test", {
@@ -473,22 +445,17 @@ Object.defineProperty(exports, "test", {
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 18. re-export combined cases (3) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "test", {
   enumerable: true,
   get: function () {
@@ -498,28 +465,23 @@ Object.defineProperty(exports, "test", {
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 19. re-export combined cases (4) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "test", {
   enumerable: true,
   get: function () {
@@ -529,28 +491,23 @@ Object.defineProperty(exports, "test", {
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 var _appleIcons = require('apple-icons');
-var _appleIcons2 = _interopDefault(_appleIcons);"
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 20. re-export all + namespaces 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 function _interopNamespace(e) {
   if (e && e.__esModule) return e;
   var n = {};
@@ -575,7 +532,7 @@ Object.defineProperty(exports, "test", {
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "AppleIcons", {
@@ -601,7 +558,7 @@ Object.keys(_appleIcons).forEach(function (k) {
     });
   }
 });
-var _appleIcons2 = _interopDefault(_appleIcons);
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');
 var _appleIcons3 = _interopNamespace(_appleIcons);"
 `;
 
@@ -609,11 +566,6 @@ exports[`with live bindings 21. re-export all multiple + namespaces 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 function _interopNamespace(e) {
   if (e && e.__esModule) return e;
   var n = {};
@@ -638,7 +590,7 @@ Object.defineProperty(exports, "test", {
 Object.defineProperty(exports, "_test", {
   enumerable: true,
   get: function () {
-    return _appleIcons2.default;
+    return _appleIcons2;
   }
 });
 Object.defineProperty(exports, "AppleIcons", {
@@ -664,7 +616,7 @@ Object.keys(_appleIcons).forEach(function (k) {
     });
   }
 });
-var _appleIcons2 = _interopDefault(_appleIcons);
+var _appleIcons2 = _$$_IMPORT_DEFAULT('apple-icons');
 var _androidIcons = require('android-icons');
 Object.keys(_androidIcons).forEach(function (k) {
   if (k !== 'default' && !Object.prototype.hasOwnProperty.call(exports, k)) {
@@ -712,14 +664,8 @@ test(AppleIcons);"
 `;
 
 exports[`with live bindings 23. import default 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-test(AppleIcons.default);"
+"var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(AppleIcons);"
 `;
 
 exports[`with live bindings 24. import specifier 1`] = `
@@ -733,91 +679,49 @@ test(_appleIcons.test);"
 `;
 
 exports[`with live bindings 26. import default specifier as local 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);
-test(local.default);"
+"var local = _$$_IMPORT_DEFAULT('apple-icons');
+test(local);"
 `;
 
 exports[`with live bindings 27. import specifier, and default 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-(0, _appleIcons.test)(AppleIcons.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+(0, _appleIcons.test)(AppleIcons, _appleIcons.test);"
 `;
 
 exports[`with live bindings 28. import specifier as local, and default 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-test(AppleIcons.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(AppleIcons, _appleIcons.test);"
 `;
 
 exports[`with live bindings 29. import default specifier as local, and default 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var _AppleIcons = _interopDefault(_appleIcons);
-test(_AppleIcons.default, _AppleIcons.default);"
+"var _AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(_AppleIcons, _AppleIcons);"
 `;
 
 exports[`with live bindings 30. import combined cases (1) 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var a = _interopDefault(_appleIcons);
-test(a.default, _appleIcons.b, a.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var a = _$$_IMPORT_DEFAULT('apple-icons');
+test(a, _appleIcons.b, a, _appleIcons.test);"
 `;
 
 exports[`with live bindings 31. import combined cases (2) 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var a = _interopDefault(_appleIcons);
-test(a.default, _appleIcons.b, a.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var a = _$$_IMPORT_DEFAULT('apple-icons');
+test(a, _appleIcons.b, a, _appleIcons.test);"
 `;
 
 exports[`with live bindings 32. import combined cases (3) 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var a = _interopDefault(_appleIcons);
-test(a.default, _appleIcons.b, a.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var a = _$$_IMPORT_DEFAULT('apple-icons');
+test(a, _appleIcons.b, a, _appleIcons.test);"
 `;
 
 exports[`with live bindings 33. import combined cases (4) 1`] = `
-"function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
-var _appleIcons = require('apple-icons');
-var a = _interopDefault(_appleIcons);
-test(a.default, _appleIcons.b, a.default, _appleIcons.test);"
+"var _appleIcons = require('apple-icons');
+var a = _$$_IMPORT_DEFAULT('apple-icons');
+test(a, _appleIcons.b, a, _appleIcons.test);"
 `;
 
 exports[`with live bindings 34. export imported namespace by specifier 1`] = `
@@ -853,19 +757,13 @@ exports[`with live bindings 35. export import default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "AppleIcons", {
   enumerable: true,
   get: function () {
-    return AppleIcons.default;
+    return AppleIcons;
   }
 });
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 36. export import specifier 1`] = `
@@ -898,34 +796,23 @@ exports[`with live bindings 38. export import default specifier as local 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "local", {
   enumerable: true,
   get: function () {
-    return local.default;
+    return local;
   }
 });
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);"
+var local = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 39. export import specifier and default (0) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "AppleIcons", {
   enumerable: true,
   get: function () {
-    return AppleIcons.default;
+    return AppleIcons;
   }
 });
 Object.defineProperty(exports, "test", {
@@ -935,23 +822,18 @@ Object.defineProperty(exports, "test", {
   }
 });
 var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-(0, _appleIcons.test)(AppleIcons.default);"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+(0, _appleIcons.test)(AppleIcons);"
 `;
 
 exports[`with live bindings 40. export import specifier and default (1) 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "AppleIcons", {
   enumerable: true,
   get: function () {
-    return AppleIcons.default;
+    return AppleIcons;
   }
 });
 Object.defineProperty(exports, "test", {
@@ -961,23 +843,18 @@ Object.defineProperty(exports, "test", {
   }
 });
 var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-(0, _appleIcons.test)(AppleIcons.default);"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+(0, _appleIcons.test)(AppleIcons);"
 `;
 
 exports[`with live bindings 41. export import specifier as local, and default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "AppleIcons", {
   enumerable: true,
   get: function () {
-    return AppleIcons.default;
+    return AppleIcons;
   }
 });
 Object.defineProperty(exports, "local", {
@@ -987,32 +864,26 @@ Object.defineProperty(exports, "local", {
   }
 });
 var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 42. export import default specifier as local, and default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "_AppleIcons", {
   enumerable: true,
   get: function () {
-    return _AppleIcons.default;
+    return _AppleIcons;
   }
 });
 Object.defineProperty(exports, "local", {
   enumerable: true,
   get: function () {
-    return _AppleIcons.default;
+    return _AppleIcons;
   }
 });
-var _appleIcons = require('apple-icons');
-var _AppleIcons = _interopDefault(_appleIcons);"
+var _AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');"
 `;
 
 exports[`with live bindings 43. export-default imported namespace by specifier 1`] = `
@@ -1049,20 +920,14 @@ exports[`with live bindings 44. export-default import default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
     return _default;
   }
 });
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-var _default = AppleIcons.default;"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+var _default = AppleIcons;"
 `;
 
 exports[`with live bindings 45. export-default import specifier 1`] = `
@@ -1097,20 +962,14 @@ exports[`with live bindings 47. export-default import default specifier as local
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "default", {
   enumerable: true,
   get: function () {
     return _default;
   }
 });
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);
-var _default = local.default;"
+var local = _$$_IMPORT_DEFAULT('apple-icons');
+var _default = local;"
 `;
 
 exports[`with live bindings 48. export-named imported namespace by specifier 1`] = `
@@ -1147,20 +1006,14 @@ exports[`with live bindings 49. export-named import default 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "AppleIcons", {
   enumerable: true,
   get: function () {
     return AppleIcons;
   }
 });
-var _appleIcons = require('apple-icons');
-var _AppleIcons = _interopDefault(_appleIcons);
-const AppleIcons = _AppleIcons.default;"
+var _AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+const AppleIcons = _AppleIcons;"
 `;
 
 exports[`with live bindings 50. export-named import specifier 1`] = `
@@ -1195,20 +1048,14 @@ exports[`with live bindings 52. export-named import default specifier as local 1
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "_local", {
   enumerable: true,
   get: function () {
     return _local;
   }
 });
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);
-const _local = local.default;"
+var local = _$$_IMPORT_DEFAULT('apple-icons');
+const _local = local;"
 `;
 
 exports[`with live bindings 53. export destructured object from imported namespace by specifier 1`] = `
@@ -1254,11 +1101,6 @@ exports[`with live bindings 54. export destructured object from import default 1
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "a", {
   enumerable: true,
   get: function () {
@@ -1271,12 +1113,11 @@ Object.defineProperty(exports, "b", {
     return b;
   }
 });
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
 const {
   a,
   b
-} = AppleIcons.default;"
+} = AppleIcons;"
 `;
 
 exports[`with live bindings 55. export destructured object from import specifier 1`] = `
@@ -1329,11 +1170,6 @@ exports[`with live bindings 57. export destructured object from import default s
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "a", {
   enumerable: true,
   get: function () {
@@ -1346,12 +1182,11 @@ Object.defineProperty(exports, "b", {
     return b;
   }
 });
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);
+var local = _$$_IMPORT_DEFAULT('apple-icons');
 const {
   a,
   b
-} = local.default;"
+} = local;"
 `;
 
 exports[`with live bindings 58. export nested destructured object w/ rest from import specifier 1`] = `
@@ -1426,11 +1261,6 @@ exports[`with live bindings 60. export destructured array from import default 1`
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "a", {
   enumerable: true,
   get: function () {
@@ -1443,9 +1273,8 @@ Object.defineProperty(exports, "b", {
     return b;
   }
 });
-var _appleIcons = require('apple-icons');
-var AppleIcons = _interopDefault(_appleIcons);
-const [a, b] = AppleIcons.default;"
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+const [a, b] = AppleIcons;"
 `;
 
 exports[`with live bindings 61. export destructured array from import specifier 1`] = `
@@ -1492,11 +1321,6 @@ exports[`with live bindings 63. export destructured array from import default sp
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
-function _interopDefault(e) {
-  return e && e.__esModule ? e : {
-    default: e
-  };
-}
 Object.defineProperty(exports, "a", {
   enumerable: true,
   get: function () {
@@ -1509,14 +1333,54 @@ Object.defineProperty(exports, "b", {
     return b;
   }
 });
-var _appleIcons = require('apple-icons');
-var local = _interopDefault(_appleIcons);
-const [a, b] = local.default;"
+var local = _$$_IMPORT_DEFAULT('apple-icons');
+const [a, b] = local;"
 `;
 
 exports[`with live bindings 64. import side effect 1`] = `"require('apple-icons');"`;
 
-exports[`with live bindings 65. export-named "__proto__" export by specifier 1`] = `
+exports[`with live bindings 65. import side effect + default import of same module 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(AppleIcons);"
+`;
+
+exports[`with live bindings 66. import side effect + namespace import of same module 1`] = `
+"function _interopNamespace(e) {
+  if (e && e.__esModule) return e;
+  var n = {};
+  if (e) Object.keys(e).forEach(function (k) {
+    var d = Object.getOwnPropertyDescriptor(e, k);
+    Object.defineProperty(n, k, d.get ? d : {
+      enumerable: true,
+      get: function () {
+        return e[k];
+      }
+    });
+  });
+  n.default = e;
+  return n;
+}
+var _appleIcons = require('apple-icons');
+var AppleIcons = _interopNamespace(_appleIcons);
+test(AppleIcons);"
+`;
+
+exports[`with live bindings 67. import side effect ordered before an unrelated side effect 1`] = `
+"require('apple-icons');
+require('android-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(AppleIcons);"
+`;
+
+exports[`with live bindings 68. import side effect after a default import of the same module 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+require('android-icons');
+test(AppleIcons);"
+`;
+
+exports[`with live bindings 69. export-named "__proto__" export by specifier 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });
@@ -2168,7 +2032,33 @@ exports.b = b;"
 
 exports[`without live bindings 64. import side effect 1`] = `"require('apple-icons');"`;
 
-exports[`without live bindings 65. export-named "__proto__" export by specifier 1`] = `
+exports[`without live bindings 65. import side effect + default import of same module 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+test(AppleIcons);"
+`;
+
+exports[`without live bindings 66. import side effect + namespace import of same module 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_ALL('apple-icons');
+test(AppleIcons);"
+`;
+
+exports[`without live bindings 67. import side effect ordered before an unrelated side effect 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+require('android-icons');
+test(AppleIcons);"
+`;
+
+exports[`without live bindings 68. import side effect after a default import of the same module 1`] = `
+"require('apple-icons');
+var AppleIcons = _$$_IMPORT_DEFAULT('apple-icons');
+require('android-icons');
+test(AppleIcons);"
+`;
+
+exports[`without live bindings 69. export-named "__proto__" export by specifier 1`] = `
 "Object.defineProperty(exports, '__esModule', {
   value: true
 });

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-interop-fallback-snapshots.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-interop-fallback-snapshots.test.ts
@@ -1,0 +1,67 @@
+import generate from '@babel/generator';
+
+import { importExportLiveBindingsPlugin } from '../index';
+import { transformToAst } from './__mocks__/test-helpers-upstream';
+
+// When the `importDefault` option is unset, the plugin emits a self-contained interop
+// wrapper instead of a call to Metro's `importDefault` helper, so that the output can be
+// evaluated without Metro's runtime. These snapshots pin that fallback output.
+
+const getExpected = (code: string) =>
+  generate(transformToAst([importExportLiveBindingsPlugin], code, {})).code;
+
+let n = 0;
+const test =
+  (name: string) =>
+  ([code]: readonly string[]): [string, string] => [`${++n}. ${name}`, code!];
+
+it.each([
+  test('import default')`
+    import AppleIcons from 'apple-icons';
+    test(AppleIcons);
+  `,
+  test('import namespace')`
+    import * as AppleIcons from 'apple-icons';
+    test(AppleIcons);
+  `,
+  test('import default + namespace')`
+    import AppleIcons, * as AllAppleIcons from 'apple-icons';
+    test(AppleIcons, AllAppleIcons);
+  `,
+  test('import default + named')`
+    import AppleIcons, { Apple } from 'apple-icons';
+    test(AppleIcons, Apple);
+  `,
+  test('import default from multiple modules (single wrapper helper)')`
+    import AppleIcons from 'apple-icons';
+    import AndroidIcons from 'android-icons';
+    test(AppleIcons, AndroidIcons);
+  `,
+  test('import namespace from multiple modules (single wrapper helper)')`
+    import * as AppleIcons from 'apple-icons';
+    import * as AndroidIcons from 'android-icons';
+    test(AppleIcons, AndroidIcons);
+  `,
+  test('import default unused (wrapper eliminated)')`
+    import AppleIcons from 'apple-icons';
+  `,
+  test('import side effect + default import of same module')`
+    import 'apple-icons';
+    import AppleIcons from 'apple-icons';
+    test(AppleIcons);
+  `,
+  test('import side effect ordered before an unrelated side effect')`
+    import 'apple-icons';
+    import 'android-icons';
+    import AppleIcons from 'apple-icons';
+    test(AppleIcons);
+  `,
+  test('export namespace by specifier')`
+    export * as AppleIcons from 'apple-icons';
+  `,
+  test('export default by specifier')`
+    export { default } from 'apple-icons';
+  `,
+])('%s', (_name, code) => {
+  expect(getExpected(code)).toMatchSnapshot();
+});

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-snapshots.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-snapshots.test.ts
@@ -304,6 +304,28 @@ describe.each([
     test('import side effect')`
       import 'apple-icons';
     `,
+    test('import side effect + default import of same module')`
+      import 'apple-icons';
+      import AppleIcons from 'apple-icons';
+      test(AppleIcons);
+    `,
+    test('import side effect + namespace import of same module')`
+      import 'apple-icons';
+      import * as AppleIcons from 'apple-icons';
+      test(AppleIcons);
+    `,
+    test('import side effect ordered before an unrelated side effect')`
+      import 'apple-icons';
+      import 'android-icons';
+      import AppleIcons from 'apple-icons';
+      test(AppleIcons);
+    `,
+    test('import side effect after a default import of the same module')`
+      import AppleIcons from 'apple-icons';
+      import 'android-icons';
+      import 'apple-icons';
+      test(AppleIcons);
+    `,
 
     // Regressions
     test('export-named "__proto__" export by specifier')`

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-upstream-live-bindings.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin-upstream-live-bindings.test.ts
@@ -28,11 +28,6 @@ it('correctly transforms and extracts "import" statements', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     function _interopNamespace(e) {
       if (e && e.__esModule) return e;
       var n = {};
@@ -48,14 +43,13 @@ it('correctly transforms and extracts "import" statements', () => {
       n.default = e;
       return n;
     }
-    var _foo = require('foo');
-    var v = _interopDefault(_foo);
+    var v = _$$_IMPORT_DEFAULT('foo');
     var _bar = require('bar');
     var w = _interopNamespace(_bar);
     var _baz = require('baz');
     var _qux = require('qux');
     require('side-effect');
-    v.default;
+    v;
     w;
     _baz.x;
     _qux.y;
@@ -91,11 +85,6 @@ it('correctly transforms complex patterns', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     function _interopNamespace(e) {
       if (e && e.__esModule) return e;
       var n = {};
@@ -113,15 +102,15 @@ it('correctly transforms complex patterns', () => {
     }
     require('first-with-side-effect');
     var _second = require('second');
-    var a = _interopDefault(_second);
+    var a = _$$_IMPORT_DEFAULT('second');
     var b = _interopNamespace(_second);
     var _third = require('third');
-    var c = _interopDefault(_third);
+    var c = _$$_IMPORT_DEFAULT('third');
     require('fourth-with-side-effect');
     var _fifth = require('fifth');
-    a.default;
+    a;
     b;
-    c.default;
+    c;
     _third.d;
     _third.f;
     _third.g;
@@ -177,19 +166,13 @@ it('exports members of another module directly from an import (as named)', () =>
 
   const expected = `
     Object.defineProperty(exports, '__esModule', {value: true});
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     Object.defineProperty(exports, "foo", {
       enumerable: true,
       get: function () {
-        return _bar2.default;
+        return _bar2;
       }
     });
-    var _bar = require('bar');
-    var _bar2 = _interopDefault(_bar);
+    var _bar2 = _$$_IMPORT_DEFAULT('bar');
   `;
 
   compare([importExportPlugin], code, expected, opts);
@@ -388,15 +371,10 @@ it('supports `import {default as LocalName}`', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     var _reactNative = require('react-native');
-    var ReactNative = _interopDefault(_reactNative);
+    var ReactNative = _$$_IMPORT_DEFAULT('react-native');
     _reactNative.Platform;
-    ReactNative.default;
+    ReactNative;
   `;
 
   compare([importExportPlugin], code, expected, opts);

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/import-export-plugin.test.ts
@@ -194,15 +194,10 @@ it('imports multiple members from another module and export them in separate sta
 
   const expected = `
     Object.defineProperty(exports, '__esModule', {value: true});
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     Object.defineProperty(exports, "bar", {
       enumerable: true,
       get: function () {
-        return bar.default;
+        return bar;
       }
     });
     Object.defineProperty(exports, "foo", {
@@ -218,13 +213,15 @@ it('imports multiple members from another module and export them in separate sta
       }
     });
     var _bar = require('bar');
-    var bar = _interopDefault(_bar);
+    var bar = _$$_IMPORT_DEFAULT('bar');
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
 
   expect(showTransformedDeps(code, [importExportLiveBindingsPlugin])).toMatchInlineSnapshot(`
     "
+    > 2 |     import bar, { foo, baz } from 'bar';
+        |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dep #0 (bar)
     > 2 |     import bar, { foo, baz } from 'bar';
         |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dep #0 (bar)"
   `);
@@ -267,11 +264,6 @@ it('transforms and extracts "import" statements as live bindings', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     function _interopNamespace(e) {
       if (e && e.__esModule) return e;
       var n = {};
@@ -287,14 +279,13 @@ it('transforms and extracts "import" statements as live bindings', () => {
       n.default = e;
       return n;
     }
-    var _foo = require('foo');
-    var v = _interopDefault(_foo);
+    var v = _$$_IMPORT_DEFAULT('foo');
     var _bar = require('bar');
     var w = _interopNamespace(_bar);
     var _baz = require('baz');
     var _qux = require('qux');
     require('side-effect');
-    test(v.default, w, _baz.x, _qux.y);
+    test(v, w, _baz.x, _qux.y);
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -489,20 +480,14 @@ it('does not transform direct export default as live binding', () => {
     Object.defineProperty(exports, '__esModule', {
       value: true
     });
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     Object.defineProperty(exports, "default", {
       enumerable: true,
       get: function () {
         return _default;
       },
     });
-    var _bar = require('bar');
-    var foo = _interopDefault(_bar);
-    var _default = foo.default;
+    var foo = _$$_IMPORT_DEFAULT('bar');
+    var _default = foo;
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -565,19 +550,13 @@ it('transforms export default as local with live binding', () => {
     Object.defineProperty(exports, '__esModule', {
       value: true
     });
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     Object.defineProperty(exports, "foo", {
       enumerable: true,
       get: function () {
-        return _bar2.default;
+        return _bar2;
       }
     });
-    var _bar = require('bar');
-    var _bar2 = _interopDefault(_bar);
+    var _bar2 = _$$_IMPORT_DEFAULT('bar');
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -594,15 +573,10 @@ it('transforms export default as local then >1 locals with live binding', () => 
     Object.defineProperty(exports, '__esModule', {
       value: true
     });
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     Object.defineProperty(exports, "b", {
       enumerable: true,
       get: function () {
-        return _bar2.default;
+        return _bar2;
       }
     });
     Object.defineProperty(exports, "c", {
@@ -618,7 +592,7 @@ it('transforms export default as local then >1 locals with live binding', () => 
       }
     });
     var _bar = require('bar');
-    var _bar2 = _interopDefault(_bar);
+    var _bar2 = _$$_IMPORT_DEFAULT('bar');
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -631,14 +605,8 @@ it('transforms import default as local with live binding', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
-    var _bar = require('bar');
-    var foo = _interopDefault(_bar);
-    test(foo.default);
+    var foo = _$$_IMPORT_DEFAULT('bar');
+    test(foo);
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -652,15 +620,10 @@ it('transforms import default as local then >1 locals with live binding', () => 
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     var _bar = require('bar');
-    var b = _interopDefault(_bar);
+    var b = _$$_IMPORT_DEFAULT('bar');
 
-    test(b.default, _bar.c, _bar.d)
+    test(b, _bar.c, _bar.d)
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });
@@ -673,14 +636,9 @@ it('transforms import default and named as local with live binding', () => {
   `;
 
   const expected = `
-    function _interopDefault(e) {
-      return e && e.__esModule ? e : {
-        default: e
-      };
-    }
     var _bar = require('bar');
-    var foo = _interopDefault(_bar);
-    console.log(foo.default, _bar.baz);
+    var foo = _$$_IMPORT_DEFAULT('bar');
+    console.log(foo, _bar.baz);
   `;
 
   compare([importExportLiveBindingsPlugin], code, expected, { ...opts });

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/import-interop-metro.test.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/import-interop-metro.test.ts
@@ -1,0 +1,169 @@
+import { IMPORT_DEFAULT_NAME, makeEval } from './utils';
+
+// The rest of this suite evaluates output built with the self-contained interop wrappers.
+// These tests instead run with Metro's `importDefault` helper, to check that the two paths
+// agree on interop semantics, and to cover the ordering of module evaluation. Namespace
+// imports keep the wrapper either way, and are covered here for the interaction with a
+// default import of the same module.
+
+const exec = makeEval({ importDefault: IMPORT_DEFAULT_NAME });
+
+it('import default of an ES module', () => {
+  const mod = exec({
+    foo: 'export default 1; export const named = 2;',
+    entry: 'import foo from "foo"; export const value = foo;',
+  });
+  expect(mod).toEqual({
+    exports: { value: 1 },
+    requests: ['foo'],
+  });
+});
+
+it('import default of a CommonJS module', () => {
+  const mod = exec({
+    foo: 'module.exports = { named: 2 };',
+    entry: 'import foo from "foo"; export const value = foo;',
+  });
+  expect(mod).toEqual({
+    exports: { value: { named: 2 } },
+    requests: ['foo'],
+  });
+});
+
+it('import namespace of an ES module', () => {
+  const mod = exec({
+    foo: 'export default 1; export const named = 2;',
+    entry: 'import * as ns from "foo"; export const value = { ...ns };',
+  });
+  expect(mod).toEqual({
+    exports: { value: { default: 1, named: 2 } },
+    requests: ['foo'],
+  });
+});
+
+it('import namespace of a CommonJS module', () => {
+  const mod = exec({
+    foo: 'module.exports = { named: 2 };',
+    entry: 'import * as ns from "foo"; export const value = { ...ns };',
+  });
+  expect(mod).toEqual({
+    exports: { value: { named: 2, default: { named: 2 } } },
+    requests: ['foo'],
+  });
+});
+
+it('import namespace of a CommonJS module exporting a function', () => {
+  const mod = exec({
+    foo: 'module.exports = function () { return 1; };',
+    entry: 'import * as ns from "foo"; export const value = ns.default;',
+  });
+  expect(mod).toEqual({
+    exports: { value: expect.any(Function) },
+    requests: ['foo'],
+  });
+  expect(mod.exports.value()).toBe(1);
+});
+
+// A CommonJS module of lazy getters is how `react-native` exposes its entry point, and
+// several of its getters throw for modules an app hasn't linked. Neither import form may
+// read a property to build its binding.
+describe('CommonJS module with lazy getters', () => {
+  const foo = `
+    module.exports = {
+      get safe() { return 1; },
+      get explodes() { throw new Error('getter invoked'); },
+    };
+  `;
+
+  it('does not invoke getters for a default import', () => {
+    const mod = exec({
+      foo,
+      entry: 'import foo from "foo"; export const value = foo.safe;',
+    });
+    expect(mod.exports.value).toBe(1);
+  });
+
+  it('does not invoke getters for a namespace import', () => {
+    const mod = exec({
+      foo,
+      entry: 'import * as ns from "foo"; export const value = ns.safe;',
+    });
+    expect(mod.exports.value).toBe(1);
+  });
+
+  it('still propagates a getter that the module body reads', () => {
+    expect(() =>
+      exec({
+        foo,
+        entry: 'import * as ns from "foo"; export const value = ns.explodes;',
+      })
+    ).toThrow('getter invoked');
+  });
+});
+
+it('import default and named from the same module', () => {
+  const mod = exec({
+    foo: 'export default 1; export const named = 2;',
+    entry: 'import foo, { named } from "foo"; export const value = [foo, named];',
+  });
+  expect(mod).toEqual({
+    exports: { value: [1, 2] },
+    requests: ['foo'],
+  });
+});
+
+describe('module evaluation order', () => {
+  // Imports are hoisted to the top of the output, so the log has to be set up out of band
+  // rather than by the entry module.
+  let order: string[];
+  beforeEach(() => {
+    order = [];
+    (globalThis as any).__order = order;
+  });
+  afterEach(() => {
+    delete (globalThis as any).__order;
+  });
+
+  it('evaluates a side-effect import before an unrelated one', () => {
+    const mod = exec({
+      foo: 'globalThis.__order.push("foo"); export default 1;',
+      bar: 'globalThis.__order.push("bar");',
+      entry: `
+        import 'foo';
+        import 'bar';
+        import foo from 'foo';
+        export const value = foo;
+      `,
+    });
+    expect(mod.exports.value).toBe(1);
+    expect(order).toEqual(['foo', 'bar']);
+  });
+
+  it('evaluates a module once when imported both bare and by default', () => {
+    const mod = exec({
+      foo: 'globalThis.__order.push("foo"); export default 1;',
+      entry: `
+        import 'foo';
+        import foo from 'foo';
+        export const value = foo;
+      `,
+    });
+    expect(mod.exports.value).toBe(1);
+    expect(order).toEqual(['foo']);
+  });
+
+  it('evaluates a side-effect import before a later namespace import', () => {
+    const mod = exec({
+      foo: 'globalThis.__order.push("foo"); export const named = 2;',
+      bar: 'globalThis.__order.push("bar");',
+      entry: `
+        import 'foo';
+        import 'bar';
+        import * as ns from 'foo';
+        export const value = ns.named;
+      `,
+    });
+    expect(mod.exports.value).toBe(2);
+    expect(order).toEqual(['foo', 'bar']);
+  });
+});

--- a/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/utils.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/__tests__/suite/utils.ts
@@ -16,11 +16,20 @@ type PluginEntry =
   | [EntryTarget, EntryOptions]
   | [EntryTarget, EntryOptions, string | void];
 
+/**
+ * Name of the `importDefault` helper the harness provides to evaluated modules. Passing this
+ * as the plugin's `importDefault` option makes it emit calls to Metro's helper rather than the
+ * self-contained interop wrapper.
+ */
+export const IMPORT_DEFAULT_NAME = '_$$_IMPORT_DEFAULT';
+
 export const makeEval = ({
   plugins = [importExportLiveBindingsPlugin],
   ...rest
 }: {
   plugins?: readonly PluginEntry[];
+  /** Must be `IMPORT_DEFAULT_NAME`, which is the name the harness binds the helper to. */
+  importDefault?: typeof IMPORT_DEFAULT_NAME;
 } = {}) => {
   return (code: string | { entry: string; [request: string]: string }) => {
     const input: Record<string, string> = {
@@ -29,13 +38,19 @@ export const makeEval = ({
     };
 
     const modules = Object.create(null);
+    /** Distinguishes "not yet resolved" from a module whose default export is `undefined`. */
+    const EMPTY = Symbol('empty');
 
     function transform(code: string): string {
       return generate(transformToAst(plugins, code, rest)).code;
     }
 
+    function resolve(target: string): string {
+      return input[path.normalize(target)] != null ? path.normalize(target) : target;
+    }
+
     function require(target: string): unknown {
-      const request = input[path.normalize(target)] != null ? path.normalize(target) : target;
+      const request = resolve(target);
       if (input[request] == null) {
         throw new Error(`Unknown request: ${request}`);
       }
@@ -44,6 +59,7 @@ export const makeEval = ({
         (modules[request] = {
           loaded: false,
           exports: Object.create(null),
+          importedDefault: EMPTY,
           require,
           path: request,
         });
@@ -57,17 +73,40 @@ export const makeEval = ({
           'module',
           '__filename',
           '__dirname',
+          IMPORT_DEFAULT_NAME,
           code
         );
         const { exports, require, path: dirname } = mod;
         try {
-          Reflect.apply(wrapper, exports, [exports, require, mod, request, dirname]);
+          // Only bound when the caller opted in, so that output built with the interop
+          // wrappers fails loudly if it ever calls the helper.
+          Reflect.apply(wrapper, exports, [
+            exports,
+            require,
+            mod,
+            request,
+            dirname,
+            rest.importDefault ? importDefault : undefined,
+          ]);
         } catch (error) {
           (error as Error).message += ` (eval: ${dirname})`;
           throw error;
         }
       }
       return mod.exports;
+    }
+
+    // Kept in 1:1 compatibility with `metroImportDefault` in `metro-runtime`'s `require`
+    // polyfill, including its per-module caching. The cache uses a sentinel rather than
+    // `undefined`, which is itself a resolvable default export.
+    function importDefault(target: string): unknown {
+      const mod = modules[resolve(target)];
+      if (mod != null && mod.importedDefault !== EMPTY) {
+        return mod.importedDefault;
+      }
+      const exports = require(target) as Record<string, unknown> | null | undefined;
+      return (modules[resolve(target)].importedDefault =
+        exports && exports.__esModule ? exports.default : exports);
     }
 
     const exports = require('entry') as any;

--- a/packages/@expo/metro-config/src/transform-plugins/helpers.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/helpers.ts
@@ -107,15 +107,15 @@ export const sideEffectRequireCall = (
   source: types.StringLiteral
 ): types.Statement => t.expressionStatement(t.callExpression(t.identifier('require'), [source]));
 
-/** `var %id% = %fnName%(%source%);` */
+/** `var %id% = %fnName%(%arg%);` */
 export const varDeclaratorCallHelper = (
   t: typeof types,
   id: string,
   fn: string,
-  arg: string
+  arg: types.Expression
 ): types.Statement =>
   t.variableDeclaration('var', [
-    t.variableDeclarator(t.identifier(id), t.callExpression(t.identifier(fn), [t.identifier(arg)])),
+    t.variableDeclarator(t.identifier(id), t.callExpression(t.identifier(fn), [arg])),
   ]);
 
 // Needs to be kept in 1:1 compatibility with Babel.

--- a/packages/@expo/metro-config/src/transform-plugins/importExportLiveBindings.ts
+++ b/packages/@expo/metro-config/src/transform-plugins/importExportLiveBindings.ts
@@ -16,6 +16,14 @@ import {
 } from './helpers';
 
 export interface Options {
+  /**
+   * Name of Metro's `importDefault` runtime helper. When set, default imports are emitted as
+   * calls to it, which Metro's inline-requires pass can defer. When unset, the output stays
+   * self-contained and needs nothing but `require`.
+   *
+   * Namespace imports deliberately have no equivalent: see `wrapNamespace` below.
+   */
+  readonly importDefault?: string;
   readonly performConstantFolding?: boolean;
   readonly resolve: boolean;
   readonly out?: {
@@ -40,6 +48,11 @@ interface ModuleSpecifiers {
   [ImportDeclarationKind.IMPORT_NAMESPACE]?: ID;
   /** Marks that the require call should be kept due to a side-effect */
   sideEffect?: boolean;
+  /**
+   * Marks that the module was imported for its side-effects alone (a bare `import 'src'`),
+   * which pins its evaluation to that import's position.
+   */
+  explicitSideEffect?: boolean;
 }
 
 /** Instruction for how to replace an expression when inlining */
@@ -104,6 +117,9 @@ export function importExportLiveBindingsPlugin({
     const moduleSpecifiers = addModuleSpecifiers(state, source);
     if (sideEffect || !state.opts.performConstantFolding) {
       moduleSpecifiers.sideEffect = true;
+    }
+    if (sideEffect) {
+      moduleSpecifiers.explicitSideEffect = true;
     }
     let id = moduleSpecifiers[ImportDeclarationKind.REQUIRE];
     if (!id) {
@@ -215,6 +231,12 @@ export function importExportLiveBindingsPlugin({
               break;
           }
 
+          // `importDefault` evaluates to the default export itself, whereas `_interopDefault`
+          // evaluates to a module-shaped wrapper that reference sites read `.default` off.
+          if (member === 'default' && state.opts.importDefault) {
+            member = undefined;
+          }
+
           state.inlineBodyRefs.set(localId, {
             parentId: importId,
             member,
@@ -302,6 +324,12 @@ export function importExportLiveBindingsPlugin({
           let importId: ID;
           let specifierLocal: string | undefined;
           let exportExpression: t.Expression;
+          // Mirrors the import side: with `importDefault` the local already holds the default
+          // export, without it the local is a wrapper carrying it under `default`.
+          const defaultExport = (id: ID): t.Expression =>
+            state.opts.importDefault
+              ? t.identifier(id)
+              : t.memberExpression(t.identifier(id), t.identifier('default'));
           switch (specifier.type) {
             case 'ExportNamespaceSpecifier':
               // The `namespaceWrapHelper` ensures a namespace object, but namespaces are accessed directly
@@ -315,23 +343,21 @@ export function importExportLiveBindingsPlugin({
               }
               specifierLocal = specifier.local.name;
               // An imported default specifier is the same as an ImportDefaultSpecifier
-              importId =
-                specifierLocal === 'default'
-                  ? addDefaultImport(path, state, source)
-                  : addImport(path, state, source);
-              exportExpression = t.memberExpression(
-                t.identifier(importId),
-                t.identifier(specifierLocal)
-              );
+              if (specifierLocal === 'default') {
+                importId = addDefaultImport(path, state, source);
+                exportExpression = defaultExport(importId);
+              } else {
+                importId = addImport(path, state, source);
+                exportExpression = t.memberExpression(
+                  t.identifier(importId),
+                  t.identifier(specifierLocal)
+                );
+              }
               break;
             case 'ExportDefaultSpecifier':
-              // The `defaultWrapHelper` works by wrapping CommonJS modules in a fake module wrapper
               specifierLocal = 'default';
               importId = addDefaultImport(path, state, source);
-              exportExpression = t.memberExpression(
-                t.identifier(importId),
-                t.identifier(specifierLocal)
-              );
+              exportExpression = defaultExport(importId);
               break;
           }
           const exportName = t.isIdentifier(specifier.exported)
@@ -490,22 +516,52 @@ export function importExportLiveBindingsPlugin({
           const preambleStatements: t.Statement[] = [];
           const esmStatements: t.Statement[] = [];
 
+          // NOTE: Metro's inline-requires pass only inlines calls it recognises, so the
+          // interop wrappers below stay eager under `inlineRequires`. Where Metro's
+          // `importDefault` helper is available we call it instead, which the pass can defer.
+          // It is equivalent to the wrapper: `exports.default` for ES modules and `exports`
+          // for CommonJS, which is what the wrapper's reference sites read off it.
+          // The source node is shared with the module's plain require declaration, so it's
+          // cloned rather than inserted twice.
+          const importDefaultName = state.opts.importDefault;
+          const importDefault = importDefaultName
+            ? (localId: string, source: ModuleRequest) =>
+                varDeclaratorCallHelper(t, localId, importDefaultName, t.cloneNode(source))
+            : null;
+
+          // A referenced default import already evaluates the module through `importDefault`,
+          // so it needs no separate side-effect require. A bare `import 'src'` is excluded: it
+          // pins evaluation to its own position, which a helper call emitted where the default
+          // import appeared wouldn't preserve.
+          const isEvaluatedByImportDefault = (moduleSpecifiers: ModuleSpecifiers) => {
+            if (!importDefault || moduleSpecifiers.explicitSideEffect) {
+              return false;
+            }
+            const defaultLocal = moduleSpecifiers[ImportDeclarationKind.IMPORT_DEFAULT];
+            return defaultLocal != null && state.referencedLocals.has(defaultLocal);
+          };
+
           let _defaultWrapName: string | null;
           const wrapDefault = (localId: string, sourceId: string) => {
             if (!_defaultWrapName) {
               _defaultWrapName = '_interopDefault';
               preambleStatements.push(defaultWrapHelper(template, _defaultWrapName));
             }
-            return varDeclaratorCallHelper(t, localId, _defaultWrapName, sourceId);
+            return varDeclaratorCallHelper(t, localId, _defaultWrapName, t.identifier(sourceId));
           };
 
+          // Namespace imports have no helper equivalent. Metro's `importAll` snapshots a
+          // CommonJS module by reading every own enumerable property, which invokes its
+          // getters; `_interopNamespace` copies their descriptors instead, so they stay lazy.
+          // `react-native`'s entry point is an object of nothing but lazy getters, several of
+          // which throw for modules the app hasn't linked, so the snapshot is not an option.
           let _namespaceWrapName: string | null;
           const wrapNamespace = (localId: string, sourceId: string) => {
             if (!_namespaceWrapName) {
               _namespaceWrapName = '_interopNamespace';
               preambleStatements.push(namespaceWrapHelper(template, _namespaceWrapName));
             }
-            return varDeclaratorCallHelper(t, localId, _namespaceWrapName, sourceId);
+            return varDeclaratorCallHelper(t, localId, _namespaceWrapName, t.identifier(sourceId));
           };
 
           // Add `__esModule` marker if we have any exports
@@ -530,7 +586,12 @@ export function importExportLiveBindingsPlugin({
             const local = addModuleSpecifiers(state, source)[importDeclaration.kind];
             if (!local || !state.referencedLocals.has(local)) {
               continue;
-            } else if (importDeclaration.local) {
+            } else if (
+              importDeclaration.local &&
+              // `importDefault` takes the module request directly, so a default import no
+              // longer needs the plain require local to feed a wrapper.
+              !(importDefault && importDeclaration.kind === ImportDeclarationKind.IMPORT_DEFAULT)
+            ) {
               state.referencedLocals.add(importDeclaration.local);
             }
           }
@@ -544,7 +605,8 @@ export function importExportLiveBindingsPlugin({
               // We check for REQUIRE, to make sure we only ever add a single side-effect require
               if (
                 importDeclaration.kind === ImportDeclarationKind.REQUIRE &&
-                moduleSpecifiers.sideEffect
+                moduleSpecifiers.sideEffect &&
+                !isEvaluatedByImportDefault(moduleSpecifiers)
               ) {
                 esmStatements.push(
                   withLocation(sideEffectRequireCall(t, source), importDeclaration.loc)
@@ -558,7 +620,9 @@ export function importExportLiveBindingsPlugin({
                 importStatement = requireCall(t, local, source);
                 break;
               case ImportDeclarationKind.IMPORT_DEFAULT:
-                importStatement = wrapDefault(local, importDeclaration.local!);
+                importStatement = importDefault
+                  ? importDefault(local, source)
+                  : wrapDefault(local, importDeclaration.local!);
                 break;
               case ImportDeclarationKind.IMPORT_NAMESPACE:
                 importStatement = wrapNamespace(local, importDeclaration.local!);

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -236,9 +236,9 @@ function getImportNames(options: JsTransformOptions, ast: t.File) {
     options.experimentalImportSupport === true &&
     options.customTransformOptions?.liveBindings !== 'false'
   ) {
-    // NOTE(@kitten): The live bindings import/export plugin doesn't use these helpers
-    // If it's used, we can assume that there's no conflicts (since we reserve this name, and assume users won't use it)
-    // and skip the expensive `generateImportNames` call
+    // NOTE(@kitten): The live bindings import/export plugin only emits `importDefault`, and
+    // never `importAll`. Both names are reserved, and we assume users won't declare them
+    // themselves, so we can skip the expensive `generateImportNames` conflict check.
     return {
       importAll: '_$$_IMPORT_ALL',
       importDefault: '_$$_IMPORT_DEFAULT',


### PR DESCRIPTION
# Why

With `inlineRequires` enabled, default imports were still evaluated eagerly at module load,
so app startup paid for modules that may never be used.

The live-bindings import plugin compiled default imports to a module-local interop wrapper
around a require (`var x = _interopDefault(require(src))`). Metro's `inline-requires` pass only
inlines calls it recognizes — `require` and the helpers in `inlineableCalls` — so these wrapper
calls were never inlined.

Separately, a referenced default import emitted a duplicate side-effect `require`.

# How

Emit `var x = _$$_IMPORT_DEFAULT(src)` when Metro's `importDefault` helper is available, so
`inline-requires` can defer evaluation to first use. The helper resolves to `exports.default`
for ES modules and `exports` for CJS — exactly what the wrapper's reference sites read — so
reference sites drop the `.default` access.

**Namespace imports keep the wrapper and stay eager.** `importAll` would be the equivalent, but
it snapshots a CJS module by reading every own enumerable property, invoking its getters;
`_interopNamespace` copies descriptors and leaves them lazy. `react-native`'s entry point is all
lazy getters, several of which throw for unlinked modules, so
`import * as ReactNative from 'react-native'` would crash on the snapshot. The non-live-bindings
plugin does use `importAll` here; that divergence is left in place rather than aligned.

**Making the wrappers inlineable instead isn't possible:** `inline-requires` resolves a module
name only from a `StringLiteral` first argument and skips any callee with a binding in scope,
which a module-local wrapper always has.

- **Fallback:** without the helper, the worker keeps emitting self-contained wrappers, for
  environments evaluating output outside Metro's runtime.
- **Bare & side-effect imports:** bare imports (`import 'src'`) are tracked separately in
  `ModuleSpecifiers`, so dropping the duplicate side-effect `require` preserves evaluation order
  relative to intermediate imports.
- **Dual imports:** a module imported by name and by default emits two call sites
  (`require(src)` and `_$$_IMPORT_DEFAULT(src)`) resolving to the same dependency, recording two
  locations for it.
- **Dependency order:** Under `inlineRequires`, default imports evaluate at first use rather than declaration, so dependency lists now reflect true execution order (updating bundle-worker snapshots). Without `inlineRequires`, calls remain hoisted and order is unchanged.

# Test Plan
## Automated

**Execution tests** — `src/transform-plugins/__tests__/suite/import-interop-metro.test.ts` (new).
The prior suites only asserted on emitted source. This one *evaluates* the transformed modules
against a stub `importDefault` bound to the same name Metro binds, so the interop is checked by
behavior rather than by shape:

- Default and namespace imports of both ES and CommonJS modules, including a CJS module whose
  default export is a function.
- **A CommonJS module of lazy getters** — the `react-native` entry-point shape that motivated
  keeping namespace imports on `_interopNamespace`. Asserts neither import form reads a property
  to build its binding (a thrower getter is never invoked), and that a getter the module body
  *does* read still propagates. This is the test that fails if someone later swaps in `importAll`.
- **Evaluation order** — a side-effect import runs before an unrelated one; a module imported both
  bare and by default evaluates exactly once; a side-effect import runs before a later namespace
  import. These cover the `ModuleSpecifiers` bare-import split and the dropped duplicate
  side-effect `require`.

**Snapshots, split by path.** `import-export-plugin-snapshots.test.ts` now covers the
side-effect/default interactions the change touches — side-effect + default import of the same
module, side-effect + namespace of the same module, and both orderings of a bare import relative
to a default import of the same module, which is what pins the ordering guarantee.
`import-export-plugin-interop-fallback-snapshots.test.ts` (new) pins the *fallback* output when
`importDefault` is unset, so the self-contained wrapper path can't silently regress for non-Metro
consumers.

**Updated expectations.** The `tree-shaking` snapshots lose the `_interopDefault` helper and its
`var` wrapper in favour of a direct `_$$_IMPORT_DEFAULT` call. `bundle-workers`'s shared-deps test
reorders: with `inlineRequires` the deferred default import registers at its use site, so the
dependency list now reflects evaluation order rather than declaration order.

Reviewer: `et check-packages @expo/metro-config`.

## Manual — bundle output

Built `apps/bare-expo` on an iOS simulator and pulled a production-mode bundle from the dev server:

    cd apps/bare-expo && npx expo run:ios
    curl -s "http://localhost:8081/.expo/.virtual-metro-entry.bundle?platform=ios&dev=false&minify=false" -o bundle.js

    grep -c '_\$\$_IMPORT_DEFAULT('              bundle.js
    grep -cE 'var [A-Za-z0-9_$]+ = _\$\$_IMPORT_DEFAULT\(' bundle.js
    grep -c 'function _interopDefault'           bundle.js
    grep -c 'function _interopNamespace'         bundle.js
    grep -c '_\$\$_IMPORT_ALL('                  bundle.js

Default config (`inlineRequires: false`), 27 MB bundle:

    _$$_IMPORT_DEFAULT( call sites   2492
      of which hoisted var decls     2492
    function _interopDefault            0
    function _interopNamespace        382
    _$$_IMPORT_ALL( call sites          0

Every default-import wrapper is gone, namespace imports keep theirs, and `importAll` is never
emitted. Re-running with `inlineRequires: true` in the app's `metro.config.js`:

| Metric | `inlineRequires: false` | `inlineRequires: true` |
| --- | --- | --- |
| `_$$_IMPORT_DEFAULT(` call sites | 2492 | 5012 |
| ...of which hoisted var decls | 2492 | 371 |

2121 of 2492 default imports (85%) move from eager to deferred; before this change that number
was 0. Call sites rise because one hoisted declaration becomes several inline call sites.

## Manual — real app

Used a pnpm override to run this fork against Soundtrack's app. The full E2E test suite passes and manual testing confirmed no regression issues.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
