### PR TITLE
[router] Use routes array as back behavior history

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
-- Store tab back state in `routes` outside `fullHistory`, move drawer status to `drawerStatus`, and reserve `ROUTE_NAMES_CHANGED` for route set changes.
+- Store tab back state in `routes` outside `fullHistory`, move drawer status to `drawerStatus`, and reserve `ROUTE_NAMES_CHANGED` for route set changes. `backBehavior: 'order'` preloads every declared tab. ([#49586](https://github.com/expo/expo/pull/49586) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
-- Store tab back state in `routes` outside `fullHistory`, move drawer status to `drawerStatus`, and reserve `ROUTE_NAMES_CHANGED` for route set changes. `backBehavior: 'order'` preloads every declared tab. ([#49586](https://github.com/expo/expo/pull/49586) by [@Ubax](https://github.com/Ubax))
+- Store tab back state in `routes` outside `fullHistory`, move drawer status to `drawerStatus`, and reserve `ROUTE_NAMES_CHANGED` for route set changes. ([#49586](https://github.com/expo/expo/pull/49586) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
+- Store tab back state in `routes` outside `fullHistory`, move drawer status to `drawerStatus`, and reserve `ROUTE_NAMES_CHANGED` for route set changes.
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -446,7 +446,7 @@ it('does not reset tab content when triggers are reordered', () => {
   fireEvent.press(screen.getByTestId('reorder'));
   expect(appleMounts).toBe(1);
   expect(tabState).toEqual({
-    routeNames: ['orange', 'apple'],
+    routeNames: ['apple', 'orange'],
     routes: ['apple'],
   });
   act(() => router.back());
@@ -454,6 +454,7 @@ it('does not reset tab content when triggers are reordered', () => {
 });
 
 it('uses the new trigger order for order back behavior', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
   renderRouter(
     {
       _layout: function TabLayout() {
@@ -490,6 +491,8 @@ it('uses the new trigger order for order back behavior', () => {
   expect(screen).toHaveSegments(['apple']);
   act(() => router.back());
   expect(screen).toHaveSegments(['orange']);
+  expect(error).not.toHaveBeenCalled();
+  error.mockRestore();
 });
 
 it('returns to the initial route after triggers are reordered', () => {

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -402,6 +402,7 @@ it('does not reset tab content when only a trigger href changes', () => {
 });
 
 it('does not reset tab content when triggers are reordered', () => {
+  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
   let appleMounts = 0;
   let tabState: { routeNames: string[]; routes: string[] } | undefined;
 
@@ -450,7 +451,11 @@ it('does not reset tab content when triggers are reordered', () => {
     routes: ['apple'],
   });
   act(() => router.back());
-  expect(screen).toHaveSegments(['orange']);
+  expect(screen).toHaveSegments(['apple']);
+  expect(error).toHaveBeenCalledWith(
+    expect.stringContaining("The action 'GO_BACK' was not handled")
+  );
+  error.mockRestore();
 });
 
 it('uses the new trigger order for order back behavior', () => {

--- a/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/headless-tabs.test.ios.tsx
@@ -402,7 +402,6 @@ it('does not reset tab content when only a trigger href changes', () => {
 });
 
 it('does not reset tab content when triggers are reordered', () => {
-  const error = jest.spyOn(console, 'error').mockImplementation(() => {});
   let appleMounts = 0;
   let tabState: { routeNames: string[]; routes: string[] } | undefined;
 
@@ -447,15 +446,11 @@ it('does not reset tab content when triggers are reordered', () => {
   fireEvent.press(screen.getByTestId('reorder'));
   expect(appleMounts).toBe(1);
   expect(tabState).toEqual({
-    routeNames: ['apple', 'orange'],
+    routeNames: ['orange', 'apple'],
     routes: ['apple'],
   });
   act(() => router.back());
-  expect(screen).toHaveSegments(['apple']);
-  expect(error).toHaveBeenCalledWith(
-    expect.stringContaining("The action 'GO_BACK' was not handled")
-  );
-  error.mockRestore();
+  expect(screen).toHaveSegments(['orange']);
 });
 
 it('uses the new trigger order for order back behavior', () => {

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -50,8 +50,8 @@ it('redirects a guarded route to the anchor default during the initial load', ()
   expect(screen.getByTestId('a')).toBeVisible();
   expect(screen).toHavePathname('/a');
   expect(navigationRef.getRootState().routes[0]!.state!.routeNames).toStrictEqual([
-    'a',
     'index',
+    'a',
     'b',
     'c',
   ]);
@@ -144,10 +144,10 @@ it('redirects nested guarded routes to the anchor and unlocks them as guards fli
   expect(screen).toHavePathname('/c');
 
   expect(navigationRef.getRootState().routes[0]!.state!.routeNames).toStrictEqual([
+    'index',
     'a',
     'b',
     'c',
-    'index',
   ]);
 });
 
@@ -198,9 +198,9 @@ it('defaults a guarded route to the navigator anchor', () => {
   expect(screen.getByTestId('a')).toBeVisible();
   expect(screen).toHavePathname('/a');
   expect(navigationRef.getRootState().routes[0]!.state!.routeNames).toStrictEqual([
-    'a',
     'b',
     'index',
+    'a',
   ]);
 });
 

--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -326,17 +326,7 @@ it('works in a nested layout Stack->Tab->Stack', () => {
               params: {},
               path: undefined,
               state: {
-                history: [
-                  {
-                    key: expect.any(String),
-                    type: 'route',
-                  },
-                  {
-                    key: expect.any(String),
-                    type: 'route',
-                  },
-                ],
-                index: 2,
+                index: 1,
                 key: expect.any(String),
                 routeNames: ['a', 'b', 'c'],
                 routes: [
@@ -345,11 +335,6 @@ it('works in a nested layout Stack->Tab->Stack', () => {
                     name: 'a',
                     params: {},
                     path: '/a',
-                  },
-                  {
-                    key: expect.any(String),
-                    name: 'b',
-                    params: {},
                   },
                   {
                     key: expect.any(String),
@@ -383,6 +368,11 @@ it('works in a nested layout Stack->Tab->Stack', () => {
                       routeKeySeq: expect.any(Number),
                       type: 'stack',
                     },
+                  },
+                  {
+                    key: expect.any(String),
+                    name: 'b',
+                    params: {},
                   },
                 ],
                 stale: false,

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -198,17 +198,7 @@ test('dismissAll nested', () => {
         key: expect.any(String),
         name: '__root',
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
-          index: 2,
+          index: 1,
           key: expect.any(String),
           routeNames: ['a', 'b', 'one'],
           routes: [
@@ -216,11 +206,6 @@ test('dismissAll nested', () => {
               key: expect.any(String),
               name: 'a',
               path: '/a',
-            },
-            {
-              key: expect.any(String),
-              name: 'b',
-              params: {},
             },
             {
               key: expect.any(String),
@@ -289,6 +274,11 @@ test('dismissAll nested', () => {
                 type: 'stack',
               },
             },
+            {
+              key: expect.any(String),
+              name: 'b',
+              params: {},
+            },
           ],
           stale: false,
           routeKeySeq: expect.any(Number),
@@ -313,17 +303,7 @@ test('dismissAll nested', () => {
         key: expect.any(String),
         name: '__root',
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
-          index: 2,
+          index: 1,
           key: expect.any(String),
           routeNames: ['a', 'b', 'one'],
           routes: [
@@ -331,11 +311,6 @@ test('dismissAll nested', () => {
               key: expect.any(String),
               name: 'a',
               path: '/a',
-            },
-            {
-              key: expect.any(String),
-              name: 'b',
-              params: {},
             },
             {
               key: expect.any(String),
@@ -392,6 +367,11 @@ test('dismissAll nested', () => {
                 type: 'stack',
               },
             },
+            {
+              key: expect.any(String),
+              name: 'b',
+              params: {},
+            },
           ],
           stale: false,
           routeKeySeq: expect.any(Number),
@@ -416,17 +396,7 @@ test('dismissAll nested', () => {
         key: expect.any(String),
         name: '__root',
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
-          index: 2,
+          index: 1,
           key: expect.any(String),
           routeNames: ['a', 'b', 'one'],
           routes: [
@@ -434,11 +404,6 @@ test('dismissAll nested', () => {
               key: expect.any(String),
               name: 'a',
               path: '/a',
-            },
-            {
-              key: expect.any(String),
-              name: 'b',
-              params: {},
             },
             {
               key: expect.any(String),
@@ -460,6 +425,11 @@ test('dismissAll nested', () => {
                 routeKeySeq: expect.any(Number),
                 type: 'stack',
               },
+            },
+            {
+              key: expect.any(String),
+              name: 'b',
+              params: {},
             },
           ],
           stale: false,

--- a/packages/expo-router/src/__tests__/tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tabs.test.ios.tsx
@@ -399,25 +399,19 @@ it('can use replace navigation', () => {
         key: expect.any(String),
         name: '__root',
         state: {
-          history: [
-            {
-              key: expect.any(String),
-              type: 'route',
-            },
-          ],
-          index: 1,
+          index: 0,
           key: expect.any(String),
           routeNames: ['one', 'two'],
           routes: [
             {
               key: expect.any(String),
-              name: 'one',
-              path: '/one',
+              name: 'two',
+              params: {},
             },
             {
               key: expect.any(String),
-              name: 'two',
-              params: {},
+              name: 'one',
+              path: '/one',
             },
           ],
           stale: false,

--- a/packages/expo-router/src/global-state/resolveNavigationDestination.ts
+++ b/packages/expo-router/src/global-state/resolveNavigationDestination.ts
@@ -232,8 +232,7 @@ function createDestinationState(
 ): NavigationState {
   const targetRoute = getFocusedRoute(targetState);
   const initialRouteName = getValidInitialRouteName(routeNode);
-  // Sort like a mounted navigator does, so the route names match on mount and no
-  // ROUTE_NAMES_CHANGED action is queued.
+  // Seed the same route-name set as the mounted navigator so HMR reconciliation is unnecessary.
   const routeNames = [...routeNode.children]
     .sort(sortRoutesWithInitial(initialRouteName))
     .map((child) => child.route);

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -87,7 +87,10 @@ type NavigationTreeResult = {
 };
 
 const warnedActions = new WeakSet<NavigationAction>();
-const ACTIONS_WITHOUT_REMOVAL_PREVENTION = new Set(['ROUTE_NAMES_CHANGED']);
+const ACTIONS_WITHOUT_REMOVAL_PREVENTION = new Set([
+  'ROUTE_NAMES_CHANGED',
+  'ROUTE_NAMES_ORDER_CHANGED',
+]);
 
 function warnIfStaleState(state: NavigationState) {
   if (process.env.NODE_ENV !== 'development') {

--- a/packages/expo-router/src/layouts/DrawerClient.tsx
+++ b/packages/expo-router/src/layouts/DrawerClient.tsx
@@ -21,7 +21,7 @@ import {
 import { unstable_integrateWithRouter } from '../standard-navigation';
 import {
   appendMissingPlaceholderTabDescriptors,
-  appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../standard-navigation/appendMissingPlaceholderTabRoutes';
 
 export const Drawer = unstable_integrateWithRouter<
@@ -33,7 +33,7 @@ export const Drawer = unstable_integrateWithRouter<
   DrawerNavigatorCreateProps
 >(createStandardDrawerNavigator, DrawerRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
-  processState: appendMissingPlaceholderTabRoutes,
+  processState: processStateWithPlaceholderTabRoutes,
   createProps: ({ state, navigation, dispatch }) => ({
     drawerState: state,
     // `createProps` exposes base helpers, but `DrawerRouter` adds drawer action helpers at runtime.

--- a/packages/expo-router/src/layouts/TabsClient.tsx
+++ b/packages/expo-router/src/layouts/TabsClient.tsx
@@ -23,7 +23,7 @@ import {
 import { unstable_integrateWithRouter } from '../standard-navigation';
 import {
   appendMissingPlaceholderTabDescriptors,
-  appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../standard-navigation/appendMissingPlaceholderTabRoutes';
 import type { Href } from '../types';
 
@@ -49,7 +49,7 @@ const Tabs = unstable_integrateWithRouter<
   BottomTabNavigatorCreateProps
 >(createStandardBottomTabNavigator, TabRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
-  processState: appendMissingPlaceholderTabRoutes,
+  processState: processStateWithPlaceholderTabRoutes,
   createProps: ({ state, dispatch }) => ({
     routeNames: state.routeNames,
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),

--- a/packages/expo-router/src/layouts/TopTabsClient.tsx
+++ b/packages/expo-router/src/layouts/TopTabsClient.tsx
@@ -21,7 +21,7 @@ import {
 import { unstable_integrateWithRouter } from '../standard-navigation';
 import {
   appendMissingPlaceholderTabDescriptors,
-  appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../standard-navigation/appendMissingPlaceholderTabRoutes';
 
 // Keep React Navigation client-only so the entry evaluates in React Server Components.
@@ -36,7 +36,7 @@ const TopTabs = unstable_integrateWithRouter<
   MaterialTopTabNavigatorCreateProps
 >(createStandardMaterialTopTabNavigator, TabRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
-  processState: appendMissingPlaceholderTabRoutes,
+  processState: processStateWithPlaceholderTabRoutes,
   createProps: ({ state, dispatch, dispatchSync }) => ({
     routeNames: state.routeNames,
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),

--- a/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
@@ -239,7 +239,10 @@ describe('Drawer backBehavior', () => {
 
   it('closes an open drawer before following the configured behavior', () => {
     function DrawerScreen() {
-      const navigation = useNavigation();
+      // The root navigation type does not include helpers added by the Drawer navigator.
+      const navigation = useNavigation() as ReturnType<typeof useNavigation> & {
+        openDrawer(): void;
+      };
       return (
         <>
           <Text testID="drawer-status">{useDrawerStatus()}</Text>

--- a/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
@@ -1,0 +1,279 @@
+import { act, fireEvent, screen } from '@testing-library/react-native';
+import { Button, Text } from 'react-native';
+
+import { router } from '../../../imperative-api';
+import type { BackBehavior } from '../../../react-navigation/routers/TabRouter';
+import { renderRouter } from '../../../testing-library';
+import { useNavigation } from '../../../useNavigation';
+import { Drawer, useDrawerStatus } from '../../Drawer';
+
+jest.mock('react-native-drawer-layout', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const actual = jest.requireActual(
+    'react-native-drawer-layout'
+  ) as typeof import('react-native-drawer-layout');
+  return {
+    ...actual,
+    Drawer: ({ children }: React.PropsWithChildren) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+const IndexTab = jest.fn(() => <Text testID="index">index</Text>);
+const SecondTab = jest.fn(() => <Text testID="second">second</Text>);
+const ThirdTab = jest.fn(() => <Text testID="third">third</Text>);
+
+type RenderCounts = { index: number; second: number; third: number };
+
+function renderTabs(
+  backBehavior?: BackBehavior,
+  { initialUrl = '/', initialRouteName }: { initialUrl?: string; initialRouteName?: string } = {}
+) {
+  const Layout = () => (
+    <Drawer backBehavior={backBehavior}>
+      <Drawer.Screen name="index" />
+      <Drawer.Screen name="second" />
+      <Drawer.Screen name="third" />
+    </Drawer>
+  );
+  renderRouter(
+    {
+      _layout: { unstable_settings: { initialRouteName }, default: Layout },
+      index: IndexTab,
+      second: SecondTab,
+      third: ThirdTab,
+    },
+    { initialUrl }
+  );
+}
+
+function expectRenders({ index, second, third }: RenderCounts) {
+  expect(IndexTab).toHaveBeenCalledTimes(index);
+  expect(SecondTab).toHaveBeenCalledTimes(second);
+  expect(ThirdTab).toHaveBeenCalledTimes(third);
+  jest.clearAllMocks();
+}
+
+function expectFocused(pathname: string, testID: string) {
+  expect(screen).toHavePathname(pathname);
+  expect(screen.getByTestId(testID)).toBeVisible();
+}
+
+describe('Drawer backBehavior', () => {
+  it('returns to the first route by default', () => {
+    renderTabs();
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  describe('firstRoute', () => {
+    it('returns to the first route after navigation', () => {
+      renderTabs('firstRoute');
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/second'));
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the first route when the app starts on another route', () => {
+      renderTabs('firstRoute', { initialUrl: '/third' });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+    });
+  });
+
+  describe('initialRoute', () => {
+    it('returns to the configured initial route after navigation', () => {
+      renderTabs('initialRoute', { initialRouteName: 'second' });
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the configured initial route when the app starts on another route', () => {
+      renderTabs('initialRoute', {
+        initialUrl: '/third',
+        initialRouteName: 'second',
+      });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+  });
+
+  it('follows route order', () => {
+    renderTabs('order');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps only the latest visit to each route in history', () => {
+    renderTabs('history');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps duplicate visits in full history', () => {
+    renderTabs('fullHistory');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('does not handle back actions with none', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTabs('none');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+
+  it('closes an open drawer before following the configured behavior', () => {
+    function DrawerScreen() {
+      const navigation = useNavigation();
+      return (
+        <>
+          <Text testID="drawer-status">{useDrawerStatus()}</Text>
+          <Button title="open drawer" onPress={() => navigation.openDrawer()} />
+        </>
+      );
+    }
+
+    renderRouter({
+      _layout: () => (
+        <Drawer>
+          <Drawer.Screen name="index" />
+          <Drawer.Screen name="second" />
+        </Drawer>
+      ),
+      index: IndexTab,
+      second: DrawerScreen,
+    });
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'drawer-status');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+
+    fireEvent.press(screen.getByText('open drawer'));
+    expect(screen.getByTestId('drawer-status')).toHaveTextContent('open');
+    act(() => router.back());
+    expectFocused('/second', 'drawer-status');
+    expect(screen.getByTestId('drawer-status')).toHaveTextContent('closed');
+    expect(router.canGoBack()).toBe(true);
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+  });
+});

--- a/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/Drawer.backBehavior.test.ios.tsx
@@ -146,7 +146,7 @@ describe('Drawer backBehavior', () => {
     renderTabs('order');
     expectFocused('/', 'index');
     expect(router.canGoBack()).toBe(false);
-    expectRenders({ index: 1, second: 1, third: 1 });
+    expectRenders({ index: 1, second: 0, third: 0 });
     act(() => router.push('/third'));
     expectFocused('/third', 'third');
     expect(router.canGoBack()).toBe(true);
@@ -154,7 +154,7 @@ describe('Drawer backBehavior', () => {
     act(() => router.back());
     expectFocused('/second', 'second');
     expect(router.canGoBack()).toBe(true);
-    expectRenders({ index: 0, second: 0, third: 0 });
+    expectRenders({ index: 0, second: 1, third: 0 });
     act(() => router.back());
     expectFocused('/', 'index');
     expect(router.canGoBack()).toBe(false);

--- a/packages/expo-router/src/layouts/__tests__/integration/Tabs.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/Tabs.backBehavior.test.ios.tsx
@@ -1,0 +1,229 @@
+import { act, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { router } from '../../../imperative-api';
+import type { BackBehavior } from '../../../react-navigation/routers/TabRouter';
+import { renderRouter } from '../../../testing-library';
+import { Tabs } from '../../Tabs';
+
+const IndexTab = jest.fn(() => <Text testID="index">index</Text>);
+const SecondTab = jest.fn(() => <Text testID="second">second</Text>);
+const ThirdTab = jest.fn(() => <Text testID="third">third</Text>);
+
+type RenderCounts = { index: number; second: number; third: number };
+
+function renderTabs(
+  backBehavior?: BackBehavior,
+  { initialUrl = '/', initialRouteName }: { initialUrl?: string; initialRouteName?: string } = {}
+) {
+  const Layout = () => (
+    <Tabs backBehavior={backBehavior}>
+      <Tabs.Screen name="index" />
+      <Tabs.Screen name="second" />
+      <Tabs.Screen name="third" />
+    </Tabs>
+  );
+
+  renderRouter(
+    {
+      _layout: { unstable_settings: { initialRouteName }, default: Layout },
+      index: IndexTab,
+      second: SecondTab,
+      third: ThirdTab,
+    },
+    { initialUrl }
+  );
+}
+
+function expectRenders({ index, second, third }: RenderCounts) {
+  expect(IndexTab).toHaveBeenCalledTimes(index);
+  expect(SecondTab).toHaveBeenCalledTimes(second);
+  expect(ThirdTab).toHaveBeenCalledTimes(third);
+  jest.clearAllMocks();
+}
+
+function expectFocused(pathname: string, testID: string) {
+  expect(screen).toHavePathname(pathname);
+  expect(screen.getByTestId(testID)).toBeVisible();
+}
+
+describe('Tabs backBehavior', () => {
+  it('returns to the first route by default', () => {
+    renderTabs();
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  describe('firstRoute', () => {
+    it('returns to the first route after navigation', () => {
+      renderTabs('firstRoute');
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/second'));
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the first route when the app starts on another route', () => {
+      renderTabs('firstRoute', { initialUrl: '/third' });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+    });
+  });
+
+  describe('initialRoute', () => {
+    it('returns to the configured initial route after navigation', () => {
+      renderTabs('initialRoute', { initialRouteName: 'second' });
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the configured initial route when the app starts on another route', () => {
+      renderTabs('initialRoute', {
+        initialUrl: '/third',
+        initialRouteName: 'second',
+      });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+  });
+
+  it('follows route order', () => {
+    renderTabs('order');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps only the latest visit to each route in history', () => {
+    renderTabs('history');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps duplicate visits in full history', () => {
+    renderTabs('fullHistory');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('does not handle back actions with none', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTabs('none');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/packages/expo-router/src/layouts/__tests__/integration/Tabs.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/Tabs.backBehavior.test.ios.tsx
@@ -134,7 +134,7 @@ describe('Tabs backBehavior', () => {
     renderTabs('order');
     expectFocused('/', 'index');
     expect(router.canGoBack()).toBe(false);
-    expectRenders({ index: 1, second: 1, third: 1 });
+    expectRenders({ index: 1, second: 0, third: 0 });
     act(() => router.push('/third'));
     expectFocused('/third', 'third');
     expect(router.canGoBack()).toBe(true);
@@ -142,7 +142,7 @@ describe('Tabs backBehavior', () => {
     act(() => router.back());
     expectFocused('/second', 'second');
     expect(router.canGoBack()).toBe(true);
-    expectRenders({ index: 0, second: 0, third: 0 });
+    expectRenders({ index: 0, second: 1, third: 0 });
     act(() => router.back());
     expectFocused('/', 'index');
     expect(router.canGoBack()).toBe(false);

--- a/packages/expo-router/src/layouts/__tests__/integration/TopTabs.backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/layouts/__tests__/integration/TopTabs.backBehavior.test.ios.tsx
@@ -1,0 +1,226 @@
+import { act, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { router } from '../../../imperative-api';
+import type { BackBehavior } from '../../../react-navigation/routers/TabRouter';
+import { renderRouter } from '../../../testing-library';
+import { TopTabs } from '../../TopTabs';
+
+const IndexTab = jest.fn(() => <Text testID="index">index</Text>);
+const SecondTab = jest.fn(() => <Text testID="second">second</Text>);
+const ThirdTab = jest.fn(() => <Text testID="third">third</Text>);
+
+type RenderCounts = { index: number; second: number; third: number };
+
+function renderTabs(
+  backBehavior?: BackBehavior,
+  { initialUrl = '/', initialRouteName }: { initialUrl?: string; initialRouteName?: string } = {}
+) {
+  const Layout = () => (
+    <TopTabs backBehavior={backBehavior}>
+      <TopTabs.Screen name="index" />
+      <TopTabs.Screen name="second" />
+      <TopTabs.Screen name="third" />
+    </TopTabs>
+  );
+  renderRouter(
+    {
+      _layout: { unstable_settings: { initialRouteName }, default: Layout },
+      index: IndexTab,
+      second: SecondTab,
+      third: ThirdTab,
+    },
+    { initialUrl }
+  );
+}
+
+function expectRenders({ index, second, third }: RenderCounts) {
+  expect(IndexTab).toHaveBeenCalledTimes(index);
+  expect(SecondTab).toHaveBeenCalledTimes(second);
+  expect(ThirdTab).toHaveBeenCalledTimes(third);
+  jest.clearAllMocks();
+}
+
+function expectFocused(pathname: string, testID: string) {
+  expect(screen).toHavePathname(pathname);
+  expect(screen.getByTestId(testID)).toBeVisible();
+}
+
+describe('TopTabs backBehavior', () => {
+  it('returns to the first route by default', () => {
+    renderTabs();
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+  });
+
+  describe('firstRoute', () => {
+    it('returns to the first route after navigation', () => {
+      renderTabs('firstRoute');
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/second'));
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+    });
+
+    it('creates the first route when the app starts on another route', () => {
+      renderTabs('firstRoute', { initialUrl: '/third' });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+    });
+  });
+
+  describe('initialRoute', () => {
+    it('returns to the configured initial route after navigation', () => {
+      renderTabs('initialRoute', { initialRouteName: 'second' });
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 1, third: 0 });
+    });
+
+    it('creates the configured initial route when the app starts on another route', () => {
+      renderTabs('initialRoute', {
+        initialUrl: '/third',
+        initialRouteName: 'second',
+      });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 1, third: 0 });
+    });
+  });
+
+  it('follows route order', () => {
+    renderTabs('order');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+  });
+
+  it('keeps only the latest visit to each route in history', () => {
+    renderTabs('history');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+  });
+
+  it('keeps duplicate visits in full history', () => {
+    renderTabs('fullHistory');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+  });
+
+  it('does not handle back actions with none', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTabs('none');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -11,7 +11,7 @@ import {
 import { unstable_createStandardRouterNavigator } from '../standard-navigation';
 import {
   appendMissingPlaceholderTabDescriptors,
-  appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../standard-navigation/appendMissingPlaceholderTabRoutes';
 import type { StandardNavigatorContentProps } from '../standard-navigation/types';
 import { usePreloadPlaceholderRoutes } from '../standard-navigation/usePreloadPlaceholderRoutes';
@@ -63,7 +63,8 @@ function NativeTabsContent({
   rippleColor,
   disableIndicator,
   labelVisibilityMode,
-  backBehavior,
+  // Consume this router option so it is not forwarded to `NativeTabsView`.
+  backBehavior: _backBehavior,
   ...viewProps
 }: StandardNavigatorContentProps<
   NativeTabOptions,
@@ -101,7 +102,6 @@ function NativeTabsContent({
     descriptors,
     preload,
     lazyByDefault: false,
-    preloadAll: backBehavior === 'order',
   });
 
   const provenanceRef = useRef(0);
@@ -190,7 +190,7 @@ const NativeTabsNavigatorWithContext = unstable_createStandardRouterNavigator<
   NativeTabsNavigatorCreateProps
 >(NativeTabsContent, NativeBottomTabsRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
-  processState: appendMissingPlaceholderTabRoutes,
+  processState: processStateWithPlaceholderTabRoutes,
   createProps: ({ state, dispatch, dispatchSync }) => ({
     routeNames: state.routeNames,
     preload: (name) => dispatch({ type: 'PRELOAD', payload: { name } }),

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -63,7 +63,8 @@ function NativeTabsContent({
   rippleColor,
   disableIndicator,
   labelVisibilityMode,
-  ...rest
+  backBehavior,
+  ...viewProps
 }: StandardNavigatorContentProps<
   NativeTabOptions,
   NativeTabNavigationEventMap,
@@ -77,7 +78,6 @@ function NativeTabsContent({
   }
 
   const { routes } = state;
-  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
 
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes,

--- a/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsNavigator.tsx
@@ -77,6 +77,7 @@ function NativeTabsContent({
   }
 
   const { routes } = state;
+  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
 
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes,
@@ -100,6 +101,7 @@ function NativeTabsContent({
     descriptors,
     preload,
     lazyByDefault: false,
+    preloadAll: backBehavior === 'order',
   });
 
   const provenanceRef = useRef(0);
@@ -156,7 +158,7 @@ function NativeTabsContent({
     NativeTabsViewProps,
     'focusedIndex' | 'provenance' | 'tabs' | 'onTabChange'
   > &
-    Record<Exclude<keyof typeof rest, keyof NativeTabsViewProps>, never> = rest;
+    Record<Exclude<keyof typeof viewProps, keyof NativeTabsViewProps>, never> = viewProps;
 
   if (visibleTabs.length === 0 || focusedIndex < 0) {
     return null;

--- a/packages/expo-router/src/native-tabs/__tests__/integration/backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/integration/backBehavior.test.ios.tsx
@@ -1,0 +1,271 @@
+import { act, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { router } from '../../../imperative-api';
+import type { BackBehavior } from '../../../react-navigation/routers/TabRouter';
+import { renderRouter } from '../../../testing-library';
+import { NativeTabs } from '../../NativeTabs';
+import type { NativeTabsProps } from '../../types';
+
+jest.mock('react-native-screens', () => {
+  const { View }: typeof import('react-native') = jest.requireActual('react-native');
+  const actualModule = jest.requireActual(
+    'react-native-screens'
+  ) as typeof import('react-native-screens');
+  return {
+    ...actualModule,
+    ScreenStackItem: jest.fn(({ children }) => <View>{children}</View>),
+    Tabs: {
+      ...actualModule.Tabs,
+      Host: jest.fn(({ children }) => <View testID="TabsHost">{children}</View>),
+      Screen: jest.fn(({ children }) => <View testID="TabsScreen">{children}</View>),
+    },
+  };
+});
+
+const IndexTab = jest.fn(() => <Text testID="index">index</Text>);
+const SecondTab = jest.fn(() => <Text testID="second">second</Text>);
+const ThirdTab = jest.fn(() => <Text testID="third">third</Text>);
+
+type RenderCounts = { index: number; second: number; third: number };
+
+function renderTabs(
+  backBehavior?: BackBehavior,
+  { initialUrl = '/', initialRouteName }: { initialUrl?: string; initialRouteName?: string } = {}
+) {
+  const Layout = () => (
+    // Native tabs uses all `TabRouter` values internally, but its public type omits these iOS tests' values.
+    <NativeTabs backBehavior={backBehavior as NativeTabsProps['backBehavior']}>
+      <NativeTabs.Trigger name="index" />
+      <NativeTabs.Trigger name="second" />
+      <NativeTabs.Trigger name="third" />
+    </NativeTabs>
+  );
+
+  renderRouter(
+    {
+      _layout: { unstable_settings: { initialRouteName }, default: Layout },
+      index: IndexTab,
+      second: SecondTab,
+      third: ThirdTab,
+    },
+    { initialUrl }
+  );
+}
+
+function expectRenders({ index, second, third }: RenderCounts) {
+  expect(IndexTab).toHaveBeenCalledTimes(index);
+  expect(SecondTab).toHaveBeenCalledTimes(second);
+  expect(ThirdTab).toHaveBeenCalledTimes(third);
+  jest.clearAllMocks();
+}
+
+function expectFocused(pathname: string, testID: string) {
+  expect(screen).toHavePathname(pathname);
+  expect(screen.getByTestId(testID)).toBeVisible();
+}
+
+describe('NativeTabs backBehavior', () => {
+  it('returns to the first route by default', () => {
+    renderTabs();
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  describe('firstRoute', () => {
+    it('returns to the first route after navigation', () => {
+      renderTabs('firstRoute');
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 1, third: 1 });
+
+      act(() => router.push('/second'));
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 0 });
+
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the first route when the app starts on another route', () => {
+      renderTabs('firstRoute', { initialUrl: '/third' });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 1, third: 1 });
+
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+  });
+
+  describe('initialRoute', () => {
+    it('returns to the configured initial route after navigation', () => {
+      renderTabs('initialRoute', { initialRouteName: 'second' });
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 1, third: 1 });
+
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the configured initial route when the app starts on another route', () => {
+      renderTabs('initialRoute', {
+        initialUrl: '/third',
+        initialRouteName: 'second',
+      });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 1, third: 1 });
+
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+  });
+
+  it('follows route order', () => {
+    renderTabs('order');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps only the latest visit to each route in history', () => {
+    renderTabs('history');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps duplicate visits in full history', () => {
+    renderTabs('fullHistory');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('does not handle back actions with none', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTabs('none');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 1, third: 1 });
+
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 1, third: 0 });
+
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -418,7 +418,7 @@ export interface NativeTabsProps extends PropsWithChildren {
    *
    * @platform android
    */
-  backBehavior?: 'none' | 'initialRoute' | 'history';
+  backBehavior?: 'none' | 'initialRoute' | 'history' | 'order';
   /**
    * The visibility mode of the tab item label.
    *

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -416,7 +416,10 @@ export interface NativeTabsProps extends PropsWithChildren {
   /**
    * The behavior when navigating back with the back button.
    *
-   * @platform android
+   * - `none`: Back navigation is not handled.
+   * - `initialRoute`: Returns to the initial tab.
+   * - `history`: Returns to the last visited tab.
+   * - `order`: Returns to the previous tab in the declared order. This preloads every declared tab.
    */
   backBehavior?: 'none' | 'initialRoute' | 'history' | 'order';
   /**

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/types.test.ts
@@ -1,7 +1,7 @@
 import type { ComponentProps } from 'react';
 
 import type { JSTabsProps, Tabs, TabsScreenOptions } from '../../../layouts/Tabs';
-import type { DescriptorRouteProp, ParamListBase, RouteProp } from '../../native';
+import type { DescriptorRouteProp, ParamListBase, RouteProp, TabRouterOptions } from '../../native';
 import type { BottomTabNavigatorContentProps } from '../navigators/createBottomTabNavigator';
 import type { BottomTabOptionsArgs } from '../types';
 
@@ -34,6 +34,9 @@ export type _ContentRequiresRouteNames = Expect<
 >;
 export type _ContentRequiresPopNestedStackToTop = Expect<
   Equal<BottomTabNavigatorContentProps['popNestedStackToTop'], (routeKey: string) => void>
+>;
+export type _ContentIncludesBackBehavior = Expect<
+  Equal<BottomTabNavigatorContentProps['backBehavior'], TabRouterOptions['backBehavior']>
 >;
 
 // The tab bar config stays a public navigator prop.

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -39,6 +39,7 @@ function BottomTabNavigatorContent({
   preload,
   ...rest
 }: ContentArgs) {
+  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
     routeNames,
@@ -65,6 +66,7 @@ function BottomTabNavigatorContent({
     descriptors: bottomTabDescriptors,
     preload,
     lazyByDefault: true,
+    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {
@@ -73,7 +75,7 @@ function BottomTabNavigatorContent({
 
   return (
     <BottomTabView
-      {...rest}
+      {...viewProps}
       state={{
         // Only routes are substituted; navigator metadata remains from the real state.
         ...state,

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -5,6 +5,7 @@ import { createStandardNavigator } from 'standard-navigation';
 import type { NavigatorContentProps } from '../../../standard-navigation/types';
 import { usePreloadPlaceholderRoutes } from '../../../standard-navigation/usePreloadPlaceholderRoutes';
 import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
+import type { TabRouterOptions } from '../../native';
 import type {
   BottomTabDescriptorMap,
   BottomTabNavigationConfig,
@@ -19,13 +20,17 @@ export interface BottomTabNavigatorCreateProps {
   preload: (name: string) => void;
 }
 
-export type BottomTabNavigatorContentProps = BottomTabNavigationConfig &
+export interface BottomTabNavigatorProps extends BottomTabNavigationConfig {
+  backBehavior?: TabRouterOptions['backBehavior'];
+}
+
+export type BottomTabNavigatorContentProps = BottomTabNavigatorProps &
   BottomTabNavigatorCreateProps;
 
 type ContentArgs = NavigatorContentProps<
   BottomTabNavigationOptions,
   BottomTabNavigationEventMap,
-  BottomTabNavigationConfig,
+  BottomTabNavigatorProps,
   BottomTabNavigatorCreateProps
 >;
 
@@ -37,9 +42,9 @@ function BottomTabNavigatorContent({
   routeNames,
   popNestedStackToTop,
   preload,
-  ...rest
+  backBehavior,
+  ...viewProps
 }: ContentArgs) {
-  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
     routeNames,

--- a/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/navigators/createBottomTabNavigator.tsx
@@ -42,7 +42,8 @@ function BottomTabNavigatorContent({
   routeNames,
   popNestedStackToTop,
   preload,
-  backBehavior,
+  // Consume this router option so it is not forwarded to `BottomTabView`.
+  backBehavior: _backBehavior,
   ...viewProps
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
@@ -71,7 +72,6 @@ function BottomTabNavigatorContent({
     descriptors: bottomTabDescriptors,
     preload,
     lazyByDefault: true,
-    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {

--- a/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/useNavigationCache.test.ios.tsx
@@ -245,33 +245,33 @@ test('returns correct value for isFocused after changing screens', () => {
     </BaseNavigationContainer>
   );
 
-  expect(navigation.isFocused()).toBe(true);
-
-  root.update(
-    <BaseNavigationContainer>
-      <TestNavigator>
-        <Screen name="first">{() => null}</Screen>
-        <Screen name="third">{() => null}</Screen>
-        <Screen name="fourth">{() => null}</Screen>
-        <Screen name="second" component={Test} />
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
-  expect(navigation.isFocused()).toBe(true);
-
-  root.update(
-    <BaseNavigationContainer>
-      <TestNavigator>
-        <Screen name="first">{() => null}</Screen>
-        <Screen name="third">{() => null}</Screen>
-        <Screen name="second" component={Test} />
-        <Screen name="fourth">{() => null}</Screen>
-      </TestNavigator>
-    </BaseNavigationContainer>
-  );
-
   expect(navigation.isFocused()).toBe(false);
+
+  root.update(
+    <BaseNavigationContainer>
+      <TestNavigator>
+        <Screen name="first">{() => null}</Screen>
+        <Screen name="third">{() => null}</Screen>
+        <Screen name="fourth">{() => null}</Screen>
+        <Screen name="second" component={Test} />
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(navigation.isFocused()).toBe(true);
+
+  root.update(
+    <BaseNavigationContainer>
+      <TestNavigator>
+        <Screen name="first">{() => null}</Screen>
+        <Screen name="third">{() => null}</Screen>
+        <Screen name="second" component={Test} />
+        <Screen name="fourth">{() => null}</Screen>
+      </TestNavigator>
+    </BaseNavigationContainer>
+  );
+
+  expect(navigation.isFocused()).toBe(true);
 });
 
 test('uses a no-op navigation object for a preloaded stack screen', () => {

--- a/packages/expo-router/src/react-navigation/core/isSetEqual.tsx
+++ b/packages/expo-router/src/react-navigation/core/isSetEqual.tsx
@@ -1,0 +1,3 @@
+export function isSetEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  return a.length === b.length && a.every((value) => b.includes(value));
+}

--- a/packages/expo-router/src/react-navigation/core/isSetEqual.tsx
+++ b/packages/expo-router/src/react-navigation/core/isSetEqual.tsx
@@ -1,3 +1,4 @@
 export function isSetEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  // Callers pass unique values; this does not detect duplicates.
   return a.length === b.length && a.every((value) => b.includes(value));
 }

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -29,7 +29,7 @@ import { NavigationStateContext } from './NavigationStateContext';
 import { NavigatorTypeContext } from './NavigatorTypeContext';
 import { RootNavigationStateContext } from './RootNavigationStateContext';
 import { Screen } from './Screen';
-import { isArrayEqual } from './isArrayEqual';
+import { isSetEqual } from './isSetEqual';
 import {
   type DefaultNavigatorOptions,
   type DescriptorRouteProp,
@@ -463,9 +463,9 @@ export function useNavigationBuilder<
     }
     const committed = committedState;
 
-    if (isArrayEqual(committed.routeNames, routeNames)) {
+    if (isSetEqual(committed.routeNames, routeNames)) {
       pendingRouteNamesRef.current = undefined;
-    } else if (!isArrayEqual(pendingRouteNamesRef.current ?? [], routeNames)) {
+    } else if (!isSetEqual(pendingRouteNamesRef.current ?? [], routeNames)) {
       pendingRouteNamesRef.current = routeNames;
       enqueue({
         type: 'ACTION',
@@ -540,6 +540,7 @@ export function useNavigationBuilder<
 
   return {
     state,
+    routeNames,
     navigation,
     describe,
     descriptors,

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/getDrawerStatusFromState.test.ts
@@ -1,52 +1,30 @@
-import type { DrawerNavigationState, ParamListBase } from '../../routers';
+import { expect, it } from '@jest/globals';
+
+import type { DrawerNavigationState, ParamListBase } from '../../native';
 import { getDrawerStatusFromState } from '../utils/getDrawerStatusFromState';
 
-const state: DrawerNavigationState<ParamListBase> = {
+const state = {
   stale: false,
-  routeKeySeq: 0,
+  type: 'drawer',
   key: 'drawer',
+  routeKeySeq: 0,
+  routeNames: ['one'],
+  routes: [{ name: 'one', key: 'one-key' }],
   index: 0,
-  routeNames: ['index'],
-  routes: [{ key: 'index', name: 'index' }],
-};
+} satisfies DrawerNavigationState<ParamListBase>;
 
-it.each(['closed', 'open'] as const)(
-  'uses the provided default status %s when history has no drawer entry',
-  (defaultStatus) => {
-    expect(getDrawerStatusFromState(state, defaultStatus)).toBe(defaultStatus);
-  }
-);
-
-it('ignores non-drawer history entries', () => {
-  expect(
-    getDrawerStatusFromState(
-      {
-        ...state,
-        history: [
-          { type: 'drawer', status: 'open' },
-          { type: 'route', key: 'index' },
-        ],
-      },
-      'closed'
-    )
-  ).toBe('open');
+it('returns the explicit drawer status', () => {
+  expect(getDrawerStatusFromState({ ...state, drawerStatus: 'open' }, 'closed')).toBe('open');
+  expect(getDrawerStatusFromState({ ...state, drawerStatus: 'closed' }, 'open')).toBe('closed');
 });
 
-it('uses the last drawer status from history instead of the provided default', () => {
+it('returns the configured default when drawerStatus is absent', () => {
+  expect(getDrawerStatusFromState(state, 'closed')).toBe('closed');
+  expect(getDrawerStatusFromState(state, 'open')).toBe('open');
+});
+
+it('does not derive status from full route history', () => {
   expect(
-    getDrawerStatusFromState(
-      {
-        ...state,
-        history: [
-          { type: 'drawer', status: 'open' },
-          { type: 'drawer', status: 'closed' },
-        ],
-      },
-      'open'
-    )
+    getDrawerStatusFromState({ ...state, history: [{ type: 'route', key: 'one-key' }] }, 'closed')
   ).toBe('closed');
-});
-
-it('uses the provided default status when history is absent', () => {
-  expect(getDrawerStatusFromState({ ...state, history: undefined }, 'open')).toBe('open');
 });

--- a/packages/expo-router/src/react-navigation/drawer/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/drawer/__tests__/types.test.ts
@@ -1,7 +1,12 @@
 import type { ComponentProps } from 'react';
 
 import type { Drawer, DrawerNavigatorProps } from '../../../layouts/Drawer';
-import type { DescriptorRouteProp, DrawerNavigationState, ParamListBase } from '../../native';
+import type {
+  DescriptorRouteProp,
+  DrawerNavigationState,
+  ParamListBase,
+  TabRouterOptions,
+} from '../../native';
 import type { DrawerNavigatorContentProps } from '../navigators/createDrawerNavigator';
 import type { DrawerNavigationHelpers, DrawerOptionsArgs } from '../types';
 
@@ -32,6 +37,9 @@ export type _ContentRequiresDrawerState = Expect<
 >;
 export type _ContentRequiresNavigation = Expect<
   Equal<DrawerNavigatorContentProps['navigation'], DrawerNavigationHelpers>
+>;
+export type _ContentIncludesBackBehavior = Expect<
+  Equal<DrawerNavigatorContentProps['backBehavior'], TabRouterOptions['backBehavior']>
 >;
 
 describe('drawer types', () => {

--- a/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
@@ -47,7 +47,9 @@ function DrawerNavigatorContent({
   defaultStatus = 'closed',
   drawerContent,
   detachInactiveScreens,
+  ...rest
 }: ContentArgs) {
+  const { backBehavior } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: drawerState.routes,
     routeNames: drawerState.routeNames,
@@ -63,6 +65,7 @@ function DrawerNavigatorContent({
     descriptors: drawerDescriptors,
     preload,
     lazyByDefault: true,
+    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {

--- a/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
@@ -5,7 +5,7 @@ import { createStandardNavigator } from 'standard-navigation';
 import type { StandardNavigatorContentProps } from '../../../standard-navigation/types';
 import { usePreloadPlaceholderRoutes } from '../../../standard-navigation/usePreloadPlaceholderRoutes';
 import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
-import type { DrawerNavigationState, ParamListBase } from '../../native';
+import type { DrawerNavigationState, ParamListBase, TabRouterOptions } from '../../native';
 import type {
   DrawerDescriptorMap,
   DrawerNavigationConfig,
@@ -22,6 +22,7 @@ export interface DrawerNavigatorCreateProps {
 }
 
 export interface DrawerNavigatorConfig extends DrawerNavigationConfig {
+  backBehavior?: TabRouterOptions['backBehavior'];
   defaultStatus?: 'open' | 'closed';
 }
 
@@ -47,9 +48,8 @@ function DrawerNavigatorContent({
   defaultStatus = 'closed',
   drawerContent,
   detachInactiveScreens,
-  ...rest
+  backBehavior,
 }: ContentArgs) {
-  const { backBehavior } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: drawerState.routes,
     routeNames: drawerState.routeNames,

--- a/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/navigators/createDrawerNavigator.tsx
@@ -48,7 +48,6 @@ function DrawerNavigatorContent({
   defaultStatus = 'closed',
   drawerContent,
   detachInactiveScreens,
-  backBehavior,
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: drawerState.routes,
@@ -65,7 +64,6 @@ function DrawerNavigatorContent({
     descriptors: drawerDescriptors,
     preload,
     lazyByDefault: true,
-    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {

--- a/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
+++ b/packages/expo-router/src/react-navigation/drawer/utils/getDrawerStatusFromState.tsx
@@ -3,16 +3,12 @@ import type { DrawerNavigationState, DrawerStatus, ParamListBase } from '../../n
 /**
  * Returns the drawer's current status.
  *
- * @param defaultStatus Status returned when the state has no drawer history entry.
+ * @param defaultStatus Status returned when the state has no explicit drawer status.
  * @deprecated Use `useDrawerStatus` instead.
  */
 export function getDrawerStatusFromState(
   state: DrawerNavigationState<ParamListBase>,
   defaultStatus: DrawerStatus
 ): DrawerStatus {
-  const entry = state.history?.findLast((it) => it.type === 'drawer') as
-    | { type: 'drawer'; status: DrawerStatus }
-    | undefined;
-
-  return entry?.status ?? defaultStatus;
+  return state.drawerStatus ?? defaultStatus;
 }

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/types.test.ts
@@ -1,5 +1,5 @@
 import type { JSTopTabsProps } from '../../../layouts/TopTabs';
-import type { DescriptorRouteProp, ParamListBase } from '../../native';
+import type { DescriptorRouteProp, ParamListBase, TabRouterOptions } from '../../native';
 import type { MaterialTopTabNavigatorContentProps } from '../navigators/createMaterialTopTabNavigator';
 import type {
   MaterialTopTabBarProps,
@@ -39,6 +39,9 @@ export type _IndicatorUsesTopTabViewState = Expect<
 >;
 export type _ContentRequiresRouteNames = Expect<
   Equal<MaterialTopTabNavigatorContentProps['routeNames'], string[]>
+>;
+export type _ContentIncludesBackBehavior = Expect<
+  Equal<MaterialTopTabNavigatorContentProps['backBehavior'], TabRouterOptions['backBehavior']>
 >;
 
 describe('material top tabs types', () => {

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -39,6 +39,7 @@ function MaterialTopTabNavigatorContent({
   navigateToTabSync,
   ...rest
 }: ContentArgs) {
+  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
     routeNames,
@@ -65,6 +66,7 @@ function MaterialTopTabNavigatorContent({
     descriptors: topTabDescriptors,
     preload,
     lazyByDefault: false,
+    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {
@@ -73,7 +75,7 @@ function MaterialTopTabNavigatorContent({
 
   return (
     <MaterialTopTabView
-      {...rest}
+      {...viewProps}
       state={{
         ...state,
         routes: visibleRoutes,

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -5,6 +5,7 @@ import { createStandardNavigator } from 'standard-navigation';
 import type { NavigatorContentProps } from '../../../standard-navigation/types';
 import { usePreloadPlaceholderRoutes } from '../../../standard-navigation/usePreloadPlaceholderRoutes';
 import { useVisibleTabsWithRedirect } from '../../../standard-navigation/useVisibleTabsWithRedirect';
+import type { TabRouterOptions } from '../../native';
 import type {
   MaterialTopTabDescriptorMap,
   MaterialTopTabNavigationConfig,
@@ -19,13 +20,17 @@ export interface MaterialTopTabNavigatorCreateProps {
   navigateToTabSync: (name: string, params: object | undefined) => void;
 }
 
-export type MaterialTopTabNavigatorContentProps = MaterialTopTabNavigationConfig &
+export interface MaterialTopTabNavigatorProps extends MaterialTopTabNavigationConfig {
+  backBehavior?: TabRouterOptions['backBehavior'];
+}
+
+export type MaterialTopTabNavigatorContentProps = MaterialTopTabNavigatorProps &
   MaterialTopTabNavigatorCreateProps;
 
 type ContentArgs = NavigatorContentProps<
   MaterialTopTabNavigationOptions,
   MaterialTopTabNavigationEventMap,
-  MaterialTopTabNavigationConfig,
+  MaterialTopTabNavigatorProps,
   MaterialTopTabNavigatorCreateProps
 >;
 
@@ -37,9 +42,9 @@ function MaterialTopTabNavigatorContent({
   routeNames,
   preload,
   navigateToTabSync,
-  ...rest
+  backBehavior,
+  ...viewProps
 }: ContentArgs) {
-  const { backBehavior, ...viewProps } = rest as typeof rest & { backBehavior?: string };
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
     routes: state.routes,
     routeNames,

--- a/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/navigators/createMaterialTopTabNavigator.tsx
@@ -42,7 +42,8 @@ function MaterialTopTabNavigatorContent({
   routeNames,
   preload,
   navigateToTabSync,
-  backBehavior,
+  // Consume this router option so it is not forwarded to `MaterialTopTabView`.
+  backBehavior: _backBehavior,
   ...viewProps
 }: ContentArgs) {
   const { visibleRoutes, focusedIndex } = useVisibleTabsWithRedirect({
@@ -71,7 +72,6 @@ function MaterialTopTabNavigatorContent({
     descriptors: topTabDescriptors,
     preload,
     lazyByDefault: false,
-    preloadAll: backBehavior === 'order',
   });
 
   if (visibleRoutes.length === 0 || focusedIndex < 0) {

--- a/packages/expo-router/src/react-navigation/routers/CommonActions.tsx
+++ b/packages/expo-router/src/react-navigation/routers/CommonActions.tsx
@@ -69,6 +69,15 @@ export type InternalRouteNamesChangedAction = {
   target?: string;
 };
 
+/**
+ * @internal
+ */
+export type InternalRouteNamesOrderChangedAction = {
+  type: 'ROUTE_NAMES_ORDER_CHANGED';
+  payload: { routeNames: string[] };
+  target?: string;
+};
+
 export type Action =
   | GoBackAction
   | NavigateAction

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -1,5 +1,5 @@
 import {
-  ensureStateHistory,
+  ensureFullHistory,
   type TabActionHelpers,
   TabActions,
   type TabActionType,
@@ -32,9 +32,11 @@ export type DrawerNavigationState<ParamList extends ParamListBase> = Omit<
    */
   type?: 'drawer';
   /**
-   * List of previously visited route keys and drawer open status.
+   * List of previously visited route keys in `fullHistory` mode.
    */
-  history?: ({ type: 'route'; key: string } | { type: 'drawer'; status: DrawerStatus })[];
+  history?: { type: 'route'; key: string; params?: object }[];
+  /** Current drawer status. When absent, the configured default is used. */
+  drawerStatus?: DrawerStatus;
 };
 
 export type DrawerActionHelpers<ParamList extends ParamListBase> = TabActionHelpers<ParamList> & {
@@ -77,75 +79,43 @@ export function DrawerRouter({
   DrawerNavigationState<ParamListBase>,
   DrawerActionType | CommonNavigationAction
 > {
-  const { backBehavior = 'firstRoute', initialRouteName } = rest;
+  const { backBehavior = 'firstRoute' } = rest;
 
   const router = TabRouter(rest) as unknown as Router<
     DrawerNavigationState<ParamListBase>,
     TabActionType | CommonNavigationAction
   >;
 
-  // `ensureStateHistory` is typed for the tab state. The drawer state differs only by the extra
-  // drawer entries in `history`, which reconstruction never produces.
-  const ensureDrawerStateOptionalProperties = (state: DrawerNavigationState<ParamListBase>) =>
-    ensureStateHistory(
-      ensureStateType(state, 'drawer') as unknown as TabNavigationState<ParamListBase>,
-      backBehavior,
-      initialRouteName
-    ) as unknown as DrawerNavigationState<ParamListBase>;
-
-  const isDrawerInHistory = (state: DrawerNavigationState<ParamListBase>) =>
-    Boolean(state.history?.some((it) => it.type === 'drawer'));
-
-  const addDrawerToHistory = (
+  const normalizeState = (
     state: DrawerNavigationState<ParamListBase>
   ): DrawerNavigationState<ParamListBase> => {
-    if (isDrawerInHistory(state)) {
-      return state;
+    const typedState = ensureStateType(state, 'drawer');
+    if (backBehavior === 'fullHistory') {
+      const history = typedState.history?.filter((item) => item.type === 'route');
+      return ensureFullHistory({
+        ...typedState,
+        history,
+      } as unknown as TabNavigationState<ParamListBase>) as unknown as DrawerNavigationState<ParamListBase>;
     }
-
-    return {
-      ...state,
-      history: [
-        ...(state.history ?? []),
-        {
-          type: 'drawer',
-          status: defaultStatus === 'open' ? 'closed' : 'open',
-        },
-      ],
-    };
+    if (typedState.history === undefined) {
+      return typedState;
+    }
+    const { history: _, ...stateWithoutHistory } = typedState;
+    return stateWithoutHistory;
   };
 
-  const removeDrawerFromHistory = (
-    state: DrawerNavigationState<ParamListBase>
+  const setDrawerStatus = (
+    state: DrawerNavigationState<ParamListBase>,
+    drawerStatus: DrawerStatus
   ): DrawerNavigationState<ParamListBase> => {
-    if (!isDrawerInHistory(state)) {
-      return state;
+    if (drawerStatus === defaultStatus) {
+      if (state.drawerStatus === undefined) {
+        return state;
+      }
+      const { drawerStatus: _, ...stateWithoutDrawerStatus } = state;
+      return stateWithoutDrawerStatus;
     }
-
-    return {
-      ...state,
-      history: (state.history ?? []).filter((it) => it.type !== 'drawer'),
-    };
-  };
-
-  const openDrawer = (
-    state: DrawerNavigationState<ParamListBase>
-  ): DrawerNavigationState<ParamListBase> => {
-    if (defaultStatus === 'open') {
-      return removeDrawerFromHistory(state);
-    }
-
-    return addDrawerToHistory(state);
-  };
-
-  const closeDrawer = (
-    state: DrawerNavigationState<ParamListBase>
-  ): DrawerNavigationState<ParamListBase> => {
-    if (defaultStatus === 'open') {
-      return addDrawerToHistory(state);
-    }
-
-    return removeDrawerFromHistory(state);
+    return state.drawerStatus === drawerStatus ? state : { ...state, drawerStatus };
   };
 
   return {
@@ -154,33 +124,28 @@ export function DrawerRouter({
     type: 'drawer',
 
     getStateForRouteFocus(state, key) {
-      const result = router.getStateForRouteFocus(ensureDrawerStateOptionalProperties(state), key);
-
-      return closeDrawer(result);
+      const normalizedState = normalizeState(state);
+      const result = router.getStateForRouteFocus(normalizedState, key);
+      return setDrawerStatus(result, defaultStatus);
     },
 
     getStateForAction(inputState, action, options) {
-      // Restore route history before drawer actions can add drawer-only history.
-      const state = ensureDrawerStateOptionalProperties(inputState);
+      const state = normalizeState(inputState);
       const focusedRouteKey = state.routes[state.index]?.key;
 
       switch (action.type) {
         case 'OPEN_DRAWER':
-          return { state: openDrawer(state), affectedRouteKey: focusedRouteKey };
+          return { state: setDrawerStatus(state, 'open'), affectedRouteKey: focusedRouteKey };
 
         case 'CLOSE_DRAWER':
-          return { state: closeDrawer(state), affectedRouteKey: focusedRouteKey };
+          return { state: setDrawerStatus(state, 'closed'), affectedRouteKey: focusedRouteKey };
 
         case 'TOGGLE_DRAWER':
-          if (isDrawerInHistory(state)) {
-            return {
-              state: removeDrawerFromHistory(state),
-              affectedRouteKey: focusedRouteKey,
-            };
-          }
-
           return {
-            state: addDrawerToHistory(state),
+            state: setDrawerStatus(
+              state,
+              (state.drawerStatus ?? defaultStatus) === 'open' ? 'closed' : 'open'
+            ),
             affectedRouteKey: focusedRouteKey,
           };
 
@@ -198,7 +163,10 @@ export function DrawerRouter({
 
             return {
               ...actionResult,
-              state: closeDrawer(nextState as DrawerNavigationState<ParamListBase>),
+              state: setDrawerStatus(
+                nextState as DrawerNavigationState<ParamListBase>,
+                defaultStatus
+              ),
             };
           }
 
@@ -206,9 +174,9 @@ export function DrawerRouter({
         }
 
         case 'GO_BACK':
-          if (isDrawerInHistory(state)) {
+          if ((state.drawerStatus ?? defaultStatus) !== defaultStatus) {
             return {
-              state: removeDrawerFromHistory(state),
+              state: setDrawerStatus(state, defaultStatus),
               affectedRouteKey: focusedRouteKey,
             };
           }

--- a/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/DrawerRouter.tsx
@@ -126,7 +126,7 @@ export function DrawerRouter({
     getStateForRouteFocus(state, key) {
       const normalizedState = normalizeState(state);
       const result = router.getStateForRouteFocus(normalizedState, key);
-      return setDrawerStatus(result, defaultStatus);
+      return setDrawerStatus(result, 'closed');
     },
 
     getStateForAction(inputState, action, options) {
@@ -157,16 +157,13 @@ export function DrawerRouter({
 
           if (actionResult !== null) {
             const nextState = actionResult.state;
-            if (nextState.index === state.index) {
+            if (nextState.routes[nextState.index]?.key === focusedRouteKey) {
               return actionResult;
             }
 
             return {
               ...actionResult,
-              state: setDrawerStatus(
-                nextState as DrawerNavigationState<ParamListBase>,
-                defaultStatus
-              ),
+              state: setDrawerStatus(nextState as DrawerNavigationState<ParamListBase>, 'closed'),
             };
           }
 

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -1,5 +1,5 @@
 import { orderRoutesByRouteNames } from '../../utils/orderRoutesByRouteNames';
-import { isArrayEqual } from '../core/isArrayEqual';
+import { isSetEqual } from '../core/isSetEqual';
 import { BaseRouter } from './BaseRouter';
 import { attachRouteState, type RouteState } from './attachRouteState';
 import { createRouteFromAction } from './createRouteFromAction';
@@ -149,141 +149,131 @@ export const TabActions = {
   },
 };
 
-const getRouteHistory = (
-  routes: Route<string>[],
-  index: number,
-  backBehavior: BackBehavior,
-  initialRouteName: string | undefined
-): NonNullable<TabNavigationState<ParamListBase>['history']> => {
-  if (routes.length === 0) {
-    return [];
-  }
-  const history = [
-    {
-      type: TYPE_ROUTE,
-      key: routes[index]!.key,
-    },
-  ];
-
-  let initialRouteIndex;
-
-  switch (backBehavior) {
-    case 'order':
-      for (let i = index; i > 0; i--) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[i - 1]!.key,
-        });
-      }
-      break;
-    case 'firstRoute':
-      if (index !== 0) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[0]!.key,
-        });
-      }
-      break;
-    case 'initialRoute':
-      initialRouteIndex = routes.findIndex((route) => route.name === initialRouteName);
-      initialRouteIndex = initialRouteIndex === -1 ? 0 : initialRouteIndex;
-
-      if (index !== initialRouteIndex) {
-        history.unshift({
-          type: TYPE_ROUTE,
-          key: routes[initialRouteIndex]!.key,
-        });
-      }
-      break;
-    case 'history':
-    case 'fullHistory':
-      // The history will fill up on navigation
-      break;
-  }
-
-  return history;
-};
-
-export const ensureStateHistory = (
-  state: TabNavigationState<ParamListBase>,
-  backBehavior: BackBehavior,
-  initialRouteName: string | undefined
+export const ensureFullHistory = (
+  state: TabNavigationState<ParamListBase>
 ): TabNavigationStateWithHistory => {
   if (state.history != null) {
     // The null check narrows the optional property, but TypeScript doesn't narrow the object type.
     return state as TabNavigationStateWithHistory;
   }
 
-  const routes = orderRoutesByRouteNames(state.routes, state.routeNames);
   const focusedRoute = state.routes[state.index];
-  const index = routes.findIndex((route) => route.key === focusedRoute?.key);
-
-  // `orderRoutesByRouteNames` drops undeclared routes, so the focused one can be missing from
-  // `routes`. Keep it in history anyway, so the current route is always the last entry.
-  const history =
-    index === -1
-      ? focusedRoute === undefined
-        ? []
-        : [{ type: TYPE_ROUTE, key: focusedRoute.key }]
-      : getRouteHistory(routes, index, backBehavior, initialRouteName);
-
-  if (backBehavior === 'fullHistory' && focusedRoute !== undefined) {
-    history[history.length - 1] = {
-      ...history[history.length - 1]!,
-      params: focusedRoute.params,
-    };
-  }
+  const history = focusedRoute
+    ? [{ type: TYPE_ROUTE, key: focusedRoute.key, params: focusedRoute.params }]
+    : [];
 
   return { ...state, history };
 };
 
-const changeIndex = (
-  state: TabNavigationStateWithHistory,
-  index: number,
-  backBehavior: BackBehavior,
-  initialRouteName: string | undefined
-) => {
+const stripHistory = (
+  state: TabNavigationState<ParamListBase>
+): TabNavigationState<ParamListBase> => {
+  if (state.history === undefined) {
+    return state;
+  }
+  const { history: _, ...stateWithoutHistory } = state;
+  return stateWithoutHistory;
+};
+
+const changeFullHistoryIndex = (state: TabNavigationStateWithHistory, index: number) => {
   if (state.routes.length === 0) {
     return { ...state, index: -1, history: [] };
   }
   let history = state.history;
 
-  if (backBehavior === 'history' || backBehavior === 'fullHistory') {
-    const currentRoute = state.routes[index]!;
-
-    if (backBehavior === 'history') {
-      // Remove the existing key from the history to de-duplicate it
-      history = history.filter((it) => (it.type === 'route' ? it.key !== currentRoute.key : false));
-    } else if (backBehavior === 'fullHistory') {
-      const lastHistoryRouteItemIndex = history.findLastIndex((item) => item.type === 'route');
-
-      if (currentRoute.key === history[lastHistoryRouteItemIndex]?.key) {
-        // For full-history, only remove if it matches the last route
-        // Useful for drawer, if current route was in history, then drawer state changed
-        // Then we only need to move the route to the front
-        history = [
-          ...history.slice(0, lastHistoryRouteItemIndex),
-          ...history.slice(lastHistoryRouteItemIndex + 1),
-        ];
-      }
-    }
-
-    history = history.concat({
-      type: TYPE_ROUTE,
-      key: currentRoute.key,
-      params: backBehavior === 'fullHistory' ? currentRoute.params : undefined,
-    });
-  } else {
-    const routes = orderRoutesByRouteNames(state.routes, state.routeNames);
-    const orderedIndex = routes.findIndex((route) => route.key === state.routes[index]!.key);
-    history = getRouteHistory(routes, orderedIndex, backBehavior, initialRouteName);
+  const currentRoute = state.routes[index]!;
+  const lastHistoryRouteItemIndex = history.findLastIndex((item) => item.type === 'route');
+  if (currentRoute.key === history[lastHistoryRouteItemIndex]?.key) {
+    history = [
+      ...history.slice(0, lastHistoryRouteItemIndex),
+      ...history.slice(lastHistoryRouteItemIndex + 1),
+    ];
   }
+  history = history.concat({
+    type: TYPE_ROUTE,
+    key: currentRoute.key,
+    params: currentRoute.params,
+  });
 
   return {
     ...state,
     index,
     history,
   };
+};
+
+const getAnchorName = (
+  routeNames: string[],
+  backBehavior: BackBehavior,
+  initialRouteName: string | undefined
+) =>
+  backBehavior === 'initialRoute' &&
+  initialRouteName !== undefined &&
+  routeNames.includes(initialRouteName)
+    ? initialRouteName
+    : routeNames[0];
+
+const changeIndex = (
+  state: TabNavigationState<ParamListBase>,
+  targetKey: string,
+  backBehavior: BackBehavior,
+  initialRouteName: string | undefined,
+  routeNames: string[],
+  mintRouteKey: (name: string) => string
+): TabNavigationState<ParamListBase> => {
+  if (state.routes.length === 0) {
+    return { ...state, index: -1 };
+  }
+
+  const target = state.routes.find((route) => route.key === targetKey);
+  if (!target) {
+    return state;
+  }
+
+  if (backBehavior === 'fullHistory') {
+    return changeFullHistoryIndex(
+      state as TabNavigationStateWithHistory,
+      state.routes.indexOf(target)
+    );
+  }
+
+  if (backBehavior === 'none') {
+    return { ...state, index: state.routes.indexOf(target) };
+  }
+
+  if (backBehavior === 'order') {
+    const routes = orderRoutesByRouteNames(state.routes, routeNames);
+    return { ...state, routes, index: routes.indexOf(target) };
+  }
+
+  if (backBehavior === 'history') {
+    if (state.routes[state.index]?.key === targetKey) {
+      return state;
+    }
+    const visited = state.routes
+      .slice(0, state.index + 1)
+      .filter((route) => route.key !== targetKey);
+    const unvisited = state.routes
+      .slice(state.index + 1)
+      .filter((route) => route.key !== targetKey);
+    return {
+      ...state,
+      routes: [...visited, target, ...unvisited],
+      index: visited.length,
+    };
+  }
+
+  const anchorName = getAnchorName(routeNames, backBehavior, initialRouteName);
+  if (anchorName === undefined) {
+    return state;
+  }
+  const anchor =
+    state.routes.find((route) => route.name === anchorName) ??
+    ({ name: anchorName, key: mintRouteKey(anchorName) } as Route<string>);
+  const rest = state.routes.filter((route) => route.key !== anchor.key && route.key !== target.key);
+  return target.key === anchor.key
+    ? { ...state, routes: [anchor, ...rest], index: 0 }
+    : { ...state, routes: [anchor, target, ...rest], index: 1 };
 };
 
 /**
@@ -306,24 +296,31 @@ export function TabRouter({
     type: 'tab',
 
     getStateForRouteFocus(inputState, key) {
-      const state = ensureStateType(
-        ensureStateHistory(inputState, backBehavior, initialRouteName),
-        'tab'
-      );
-      const index = state.routes.findIndex((r) => r.key === key);
+      const normalizedState =
+        backBehavior === 'fullHistory' ? ensureFullHistory(inputState) : stripHistory(inputState);
+      const state = ensureStateType(normalizedState, 'tab');
+      const route = state.routes.find((route) => route.key === key);
 
-      if (index === -1 || index === state.index) {
+      if (!route || route.key === state.routes[state.index]?.key) {
         return state;
       }
 
-      return changeIndex(state, index, backBehavior, initialRouteName);
+      const minter = createRouteKeyMinter(state);
+      const result = changeIndex(
+        state,
+        route.key,
+        backBehavior,
+        initialRouteName,
+        state.routeNames,
+        minter.mint
+      );
+      return { ...result, routeKeySeq: minter.routeKeySeq };
     },
 
-    getStateForAction(inputState, action, { routeGetIdList }) {
-      const state = ensureStateType(
-        ensureStateHistory(inputState, backBehavior, initialRouteName),
-        'tab'
-      );
+    getStateForAction(inputState, action, { routeGetIdList, routeNames: declaredRouteNames }) {
+      const normalizedState =
+        backBehavior === 'fullHistory' ? ensureFullHistory(inputState) : stripHistory(inputState);
+      const state = ensureStateType(normalizedState, 'tab');
 
       if (action.target && action.target !== state.key) {
         return null;
@@ -334,94 +331,54 @@ export function TabRouter({
         case 'ROUTE_NAMES_CHANGED': {
           const routeNames = action.payload.routeNames;
 
-          if (isArrayEqual(state.routeNames, routeNames)) {
+          if (isSetEqual(state.routeNames, routeNames)) {
             return { state, affectedRouteKey: state.routes[state.index]?.key };
           }
 
-          const routes = addFallbackRouteIfEmpty(
+          let routes = addFallbackRouteIfEmpty(
             state.routes.filter((route) => routeNames.includes(route.name)),
             routeNames,
             initialRouteName,
             minter.mint
           );
 
-          if (routes.length === 0) {
-            return {
-              state: {
-                ...state,
-                routeNames,
-                routes,
-                routeKeySeq: minter.routeKeySeq,
-                index: -1,
-                history: [],
-              },
-              affectedRouteKey: undefined,
-            };
+          if (backBehavior === 'order') {
+            routes = orderRoutesByRouteNames(routes, routeNames);
           }
 
           const focusedKey = state.routes[state.index]?.key;
           const focusedIndex = routes.findIndex((route) => route.key === focusedKey);
-          const index = Math.max(focusedIndex, 0);
-          const routeKeys = routes.map((route) => route.key);
-          let history = state.history.filter(
-            (item) => item.type !== 'route' || routeKeys.includes(item.key)
-          );
-
-          if (
-            focusedIndex === -1 &&
-            (backBehavior === 'history' || backBehavior === 'fullHistory')
-          ) {
-            const currentRoute = routes[index]!;
-            const nonRouteHistory = history.filter((item) => item.type !== 'route');
-            let routeHistory = history.filter((item) => item.type === 'route');
-
-            if (backBehavior === 'history') {
-              routeHistory = routeHistory.filter((item) => item.key !== currentRoute.key);
-            } else if (routeHistory[routeHistory.length - 1]?.key === currentRoute.key) {
-              routeHistory = routeHistory.slice(0, -1);
-            }
-
-            history = [
-              ...routeHistory,
-              {
-                type: TYPE_ROUTE,
-                key: currentRoute.key,
-                params: backBehavior === 'fullHistory' ? currentRoute.params : undefined,
-              },
-              ...nonRouteHistory,
-            ];
-          }
-
-          if (
-            backBehavior === 'firstRoute' ||
-            backBehavior === 'initialRoute' ||
-            backBehavior === 'order'
-          ) {
-            const orderedRoutes = orderRoutesByRouteNames(routes, routeNames);
-            const orderedIndex = orderedRoutes.findIndex(
-              (route) => route.key === routes[index]!.key
-            );
-            history = [
-              ...getRouteHistory(orderedRoutes, orderedIndex, backBehavior, initialRouteName),
-              ...history.filter((item) => item.type !== 'route'),
-            ];
-          } else if (!history.some((item) => item.type === 'route')) {
-            history = [
-              ...getRouteHistory(routes, index, backBehavior, initialRouteName),
-              ...history.filter((item) => item.type !== 'route'),
-            ];
-          }
+          const index = routes.length === 0 ? -1 : Math.max(focusedIndex, 0);
+          const history =
+            backBehavior === 'fullHistory'
+              ? state.history!.filter((item) => routes.some((route) => route.key === item.key))
+              : undefined;
 
           return {
             state: {
               ...state,
-              history,
               routeNames,
               routes,
               routeKeySeq: minter.routeKeySeq,
               index,
+              ...(history === undefined ? undefined : { history }),
             },
-            affectedRouteKey: routes[index]!.key,
+            affectedRouteKey: routes[index]?.key,
+          };
+        }
+
+        case 'ROUTE_NAMES_ORDER_CHANGED': {
+          const routeNames = action.payload.routeNames;
+          if (backBehavior !== 'order' || !isSetEqual(state.routeNames, routeNames)) {
+            return null;
+          }
+          const focusedKey = state.routes[state.index]?.key;
+          const routes = orderRoutesByRouteNames(state.routes, routeNames);
+          const index =
+            focusedKey === undefined ? -1 : routes.findIndex((route) => route.key === focusedKey);
+          return {
+            state: { ...state, routeNames, routes, index },
+            affectedRouteKey: focusedKey,
           };
         }
 
@@ -429,11 +386,11 @@ export function TabRouter({
         case 'REPLACE':
         case 'JUMP_TO':
         case 'NAVIGATE': {
-          if (!state.routeNames.includes(action.payload.name)) {
+          if (!declaredRouteNames.includes(action.payload.name)) {
             return null;
           }
 
-          const { routes, index } = addRouteIfMissing(state.routes, action.payload.name, () => {
+          const { routes } = addRouteIfMissing(state.routes, action.payload.name, () => {
             const route = createRouteFromAction({
               action,
               key: minter.mint(action.payload.name),
@@ -443,79 +400,85 @@ export function TabRouter({
               : route;
           });
 
-          const updatedState = changeIndex(
+          const previousFocusedRoute = state.routes[state.index];
+          const updatedRoutes = routes.map((route) => {
+            if (route.name !== action.payload.name) {
+              return route;
+            }
+
+            const getId = routeGetIdList[route.name];
+            const currentId = getId?.({ params: route.params });
+            const nextId = getId?.({ params: action.payload.params });
+            const key = currentId === nextId ? route.key : minter.mint(route.name);
+
+            let params;
+            if (action.type === 'NAVIGATE' && action.payload.merge && currentId === nextId) {
+              params =
+                action.payload.params !== undefined
+                  ? { ...route.params, ...action.payload.params }
+                  : route.params;
+            } else {
+              params = action.payload.params;
+            }
+
+            const path =
+              action.type === 'NAVIGATE' && action.payload.path != null
+                ? action.payload.path
+                : route.path;
+            const updatedRoute =
+              params !== route.params || path !== route.path || key !== route.key
+                ? { ...route, key, path, params }
+                : route;
+            return attachRouteState(updatedRoute, action);
+          });
+          const targetRoute = updatedRoutes.find((route) => route.name === action.payload.name)!;
+          let updatedState = changeIndex(
             {
               ...state,
-              routes: routes.map((route) => {
-                if (route.name !== action.payload.name) {
-                  return route;
-                }
-
-                const getId = routeGetIdList[route.name];
-
-                const currentId = getId?.({ params: route.params });
-                const nextId = getId?.({ params: action.payload.params });
-
-                // TODO(@ubax): Rewrite `history` when `getId` re-keys a route, as `PRELOAD` does with `replacedKey`.
-                const key = currentId === nextId ? route.key : minter.mint(route.name);
-
-                let params;
-
-                if (action.type === 'NAVIGATE' && action.payload.merge && currentId === nextId) {
-                  params =
-                    action.payload.params !== undefined
-                      ? {
-                          ...route.params,
-                          ...action.payload.params,
-                        }
-                      : route.params;
-                } else {
-                  params = action.payload.params;
-                }
-
-                const path =
-                  action.type === 'NAVIGATE' && action.payload.path != null
-                    ? action.payload.path
-                    : route.path;
-
-                const updatedRoute =
-                  params !== route.params || path !== route.path
-                    ? { ...route, key, path, params }
-                    : route;
-                return attachRouteState(updatedRoute, action);
-              }),
+              routes: updatedRoutes,
               routeKeySeq: minter.routeKeySeq,
             },
-            index,
+            targetRoute.key,
             backBehavior,
-            initialRouteName
+            initialRouteName,
+            declaredRouteNames,
+            minter.mint
           );
 
-          const result =
-            action.type === 'REPLACE'
-              ? removeReplacedRouteFromHistory(state, updatedState)
-              : updatedState;
-          return { state: result, affectedRouteKey: result.routes[result.index]?.key };
+          if (action.type === 'REPLACE' && previousFocusedRoute) {
+            updatedState = removeReplacedRoute(
+              state,
+              updatedState,
+              previousFocusedRoute,
+              backBehavior,
+              initialRouteName,
+              declaredRouteNames
+            );
+          }
+          return {
+            state: updatedState,
+            affectedRouteKey: updatedState.routes[updatedState.index]?.key,
+          };
         }
 
         case 'SET_PARAMS':
         case 'REPLACE_PARAMS': {
           const actionResult = BaseRouter.getStateForAction(state, action);
 
-          if (actionResult !== null) {
+          if (actionResult !== null && backBehavior === 'fullHistory') {
             const nextState = actionResult.state;
             const index = nextState.index;
 
             if (index != null) {
               const focusedRoute = nextState.routes[index]!;
-              const historyItemIndex = state.history.findLastIndex(
+              const historyItemIndex = state.history!.findLastIndex(
                 (item) => item.key === focusedRoute.key
               );
 
-              let updatedHistory = state.history;
+              let updatedHistory = state.history!;
 
               if (historyItemIndex !== -1) {
-                updatedHistory = [...state.history];
+                updatedHistory = [...state.history!];
                 updatedHistory[historyItemIndex] = {
                   ...updatedHistory[historyItemIndex]!,
                   params: focusedRoute.params,
@@ -544,42 +507,52 @@ export function TabRouter({
           if (!focusedRoute) {
             return null;
           }
-          let backTargetName: string | undefined;
-
-          if (backBehavior === 'firstRoute') {
-            backTargetName = state.routeNames[0];
-          } else if (backBehavior === 'initialRoute') {
-            backTargetName =
-              initialRouteName !== undefined && state.routeNames.includes(initialRouteName)
-                ? initialRouteName
-                : state.routeNames[0];
-          } else if (backBehavior === 'order') {
-            const declaredIndex = state.routeNames.indexOf(focusedRoute.name);
-            backTargetName = declaredIndex > 0 ? state.routeNames[declaredIndex - 1] : undefined;
-          }
-
-          if (backTargetName !== undefined && backTargetName !== focusedRoute.name) {
-            const { routes, index } = addRouteIfMissing(state.routes, backTargetName, () => ({
-              name: backTargetName,
-              key: minter.mint(backTargetName),
-            }));
-
-            if (routes !== state.routes) {
-              const result = changeIndex(
-                { ...state, routes, routeKeySeq: minter.routeKeySeq },
-                index,
-                backBehavior,
-                initialRouteName
-              );
-              return { state: result, affectedRouteKey: result.routes[result.index]?.key };
+          if (backBehavior !== 'fullHistory') {
+            if (state.index > 0) {
+              const index = state.index - 1;
+              return {
+                state: { ...state, index },
+                affectedRouteKey: state.routes[index]!.key,
+              };
             }
-          }
-
-          if (state.history.length === 1) {
+            if (backBehavior === 'firstRoute' || backBehavior === 'initialRoute') {
+              const anchorName = getAnchorName(declaredRouteNames, backBehavior, initialRouteName);
+              const existingAnchor = state.routes.find((route) => route.name === anchorName);
+              if (
+                anchorName !== undefined &&
+                focusedRoute.name !== anchorName &&
+                existingAnchor === undefined
+              ) {
+                const anchor = {
+                  name: anchorName,
+                  key: minter.mint(anchorName),
+                };
+                const routes = [
+                  anchor,
+                  focusedRoute,
+                  ...state.routes.filter(
+                    (route) => route.key !== anchor.key && route.key !== focusedRoute.key
+                  ),
+                ];
+                return {
+                  state: {
+                    ...state,
+                    routes,
+                    index: 0,
+                    routeKeySeq: minter.routeKeySeq,
+                  },
+                  affectedRouteKey: anchor.key,
+                };
+              }
+            }
             return null;
           }
 
-          const previousHistoryItem = state.history[state.history.length - 2];
+          if (state.history!.length === 1) {
+            return null;
+          }
+
+          const previousHistoryItem = state.history![state.history!.length - 2];
           const previousKey = previousHistoryItem?.key;
           const index = state.routes.findLastIndex((route) => route.key === previousKey);
 
@@ -604,7 +577,7 @@ export function TabRouter({
             state: {
               ...state,
               routes,
-              history: state.history.slice(0, -1),
+              history: state.history!.slice(0, -1),
               index,
             },
             affectedRouteKey: routes[index]!.key,
@@ -612,7 +585,7 @@ export function TabRouter({
         }
 
         case 'PRELOAD': {
-          if (!state.routeNames.includes(action.payload.name)) {
+          if (!declaredRouteNames.includes(action.payload.name)) {
             return null;
           }
 
@@ -620,13 +593,29 @@ export function TabRouter({
           let affectedRouteKey: string;
           let replacedKey: string | undefined;
           let routes: Route<string>[];
+          let index = state.index;
 
           if (routeIndex === -1) {
             const route = attachRouteState(
-              createRouteFromAction({ action, key: minter.mint(action.payload.name) }),
+              createRouteFromAction({
+                action,
+                key: minter.mint(action.payload.name),
+              }),
               action
             );
             routes = [...state.routes, route];
+            if (backBehavior === 'order') {
+              const focusedKey = state.routes[state.index]?.key;
+              routes = orderRoutesByRouteNames(routes, declaredRouteNames);
+              index = routes.findIndex((route) => route.key === focusedKey);
+            } else if (
+              (backBehavior === 'firstRoute' || backBehavior === 'initialRoute') &&
+              route.name === getAnchorName(declaredRouteNames, backBehavior, initialRouteName) &&
+              index >= 0
+            ) {
+              routes = [...state.routes.slice(0, index), route, ...state.routes.slice(index)];
+              index += 1;
+            }
             affectedRouteKey = route.key;
           } else {
             const route = state.routes[routeIndex]!;
@@ -647,48 +636,33 @@ export function TabRouter({
 
           let history = state.history;
 
-          if (backBehavior === 'history' || backBehavior === 'fullHistory') {
-            if (replacedKey !== undefined) {
-              // Re-key in place, so the focused route stays the last history entry for `goBack`.
-              // Only the newest entry takes the new params - `fullHistory` keeps duplicate entries
-              // and each older one still holds the params of its own visit.
-              const newRoute = routes[routeIndex]!;
-              const newestIndex = history.findLastIndex(
-                (record) => record.type === TYPE_ROUTE && record.key === replacedKey
-              );
+          if (backBehavior === 'fullHistory' && replacedKey !== undefined) {
+            // Re-key in place, so the focused route stays the last history entry for `goBack`.
+            // Only the newest entry takes the new params - `fullHistory` keeps duplicate entries
+            // and each older one still holds the params of its own visit.
+            const newRoute = routes[routeIndex]!;
+            const newestIndex = history!.findLastIndex(
+              (record) => record.type === TYPE_ROUTE && record.key === replacedKey
+            );
 
-              history = history.map((record, index) =>
-                record.type === TYPE_ROUTE && record.key === replacedKey
-                  ? {
-                      ...record,
-                      key: newRoute.key,
-                      params:
-                        backBehavior === 'fullHistory' && index === newestIndex
-                          ? newRoute.params
-                          : record.params,
-                    }
-                  : record
-              );
-            }
-          } else {
-            const orderedRoutes = orderRoutesByRouteNames(routes, state.routeNames);
-            const focusedKey = routes[state.index]?.key;
-            const focusedIndex = orderedRoutes.findIndex((route) => route.key === focusedKey);
-            const routeHistory =
-              focusedIndex === -1
-                ? []
-                : getRouteHistory(orderedRoutes, focusedIndex, backBehavior, initialRouteName);
-
-            // TODO: Refactor history handling together with web state synchronization.
-            history = [...routeHistory, ...history.filter((item) => item.type !== 'route')];
+            history = history!.map((record, index) =>
+              record.type === TYPE_ROUTE && record.key === replacedKey
+                ? {
+                    ...record,
+                    key: newRoute.key,
+                    params: index === newestIndex ? newRoute.params : record.params,
+                  }
+                : record
+            );
           }
 
           return {
             state: {
               ...state,
+              index,
               routes,
-              history,
               routeKeySeq: minter.routeKeySeq,
+              ...(history === undefined ? undefined : { history }),
             },
             affectedRouteKey,
           };
@@ -704,12 +678,9 @@ export function TabRouter({
           return {
             ...result,
             state: ensureStateType(
-              ensureStateHistory(
-                // BaseRouter throws instead of returning partial RESET payloads.
-                result.state as TabNavigationState<ParamListBase>,
-                backBehavior,
-                initialRouteName
-              ),
+              backBehavior === 'fullHistory'
+                ? ensureFullHistory(result.state as TabNavigationState<ParamListBase>)
+                : stripHistory(result.state as TabNavigationState<ParamListBase>),
               state.type
             ),
           };
@@ -723,23 +694,55 @@ export function TabRouter({
   return router;
 }
 
-function removeReplacedRouteFromHistory(
-  previousState: TabNavigationStateWithHistory,
-  nextState: TabNavigationStateWithHistory
+function removeReplacedRoute(
+  previousState: TabNavigationState<ParamListBase>,
+  nextState: TabNavigationState<ParamListBase>,
+  replacedRoute: Route<string>,
+  backBehavior: BackBehavior,
+  initialRouteName: string | undefined,
+  routeNames: string[]
 ) {
-  const replacedRouteKey = previousState.routes[previousState.index]?.key;
   const focusedRouteKey = nextState.routes[nextState.index]?.key;
-  if (!replacedRouteKey || replacedRouteKey === focusedRouteKey) {
+  if (replacedRoute.key === focusedRouteKey) {
     return nextState;
   }
 
-  const replacedIndex = nextState.history.findLastIndex((item) => item.key === replacedRouteKey);
-  if (replacedIndex === -1) {
+  if (backBehavior === 'fullHistory') {
+    const history = nextState.history!;
+    const replacedIndex = history.findLastIndex((item) => item.key === replacedRoute.key);
+    if (replacedIndex === -1) {
+      return nextState;
+    }
+    return {
+      ...nextState,
+      history: history.filter((_, index) => index !== replacedIndex),
+    };
+  }
+
+  if (backBehavior === 'history') {
+    const routes = nextState.routes.filter((route) => route.key !== replacedRoute.key);
+    const index = routes.findIndex((route) => route.key === focusedRouteKey);
+    routes.splice(index + 1, 0, replacedRoute);
+    return { ...nextState, routes, index };
+  }
+
+  const anchorName = getAnchorName(routeNames, backBehavior, initialRouteName);
+  if (
+    (backBehavior !== 'firstRoute' && backBehavior !== 'initialRoute') ||
+    replacedRoute.name !== anchorName
+  ) {
     return nextState;
   }
 
+  const routes = nextState.routes.filter((route) => route.key !== replacedRoute.key);
+  const index = routes.findIndex((route) => route.key === focusedRouteKey);
   return {
     ...nextState,
-    history: nextState.history.filter((_, index) => index !== replacedIndex),
+    routes: [
+      routes[index]!,
+      replacedRoute,
+      ...routes.filter((_, routeIndex) => routeIndex !== index),
+    ],
+    index: 0,
   };
 }

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -47,7 +47,7 @@ export type TabRouterOptions = DefaultRouterOptions & {
    * Control how going back should behave
    * - `firstRoute` - return to the first defined route
    * - `initialRoute` - return to the route from `initialRouteName`
-   * - `order` - return to the route defined before the focused route
+   * - `order` - return to the route defined before the focused route; all declared routes are preloaded
    * - `history` - return to last visited route; if the same route is visited multiple times, the older entries are dropped from the history
    * - `fullHistory` - return to last visited route; doesn't drop duplicate entries unlike `history` - matches behavior of web pages
    * - `none` - do not handle going back
@@ -353,15 +353,21 @@ export function TabRouter({
             backBehavior === 'fullHistory'
               ? state.history!.filter((item) => routes.some((route) => route.key === item.key))
               : undefined;
+          const nextState =
+            backBehavior === 'fullHistory' && focusedIndex === -1 && routes.length > 0
+              ? changeFullHistoryIndex({ ...state, routes, history: history! }, index)
+              : {
+                  ...state,
+                  routes,
+                  index,
+                  ...(history === undefined ? undefined : { history }),
+                };
 
           return {
             state: {
-              ...state,
+              ...nextState,
               routeNames,
-              routes,
               routeKeySeq: minter.routeKeySeq,
-              index,
-              ...(history === undefined ? undefined : { history }),
             },
             affectedRouteKey: routes[index]?.key,
           };
@@ -409,6 +415,7 @@ export function TabRouter({
             const getId = routeGetIdList[route.name];
             const currentId = getId?.({ params: route.params });
             const nextId = getId?.({ params: action.payload.params });
+            // TODO(@ubax): Rewrite `history` when `getId` re-keys a route, as `PRELOAD` does with `replacedKey`.
             const key = currentId === nextId ? route.key : minter.mint(route.name);
 
             let params;
@@ -516,7 +523,7 @@ export function TabRouter({
               };
             }
             if (backBehavior === 'firstRoute' || backBehavior === 'initialRoute') {
-              const anchorName = getAnchorName(declaredRouteNames, backBehavior, initialRouteName);
+              const anchorName = getAnchorName(state.routeNames, backBehavior, initialRouteName);
               const existingAnchor = state.routes.find((route) => route.name === anchorName);
               if (
                 anchorName !== undefined &&

--- a/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
+++ b/packages/expo-router/src/react-navigation/routers/TabRouter.tsx
@@ -47,7 +47,7 @@ export type TabRouterOptions = DefaultRouterOptions & {
    * Control how going back should behave
    * - `firstRoute` - return to the first defined route
    * - `initialRoute` - return to the route from `initialRouteName`
-   * - `order` - return to the route defined before the focused route; all declared routes are preloaded
+   * - `order` - return to the route defined before the focused route
    * - `history` - return to last visited route; if the same route is visited multiple times, the older entries are dropped from the history
    * - `fullHistory` - return to last visited route; doesn't drop duplicate entries unlike `history` - matches behavior of web pages
    * - `none` - do not handle going back
@@ -375,9 +375,17 @@ export function TabRouter({
 
         case 'ROUTE_NAMES_ORDER_CHANGED': {
           const routeNames = action.payload.routeNames;
-          if (backBehavior !== 'order' || !isSetEqual(state.routeNames, routeNames)) {
+          if (!isSetEqual(state.routeNames, routeNames)) {
             return null;
           }
+
+          if (backBehavior !== 'order') {
+            return {
+              state: { ...state, routeNames },
+              affectedRouteKey: state.routes[state.index]?.key,
+            };
+          }
+
           const focusedKey = state.routes[state.index]?.key;
           const routes = orderRoutesByRouteNames(state.routes, routeNames);
           const index =
@@ -463,7 +471,7 @@ export function TabRouter({
             );
           }
           return {
-            state: updatedState,
+            state: { ...updatedState, routeKeySeq: minter.routeKeySeq },
             affectedRouteKey: updatedState.routes[updatedState.index]?.key,
           };
         }
@@ -515,6 +523,26 @@ export function TabRouter({
             return null;
           }
           if (backBehavior !== 'fullHistory') {
+            if (backBehavior === 'order') {
+              const declaredIndex = declaredRouteNames.indexOf(focusedRoute.name);
+              if (declaredIndex <= 0) {
+                return null;
+              }
+
+              const previousName = declaredRouteNames[declaredIndex - 1]!;
+              let routes = state.routes;
+              let previousRoute = routes.find((route) => route.name === previousName);
+              if (!previousRoute) {
+                previousRoute = { name: previousName, key: minter.mint(previousName) };
+                routes = orderRoutesByRouteNames([...routes, previousRoute], declaredRouteNames);
+              }
+              const index = routes.indexOf(previousRoute);
+              return {
+                state: { ...state, routes, index, routeKeySeq: minter.routeKeySeq },
+                affectedRouteKey: previousRoute.key,
+              };
+            }
+
             if (state.index > 0) {
               const index = state.index - 1;
               return {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -1,998 +1,150 @@
-import { expect, jest, test } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 
 import {
   CommonActions,
-  type DrawerActionType,
   DrawerActions,
   type DrawerNavigationState,
   DrawerRouter,
   type ParamListBase,
   type RouterConfigOptions,
-} from '..';
-import { createInitialState } from '../../core/createInitialState';
+  TabActions,
+} from '../index';
 
-test('actions return drawer metadata for state without router metadata', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const createState = (): DrawerNavigationState<ParamListBase> => ({
-    stale: false,
-    routeKeySeq: 0,
-    key: 'root',
-    index: 1,
-    routeNames: options.routeNames,
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-    ],
-  });
-  const resetState = createState();
-  const actions = [
-    DrawerActions.jumpTo('bar'),
-    DrawerActions.openDrawer(),
-    CommonActions.goBack(),
-    CommonActions.reset({ ...resetState, index: 0, routes: [resetState.routes[0]!] }),
-  ];
-
-  for (const action of actions) {
-    const result = router.getStateForAction(createState(), action, options);
-    expect(result?.state).toMatchObject({ type: 'drawer', history: expect.any(Array) });
-  }
-});
-
-test('route focus returns drawer metadata for state without router metadata', () => {
-  const state: DrawerNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    key: 'root',
-    index: 0,
-    routeNames: ['bar', 'baz'],
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-    ],
-  };
-
-  expect(DrawerRouter({}).getStateForRouteFocus(state, 'baz')).toMatchObject({
-    type: 'drawer',
-    history: expect.any(Array),
-  });
-});
-
-test('warns and ignores a partial RESET state', () => {
-  const state: DrawerNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    key: 'root',
-    index: 0,
-    routeNames: ['bar'],
-    routes: [{ key: 'bar', name: 'bar' }],
-  };
-  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-  const result = DrawerRouter({}).getStateForAction(
-    state,
-    CommonActions.reset({ routes: [{ name: 'bar' }] }),
-    { routeNames: ['bar'], routeGetIdList: {} }
-  );
-
-  expect(result).toBeNull();
-  expect(warn).toHaveBeenCalledWith(
-    expect.stringContaining('The RESET action payload must contain a complete navigation state.')
-  );
-  warn.mockRestore();
-});
-
-type DrawerHistory = NonNullable<DrawerNavigationState<ParamListBase>['history']>;
-
-const stateWithoutHistory = (): DrawerNavigationState<ParamListBase> => ({
-  stale: false,
-  routeKeySeq: 0,
-  type: 'drawer',
-  key: 'root',
-  index: 0,
-  routeNames: ['bar'],
-  routes: [{ key: 'bar', name: 'bar' }],
-});
-
-const optionsWithoutHistory: RouterConfigOptions = {
-  routeNames: ['bar'],
+const options: RouterConfigOptions = {
+  routeNames: ['one', 'two', 'three'],
   routeGetIdList: {},
 };
 
-test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
-  {
-    action: DrawerActions.openDrawer(),
-    expectedHistory: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
-  },
-  {
-    action: DrawerActions.toggleDrawer(),
-    expectedHistory: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
-  },
-  {
-    action: DrawerActions.closeDrawer(),
-    expectedHistory: [{ type: 'route', key: 'bar' }],
-  },
-])('handles $action.type without history', ({ action, expectedHistory }) => {
-  const router = DrawerRouter({});
-
-  expect(
-    router.getStateForAction(stateWithoutHistory(), action, optionsWithoutHistory)?.state.history
-  ).toEqual(expectedHistory);
+const state = (
+  names: string[] = ['one'],
+  index = 0,
+  extra: Partial<DrawerNavigationState<ParamListBase>> = {}
+): DrawerNavigationState<ParamListBase> => ({
+  stale: false,
+  type: 'drawer',
+  key: 'drawer',
+  routeKeySeq: 0,
+  routeNames: options.routeNames,
+  routes: names.map((name) => ({ name, key: `${name}-key` })),
+  index,
+  ...extra,
 });
 
-// With `defaultStatus: 'open'` the encoding is inverted: an open drawer is the absence of a
-// history entry, so opening removes one and closing adds one.
-test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
-  {
-    action: DrawerActions.openDrawer(),
-    expectedHistory: [{ type: 'route', key: 'bar' }],
-  },
-  {
-    action: DrawerActions.toggleDrawer(),
-    expectedHistory: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'closed' },
-    ],
-  },
-  {
-    action: DrawerActions.closeDrawer(),
-    expectedHistory: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'closed' },
-    ],
-  },
-])(
-  'handles $action.type without history and defaultStatus: open',
-  ({ action, expectedHistory }) => {
+describe('drawer status', () => {
+  test('open, close and toggle use drawerStatus instead of history', () => {
+    const router = DrawerRouter({});
+    let next = router.getStateForAction(state(), DrawerActions.openDrawer(), options)!.state;
+    expect(next.drawerStatus).toBe('open');
+    expect(next.history).toBeUndefined();
+
+    next = router.getStateForAction(next, DrawerActions.toggleDrawer(), options)!.state;
+    expect(next.drawerStatus).toBeUndefined();
+    next = router.getStateForAction(next, DrawerActions.closeDrawer(), options)!.state;
+    expect(next.drawerStatus).toBeUndefined();
+  });
+
+  test('absent status means the configured open default', () => {
     const router = DrawerRouter({ defaultStatus: 'open' });
-
-    expect(
-      router.getStateForAction(stateWithoutHistory(), action, optionsWithoutHistory)?.state.history
-    ).toEqual(expectedHistory);
-  }
-);
-
-// `getRouteHistory` falls through its switch for `none`, so only the focused route is
-// reconstructed. `firstRoute` would additionally prepend `bar` here.
-test.each<{ action: DrawerActionType; expectedHistory: DrawerHistory }>([
-  {
-    action: DrawerActions.openDrawer(),
-    expectedHistory: [
-      { type: 'route', key: 'baz' },
-      { type: 'drawer', status: 'open' },
-    ],
-  },
-  {
-    action: DrawerActions.closeDrawer(),
-    expectedHistory: [{ type: 'route', key: 'baz' }],
-  },
-])('handles $action.type without history and backBehavior: none', ({ action, expectedHistory }) => {
-  const router = DrawerRouter({ backBehavior: 'none' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state: DrawerNavigationState<ParamListBase> = {
-    ...stateWithoutHistory(),
-    index: 1,
-    routeNames: options.routeNames,
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, action, options)?.state.history).toEqual(expectedHistory);
-});
-
-test('preserves reconstructed history after closing the drawer', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state: DrawerNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 1,
-    routeNames: options.routeNames,
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-    ],
-  };
-
-  const openState = router.getStateForAction(state, DrawerActions.openDrawer(), options)!.state;
-  const closedState = router.getStateForAction(openState, CommonActions.goBack(), options)!.state;
-  const result = router.getStateForAction(closedState, CommonActions.goBack(), options);
-
-  expect(result?.state.routes[result.state.index ?? -1]?.name).toBe('bar');
-});
-
-test('preserves drawer status when route names change', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const initialState = createInitialState<DrawerNavigationState<ParamListBase>>({
-    ...options,
-    parentChain: 'test',
+    const closed = router.getStateForAction(state(), DrawerActions.closeDrawer(), options)!.state;
+    expect(closed.drawerStatus).toBe('closed');
+    const open = router.getStateForAction(closed, DrawerActions.openDrawer(), options)!.state;
+    expect(open.drawerStatus).toBeUndefined();
   });
-  const openState = router.getStateForAction(
-    initialState,
-    DrawerActions.openDrawer(),
-    options
-  )!.state;
 
-  const state = router.getStateForAction(
-    openState,
-    { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['baz', 'bar'] } },
-    { ...options, routeNames: ['baz', 'bar'] }
-  );
-
-  expect(state!.state.history).toContainEqual({ type: 'drawer', status: 'open' });
-});
-
-test('restores route history without dropping drawer status when the active route is removed', () => {
-  const router = DrawerRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const initialState = createInitialState<DrawerNavigationState<ParamListBase>>({
-    ...options,
-    parentChain: 'test',
-  });
-  const openState = router.getStateForAction(
-    initialState,
-    DrawerActions.openDrawer(),
-    options
-  )!.state;
-
-  const state = router.getStateForAction(
-    openState,
-    { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['baz'] } },
-    { ...options, routeNames: ['baz'] }
-  );
-
-  expect(state!.state.history).toEqual([
-    { type: 'route', key: 'baz:test-1' },
-    { type: 'drawer', status: 'open' },
-  ]);
-});
-
-test('PRELOAD rebuilds route history without dropping drawer status', () => {
-  const router = DrawerRouter({ backBehavior: 'order' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  const focusedState: DrawerNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'navigator:drawer',
-    index: 0,
-    routeNames: options.routeNames,
-    routes: [{ key: 'qux-key', name: 'qux' }],
-  };
-  const openState = router.getStateForAction(
-    focusedState,
-    DrawerActions.openDrawer(),
-    options
-  )!.state;
-
-  const state = router.getStateForAction(
-    openState,
-    { type: 'PRELOAD', payload: { name: 'baz' } },
-    options
-  );
-
-  expect(state!.state.history).toEqual([
-    { type: 'route', key: 'baz:drawer-0' },
-    { type: 'route', key: 'qux-key' },
-    { type: 'drawer', status: 'open' },
-  ]);
-});
-
-test('handles navigate action', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz', params: { color: 'tomato' } },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('baz', { answer: 42 }),
+  test('navigation to another route resets status to default', () => {
+    const router = DrawerRouter({ backBehavior: 'history' });
+    const next = router.getStateForAction(
+      state(['one', 'two'], 0, { drawerStatus: 'open' }),
+      TabActions.jumpTo('two'),
       options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz', params: { answer: 42 } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
+    )!.state;
+    expect(next.drawerStatus).toBeUndefined();
+    expect(next.routes[next.index]?.name).toBe('two');
+  });
+
+  test('navigation to the focused route preserves status', () => {
+    const router = DrawerRouter({ backBehavior: 'history' });
+    const next = router.getStateForAction(
+      state(['one'], 0, { drawerStatus: 'open' }),
+      CommonActions.setParams({ value: 1 }),
+      options
+    )!.state;
+    expect(next.drawerStatus).toBe('open');
+  });
+
+  test('route focus closes the drawer', () => {
+    const router = DrawerRouter({ backBehavior: 'history' });
+    const current = state(['one', 'two'], 0, { drawerStatus: 'open' });
+    expect(router.getStateForRouteFocus(current, 'one-key').drawerStatus).toBeUndefined();
+    expect(router.getStateForRouteFocus(current, 'two-key').drawerStatus).toBeUndefined();
   });
 });
 
-test('handles navigate action with open drawer', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
+describe('back behavior', () => {
+  test.each(['firstRoute', 'initialRoute', 'order', 'history', 'fullHistory', 'none'] as const)(
+    'closes the drawer before delegating with %s',
+    (backBehavior) => {
+      const router = DrawerRouter({ backBehavior, initialRouteName: 'one' });
+      const current = state(['one', 'two'], 1, {
+        drawerStatus: 'open',
+        ...(backBehavior === 'fullHistory'
+          ? {
+              history: [
+                { type: 'route' as const, key: 'one-key' },
+                { type: 'route' as const, key: 'two-key' },
+              ],
+            }
+          : undefined),
+      });
+      const closed = router.getStateForAction(current, CommonActions.goBack(), options)!.state;
+      expect(closed.drawerStatus).toBeUndefined();
+      expect(closed.index).toBe(1);
 
-  const result = router.getStateForAction(
-    {
-      stale: false,
-      routeKeySeq: 0,
-      type: 'drawer',
-      key: 'root',
-      index: 1,
-      routeNames: ['baz', 'bar'],
-      routes: [
-        { key: 'baz', name: 'baz' },
-        { key: 'bar', name: 'bar' },
-      ],
+      const backed = router.getStateForAction(closed, CommonActions.goBack(), options);
+      if (backBehavior === 'none') {
+        expect(backed).toBeNull();
+      } else {
+        expect(backed?.state.index).toBe(0);
+      }
+    }
+  );
+});
+
+describe('history migration', () => {
+  test('strips legacy drawer entries and keeps route entries in fullHistory', () => {
+    const legacy = state(['one'], 0, {
       history: [
-        { type: 'route', key: 'bar' },
-        { type: 'drawer', status: 'open' },
+        { type: 'route', key: 'one-key' },
+        // Persisted states may still contain the old drawer entry shape.
+        { type: 'drawer', status: 'open' } as never,
       ],
-    },
-    CommonActions.navigate('baz', { answer: 42 }),
-    options
-  );
-
-  expect(result?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz', params: { answer: 42 } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
-  });
-  expect(result?.affectedRouteKey).toBe('baz');
-});
-
-test('attaches trusted state while closing the drawer', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-  const childState = { routes: [{ name: 'child' }], __internal__routerActionState: true as const };
-
-  const result = router.getStateForAction(
-    {
-      stale: false,
-      routeKeySeq: 0,
-      type: 'drawer',
-      key: 'root',
-      index: 1,
-      routeNames: ['baz', 'bar'],
-      routes: [
-        { key: 'baz', name: 'baz' },
-        { key: 'bar', name: 'bar' },
-      ],
-      history: [
-        { type: 'route', key: 'bar' },
-        { type: 'drawer', status: 'open' },
-      ],
-    },
-    {
-      type: 'NAVIGATE',
-      payload: { name: 'baz', state: childState },
-    },
-    options
-  );
-
-  expect(result?.state.routes[0]?.state).toEqual({ routes: [{ name: 'child' }] });
-  expect(result?.state.history).toEqual([{ type: 'route', key: 'baz' }]);
-});
-
-test('closes open drawer on replace with backBehavior: fullHistory', () => {
-  const router = DrawerRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [
-          { type: 'route', key: 'bar' },
-          { type: 'drawer', status: 'open' },
-        ],
-      },
-      DrawerActions.replace('baz'),
+    });
+    const next = DrawerRouter({ backBehavior: 'fullHistory' }).getStateForAction(
+      legacy,
+      CommonActions.setParams({ value: 1 }),
       options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
+    )!.state;
+    expect(next.history).toEqual([{ type: 'route', key: 'one-key', params: { value: 1 } }]);
   });
-});
 
-test('handles open drawer action', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  const result = router.getStateForAction(
-    {
-      stale: false,
-      routeKeySeq: 0,
-      type: 'drawer',
-      key: 'root',
-      index: 1,
-      routeNames: ['baz', 'bar'],
-      routes: [
-        { key: 'baz', name: 'baz' },
-        { key: 'bar', name: 'bar' },
-      ],
-      history: [{ type: 'route', key: 'bar' }],
-    },
-    DrawerActions.openDrawer(),
-    options
-  );
-
-  expect(result?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
-  });
-  expect(result?.affectedRouteKey).toBe('bar');
-
-  const state: DrawerNavigationState<ParamListBase> = {
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'drawer' as const,
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, DrawerActions.openDrawer(), options)?.state).toBe(state);
-});
-
-test('handles close drawer action', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  const result = router.getStateForAction(
-    {
-      stale: false,
-      routeKeySeq: 0,
-      type: 'drawer',
-      key: 'root',
-      index: 1,
-      routeNames: ['baz', 'bar'],
-      routes: [
-        { key: 'baz', name: 'baz' },
-        { key: 'bar', name: 'bar' },
-      ],
-      history: [
-        { type: 'route', key: 'bar' },
-        { type: 'drawer', status: 'open' },
-      ],
-    },
-    DrawerActions.closeDrawer(),
-    options
-  );
-
-  expect(result?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'bar' }],
-  });
-  expect(result?.affectedRouteKey).toBe('bar');
-
-  const state: DrawerNavigationState<ParamListBase> = {
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'drawer' as const,
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'route', key: 'baz' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, DrawerActions.closeDrawer(), options)?.state).toBe(state);
-});
-
-test('handles toggle drawer action', () => {
-  const router = DrawerRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [
-          { type: 'route', key: 'bar' },
-          { type: 'drawer', status: 'open' },
-        ],
-      },
-      DrawerActions.toggleDrawer(),
+  test('strips all history outside fullHistory', () => {
+    const next = DrawerRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one'], 0, { history: [{ type: 'route', key: 'one-key' }] }),
+      DrawerActions.openDrawer(),
       options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'bar' }],
+    )!.state;
+    expect(next.history).toBeUndefined();
+    expect(next.drawerStatus).toBe('open');
   });
 
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-        key: 'root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      DrawerActions.toggleDrawer(),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-    key: 'root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [
-      { type: 'route', key: 'bar' },
-      { type: 'drawer', status: 'open' },
-    ],
-  });
-});
-
-test('updates history on focus change with backBehavior: history', () => {
-  const router = DrawerRouter({ backBehavior: 'history' });
-
-  let state: DrawerNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'drawer' as const,
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-});
-
-test('updates history on focus change with backBehavior: fullHistory', () => {
-  const router = DrawerRouter({ backBehavior: 'fullHistory' });
-
-  let state: DrawerNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'drawer' as const,
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-});
-
-test('closes drawer on focus change with backBehavior: history', () => {
-  const router = DrawerRouter({ backBehavior: 'history' });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'bar-0' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'bar-0'
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-  });
-});
-
-test('closes drawer on focus change with backBehavior: fullHistory', () => {
-  const router = DrawerRouter({ backBehavior: 'fullHistory' });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'bar-0' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'bar-0'
-    )
-  ).toEqual({
-    index: 0,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-0' }],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
-  });
-
-  expect(
-    router.getStateForRouteFocus(
-      {
-        index: 0,
-        key: 'drawer-test',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-0' },
-          { type: 'drawer', status: 'open' },
-        ],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'drawer',
-      },
-      'baz-0'
-    )
-  ).toEqual({
-    index: 1,
-    key: 'drawer-test',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz' },
-      { key: 'qux-0', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-0' },
-      { type: 'route', key: 'baz-0' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'drawer',
+  test('preserves drawerStatus during route-name reconciliation and preload', () => {
+    const router = DrawerRouter({ backBehavior: 'history' });
+    let next = router.getStateForAction(
+      state(['one'], 0, { drawerStatus: 'open' }),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['one', 'two'] } },
+      { ...options, routeNames: ['one', 'two'] }
+    )!.state;
+    next = router.getStateForAction(next, CommonActions.preload('two'), options)!.state;
+    expect(next.drawerStatus).toBe('open');
   });
 });

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, jest, test } from '@jest/globals';
 
+import { createInitialState } from '../../core/createInitialState';
 import {
   CommonActions,
   DrawerActions,
@@ -43,12 +44,14 @@ describe('drawer status', () => {
     expect(next.drawerStatus).toBeUndefined();
   });
 
-  test('absent status means the configured open default', () => {
+  test('absent status means the configured open default for close, open and toggle', () => {
     const router = DrawerRouter({ defaultStatus: 'open' });
     const closed = router.getStateForAction(state(), DrawerActions.closeDrawer(), options)!.state;
     expect(closed.drawerStatus).toBe('closed');
     const open = router.getStateForAction(closed, DrawerActions.openDrawer(), options)!.state;
     expect(open.drawerStatus).toBeUndefined();
+    const toggled = router.getStateForAction(open, DrawerActions.toggleDrawer(), options)!.state;
+    expect(toggled.drawerStatus).toBe('closed');
   });
 
   test('navigation to another route resets status to default', () => {
@@ -146,5 +149,437 @@ describe('history migration', () => {
     )!.state;
     next = router.getStateForAction(next, CommonActions.preload('two'), options)!.state;
     expect(next.drawerStatus).toBe('open');
+  });
+});
+
+test('actions return drawer metadata for state without router metadata', () => {
+  const router = DrawerRouter({});
+  const actionOptions: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeGetIdList: {},
+  };
+  const createState = (): DrawerNavigationState<ParamListBase> => ({
+    stale: false,
+    routeKeySeq: 0,
+    key: 'root',
+    index: 1,
+    routeNames: actionOptions.routeNames,
+    routes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'baz', name: 'baz' },
+    ],
+  });
+  const resetState = createState();
+  const actions = [
+    DrawerActions.jumpTo('bar'),
+    DrawerActions.openDrawer(),
+    CommonActions.goBack(),
+    CommonActions.reset({ ...resetState, index: 0, routes: [resetState.routes[0]!] }),
+  ];
+
+  for (const action of actions) {
+    const result = router.getStateForAction(createState(), action, actionOptions);
+    expect(result?.state.type).toBe('drawer');
+    expect(result?.state.history).toBeUndefined();
+  }
+});
+
+test('route focus returns drawer metadata for state without router metadata', () => {
+  const current: DrawerNavigationState<ParamListBase> = {
+    stale: false,
+    routeKeySeq: 0,
+    key: 'root',
+    index: 0,
+    routeNames: ['bar', 'baz'],
+    routes: [
+      { key: 'bar', name: 'bar' },
+      { key: 'baz', name: 'baz' },
+    ],
+  };
+
+  expect(DrawerRouter({}).getStateForRouteFocus(current, 'baz')).toMatchObject({
+    type: 'drawer',
+    index: 1,
+  });
+  expect(DrawerRouter({}).getStateForRouteFocus(current, 'baz').history).toBeUndefined();
+});
+
+test('warns and ignores a partial RESET state', () => {
+  const current: DrawerNavigationState<ParamListBase> = {
+    stale: false,
+    routeKeySeq: 0,
+    key: 'root',
+    index: 0,
+    routeNames: ['bar'],
+    routes: [{ key: 'bar', name: 'bar' }],
+  };
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+  const result = DrawerRouter({}).getStateForAction(
+    current,
+    CommonActions.reset({ routes: [{ name: 'bar' }] }),
+    { routeNames: ['bar'], routeGetIdList: {} }
+  );
+
+  expect(result).toBeNull();
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining('The RESET action payload must contain a complete navigation state.')
+  );
+  warn.mockRestore();
+});
+
+test('keeps drawer status when the active route is removed', () => {
+  const router = DrawerRouter({ backBehavior: 'history' });
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['bar', 'baz'],
+    routeGetIdList: {},
+  };
+  const initialState = createInitialState<DrawerNavigationState<ParamListBase>>({
+    ...routeOptions,
+    parentChain: 'test',
+  });
+  const openState = router.getStateForAction(
+    initialState,
+    DrawerActions.openDrawer(),
+    routeOptions
+  )!.state;
+
+  const result = router.getStateForAction(
+    openState,
+    { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['baz'] } },
+    { ...routeOptions, routeNames: ['baz'] }
+  );
+
+  expect(result?.state).toEqual({
+    stale: false,
+    routeKeySeq: 2,
+    type: 'drawer',
+    key: 'navigator:test',
+    index: 0,
+    routeNames: ['baz'],
+    routes: [{ key: 'baz:test-1', name: 'baz' }],
+    drawerStatus: 'open',
+  });
+});
+
+test('PRELOAD keeps ordered routes and drawer status', () => {
+  const router = DrawerRouter({ backBehavior: 'order' });
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['bar', 'baz', 'qux'],
+    routeGetIdList: {},
+  };
+  const focusedState: DrawerNavigationState<ParamListBase> = {
+    stale: false,
+    routeKeySeq: 0,
+    type: 'drawer',
+    key: 'navigator:drawer',
+    index: 0,
+    routeNames: routeOptions.routeNames,
+    routes: [{ key: 'qux-key', name: 'qux' }],
+    drawerStatus: 'open',
+  };
+
+  const result = router.getStateForAction(focusedState, CommonActions.preload('baz'), routeOptions);
+
+  expect(result?.state).toEqual({
+    stale: false,
+    routeKeySeq: 1,
+    type: 'drawer',
+    key: 'navigator:drawer',
+    index: 1,
+    routeNames: ['bar', 'baz', 'qux'],
+    routes: [
+      { key: 'baz:drawer-0', name: 'baz' },
+      { key: 'qux-key', name: 'qux' },
+    ],
+    drawerStatus: 'open',
+  });
+});
+
+test('handles navigate action', () => {
+  const router = DrawerRouter({});
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        routeKeySeq: 0,
+        type: 'drawer',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar'],
+        routes: [
+          { key: 'baz', name: 'baz', params: { color: 'tomato' } },
+          { key: 'bar', name: 'bar' },
+        ],
+      },
+      CommonActions.navigate('baz', { answer: 42 }),
+      routeOptions
+    )?.state
+  ).toEqual({
+    stale: false,
+    routeKeySeq: 0,
+    type: 'drawer',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz', params: { answer: 42 } },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+});
+
+test('handles navigate action with open drawer', () => {
+  const router = DrawerRouter({});
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+
+  const result = router.getStateForAction(
+    {
+      stale: false,
+      routeKeySeq: 0,
+      type: 'drawer',
+      key: 'root',
+      index: 1,
+      routeNames: ['baz', 'bar'],
+      routes: [
+        { key: 'baz', name: 'baz' },
+        { key: 'bar', name: 'bar' },
+      ],
+      drawerStatus: 'open',
+    },
+    CommonActions.navigate('baz', { answer: 42 }),
+    routeOptions
+  );
+
+  expect(result?.state).toEqual({
+    stale: false,
+    routeKeySeq: 0,
+    type: 'drawer',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz', params: { answer: 42 } },
+      { key: 'bar', name: 'bar' },
+    ],
+  });
+  expect(result?.affectedRouteKey).toBe('baz');
+});
+
+test('attaches trusted state while closing the drawer', () => {
+  const router = DrawerRouter({});
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+  const childState = { routes: [{ name: 'child' }], __internal__routerActionState: true as const };
+
+  const result = router.getStateForAction(
+    {
+      stale: false,
+      routeKeySeq: 0,
+      type: 'drawer',
+      key: 'root',
+      index: 1,
+      routeNames: ['baz', 'bar'],
+      routes: [
+        { key: 'baz', name: 'baz' },
+        { key: 'bar', name: 'bar' },
+      ],
+      drawerStatus: 'open',
+    },
+    {
+      type: 'NAVIGATE',
+      payload: { name: 'baz', state: childState },
+    },
+    routeOptions
+  );
+
+  expect(result?.state.routes[0]?.state).toEqual({ routes: [{ name: 'child' }] });
+  expect(result?.state.drawerStatus).toBeUndefined();
+});
+
+test('closes open drawer on replace with backBehavior: fullHistory', () => {
+  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+
+  expect(
+    router.getStateForAction(
+      {
+        stale: false,
+        routeKeySeq: 0,
+        type: 'drawer',
+        key: 'root',
+        index: 1,
+        routeNames: ['baz', 'bar'],
+        routes: [
+          { key: 'baz', name: 'baz' },
+          { key: 'bar', name: 'bar' },
+        ],
+        history: [{ type: 'route', key: 'bar' }],
+        drawerStatus: 'open',
+      },
+      DrawerActions.replace('baz'),
+      routeOptions
+    )?.state
+  ).toEqual({
+    stale: false,
+    routeKeySeq: 0,
+    type: 'drawer',
+    key: 'root',
+    index: 0,
+    routeNames: ['baz', 'bar'],
+    routes: [
+      { key: 'baz', name: 'baz' },
+      { key: 'bar', name: 'bar' },
+    ],
+    history: [{ type: 'route', key: 'baz' }],
+  });
+});
+
+test('handles open drawer action and reports the focused route', () => {
+  const router = DrawerRouter({});
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+  const current = state(['baz', 'bar'], 1);
+
+  const result = router.getStateForAction(current, DrawerActions.openDrawer(), routeOptions);
+
+  expect(result?.state.drawerStatus).toBe('open');
+  expect(result?.state.history).toBeUndefined();
+  expect(result?.affectedRouteKey).toBe('bar-key');
+  expect(
+    router.getStateForAction(result!.state, DrawerActions.openDrawer(), routeOptions)?.state
+  ).toBe(result?.state);
+});
+
+test('handles close drawer action and reports the focused route', () => {
+  const router = DrawerRouter({});
+  const routeOptions: RouterConfigOptions = {
+    routeNames: ['baz', 'bar'],
+    routeGetIdList: {},
+  };
+  const current = state(['baz', 'bar'], 1, { drawerStatus: 'open' });
+
+  const result = router.getStateForAction(current, DrawerActions.closeDrawer(), routeOptions);
+
+  expect(result?.state.drawerStatus).toBeUndefined();
+  expect(result?.state.history).toBeUndefined();
+  expect(result?.affectedRouteKey).toBe('bar-key');
+  expect(
+    router.getStateForAction(result!.state, DrawerActions.closeDrawer(), routeOptions)?.state
+  ).toBe(result?.state);
+});
+
+test('updates route order on focus change with backBehavior: history', () => {
+  const router = DrawerRouter({ backBehavior: 'history' });
+  let current = state(['bar', 'baz', 'qux']);
+
+  current = router.getStateForRouteFocus(current, 'bar-key');
+  expect(current.routes.map((route) => route.name)).toEqual(['bar', 'baz', 'qux']);
+  expect(current.index).toBe(0);
+
+  current = router.getStateForRouteFocus(current, 'baz-key');
+  expect(current.routes.map((route) => route.name)).toEqual(['bar', 'baz', 'qux']);
+  expect(current.index).toBe(1);
+
+  current = router.getStateForRouteFocus(current, 'qux-key');
+  expect(current.routes.map((route) => route.name)).toEqual(['bar', 'baz', 'qux']);
+  expect(current.index).toBe(2);
+
+  current = router.getStateForRouteFocus(current, 'baz-key');
+  expect(current.routes.map((route) => route.name)).toEqual(['bar', 'qux', 'baz']);
+  expect(current.index).toBe(2);
+  expect(current.history).toBeUndefined();
+});
+
+test('updates history on focus change with backBehavior: fullHistory', () => {
+  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+  let current = state(['bar', 'baz', 'qux'], 0, {
+    routes: [
+      { key: 'bar-key', name: 'bar' },
+      { key: 'baz-key', name: 'baz', params: { answer: 42 } },
+      { key: 'qux-key', name: 'qux', params: { name: 'Jane' } },
+    ],
+    history: [{ type: 'route', key: 'bar-key' }],
+  });
+
+  current = router.getStateForRouteFocus(current, 'bar-key');
+  expect(current.history).toEqual([{ type: 'route', key: 'bar-key' }]);
+
+  current = router.getStateForRouteFocus(current, 'baz-key');
+  expect(current.history).toEqual([
+    { type: 'route', key: 'bar-key' },
+    { type: 'route', key: 'baz-key', params: { answer: 42 } },
+  ]);
+
+  current = router.getStateForRouteFocus(current, 'qux-key');
+  expect(current.history).toEqual([
+    { type: 'route', key: 'bar-key' },
+    { type: 'route', key: 'baz-key', params: { answer: 42 } },
+    { type: 'route', key: 'qux-key', params: { name: 'Jane' } },
+  ]);
+
+  current = router.getStateForRouteFocus(current, 'baz-key');
+  expect(current.history).toEqual([
+    { type: 'route', key: 'bar-key' },
+    { type: 'route', key: 'baz-key', params: { answer: 42 } },
+    { type: 'route', key: 'qux-key', params: { name: 'Jane' } },
+    { type: 'route', key: 'baz-key', params: { answer: 42 } },
+  ]);
+});
+
+test('closes drawer on focus change with backBehavior: history', () => {
+  const router = DrawerRouter({ backBehavior: 'history' });
+  const current = state(['bar', 'baz', 'qux'], 0, { drawerStatus: 'open' });
+
+  expect(router.getStateForRouteFocus(current, 'bar-key')).toEqual({
+    ...current,
+    drawerStatus: undefined,
+  });
+  expect(router.getStateForRouteFocus(current, 'baz-key')).toEqual({
+    ...current,
+    routes: [
+      { key: 'bar-key', name: 'bar' },
+      { key: 'baz-key', name: 'baz' },
+      { key: 'qux-key', name: 'qux' },
+    ],
+    index: 1,
+    drawerStatus: undefined,
+  });
+});
+
+test('closes drawer on focus change with backBehavior: fullHistory', () => {
+  const router = DrawerRouter({ backBehavior: 'fullHistory' });
+  const current = state(['bar', 'baz', 'qux'], 0, {
+    history: [{ type: 'route', key: 'bar-key' }],
+    drawerStatus: 'open',
+  });
+
+  expect(router.getStateForRouteFocus(current, 'bar-key')).toEqual({
+    ...current,
+    drawerStatus: undefined,
+  });
+  expect(router.getStateForRouteFocus(current, 'baz-key')).toEqual({
+    ...current,
+    index: 1,
+    history: [
+      { type: 'route', key: 'bar-key' },
+      { type: 'route', key: 'baz-key' },
+    ],
+    drawerStatus: undefined,
   });
 });

--- a/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/DrawerRouter.test.tsx
@@ -54,15 +54,34 @@ describe('drawer status', () => {
     expect(toggled.drawerStatus).toBe('closed');
   });
 
-  test('navigation to another route resets status to default', () => {
-    const router = DrawerRouter({ backBehavior: 'history' });
+  test.each([
+    ['closed', 'open'],
+    ['open', undefined],
+  ] satisfies ['closed' | 'open', 'open' | undefined][])(
+    'navigation to another route closes the drawer with %s default',
+    (defaultStatus, drawerStatus) => {
+      const router = DrawerRouter({ backBehavior: 'history', defaultStatus });
+      const next = router.getStateForAction(
+        state(['one', 'two'], 0, { drawerStatus }),
+        TabActions.jumpTo('two'),
+        options
+      )!.state;
+      expect(next.drawerStatus).toBe(defaultStatus === 'open' ? 'closed' : undefined);
+      expect(next.routes[next.index]?.name).toBe('two');
+    }
+  );
+
+  test('navigation closes the drawer when history reordering preserves the index', () => {
+    const router = DrawerRouter({ backBehavior: 'history', defaultStatus: 'open' });
     const next = router.getStateForAction(
-      state(['one', 'two'], 0, { drawerStatus: 'open' }),
-      TabActions.jumpTo('two'),
+      state(['one', 'two', 'three'], 1),
+      TabActions.jumpTo('one'),
       options
     )!.state;
-    expect(next.drawerStatus).toBeUndefined();
-    expect(next.routes[next.index]?.name).toBe('two');
+
+    expect(next.index).toBe(1);
+    expect(next.routes[next.index]?.name).toBe('one');
+    expect(next.drawerStatus).toBe('closed');
   });
 
   test('navigation to the focused route preserves status', () => {
@@ -75,12 +94,19 @@ describe('drawer status', () => {
     expect(next.drawerStatus).toBe('open');
   });
 
-  test('route focus closes the drawer', () => {
-    const router = DrawerRouter({ backBehavior: 'history' });
-    const current = state(['one', 'two'], 0, { drawerStatus: 'open' });
-    expect(router.getStateForRouteFocus(current, 'one-key').drawerStatus).toBeUndefined();
-    expect(router.getStateForRouteFocus(current, 'two-key').drawerStatus).toBeUndefined();
-  });
+  test.each([
+    ['closed', 'open'],
+    ['open', undefined],
+  ] satisfies ['closed' | 'open', 'open' | undefined][])(
+    'route focus closes the drawer with %s default',
+    (defaultStatus, drawerStatus) => {
+      const router = DrawerRouter({ backBehavior: 'history', defaultStatus });
+      const current = state(['one', 'two'], 0, { drawerStatus });
+      const expectedStatus = defaultStatus === 'open' ? 'closed' : undefined;
+      expect(router.getStateForRouteFocus(current, 'one-key').drawerStatus).toBe(expectedStatus);
+      expect(router.getStateForRouteFocus(current, 'two-key').drawerStatus).toBe(expectedStatus);
+    }
+  );
 });
 
 describe('back behavior', () => {

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,10 +1,12 @@
 import { describe, expect, jest, test } from '@jest/globals';
+import { expectTypeOf } from 'expect-type';
 
 import {
   CommonActions,
   type ParamListBase,
   type RouterConfigOptions,
   TabActions,
+  type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
 } from '../index';
@@ -21,7 +23,7 @@ const state = (
 ): TabNavigationState<ParamListBase> => ({
   stale: false,
   type: 'tab',
-  key: 'tabs',
+  key: 'navigator:tab',
   routeKeySeq: 0,
   routeNames: options.routeNames,
   routes: names.map((name) => ({ name, key: `${name}-key` })),
@@ -116,8 +118,12 @@ describe('route storage by back behavior', () => {
       options
     )!.state;
 
-    expect(names(next)).toEqual(['two', 'three']);
+    expect(next.routes).toEqual([
+      { key: 'two:tab-0', name: 'two' },
+      { key: 'three-key', name: 'three' },
+    ]);
     expect(next.index).toBe(0);
+    expect(next.routeKeySeq).toBe(1);
   });
 
   test.each([
@@ -134,6 +140,7 @@ describe('route storage by back behavior', () => {
       )!.state;
 
       expect(names(next)).toEqual([anchor, 'three', anchor === 'one' ? 'two' : 'one']);
+      expect(next.routes[0]?.key).toBe(`${anchor}:tab-0`);
       expect(next.index).toBe(1);
 
       next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
@@ -170,13 +177,34 @@ describe('full history', () => {
     }).getStateForRouteFocus(state(['one', 'two'], 0), 'two-key');
     expect(next.history?.map((entry) => entry.key)).toEqual(['one-key', 'two-key']);
   });
+
+  test('keeps visit history aligned when the focused route is removed', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    const reconciled = router.getStateForAction(
+      state(['one', 'two', 'three'], 2, {
+        history: [
+          { type: 'route', key: 'one-key' },
+          { type: 'route', key: 'two-key' },
+          { type: 'route', key: 'three-key' },
+        ],
+      }),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['one', 'two'] } },
+      { ...options, routeNames: ['one', 'two'] }
+    )!.state;
+
+    expect(reconciled.history?.at(-1)?.key).toBe('one-key');
+
+    const next = router.getStateForAction(reconciled, CommonActions.goBack(), {
+      ...options,
+      routeNames: ['one', 'two'],
+    })!.state;
+    expect(next.routes[next.index]?.name).toBe('two');
+  });
 });
 
 describe('route name reconciliation', () => {
   test('ROUTE_NAMES_CHANGED ignores an order-only update', () => {
-    const current = state(['one', 'two'], 1, {
-      history: [{ type: 'route', key: 'two-key' }],
-    });
+    const current = state(['one', 'two'], 1);
     const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
       current,
       {
@@ -186,8 +214,7 @@ describe('route name reconciliation', () => {
       { ...options, routeNames: ['four', 'three', 'two', 'one'] }
     )!.state;
 
-    expect(next.routeNames).toEqual(options.routeNames);
-    expect(next.history).toBeUndefined();
+    expect(next).toBe(current);
   });
 
   test('ROUTE_NAMES_CHANGED filters removed routes and preserves surviving focus', () => {
@@ -208,7 +235,19 @@ describe('route name reconciliation', () => {
       { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['four'] } },
       { ...options, routeNames: ['four'] }
     )!.state;
-    expect(names(next)).toEqual(['four']);
+    expect(next.routes).toEqual([{ key: 'four:tab-0', name: 'four' }]);
+    expect(next.index).toBe(0);
+    expect(next.routeKeySeq).toBe(1);
+  });
+
+  test('GO_BACK uses the route names stored in state for its anchor', () => {
+    const next = TabRouter({ backBehavior: 'firstRoute' }).getStateForAction(
+      state(['two'], 0, { routeNames: ['one', 'two'] }),
+      CommonActions.goBack(),
+      { ...options, routeNames: ['two', 'one'] }
+    )!.state;
+
+    expect(names(next)).toEqual(['one', 'two']);
     expect(next.index).toBe(0);
   });
 
@@ -247,7 +286,10 @@ describe('preload and replace', () => {
       CommonActions.preload('three'),
       options
     )!.state;
-    expect(names(next)).toEqual(['one', 'three']);
+    expect(next.routes).toEqual([
+      { key: 'one-key', name: 'one' },
+      { key: 'three:tab-0', name: 'three' },
+    ]);
     expect(next.index).toBe(0);
   });
 
@@ -257,8 +299,49 @@ describe('preload and replace', () => {
       CommonActions.preload('two'),
       options
     )!.state;
-    expect(names(next)).toEqual(['one', 'two', 'three']);
+    expect(next.routes).toEqual([
+      { key: 'one-key', name: 'one' },
+      { key: 'two:tab-0', name: 'two' },
+      { key: 'three-key', name: 'three' },
+    ]);
     expect(next.index).toBe(2);
+  });
+
+  test('PRELOAD keeps a matching getId key and re-keys a changed ID', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    const routerOptions: RouterConfigOptions = {
+      ...options,
+      routeGetIdList: { two: ({ params }) => params?.id as string | undefined },
+    };
+    const current = state(['one', 'two'], 0, {
+      routes: [
+        { key: 'one-key', name: 'one' },
+        { key: 'two-key', name: 'two', params: { id: 'old', removed: true } },
+      ],
+    });
+
+    const matching = router.getStateForAction(
+      current,
+      CommonActions.preload('two', { id: 'old' }),
+      routerOptions
+    )!.state;
+    expect(matching.routes[1]).toEqual({ key: 'two-key', name: 'two', params: { id: 'old' } });
+    expect(matching.index).toBe(0);
+    expect(matching.routeKeySeq).toBe(0);
+
+    const changed = router.getStateForAction(
+      current,
+      CommonActions.preload('two', { id: 'new' }),
+      routerOptions
+    )!.state;
+    expect(changed.routes[1]).toEqual({
+      key: 'two:tab-0',
+      name: 'two',
+      params: { id: 'new' },
+    });
+    expect(changed.index).toBe(0);
+    expect(changed.routeKeySeq).toBe(1);
+    expect(changed.history).toBeUndefined();
   });
 
   test('fullHistory PRELOAD re-keys history when getId changes', () => {
@@ -274,17 +357,17 @@ describe('preload and replace', () => {
       CommonActions.preload('one', { id: 'new' }),
       routerOptions
     )!.state;
-    expect(next.routes[0]?.key).not.toBe('old');
-    expect(next.history?.[0]?.key).toBe(next.routes[0]?.key);
+    expect(next.routes[0]?.key).toBe('one:tab-0');
+    expect(next.history?.[0]?.key).toBe('one:tab-0');
   });
 
   test('history REPLACE moves the replaced route to the forward region', () => {
     const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
-      state(['one', 'two', 'three'], 2),
-      TabActions.replace('two'),
+      state(['one', 'two', 'three', 'four'], 1),
+      TabActions.replace('four'),
       options
     )!.state;
-    expect(names(next)).toEqual(['one', 'two', 'three']);
+    expect(names(next)).toEqual(['one', 'four', 'two', 'three']);
     expect(next.index).toBe(1);
     expect(next.history).toBeUndefined();
   });
@@ -335,5 +418,507 @@ describe('state migration', () => {
     ).toBeNull();
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
+  });
+});
+
+describe('router contract', () => {
+  test('types replace action helper params', () => {
+    type Params = {
+      optional: undefined;
+      required: { id: string };
+    };
+
+    expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('optional');
+    expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: '1' });
+    // @ts-expect-error: Required route params cannot be omitted.
+    expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required');
+    // @ts-expect-error: Route params must match the route's param type.
+    expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: 1 });
+    // @ts-expect-error: The route must exist in the param list.
+    expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('missing');
+  });
+
+  test('handled actions and route focus normalize tab metadata', () => {
+    const router = TabRouter({});
+    const legacy = state(['one', 'two'], 0, {
+      type: undefined,
+      history: [{ type: 'route', key: 'one-key' }],
+    });
+
+    const handled = router.getStateForAction(legacy, TabActions.jumpTo('two'), options)!.state;
+    expect(handled.type).toBe('tab');
+    expect(handled.history).toBeUndefined();
+
+    const focused = router.getStateForRouteFocus(legacy, 'two-key');
+    expect(focused.type).toBe('tab');
+    expect(focused.history).toBeUndefined();
+  });
+
+  test('complete RESET state gets tab type and strips legacy history', () => {
+    const current = state(['one', 'two'], 1);
+    const next = TabRouter({}).getStateForAction(
+      current,
+      CommonActions.reset({
+        ...current,
+        type: undefined,
+        index: 0,
+        routes: [current.routes[0]!],
+        history: [{ type: 'route', key: 'one-key' }],
+      }),
+      options
+    )!.state;
+
+    expect(next).toMatchObject({ type: 'tab', index: 0, routes: [current.routes[0]!] });
+    expect(next.history).toBeUndefined();
+  });
+
+  test('preserves drawer type when used by DrawerRouter', () => {
+    const drawerState = { ...state(['one', 'two']), type: 'drawer' as const };
+    // DrawerRouter delegates with a structurally compatible drawer state.
+    const next = TabRouter({}).getStateForAction(
+      drawerState as unknown as TabNavigationState<ParamListBase>,
+      TabActions.jumpTo('two'),
+      options
+    )!.state;
+
+    expect(next.type).toBe('drawer');
+  });
+
+  test.each([
+    [CommonActions.navigate('two'), 'two-key'],
+    [CommonActions.navigate('two', { id: 'new' }), 'two:tab-0'],
+    [CommonActions.preload('two'), 'two-key'],
+  ])('returns the affected route key for $type', (action, affectedRouteKey) => {
+    const routeGetIdList: RouterConfigOptions['routeGetIdList'] =
+      action.type === 'NAVIGATE' && action.payload.params
+        ? {
+            two: ({ params }) =>
+              params && 'id' in params && typeof params.id === 'string' ? params.id : undefined,
+          }
+        : {};
+    const current = state(['one', 'two'], 0, {
+      routes: [
+        { key: 'one-key', name: 'one' },
+        { key: 'two-key', name: 'two', params: { id: 'old' } },
+      ],
+    });
+    const result = TabRouter({}).getStateForAction(current, action, {
+      ...options,
+      routeGetIdList,
+    });
+
+    expect(result?.affectedRouteKey).toBe(affectedRouteKey);
+  });
+
+  test('returns the back destination key', () => {
+    const result = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one', 'two'], 1),
+      CommonActions.goBack(),
+      options
+    );
+
+    expect(result?.affectedRouteKey).toBe('one-key');
+  });
+});
+
+describe('route creation and child state', () => {
+  test.each([
+    [CommonActions.navigate('two', { value: 2 }), ['one', 'two']],
+    [TabActions.jumpTo('two', { value: 2 }), ['one', 'two']],
+    [TabActions.replace('two', { value: 2 }), ['two', 'one']],
+  ])('$0.type mints and focuses an absent declared route', (action, expectedNames) => {
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one']),
+      action,
+      options
+    )!.state;
+
+    expect(names(next)).toEqual(expectedNames);
+    expect(next.routes[next.index]).toEqual({
+      key: 'two:tab-0',
+      name: 'two',
+      params: { value: 2 },
+    });
+  });
+
+  test('actions do not mint undeclared routes', () => {
+    const current = state(['one']);
+    const router = TabRouter({});
+    const declared = { ...options, routeNames: ['one'] };
+
+    expect(router.getStateForAction(current, CommonActions.navigate('two'), declared)).toBeNull();
+    expect(router.getStateForAction(current, TabActions.jumpTo('two'), declared)).toBeNull();
+    expect(router.getStateForAction(current, CommonActions.preload('two'), declared)).toBeNull();
+  });
+
+  test.each(['JUMP_TO', 'PRELOAD'] as const)(
+    '%s attaches trusted child state to an existing route',
+    (type) => {
+      const childState = {
+        routes: [{ name: 'child' }],
+        __internal__routerActionState: true as const,
+      };
+      const next = TabRouter({}).getStateForAction(
+        state(['one', 'two']),
+        { type, payload: { name: 'two', state: childState } },
+        options
+      )!.state;
+
+      expect(next.routes[1]?.state).toEqual({ routes: [{ name: 'child' }] });
+    }
+  );
+
+  test('PRELOAD attaches trusted child state to an absent route without changing focus', () => {
+    const childState = {
+      routes: [{ name: 'child' }],
+      __internal__routerActionState: true as const,
+    };
+    const result = TabRouter({}).getStateForAction(
+      state(['one']),
+      { type: 'PRELOAD', payload: { name: 'two', state: childState } },
+      options
+    )!;
+
+    expect(result.state.index).toBe(0);
+    expect(result.state.routes[1]).toEqual({
+      key: 'two:tab-0',
+      name: 'two',
+      state: { routes: [{ name: 'child' }] },
+    });
+    expect(result.affectedRouteKey).toBe('two:tab-0');
+  });
+});
+
+describe('navigation updates', () => {
+  test('navigate replaces params unless merge is true', () => {
+    const router = TabRouter({});
+    const current = state(['one', 'two'], 1, {
+      routes: [
+        { key: 'one-key', name: 'one' },
+        { key: 'two-key', name: 'two', params: { answer: 42 } },
+      ],
+    });
+
+    const replaced = router.getStateForAction(
+      current,
+      CommonActions.navigate('two', { fruit: 'orange' }),
+      options
+    )!.state;
+    expect(replaced.routes[1]?.params).toEqual({ fruit: 'orange' });
+
+    const merged = router.getStateForAction(
+      current,
+      CommonActions.navigate({ name: 'two', params: { fruit: 'orange' }, merge: true }),
+      options
+    )!.state;
+    expect(merged.routes[1]?.params).toEqual({ answer: 42, fruit: 'orange' });
+  });
+
+  test('jumpTo replaces params instead of merging them', () => {
+    const next = TabRouter({}).getStateForAction(
+      state(['one', 'two'], 1, {
+        routes: [
+          { key: 'one-key', name: 'one' },
+          { key: 'two-key', name: 'two', params: { answer: 42 } },
+        ],
+      }),
+      TabActions.jumpTo('two', { fruit: 'orange' }),
+      options
+    )!.state;
+
+    expect(next.routes[1]?.params).toEqual({ fruit: 'orange' });
+  });
+
+  test('navigate adds, updates, and preserves paths', () => {
+    const router = TabRouter({});
+    let next = router.getStateForAction(
+      state(['one', 'two'], 1),
+      CommonActions.navigate({ name: 'two', path: '/first' }),
+      options
+    )!.state;
+    expect(next.routes[1]?.path).toBe('/first');
+
+    next = router.getStateForAction(
+      next,
+      CommonActions.navigate({ name: 'two', path: '/second' }),
+      options
+    )!.state;
+    expect(next.routes[1]?.path).toBe('/second');
+
+    next = router.getStateForAction(next, CommonActions.navigate('two'), options)!.state;
+    expect(next.routes[1]?.path).toBe('/second');
+  });
+
+  test.each([
+    CommonActions.navigate('two', { id: 'new' }),
+    TabActions.jumpTo('two', { id: 'new' }),
+  ])('$type re-keys with getId using the exact minted key', (action) => {
+    const next = TabRouter({}).getStateForAction(
+      state(['one', 'two'], 0, {
+        routes: [
+          { key: 'one-key', name: 'one' },
+          { key: 'two-old', name: 'two', params: { id: 'old' } },
+        ],
+      }),
+      action,
+      {
+        ...options,
+        routeGetIdList: { two: ({ params }) => params?.id as string | undefined },
+      }
+    )!.state;
+
+    expect(next.routes[next.index]?.key).toBe('two:tab-0');
+    expect(next.routeKeySeq).toBe(1);
+  });
+
+  test('navigation re-keys a preloaded route with the next exact minted key', () => {
+    const router = TabRouter({});
+    const routerOptions: RouterConfigOptions = {
+      ...options,
+      routeGetIdList: { two: ({ params }) => params?.id as string | undefined },
+    };
+    const preloaded = router.getStateForAction(
+      state(['one']),
+      CommonActions.preload('two', { id: 'one' }),
+      routerOptions
+    )!.state;
+    const next = router.getStateForAction(
+      preloaded,
+      CommonActions.navigate('two', { id: 'two' }),
+      routerOptions
+    )!.state;
+
+    expect(next.routes[next.index]?.key).toBe('two:tab-1');
+    expect(next.routeKeySeq).toBe(2);
+  });
+});
+
+describe('replace behavior', () => {
+  test('history replaces from visit order rather than declared order', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    let next = router.getStateForAction(state(['one']), TabActions.jumpTo('four'), options)!.state;
+    next = router.getStateForAction(next, TabActions.jumpTo('two'), options)!.state;
+    next = router.getStateForAction(next, TabActions.replace('three'), options)!.state;
+
+    expect(names(next)).toEqual(['one', 'four', 'three', 'two']);
+    expect(next.routes.map((route) => route.key)).toEqual([
+      'one-key',
+      'four:tab-0',
+      'three:tab-2',
+      'two:tab-1',
+    ]);
+    expect(next.index).toBe(2);
+  });
+
+  test('fullHistory removes only the latest replaced visit', () => {
+    const next = TabRouter({ backBehavior: 'fullHistory' }).getStateForAction(
+      state(['one', 'two', 'three'], 0, {
+        history: [
+          { type: 'route', key: 'one-key' },
+          { type: 'route', key: 'two-key' },
+          { type: 'route', key: 'one-key' },
+        ],
+      }),
+      TabActions.replace('three'),
+      options
+    )!.state;
+
+    expect(next.history).toEqual([
+      { type: 'route', key: 'one-key' },
+      { type: 'route', key: 'two-key' },
+      { type: 'route', key: 'three-key' },
+    ]);
+  });
+
+  test.each([
+    ['firstRoute', undefined, ['three', 'one', 'two']],
+    ['initialRoute', 'two', ['three', 'two', 'one']],
+    ['none', undefined, ['one', 'two', 'three']],
+    ['order', undefined, ['one', 'two', 'three']],
+  ] satisfies ['firstRoute' | 'initialRoute' | 'none' | 'order', string | undefined, string[]][])(
+    '%s keeps its route-array replacement semantics',
+    (backBehavior, initialRouteName, expectedNames) => {
+      const next = TabRouter({ backBehavior, initialRouteName }).getStateForAction(
+        state(['one', 'two', 'three'], backBehavior === 'initialRoute' ? 1 : 0),
+        TabActions.replace('three'),
+        options
+      )!.state;
+
+      expect(names(next)).toEqual(expectedNames);
+      expect(next.routes[next.index]?.name).toBe('three');
+    }
+  );
+
+  test('replacing a route with itself preserves route order and the navigator key', () => {
+    const current = state(['one', 'two', 'three'], 1);
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      current,
+      TabActions.replace('two'),
+      options
+    )!.state;
+
+    expect(next.key).toBe(current.key);
+    expect(names(next)).toEqual(['one', 'two', 'three']);
+    expect(next.index).toBe(1);
+  });
+
+  test('preserves the navigator key across repeated replaces', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    const current = state(['one'], 0);
+    const replaced = router.getStateForAction(current, TabActions.replace('two'), options)!.state;
+    const replacedAgain = router.getStateForAction(
+      replaced,
+      TabActions.replace('three'),
+      options
+    )!.state;
+
+    expect(replaced.key).toBe(current.key);
+    expect(replacedAgain.key).toBe(current.key);
+  });
+});
+
+describe('fullHistory details', () => {
+  test('keeps duplicate visits and params through focus changes', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    let next = state(['one', 'two', 'three'], 0, {
+      routes: [
+        { key: 'one-key', name: 'one' },
+        { key: 'two-key', name: 'two', params: { answer: 42 } },
+        { key: 'three-key', name: 'three', params: { name: 'Jane' } },
+      ],
+      history: [{ type: 'route', key: 'one-key' }],
+    });
+
+    next = router.getStateForRouteFocus(next, 'two-key');
+    next = router.getStateForRouteFocus(next, 'three-key');
+    next = router.getStateForRouteFocus(next, 'two-key');
+    next = router.getStateForRouteFocus(next, 'two-key');
+
+    expect(next.history).toEqual([
+      { type: 'route', key: 'one-key' },
+      { type: 'route', key: 'two-key', params: { answer: 42 } },
+      { type: 'route', key: 'three-key', params: { name: 'Jane' } },
+      { type: 'route', key: 'two-key', params: { answer: 42 } },
+    ]);
+  });
+
+  test('SET_PARAMS and REPLACE_PARAMS update the latest params snapshot', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    let next = router.getStateForAction(
+      state(['one', 'two'], 1, {
+        routes: [
+          { key: 'one-key', name: 'one' },
+          { key: 'two-key', name: 'two', params: { value: 'old' } },
+        ],
+        history: [
+          { type: 'route', key: 'two-key', params: { value: 'first' } },
+          { type: 'route', key: 'one-key' },
+          { type: 'route', key: 'two-key', params: { value: 'old' } },
+        ],
+      }),
+      CommonActions.setParams({ value: 'set' }),
+      options
+    )!.state;
+    expect(next.history).toEqual([
+      { type: 'route', key: 'two-key', params: { value: 'first' } },
+      { type: 'route', key: 'one-key' },
+      { type: 'route', key: 'two-key', params: { value: 'set' } },
+    ]);
+
+    next = router.getStateForAction(
+      next,
+      CommonActions.replaceParams({ value: 'replaced' }),
+      options
+    )!.state;
+    expect(next.history?.[2]?.params).toEqual({ value: 'replaced' });
+  });
+
+  test('PRELOAD re-keys duplicate visits but updates only the newest params snapshot', () => {
+    const next = TabRouter({ backBehavior: 'fullHistory' }).getStateForAction(
+      state(['one', 'two'], 1, {
+        routes: [
+          { key: 'one-key', name: 'one' },
+          { key: 'two-old', name: 'two', params: { id: 'old', page: 2 } },
+        ],
+        history: [
+          { type: 'route', key: 'two-old', params: { id: 'old', page: 1 } },
+          { type: 'route', key: 'one-key' },
+          { type: 'route', key: 'two-old', params: { id: 'old', page: 2 } },
+        ],
+      }),
+      CommonActions.preload('two', { id: 'new' }),
+      {
+        ...options,
+        routeGetIdList: { two: ({ params }) => params?.id as string | undefined },
+      }
+    )!.state;
+
+    expect(next.routes[1]?.key).toBe('two:tab-0');
+    expect(next.history).toEqual([
+      { type: 'route', key: 'two:tab-0', params: { id: 'old', page: 1 } },
+      { type: 'route', key: 'one-key' },
+      { type: 'route', key: 'two:tab-0', params: { id: 'new' } },
+    ]);
+  });
+
+  test('restores params for an undeclared focused route', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    const current = state(['one', 'zap'], 1, {
+      routeNames: ['one'],
+      routes: [
+        { key: 'one-key', name: 'one' },
+        { key: 'zap-key', name: 'zap', params: { answer: 42 } },
+      ],
+    });
+    const navigated = router.getStateForAction(current, TabActions.jumpTo('one'), options)!.state;
+    const backed = router.getStateForAction(navigated, CommonActions.goBack(), options)!.state;
+
+    expect(backed.routes[1]?.params).toEqual({ answer: 42 });
+  });
+});
+
+describe('additional reconciliation coverage', () => {
+  test('fullHistory keeps an empty state without a back target', () => {
+    const router = TabRouter({ backBehavior: 'fullHistory' });
+    const empty = state([], -1, { routeNames: [] });
+    const next = router.getStateForRouteFocus(empty, 'missing');
+
+    expect(next.history).toEqual([]);
+    expect(router.getStateForAction(next, CommonActions.goBack(), options)).toBeNull();
+  });
+
+  test('ROUTE_NAMES_CHANGED handles an empty declared set', () => {
+    const next = TabRouter({}).getStateForAction(
+      state(['one']),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: [] } },
+      { ...options, routeNames: [] }
+    )!.state;
+
+    expect(next).toMatchObject({ routeNames: [], routes: [], index: -1 });
+    expect(next.history).toBeUndefined();
+  });
+
+  test('ROUTE_NAMES_CHANGED falls back to the first surviving route in state order', () => {
+    const next = TabRouter({}).getStateForAction(
+      state(['one', 'two', 'three'], 1),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['three', 'one'] } },
+      { ...options, routeNames: ['three', 'one'] }
+    )!.state;
+
+    expect(names(next)).toEqual(['one', 'three']);
+    expect(next.routes[next.index]?.name).toBe('one');
+  });
+
+  test('ROUTE_NAMES_ORDER_CHANGED preserves the affected focused route key', () => {
+    const result = TabRouter({ backBehavior: 'order' }).getStateForAction(
+      state(['one', 'two', 'three', 'four'], 1),
+      {
+        type: 'ROUTE_NAMES_ORDER_CHANGED',
+        payload: { routeNames: ['four', 'three', 'two', 'one'] },
+      },
+      options
+    );
+
+    expect(result?.affectedRouteKey).toBe('two-key');
   });
 });

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -1,3046 +1,339 @@
 import { describe, expect, jest, test } from '@jest/globals';
-import { expectTypeOf } from 'expect-type';
 
-import { createInitialState } from '../../core/createInitialState';
 import {
   CommonActions,
   type ParamListBase,
   type RouterConfigOptions,
   TabActions,
-  type TabActionHelpers,
   type TabNavigationState,
   TabRouter,
 } from '../index';
 
-describe('state without router metadata', () => {
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const createState = (index = 1): TabNavigationState<ParamListBase> => ({
-    stale: false,
-    routeKeySeq: 0,
-    key: 'navigator:root',
-    index,
-    routeNames: options.routeNames,
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-    ],
-  });
-
-  test('handled actions return tab type and history', () => {
-    const result = TabRouter({}).getStateForAction(
-      createState(0),
-      TabActions.jumpTo('baz'),
-      options
-    );
-
-    expect(result?.state).toMatchObject({ type: 'tab', history: expect.any(Array) });
-  });
-
-  test('complete RESET state gets tab type and rebuilt history', () => {
-    const state = createState();
-    const result = TabRouter({}).getStateForAction(
-      state,
-      CommonActions.reset({ ...state, index: 0, routes: [state.routes[0]!] }),
-      options
-    );
-
-    expect(result?.state).toMatchObject({
-      type: 'tab',
-      history: [{ type: 'route', key: 'bar' }],
-    });
-  });
-
-  test('warns and ignores a partial RESET state', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const result = TabRouter({}).getStateForAction(
-      createState(),
-      CommonActions.reset({ routes: [{ name: 'bar' }] }),
-      options
-    );
-
-    expect(result).toBeNull();
-    expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('The RESET action payload must contain a complete navigation state.')
-    );
-    warn.mockRestore();
-  });
-
-  test('route focus returns tab type and history', () => {
-    expect(TabRouter({}).getStateForRouteFocus(createState(0), 'baz')).toMatchObject({
-      type: 'tab',
-      history: expect.any(Array),
-    });
-  });
-
-  test('preserves drawer type when used by DrawerRouter', () => {
-    const state = { ...createState(0), type: 'drawer' as const };
-    // DrawerRouter delegates to TabRouter with the structurally compatible drawer state.
-    const result = TabRouter({}).getStateForAction(
-      state as unknown as TabNavigationState<ParamListBase>,
-      TabActions.jumpTo('baz'),
-      options
-    );
-
-    expect(result?.state.type).toBe('drawer');
-  });
-});
-
-const createTabState = (
-  options: RouterConfigOptions,
-  initialRouteName?: string
-): TabNavigationState<ParamListBase> => {
-  const state = createInitialState<TabNavigationState<ParamListBase>>({
-    ...options,
-    initialRouteName,
-    parentChain: 'tab',
-  });
-  const routes = state.routes.map((route) => ({ ...route, key: `${route.name}-test` }));
-
-  return {
-    ...state,
-    routeKeySeq: 0,
-    type: 'tab',
-    routes,
-    history: routes.length === 0 ? [] : [{ type: 'route', key: routes[0]!.key }],
-  };
+const options: RouterConfigOptions = {
+  routeNames: ['one', 'two', 'three', 'four'],
+  routeGetIdList: {},
 };
 
-test('types replace action helper params', () => {
-  type Params = {
-    optional: undefined;
-    required: { id: string };
-  };
-
-  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('optional');
-  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: '1' });
-  // @ts-expect-error: Required route params cannot be omitted.
-  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required');
-  // @ts-expect-error: Route params must match the route's param type.
-  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('required', { id: 1 });
-  // @ts-expect-error: The route must exist in the param list.
-  expectTypeOf<TabActionHelpers<Params>['replace']>().toBeCallableWith('missing');
+const state = (
+  names: string[] = ['one'],
+  index = 0,
+  extra: Partial<TabNavigationState<ParamListBase>> = {}
+): TabNavigationState<ParamListBase> => ({
+  stale: false,
+  type: 'tab',
+  key: 'tabs',
+  routeKeySeq: 0,
+  routeNames: options.routeNames,
+  routes: names.map((name) => ({ name, key: `${name}-key` })),
+  index,
+  ...extra,
 });
 
-test('handles empty tab states', () => {
-  const router = TabRouter({});
-  const emptyOptions: RouterConfigOptions = {
-    routeNames: [],
-    routeGetIdList: {},
-  };
-  const state = createTabState({
-    routeNames: ['index'],
-    routeGetIdList: {},
+const names = (value: TabNavigationState<ParamListBase>) => value.routes.map((route) => route.name);
+
+describe('route storage by back behavior', () => {
+  test('none keeps insertion order and never handles back', () => {
+    const router = TabRouter({ backBehavior: 'none' });
+    let next = router.getStateForAction(state(), TabActions.jumpTo('three'), options)!.state;
+    next = router.getStateForAction(next, TabActions.jumpTo('two'), options)!.state;
+
+    expect(names(next)).toEqual(['one', 'three', 'two']);
+    expect(next.index).toBe(2);
+    expect(next.history).toBeUndefined();
+    expect(router.getStateForAction(next, CommonActions.goBack(), options)).toBeNull();
   });
 
-  const emptyState = router.getStateForAction(
-    state,
-    { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: [] } },
-    emptyOptions
-  )!.state;
-  expect(emptyState).toMatchObject({ index: -1, routes: [], history: [] });
-  expect(router.getStateForAction(emptyState, CommonActions.goBack(), emptyOptions)).toBeNull();
-});
+  test('history stores the deduped visit stack in the route prefix', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    let next = router.getStateForAction(state(), TabActions.jumpTo('three'), options)!.state;
+    next = router.getStateForAction(next, TabActions.jumpTo('two'), options)!.state;
 
-test.each([
-  CommonActions.navigate('baz', { value: 2 }),
-  TabActions.jumpTo('baz', { value: 2 }),
-  TabActions.replace('baz', { value: 2 }),
-])('$type mints and focuses an absent declared route', (action) => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = createTabState(options);
+    expect(names(next)).toEqual(['one', 'three', 'two']);
+    expect(next.index).toBe(2);
+    next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
+    expect(next.index).toBe(1);
+    expect(next.routes[next.index]?.name).toBe('three');
 
-  const result = router.getStateForAction(state, action, options)!.state;
-
-  expect(result.routes).toEqual([
-    { key: 'bar-test', name: 'bar' },
-    { key: 'baz:tab-0', name: 'baz', params: { value: 2 } },
-  ]);
-  expect(result.index).toBe(1);
-  expect(result.routes.filter((route) => route.name === 'baz')).toHaveLength(1);
-});
-
-test('returns the selected route key when selecting an existing route', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-key', name: 'baz' },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-key' }],
-  };
-
-  const result = router.getStateForAction(state, CommonActions.navigate('baz'), options);
-
-  expect(result?.affectedRouteKey).toBe('baz-key');
-});
-
-test('attaches trusted state when selecting an existing route', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const childState = { routes: [{ name: 'child' }], __internal__routerActionState: true as const };
-  const state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-key', name: 'baz' },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-key' }],
-  };
-
-  const result = router.getStateForAction(
-    state,
-    {
-      type: 'JUMP_TO',
-      payload: { name: 'baz', state: childState },
-    },
-    options
-  );
-
-  expect(result?.state.routes[1]?.state).toEqual({ routes: [{ name: 'child' }] });
-});
-
-test('returns the regenerated route key when the route ID changes', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: { baz: ({ params }) => params?.id as string | undefined },
-  };
-  const state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-one', name: 'baz', params: { id: 'one' } },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-key' }],
-  };
-
-  const result = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { id: 'two' }),
-    options
-  );
-
-  expect(result?.affectedRouteKey).toBe('baz:tab-0');
-});
-
-test('returns the preloaded route key while focus differs', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-key', name: 'baz' },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-key' }],
-  };
-
-  const result = router.getStateForAction(state, CommonActions.preload('baz'), options);
-
-  expect(result?.state.index).toBe(0);
-  expect(result?.affectedRouteKey).toBe('baz-key');
-});
-
-test('attaches trusted state when preloading an unfocused route', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const childState = { routes: [{ name: 'child' }], __internal__routerActionState: true as const };
-  const state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-key', name: 'baz' },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-key' }],
-  };
-
-  const result = router.getStateForAction(
-    state,
-    {
-      type: 'PRELOAD',
-      payload: { name: 'baz', state: childState },
-    },
-    options
-  );
-
-  expect(result?.state.index).toBe(0);
-  expect(result?.state.routes[1]?.state).toEqual({ routes: [{ name: 'child' }] });
-});
-
-test('attaches trusted state when preloading an absent route', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const childState = { routes: [{ name: 'child' }], __internal__routerActionState: true as const };
-
-  const result = router.getStateForAction(
-    createTabState(options),
-    {
-      type: 'PRELOAD',
-      payload: { name: 'baz', state: childState },
-    },
-    options
-  );
-
-  expect(result?.state.index).toBe(0);
-  expect(result?.state.routes.find((route) => route.name === 'baz')?.state).toEqual({
-    routes: [{ name: 'child' }],
+    next = router.getStateForAction(next, TabActions.jumpTo('four'), options)!.state;
+    expect(names(next)).toEqual(['one', 'three', 'four', 'two']);
+    expect(next.index).toBe(2);
+    expect(next.history).toBeUndefined();
   });
-});
 
-test('returns the history destination key on go back', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = {
-    ...createTabState(options),
-    index: 1,
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-key', name: 'baz' },
-    ],
-    history: [
-      { type: 'route' as const, key: 'bar-key' },
-      { type: 'route' as const, key: 'baz-key' },
-    ],
-  };
-
-  const result = router.getStateForAction(state, CommonActions.goBack(), options);
-
-  expect(result?.affectedRouteKey).toBe('bar-key');
-});
-
-test('PRELOAD mints an absent declared route without changing focus', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = createTabState(options);
-
-  const result = router.getStateForAction(
-    state,
-    { type: 'PRELOAD', payload: { name: 'baz', params: { value: 2 } } },
-    options
-  )!;
-
-  expect(result.state.routes).toEqual([
-    { key: 'bar-test', name: 'bar' },
-    { key: 'baz:tab-0', name: 'baz', params: { value: 2 } },
-  ]);
-  expect(result.state.index).toBe(0);
-  expect(result.state.history).toEqual(state.history);
-});
-
-test('navigation re-keys a preloaded route when the route ID changes', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: { baz: ({ params }) => params?.id as string | undefined },
-  };
-  const preloadedState = router.getStateForAction(
-    createTabState(options),
-    { type: 'PRELOAD', payload: { name: 'baz', params: { id: 'one' } } },
-    options
-  )!.state;
-  // PRELOAD returns a full tab state, but the Router interface also permits partial states.
-  const state = {
-    ...preloadedState,
-    routes: preloadedState.routes.map((route) =>
-      route.name === 'baz' ? { ...route, key: 'baz-one' } : route
-    ),
-  } as TabNavigationState<ParamListBase>;
-
-  const result = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { id: 'two' }),
-    options
-  )!;
-
-  expect(result.state.routes[result.state.index!]!.key).toBe('baz:tab-1');
-});
-
-test('PRELOAD rebuilds history when re-keying the focused route', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz'],
-    routeGetIdList: { baz: ({ params }) => params?.id as string | undefined },
-  };
-  const state: TabNavigationState<ParamListBase> = {
-    ...createTabState(options),
-    routes: [{ key: 'baz-one', name: 'baz', params: { id: 'one' } }],
-    history: [{ type: 'route', key: 'baz-one' }],
-  };
-
-  const result = router.getStateForAction(
-    state,
-    CommonActions.preload('baz', { id: 'two' }),
-    options
-  );
-
-  expect(result?.state.routes).toEqual([{ key: 'baz:tab-0', name: 'baz', params: { id: 'two' } }]);
-  expect(result?.state.history).toEqual([{ type: 'route', key: 'baz:tab-0' }]);
-});
-
-test.each<['history' | 'fullHistory']>([['history'], ['fullHistory']])(
-  '%s back behavior re-keys the focused route in history on PRELOAD',
-  (backBehavior) => {
-    const router = TabRouter({ backBehavior });
-    const options: RouterConfigOptions = {
-      routeNames: ['bar', 'baz'],
-      routeGetIdList: { baz: ({ params }) => params?.id as string | undefined },
-    };
-    const state: TabNavigationState<ParamListBase> = {
-      ...createTabState(options),
-      index: 1,
-      routes: [
-        { key: 'bar-key', name: 'bar' },
-        { key: 'baz-one', name: 'baz', params: { id: 'one' } },
-      ],
-      history: [
-        { type: 'route', key: 'bar-key' },
-        { type: 'route', key: 'baz-one' },
-      ],
-    };
-
-    // PRELOAD returns a full tab state, but the Router interface also permits partial states.
-    const preloaded = router.getStateForAction(
-      state,
-      CommonActions.preload('baz', { id: 'two' }),
+  test('history focuses an existing visited route without duplicates', () => {
+    const router = TabRouter({ backBehavior: 'history' });
+    const next = router.getStateForAction(
+      state(['one', 'three', 'two'], 2),
+      TabActions.jumpTo('one'),
       options
-    )!.state as TabNavigationState<ParamListBase>;
+    )!.state;
 
-    // The last history entry must stay the focused route, otherwise `goBack` reads the wrong target.
-    expect(preloaded.history).toEqual([
-      { type: 'route', key: 'bar-key' },
-      {
-        type: 'route',
-        key: 'baz:tab-0',
-        params: backBehavior === 'fullHistory' ? { id: 'two' } : undefined,
-      },
-    ]);
-    expect(router.getStateForAction(preloaded, CommonActions.goBack(), options)!.state.index).toBe(
-      0
-    );
-  }
-);
-
-test('fullHistory back behavior keeps earlier params snapshots when PRELOAD re-keys a route', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: { baz: ({ params }) => params?.id as string | undefined },
-  };
-  const state: TabNavigationState<ParamListBase> = {
-    ...createTabState(options),
-    index: 1,
-    routes: [
-      { key: 'bar-key', name: 'bar' },
-      { key: 'baz-one', name: 'baz', params: { id: 'one', page: 2 } },
-    ],
-    // `fullHistory` keeps duplicate entries, each holding the params of that visit.
-    history: [
-      { type: 'route', key: 'baz-one', params: { id: 'one', page: 1 } },
-      { type: 'route', key: 'bar-key' },
-      { type: 'route', key: 'baz-one', params: { id: 'one', page: 2 } },
-    ],
-  };
-
-  const preloaded = router.getStateForAction(
-    state,
-    CommonActions.preload('baz', { id: 'two' }),
-    options
-  )!.state;
-
-  expect(preloaded.history).toEqual([
-    { type: 'route', key: 'baz:tab-0', params: { id: 'one', page: 1 } },
-    { type: 'route', key: 'bar-key' },
-    { type: 'route', key: 'baz:tab-0', params: { id: 'two' } },
-  ]);
-});
-
-test('actions do not mint undeclared routes', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar'],
-    routeGetIdList: {},
-  };
-  const state = createTabState(options);
-
-  expect(router.getStateForAction(state, CommonActions.navigate('baz'), options)).toBeNull();
-  expect(
-    router.getStateForAction(state, { type: 'PRELOAD', payload: { name: 'baz' } }, options)
-  ).toBeNull();
-});
-
-test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>([
-  ['firstRoute', undefined, 'bar'],
-  ['initialRoute', 'baz', 'baz'],
-  ['order', undefined, 'baz'],
-])('%s back behavior mints an absent back target', (backBehavior, initialRouteName, name) => {
-  const router = TabRouter({ backBehavior, initialRouteName });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  const state: TabNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: options.routeNames,
-    routes: [{ key: 'qux-key', name: 'qux' }],
-  };
-
-  const result = router.getStateForAction(state, CommonActions.goBack(), options)!.state;
-
-  expect(result.routes.map((route) => route.name)).toEqual(['qux', name]);
-  expect(result.routes[result.index!]).toEqual({ key: `${name}:0`, name });
-});
-
-test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>([
-  ['firstRoute', undefined, 'bar'],
-  ['initialRoute', 'baz', 'baz'],
-  ['order', undefined, 'baz'],
-])('%s PRELOAD inserts the back target into history', (backBehavior, initialRouteName, name) => {
-  const router = TabRouter({ backBehavior, initialRouteName });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  const focusedState: TabNavigationState<ParamListBase> = {
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: options.routeNames,
-    routes: [{ key: 'qux-key', name: 'qux' }],
-  };
-  const state = router.getStateForAction(
-    focusedState,
-    { type: 'PRELOAD', payload: { name } },
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: `${name}:0` },
-    { type: 'route', key: 'qux-key' },
-  ]);
-
-  const result = router.getStateForAction(state, CommonActions.goBack(), options)!;
-
-  expect(result.state.routes[result.state.index!]!.name).toBe(name);
-  expect(result.state.history).toEqual([{ type: 'route', key: `${name}:0` }]);
-});
-
-test('gets state on route names change', () => {
-  const router = TabRouter({});
-
-  expect(
-    router.getStateForAction(
-      {
-        index: 0,
-        key: 'navigator:tab',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-test', name: 'bar' },
-          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-        ],
-        history: [{ type: 'route', key: 'bar-test' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-      },
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['qux', 'baz', 'foo', 'fiz'] } },
-      {
-        routeNames: ['qux', 'baz', 'foo', 'fiz'],
-        routeGetIdList: {},
-      }
-    )?.state
-  ).toEqual({
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['qux', 'baz', 'foo', 'fiz'],
-    routes: [
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
+    expect(names(next)).toEqual(['three', 'two', 'one']);
+    expect(next.index).toBe(2);
   });
 
-  expect(
-    router.getStateForAction(
-      {
-        index: 0,
-        key: 'navigator:tab',
-        routeNames: ['bar', 'baz'],
-        routes: [
-          { key: 'bar-test', name: 'bar' },
-          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-        ],
-        history: [{ type: 'route', key: 'bar-test' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-      },
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['foo', 'fiz'] } },
-      {
-        routeNames: ['foo', 'fiz'],
-        routeGetIdList: {},
-      }
-    )?.state
-  ).toEqual({
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['foo', 'fiz'],
-    routes: [{ key: 'foo:tab-0', name: 'foo' }],
-    history: [{ type: 'route', key: 'foo:tab-0' }],
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-  });
-});
-
-test('preserves focused route on route names change', () => {
-  const router = TabRouter({});
-
-  expect(
-    router.getStateForAction(
-      {
-        index: 1,
-        key: 'navigator:tab',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-test', name: 'bar' },
-          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-      },
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['qux', 'foo', 'fiz', 'baz'] } },
-      {
-        routeNames: ['qux', 'foo', 'fiz', 'baz'],
-        routeGetIdList: {},
-      }
-    )?.state
-  ).toEqual({
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['qux', 'foo', 'fiz', 'baz'],
-    routes: [
-      { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-  });
-});
-
-test('falls back to first route if route is removed on route names change', () => {
-  const router = TabRouter({});
-
-  expect(
-    router.getStateForAction(
-      {
-        index: 1,
-        key: 'navigator:tab',
-        routeNames: ['bar', 'baz', 'qux'],
-        routes: [
-          { key: 'bar-test', name: 'bar' },
-          { key: 'baz-test', name: 'baz', params: { answer: 42 } },
-          { key: 'qux-test', name: 'qux', params: { name: 'Jane' } },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-      },
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['qux', 'foo', 'fiz'] } },
-      {
-        routeNames: ['qux', 'foo', 'fiz'],
-        routeGetIdList: {},
-      }
-    )?.state
-  ).toEqual({
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['qux', 'foo', 'fiz'],
-    routes: [{ key: 'qux-test', name: 'qux', params: { name: 'Jane' } }],
-    history: [{ type: 'route', key: 'qux-test' }],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-  });
-});
-
-test('falls back to the first surviving route in state order', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['qux', 'bar'],
-    routeGetIdList: {},
-  };
-  const state = {
-    ...createTabState({ ...options, routeNames: ['bar', 'baz', 'qux'] }),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    index: 1,
-  };
-
-  const result = router.getStateForAction(
-    state,
-    {
-      type: 'ROUTE_NAMES_CHANGED',
-      payload: { routeNames: options.routeNames },
-    },
-    options
-  )!.state;
-
-  expect(result.routes[result.index!]!.name).toBe('bar');
-});
-
-test('returns the same tab state when route names already match', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-  const state = createTabState(options);
-
-  expect(
-    router.getStateForAction(
-      state,
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['bar', 'baz'] } },
+  test('order keeps declared order and decrements index on back', () => {
+    const router = TabRouter({ backBehavior: 'order' });
+    let next = router.getStateForAction(
+      state(['one', 'two', 'three', 'four']),
+      TabActions.jumpTo('three'),
       options
-    )?.state
-  ).toBe(state);
-});
+    )!.state;
 
-test.each<[Parameters<typeof TabRouter>[0]['backBehavior'], string[]]>([
-  ['firstRoute', ['qux-test', 'baz-test']],
-  ['initialRoute', ['bar-test', 'baz-test']],
-  ['order', ['qux-test', 'baz-test']],
-  ['history', ['bar-test', 'baz-test']],
-  ['fullHistory', ['bar-test', 'baz-test']],
-  ['none', ['bar-test', 'baz-test']],
-])(
-  'keeps route order and focus on an order-only change with backBehavior: %s',
-  (backBehavior, expectedHistory) => {
-    const router = TabRouter({ backBehavior, initialRouteName: 'bar' });
-    const options: RouterConfigOptions = {
-      routeNames: ['bar', 'baz', 'qux'],
-      routeGetIdList: {},
-    };
-    const state = {
-      ...createTabState(options),
-      routes: [
-        { key: 'bar-test', name: 'bar' },
-        { key: 'baz-test', name: 'baz' },
-        { key: 'qux-test', name: 'qux' },
-      ],
-      index: 1,
-      history: [
-        { type: 'route' as const, key: 'bar-test' },
-        { type: 'route' as const, key: 'baz-test' },
-      ],
-    };
-
-    expect(
-      router.getStateForAction(
-        state,
-        { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['qux', 'baz', 'bar'] } },
-        { ...options, routeNames: ['qux', 'baz', 'bar'] }
-      )?.state
-    ).toMatchObject({
-      index: 1,
-      routeNames: ['qux', 'baz', 'bar'],
-      routes: state.routes,
-      history: expectedHistory.map((key) => ({ type: 'route', key })),
-    });
-  }
-);
-
-test.each<['history' | 'fullHistory', string[]]>([
-  ['history', ['qux-test', 'bar-test']],
-  ['fullHistory', ['bar-test', 'qux-test', 'bar-test']],
-])(
-  'keeps visit history aligned when the focused route is removed with backBehavior: %s',
-  (backBehavior, expectedHistory) => {
-    const router = TabRouter({ backBehavior });
-    const options: RouterConfigOptions = {
-      routeNames: ['bar', 'baz', 'qux'],
-      routeGetIdList: {},
-    };
-    const state = {
-      ...createTabState(options),
-      routes: [
-        { key: 'bar-test', name: 'bar' },
-        { key: 'baz-test', name: 'baz' },
-        { key: 'qux-test', name: 'qux' },
-      ],
-      index: 1,
-      history: [
-        { type: 'route' as const, key: 'bar-test' },
-        { type: 'route' as const, key: 'qux-test' },
-        { type: 'route' as const, key: 'baz-test' },
-      ],
-    };
-
-    expect(
-      router.getStateForAction(
-        state,
-        { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['bar', 'qux'] } },
-        { ...options, routeNames: ['bar', 'qux'] }
-      )?.state
-    ).toMatchObject({
-      index: 0,
-      history: expectedHistory.map((key) => ({ type: 'route', key })),
-    });
-  }
-);
-
-test('handles navigate action', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz', params: { color: 'tomato' } },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('baz', { answer: 42 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz', params: { answer: 42 } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
+    expect(names(next)).toEqual(options.routeNames);
+    expect(next.index).toBe(2);
+    next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
+    expect(next.index).toBe(1);
+    expect(next.routes[next.index]?.name).toBe('two');
   });
-});
-
-test('merges params on navigate when specified', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz', params: { color: 'tomato' } },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('baz', { answer: 42 }, { merge: true }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz', params: { color: 'tomato', answer: 42 } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
-  });
-});
-
-test("doesn't navigate to nonexistent screen", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('non-existent'),
-      options
-    )
-  ).toBeNull();
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('foo', { answer: 42 }),
-      options
-    )
-  ).toBeNull();
-});
-
-test('ensures unique ID for navigate', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {
-      baz: ({ params }) => params?.foo,
-      bar: ({ params }) => params?.foo,
-    },
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('baz', { foo: 'a' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz:0', name: 'baz', params: { foo: 'a' } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz:0' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      CommonActions.navigate('bar', { foo: 'a' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar:0', name: 'bar', params: { foo: 'a' } },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar:0' },
-    ],
-  });
-});
-
-test('handles jump to action', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar'),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test("doesn't jump to nonexistent screen", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      TabActions.jumpTo('foo', { answer: 42 }),
-      options
-    )
-  ).toBeNull();
-});
-
-test('ensures unique ID for jump to', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {
-      baz: ({ params }) => params?.foo,
-      bar: ({ params }) => params?.foo,
-    },
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('baz', { foo: 'a' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz:0', name: 'baz', params: { foo: 'a' } },
-      { key: 'bar', name: 'bar' },
-    ],
-    history: [{ type: 'route', key: 'baz:0' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-        ],
-        history: [{ type: 'route', key: 'bar' }],
-      },
-      TabActions.jumpTo('bar', { foo: 'a' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar:0', name: 'bar', params: { foo: 'a' } },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar:0' },
-    ],
-  });
-});
-
-test('replaces the focused route when the destination is the first tab', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options);
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('bar'), options);
-
-  expect(nextState?.state.history).toEqual([
-    { type: 'route', key: 'baz:tab-0' },
-    { type: 'route', key: 'bar-test' },
-  ]);
-});
-
-test('replaces the focused route based on visit history instead of route order', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux', 'foo'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options);
-  state = router.getStateForAction(state, TabActions.jumpTo('foo'), options)!
-    .state as TabNavigationState<ParamListBase>;
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
-
-  expect(nextState?.state.history).toEqual([
-    { type: 'route', key: 'bar-test' },
-    { type: 'route', key: 'foo:tab-0' },
-    { type: 'route', key: 'qux:tab-2' },
-  ]);
-});
-
-test('only removes the latest visit when replacing with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options);
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options);
-
-  expect(nextState?.state.history).toEqual([
-    { type: 'route', key: 'bar-test' },
-    { type: 'route', key: 'baz:tab-0' },
-    { type: 'route', key: 'qux:tab-1' },
-  ]);
-});
-
-test('replaces the focused route with default backBehavior: firstRoute', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options);
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(nextState.index).toBe(2);
-  expect(nextState.history).toEqual([
-    { type: 'route', key: 'bar-test' },
-    { type: 'route', key: 'qux:tab-1' },
-  ]);
-  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.state.index).toBe(0);
-});
-
-test('replaces the focused route with backBehavior: order', () => {
-  const router = TabRouter({ backBehavior: 'order' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options);
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(nextState.index).toBe(2);
-  expect(nextState.history).toEqual([
-    { type: 'route', key: 'bar-test' },
-    { type: 'route', key: 'qux:tab-1' },
-  ]);
-  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.state.index).toBe(0);
-});
-
-test('replaces the focused route with backBehavior: initialRoute', () => {
-  const router = TabRouter({
-    backBehavior: 'initialRoute',
-    initialRouteName: 'baz',
-  });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = createTabState(options, 'baz');
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(nextState.index).toBe(2);
-  expect(nextState.history).toEqual([
-    { type: 'route', key: 'baz-test' },
-    { type: 'route', key: 'qux:tab-1' },
-  ]);
-  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)?.state.index).toBe(0);
-});
-
-test('replaces the focused route with backBehavior: none', () => {
-  const router = TabRouter({ backBehavior: 'none' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  const state = createTabState(options);
-
-  const nextState = router.getStateForAction(state, TabActions.replace('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(nextState.index).toBe(1);
-  expect(nextState.history).toEqual([{ type: 'route', key: 'qux:tab-0' }]);
-  expect(router.getStateForAction(nextState, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('preserves history when replacing a tab with itself', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  let state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  const nextState = router.getStateForAction(state, TabActions.replace('baz'), options);
-
-  expect(nextState?.state.history).toEqual([
-    { type: 'route', key: 'bar-test' },
-    { type: 'route', key: 'baz-test' },
-  ]);
-});
-
-test('preserves the navigator key across repeated replaces', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-  const initialState = createTabState(options);
-
-  const replacedState = router.getStateForAction(initialState, TabActions.replace('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-  const replacedAgainState = router.getStateForAction(
-    replacedState,
-    TabActions.replace('qux'),
-    options
-  );
-
-  expect(replacedState.key).toBe(initialState.key);
-  expect(replacedAgainState?.state.key).toBe(initialState.key);
-});
-
-test('handles back action with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 2,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-});
-
-test('handles back action with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 2,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'qux-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-});
-
-test('handles back action with backBehavior: order', () => {
-  const router = TabRouter({ backBehavior: 'order' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'bar-test' },
-      { type: 'route', key: 'baz-test' },
-    ],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: initialRoute', () => {
-  const router = TabRouter({ backBehavior: 'initialRoute' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = {
-    ...createTabState(options),
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 0,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'bar-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: initialRoute and initialRouteName', () => {
-  const router = TabRouter({
-    backBehavior: 'initialRoute',
-    initialRouteName: 'baz',
-  });
-
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = {
-    ...createTabState(options, 'baz'),
-    index: 1,
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-  };
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)?.state).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:tab',
-    index: 1,
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-test', name: 'bar' },
-      { key: 'baz-test', name: 'baz' },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('handles back action with backBehavior: none', () => {
-  const router = TabRouter({ backBehavior: 'none' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = createTabState(options);
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(router.getStateForAction(state, CommonActions.goBack(), options)).toBeNull();
-});
-
-test('updates route key history on navigate and jump to with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 1,
-    key: 'navigator:tab',
-    routeNames: ['bar', 'baz', 'qux'],
-    history: [{ type: 'route', key: 'baz-0' }],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'tab',
-  };
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.navigate('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([{ type: 'route', key: 'qux-0' }]);
-});
-
-test('updates route key history on focus change with backBehavior: history', () => {
-  const router = TabRouter({ backBehavior: 'history' });
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-0' }],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-});
-
-test('updates route key history on navigate and jump to with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 1,
-    key: 'navigator:tab',
-    routeNames: ['bar', 'baz', 'qux'],
-    history: [{ type: 'route', key: 'baz-0' }],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    stale: false as const,
-    routeKeySeq: 0,
-    type: 'tab',
-  };
-
-  state = router.getStateForAction(state, TabActions.jumpTo('qux'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.navigate('bar'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(state, TabActions.jumpTo('baz'), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-    { type: 'route', key: 'bar-0' },
-  ]);
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'baz-0' },
-    { type: 'route', key: 'qux-0' },
-  ]);
-});
-
-test('preserves params in history with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  let state = createTabState({
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { value: 'first' }),
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[1]!.params).toEqual({ value: 'first' });
-  expect(state.history?.[1]!.params).toEqual({ value: 'first' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('qux', { value: 'second' }),
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'second' });
-  expect(state.history?.[2]!.params).toEqual({ value: 'second' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.setParams({ value: 'updated with setParams' }),
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'updated with setParams' });
-  expect(state.history?.[2]!.params).toEqual({ value: 'updated with setParams' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.replaceParams({ value: 'replaced params' }),
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[2]!.params).toEqual({ value: 'replaced params' });
-  expect(state.history?.[2]!.params).toEqual({ value: 'replaced params' });
-
-  state = router.getStateForAction(
-    state,
-    CommonActions.navigate('baz', { value: 'updated' }),
-    options
-  )!.state as TabNavigationState<ParamListBase>;
-
-  expect(state.routes[1]!.params).toEqual({ value: 'updated' });
-  expect(state.history?.[3]!.params).toEqual({ value: 'updated' });
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.index).toBe(2);
-  expect(state.routes[2]!.params).toEqual({ value: 'replaced params' });
-
-  state = router.getStateForAction(state, CommonActions.goBack(), options)!
-    .state as TabNavigationState<ParamListBase>;
-
-  expect(state.index).toBe(1);
-  expect(state.routes[1]!.params).toEqual({ value: 'first' });
-});
-
-test('updates route key history on focus change with backBehavior: fullHistory', () => {
-  const router = TabRouter({ backBehavior: 'fullHistory' });
-
-  let state: TabNavigationState<ParamListBase> = {
-    index: 0,
-    key: 'navigator:tab',
-    routeNames: ['bar', 'baz', 'qux'],
-    routes: [
-      { key: 'bar-0', name: 'bar' },
-      { key: 'baz-0', name: 'baz', params: { answer: 42 } },
-      { key: 'qux-0', name: 'qux', params: { name: 'Jane' } },
-    ],
-    history: [{ type: 'route' as const, key: 'bar-0' }],
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-  };
-
-  state = router.getStateForRouteFocus(state, 'bar-0');
-
-  expect(state.history).toEqual([{ type: 'route', key: 'bar-0' }]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'qux-0');
-
-  expect(state.history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-
-  state = router.getStateForRouteFocus(state, 'baz-0');
-
-  expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual([
-    { type: 'route', key: 'bar-0' },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-    { type: 'route', key: 'qux-0', params: { name: 'Jane' } },
-    { type: 'route', key: 'baz-0', params: { answer: 42 } },
-  ]);
-});
-
-test('adds path on navigate if provided', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        path: '/foo/bar',
-      }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', path: '/foo/bar' },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          {
-            key: 'bar',
-            name: 'bar',
-            path: '/foo/bar',
-          },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        path: '/foo/baz',
-      }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      {
-        key: 'bar',
-        name: 'bar',
-        params: { fruit: 'orange' },
-        path: '/foo/baz',
-      },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test("doesn't remove existing path on navigate if not provided", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', path: '/foo/bar' },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({ name: 'bar' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', path: '/foo/bar' },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test("doesn't merge params on navigate to an existing screen", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('bar'),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('bar', { fruit: 'orange' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar' },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate('qux', { test: 12 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-      { key: 'qux', name: 'qux', params: { test: 12 } },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'qux' },
-    ],
-  });
-});
-
-test('merges params on navigate to an existing screen if merge: true', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        merge: true,
-      }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { answer: 42 } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.navigate({
-        name: 'bar',
-        params: { fruit: 'orange' },
-        merge: true,
-      }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { answer: 42, fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test("doesn't merge params on jump to an existing screen", () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {},
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar'),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar' },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 1,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      TabActions.jumpTo('bar', { fruit: 'orange' }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 1,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { fruit: 'orange' } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz' },
-      { type: 'route', key: 'bar' },
-    ],
-  });
-});
-
-test('handles screen preloading', () => {
-  const router = TabRouter({});
-  const options: RouterConfigOptions = {
-    routeNames: ['baz', 'bar', 'qux'],
-    routeGetIdList: {
-      bar: ({ params }) => `bar-${params?.answer}`,
-    },
-  };
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz', name: 'baz' },
-          { key: 'bar', name: 'bar', params: { answer: 42 } },
-          { key: 'qux', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz' }],
-      },
-      CommonActions.preload('qux'),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz', name: 'baz' },
-      { key: 'bar', name: 'bar', params: { answer: 42 } },
-      { key: 'qux', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          { key: 'bar-test', name: 'bar', params: { answer: 42 } },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.preload('bar', { answer: 43 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      { key: 'bar:0', name: 'bar', params: { answer: 43 } },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test-old',
-            name: 'bar',
-            params: { answer: 42, willBe: 'removed' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.preload('bar', { answer: 43 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      { key: 'bar:0', name: 'bar', params: { answer: 43 } },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'overrode' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.preload('bar', { answer: 42 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42 },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 0,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'merged' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [{ type: 'route', key: 'baz-test' }],
-      },
-      CommonActions.navigate('qux'),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42, willBe: 'merged' },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 2,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-test',
-            name: 'bar',
-            params: { answer: 42, willBe: 'merged' },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'baz-test' },
-          { type: 'route', key: 'qux-test' },
-        ],
-      },
-      CommonActions.goBack(),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 0,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-test',
-        name: 'bar',
-        params: { answer: 42, willBe: 'merged' },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [{ type: 'route', key: 'baz-test' }],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 2,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-some',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-some' },
-          { type: 'route', key: 'qux-test' },
-        ],
-      },
-      CommonActions.preload('bar', { answer: 42 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar-some',
-        name: 'bar',
-        params: { answer: 42 },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-
-  expect(
-    router.getStateForAction(
-      {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:root',
-        index: 2,
-        routeNames: ['baz', 'bar', 'qux'],
-        routes: [
-          { key: 'baz-test', name: 'baz' },
-          {
-            key: 'bar-some',
-            name: 'bar',
-            params: { answer: 42 },
-          },
-          { key: 'qux-test', name: 'qux' },
-        ],
-        history: [
-          { type: 'route', key: 'bar-some' },
-          { type: 'route', key: 'qux-test' },
-        ],
-      },
-      CommonActions.preload('bar', { answer: 43 }),
-      options
-    )?.state
-  ).toEqual({
-    stale: false,
-    routeKeySeq: 1,
-    type: 'tab',
-    key: 'navigator:root',
-    index: 2,
-    routeNames: ['baz', 'bar', 'qux'],
-    routes: [
-      { key: 'baz-test', name: 'baz' },
-      {
-        key: 'bar:0',
-        name: 'bar',
-        params: { answer: 43 },
-      },
-      { key: 'qux-test', name: 'qux' },
-    ],
-    history: [
-      { type: 'route', key: 'baz-test' },
-      { type: 'route', key: 'qux-test' },
-    ],
-  });
-});
-
-describe('state without history', () => {
-  const options: RouterConfigOptions = {
-    routeNames: ['bar', 'baz', 'qux'],
-    routeGetIdList: {},
-  };
-
-  const createState = (index = 1): TabNavigationState<ParamListBase> => ({
-    stale: false,
-    routeKeySeq: 0,
-    type: 'tab',
-    key: 'navigator:root',
-    index,
-    routeNames: options.routeNames,
-    routes: [
-      { key: 'bar', name: 'bar' },
-      { key: 'baz', name: 'baz' },
-      { key: 'qux', name: 'qux' },
-    ],
-  });
-
-  test.each<['firstRoute' | 'history' | 'fullHistory', string[]]>([
-    ['firstRoute', ['bar', 'qux']],
-    ['history', ['baz', 'qux']],
-    ['fullHistory', ['baz', 'qux']],
-  ])('handles navigation with backBehavior: %s', (backBehavior, expectedKeys) => {
-    const router = TabRouter({ backBehavior });
-
-    for (const action of [CommonActions.navigate('qux'), TabActions.jumpTo('qux')]) {
-      const result = router.getStateForAction(createState(), action, options);
-
-      expect(result?.state.history?.map((item) => item.key)).toEqual(expectedKeys);
-    }
-  });
-
-  test.each<['firstRoute' | 'initialRoute' | 'order', string | undefined, string]>([
-    ['firstRoute', undefined, 'bar'],
-    ['initialRoute', 'baz', 'baz'],
-    ['order', undefined, 'baz'],
-  ])(
-    'reconstructs the back target with backBehavior: %s',
-    (backBehavior, initialRouteName, expectedName) => {
-      const router = TabRouter({ backBehavior, initialRouteName });
-      const result = router.getStateForAction(createState(2), CommonActions.goBack(), options);
-
-      expect(result && result.state.routes[result.state.index ?? -1]?.name).toBe(expectedName);
-      expect(result?.state.history).toBeDefined();
-    }
-  );
-
-  test.each(['history', 'fullHistory'] as const)(
-    'does not go back with an absent visit history and backBehavior: %s',
-    (backBehavior) => {
-      const router = TabRouter({ backBehavior });
-
-      expect(router.getStateForAction(createState(2), CommonActions.goBack(), options)).toBeNull();
-    }
-  );
 
   test.each([
-    CommonActions.setParams({ answer: 42 }),
-    CommonActions.preload('bar'),
-    TabActions.replace('qux'),
-  ])('handles $type', (action) => {
-    const router = TabRouter({ backBehavior: 'history' });
-    const result = router.getStateForAction(createState(), action, options);
-
-    expect(result?.state.history).toBeDefined();
-  });
-
-  test('handles ROUTE_NAMES_CHANGED', () => {
-    const router = TabRouter({ backBehavior: 'history' });
-    const routeNames = ['qux', 'baz', 'bar'];
-    const result = router.getStateForAction(
-      createState(),
-      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames } },
-      { ...options, routeNames }
-    );
-
-    expect(result?.state.history).toBeDefined();
-  });
-
-  test.each<
-    [Parameters<typeof TabRouter>[0]['backBehavior'], string | undefined, string[], string[]]
-  >([
-    ['order', undefined, ['foo-0', 'bar-0', 'baz-0'], ['foo-0', 'bar-0', 'baz-0', 'qux-0']],
-    ['history', undefined, ['baz-0'], ['baz-0', 'qux-0']],
-    ['fullHistory', undefined, ['baz-0'], ['baz-0', 'qux-0']],
-    ['firstRoute', 'bar', ['foo-0', 'baz-0'], ['foo-0', 'qux-0']],
-    ['initialRoute', 'bar', ['bar-0', 'baz-0'], ['bar-0', 'qux-0']],
-    ['none', undefined, ['baz-0'], ['qux-0']],
-  ])(
-    'reconstructs history during route focus with backBehavior: %s',
-    (backBehavior, initialRouteName, focusedKeys, movedKeys) => {
+    ['firstRoute', undefined, 'one'],
+    ['initialRoute', 'two', 'two'],
+  ] satisfies ['firstRoute' | 'initialRoute', string | undefined, string][])(
+    '%s keeps its anchor at route zero',
+    (backBehavior, initialRouteName, anchor) => {
       const router = TabRouter({ backBehavior, initialRouteName });
-      const state: TabNavigationState<ParamListBase> = {
-        stale: false,
-        routeKeySeq: 0,
-        type: 'tab',
-        key: 'navigator:tab',
-        index: 2,
-        routeNames: ['foo', 'bar', 'baz', 'qux'],
-        routes: [
-          { key: 'foo-0', name: 'foo' },
-          { key: 'bar-0', name: 'bar' },
-          { key: 'baz-0', name: 'baz' },
-          { key: 'qux-0', name: 'qux' },
-        ],
-      };
+      let next = router.getStateForAction(state(), TabActions.jumpTo('three'), options)!.state;
 
-      expect(router.getStateForRouteFocus(state, 'baz-0').history).toEqual(
-        focusedKeys.map((key) => ({ type: 'route', key }))
-      );
-      expect(router.getStateForRouteFocus(state, 'qux-0').history).toEqual(
-        movedKeys.map((key) => ({ type: 'route', key }))
-      );
+      expect(names(next).slice(0, 2)).toEqual([anchor, 'three']);
+      expect(next.index).toBe(1);
+      next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
+      expect(next.index).toBe(0);
+      expect(next.routes[0]?.name).toBe(anchor);
+      expect(router.getStateForAction(next, CommonActions.goBack(), options)).toBeNull();
     }
   );
 
-  test('preserves params when reconstructing full history', () => {
-    const router = TabRouter({ backBehavior: 'fullHistory' });
-    const state = createState(0);
-    const stateWithParams = {
-      ...state,
-      routes: state.routes.map((route, index) =>
-        index === 0 ? { ...route, params: { answer: 42 } } : route
-      ),
-    };
-    // The action starts from a complete state and returns a complete state.
-    const navigatedState = router.getStateForAction(
-      stateWithParams,
-      TabActions.jumpTo('baz'),
+  test('anchor back creates a missing anchor for a seeded deep link', () => {
+    const router = TabRouter({
+      backBehavior: 'initialRoute',
+      initialRouteName: 'two',
+    });
+    const next = router.getStateForAction(
+      state(['three'], 0),
+      CommonActions.goBack(),
       options
     )!.state;
-    const result = router.getStateForAction(navigatedState, CommonActions.goBack(), options);
 
-    expect(result?.state.routes[0]!.params).toEqual({ answer: 42 });
+    expect(names(next)).toEqual(['two', 'three']);
+    expect(next.index).toBe(0);
   });
 
-  test('keeps the focused route in history when it is not declared', () => {
-    const router = TabRouter({});
-    const state = {
-      ...createState(1),
-      routeNames: ['bar'],
-      routes: [
-        { key: 'bar', name: 'bar' },
-        { key: 'zap', name: 'zap' },
-      ],
-    };
+  test.each([
+    ['firstRoute', undefined, 'one'],
+    ['initialRoute', 'two', 'two'],
+  ] satisfies ['firstRoute' | 'initialRoute', string | undefined, string][])(
+    '%s preloads its anchor before a seeded deep link',
+    (backBehavior, initialRouteName, anchor) => {
+      const router = TabRouter({ backBehavior, initialRouteName });
+      let next = router.getStateForAction(
+        state(['three', anchor === 'one' ? 'two' : 'one'], 0),
+        CommonActions.preload(anchor),
+        options
+      )!.state;
 
-    expect(router.getStateForRouteFocus(state, 'missing').history).toEqual([
-      { type: 'route', key: 'zap' },
-    ]);
-  });
+      expect(names(next)).toEqual([anchor, 'three', anchor === 'one' ? 'two' : 'one']);
+      expect(next.index).toBe(1);
 
-  test('keeps the params of an undeclared focused route with backBehavior: fullHistory', () => {
+      next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
+
+      expect(names(next)).toEqual([anchor, 'three', anchor === 'one' ? 'two' : 'one']);
+      expect(next.index).toBe(0);
+    }
+  );
+});
+
+describe('full history', () => {
+  test('keeps duplicate visits and restores parameter snapshots', () => {
     const router = TabRouter({ backBehavior: 'fullHistory' });
-    const state = {
-      ...createState(1),
-      routeNames: ['bar'],
-      routes: [
-        { key: 'bar', name: 'bar' },
-        { key: 'zap', name: 'zap', params: { answer: 42 } },
-      ],
-    };
-
-    // Going back must restore the params, not overwrite them with `undefined`.
-    const navigatedState = router.getStateForAction(
-      state,
-      TabActions.jumpTo('bar'),
+    let next = router.getStateForAction(
+      state(['one', 'two'], 0),
+      CommonActions.navigate('two', { value: 1 }),
       options
     )!.state;
-    const result = router.getStateForAction(navigatedState, CommonActions.goBack(), options);
+    next = router.getStateForAction(
+      next,
+      CommonActions.navigate('one', { value: 2 }),
+      options
+    )!.state;
 
-    expect(result?.state.routes[1]!.params).toEqual({ answer: 42 });
+    expect(next.history?.map((entry) => entry.key)).toEqual(['one-key', 'two-key', 'one-key']);
+    next = router.getStateForAction(next, CommonActions.goBack(), options)!.state;
+    expect(next.routes[next.index]?.name).toBe('two');
+    expect(next.routes[next.index]?.params).toEqual({ value: 1 });
   });
 
-  test('handles an empty state', () => {
-    const router = TabRouter({});
-    const state = {
-      ...createState(-1),
-      routeNames: [],
-      routes: [],
-    };
+  test('reconstructs missing history from the focused route', () => {
+    const next = TabRouter({
+      backBehavior: 'fullHistory',
+    }).getStateForRouteFocus(state(['one', 'two'], 0), 'two-key');
+    expect(next.history?.map((entry) => entry.key)).toEqual(['one-key', 'two-key']);
+  });
+});
 
-    expect(router.getStateForRouteFocus(state, 'missing').history).toEqual([]);
+describe('route name reconciliation', () => {
+  test('ROUTE_NAMES_CHANGED ignores an order-only update', () => {
+    const current = state(['one', 'two'], 1, {
+      history: [{ type: 'route', key: 'two-key' }],
+    });
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      current,
+      {
+        type: 'ROUTE_NAMES_CHANGED',
+        payload: { routeNames: ['four', 'three', 'two', 'one'] },
+      },
+      { ...options, routeNames: ['four', 'three', 'two', 'one'] }
+    )!.state;
+
+    expect(next.routeNames).toEqual(options.routeNames);
+    expect(next.history).toBeUndefined();
+  });
+
+  test('ROUTE_NAMES_CHANGED filters removed routes and preserves surviving focus', () => {
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one', 'two', 'three'], 1),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['two', 'four'] } },
+      { ...options, routeNames: ['two', 'four'] }
+    )!.state;
+
+    expect(next.routeNames).toEqual(['two', 'four']);
+    expect(names(next)).toEqual(['two']);
+    expect(next.index).toBe(0);
+  });
+
+  test('ROUTE_NAMES_CHANGED creates a fallback when no route survives', () => {
+    const next = TabRouter({}).getStateForAction(
+      state(['one']),
+      { type: 'ROUTE_NAMES_CHANGED', payload: { routeNames: ['four'] } },
+      { ...options, routeNames: ['four'] }
+    )!.state;
+    expect(names(next)).toEqual(['four']);
+    expect(next.index).toBe(0);
+  });
+
+  test('ROUTE_NAMES_ORDER_CHANGED validates the set and remaps focus', () => {
+    const router = TabRouter({ backBehavior: 'order' });
+    const current = state(['one', 'two', 'three', 'four'], 1);
+    expect(
+      router.getStateForAction(
+        current,
+        {
+          type: 'ROUTE_NAMES_ORDER_CHANGED',
+          payload: { routeNames: ['one', 'two'] },
+        },
+        options
+      )
+    ).toBeNull();
+
+    const next = router.getStateForAction(
+      current,
+      {
+        type: 'ROUTE_NAMES_ORDER_CHANGED',
+        payload: { routeNames: ['four', 'three', 'two', 'one'] },
+      },
+      options
+    )!.state;
+    expect(names(next)).toEqual(['four', 'three', 'two', 'one']);
+    expect(next.index).toBe(2);
+    expect(next.routes[next.index]?.name).toBe('two');
+  });
+});
+
+describe('preload and replace', () => {
+  test('PRELOAD uses declared membership and appends outside order mode', () => {
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one'], 0, { routeNames: ['one'] }),
+      CommonActions.preload('three'),
+      options
+    )!.state;
+    expect(names(next)).toEqual(['one', 'three']);
+    expect(next.index).toBe(0);
+  });
+
+  test('order PRELOAD inserts at the declared position and preserves focus', () => {
+    const next = TabRouter({ backBehavior: 'order' }).getStateForAction(
+      state(['one', 'three'], 1),
+      CommonActions.preload('two'),
+      options
+    )!.state;
+    expect(names(next)).toEqual(['one', 'two', 'three']);
+    expect(next.index).toBe(2);
+  });
+
+  test('fullHistory PRELOAD re-keys history when getId changes', () => {
+    const routerOptions: RouterConfigOptions = {
+      ...options,
+      routeGetIdList: { one: ({ params }) => params?.id as string | undefined },
+    };
+    const next = TabRouter({ backBehavior: 'fullHistory' }).getStateForAction(
+      state(['one'], 0, {
+        routes: [{ name: 'one', key: 'old', params: { id: 'old' } }],
+        history: [{ type: 'route', key: 'old', params: { id: 'old' } }],
+      }),
+      CommonActions.preload('one', { id: 'new' }),
+      routerOptions
+    )!.state;
+    expect(next.routes[0]?.key).not.toBe('old');
+    expect(next.history?.[0]?.key).toBe(next.routes[0]?.key);
+  });
+
+  test('history REPLACE moves the replaced route to the forward region', () => {
+    const next = TabRouter({ backBehavior: 'history' }).getStateForAction(
+      state(['one', 'two', 'three'], 2),
+      TabActions.replace('two'),
+      options
+    )!.state;
+    expect(names(next)).toEqual(['one', 'two', 'three']);
+    expect(next.index).toBe(1);
+    expect(next.history).toBeUndefined();
+  });
+
+  test('replacing a focused anchor leaves no back target', () => {
+    const router = TabRouter({ backBehavior: 'firstRoute' });
+    const next = router.getStateForAction(
+      state(['one', 'two'], 0),
+      TabActions.replace('two'),
+      options
+    )!.state;
+    expect(names(next)).toEqual(['two', 'one']);
+    expect(next.index).toBe(0);
+    expect(router.getStateForAction(next, CommonActions.goBack(), options)).toBeNull();
+  });
+});
+
+describe('state migration', () => {
+  test.each(['firstRoute', 'initialRoute', 'order', 'history', 'none'] as const)(
+    '%s strips legacy history on the first handled action',
+    (backBehavior) => {
+      const next = TabRouter({ backBehavior }).getStateForAction(
+        state(['one', 'two'], 0, {
+          history: [{ type: 'route', key: 'one-key' }],
+        }),
+        CommonActions.setParams({ value: 1 }),
+        options
+      )!.state;
+      expect(next.history).toBeUndefined();
+    }
+  );
+
+  test('keeps an empty state at index -1', () => {
+    const empty = state([], -1);
+    expect(TabRouter({ backBehavior: 'history' }).getStateForRouteFocus(empty, 'missing')).toEqual(
+      empty
+    );
+  });
+
+  test('warns and ignores partial RESET', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(
+      TabRouter({}).getStateForAction(
+        state(),
+        CommonActions.reset({ routes: [{ name: 'one' }] }),
+        options
+      )
+    ).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
+++ b/packages/expo-router/src/react-navigation/routers/__tests__/TabRouter.test.tsx
@@ -89,6 +89,46 @@ describe('route storage by back behavior', () => {
     expect(next.routes[next.index]?.name).toBe('two');
   });
 
+  test('order back mints missing routes in declared order', () => {
+    const router = TabRouter({ backBehavior: 'order' });
+    const firstBack = router.getStateForAction(state(['three']), CommonActions.goBack(), options)!;
+
+    expect(firstBack.state.routes).toEqual([
+      { key: 'two:tab-0', name: 'two' },
+      { key: 'three-key', name: 'three' },
+    ]);
+    expect(firstBack.state.index).toBe(0);
+    expect(firstBack.state.routeKeySeq).toBe(1);
+    expect(firstBack.affectedRouteKey).toBe('two:tab-0');
+
+    const secondBack = router.getStateForAction(firstBack.state, CommonActions.goBack(), options)!;
+    expect(secondBack.state.routes).toEqual([
+      { key: 'one:tab-1', name: 'one' },
+      { key: 'two:tab-0', name: 'two' },
+      { key: 'three-key', name: 'three' },
+    ]);
+    expect(secondBack.state.index).toBe(0);
+    expect(secondBack.state.routeKeySeq).toBe(2);
+    expect(secondBack.affectedRouteKey).toBe('one:tab-1');
+    expect(router.getStateForAction(secondBack.state, CommonActions.goBack(), options)).toBeNull();
+  });
+
+  test('order back reuses an existing previous declared route', () => {
+    const result = TabRouter({ backBehavior: 'order' }).getStateForAction(
+      state(['two', 'three'], 1),
+      CommonActions.goBack(),
+      options
+    )!;
+
+    expect(result.state.routes).toEqual([
+      { key: 'two-key', name: 'two' },
+      { key: 'three-key', name: 'three' },
+    ]);
+    expect(result.state.index).toBe(0);
+    expect(result.state.routeKeySeq).toBe(0);
+    expect(result.affectedRouteKey).toBe('two-key');
+  });
+
   test.each([
     ['firstRoute', undefined, 'one'],
     ['initialRoute', 'two', 'two'],
@@ -276,6 +316,27 @@ describe('route name reconciliation', () => {
     expect(names(next)).toEqual(['four', 'three', 'two', 'one']);
     expect(next.index).toBe(2);
     expect(next.routes[next.index]?.name).toBe('two');
+  });
+
+  test('ROUTE_NAMES_ORDER_CHANGED updates the anchor outside order behavior', () => {
+    const router = TabRouter({ backBehavior: 'firstRoute' });
+    const current = state(['two']);
+    const reordered = router.getStateForAction(
+      current,
+      {
+        type: 'ROUTE_NAMES_ORDER_CHANGED',
+        payload: { routeNames: ['four', 'three', 'two', 'one'] },
+      },
+      options
+    )!.state;
+
+    expect(reordered.routeNames).toEqual(['four', 'three', 'two', 'one']);
+    expect(reordered.routes).toBe(current.routes);
+    expect(reordered.index).toBe(current.index);
+
+    const backed = router.getStateForAction(reordered, CommonActions.goBack(), options)!.state;
+    expect(names(backed)).toEqual(['four', 'two']);
+    expect(backed.index).toBe(0);
   });
 });
 
@@ -590,6 +651,35 @@ describe('route creation and child state', () => {
 });
 
 describe('navigation updates', () => {
+  test.each([
+    ['firstRoute', undefined],
+    ['initialRoute', 'one'],
+  ] satisfies ['firstRoute' | 'initialRoute', string | undefined][])(
+    '%s preserves route key sequence after minting an anchor',
+    (backBehavior, initialRouteName) => {
+      const router = TabRouter({ backBehavior, initialRouteName });
+      const navigated = router.getStateForAction(
+        state(['three']),
+        CommonActions.navigate('two'),
+        options
+      )!.state;
+
+      expect(navigated.routes).toEqual([
+        { key: 'one:tab-1', name: 'one' },
+        { key: 'two:tab-0', name: 'two' },
+        { key: 'three-key', name: 'three' },
+      ]);
+      expect(navigated.routeKeySeq).toBe(2);
+
+      const next = router.getStateForAction(
+        navigated,
+        CommonActions.navigate('four'),
+        options
+      )!.state;
+      expect(next.routes.find((route) => route.name === 'four')?.key).toBe('four:tab-2');
+    }
+  );
+
   test('navigate replaces params unless merge is true', () => {
     const router = TabRouter({});
     const current = state(['one', 'two'], 1, {

--- a/packages/expo-router/src/react-navigation/routers/types.tsx
+++ b/packages/expo-router/src/react-navigation/routers/types.tsx
@@ -2,7 +2,8 @@ import type * as CommonActions from './CommonActions';
 
 export type CommonNavigationAction =
   | CommonActions.Action
-  | CommonActions.InternalRouteNamesChangedAction;
+  | CommonActions.InternalRouteNamesChangedAction
+  | CommonActions.InternalRouteNamesOrderChangedAction;
 
 export type NavigationRoute<
   ParamList extends ParamListBase,

--- a/packages/expo-router/src/standard-navigation/__tests__/appendMissingPlaceholderTabRoutes.test.ts
+++ b/packages/expo-router/src/standard-navigation/__tests__/appendMissingPlaceholderTabRoutes.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@jest/globals';
+
+import type { NavigationState } from '../../react-navigation/native';
+import { appendMissingPlaceholderTabRoutes } from '../appendMissingPlaceholderTabRoutes';
+import type { PlaceholderDescriptorMap } from '../types';
+
+const descriptors = {
+  one: { route: { name: 'one' } },
+  two: { route: { name: 'two' } },
+  three: { route: { name: 'three' } },
+} as unknown as PlaceholderDescriptorMap;
+
+const state: NavigationState = {
+  stale: false,
+  key: 'tabs',
+  routeKeySeq: 0,
+  routeNames: ['one', 'two', 'three'],
+  routes: [
+    { name: 'three', key: 'three-key' },
+    { name: 'one', key: 'one-key' },
+  ],
+  index: 0,
+};
+
+test('always projects routes in declared order and preserves focus', () => {
+  const next = appendMissingPlaceholderTabRoutes(state, descriptors, undefined, [
+    'one',
+    'two',
+    'three',
+  ]);
+  expect(next.routes.map((route) => route.name)).toEqual(['one', 'two', 'three']);
+  expect(next.routes[next.index]?.key).toBe('three-key');
+  expect(next.routes[0]).toBe(state.routes[1]);
+});
+
+test('uses builder route names instead of stale state route names', () => {
+  const next = appendMissingPlaceholderTabRoutes(
+    { ...state, routes: [...state.routes, { name: 'two', key: 'two-key' }] },
+    descriptors,
+    undefined,
+    ['three', 'two', 'one']
+  );
+  expect(next.routes.map((route) => route.name)).toEqual(['three', 'two', 'one']);
+  expect(next.index).toBe(0);
+});
+
+test('keeps empty routes at index -1', () => {
+  const next = appendMissingPlaceholderTabRoutes(
+    { ...state, routeNames: [], routes: [], index: -1 },
+    {},
+    undefined,
+    []
+  );
+  expect(next.routes).toEqual([]);
+  expect(next.index).toBe(-1);
+});

--- a/packages/expo-router/src/standard-navigation/__tests__/appendMissingPlaceholderTabRoutes.test.ts
+++ b/packages/expo-router/src/standard-navigation/__tests__/appendMissingPlaceholderTabRoutes.test.ts
@@ -23,11 +23,7 @@ const state: NavigationState = {
 };
 
 test('always projects routes in declared order and preserves focus', () => {
-  const next = appendMissingPlaceholderTabRoutes(state, descriptors, undefined, [
-    'one',
-    'two',
-    'three',
-  ]);
+  const next = appendMissingPlaceholderTabRoutes(state, descriptors, ['one', 'two', 'three']);
   expect(next.routes.map((route) => route.name)).toEqual(['one', 'two', 'three']);
   expect(next.routes[next.index]?.key).toBe('three-key');
   expect(next.routes[0]).toBe(state.routes[1]);
@@ -37,7 +33,6 @@ test('uses builder route names instead of stale state route names', () => {
   const next = appendMissingPlaceholderTabRoutes(
     { ...state, routes: [...state.routes, { name: 'two', key: 'two-key' }] },
     descriptors,
-    undefined,
     ['three', 'two', 'one']
   );
   expect(next.routes.map((route) => route.name)).toEqual(['three', 'two', 'one']);
@@ -48,7 +43,6 @@ test('keeps empty routes at index -1', () => {
   const next = appendMissingPlaceholderTabRoutes(
     { ...state, routeNames: [], routes: [], index: -1 },
     {},
-    undefined,
     []
   );
   expect(next.routes).toEqual([]);

--- a/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/integration.test.ios.tsx
@@ -19,6 +19,7 @@ import { act, fireEvent, renderRouter, screen } from '../../testing-library';
 import {
   appendMissingPlaceholderTabDescriptors,
   appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../appendMissingPlaceholderTabRoutes';
 import { unstable_createStandardRouterNavigator, unstable_integrateWithRouter } from '../index';
 import type { NavigatorContentProps, StandardNavigatorDescriptor } from '../types';
@@ -754,7 +755,7 @@ describe('custom-navigators guide example', () => {
 
   const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
     processDescriptors: appendMissingPlaceholderTabDescriptors,
-    processState: appendMissingPlaceholderTabRoutes,
+    processState: processStateWithPlaceholderTabRoutes,
   });
 
   const renderExample = () =>

--- a/packages/expo-router/src/standard-navigation/__tests__/useBuildHref.integration.test.ios.tsx
+++ b/packages/expo-router/src/standard-navigation/__tests__/useBuildHref.integration.test.ios.tsx
@@ -11,7 +11,7 @@ import {
 import { renderRouter } from '../../testing-library';
 import {
   appendMissingPlaceholderTabDescriptors,
-  appendMissingPlaceholderTabRoutes,
+  processStateWithPlaceholderTabRoutes,
 } from '../appendMissingPlaceholderTabRoutes';
 import { unstable_createStandardRouterNavigator } from '../index';
 
@@ -39,7 +39,7 @@ const StandardTabs = unstable_createStandardRouterNavigator<
   TabRouterOptions
 >(NavigatorContent, TabRouter, {
   processDescriptors: appendMissingPlaceholderTabDescriptors,
-  processState: appendMissingPlaceholderTabRoutes,
+  processState: processStateWithPlaceholderTabRoutes,
 });
 
 describe('useBuildHref (integration)', () => {

--- a/packages/expo-router/src/standard-navigation/appendMissingPlaceholderTabRoutes.ts
+++ b/packages/expo-router/src/standard-navigation/appendMissingPlaceholderTabRoutes.ts
@@ -4,9 +4,10 @@ import type { DescribePlaceholderRoute, PlaceholderDescriptorMap } from './types
 export function appendMissingPlaceholderTabDescriptors<State extends NavigationState>(
   descriptors: PlaceholderDescriptorMap,
   state: State,
-  describe: DescribePlaceholderRoute
+  describe: DescribePlaceholderRoute,
+  routeNames = state.routeNames
 ): PlaceholderDescriptorMap {
-  const missingRouteNames = state.routeNames.filter(
+  const missingRouteNames = routeNames.filter(
     (name) => !state.routes.some((route) => route.name === name)
   );
   if (missingRouteNames.length === 0) {
@@ -26,29 +27,27 @@ export function appendMissingPlaceholderTabDescriptors<State extends NavigationS
 // TODO: Evaluate making this function public.
 export function appendMissingPlaceholderTabRoutes<State extends NavigationState>(
   state: State,
-  descriptors: PlaceholderDescriptorMap
+  descriptors: PlaceholderDescriptorMap,
+  _describe?: DescribePlaceholderRoute,
+  routeNames = state.routeNames
 ): State {
-  const hasMissingRoute = state.routeNames.some(
-    (name) => !state.routes.some((route) => route.name === name)
-  );
-  if (!hasMissingRoute) {
-    return state;
-  }
-
   const focusedKey = state.routes[state.index]?.key;
-  const routes = state.routeNames.map((name) => {
+  const routes = routeNames.map((name) => {
     const existingRoute = state.routes.find((route) => route.name === name);
     if (existingRoute) {
       return existingRoute;
     }
     return createPlaceholderRoute<State>(name, descriptors);
   });
-  const index = Math.max(
-    0,
-    routes.findIndex((route) => route.key === focusedKey)
-  );
+  const index =
+    routes.length === 0
+      ? -1
+      : Math.max(
+          0,
+          routes.findIndex((route) => route.key === focusedKey)
+        );
 
-  return { ...state, index, routes };
+  return { ...state, routeNames, index, routes };
 }
 
 function createPlaceholderRoute<State extends NavigationState>(

--- a/packages/expo-router/src/standard-navigation/appendMissingPlaceholderTabRoutes.ts
+++ b/packages/expo-router/src/standard-navigation/appendMissingPlaceholderTabRoutes.ts
@@ -28,7 +28,6 @@ export function appendMissingPlaceholderTabDescriptors<State extends NavigationS
 export function appendMissingPlaceholderTabRoutes<State extends NavigationState>(
   state: State,
   descriptors: PlaceholderDescriptorMap,
-  _describe?: DescribePlaceholderRoute,
   routeNames = state.routeNames
 ): State {
   const focusedKey = state.routes[state.index]?.key;
@@ -48,6 +47,15 @@ export function appendMissingPlaceholderTabRoutes<State extends NavigationState>
         );
 
   return { ...state, routeNames, index, routes };
+}
+
+export function processStateWithPlaceholderTabRoutes<State extends NavigationState>(
+  state: State,
+  descriptors: PlaceholderDescriptorMap,
+  _describe: DescribePlaceholderRoute,
+  routeNames: string[]
+): State {
+  return appendMissingPlaceholderTabRoutes(state, descriptors, routeNames);
 }
 
 function createPlaceholderRoute<State extends NavigationState>(

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -24,6 +24,7 @@ import type {
 import { useStandardActions } from './useStandardActions';
 import { useStandardEmitter } from './useStandardEmitter';
 import { useStandardState } from './useStandardState';
+import { useSyncRouteNamesOrder } from './useSyncRouteNamesOrder';
 
 export type {
   IntegrateWithRouterOptions,
@@ -184,26 +185,34 @@ export function unstable_integrateWithRouter<
       NavigatorProps,
       RouterOptions
     >(props, getValidInitialRouteName(routeNode));
-    const { state, navigation, describe, descriptors, NavigationContent } = useNavigationBuilder<
-      State,
-      RouterOptions,
-      Record<string, (...args: unknown[]) => void>,
-      NavigatorOptions,
-      EventMap
-    >(router, useNavigationBuilderProps);
+    const { state, routeNames, navigation, describe, descriptors, NavigationContent } =
+      useNavigationBuilder<
+        State,
+        RouterOptions,
+        Record<string, (...args: unknown[]) => void>,
+        NavigatorOptions,
+        EventMap
+      >(router, useNavigationBuilderProps);
+
+    useSyncRouteNamesOrder({
+      backBehavior: (extraProps as { backBehavior?: string }).backBehavior,
+      routeNames,
+      state,
+      dispatch: navigation.dispatchSync,
+    });
 
     const { dispatch, dispatchSync } = navigation;
 
     const processedDescriptors = useMemo(
       () =>
-        (options?.processDescriptors?.(descriptors, state, describe) as
+        (options?.processDescriptors?.(descriptors, state, describe, routeNames) as
           | typeof descriptors
           | undefined) ?? descriptors,
-      [state, descriptors, describe, options]
+      [state, descriptors, describe, options, routeNames]
     );
     const processedState = useMemo(
-      () => options?.processState?.(state, processedDescriptors, describe) ?? state,
-      [state, processedDescriptors, describe, options]
+      () => options?.processState?.(state, processedDescriptors, describe, routeNames) ?? state,
+      [state, processedDescriptors, describe, options, routeNames]
     );
 
     const derivedProps = useMemo<Partial<CreateProps>>(

--- a/packages/expo-router/src/standard-navigation/index.tsx
+++ b/packages/expo-router/src/standard-navigation/index.tsx
@@ -195,7 +195,6 @@ export function unstable_integrateWithRouter<
       >(router, useNavigationBuilderProps);
 
     useSyncRouteNamesOrder({
-      backBehavior: (extraProps as { backBehavior?: string }).backBehavior,
       routeNames,
       state,
       dispatch: navigation.dispatchSync,

--- a/packages/expo-router/src/standard-navigation/types.ts
+++ b/packages/expo-router/src/standard-navigation/types.ts
@@ -119,13 +119,15 @@ export type IntegrateWithRouterOptions<
   processState?: (
     state: State,
     descriptors: PlaceholderDescriptorMap,
-    describe: DescribePlaceholderRoute
+    describe: DescribePlaceholderRoute,
+    routeNames: string[]
   ) => State;
   /** Creates additional descriptors before `processState` and navigator rendering. */
   processDescriptors?: (
     descriptors: PlaceholderDescriptorMap,
     state: State,
-    describe: DescribePlaceholderRoute
+    describe: DescribePlaceholderRoute,
+    routeNames: string[]
   ) => PlaceholderDescriptorMap;
   /**
    * Transforms the screens declared as children of the navigator before they are rendered.

--- a/packages/expo-router/src/standard-navigation/usePreloadPlaceholderRoutes.ts
+++ b/packages/expo-router/src/standard-navigation/usePreloadPlaceholderRoutes.ts
@@ -11,21 +11,24 @@ export function usePreloadPlaceholderRoutes({
   descriptors,
   preload,
   lazyByDefault,
+  preloadAll = false,
 }: {
   routes: Route[];
   descriptors: Record<string, Descriptor | undefined>;
   preload: (name: string) => void;
   /** Used when a route does not specify `options.lazy`. */
   lazyByDefault: boolean;
+  preloadAll?: boolean;
 }) {
   useEffect(() => {
+    // TODO(ENG-26318): Preload routes into state without rendering screens instead of PRELOAD.
     for (const route of routes) {
       const descriptor = descriptors[route.key];
       // Options stay generic so navigators without `lazy` remain assignable; tab options may define it.
       const lazy = (descriptor?.options as { lazy?: boolean } | undefined)?.lazy;
-      if (descriptor?.route?.key === undefined && !(lazy ?? lazyByDefault)) {
+      if (descriptor?.route?.key === undefined && (preloadAll || !(lazy ?? lazyByDefault))) {
         preload(route.name);
       }
     }
-  }, [descriptors, lazyByDefault, preload, routes]);
+  }, [descriptors, lazyByDefault, preload, preloadAll, routes]);
 }

--- a/packages/expo-router/src/standard-navigation/usePreloadPlaceholderRoutes.ts
+++ b/packages/expo-router/src/standard-navigation/usePreloadPlaceholderRoutes.ts
@@ -11,14 +11,12 @@ export function usePreloadPlaceholderRoutes({
   descriptors,
   preload,
   lazyByDefault,
-  preloadAll = false,
 }: {
   routes: Route[];
   descriptors: Record<string, Descriptor | undefined>;
   preload: (name: string) => void;
   /** Used when a route does not specify `options.lazy`. */
   lazyByDefault: boolean;
-  preloadAll?: boolean;
 }) {
   useEffect(() => {
     // TODO(ENG-26318): Preload routes into state without rendering screens instead of PRELOAD.
@@ -26,9 +24,9 @@ export function usePreloadPlaceholderRoutes({
       const descriptor = descriptors[route.key];
       // Options stay generic so navigators without `lazy` remain assignable; tab options may define it.
       const lazy = (descriptor?.options as { lazy?: boolean } | undefined)?.lazy;
-      if (descriptor?.route?.key === undefined && (preloadAll || !(lazy ?? lazyByDefault))) {
+      if (descriptor?.route?.key === undefined && !(lazy ?? lazyByDefault)) {
         preload(route.name);
       }
     }
-  }, [descriptors, lazyByDefault, preload, preloadAll, routes]);
+  }, [descriptors, lazyByDefault, preload, routes]);
 }

--- a/packages/expo-router/src/standard-navigation/useSyncRouteNamesOrder.ts
+++ b/packages/expo-router/src/standard-navigation/useSyncRouteNamesOrder.ts
@@ -1,0 +1,41 @@
+import { useRef } from 'react';
+
+import { isArrayEqual } from '../react-navigation/core/isArrayEqual';
+import { isSetEqual } from '../react-navigation/core/isSetEqual';
+import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
+
+export function useSyncRouteNamesOrder({
+  backBehavior,
+  routeNames,
+  state,
+  dispatch,
+}: {
+  backBehavior: string | undefined;
+  routeNames: string[];
+  state: { key: string; routeNames: string[] };
+  dispatch: (action: {
+    type: 'ROUTE_NAMES_ORDER_CHANGED';
+    payload: { routeNames: string[] };
+    target: string;
+  }) => void;
+}) {
+  const previousRouteNamesRef = useRef(routeNames);
+
+  useClientLayoutEffect(() => {
+    const previousRouteNames = previousRouteNamesRef.current;
+    previousRouteNamesRef.current = routeNames;
+    // The router registry is not available during this component's first layout effect.
+    if (
+      backBehavior === 'order' &&
+      !isArrayEqual(previousRouteNames, routeNames) &&
+      isSetEqual(state.routeNames, routeNames) &&
+      !isArrayEqual(state.routeNames, routeNames)
+    ) {
+      dispatch({
+        type: 'ROUTE_NAMES_ORDER_CHANGED',
+        payload: { routeNames },
+        target: state.key,
+      });
+    }
+  }, [backBehavior, dispatch, routeNames, state.key, state.routeNames]);
+}

--- a/packages/expo-router/src/standard-navigation/useSyncRouteNamesOrder.ts
+++ b/packages/expo-router/src/standard-navigation/useSyncRouteNamesOrder.ts
@@ -5,12 +5,10 @@ import { isSetEqual } from '../react-navigation/core/isSetEqual';
 import { useClientLayoutEffect } from '../react-navigation/core/useClientLayoutEffect';
 
 export function useSyncRouteNamesOrder({
-  backBehavior,
   routeNames,
   state,
   dispatch,
 }: {
-  backBehavior: string | undefined;
   routeNames: string[];
   state: { key: string; routeNames: string[] };
   dispatch: (action: {
@@ -26,7 +24,6 @@ export function useSyncRouteNamesOrder({
     previousRouteNamesRef.current = routeNames;
     // The router registry is not available during this component's first layout effect.
     if (
-      backBehavior === 'order' &&
       !isArrayEqual(previousRouteNames, routeNames) &&
       isSetEqual(state.routeNames, routeNames) &&
       !isArrayEqual(state.routeNames, routeNames)
@@ -37,5 +34,5 @@ export function useSyncRouteNamesOrder({
         target: state.key,
       });
     }
-  }, [backBehavior, dispatch, routeNames, state.key, state.routeNames]);
+  }, [dispatch, routeNames, state.key, state.routeNames]);
 }

--- a/packages/expo-router/src/ui/TabRouter.tsx
+++ b/packages/expo-router/src/ui/TabRouter.tsx
@@ -7,7 +7,7 @@ import {
   type TabRouterOptions as RNTabRouterOptions,
   TabRouter as RNTabRouter,
 } from '../react-navigation/native';
-import { ensureStateHistory } from '../react-navigation/routers/TabRouter';
+import { ensureFullHistory } from '../react-navigation/routers/TabRouter';
 import { attachRouteState, type RouteState } from '../react-navigation/routers/attachRouteState';
 import { ensureStateType } from '../react-navigation/routers/ensureStateType';
 import { getTabRoute, type TriggerMap } from './common';
@@ -68,14 +68,13 @@ export function ExpoTabRouter(options: ExpoTabRouterOptions) {
       if (!isSwitching && route.state !== undefined) {
         const selectedRoute = attachRouteState(route, action);
         if (selectedRoute === route) {
-          state = ensureStateType(
-            ensureStateHistory(
-              state,
-              options.backBehavior ?? 'firstRoute',
-              options.initialRouteName
-            ),
-            'tab'
-          );
+          if (options.backBehavior === 'fullHistory') {
+            state = ensureFullHistory(state);
+          } else if (state.history !== undefined) {
+            const { history: _, ...stateWithoutHistory } = state;
+            state = stateWithoutHistory;
+          }
+          state = ensureStateType(state, 'tab');
           return { state, affectedRouteKey: route.key };
         }
       }

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -8,19 +8,23 @@ import { useComponent } from '../fork/useComponent';
 import { useRouteInfo } from '../hooks';
 import { GuardContextProvider, type GuardedRedirects } from '../layouts/GuardContext';
 import { resolveHref } from '../link/href';
-import type {
-  DefaultNavigatorOptions,
-  ParamListBase,
-  TabActionHelpers,
-  TabNavigationState,
-  TabRouterOptions,
+import {
+  CommonActions,
+  LinkingContext,
+  useNavigationBuilder,
+  type DefaultNavigatorOptions,
+  type ParamListBase,
+  type TabActionHelpers,
+  type TabNavigationState,
+  type TabRouterOptions,
 } from '../react-navigation/native';
-import { LinkingContext, useNavigationBuilder } from '../react-navigation/native';
 import {
   appendMissingPlaceholderTabDescriptors,
   appendMissingPlaceholderTabRoutes,
 } from '../standard-navigation/appendMissingPlaceholderTabRoutes';
 import type { PlaceholderDescriptorMap } from '../standard-navigation/types';
+import { usePreloadPlaceholderRoutes } from '../standard-navigation/usePreloadPlaceholderRoutes';
+import { useSyncRouteNamesOrder } from '../standard-navigation/useSyncRouteNamesOrder';
 import { useVisibleTabsWithRedirect } from '../standard-navigation/useVisibleTabsWithRedirect';
 import { shouldLinkExternally } from '../utils/url';
 import type { NavigatorContextValue } from '../views/Navigator';
@@ -189,19 +193,27 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
 
   const {
     state,
+    routeNames,
     describe,
     descriptors: sparseDescriptors,
     navigation,
     NavigationContent: RNNavigationContent,
   } = navigatorContext;
+  useSyncRouteNamesOrder({
+    backBehavior: rest.backBehavior,
+    routeNames,
+    state,
+    dispatch: navigation.dispatchSync,
+  });
   const descriptors = useMemo(
     () =>
       appendMissingPlaceholderTabDescriptors(
         sparseDescriptors,
         state,
-        describe
+        describe,
+        routeNames
       ) as typeof sparseDescriptors,
-    [describe, sparseDescriptors, state]
+    [describe, routeNames, sparseDescriptors, state]
   );
   const navigatorStates = useMemo(
     () => ({ ...parentNavigatorStates, [contextKey]: state }),
@@ -221,7 +233,13 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
   const NavigationContent = useComponent((children: React.ReactNode) => (
     // Headless tabs have no guards, so shadow parent guards whose route names may collide.
     <GuardContextProvider node={routeNode} guardedRedirects={emptyGuardedRedirects}>
-      <TabVisibilityRedirect state={state} descriptors={descriptors} />
+      <TabVisibilityRedirect
+        state={state}
+        routeNames={routeNames}
+        descriptors={descriptors}
+        navigation={navigation}
+        preloadAll={rest.backBehavior === 'order'}
+      />
       <TabTriggerMapContext.Provider value={triggerMap}>
         <TabNavigatorStatesContext.Provider value={navigatorStates}>
           <NavigatorContext.Provider value={navigatorContextValue}>
@@ -232,20 +250,33 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     </GuardContextProvider>
   )) as TabsContextValue['NavigationContent'];
 
-  return { state, describe, descriptors, navigation, NavigationContent };
+  return { state, routeNames, describe, descriptors, navigation, NavigationContent };
 }
 
 function TabVisibilityRedirect({
   state,
+  routeNames,
   descriptors,
+  navigation,
+  preloadAll,
 }: {
   state: TabNavigationState<any>;
+  routeNames: string[];
   descriptors: PlaceholderDescriptorMap;
+  navigation: { dispatch: (action: ReturnType<typeof CommonActions.preload>) => void };
+  preloadAll: boolean;
 }) {
   const stateWithPlaceholders = useMemo(
-    () => appendMissingPlaceholderTabRoutes(state, descriptors),
-    [descriptors, state]
+    () => appendMissingPlaceholderTabRoutes(state, descriptors, undefined, routeNames),
+    [descriptors, routeNames, state]
   );
+  usePreloadPlaceholderRoutes({
+    routes: stateWithPlaceholders.routes,
+    descriptors,
+    preload: (name) => navigation.dispatch(CommonActions.preload(name)),
+    lazyByDefault: true,
+    preloadAll,
+  });
   useVisibleTabsWithRedirect({
     routes: stateWithPlaceholders.routes,
     routeNames: stateWithPlaceholders.routeNames,

--- a/packages/expo-router/src/ui/Tabs.tsx
+++ b/packages/expo-router/src/ui/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { ComponentProps, ReactElement, ReactNode, PropsWithChildren } from 'react';
-import { Children, Fragment, isValidElement, use, useMemo } from 'react';
+import { Children, Fragment, isValidElement, use, useCallback, useMemo } from 'react';
 import type { ViewProps } from 'react-native';
 import { StyleSheet, View } from 'react-native';
 
@@ -200,7 +200,6 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
     NavigationContent: RNNavigationContent,
   } = navigatorContext;
   useSyncRouteNamesOrder({
-    backBehavior: rest.backBehavior,
     routeNames,
     state,
     dispatch: navigation.dispatchSync,
@@ -238,7 +237,6 @@ export function useTabsWithTriggers(options: UseTabsWithTriggersOptions): TabsCo
         routeNames={routeNames}
         descriptors={descriptors}
         navigation={navigation}
-        preloadAll={rest.backBehavior === 'order'}
       />
       <TabTriggerMapContext.Provider value={triggerMap}>
         <TabNavigatorStatesContext.Provider value={navigatorStates}>
@@ -258,24 +256,25 @@ function TabVisibilityRedirect({
   routeNames,
   descriptors,
   navigation,
-  preloadAll,
 }: {
   state: TabNavigationState<any>;
   routeNames: string[];
   descriptors: PlaceholderDescriptorMap;
   navigation: { dispatch: (action: ReturnType<typeof CommonActions.preload>) => void };
-  preloadAll: boolean;
 }) {
   const stateWithPlaceholders = useMemo(
-    () => appendMissingPlaceholderTabRoutes(state, descriptors, undefined, routeNames),
+    () => appendMissingPlaceholderTabRoutes(state, descriptors, routeNames),
     [descriptors, routeNames, state]
+  );
+  const preload = useCallback(
+    (name: string) => navigation.dispatch(CommonActions.preload(name)),
+    [navigation]
   );
   usePreloadPlaceholderRoutes({
     routes: stateWithPlaceholders.routes,
     descriptors,
-    preload: (name) => navigation.dispatch(CommonActions.preload(name)),
+    preload,
     lazyByDefault: true,
-    preloadAll,
   });
   useVisibleTabsWithRedirect({
     routes: stateWithPlaceholders.routes,

--- a/packages/expo-router/src/ui/__tests__/TabRouter.test.ios.tsx
+++ b/packages/expo-router/src/ui/__tests__/TabRouter.test.ios.tsx
@@ -15,7 +15,6 @@ function buildTabState(
     index,
     routeNames: routes.map((route) => route.name),
     routes,
-    history: [{ type: 'route', key: routes[0]!.key }],
   };
 }
 
@@ -57,12 +56,11 @@ test('reselecting a seeded tab returns tab metadata', () => {
           state: { routes: [{ name: 'child' }] },
         },
       ],
-      history: [{ type: 'route', key: 'first-key' }],
     },
   });
 });
 
-test('reselecting a tab with matching carried state preserves its history', () => {
+test('reselecting a tab with matching carried state preserves the state', () => {
   const router = ExpoTabRouter({ triggerMap: {} });
   const options = { routeNames: ['first', 'second'], routeGetIdList: {} };
   const childState = {

--- a/packages/expo-router/src/ui/__tests__/integration/backBehavior.test.ios.tsx
+++ b/packages/expo-router/src/ui/__tests__/integration/backBehavior.test.ios.tsx
@@ -1,0 +1,229 @@
+import { act, screen } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { TabList, TabSlot, TabTrigger, Tabs } from '../..';
+import { router } from '../../../imperative-api';
+import type { BackBehavior } from '../../../react-navigation/routers/TabRouter';
+import { renderRouter } from '../../../testing-library';
+
+const IndexTab = jest.fn(() => <Text testID="index">index</Text>);
+const SecondTab = jest.fn(() => <Text testID="second">second</Text>);
+const ThirdTab = jest.fn(() => <Text testID="third">third</Text>);
+
+type RenderCounts = { index: number; second: number; third: number };
+
+function renderTabs(
+  backBehavior?: BackBehavior,
+  { initialUrl = '/', initialRouteName }: { initialUrl?: string; initialRouteName?: string } = {}
+) {
+  const Layout = () => (
+    <Tabs options={{ backBehavior }}>
+      <TabList>
+        <TabTrigger name="index" href="/" />
+        <TabTrigger name="second" href="/second" />
+        <TabTrigger name="third" href="/third" />
+      </TabList>
+      <TabSlot />
+    </Tabs>
+  );
+  renderRouter(
+    {
+      _layout: { unstable_settings: { initialRouteName }, default: Layout },
+      index: IndexTab,
+      second: SecondTab,
+      third: ThirdTab,
+    },
+    { initialUrl }
+  );
+}
+
+function expectRenders({ index, second, third }: RenderCounts) {
+  expect(IndexTab).toHaveBeenCalledTimes(index);
+  expect(SecondTab).toHaveBeenCalledTimes(second);
+  expect(ThirdTab).toHaveBeenCalledTimes(third);
+  jest.clearAllMocks();
+}
+
+function expectFocused(pathname: string, testID: string) {
+  expect(screen).toHavePathname(pathname);
+  expect(screen.getByTestId(testID)).toBeVisible();
+}
+
+describe('headless Tabs backBehavior', () => {
+  it('returns to the first route by default', () => {
+    renderTabs();
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  describe('firstRoute', () => {
+    it('returns to the first route after navigation', () => {
+      renderTabs('firstRoute');
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/second'));
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 1, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 0, third: 0 });
+    });
+
+    it('creates the first route when the app starts on another route', () => {
+      renderTabs('firstRoute', { initialUrl: '/third' });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 1, second: 0, third: 0 });
+    });
+  });
+
+  describe('initialRoute', () => {
+    it('returns to the configured initial route after navigation', () => {
+      renderTabs('initialRoute', { initialRouteName: 'second' });
+      expectFocused('/', 'index');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 1, second: 0, third: 0 });
+      act(() => router.push('/third'));
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 1, third: 0 });
+    });
+
+    it('creates the configured initial route when the app starts on another route', () => {
+      renderTabs('initialRoute', {
+        initialUrl: '/third',
+        initialRouteName: 'second',
+      });
+      expectFocused('/third', 'third');
+      expect(router.canGoBack()).toBe(true);
+      expectRenders({ index: 0, second: 0, third: 1 });
+      act(() => router.back());
+      expectFocused('/second', 'second');
+      expect(router.canGoBack()).toBe(false);
+      expectRenders({ index: 0, second: 1, third: 0 });
+    });
+  });
+
+  it('follows route order', () => {
+    renderTabs('order');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps only the latest visit to each route in history', () => {
+    renderTabs('history');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('keeps duplicate visits in full history', () => {
+    renderTabs('fullHistory');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.push('/third'));
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 1 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/third', 'third');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(true);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+  });
+
+  it('does not handle back actions with none', () => {
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+    renderTabs('none');
+    expectFocused('/', 'index');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 1, second: 0, third: 0 });
+    act(() => router.push('/second'));
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 1, third: 0 });
+    act(() => router.back());
+    expectFocused('/second', 'second');
+    expect(router.canGoBack()).toBe(false);
+    expectRenders({ index: 0, second: 0, third: 0 });
+    expect(error).not.toHaveBeenCalled();
+    error.mockRestore();
+  });
+});

--- a/packages/expo-router/src/utils/__tests__/stack.test.ts
+++ b/packages/expo-router/src/utils/__tests__/stack.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@jest/globals';
+
+import { getHistoryLength } from '../stack';
+
+const routes = [
+  { name: 'one', key: 'one-key' },
+  { name: 'two', key: 'two-key' },
+  { name: 'three', key: 'three-key' },
+];
+
+test('uses index for tab and drawer states without history', () => {
+  expect(getHistoryLength({ type: 'tab', routes, index: 1 })).toBe(2);
+  expect(getHistoryLength({ type: 'drawer', routes, index: 0 })).toBe(1);
+  expect(getHistoryLength({ type: 'tab', routes: [], index: -1 })).toBe(0);
+});
+
+test('uses full history before index', () => {
+  expect(
+    getHistoryLength({
+      type: 'tab',
+      routes,
+      index: 0,
+      history: [{ key: 'one' }, { key: 'two' }],
+    })
+  ).toBe(2);
+});
+
+test('keeps stack and typeless fallbacks', () => {
+  expect(getHistoryLength({ type: 'stack', routes, index: 1 })).toBe(2);
+  expect(getHistoryLength({ routes })).toBe(3);
+});

--- a/packages/expo-router/src/utils/stack.ts
+++ b/packages/expo-router/src/utils/stack.ts
@@ -15,7 +15,11 @@ export function getHistoryLength(state: ReactNavigationState): number {
     return state.index + 1;
   }
 
-  // Without a type or history, stack and tabs both use the route count as their history length.
+  if (state.type === 'tab' || state.type === 'drawer') {
+    return (state.index ?? 0) + 1;
+  }
+
+  // Typeless states may still represent a stack, so route count remains the fallback.
   return state.routes.length;
 }
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
