### PR TITLE
[router] prefer nested index routes when sorting

### DIFF
--- a/packages/@expo/router-server/src/__tests__/getServerManifest.test.node.ts
+++ b/packages/@expo/router-server/src/__tests__/getServerManifest.test.node.ts
@@ -160,15 +160,15 @@ it(`converts index routes`, () => {
     htmlRoutes: [
       { file: './index.tsx', namedRegex: '^/(?:/)?$', page: '/index', routeKeys: {} },
       {
-        file: './a/index/b.tsx',
-        namedRegex: '^/a/index/b(?:/)?$',
-        page: '/a/index/b',
-        routeKeys: {},
-      },
-      {
         file: './a/index/index.js',
         namedRegex: '^/a/index(?:/)?$',
         page: '/a/index/index',
+        routeKeys: {},
+      },
+      {
+        file: './a/index/b.tsx',
+        namedRegex: '^/a/index/b(?:/)?$',
+        page: '/a/index/b',
         routeKeys: {},
       },
     ],

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### 🐛 Bug fixes
 
+- Prefer nested index routes when choosing a navigator's initial route.
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ### 🐛 Bug fixes
 
-- Prefer nested index routes when choosing a navigator's initial route.
+- Prefer nested index routes when choosing a navigator's initial route. ([#49596](https://github.com/expo/expo/pull/49596) by [@Ubax](https://github.com/Ubax))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/__tests__/Route.test.ios.ts
+++ b/packages/expo-router/src/__tests__/Route.test.ios.ts
@@ -58,6 +58,17 @@ describe(sortRoutes, () => {
     // Index tied with group
     expect(sortRoutes(asRouteNode('index'), asRouteNode('(z)'))).toBe(2);
   });
+  it(`sorts nested index routes by priority`, () => {
+    expect(getSortedRoutes('sessions/main', 'sessions/index')).toEqual([
+      'sessions/index',
+      'sessions/main',
+    ]);
+    expect(getSortedRoutes('a/b/main', 'a/b/index')).toEqual(['a/b/index', 'a/b/main']);
+    expect(getSortedRoutes('sessions/index', 'index')).toEqual(['index', 'sessions/index']);
+  });
+  it(`ties equal-length named segments`, () => {
+    expect(sortRoutes(asRouteNode('zebra'), asRouteNode('apple'))).toBe(0);
+  });
   it(`sorts group routes by priority`, () => {
     expect(sortRoutes(asRouteNode('(zzz)'), asRouteNode('[...a]'))).toBe(-1);
     expect(sortRoutes(asRouteNode('(zzz)'), asRouteNode('[a]'))).toBe(-1);

--- a/packages/expo-router/src/__tests__/Route.test.ios.ts
+++ b/packages/expo-router/src/__tests__/Route.test.ios.ts
@@ -65,6 +65,12 @@ describe(sortRoutes, () => {
     ]);
     expect(getSortedRoutes('a/b/main', 'a/b/index')).toEqual(['a/b/index', 'a/b/main']);
     expect(getSortedRoutes('sessions/index', 'index')).toEqual(['index', 'sessions/index']);
+    // A group segment anywhere in the route does not hide a nested index
+    expect(getSortedRoutes('a/(b)/main', 'a/(b)/index')).toEqual(['a/(b)/index', 'a/(b)/main']);
+  });
+  it(`sorts routes without an index segment by route length`, () => {
+    expect(getSortedRoutes('test/1234', 'explore')).toEqual(['explore', 'test/1234']);
+    expect(getSortedRoutes('a/b/cccc', 'z/qqqqq')).toEqual(['z/qqqqq', 'a/b/cccc']);
   });
   it(`ties equal-length named segments`, () => {
     expect(sortRoutes(asRouteNode('zebra'), asRouteNode('apple'))).toBe(0);

--- a/packages/expo-router/src/__tests__/prefetch.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/prefetch.test.ios.tsx
@@ -148,7 +148,7 @@ it('will prefetch the correct route within a group', () => {
         state: {
           index: 0,
           key: expect.any(String),
-          routeNames: ['(a)/test', '(b)/test', '(a)/index', '(b)/index'],
+          routeNames: ['(a)/index', '(a)/test', '(b)/index', '(b)/test'],
           routes: [
             {
               key: expect.any(String),
@@ -180,7 +180,7 @@ it('will prefetch the correct route within a group', () => {
         state: {
           index: 0,
           key: expect.any(String),
-          routeNames: ['(a)/test', '(b)/test', '(a)/index', '(b)/index'],
+          routeNames: ['(a)/index', '(a)/test', '(b)/index', '(b)/test'],
           routes: [
             {
               key: expect.any(String),
@@ -223,7 +223,7 @@ it('will prefetch the correct route within nested groups', () => {
         state: {
           index: 0,
           key: expect.any(String),
-          routeNames: ['(b)/test', '(a)/index', '(b)/index', '(a)/(c)/test'],
+          routeNames: ['(a)/index', '(b)/index', '(b)/test', '(a)/(c)/test'],
           routes: [
             {
               key: expect.any(String),
@@ -255,7 +255,7 @@ it('will prefetch the correct route within nested groups', () => {
         state: {
           index: 0,
           key: expect.any(String),
-          routeNames: ['(b)/test', '(a)/index', '(b)/index', '(a)/(c)/test'],
+          routeNames: ['(a)/index', '(b)/index', '(b)/test', '(a)/(c)/test'],
           routes: [
             {
               key: expect.any(String),

--- a/packages/expo-router/src/__tests__/redirects.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/redirects.test.ios.tsx
@@ -522,7 +522,7 @@ it('not existing nested route redirects correctly', () => {
         state: {
           index: 1,
           key: expect.any(String),
-          routeNames: ['index', 'explore', 'test/1234', '[id]'],
+          routeNames: ['index', 'test/1234', 'explore', '[id]'],
           routes: [
             {
               key: expect.any(String),

--- a/packages/expo-router/src/__tests__/redirects.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/redirects.test.ios.tsx
@@ -522,7 +522,7 @@ it('not existing nested route redirects correctly', () => {
         state: {
           index: 1,
           key: expect.any(String),
-          routeNames: ['index', 'test/1234', 'explore', '[id]'],
+          routeNames: ['index', 'explore', 'test/1234', '[id]'],
           routes: [
             {
               key: expect.any(String),

--- a/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/navigation.test.ios.tsx
@@ -1,7 +1,13 @@
 import { screen, fireEvent } from '@testing-library/react-native';
 import { act, useState } from 'react';
-import { View } from 'react-native';
-import { Tabs } from 'react-native-screens';
+import { View, type NativeSyntheticEvent } from 'react-native';
+import {
+  Tabs,
+  type TabSelectedEvent,
+  type TabsHostProps,
+  // @ts-expect-error: method is declared in mock below
+  __triggerTabSelected,
+} from 'react-native-screens';
 
 import { router } from '../../imperative-api';
 import Stack from '../../layouts/StackClient';
@@ -14,19 +20,39 @@ jest.mock('react-native-screens', () => {
   const actualModule = jest.requireActual(
     'react-native-screens'
   ) as typeof import('react-native-screens');
+  let triggerTabSelected: NonNullable<TabsHostProps['onTabSelected']> = () => {};
   return {
     ...actualModule,
     ScreenStackItem: jest.fn(({ children }) => <View>{children}</View>),
     Tabs: {
       ...actualModule.Tabs,
-      Host: jest.fn(({ children }) => <View testID="TabsHost">{children}</View>),
+      Host: jest.fn(({ children, onTabSelected }) => {
+        triggerTabSelected = onTabSelected || (() => {});
+        return <View testID="TabsHost">{children}</View>;
+      }),
       Screen: jest.fn(({ children }) => <View testID="TabsScreen">{children}</View>),
     },
+    __triggerTabSelected: (event: Parameters<NonNullable<TabsHostProps['onTabSelected']>>[0]) =>
+      triggerTabSelected(event),
   };
 });
 
 const TabsHost = Tabs.Host as jest.MockedFunction<typeof Tabs.Host>;
 const TabsScreen = Tabs.Screen as jest.MockedFunction<typeof Tabs.Screen>;
+
+function selectTab(screenKey: string) {
+  act(() => {
+    __triggerTabSelected({
+      nativeEvent: {
+        selectedScreenKey: screenKey,
+        provenance: 0,
+        isRepeated: false,
+        hasTriggeredSpecialEffect: false,
+        actionOrigin: 'user',
+      },
+    } as NativeSyntheticEvent<TabSelectedEvent>);
+  });
+}
 
 describe('Native Bottom Tabs Navigation', () => {
   function expectOneRender() {
@@ -161,6 +187,50 @@ describe('Native Bottom Tabs Navigation', () => {
     act(() => router.push('/notSpecified'));
     expect(lastHostSelectedKey()).toBe('index');
     expect(screen).toHavePathname('/');
+  });
+});
+
+describe('Native Bottom Tabs nested initial routes', () => {
+  it('opens a nested index route when selecting a group tab', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="(metrics)" />
+          <NativeTabs.Trigger name="(sessions)" />
+        </NativeTabs>
+      ),
+      '(metrics)/_layout': () => <Stack />,
+      '(metrics)/index': () => <View testID="metrics" />,
+      '(sessions)/_layout': () => <Stack />,
+      '(sessions)/sessions/index': () => <View testID="sessions" />,
+      '(sessions)/sessions/main': () => <View testID="sessions-main" />,
+    });
+
+    selectTab(TabsScreen.mock.calls[TabsScreen.mock.calls.length - 1][0].screenKey);
+
+    expect(screen).toHavePathname('/sessions');
+    expect(screen.getByTestId('sessions')).toBeVisible();
+  });
+
+  it('opens a nested index route whose directory differs from the group name', () => {
+    renderRouter({
+      _layout: () => (
+        <NativeTabs>
+          <NativeTabs.Trigger name="(metrics)" />
+          <NativeTabs.Trigger name="(sessions)" />
+        </NativeTabs>
+      ),
+      '(metrics)/_layout': () => <Stack />,
+      '(metrics)/index': () => <View testID="metrics" />,
+      '(sessions)/_layout': () => <Stack />,
+      '(sessions)/session/index': () => <View testID="session" />,
+      '(sessions)/session/main': () => <View testID="session-main" />,
+    });
+
+    selectTab(TabsScreen.mock.calls[TabsScreen.mock.calls.length - 1][0].screenKey);
+
+    expect(screen).toHavePathname('/session');
+    expect(screen.getByTestId('session')).toBeVisible();
   });
 });
 

--- a/packages/expo-router/src/sortRoutes.ts
+++ b/packages/expo-router/src/sortRoutes.ts
@@ -11,6 +11,38 @@ function sortDynamicConvention(a: DynamicConvention, b: DynamicConvention) {
   return 0;
 }
 
+function isIndexLikeSegment(segment: string): boolean {
+  return segment === 'index' || matchGroupName(segment) != null;
+}
+
+function compareSegments(a: string, b: string): number {
+  const aSegments = a.split('/');
+  const bSegments = b.split('/');
+  const length = Math.min(aSegments.length, bSegments.length);
+
+  for (let i = 0; i < length; i++) {
+    const aSegment = aSegments[i]!;
+    const bSegment = bSegments[i]!;
+
+    if (aSegment === bSegment) {
+      continue;
+    }
+
+    const aIndex = isIndexLikeSegment(aSegment);
+    const bIndex = isIndexLikeSegment(bSegment);
+
+    if (aIndex && !bIndex) {
+      return -1;
+    }
+    if (!aIndex && bIndex) {
+      return 1;
+    }
+    return aSegment.length - bSegment.length || a.length - b.length;
+  }
+
+  return aSegments.length - bSegments.length;
+}
+
 export function sortRoutes(a: RouteNode, b: RouteNode): number {
   if (a.dynamic && !b.dynamic) {
     return 1;
@@ -57,8 +89,11 @@ export function sortRoutes(a: RouteNode, b: RouteNode): number {
   if (!aIndex && bIndex) {
     return 1;
   }
+  if (aIndex && bIndex) {
+    return a.route.length - b.route.length;
+  }
 
-  return a.route.length - b.route.length;
+  return compareSegments(a.route, b.route);
 }
 
 export function sortRoutesWithInitial(initialRouteName?: string) {

--- a/packages/expo-router/src/sortRoutes.ts
+++ b/packages/expo-router/src/sortRoutes.ts
@@ -15,6 +15,12 @@ function isIndexLikeSegment(segment: string): boolean {
   return segment === 'index' || matchGroupName(segment) != null;
 }
 
+function hasIndexSegment(route: string): boolean {
+  return route.split('/').includes('index');
+}
+
+// Ranks the first segment where the routes differ, preferring `index` and group segments. When
+// that segment ranks the same for both, the whole route length decides.
 function compareSegments(a: string, b: string): number {
   const aSegments = a.split('/');
   const bSegments = b.split('/');
@@ -37,10 +43,10 @@ function compareSegments(a: string, b: string): number {
     if (!aIndex && bIndex) {
       return 1;
     }
-    return aSegment.length - bSegment.length || a.length - b.length;
+    break;
   }
 
-  return aSegments.length - bSegments.length;
+  return a.length - b.length;
 }
 
 export function sortRoutes(a: RouteNode, b: RouteNode): number {
@@ -89,11 +95,14 @@ export function sortRoutes(a: RouteNode, b: RouteNode): number {
   if (!aIndex && bIndex) {
     return 1;
   }
-  if (aIndex && bIndex) {
-    return a.route.length - b.route.length;
+
+  // Only routes holding a nested `index` need the per-segment comparison; the rest are ordered
+  // by whole route length.
+  if (hasIndexSegment(a.route) || hasIndexSegment(b.route)) {
+    return compareSegments(a.route, b.route);
   }
 
-  return compareSegments(a.route, b.route);
+  return a.route.length - b.route.length;
 }
 
 export function sortRoutesWithInitial(initialRouteName?: string) {


### PR DESCRIPTION
# Why

After the global state refactor, the order of routes declared by users with `Stack.Screen` is no longer used to select the initial route.

In most cases, this does not matter because pages are opened either through deep links or navigation using a full `href`. However, it becomes relevant when a stack is nested within tabs.

Given the following route structure:

```text
/
|- (tabs)
  |- _layout.tsx
  |- index.tsx
  |- second
    |- _layout.tsx // Stack
      |- nested
        |- index.tsx
        |- a.tsx
```

and `/(tabs)/second/_layout.tsx`:

```tsx
export function SecondLayout() {
  return (
    <Stack>
      <Stack.Screen name="nested/index" />
      <Stack.Screen name="nested/a" />
    </Stack>
  );
}
```

**SDK 57**

Pressing the second tab would show:

```text
/(tabs)/second/nested/index
```

**Before this change**

Pressing the second tab would show:

```text
/(tabs)/second/nested/a
```

This happens because `nested/a` is shorter than `nested/index`.

**After this change**

Pressing the second tab shows:

```text
/(tabs)/second/nested/index
```
# How

Update `sortRoutes` so that `index` routes are sorted first at each level of nesting.

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

* [ ] I added a `changelog.md` entry and rebuilt the package sources according to [[this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
* [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (e.g. updated a module plugin).
* [ ] Conforms with the [[Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)