### PR TITLE
[docs] Document EAS Simulator create links

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -753,6 +753,7 @@ const preview = [
         makePage('preview/eas-simulator/introduction.mdx'),
         makePage('preview/eas-simulator/get-started.mdx'),
         makePage('preview/eas-simulator/run-and-control.mdx'),
+        makePage('preview/eas-simulator/create-session-links.mdx'),
         makePage('preview/eas-simulator/cli-reference.mdx'),
         makePage('preview/eas-simulator/rest-api.mdx'),
         makePage('preview/eas-simulator/troubleshooting.mdx'),

--- a/docs/pages/preview/eas-simulator/create-session-links.mdx
+++ b/docs/pages/preview/eas-simulator/create-session-links.mdx
@@ -26,23 +26,25 @@ The person opening the link must sign in to an Expo account that can access the 
 
 Every create session link requires exactly one application source:
 
-| Parameter               | Description                                                                                                                                                                                           |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `buildId`               | ID of a finished, unexpired EAS Build for the iOS Simulator. The build determines the platform.                                                                                                       |
-| `buildFingerprint`      | Fingerprint hash of an EAS Build. Requires `platform`. EAS selects the newest finished, unexpired build with this fingerprint on the requested platform. On iOS, the build must target the Simulator. |
-| `applicationArchiveUrl` | URL of a downloadable iOS application archive. Encode this URL because it is nested inside the create session URL. Supported extensions are **.tar.gz**, **.tgz**, **.app**, and **.app.zip**.        |
+| Parameter               | Description                                                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `buildId`               | ID of a finished, unexpired EAS Build for the iOS Simulator. The build determines the platform.                                                                                                |
+| `buildFingerprint`      | Fingerprint hash of an EAS Build. Requires `platform`. EAS resolves it to the most recent installable build with this fingerprint on the requested platform.                                   |
+| `applicationArchiveUrl` | URL of a downloadable iOS application archive. Encode this URL because it is nested inside the create session URL. Supported extensions are **.tar.gz**, **.tgz**, **.app**, and **.app.zip**. |
 
 Do not include more than one application source. A link without an application source cannot create a session.
 
+An empty application source value, such as `buildId=`, is treated as absent.
+
 ### Add other parameters
 
-| Parameter          | Description                                                                                                                                                                                                                                                                                       |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `platform`         | Platform for `buildFingerprint` or `applicationArchiveUrl`. Create session links currently support `ios`. It is required with `buildFingerprint` and can be omitted when an archive URL has a supported iOS extension. The value does not override the platform of a build selected by `buildId`. |
-| `launchArgs`       | Argument passed to the application when it launches. Repeat this parameter to pass multiple arguments. Their order is preserved.                                                                                                                                                                  |
-| `openUrl`          | Expo, development-client, or application deep link to open after the application launches.                                                                                                                                                                                                        |
-| `deviceIdentifier` | iOS Simulator name or unique device identifier (UDID), such as `iPhone 16 Pro`. The runner chooses the default device when this parameter is omitted.                                                                                                                                             |
-| `name`             | Descriptive session name with a maximum of 255 characters.                                                                                                                                                                                                                                        |
+| Parameter          | Description                                                                                                                                                                                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `platform`         | Platform for `buildFingerprint` or `applicationArchiveUrl`. Create session links currently support `ios`. It is required with `buildFingerprint` and can be omitted when an archive URL has a supported iOS extension. It is ignored when the application source is `buildId` because the build determines its platform. |
+| `launchArgs`       | Argument passed to the application when it launches. Repeat this parameter to pass multiple arguments. Their order is preserved.                                                                                                                                                                                         |
+| `openUrl`          | Expo, development-client, or application deep link to open after the application launches.                                                                                                                                                                                                                               |
+| `deviceIdentifier` | iOS Simulator name or unique device identifier (UDID), such as `iPhone 16 Pro`. The runner chooses the default device when this parameter is omitted.                                                                                                                                                                    |
+| `name`             | Descriptive session name with a maximum of 255 characters.                                                                                                                                                                                                                                                               |
 
 URL-encode parameter values, especially nested URLs and values that contain spaces. Most programming languages provide a URL builder that handles this encoding. For example:
 
@@ -70,13 +72,13 @@ https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId
 
 The build must be finished, its artifact must not be expired, and it must target the iOS Simulator instead of a physical iOS device.
 
-### Start the latest compatible build with a fingerprint
+### Start the most recent installable build with a fingerprint
 
 ```text
 https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildFingerprint=FINGERPRINT_HASH&platform=ios
 ```
 
-EAS selects the newest finished, unexpired iOS Simulator build with this fingerprint. If no compatible build exists, the link shows a validation error. Use `buildId` instead when you need to select one specific build.
+EAS resolves the fingerprint to the most recent installable iOS Simulator build. If no installable build with this fingerprint exists, the link shows a validation error. Use `buildId` instead when you need to select one specific build.
 
 ### Name the session and choose a device
 
@@ -108,4 +110,4 @@ The session page shows its startup progress and the browser preview when it beco
 
 Closing the page or navigating away does not cancel a session creation that the service already accepted, and it does not stop a running session. Stop the session when you finish so that it does not continue consuming usage.
 
-If the parameters or build are invalid, expo.dev shows a **Cannot start simulator session** error instead. Common causes include an unfinished or expired build, an iOS device build, a fingerprint without `platform`, no compatible build for a fingerprint, an unsupported archive URL, or more than one application source.
+If the parameters or build are invalid, expo.dev shows a **Cannot start simulator session** error instead. Common causes include an unfinished or expired build, an iOS device build, a fingerprint without `platform`, no installable build for a fingerprint, an unsupported archive URL, or more than one application source.

--- a/docs/pages/preview/eas-simulator/create-session-links.mdx
+++ b/docs/pages/preview/eas-simulator/create-session-links.mdx
@@ -34,7 +34,7 @@ Every create session link requires exactly one application source:
 
 Do not include more than one application source. A link without an application source cannot create a session.
 
-An empty application source value, such as `buildId=`, is treated as absent.
+EAS treats an empty application source value, such as `buildId=`, as absent.
 
 ### Add other parameters
 
@@ -64,7 +64,7 @@ console.log(url.toString());
 
 ## Examples
 
-### Start an EAS Build
+### Start a session from an EAS Build
 
 ```text
 https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId=BUILD_UUID
@@ -86,7 +86,7 @@ EAS resolves the fingerprint to the most recent installable iOS Simulator build.
 https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId=BUILD_UUID&name=PR%20preview&deviceIdentifier=iPhone%2016%20Pro
 ```
 
-### Start an application archive
+### Start a session from an application archive
 
 ```text
 https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?applicationArchiveUrl=https%3A%2F%2Fcdn.example.com%2FMyApp.app.zip&platform=ios

--- a/docs/pages/preview/eas-simulator/create-session-links.mdx
+++ b/docs/pages/preview/eas-simulator/create-session-links.mdx
@@ -1,0 +1,101 @@
+---
+title: Start an EAS Simulator session from a link
+sidebar_title: Create session links
+description: Construct an authenticated expo.dev URL that creates and opens an EAS Simulator session from an EAS Build or application archive.
+---
+
+> **important** **EAS Simulator is a limited-access preview.** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulators) if you are interested in trying it.
+
+A create session link starts an iOS Simulator session from an EAS Build or application archive and opens its session page on expo.dev. Use one to add an EAS Simulator action to a pull request, CI result, or an internal tool without integrating the [REST API](/preview/eas-simulator/rest-api/).
+
+Create session links start browser-preview-only sessions. They do not provision agent-device, Appium, or Argent. Use [EAS CLI](/preview/eas-simulator/cli-reference/) or the [REST API](/preview/eas-simulator/rest-api/) when you need a controller, an Android Emulator, a blank device, Expo Go, or custom duration and idle limits.
+
+> **warning** Opening a create session link starts a new session without a confirmation step. The link is not idempotent: opening it again can create another session that consumes EAS Simulator usage. Share the resulting session page URL when you want someone to view an existing session instead of starting a new one.
+
+## Construct the URL
+
+Use the Expo account name and project slug in the URL:
+
+```text
+https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions/create?<parameters>
+```
+
+The person opening the link must sign in to an Expo account that can access the project. If they are signed out, expo.dev preserves the complete URL during authentication and starts the session after they sign in.
+
+### Choose an application source
+
+Every create session link requires exactly one application source:
+
+| Parameter               | Description                                                                                                                                                                                    |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `buildId`               | ID of a finished, unexpired EAS Build for the iOS Simulator. The build determines the platform.                                                                                                |
+| `applicationArchiveUrl` | URL of a downloadable iOS application archive. Encode this URL because it is nested inside the create session URL. Supported extensions are **.tar.gz**, **.tgz**, **.app**, and **.app.zip**. |
+
+Do not include both parameters. A link without either parameter cannot create a session.
+
+### Add optional parameters
+
+| Parameter          | Description                                                                                                                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `platform`         | Platform for `applicationArchiveUrl`. Create session links currently support `ios`. You can omit it when the archive URL has a supported iOS extension. The value does not override the platform of an EAS Build. |
+| `launchArgs`       | Argument passed to the application when it launches. Repeat this parameter to pass multiple arguments. Their order is preserved.                                                                                  |
+| `openUrl`          | Expo, development-client, or application deep link to open after the application launches.                                                                                                                        |
+| `deviceIdentifier` | iOS Simulator name or unique device identifier (UDID), such as `iPhone 16 Pro`. The runner chooses the default device when this parameter is omitted.                                                             |
+| `name`             | Descriptive session name with a maximum of 255 characters.                                                                                                                                                        |
+
+URL-encode parameter values, especially nested URLs and values that contain spaces. Most programming languages provide a URL builder that handles this encoding. For example:
+
+```js
+const url = new URL('https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create');
+
+url.searchParams.set('buildId', 'BUILD_UUID');
+url.searchParams.set('name', 'PR preview');
+url.searchParams.set('deviceIdentifier', 'iPhone 16 Pro');
+url.searchParams.append('launchArgs', '-UITestMode');
+url.searchParams.append('launchArgs', '1');
+url.searchParams.set('openUrl', 'myapp://profile/42');
+
+console.log(url.toString());
+```
+
+## Examples
+
+### Start an EAS Build
+
+```text
+https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId=BUILD_UUID
+```
+
+The build must be finished, its artifact must not be expired, and it must target the iOS Simulator instead of a physical iOS device.
+
+### Name the session and choose a device
+
+```text
+https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId=BUILD_UUID&name=PR%20preview&deviceIdentifier=iPhone%2016%20Pro
+```
+
+### Start an application archive
+
+```text
+https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?applicationArchiveUrl=https%3A%2F%2Fcdn.example.com%2FMyApp.app.zip&platform=ios
+```
+
+### Pass launch arguments and open a deep link
+
+```text
+https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId=BUILD_UUID&launchArgs=-UITestMode&launchArgs=1&openUrl=myapp%3A%2F%2Fprofile%2F42
+```
+
+## What happens when the link opens
+
+After authentication, expo.dev validates the parameters and build, creates the session, and redirects to its session page:
+
+```text
+https://expo.dev/accounts/<account>/projects/<project>/simulator-sessions/<session-id>
+```
+
+The session page shows its startup progress and the browser preview when it becomes available. Keep this resulting URL to return to or share the same session.
+
+Closing the page or navigating away does not cancel a session creation that the service already accepted, and it does not stop a running session. Stop the session when you finish so that it does not continue consuming usage.
+
+If the parameters or build are invalid, expo.dev shows a **Cannot start simulator session** error instead. Common causes include an unfinished or expired build, an iOS device build, an unsupported archive URL, or more than one application source.

--- a/docs/pages/preview/eas-simulator/create-session-links.mdx
+++ b/docs/pages/preview/eas-simulator/create-session-links.mdx
@@ -1,12 +1,12 @@
 ---
 title: Start an EAS Simulator session from a link
 sidebar_title: Create session links
-description: Construct an authenticated expo.dev URL that creates and opens an EAS Simulator session from an EAS Build or application archive.
+description: Construct an authenticated expo.dev URL that creates and opens an EAS Simulator session from an EAS Build, build fingerprint, or application archive.
 ---
 
 > **important** **EAS Simulator is a limited-access preview.** It is not included with paid or free plans and is currently available only to select partners. [Join the waitlist](https://expo.dev/services/simulators) if you are interested in trying it.
 
-A create session link starts an iOS Simulator session from an EAS Build or application archive and opens its session page on expo.dev. Use one to add an EAS Simulator action to a pull request, CI result, or an internal tool without integrating the [REST API](/preview/eas-simulator/rest-api/).
+A create session link starts an iOS Simulator session from an EAS Build, build fingerprint, or application archive and opens its session page on expo.dev. Use one to add an EAS Simulator action to a pull request, CI result, or an internal tool without integrating the [REST API](/preview/eas-simulator/rest-api/).
 
 Create session links start browser-preview-only sessions. They do not provision agent-device, Appium, or Argent. Use [EAS CLI](/preview/eas-simulator/cli-reference/) or the [REST API](/preview/eas-simulator/rest-api/) when you need a controller, an Android Emulator, a blank device, Expo Go, or custom duration and idle limits.
 
@@ -26,29 +26,31 @@ The person opening the link must sign in to an Expo account that can access the 
 
 Every create session link requires exactly one application source:
 
-| Parameter               | Description                                                                                                                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `buildId`               | ID of a finished, unexpired EAS Build for the iOS Simulator. The build determines the platform.                                                                                                |
-| `applicationArchiveUrl` | URL of a downloadable iOS application archive. Encode this URL because it is nested inside the create session URL. Supported extensions are **.tar.gz**, **.tgz**, **.app**, and **.app.zip**. |
+| Parameter               | Description                                                                                                                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `buildId`               | ID of a finished, unexpired EAS Build for the iOS Simulator. The build determines the platform.                                                                                                       |
+| `buildFingerprint`      | Fingerprint hash of an EAS Build. Requires `platform`. EAS selects the newest finished, unexpired build with this fingerprint on the requested platform. On iOS, the build must target the Simulator. |
+| `applicationArchiveUrl` | URL of a downloadable iOS application archive. Encode this URL because it is nested inside the create session URL. Supported extensions are **.tar.gz**, **.tgz**, **.app**, and **.app.zip**.        |
 
-Do not include both parameters. A link without either parameter cannot create a session.
+Do not include more than one application source. A link without an application source cannot create a session.
 
-### Add optional parameters
+### Add other parameters
 
-| Parameter          | Description                                                                                                                                                                                                       |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `platform`         | Platform for `applicationArchiveUrl`. Create session links currently support `ios`. You can omit it when the archive URL has a supported iOS extension. The value does not override the platform of an EAS Build. |
-| `launchArgs`       | Argument passed to the application when it launches. Repeat this parameter to pass multiple arguments. Their order is preserved.                                                                                  |
-| `openUrl`          | Expo, development-client, or application deep link to open after the application launches.                                                                                                                        |
-| `deviceIdentifier` | iOS Simulator name or unique device identifier (UDID), such as `iPhone 16 Pro`. The runner chooses the default device when this parameter is omitted.                                                             |
-| `name`             | Descriptive session name with a maximum of 255 characters.                                                                                                                                                        |
+| Parameter          | Description                                                                                                                                                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `platform`         | Platform for `buildFingerprint` or `applicationArchiveUrl`. Create session links currently support `ios`. It is required with `buildFingerprint` and can be omitted when an archive URL has a supported iOS extension. The value does not override the platform of a build selected by `buildId`. |
+| `launchArgs`       | Argument passed to the application when it launches. Repeat this parameter to pass multiple arguments. Their order is preserved.                                                                                                                                                                  |
+| `openUrl`          | Expo, development-client, or application deep link to open after the application launches.                                                                                                                                                                                                        |
+| `deviceIdentifier` | iOS Simulator name or unique device identifier (UDID), such as `iPhone 16 Pro`. The runner chooses the default device when this parameter is omitted.                                                                                                                                             |
+| `name`             | Descriptive session name with a maximum of 255 characters.                                                                                                                                                                                                                                        |
 
 URL-encode parameter values, especially nested URLs and values that contain spaces. Most programming languages provide a URL builder that handles this encoding. For example:
 
 ```js
 const url = new URL('https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create');
 
-url.searchParams.set('buildId', 'BUILD_UUID');
+url.searchParams.set('buildFingerprint', 'FINGERPRINT_HASH');
+url.searchParams.set('platform', 'ios');
 url.searchParams.set('name', 'PR preview');
 url.searchParams.set('deviceIdentifier', 'iPhone 16 Pro');
 url.searchParams.append('launchArgs', '-UITestMode');
@@ -67,6 +69,14 @@ https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildId
 ```
 
 The build must be finished, its artifact must not be expired, and it must target the iOS Simulator instead of a physical iOS device.
+
+### Start the latest compatible build with a fingerprint
+
+```text
+https://expo.dev/accounts/acme/projects/my-app/simulator-sessions/create?buildFingerprint=FINGERPRINT_HASH&platform=ios
+```
+
+EAS selects the newest finished, unexpired iOS Simulator build with this fingerprint. If no compatible build exists, the link shows a validation error. Use `buildId` instead when you need to select one specific build.
 
 ### Name the session and choose a device
 
@@ -98,4 +108,4 @@ The session page shows its startup progress and the browser preview when it beco
 
 Closing the page or navigating away does not cancel a session creation that the service already accepted, and it does not stop a running session. Stop the session when you finish so that it does not continue consuming usage.
 
-If the parameters or build are invalid, expo.dev shows a **Cannot start simulator session** error instead. Common causes include an unfinished or expired build, an iOS device build, an unsupported archive URL, or more than one application source.
+If the parameters or build are invalid, expo.dev shows a **Cannot start simulator session** error instead. Common causes include an unfinished or expired build, an iOS device build, a fingerprint without `platform`, no compatible build for a fingerprint, an unsupported archive URL, or more than one application source.

--- a/docs/pages/preview/eas-simulator/get-started.mdx
+++ b/docs/pages/preview/eas-simulator/get-started.mdx
@@ -36,7 +36,7 @@ If you use an AI agent, install [Expo Skills](/skills/) and ask it to use the EA
 
 ## Start a session manually
 
-The steps below use EAS CLI. To manage sessions directly from your own HTTP client, see the [REST API reference](/preview/eas-simulator/rest-api/).
+The steps below use EAS CLI. To manage sessions directly from your own HTTP client, see the [REST API reference](/preview/eas-simulator/rest-api/). To start a browser-preview-only session when someone opens an authenticated expo.dev URL, see [Create session links](/preview/eas-simulator/create-session-links/).
 
 <Step label="1">
 

--- a/docs/pages/preview/eas-simulator/introduction.mdx
+++ b/docs/pages/preview/eas-simulator/introduction.mdx
@@ -49,7 +49,7 @@ A common setup is a [Cursor cloud agent](https://cursor.com/cloud) or another ba
 
 An EAS Simulator workflow has four stages:
 
-1. **Start a session** with EAS CLI or the [REST API](/preview/eas-simulator/rest-api/). Give the session a descriptive name, choose a remote device and session type, and optionally set automatic duration or idle limits.
+1. **Start a session** with EAS CLI, the [REST API](/preview/eas-simulator/rest-api/), or an authenticated [create session link](/preview/eas-simulator/create-session-links/). Give the session a descriptive name, choose a remote device and session type, and optionally set automatic duration or idle limits.
 2. **Install your app.** Pass an EAS Build, application archive URL, or Expo Go to the start command, or install a local build through the controller after the session starts. A session without an application source starts with a blank device.
 3. **Drive the device.** Use [agent-device](/agents/agent-device/), [Argent](/agents/argent/), or [Appium](https://appium.io/docs/en/) for programmatic control. Supported iOS sessions also include a web preview.
 4. **Stop the session.** Stop it explicitly when you finish. An unattended non-interactive session continues consuming usage until it stops or reaches a configured limit.
@@ -85,6 +85,13 @@ Use [EAS Build](/build/introduction/) to create installable builds, and use loca
   title="Run and control your app"
   description="Install a local or EAS build, interact with the app, and capture evidence."
   href="/preview/eas-simulator/run-and-control/"
+  Icon={Cloud01Icon}
+/>
+
+<BoxLink
+  title="Create session links"
+  description="Construct a URL that starts a browser preview from an EAS Build or application archive."
+  href="/preview/eas-simulator/create-session-links/"
   Icon={Cloud01Icon}
 />
 


### PR DESCRIPTION
# Why

Document the authenticated `/simulator-sessions/create` URL so teams can start browser-preview-only EAS Simulator sessions from pull requests, CI results, and internal tools without integrating the REST API.

The guide also makes the action URL's immediate, non-idempotent behavior explicit so readers do not accidentally create duplicate sessions or share a creation link when they mean to share an existing session.

This documentation mirrors the merged website implementation in [expo/universe#30640](https://github.com/expo/universe/pull/30640), the source of truth for the create-link URL contract.

# How

- Add a dedicated create session links guide with the URL contract, application sources, additional parameters, URL encoding guidance, and examples.
- Document `buildFingerprint`, its required `platform`, and how EAS resolves it to the most recent installable build.
- Document empty source values and that `platform` is ignored for `buildId` links.
- Document authentication, current iOS/browser-preview-only limitations, validation behavior, session lifecycle, and the resulting shareable session URL.
- Register the page in EAS Simulator navigation and link it from the introduction and get-started pages.

# Test Plan

CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
