### PR TITLE
[router] Remove onStateChange prop from NavigationContainer

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -88,6 +88,7 @@
 ### 💡 Others
 
 - Pass toolbar menu icons straight to react-navigation instead of converting them to react-native-screens icons. (by [@Ubax](https://github.com/Ubax)) ([#49584](https://github.com/expo/expo/pull/49584) by [@Ubax](https://github.com/Ubax))
+- Remove `onStateChange` from `BaseNavigationContainer` and `NavigationContainerProps` in `expo-router/react-navigation`
 - Remove module-level mutable navigation state from Expo Router. ([#49403](https://github.com/expo/expo/pull/49403) by [@Ubax](https://github.com/Ubax))
 - Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`. ([#49431](https://github.com/expo/expo/pull/49431) by [@Ubax](https://github.com/Ubax))
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -88,7 +88,7 @@
 ### 💡 Others
 
 - Pass toolbar menu icons straight to react-navigation instead of converting them to react-native-screens icons. (by [@Ubax](https://github.com/Ubax)) ([#49584](https://github.com/expo/expo/pull/49584) by [@Ubax](https://github.com/Ubax))
-- Remove `onStateChange` from `BaseNavigationContainer` and `NavigationContainerProps` in `expo-router/react-navigation`
+- Remove `onStateChange` from `BaseNavigationContainer` and `NavigationContainerProps` in `expo-router/react-navigation` ([#49588](https://github.com/expo/expo/pull/49588) by [@Ubax](https://github.com/Ubax))
 - Remove module-level mutable navigation state from Expo Router. ([#49403](https://github.com/expo/expo/pull/49403) by [@Ubax](https://github.com/Ubax))
 - Remove the dev-only `stack` field from the `__unsafe_action__` event in `expo-router/react-navigation`. ([#49431](https://github.com/expo/expo/pull/49431) by [@Ubax](https://github.com/Ubax))
 - Read navigation state from the React tree instead of imperative refs. ([#49433](https://github.com/expo/expo/pull/49433) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/fork/NavigationContainer.tsx
+++ b/packages/expo-router/src/fork/NavigationContainer.tsx
@@ -47,7 +47,6 @@ type Props<ParamList extends object> = Omit<NavigationContainerProps, 'initialSt
  * This should be rendered at the root wrapping the whole app.
  *
  * @param props.onReady Callback which is called after the navigation tree mounts.
- * @param props.onStateChange Callback which is called with the latest navigation state when it changes.
  * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.direction Text direction of the components. Defaults to `'ltr'`.
  * @param props.theme Theme object for the UI elements.

--- a/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
+++ b/packages/expo-router/src/fork/__tests__/useLinking.test.web.tsx
@@ -348,7 +348,6 @@ test('does not add browser history when preloading a stack route', async () => {
       <NavigationContainer
         ref={ref}
         documentTitle={{ enabled: false }}
-        onStateChange={onStateChange}
         linking={{
           prefixes: [],
           config: { screens: { home: 'home', details: 'details' } },
@@ -364,6 +363,7 @@ test('does not add browser history when preloading a stack route', async () => {
   );
 
   await waitFor(() => expect(ref.current).not.toBeNull());
+  ref.current?.addListener('state', onStateChange);
   history.push.mockClear();
   history.replace.mockClear();
 

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -22,7 +22,6 @@ import {
   CommonActions,
   type InitialState,
   type NavigationAction,
-  type NavigationState,
   type ParamListBase,
   type Route,
 } from '../routers';
@@ -60,14 +59,13 @@ const duplicateNameWarnings: string[] = [];
  *
  * @param props.initialState Initial state object for the navigation tree.
  * @param props.onReady Callback which is called after the navigation tree mounts.
- * @param props.onStateChange Callback which is called with the latest navigation state when it changes.
  * @param props.onUnhandledAction Callback which is called when an action is not handled. TODO(@ubax): restore this callback. https://linear.app/expo/issue/ENG-26123
  * @param props.theme Theme object for the UI elements.
  * @param props.children Child elements to render the content.
  * @param props.ref Ref object which refers to the navigation object containing helper methods.
  */
 export function BaseNavigationContainer(props: InternalNavigationContainerProps) {
-  const { ref, initialState, onStateChange, onReady, UNSTABLE_routeNode, theme, children } = props;
+  const { ref, initialState, onReady, UNSTABLE_routeNode, theme, children } = props;
   const parent = use(NavigationStateContext);
   const inheritedRouteInfo = use(RouteInfoContext);
   const routerConfig = use(RouterConfigContext);
@@ -104,9 +102,6 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
       redirects: routerConfig?.redirects,
     });
   useNavigationTreeReportEvents(report, consumeReportEvents);
-
-  const hasNotifiedInitialStateRef = React.useRef(false);
-  const lastNotifiedStateRef = React.useRef<NavigationState | undefined>(undefined);
 
   const { listeners, addListener } = useChildListeners();
 
@@ -247,10 +242,8 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   }
 
   const onReadyRef = React.useRef(onReady);
-  const onStateChangeRef = React.useRef(onStateChange);
 
   React.useEffect(() => {
-    onStateChangeRef.current = onStateChange;
     onReadyRef.current = onReady;
   });
 
@@ -331,24 +324,8 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   }, [getRootState, state]);
 
   useClientLayoutEffect(() => {
-    const hydratedState = getRootState();
-
-    // TODO(@ubax): invesitagte if there is cleaner way to do it
-    // If not consider deprecating the prop
-    const onStateChange = onStateChangeRef.current;
-    const shouldNotifyStateChange =
-      hasNotifiedInitialStateRef.current &&
-      lastNotifiedStateRef.current !== hydratedState &&
-      onStateChange !== undefined;
-    hasNotifiedInitialStateRef.current = true;
-    lastNotifiedStateRef.current = hydratedState;
-
     emitter.emit({ type: 'state', data: { state } });
-
-    if (shouldNotifyStateChange) {
-      onStateChange(hydratedState);
-    }
-  }, [getRootState, emitter, state]);
+  }, [emitter, state]);
 
   return (
     <NavigationContainerRefContext.Provider value={navigation}>

--- a/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/BaseNavigationContainer.test.ios.tsx
@@ -243,10 +243,7 @@ test('handle dispatching with ref', () => {
     <RoutingQueueProvider>
       <RouterRegistryProvider>
         <RemovalPreventionProvider>
-          <RawBaseNavigationContainer
-            ref={ref}
-            initialState={initialState}
-            onStateChange={onStateChange}>
+          <RawBaseNavigationContainer ref={ref} initialState={initialState}>
             <RootNavigator>
               <Screen name="foo">{() => null}</Screen>
               <Screen name="foo2">{() => null}</Screen>
@@ -260,6 +257,7 @@ test('handle dispatching with ref', () => {
   );
 
   render(element).update(element);
+  ref.current?.addListener('state', () => onStateChange(ref.current!.getRootState()));
 
   act(() => {
     ref.current?.dispatch({ type: 'REVERSE' });

--- a/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/__tests__/__fixtures__/BaseNavigationContainer.tsx
@@ -4,14 +4,19 @@ import { nanoid } from 'nanoid/non-secure';
 import { RemovalPreventionProvider } from '../../../../global-state/removalPrevention';
 import { RouterRegistryProvider } from '../../../../global-state/routerRegistry';
 import { RoutingQueueProvider } from '../../../../global-state/routingQueueContext';
+import useLatestCallback from '../../../../utils/useLatestCallback';
 import type { NavigationState, ParamListBase, PartialState } from '../../../routers';
 import type { NavigationContainerRef } from '../../types';
 import { BaseNavigationContainer as BaseNavigationContainerImpl } from '../../BaseNavigationContainer';
 import { MockRouterKey } from './MockRouter';
 
 type TestInitialState = NavigationState | PartialState<NavigationState>;
-type Props = Omit<React.ComponentProps<typeof BaseNavigationContainerImpl>, 'initialState'> & {
+type Props = Omit<
+  React.ComponentProps<typeof BaseNavigationContainerImpl>,
+  'initialState' | 'onStateChange'
+> & {
   initialState?: TestInitialState;
+  onStateChange?: (state: NavigationState | undefined) => void;
 };
 
 function getInitialState(children: React.ReactNode): NavigationState {
@@ -127,8 +132,16 @@ function completeState(
 }
 
 export function BaseNavigationContainer(props: Props) {
-  const { ref, ...rest } = props;
+  const { onStateChange, ref, ...rest } = props;
   const navigationRef = React.useRef<NavigationContainerRef<ParamListBase> | null>(null);
+  const notifyStateChange = useLatestCallback(() => {
+    onStateChange?.(navigationRef.current?.getRootState());
+  });
+
+  React.useEffect(() => {
+    // Subscribe after mount so the container's initial state event is ignored.
+    return navigationRef.current?.addListener('state', notifyStateChange);
+  }, []);
 
   const setRef = React.useCallback(
     (navigation: NavigationContainerRef<ParamListBase> | null) => {

--- a/packages/expo-router/src/react-navigation/core/types.tsx
+++ b/packages/expo-router/src/react-navigation/core/types.tsx
@@ -400,10 +400,6 @@ export type NavigationContainerProps = {
    */
   initialState?: InitialState;
   /**
-   * Callback which is called with the latest navigation state when it changes.
-   */
-  onStateChange?: (state: Readonly<NavigationState> | undefined) => void;
-  /**
    * Callback which is called after the navigation tree mounts.
    */
   onReady?: () => void;


### PR DESCRIPTION
# Why

`onStateChange` is unused prop of `NavigationContainer` which cannot be used by users - expo-router exposes no way to use it.

# How

1. Remove the `onStateChange`

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
