### PR TITLE
[docs][font] Add a Fonts guide section on multi-face font families

### DIFF
--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -252,6 +252,42 @@ Use the font on the `<Text>` by using `fontFamily` style prop in a React compone
 
 </Step>
 
+#### Loading multiple weights and styles for one font family
+
+> **info** Loading several font files under one family name is available in SDK 58 and later.
+
+The map syntax above treats each key as a separate font family. To load several font files (for example regular, bold, and italic cuts) under one `fontFamily` name, pass `useFonts` an array of [`FontFamilyDefinition`](/versions/latest/sdk/font/#fontfamilydefinition)s instead of a map:
+
+```tsx src/app/_layout.tsx
+const [loaded, error] = useFonts([
+  {
+    fontFamily: 'Inter',
+    fontDefinitions: [
+      { path: require('./assets/fonts/Inter-Regular.otf'), weight: 400 },
+      { path: require('./assets/fonts/Inter-Italic.otf'), weight: 400, style: 'italic' },
+      { path: require('./assets/fonts/Inter-Bold.otf'), weight: 700 },
+    ],
+  },
+]);
+```
+
+Then select a face with the `fontWeight` and `fontStyle` style props:
+
+```tsx
+<Text style={{ fontFamily: 'Inter', fontWeight: '700' }}>Inter Bold</Text>
+<Text style={{ fontFamily: 'Inter', fontWeight: '400', fontStyle: 'italic' }}>Inter Italic</Text>
+```
+
+Declare every face of a family in one call. A `fontFamily` loads once, so a later `loadAsync` or `useFonts` call for a name that is already loaded adds no faces to it. This also applies across the two call styles: after `useFonts({ Inter: regular })`, passing an array for `Inter` loads nothing more.
+
+Declare `weight` and `style` on every face of a multi-face family. Web needs both values, and explicit values keep the three platforms in agreement. A single variable font file is the exception: leave its `style` unset, and leave its `weight` unset or declare a weight range such as `'100 900'`. Android then instances the font's `wght` axis for every `fontWeight` instead of pinning it to one weight.
+
+Platform notes:
+
+- **Android** uses the declared `weight` and `style` values, and falls back to the values in the font file when not declared. A declared `weight` pins a variable font face to that one weight, and Android synthesizes the others. Below API 29 (Android 10), only the default face loads, chosen by the declared values (closest to weight 400, upright). Fonts embedded with the [config plugin](#with-expo-font-config-plugin) use Android's XML font resources and do not have this limit.
+- **iOS** matches faces by the weight and style metadata embedded in the font files. It does not use the declared `weight` and `style` values for matching. It uses them only to pick the family's default face when a file carries no readable metadata.
+- **Web** generates one CSS `@font-face` rule per face, with the declared `weight` and `style` values. CSS cannot read the metadata inside a font file, so a face that declares no `style` renders as upright. Two faces of one family that leave the same values undeclared produce the same CSS rule, and the browser then chooses between them.
+
 ## Use Google Fonts
 
 Expo has first-class support for all fonts listed in [Google Fonts](https://fonts.google.com/). They are available using [`@expo-google-fonts`](https://github.com/expo/google-fonts) library. With any of the font package from this library, you can quickly integrate that font and its variants.


### PR DESCRIPTION
# Why

The rest of this stack (#49485, #49486, #49487, #49497) lets one `fontFamily` hold several font files. The Fonts guide is where readers land, so it needs the full explanation.

The earlier draft of this section was titled "Loading multiple weights and styles for one font family on web". The feature now works on Android, iOS, and web, so the title drops "on web".

# How

Adds `#### Loading multiple weights and styles for one font family` under **Use a local font file → With `useFonts` hook**. It covers:

- passing `useFonts` an array of `FontFamilyDefinition`s instead of a map,
- selecting a face with the `fontWeight` and `fontStyle` style props,
- the rules for declaring faces (declare a whole family in one call; declare `weight` and `style` on every face; the variable-font exception),
- per-platform notes for Android, iOS, and web.

The guide is not versioned, so the section opens with an availability callout: the feature is available in SDK 58 and later.

`versions/unversioned/sdk/font.mdx` links here from #49597, the layer below.

# Test Plan

Docs-only change. In `docs/`:

- `pnpm lint` — passes (oxfmt, oxlint, tsc, eslint).
- `vale` prose lint on both changed pages — 0 errors, 0 warnings, 0 suggestions.
- `pnpm check-internal-links` needs an `out/` directory, so it was not run. Anchor targets were checked by hand instead.

The rendered page was not previewed in a local dev server.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — docs only, no package sources changed
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
