### PR TITLE
[Android][dev-launcher] Fix NPE from key events after the activity was invalidated

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Exclude the manifest parser requests from app metrics, so the bundler reachability check no longer skews the observed network summary. ([#48616](https://github.com/expo/expo/pull/48616) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Remove an unused `RCTRootContentView.h` import. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Bump the Gradle plugin's Kotlin version to 2.2.21. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fixed a crash when a key event arrived after the launcher had invalidated the current activity, e.g. while switching to another app. ([#49565](https://github.com/expo/expo/pull/49565) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegate.kt
@@ -3,6 +3,7 @@ package expo.modules.devlauncher.react.activitydelegates
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Bundle
+import android.view.KeyEvent
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 
@@ -16,6 +17,9 @@ open class DevLauncherReactActivityNOPDelegate(activity: ReactActivity) :
   override fun onDestroy() {}
   override fun onNewIntent(intent: Intent?): Boolean = true
   override fun onBackPressed(): Boolean = true
+  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean = false
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean = false
+  override fun onKeyLongPress(keyCode: Int, event: KeyEvent): Boolean = false
   override fun onWindowFocusChanged(hasFocus: Boolean) {}
   override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {}
   override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray) {}

--- a/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegateTest.kt
+++ b/packages/expo-dev-launcher/android/src/testDebug/java/expo/modules/devlauncher/react/activitydelegates/DevLauncherReactActivityNOPDelegateTest.kt
@@ -1,0 +1,21 @@
+package expo.modules.devlauncher.react.activitydelegates
+
+import android.view.KeyEvent
+import com.facebook.react.ReactActivity
+import com.google.common.truth.Truth
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DevLauncherReactActivityNOPDelegateTest {
+  @Test
+  fun `key events do not crash after the delegate was invalidated`() {
+    val delegate = DevLauncherReactActivityNOPDelegate(mockk<ReactActivity>())
+    val event = KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_A)
+    Truth.assertThat(delegate.onKeyDown(KeyEvent.KEYCODE_A, event)).isFalse()
+    Truth.assertThat(delegate.onKeyUp(KeyEvent.KEYCODE_A, event)).isFalse()
+    Truth.assertThat(delegate.onKeyLongPress(KeyEvent.KEYCODE_A, event)).isFalse()
+  }
+}


### PR DESCRIPTION
# Why

Fixes #49542.

`DevLauncherReactActivityNOPDelegate` neutralizes every `ReactActivityDelegate` method that dereferences `mReactDelegate`, except `onKeyDown`, `onKeyUp` and `onKeyLongPress`. When a key event lands after `DevLauncherController.invalidateActivity()` swapped in the NOP delegate (the IME can re-deliver a declined key with a delay), the base implementation hits `Objects.requireNonNull(mReactDelegate)` and crashes. Debug builds only, since the NOP delegate lives in the debug source set.

# How

Added the three missing overrides, returning `false` so `ReactActivity` falls back to the standard `Activity` handling.

# Test Plan

New unit test sends all three key events through the NOP delegate. It failed with the reported NPE before the fix and passes now. Note that CI doesn't run it: `expo-dev-launcher` is on the exclusion list in `et android-native-unit-tests`, so I ran it locally with `./gradlew :expo-dev-launcher:testDebugUnitTest` in `apps/bare-expo/android` (41 tests, 0 failures).
