### PR TITLE
[cli][server] Cache resolved manifest runtime version per dev-server session

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Cache the resolved manifest runtime version per platform for the dev-server session, instead of recomputing it (including a full `@expo/fingerprint` computation under `runtimeVersion: { policy: 'fingerprint' }`) on every manifest request, which could take longer than a dev client's connection timeout and surface as "failed to connect".
 - Stop writing DOM component source maps into the app binary during `expo export:embed`, so Android release builds no longer ship `www.bundle` source maps with the original app source. ([#49480](https://github.com/expo/expo/pull/49480) by [@expo-bot](https://github.com/expo-bot))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.

--- a/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ExpoGoManifestHandlerMiddleware.ts
@@ -1,5 +1,5 @@
 import { events } from '2g';
-import type { ExpoUpdatesManifest } from '@expo/config';
+import type { ExpoConfig, ExpoUpdatesManifest } from '@expo/config';
 import { Updates } from '@expo/config-plugins';
 import accepts from 'accepts';
 import crypto from 'crypto';
@@ -18,6 +18,7 @@ import type { ManifestRequestInfo } from './ManifestMiddleware';
 import { ManifestMiddleware } from './ManifestMiddleware';
 import { manifestDebugEvent } from './events';
 import { parseForwardedRequestInfo } from './resolveForwarded';
+import type { RuntimePlatform } from './resolvePlatform';
 import { assertRuntimePlatform, parsePlatformHeader } from './resolvePlatform';
 import { resolveRuntimeVersionWithExpoUpdatesAsync } from './resolveRuntimeVersionWithExpoUpdatesAsync';
 import type { ServerRequest } from './server.types';
@@ -55,6 +56,14 @@ interface ExpoGoManifestRequestInfo extends ManifestRequestInfo {
 }
 
 export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoManifestRequestInfo> {
+  // Resolving the runtime version can shell out to `expo-updates runtimeversion:resolve`, which
+  // recomputes the project fingerprint under `runtimeVersion: { policy: 'fingerprint' }` — this can
+  // take several seconds, longer than some clients' connection timeout. Cache the result per platform
+  // for the lifetime of this dev-server session (like other config-derived values already are),
+  // instead of recomputing it on every manifest request.
+  // https://github.com/expo/expo/issues/46415
+  private runtimeVersionCache = new Map<RuntimePlatform, Promise<string | null>>();
+
   public getParsedHeaders(req: ServerRequest): ExpoGoManifestRequestInfo {
     let platform = parsePlatformHeader(req);
 
@@ -107,6 +116,34 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     };
   }
 
+  private resolveCachedRuntimeVersionAsync(
+    exp: ExpoConfig,
+    platform: RuntimePlatform
+  ): Promise<string | null> {
+    if (!this.runtimeVersionCache.has(platform)) {
+      const runtimeVersionPromise = (async () =>
+        (await resolveRuntimeVersionWithExpoUpdatesAsync({
+          projectRoot: this.projectRoot,
+          platform,
+        })) ??
+        // if expo-updates can't determine runtime version, fall back to calculation from config-plugin.
+        // this happens when expo-updates is installed but runtimeVersion hasn't yet been configured or when
+        // expo-updates is not installed.
+        (await Updates.getRuntimeVersionAsync(
+          this.projectRoot,
+          { ...exp, runtimeVersion: exp.runtimeVersion ?? { policy: 'sdkVersion' } },
+          // TODO(@kitten): Runtime-version resolution only reads ios/android config
+          // tvos/macos fall back to the shared `runtimeVersion` until they get explicit support
+          platform as 'android' | 'ios'
+        )))();
+      // Don't cache a rejection: a transient failure (e.g. a subprocess error) shouldn't
+      // permanently break manifest requests for the rest of the dev-server session.
+      runtimeVersionPromise.catch(() => this.runtimeVersionCache.delete(platform));
+      this.runtimeVersionCache.set(platform, runtimeVersionPromise);
+    }
+    return this.runtimeVersionCache.get(platform)!;
+  }
+
   private getDefaultResponseHeaders(): Headers {
     const headers = new Headers();
     // set required headers for Expo Updates manifest specification
@@ -122,21 +159,10 @@ export class ExpoGoManifestHandlerMiddleware extends ManifestMiddleware<ExpoGoMa
     const { exp, hostUri, expoGoConfig, bundleUrl } =
       await this._resolveProjectSettingsAsync(requestOptions);
 
-    const runtimeVersion =
-      (await resolveRuntimeVersionWithExpoUpdatesAsync({
-        projectRoot: this.projectRoot,
-        platform: requestOptions.platform,
-      })) ??
-      // if expo-updates can't determine runtime version, fall back to calculation from config-plugin.
-      // this happens when expo-updates is installed but runtimeVersion hasn't yet been configured or when
-      // expo-updates is not installed.
-      (await Updates.getRuntimeVersionAsync(
-        this.projectRoot,
-        { ...exp, runtimeVersion: exp.runtimeVersion ?? { policy: 'sdkVersion' } },
-        // TODO(@kitten): Runtime-version resolution only reads ios/android config
-        // tvos/macos fall back to the shared `runtimeVersion` until they get explicit support
-        requestOptions.platform as 'android' | 'ios'
-      ));
+    const runtimeVersion = await this.resolveCachedRuntimeVersionAsync(
+      exp,
+      requestOptions.platform
+    );
     if (!runtimeVersion) {
       throw new CommandError(
         'MANIFEST_MIDDLEWARE',

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -848,4 +848,45 @@ describe('_getManifestResponseAsync', () => {
 
     expect(partsSeen.has('manifest')).toBeTruthy();
   });
+
+  it('caches the resolved runtime version across requests for the same platform', async () => {
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('testrtv');
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    const requestOptions = {
+      responseContentType: ResponseContentType.APPLICATION_JSON,
+      platform: 'android' as const,
+      expectSignature: null,
+      hostname: 'localhost',
+    };
+
+    await middleware._getManifestResponseAsync(requestOptions);
+    await middleware._getManifestResponseAsync(requestOptions);
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the runtime version separately per platform', async () => {
+    jest.mocked(resolveRuntimeVersionWithExpoUpdatesAsync).mockResolvedValue('testrtv');
+
+    const middleware = createMiddleware();
+    process.env.EXPO_OFFLINE = '1';
+
+    await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.APPLICATION_JSON,
+      platform: 'android',
+      expectSignature: null,
+      hostname: 'localhost',
+    });
+    await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.APPLICATION_JSON,
+      platform: 'ios',
+      expectSignature: null,
+      hostname: 'localhost',
+    });
+
+    expect(resolveRuntimeVersionWithExpoUpdatesAsync).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
# Why

Fixes #46415.

`ExpoGoManifestHandlerMiddleware._getManifestResponseAsync` resolves the manifest's `runtimeVersion` on every request by calling `resolveRuntimeVersionWithExpoUpdatesAsync`, which shells out to `expo-updates runtimeversion:resolve` with no caching. Under `runtimeVersion: { policy: 'fingerprint' }`, that subprocess recomputes the full `@expo/fingerprint` on every call — several seconds on a real project, per the issue's repro (~13s; ~4s even on a blank `create-expo-app`).

The dev client fetches the manifest before the bundle, and some launchers (iOS) have a shorter connection timeout (~10s) than that computation, so the client times out with `error loading app, failed to connect to http://<host>:8081` while the manifest request is still resolving server-side — Android tolerates the delay better, so this looks like "Metro only works on Android" with no obvious cause. It's also a regression trap: anything that cold-invalidates the fingerprint (`prebuild --clean`, a clean reinstall, adding a native module) can start breaking iOS connections with no corresponding change in the project's own code.

Two external reporters (issue author + a commenter) independently hit this and converged on the same fix shape: cache the resolved runtime version for the dev-server session instead of recomputing it per request.

# How

Added a `Map<RuntimePlatform, Promise<string | null>>` cache on `ExpoGoManifestHandlerMiddleware` (this middleware is instantiated once per dev-server start in `BundlerDevServer.getManifestMiddlewareAsync`, so the instance already lives for the session, same as other per-session state in this file). `resolveCachedRuntimeVersionAsync` memoizes the existing resolution logic (`resolveRuntimeVersionWithExpoUpdatesAsync` falling back to `Updates.getRuntimeVersionAsync`) per platform, storing the in-flight promise immediately so concurrent requests for the same platform share one resolution instead of triggering redundant subprocess calls.

A rejected promise is removed from the cache (`.catch(() => cache.delete(platform))`) rather than cached, so a transient failure doesn't permanently break manifest requests for the rest of the session — only a successfully resolved (or `null`) result is kept, consistent with how a similar cache was scoped in #49259 in this repo.

Like other config-derived values already fixed for a session (`baseUrl`, `reactCompiler`), this requires a dev-server restart to pick up a runtime-version change mid-session — consistent with existing behavior elsewhere in the CLI.

# Test Plan

Added two tests to `ExpoGoManifestHandlerMiddleware-test.ts`:
- `caches the resolved runtime version across requests for the same platform` — calls `_getManifestResponseAsync` twice for the same platform and asserts `resolveRuntimeVersionWithExpoUpdatesAsync` was only invoked once.
- `resolves the runtime version separately per platform` — confirms `ios` and `android` get independent resolutions.

Confirmed both fail against the pre-fix code (2 calls instead of 1) and pass after the fix. All existing tests in the file (19 total) still pass.

Ran `et check-packages @expo/cli` — build, typecheck, depscheck, test, lint, and format all pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — n/a, dev-server-only middleware, no native/config-plugin surface.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
