### PR TITLE
[observe] Rename exception to js.exception

### DIFF
--- a/apps/test-suite/tests/AppMetrics.ts
+++ b/apps/test-suite/tests/AppMetrics.ts
@@ -524,15 +524,15 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
 
   describe('error handler', () => {
     // `installErrorHandler` ran on import, wrapping `global.ErrorUtils`. The end-to-end test drives
-    // the native `reportError` path with a non-fatal error and reads the recorded `exception` log
+    // the native `reportError` path with a non-fatal error and reads the recorded `js.exception` log
     // event back from the main session. (A fatal error can't be round-tripped in-process: it goes to
     // the file sink and is ingested on the next launch — see the native `PendingErrorStore` tests.)
     // A separate test drives the installed global handler to cover the JS wrapper's forwarding logic.
     //
-    // The event follows OpenTelemetry's exception-in-logs convention: event name `exception`, with
+    // The event follows OpenTelemetry's exception-in-logs convention: event name `js.exception`, with
     // `exception.type` / `exception.message` / `exception.stacktrace` attributes, plus `expo.error.*`
     // for the bits OTel has no field for (capture source, fatal flag).
-    async function waitForExceptionLog(
+    async function waitForJsExceptionLog(
       predicate: (log: LogRecord) => boolean,
       timeoutMs = EVENT_TIMEOUT_MS
     ): Promise<LogRecord> {
@@ -540,13 +540,13 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
         const logs = await session.getLogs();
-        const match = logs.find((log) => log.name === 'exception' && predicate(log));
+        const match = logs.find((log) => log.name === 'js.exception' && predicate(log));
         if (match) {
           return match;
         }
         await new Promise((resolve) => setTimeout(resolve, 100));
       }
-      throw new Error(`Timed out after ${timeoutMs}ms waiting for the exception log event`);
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for the js.exception log event`);
     }
 
     it('installs by wrapping the global ErrorUtils handler', () => {
@@ -557,7 +557,7 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
     // Only non-fatal errors are readable via `getLogs` in-process: the fatal path writes to the file
     // sink and is ingested on the next launch, so it can't be round-tripped here. Fatal persistence is
     // covered by the native `PendingErrorStore` write/drain tests.
-    it('records a non-fatal error as an exception log event with OTel attributes', async () => {
+    it('records a non-fatal error as a js.exception log event with OTel attributes', async () => {
       const message = `test-suite error ${Date.now()}`;
       AppMetrics.reportError({
         source: 'global',
@@ -567,7 +567,7 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
         isFatal: false,
       });
 
-      const log = await waitForExceptionLog(
+      const log = await waitForJsExceptionLog(
         (entry) => (entry.attributes ?? {})['exception.message'] === message
       );
       expect(log.severity).toBe('error');

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - [Android] Remove `SessionManager` insert listeners and `JsMetric.metricId` ([#49547](https://github.com/expo/expo/pull/49547) by [@Ubax](https://github.com/Ubax))
+- [iOS] [Android] Rename JavaScript exception log events from `exception` to `js.exception`.
 
 ### 🎉 New features
 

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - [Android] Remove `SessionManager` insert listeners and `JsMetric.metricId` ([#49547](https://github.com/expo/expo/pull/49547) by [@Ubax](https://github.com/Ubax))
-- [iOS] [Android] Rename JavaScript exception log events from `exception` to `js.exception`.
+- [iOS] [Android] Rename JavaScript exception log events from `exception` to `js.exception`. ([#49594](https://github.com/expo/expo/pull/49594) by [@Ubax](https://github.com/Ubax))
 
 ### 🎉 New features
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/ErrorReport.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/ErrorReport.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * An unhandled JavaScript error forwarded from the JS-side `global.ErrorUtils` handler. Recorded as
- * an `exception` log event following OpenTelemetry's exception conventions.
+ * a `js.exception` log event following OpenTelemetry's exception conventions.
  */
 @OptimizedRecord
 data class ErrorReport(
@@ -22,7 +22,7 @@ data class ErrorReport(
   @Field val componentStack: String? = null,
   @Field val isFatal: Boolean = false
 ) : Record {
-  /** Builds the `exception` log event for the live path. */
+  /** Builds the `js.exception` log event for the live path. */
   fun toLogRecord(sessionId: String): LogRecord =
     makeExceptionLogRecord(
       sessionId = sessionId,
@@ -60,7 +60,7 @@ enum class ErrorSource(val rawValue: String) : Enumerable {
 }
 
 /**
- * Builds the `exception` log event for a fatal error ingested from disk on the next launch, using the
+ * Builds the `js.exception` log event for a fatal error ingested from disk on the next launch, using the
  * session and timestamp captured at fatal time.
  */
 fun PendingErrorStore.PendingError.toLogRecord(): LogRecord =
@@ -76,13 +76,12 @@ fun PendingErrorStore.PendingError.toLogRecord(): LogRecord =
   )
 
 /**
- * Builds an `exception` log event following OpenTelemetry's exception-in-logs convention: the error
- * rides as `exception.*` attributes (the event name is `exception` because this captures errors from a
- * handler, not a specific operation), and `expo.error.*` carries the bits OTel has no field for (the
+ * Builds a `js.exception` log event following OpenTelemetry's exception-in-logs convention. The error
+ * rides as `exception.*` attributes, while `expo.error.*` carries the bits OTel has no field for (the
  * capture source and whether the error was fatal). Fatal errors log at `fatal` severity, the rest at
  * `error`. Shared by the live and ingested-fatal paths so both events keep the same shape.
  *
- * Absent `type`/`stacktrace` are kept as explicit `null` rather than omitted, so every `exception`
+ * Absent `type`/`stacktrace` are kept as explicit `null` rather than omitted, so every `js.exception`
  * event carries the same attribute keys. The React component stack only exists for error-boundary
  * captures, so `expo.error.component_stack` is omitted entirely when absent rather than logged as
  * `null` on every event.
@@ -110,7 +109,7 @@ private fun makeExceptionLogRecord(
   return LogRecord(
     sessionId = sessionId,
     timestamp = timestamp,
-    name = "exception",
+    name = "js.exception",
     severity = (if (isFatal) Severity.FATAL else Severity.ERROR).rawValue,
     attributes = JsonAny.encodeMapToJsonString(attributes)
   )

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/PendingErrorStore.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/jserrors/PendingErrorStore.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.Json
  * normal async (coroutine + Room) log path can race the shutdown and lose the record. Instead, the
  * fatal path writes the error to a small JSON file **synchronously** on the calling thread (no
  * coroutine, no database) before React Native tears the app down. On the next launch the pending
- * files are drained into the regular log pipeline as `exception` events.
+ * files are drained into the regular log pipeline as `js.exception` events.
  */
 object PendingErrorStore {
   private const val TAG = "AppMetrics"

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/jserrors/ErrorReportTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/jserrors/ErrorReportTest.kt
@@ -55,6 +55,22 @@ class ErrorReportTest {
     val record = report.toLogRecord(sessionId = "s")
     val attributes = record.attributes ?: ""
     assertTrue(attributes.contains("\"expo.error.source\":\"reportedByUser\""))
+    assertEquals("js.exception", record.name)
     assertEquals("error", record.severity)
+  }
+
+  @Test
+  fun `builds a js exception log from a pending fatal error`() {
+    val record = PendingErrorStore.PendingError(
+      source = "global",
+      type = "Error",
+      message = "boom",
+      stacktrace = "at f (app.js:1:1)",
+      sessionId = "s",
+      timestamp = "2026-01-01T00:00:00Z"
+    ).toLogRecord()
+
+    assertEquals("js.exception", record.name)
+    assertEquals("fatal", record.severity)
   }
 }

--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -23,7 +23,7 @@ public struct AppMetrics {
 
   /// Ingests fatal JavaScript errors that were written to disk before the process was terminated on a
   /// previous launch (see `PendingErrorStore`). Reads the files synchronously, then inserts each as an
-  /// `exception` log attributed to the session it was captured in. Called once at launch.
+  /// `js.exception` log attributed to the session it was captured in. Called once at launch.
   static func ingestPendingErrors() {
     let pendingErrors = PendingErrorStore.drain()
     guard !pendingErrors.isEmpty else {

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -3,7 +3,7 @@
 /// Structured crash report extracted from MetricKit's `MXCrashDiagnostic`.
 ///
 /// This is the native-crash shape: a Mach exception, signal, and native call-stack tree over a
-/// payload time window. Unhandled JavaScript errors are recorded separately as `exception` log
+/// payload time window. Unhandled JavaScript errors are recorded separately as `js.exception` log
 /// events (see `ErrorReport`).
 public struct CrashReport: Codable, Sendable {
   private static let maxLogStackFrames = 25

--- a/packages/expo-app-metrics/ios/LogEvents/ErrorReport.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/ErrorReport.swift
@@ -3,7 +3,7 @@
 import ExpoModulesCore
 
 /// An unhandled JavaScript error forwarded from the JS-side `global.ErrorUtils` handler. Recorded as
-/// an `exception` log event following OpenTelemetry's exception conventions.
+/// a `js.exception` log event following OpenTelemetry's exception conventions.
 @Record
 struct ErrorReport {
   var source: Source = .global
@@ -20,7 +20,7 @@ struct ErrorReport {
     case reportedByUser
   }
 
-  /// Builds the `exception` log event for the live path.
+  /// Builds the `js.exception` log event for the live path.
   func toLogRecord() -> LogRecord {
     return makeExceptionLogRecord(
       source: source.rawValue,
@@ -50,7 +50,7 @@ struct ErrorReport {
 }
 
 extension PendingErrorStore.PendingError {
-  /// Builds the `exception` log event for a fatal error ingested from disk on the next launch, using
+  /// Builds the `js.exception` log event for a fatal error ingested from disk on the next launch, using
   /// the session and timestamp captured at fatal time.
   func toLogRecord() -> LogRecord {
     return makeExceptionLogRecord(
@@ -65,14 +65,13 @@ extension PendingErrorStore.PendingError {
   }
 }
 
-/// Builds an `exception` log event following OpenTelemetry's exception-in-logs convention: the error
-/// rides as `exception.*` attributes (the event name is `exception` because this captures errors from
-/// a handler, not a specific operation), and `expo.error.*` carries the bits OTel has no field for (the
+/// Builds a `js.exception` log event following OpenTelemetry's exception-in-logs convention. The error
+/// rides as `exception.*` attributes, while `expo.error.*` carries the bits OTel has no field for (the
 /// capture source and whether the error was fatal). Fatal errors log at `fatal` severity, the rest at
 /// `error`. Shared by the live and ingested-fatal paths so both events keep the same shape.
 ///
 /// Absent `type`/`stacktrace` are kept as explicit `null` rather than omitted (the boxed optionals
-/// encode as JSON `null`), so every `exception` event carries the same attribute keys. The React
+/// encode as JSON `null`), so every `js.exception` event carries the same attribute keys. The React
 /// component stack only exists for error-boundary captures, so `expo.error.component_stack` is
 /// omitted entirely when absent rather than logged as `null` on every event.
 private func makeExceptionLogRecord(
@@ -95,7 +94,7 @@ private func makeExceptionLogRecord(
     attributes["expo.error.component_stack"] = componentStack
   }
   return LogRecord(
-    name: "exception",
+    name: "js.exception",
     attributes: attributes,
     severity: isFatal ? .fatal : .error,
     timestamp: timestamp

--- a/packages/expo-app-metrics/ios/LogEvents/PendingErrorStore.swift
+++ b/packages/expo-app-metrics/ios/LogEvents/PendingErrorStore.swift
@@ -8,7 +8,7 @@ import Foundation
 /// normal async (actor + SQLite) log path can race the shutdown and lose the record. Instead, the
 /// fatal path writes the error to a small JSON file **synchronously** on the calling thread (no actor,
 /// no database) before React Native tears the app down. On the next launch the pending files are
-/// drained into the regular log pipeline as `exception` events. This mirrors how MetricKit delivers
+/// drained into the regular log pipeline as `js.exception` events. This mirrors how MetricKit delivers
 /// crash diagnostics on the following launch.
 enum PendingErrorStore {
   /// The single error captured at fatal time. Carries the owning session id and timestamp resolved at

--- a/packages/expo-app-metrics/ios/Tests/ErrorReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/ErrorReportTests.swift
@@ -50,6 +50,22 @@ struct ErrorReportTests {
     let attributes = try! #require(record.attributes?.value as? [String: Any])
     #expect(attributes["expo.error.source"] as? String == "reportedByUser")
     #expect(attributes["expo.error.is_fatal"] as? Bool == false)
+    #expect(record.name == "js.exception")
     #expect(record.severity == .error)
+  }
+
+  @Test
+  func `builds a js exception log from a pending fatal error`() {
+    let record = PendingErrorStore.PendingError(
+      source: "global",
+      type: "Error",
+      message: "boom",
+      stacktrace: "at f (app.js:1:1)",
+      sessionId: "s",
+      timestamp: "2026-01-01T00:00:00Z"
+    ).toLogRecord()
+
+    #expect(record.name == "js.exception")
+    #expect(record.severity == .fatal)
   }
 }

--- a/packages/expo-app-metrics/src/AppMetricsErrorBoundary.tsx
+++ b/packages/expo-app-metrics/src/AppMetricsErrorBoundary.tsx
@@ -49,7 +49,7 @@ type State = {
 };
 
 /**
- * A React error boundary that records render-phase errors as non-fatal `exception` log events (with
+ * A React error boundary that records render-phase errors as non-fatal `js.exception` log events (with
  * the React component stack) and renders a `fallback` in place of the subtree that threw.
  *
  * Render-phase errors don't reach `global.ErrorUtils`, so a boundary is the only way to capture them

--- a/packages/expo-app-metrics/src/installErrorHandler.ts
+++ b/packages/expo-app-metrics/src/installErrorHandler.ts
@@ -24,7 +24,7 @@ export function setErrorHandlerEnabled(value: boolean): void {
 /**
  * Installs a handler for unhandled JavaScript errors by wrapping React Native's
  * `global.ErrorUtils` global handler. The error is reported to the native module (recorded as an
- * `exception` log event following OpenTelemetry's exception conventions), then the
+ * `js.exception` log event following OpenTelemetry's exception conventions), then the
  * previously-installed handler runs so React Native's default behavior (red box in development,
  * fatal termination in production) is unchanged.
  *

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -549,7 +549,7 @@ export interface ExpoAppMetricsModuleType {
   getAllCrashReports?: () => Promise<CrashReport[]>;
 
   /**
-   * Reports an unhandled JavaScript error, recorded natively as an `exception` log event following
+   * Reports an unhandled JavaScript error, recorded natively as a `js.exception` log event following
    * OpenTelemetry's exception conventions. Called by the global `ErrorUtils` handler that
    * `installErrorHandler` installs and by `AppMetricsErrorBoundary`; the `source` field records
    * which path captured the error.


### PR DESCRIPTION
# Why

Rename `exception` to `js.exception`

Related PR for www - https://github.com/expo/universe/pull/30714

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

https://expo.dev/accounts/expo/projects/observability/observe/sessions/82e994d1-4403-4e99-990e-4d7f5fd1e310?platform=android&environment=all&t=1h

https://expo.dev/accounts/expo/projects/observability/observe/sessions/be9d882b-549c-40d1-9d97-099ab61a0505?platform=android&environment=all&t=1h

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>