### PR TITLE
[ios][camera] Restore shutter animation

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] Return zeroed `bounds` and `cornerPoints` from the ZXing fallback scanner so scanning a `pdf417`, `code39`, or `codabar` code no longer crashes with `Cannot read property 'origin' of undefined`. ([#47854](https://github.com/expo/expo/pull/47854) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix `responsiveOrientationWhenOrientationLocked: false` being ignored — photos and videos captured while the app orientation is locked now follow the locked interface orientation instead of the physical device rotation. ([#47881](https://github.com/expo/expo/pull/47881) by [@jiunshinn](https://github.com/jiunshinn))
 - [iOS] Read the capture interface orientation from the scene the camera view is in rather than an arbitrary connected scene. ([#48315](https://github.com/expo/expo/pull/48315) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Restore the shutter animation on capture, which stopped running when the photo capture delegate moved off `CameraView`, leaving `animateShutter` with no effect.
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [iOS] Return zeroed `bounds` and `cornerPoints` from the ZXing fallback scanner so scanning a `pdf417`, `code39`, or `codabar` code no longer crashes with `Cannot read property 'origin' of undefined`. ([#47854](https://github.com/expo/expo/pull/47854) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix `responsiveOrientationWhenOrientationLocked: false` being ignored — photos and videos captured while the app orientation is locked now follow the locked interface orientation instead of the physical device rotation. ([#47881](https://github.com/expo/expo/pull/47881) by [@jiunshinn](https://github.com/jiunshinn))
 - [iOS] Read the capture interface orientation from the scene the camera view is in rather than an arbitrary connected scene. ([#48315](https://github.com/expo/expo/pull/48315) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Restore the shutter animation on capture, which stopped running when the photo capture delegate moved off `CameraView`, leaving `animateShutter` with no effect.
+- [iOS] Restore the shutter animation on capture, which stopped running when the photo capture delegate moved off `CameraView`, leaving `animateShutter` with no effect. ([#49591](https://github.com/expo/expo/pull/49591) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
+++ b/packages/expo-camera/ios/Current/CameraPhotoCapture.swift
@@ -11,7 +11,10 @@ protocol CameraPhotoCaptureDelegate: AnyObject {
   var presetCamera: AVCaptureDevice.Position { get }
   var mirror: Bool { get }
   var flashMode: FlashMode { get }
+  var animateShutter: Bool { get }
   var onPictureSaved: EventDispatcher { get }
+
+  func playShutterAnimation()
 }
 
 class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
@@ -111,9 +114,18 @@ class CameraPhotoCapture: NSObject, AVCapturePhotoCaptureDelegate {
   }
 
   func photoOutput(_ output: AVCapturePhotoOutput, willCapturePhotoFor resolvedSettings: AVCaptureResolvedPhotoSettings) {
+    willCapturePhoto()
+  }
+
+  func willCapturePhoto() {
     if photoCaptureOptions?.shutterSound == false {
       AudioServicesDisposeSystemSoundID(1108)
     }
+
+    guard let captureDelegate, captureDelegate.animateShutter else {
+      return
+    }
+    captureDelegate.playShutterAnimation()
   }
 
   func photoOutput(

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -299,6 +299,15 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     return try await photoCapture.takePicturePromise(options: options, photoOutput: photoOutput)
   }
 
+  func playShutterAnimation() {
+    Task { @MainActor in
+      self.previewLayer.opacity = 0
+      UIView.animate(withDuration: 0.25) {
+        self.previewLayer.opacity = 1
+      }
+    }
+  }
+
   func record(options: CameraRecordingOptions, promise: Promise) async {
     guard let videoFileOutput = sessionManager.currentVideoFileOutput else {
       promise.reject(CameraOutputNotReadyException())

--- a/packages/expo-camera/ios/Tests/CameraPhotoCaptureTests.swift
+++ b/packages/expo-camera/ios/Tests/CameraPhotoCaptureTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import UIKit
+import AVFoundation
+import ExpoModulesCore
+
+@testable import ExpoCamera
+
+/// Minimal stand-in for `CameraView` as seen by `CameraPhotoCapture`.
+/// Every property mirrors the real defaults in `CameraView.swift`.
+private final class MockCameraViewDelegate: CameraPhotoCaptureDelegate {
+  var appContext: AppContext?
+  let previewLayer = AVCaptureVideoPreviewLayer()
+  var deviceOrientation: UIInterfaceOrientation = .portrait
+  var responsiveWhenOrientationLocked = false
+  var physicalOrientation: UIDeviceOrientation = .portrait
+  var presetCamera: AVCaptureDevice.Position = .back
+  var mirror = false
+  var flashMode: FlashMode = .off
+  let onPictureSaved = EventDispatcher()
+
+  var animateShutter = true
+  private(set) var shutterAnimationCount = 0
+
+  func playShutterAnimation() {
+    shutterAnimationCount += 1
+  }
+}
+
+@Suite("CameraPhotoCapture")
+struct CameraPhotoCaptureTests {
+  // Moving the `AVCapturePhotoCaptureDelegate` conformance off `CameraView` in #37393 carried
+  // over the shutter *sound* handling but dropped the shutter *animation*, so `animateShutter`
+  // became a prop nothing on iOS ever read. See https://github.com/expo/expo/issues/47433.
+  @Test
+  func `plays the shutter animation when a capture begins`() {
+    let delegate = MockCameraViewDelegate()
+    let capture = CameraPhotoCapture(delegate: delegate)
+
+    capture.willCapturePhoto()
+
+    #expect(delegate.shutterAnimationCount == 1)
+  }
+
+  @Test
+  func `does not play the shutter animation when animateShutter is false`() {
+    let delegate = MockCameraViewDelegate()
+    delegate.animateShutter = false
+    let capture = CameraPhotoCapture(delegate: delegate)
+
+    capture.willCapturePhoto()
+
+    #expect(delegate.shutterAnimationCount == 0)
+  }
+}


### PR DESCRIPTION
# Why
Closes #47433
Fixes a regression from  #37393
On iOS, CameraView no longer plays the shutter animation when it takes a picture. The animateShutter prop has no effect. Android is unaffected.

# How
CameraPhotoCaptureDelegate gains animateShutter and a playShutterAnimation() method. CameraPhotoCapture calls the method when a capture begins, and CameraView implements it.

# Test Plan
Bare expo

