### PR TITLE
[router] Fix animation when pushing to stack nested in tab

### DIFF
--- a/packages/expo-router/src/native-tabs/NativeBottomTabsRouter.tsx
+++ b/packages/expo-router/src/native-tabs/NativeBottomTabsRouter.tsx
@@ -53,6 +53,34 @@ function removeZoomParamsFromState<T extends NavigationState | PartialState<Navi
   return changed ? ({ ...state, routes } as T) : state;
 }
 
+function appendNoAnimationParamToFocusedRoutes<
+  T extends NavigationState | PartialState<NavigationState>,
+>(state: T): T {
+  const focusedIndex = state.index ?? state.routes.length - 1;
+  const focusedRoute = state.routes[focusedIndex];
+  if (!focusedRoute) {
+    return state;
+  }
+
+  const childState = focusedRoute.state
+    ? appendNoAnimationParamToFocusedRoutes(focusedRoute.state)
+    : undefined;
+  const routes = state.routes.map((route, index) =>
+    index === focusedIndex
+      ? {
+          ...route,
+          params: appendInternalExpoRouterParams(route.params, {
+            [INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME]: true,
+          }),
+          ...(childState ? { state: childState } : undefined),
+        }
+      : route
+  );
+
+  // The mapped routes preserve the input state's full or partial route shape.
+  return { ...state, routes } as T;
+}
+
 export function NativeBottomTabsRouter(options: TabRouterOptions) {
   const tabRouter = TabRouter({ ...options });
 
@@ -71,6 +99,13 @@ export function NativeBottomTabsRouter(options: TabRouterOptions) {
           if (!newStateFromNavigation) {
             return actionResult;
           }
+          const focusedRouteKey = state.routes[state.index]?.key;
+          const nextFocusedRouteKey =
+            newStateFromNavigation.routes[newStateFromNavigation.index]?.key;
+          const didTabChange =
+            focusedRouteKey !== undefined &&
+            nextFocusedRouteKey !== undefined &&
+            focusedRouteKey !== nextFocusedRouteKey;
           const index = newStateFromNavigation.routes.findIndex(
             (route) => route.name === action.payload.name
           );
@@ -89,13 +124,6 @@ export function NativeBottomTabsRouter(options: TabRouterOptions) {
                 action.payload.params
               );
 
-              // TODO(@uabx): After __internal__routerActionState, change this to just state
-              const isDeepDestination =
-                action.payload.state?.__internal__routerActionState === true;
-              if (isDeepDestination) {
-                expoParams[INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME] = true;
-              }
-
               if (process.env.NODE_ENV !== 'production') {
                 if (expoParams[INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME]) {
                   console.warn(
@@ -111,7 +139,14 @@ export function NativeBottomTabsRouter(options: TabRouterOptions) {
                 appendInternalExpoRouterParams(route.params, expoParams),
                 zoomParamNames
               );
-              const childState = route.state ? removeZoomParamsFromState(route.state) : undefined;
+              let childState = route.state ? removeZoomParamsFromState(route.state) : undefined;
+              if (
+                childState &&
+                didTabChange &&
+                action.payload.state?.__internal__routerActionState === true
+              ) {
+                childState = appendNoAnimationParamToFocusedRoutes(childState);
+              }
               return {
                 ...route,
                 ...(childState ? { state: childState } : undefined),

--- a/packages/expo-router/src/native-tabs/__tests__/NativeBottomTabsRouter.test.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/NativeBottomTabsRouter.test.tsx
@@ -75,16 +75,75 @@ test('post-processes a first navigation to an unvisited tab', () => {
 
   expect(route.name).toBe('second');
   expect(affectedRouteKey).toBe(route.key);
-  expect(params[INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME]).toBe(true);
+  expect(params).not.toHaveProperty(INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME);
   expect(params).not.toHaveProperty(INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SCREEN_ID_PARAM_NAME);
   expect(params).not.toHaveProperty(INTERNAL_EXPO_ROUTER_ZOOM_TRANSITION_SOURCE_ID_PARAM_NAME);
-  expect(route.state?.routes[0]?.params).toEqual({});
+  expect(route.state?.routes[0]?.params).toEqual({
+    [INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME]: true,
+  });
   expect(route.state?.routes[0]?.state?.routes[0]?.params).toEqual({
     value: 'kept',
+    [INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME]: true,
   });
   expect(warn).toHaveBeenCalledWith(
     'Zoom transition is not supported when navigating between tabs. Falling back to standard navigation transition.'
   );
+});
+
+test('does not disable animation when navigating within the focused tab', () => {
+  const router = NativeBottomTabsRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['index', 'second'],
+    routeGetIdList: {},
+  };
+  const state = createInitialState<TabNavigationState<ParamListBase>>({
+    ...options,
+    parentChain: 'test',
+  });
+
+  const result = router.getStateForAction(
+    state,
+    {
+      type: 'NAVIGATE',
+      payload: {
+        name: 'index',
+        state: {
+          routes: [
+            {
+              name: 'nested',
+              state: {
+                routes: [{ name: 'deep' }],
+              },
+            },
+          ],
+          __internal__routerActionState: true,
+        },
+      },
+    },
+    options
+  )!;
+  const route = result.state.routes[result.state.index!]!;
+
+  expect(route.params).toBeUndefined();
+  expect(route.state?.routes[0]?.params).toBeUndefined();
+  expect(route.state?.routes[0]?.state?.routes[0]?.params).toBeUndefined();
+});
+
+test('does not disable animation for a tab-bar navigation action', () => {
+  const router = NativeBottomTabsRouter({});
+  const options: RouterConfigOptions = {
+    routeNames: ['index', 'second'],
+    routeGetIdList: {},
+  };
+  const state = createInitialState<TabNavigationState<ParamListBase>>({
+    ...options,
+    parentChain: 'test',
+  });
+
+  const result = router.getStateForAction(state, CommonActions.navigate('second'), options)!;
+  const route = result.state.routes[result.state.index!]!;
+
+  expect(route.params).toBeUndefined();
 });
 
 test('does not treat a screen param as a deep destination', () => {

--- a/packages/expo-router/src/native-tabs/__tests__/stack-animation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/stack-animation.test.ios.tsx
@@ -1,0 +1,94 @@
+import { act } from '@testing-library/react-native';
+import { View } from 'react-native';
+
+import { router } from '../../imperative-api';
+import Stack from '../../layouts/StackClient';
+import { INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME } from '../../navigationParams';
+import { renderRouter, screen } from '../../testing-library';
+import { NativeTabs } from '../NativeTabs';
+
+jest.mock('react-native-screens', () => {
+  const { View }: typeof import('react-native') = jest.requireActual('react-native');
+  const actualScreens = jest.requireActual(
+    'react-native-screens'
+  ) as typeof import('react-native-screens');
+  return {
+    ...actualScreens,
+    ScreenStackItem: jest.fn((props) => <actualScreens.ScreenStackItem {...props} />),
+    Tabs: {
+      ...actualScreens.Tabs,
+      Host: jest.fn(({ children }) => <View>{children}</View>),
+      Screen: jest.fn(({ children }) => <View>{children}</View>),
+    },
+  };
+});
+
+const { ScreenStackItem } = jest.requireMock(
+  'react-native-screens'
+) as typeof import('react-native-screens');
+const MockedScreenStackItem = ScreenStackItem as jest.MockedFunction<typeof ScreenStackItem>;
+type StackItemProps = Parameters<typeof ScreenStackItem>[0];
+
+function latestStackItemProps(routeName: string): StackItemProps | undefined {
+  return MockedScreenStackItem.mock.calls
+    .map((call) => call[0])
+    .filter(
+      (props) => typeof props.screenId === 'string' && props.screenId.startsWith(`${routeName}:`)
+    )
+    .at(-1);
+}
+
+const routes = {
+  _layout: () => (
+    <NativeTabs>
+      <NativeTabs.Trigger name="first" />
+      <NativeTabs.Trigger name="second" />
+    </NativeTabs>
+  ),
+  'first/_layout': () => <Stack />,
+  'first/index': () => <View testID="first-index" />,
+  'second/_layout': () => <Stack />,
+  'second/index': () => <View testID="second-index" />,
+  'second/details': () => <View testID="second-details" />,
+  'second/final': () => <View testID="second-final" />,
+};
+
+beforeEach(() => {
+  MockedScreenStackItem.mockClear();
+});
+
+it('disables animation only for the first stack screen reached across tabs', () => {
+  const result = renderRouter(routes, { initialUrl: '/first' });
+
+  act(() => router.push('/second/details'));
+
+  expect(screen).toHavePathname('/second/details');
+  expect(latestStackItemProps('details')?.stackAnimation).toBe('none');
+
+  const tabsState = result.getRouterState()!.routes[0]!.state!;
+  const secondTab = tabsState.routes.find((route) => route.name === 'second')!;
+  const details = secondTab.state!.routes.find((route) => route.name === 'details')!;
+  expect(details.params).toHaveProperty(INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME, true);
+
+  act(() => latestStackItemProps('details')!.onAppear!({} as never));
+
+  const updatedTabsState = result.getRouterState()!.routes[0]!.state!;
+  const updatedSecondTab = updatedTabsState.routes.find((route) => route.name === 'second')!;
+  const updatedDetails = updatedSecondTab.state!.routes.find((route) => route.name === 'details')!;
+  expect(updatedDetails.params).not.toHaveProperty(INTERNAL_EXPO_ROUTER_NO_ANIMATION_PARAM_NAME);
+
+  MockedScreenStackItem.mockClear();
+  act(() => router.push('/second/final'));
+
+  expect(screen).toHavePathname('/second/final');
+  expect(latestStackItemProps('final')?.stackAnimation).toBeUndefined();
+});
+
+it('keeps the default animation when pushing within the focused tab', () => {
+  renderRouter(routes, { initialUrl: '/second' });
+
+  act(() => router.push('/second/details'));
+
+  expect(screen).toHavePathname('/second/details');
+  expect(latestStackItemProps('details')?.stackAnimation).toBeUndefined();
+});


### PR DESCRIPTION
# Why

When a route is pushed to a stack in another tab the animation looks weird. The route should push without animation, and there should only be the animation of tab change.

This is the regression after global state refactor. 

# How

Whenever tab is changed native tabs router will append no animation param to disable animation for leaf route (newly pushed/removed)

# Test Plan

1. CI
2. Router e2e

https://github.com/user-attachments/assets/ed9bb4b3-dafb-4ec6-835e-8cabbcacf614

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
