### PR TITLE
[require-utils] Add default-import interop to the CommonJS fallback

### DIFF
--- a/packages/@expo/require-utils/CHANGELOG.md
+++ b/packages/@expo/require-utils/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed default imports of `__esModule` CommonJS modules, such as compiled config plugins, resolving to the module namespace object instead of the default export when a TypeScript file is transformed to CommonJS without `typescript` installed ([#49566](https://github.com/expo/expo/pull/49566) by [@gustavohariel](https://github.com/gustavohariel))
+
 ### 💡 Others
 
 - Support Node 26's `stripTypeScriptTypes` and call without transform-mode, to fix the fallback when TypeScript isn't installed ([#48826](https://github.com/expo/expo/pull/48826) by [@kkkhs](https://github.com/kkkhs))

--- a/packages/@expo/require-utils/src/__tests__/fixtures/commonjs-plugin.js
+++ b/packages/@expo/require-utils/src/__tests__/fixtures/commonjs-plugin.js
@@ -1,0 +1,4 @@
+// A hand-written CommonJS module, without an `__esModule` marker
+module.exports = function withPlugin(config) {
+  return { ...config, pluginRan: true };
+};

--- a/packages/@expo/require-utils/src/__tests__/fixtures/esmodule-plugin.js
+++ b/packages/@expo/require-utils/src/__tests__/fixtures/esmodule-plugin.js
@@ -1,0 +1,6 @@
+// A compiled ES module, as every transpiled Expo config plugin looks
+function withPlugin(config) {
+  return { ...config, pluginRan: true };
+}
+exports.__esModule = true;
+exports.default = withPlugin;

--- a/packages/@expo/require-utils/src/__tests__/load-test.ts
+++ b/packages/@expo/require-utils/src/__tests__/load-test.ts
@@ -87,6 +87,70 @@ describe('evalModule', () => {
     expect(mod).toMatchObject({ default: 'test' });
   });
 
+  it('resolves a default import of an __esModule module to its default export', () => {
+    const mod = evalModule(
+      `
+      import withPlugin from './esmodule-plugin.js';
+      export default withPlugin({ name: 'test' });
+    `,
+      path.join(basepath, 'eval.js')
+    );
+
+    expect(mod).toEqual({
+      __esModule: true,
+      default: { name: 'test', pluginRan: true },
+    });
+  });
+
+  it('resolves a default import of a plain CommonJS module to its module.exports', () => {
+    const mod = evalModule(
+      `
+      import withPlugin from './commonjs-plugin.js';
+      export default withPlugin({ name: 'test' });
+    `,
+      path.join(basepath, 'eval.js')
+    );
+
+    expect(mod).toEqual({
+      __esModule: true,
+      default: { name: 'test', pluginRan: true },
+    });
+  });
+
+  it('resolves default imports when falling back to Node TypeScript stripping', () => {
+    jest.isolateModules(() => {
+      const actualNodeModule = jest.requireActual('node:module');
+      const moduleNotFoundError = new Error(
+        "Cannot find module 'typescript'"
+      ) as NodeJS.ErrnoException;
+      moduleNotFoundError.code = 'MODULE_NOT_FOUND';
+
+      jest.doMock('node:module', () => ({
+        ...actualNodeModule,
+        stripTypeScriptTypes: (code: string) => code.replace(': Config', ''),
+      }));
+      jest.doMock('typescript', () => {
+        throw moduleNotFoundError;
+      });
+
+      const { evalModule } = require('../load') as typeof import('../load');
+      const mod = evalModule(
+        `
+        import esModulePlugin from './esmodule-plugin.js';
+        import commonjsPlugin from './commonjs-plugin.js';
+        const config: Config = { name: 'test' };
+        export default [esModulePlugin(config), commonjsPlugin(config)];
+      `,
+        path.join(basepath, 'eval.ts')
+      );
+
+      expect(mod.default).toEqual([
+        { name: 'test', pluginRan: true },
+        { name: 'test', pluginRan: true },
+      ]);
+    });
+  });
+
   it('evaluates .js using import.meta as ESM instead of CommonJS', () => {
     const mod = evalModule(
       `

--- a/packages/@expo/require-utils/src/transform.ts
+++ b/packages/@expo/require-utils/src/transform.ts
@@ -9,13 +9,13 @@ export function toCommonJS(filename: string, code: string) {
       [
         require('@babel/plugin-transform-modules-commonjs'),
         {
-          // NOTE(@kitten): We used to use sucrase to transform, which is why
-          // we're doing this CJS-to-ESM transform in the first place. Our
-          // previous transformation isn't 100% compatible with the standard
-          // Node ESM loading. In Babel, this is the "node" flag (although
-          // node behaviour is explicitly different from this). This skips
-          // the `__esModule -> default` wrapper
-          importInterop: 'node',
+          // NOTE(@gustavohariel): We must keep Babel's default `__esModule` interop here, so that
+          // a default import of a transpiled module resolves to its `exports.default` rather than
+          // to the module namespace object. Every compiled Expo config plugin has that shape, and
+          // Node's `require(esm)` namespace carries `__esModule` too. This matches what
+          // TypeScript's `transpileModule` emits on the other code path in `evalModule`, so both
+          // transforms agree on what a default import means.
+          importInterop: 'babel',
           loose: true,
         },
       ],


### PR DESCRIPTION
# Why

An `app.config.ts` that default-imports a config plugin fails to load whenever `typescript` is missing or `typescript@7` is installed. `expo config`, `expo start`, `expo prebuild` and `expo-doctor` all stop with `TypeError: <plugin> is not a function`.

Fixes #49564. Reproduction: https://github.com/gustavohariel/expo-ts7-config-interop-repro

TypeScript 7 ships no compiler API, so `loadTypescript()` returns `null` (#47759) and `evalModule` falls back to `stripTypeScriptTypes` plus `toCommonJS`. `toCommonJS` passed `importInterop: 'node'` to `@babel/plugin-transform-modules-commonjs`, which skips the `__esModule -> default` unwrapping, so this config:

```ts
import withThing from './plugins/with-thing';
export default withThing(config);
```

was emitted as:

```js
var _withThing = require("./plugins/with-thing"); // namespace object, not exports.default
var _default = exports.default = _withThing(config);
```

Every compiled config plugin (`expo-router/plugin`, `expo-font/plugin`, and so on) is `exports.__esModule = true; exports.default = fn`, so `_withThing` is `{ __esModule: true, default: fn }` and calling it throws. The TypeScript path in the same function transpiles with `esModuleInterop: true` and emits `_interopRequireDefault` in that position, so the two transforms disagreed on what a default import means, and which one you got depended on whether `typescript` happened to be installed.

Default imports of real ESM were affected too: Node's `require(esm)` namespace carries `__esModule: true`, and `'node'` interop hands that namespace straight to the binding instead of its `default`.

# How

`toCommonJS` now uses Babel's default `__esModule` interop, which emits `_interopRequireDefault`:

- a module with `exports.__esModule = true` resolves the default import to `exports.default`
- a plain CommonJS module resolves the default import to the whole `module.exports`

`loose: true` is unchanged, and named imports, namespace imports and re-exports emit the same code as before. The only behaviour that changes is the default import of an `__esModule` module, which was the bug.

# Test Plan

Three tests added to `packages/@expo/require-utils/src/__tests__/load-test.ts`, with two new fixtures:

- default import of an `__esModule` module resolves to its default export
- default import of a plain CommonJS module resolves to its `module.exports`
- both of the above through the `stripTypeScriptTypes` fallback, with `typescript` mocked as not installed, which is the reported path

All 4 suites and 95 tests in the package pass. Reverting only `src/transform.ts` and keeping the tests makes the two `__esModule` cases fail with the reported error:

```
● evalModule › resolves a default import of an __esModule module to its default export
  TypeError: _esmodulePlugin is not a function
● evalModule › resolves default imports when falling back to Node TypeScript stripping
  TypeError: _esmodulePlugin is not a function

Tests: 2 failed, 93 passed, 95 total
```

End to end, on the reproduction app (Node 26.7.0, `typescript@7.0.2`, `expo@57.0.18`) with this package built and dropped into its `node_modules`:

```
$ bunx expo config --type public   # before
TypeError: Error reading Expo config at .../app.config.ts:

_withThing is not a function
    at Object.<anonymous> (.../app.config.js:10:34)
    at compileModule (.../@expo/require-utils/build/load.js:237:9)
    at evalModule (.../@expo/require-utils/build/load.js:361:17)

$ bunx expo config --type public   # after
{
  name: 'expo-ts7-repro',
  slug: 'expo-ts7-repro',
  version: '1.0.0',
  description: undefined,
  sdkVersion: '57.0.0',
  platforms: [ 'ios', 'android' ],
  extra: { pluginRan: true }
}
```

`extra.pluginRan` confirms the plugin was called rather than skipped. Downgrading the same app to `typescript@6.0.3`, which takes the `transpileModule` path instead, still prints the same config, so the fix does not regress the primary path.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
