### PR TITLE
[router] Remove redundant processing logic for menu icon

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -85,6 +85,7 @@
 
 ### 💡 Others
 
+- Pass toolbar menu icons straight to react-navigation instead of converting them to react-native-screens icons. (by [@Ubax](https://github.com/Ubax))
 - Remove module-level mutable navigation state from Expo Router. ([#49403](https://github.com/expo/expo/pull/49403) by [@Ubax](https://github.com/Ubax))
 - Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`. ([#49431](https://github.com/expo/expo/pull/49431) by [@Ubax](https://github.com/Ubax))
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -85,7 +85,7 @@
 
 ### 💡 Others
 
-- Pass toolbar menu icons straight to react-navigation instead of converting them to react-native-screens icons. (by [@Ubax](https://github.com/Ubax))
+- Pass toolbar menu icons straight to react-navigation instead of converting them to react-native-screens icons. (by [@Ubax](https://github.com/Ubax)) ([#49584](https://github.com/expo/expo/pull/49584) by [@Ubax](https://github.com/Ubax))
 - Remove module-level mutable navigation state from Expo Router. ([#49403](https://github.com/expo/expo/pull/49403) by [@Ubax](https://github.com/Ubax))
 - Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`. ([#49431](https://github.com/expo/expo/pull/49431) by [@Ubax](https://github.com/Ubax))
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarMenu.test.ios.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarMenu.test.ios.tsx
@@ -208,26 +208,28 @@ describe(convertStackToolbarMenuActionPropsToRNHeaderItem, () => {
   });
 
   describe('image icons', () => {
-    it('converts image icon to imageSource format by default', () => {
+    it('passes image icon as untinted by default', () => {
       const result = convertStackToolbarMenuActionPropsToRNHeaderItem({
         icon: { uri: 'https://example.com/icon.png' },
       });
 
       expect(result.icon).toEqual({
-        type: 'imageSource',
-        imageSource: { uri: 'https://example.com/icon.png' },
+        type: 'image',
+        source: { uri: 'https://example.com/icon.png' },
+        tinted: false,
       });
     });
 
-    it('converts image icon to templateSource format when iconRenderingMode is template', () => {
+    it('passes image icon as tinted when iconRenderingMode is template', () => {
       const result = convertStackToolbarMenuActionPropsToRNHeaderItem({
         icon: { uri: 'https://example.com/icon.png' },
         iconRenderingMode: 'template',
       });
 
       expect(result.icon).toEqual({
-        type: 'templateSource',
-        templateSource: { uri: 'https://example.com/icon.png' },
+        type: 'image',
+        source: { uri: 'https://example.com/icon.png' },
+        tinted: true,
       });
     });
   });
@@ -413,7 +415,7 @@ describe('submenu conversion', () => {
       });
     });
 
-    it('converts image icons to imageSource format in submenu', () => {
+    it('passes image icons in submenu', () => {
       const result = convertStackToolbarMenuPropsToRNHeaderItem({
         children: (
           <StackToolbarMenu title="Submenu" icon={{ uri: 'https://example.com/icon.png' }}>
@@ -424,13 +426,14 @@ describe('submenu conversion', () => {
 
       expect(result?.menu.items[0]).toMatchObject({
         icon: {
-          type: 'imageSource',
-          imageSource: { uri: 'https://example.com/icon.png' },
+          type: 'image',
+          source: { uri: 'https://example.com/icon.png' },
+          tinted: false,
         },
       });
     });
 
-    it('converts xcasset icons in submenu to imageSource format', () => {
+    it('passes xcasset icons in submenu as image icons', () => {
       const result = convertStackToolbarMenuPropsToRNHeaderItem({
         children: (
           <StackToolbarMenu title="Submenu">
@@ -441,7 +444,7 @@ describe('submenu conversion', () => {
       });
 
       expect(result?.menu.items[0]).toMatchObject({
-        icon: { type: 'imageSource', imageSource: { uri: 'custom-icon' } },
+        icon: { type: 'image', source: { uri: 'custom-icon' }, tinted: false },
       });
     });
   });

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/index.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/index.tsx
@@ -1,7 +1,5 @@
 'use client';
 import { Children, useMemo, type ReactNode } from 'react';
-import type { ImageSourcePropType } from 'react-native';
-import type { PlatformIconIOS } from 'react-native-screens';
 
 import type {
   NativeStackHeaderItemMenu,
@@ -190,19 +188,6 @@ export function convertStackToolbarMenuPropsToRNHeaderItem(
   return item;
 }
 
-// Custom menu action icons are not supported in react-navigation yet
-// But they are supported in react-native-screens
-// TODO(@ubax): Remove this workaround once react-navigation supports custom icons for menu actions.
-// https://linear.app/expo/issue/ENG-19853/remove-custom-conversion-logic-for-icon-from-packagesexpo
-function convertImageIconToPlatformIcon(icon: {
-  source: ImageSourcePropType;
-  tinted?: boolean;
-}): PlatformIconIOS {
-  return icon.tinted
-    ? { type: 'templateSource', templateSource: icon.source }
-    : { type: 'imageSource', imageSource: icon.source };
-}
-
 function convertStackToolbarSubmenuMenuPropsToRNHeaderItem(
   props: StackToolbarMenuProps
 ): NativeStackHeaderItemMenuSubmenu | undefined {
@@ -241,13 +226,7 @@ function convertStackToolbarSubmenuMenuPropsToRNHeaderItem(
   // TODO: Add elementSize to react-native-screens
 
   if (sharedProps.icon) {
-    if (sharedProps.icon.type === 'sfSymbol') {
-      item.icon = sharedProps.icon;
-    } else {
-      item.icon = convertImageIconToPlatformIcon(
-        sharedProps.icon
-      ) as unknown as NativeStackHeaderItemMenuSubmenu['icon'];
-    }
+    item.icon = sharedProps.icon;
   }
 
   return item;
@@ -317,13 +296,7 @@ export function convertStackToolbarMenuActionPropsToRNHeaderItem(
     item.keepsMenuPresented = unstable_keepPresented;
   }
   if (sharedProps.icon) {
-    if (sharedProps.icon.type === 'sfSymbol') {
-      item.icon = sharedProps.icon;
-    } else {
-      item.icon = convertImageIconToPlatformIcon(
-        sharedProps.icon
-      ) as unknown as NativeStackHeaderItemMenuAction['icon'];
-    }
+    item.icon = sharedProps.icon;
   }
   return item;
 }

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
@@ -895,7 +895,7 @@ describe('processBarButtonItems', () => {
 // ─── getMenuItem (via menu items) ───────────────────────────────────────────────
 // TODO(@ubax): Consider refactoring getMenuItem to be a separate function that can be tested in isolation instead of testing it indirectly via headerLeft items
 describe('getMenuItem', () => {
-  test('action item: label becomes title, description becomes subtitle', () => {
+  test('action item transforms label, description, and icon', () => {
     const onPress = jest.fn();
     const { result } = renderHook(() =>
       useHeaderConfigProps(
@@ -908,7 +908,13 @@ describe('getMenuItem', () => {
                 onPress: jest.fn(),
                 menu: {
                   items: [
-                    { type: 'action', label: 'Copy', description: 'Copy to clipboard', onPress },
+                    {
+                      type: 'action',
+                      label: 'Copy',
+                      description: 'Copy to clipboard',
+                      icon: { type: 'image', source: { uri: 'copy.png' }, tinted: false },
+                      onPress,
+                    },
                   ],
                 },
               },
@@ -919,6 +925,7 @@ describe('getMenuItem', () => {
     const menuItem = (result.current.headerLeftBarButtonItems![0] as any).menu.items[0];
     expect(menuItem.title).toBe('Copy');
     expect(menuItem.subtitle).toBe('Copy to clipboard');
+    expect(menuItem.icon).toEqual({ type: 'imageSource', imageSource: { uri: 'copy.png' } });
     expect(menuItem.label).toBeUndefined();
     expect(menuItem.description).toBeUndefined();
   });


### PR DESCRIPTION
# Why

Remove custom conversion logic for icon following https://github.com/react-navigation/react-navigation/pull/12987

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
