### PR TITLE
[router] Remove unnecessary wrapping of navigation containers

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### 🛠 Breaking changes
 
+- Remove `BaseNavigationContainer` export from `expo-router/react-navigation`.
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### 🛠 Breaking changes
 
-- Remove `BaseNavigationContainer` export from `expo-router/react-navigation`.
+- Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))
 - Remove `beforeRemove`, `__unsafe_action__`, `PreventRemoveContext`, and `usePreventRemoveContext` from `expo-router/react-navigation`. ([#49408](https://github.com/expo/expo/pull/49408) by [@Ubax](https://github.com/Ubax))
 - Preserve the focused route when switching navigator types in a conditional layout. ([#49297](https://github.com/expo/expo/pull/49297) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { I18nManager } from 'react-native';
 
 import { RouterConfigContext } from '../global-state/routerConfigContext';
-import { RoutingQueueApiContext, RoutingQueueProvider } from '../global-state/routingQueueContext';
+import { BaseNavigationContainer } from '../react-navigation/core/BaseNavigationContainer';
 import type {
   DocumentTitleOptions,
   LinkingOptions,
@@ -13,7 +13,6 @@ import type {
   ParamListBase,
 } from '../react-navigation/native';
 import {
-  BaseNavigationContainer,
   DefaultTheme,
   LinkingContext,
   LocaleDirContext,
@@ -61,19 +60,19 @@ type Props<ParamList extends object> = Omit<NavigationContainerProps, 'initialSt
  * @param props.children Child elements to render the content.
  * @param props.ref Ref object which refers to the navigation object containing helper methods.
  */
-function NavigationContainerInner(
-  {
-    direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
-    theme = DefaultTheme,
-    linking,
-    fallback = null,
-    documentTitle,
-    onReady,
-    onStateChange,
-    ...rest
-  }: Props<ParamListBase>,
-  ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>
-) {
+function NavigationContainerInner({
+  direction = I18nManager.getConstants().isRTL ? 'rtl' : 'ltr',
+  theme = DefaultTheme,
+  linking,
+  fallback = null,
+  documentTitle,
+  onReady,
+  onStateChange,
+  ref,
+  ...rest
+}: Props<ParamListBase> & {
+  ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>;
+}) {
   const routerConfig = React.use(RouterConfigContext);
 
   if (linking?.config) {
@@ -179,20 +178,8 @@ function NavigationContainerInner(
   );
 }
 
-const NavigationContainerContent = React.forwardRef(NavigationContainerInner);
-
-// TODO(@ubax): Remove this component once we require single container in the whole app
-function NavigationContainerWithQueue(
-  props: Props<ParamListBase>,
-  ref?: React.Ref<NavigationContainerRef<ParamListBase> | null>
-) {
-  const api = React.use(RoutingQueueApiContext);
-  const content = <NavigationContainerContent {...props} ref={ref} />;
-
-  return api === undefined ? <RoutingQueueProvider>{content}</RoutingQueueProvider> : content;
-}
-
-export const NavigationContainer = React.forwardRef(NavigationContainerWithQueue) as <
+// The implementation uses the base param list, while callers retain their concrete route types.
+export const NavigationContainer = NavigationContainerInner as <
   RootParamList extends object = ReactNavigation.RootParamList,
 >(
   props: Props<RootParamList> & {

--- a/packages/expo-router/src/fork/__tests__/__fixtures__/store.tsx
+++ b/packages/expo-router/src/fork/__tests__/__fixtures__/store.tsx
@@ -12,7 +12,9 @@ import type { RoutingIntent } from '../../../global-state/routingQueue';
 import type { RouteNode } from '../../../Route';
 import { defaultRouteInfo, getRouteInfoFromState } from '../../../global-state/getRouteInfoFromState';
 import { RouteInfoContext } from '../../../global-state/routeInfoContext';
+import { RemovalPreventionProvider } from '../../../global-state/removalPrevention';
 import { RouterConfigContext } from '../../../global-state/routerConfigContext';
+import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
 import type { NavigationState } from '../../../react-navigation/routers';
 
 let routeNode: RouteNode | null = null;
@@ -45,7 +47,11 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   return (
     <RoutingQueueProvider>
       <RouterConfigContext.Provider value={{ linking: undefined, redirects: [], routeNode }}>
-        <RouteInfoContext.Provider value={routeInfo}>{children}</RouteInfoContext.Provider>
+        <RouterRegistryProvider>
+          <RemovalPreventionProvider>
+            <RouteInfoContext.Provider value={routeInfo}>{children}</RouteInfoContext.Provider>
+          </RemovalPreventionProvider>
+        </RouterRegistryProvider>
         <PendingIntentsProbe />
       </RouterConfigContext.Provider>
     </RoutingQueueProvider>

--- a/packages/expo-router/src/react-navigation/__tests__/exports.test.ts
+++ b/packages/expo-router/src/react-navigation/__tests__/exports.test.ts
@@ -7,6 +7,7 @@ describe('react-navigation/index re-exports', () => {
     expect(Index).not.toHaveProperty('createComponentForStaticNavigation');
     expect(Index).not.toHaveProperty('createPathConfigForStaticNavigation');
     expect(Index).not.toHaveProperty('NavigationContainer');
+    expect(Index).not.toHaveProperty('BaseNavigationContainer');
   });
 
   it.each([

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -10,13 +10,11 @@ import {
   areUrlObjectsEqual,
   getRouteInfoFromState,
 } from '../../global-state/getRouteInfoFromState';
-import {
-  GlobalRoutesWithRemovalPreventedContext,
-  RemovalPreventionProvider,
-} from '../../global-state/removalPrevention';
+import { GlobalRoutesWithRemovalPreventedContext } from '../../global-state/removalPrevention';
 import { RouteInfoContext } from '../../global-state/routeInfoContext';
 import { RouterConfigContext } from '../../global-state/routerConfigContext';
-import { RouterRegistryContext, RouterRegistryProvider } from '../../global-state/routerRegistry';
+import { RouterRegistryContext } from '../../global-state/routerRegistry';
+import { RoutingQueueApiContext } from '../../global-state/routingQueueContext';
 import { useNavigationTreeReducer } from '../../global-state/useNavigationTreeReducer';
 import { useNavigationTreeReportEvents } from '../../global-state/useNavigationTreeReportEvents';
 import useLatestCallback from '../../utils/useLatestCallback';
@@ -69,32 +67,13 @@ const duplicateNameWarnings: string[] = [];
  * @param props.ref Ref object which refers to the navigation object containing helper methods.
  */
 export function BaseNavigationContainer(props: InternalNavigationContainerProps) {
-  const registry = use(RouterRegistryContext);
-  const routesWithRemovalPrevented = use(GlobalRoutesWithRemovalPreventedContext);
-
-  // TODO(@ubax): investigate if this is really needed
-  let content = <BaseNavigationContainerInner {...props} />;
-  if (routesWithRemovalPrevented === undefined) {
-    content = <RemovalPreventionProvider>{content}</RemovalPreventionProvider>;
-  }
-  if (registry === undefined) {
-    content = <RouterRegistryProvider>{content}</RouterRegistryProvider>;
-  }
-  return content;
-}
-
-function BaseNavigationContainerInner({
-  ref,
-  initialState,
-  onStateChange,
-  onReady,
-  UNSTABLE_routeNode,
-  theme,
-  children,
-}: InternalNavigationContainerProps) {
+  const { ref, initialState, onStateChange, onReady, UNSTABLE_routeNode, theme, children } = props;
   const parent = use(NavigationStateContext);
   const inheritedRouteInfo = use(RouteInfoContext);
   const routerConfig = use(RouterConfigContext);
+  const routingQueue = use(RoutingQueueApiContext);
+  const registry = use(RouterRegistryContext);
+  const routesWithRemovalPrevented = use(GlobalRoutesWithRemovalPreventedContext);
 
   if (!parent.isDefault) {
     throw new Error(
@@ -102,8 +81,16 @@ function BaseNavigationContainerInner({
     );
   }
 
-  const registry = use(RouterRegistryContext)!;
-  const routesWithRemovalPrevented = use(GlobalRoutesWithRemovalPreventedContext)!;
+  if (
+    routingQueue === undefined ||
+    registry === undefined ||
+    routesWithRemovalPrevented === undefined
+  ) {
+    throw new Error(
+      'The navigation container requires the shared routing state provided by `ExpoRoot`. Render the navigation container inside `ExpoRoot`.'
+    );
+  }
+
   const emitter = useEventEmitter<NavigationContainerEventMap>();
 
   // TODO(@ubax): consider moving this state to ExpoRoot.

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react-native';
 import * as React from 'react';
 
+import { RemovalPreventionProvider } from '../../../global-state/removalPrevention';
 import { RouterRegistryProvider } from '../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../global-state/routingQueueContext';
 import {
@@ -32,6 +33,16 @@ beforeEach(() => {
   require('nanoid/non-secure').__key = 0;
 });
 
+function RootProviders({ children }: React.PropsWithChildren) {
+  return (
+    <RoutingQueueProvider>
+      <RouterRegistryProvider>
+        <RemovalPreventionProvider>{children}</RemovalPreventionProvider>
+      </RouterRegistryProvider>
+    </RoutingQueueProvider>
+  );
+}
+
 test('throws when nesting containers', () => {
   expect(() =>
     render(
@@ -44,12 +55,33 @@ test('throws when nesting containers', () => {
   ).toThrow("install '@react-navigation/native' and use its NavigationContainer instead.");
 });
 
+test('throws when rendered outside ExpoRoot', () => {
+  expect(() =>
+    render(
+      <RawBaseNavigationContainer
+        initialState={
+          {
+            stale: false,
+            routeKeySeq: 0,
+            key: 'root',
+            index: 0,
+            routeNames: ['home'],
+            routes: [{ key: 'home', name: 'home' }],
+          } as NavigationState
+        }>
+        {null}
+      </RawBaseNavigationContainer>
+    )
+  ).toThrow('Render the navigation container inside `ExpoRoot`.');
+});
+
 test('rejects a partial initial state', () => {
   const initialState = { routes: [{ name: 'home' }] };
 
   expect(() =>
     render(
-      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>
+      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>,
+      { wrapper: RootProviders }
     )
   ).toThrow('The navigation container received an incomplete initial state.');
 });
@@ -74,7 +106,8 @@ test('rejects a partial nested initial state', () => {
 
   expect(() =>
     render(
-      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>
+      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>,
+      { wrapper: RootProviders }
     )
   ).toThrow('The navigation container received an incomplete initial state.');
 });
@@ -90,7 +123,8 @@ test('rejects an initial state without an index', () => {
 
   expect(() =>
     render(
-      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>
+      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>,
+      { wrapper: RootProviders }
     )
   ).toThrow('The navigation container received an incomplete initial state.');
 });
@@ -107,7 +141,8 @@ test('rejects an initial state without route keys', () => {
 
   expect(() =>
     render(
-      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>
+      <RawBaseNavigationContainer initialState={initialState}>{null}</RawBaseNavigationContainer>,
+      { wrapper: RootProviders }
     )
   ).toThrow('The navigation container received an incomplete initial state.');
 });
@@ -136,11 +171,13 @@ test('preserves a complete initial state by identity', () => {
   render(
     <RoutingQueueProvider>
       <RouterRegistryProvider>
-        <RawBaseNavigationContainer ref={ref} initialState={initialState}>
-          <Stack>
-            <Screen name="home">{() => null}</Screen>
-          </Stack>
-        </RawBaseNavigationContainer>
+        <RemovalPreventionProvider>
+          <RawBaseNavigationContainer ref={ref} initialState={initialState}>
+            <Stack>
+              <Screen name="home">{() => null}</Screen>
+            </Stack>
+          </RawBaseNavigationContainer>
+        </RemovalPreventionProvider>
       </RouterRegistryProvider>
     </RoutingQueueProvider>
   );
@@ -205,17 +242,19 @@ test('handle dispatching with ref', () => {
   const element = (
     <RoutingQueueProvider>
       <RouterRegistryProvider>
-        <RawBaseNavigationContainer
-          ref={ref}
-          initialState={initialState}
-          onStateChange={onStateChange}>
-          <RootNavigator>
-            <Screen name="foo">{() => null}</Screen>
-            <Screen name="foo2">{() => null}</Screen>
-            <Screen name="bar">{() => null}</Screen>
-            <Screen name="baz">{() => null}</Screen>
-          </RootNavigator>
-        </RawBaseNavigationContainer>
+        <RemovalPreventionProvider>
+          <RawBaseNavigationContainer
+            ref={ref}
+            initialState={initialState}
+            onStateChange={onStateChange}>
+            <RootNavigator>
+              <Screen name="foo">{() => null}</Screen>
+              <Screen name="foo2">{() => null}</Screen>
+              <Screen name="bar">{() => null}</Screen>
+              <Screen name="baz">{() => null}</Screen>
+            </RootNavigator>
+          </RawBaseNavigationContainer>
+        </RemovalPreventionProvider>
       </RouterRegistryProvider>
     </RoutingQueueProvider>
   );

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { nanoid } from 'nanoid/non-secure';
 
+import { RemovalPreventionProvider } from '../../../../global-state/removalPrevention';
 import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../../global-state/routingQueueContext';
 import type { NavigationState, ParamListBase, PartialState } from '../../../routers';
@@ -144,11 +145,13 @@ export function BaseNavigationContainer(props: Props) {
   return (
     <RoutingQueueProvider>
       <RouterRegistryProvider>
-        <BaseNavigationContainerImpl
-          {...rest}
-          ref={setRef}
-          initialState={completeState(rest.initialState, rest.children)}
-        />
+        <RemovalPreventionProvider>
+          <BaseNavigationContainerImpl
+            {...rest}
+            ref={setRef}
+            initialState={completeState(rest.initialState, rest.children)}
+          />
+        </RemovalPreventionProvider>
       </RouterRegistryProvider>
     </RoutingQueueProvider>
   );

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/NavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/NavigationContainer.tsx
@@ -2,7 +2,9 @@ import * as React from 'react';
 
 import { NavigationContainer as NavigationContainerImpl } from '../../../../fork/NavigationContainer';
 import { getStateFromPath, type ResultState } from '../../../../fork/getStateFromPath';
+import { RemovalPreventionProvider } from '../../../../global-state/removalPrevention';
 import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
+import { RoutingQueueProvider } from '../../../../global-state/routingQueueContext';
 import type { NavigationState } from '../../../routers';
 
 type Props = React.ComponentProps<typeof NavigationContainerImpl> & {
@@ -32,8 +34,12 @@ export const NavigationContainer = React.forwardRef(function NavigationContainer
     : linking;
 
   return (
-    <RouterRegistryProvider>
-      <NavigationContainerImpl {...props} linking={linkingWithInitialState} ref={ref} />
-    </RouterRegistryProvider>
+    <RoutingQueueProvider>
+      <RouterRegistryProvider>
+        <RemovalPreventionProvider>
+          <NavigationContainerImpl {...props} linking={linkingWithInitialState} ref={ref} />
+        </RemovalPreventionProvider>
+      </RouterRegistryProvider>
+    </RoutingQueueProvider>
   );
 });

--- a/packages/expo-router/src/react-navigation/core/index.tsx
+++ b/packages/expo-router/src/react-navigation/core/index.tsx
@@ -1,8 +1,3 @@
-/**
- * @deprecated `ExpoRoot` mounts the navigation container automatically — there is no need
- * to render `BaseNavigationContainer` directly. Will be removed in a future SDK.
- */
-export { BaseNavigationContainer } from './BaseNavigationContainer';
 export { createNavigationContainerRef } from './createNavigationContainerRef';
 export { createNavigatorFactory } from './createNavigatorFactory';
 /**


### PR DESCRIPTION
# Why

During global state refactor unnecessary wrapping was added to `BaseNavigationContainer` and `NavigationContainer`

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
