### PR TITLE
[core][android] Fix Expo module views not receiving props with React Native 0.87

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix Expo module views not receiving props with React Native 0.87.
 - [iOS][Android] Fixed a `matchContents` `RNHostView` and the `matchContents` host around it feeding each other's size back and forth, which grew the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed SwiftUI view props re-decoding every field on every props update. Fabric sends the whole props map rather than a delta, so an unrelated prop change replaced each decoded value with an equal but distinct one, which cost a decode per field and stopped SwiftUI from pruning the view tree that reads it. A field whose raw value is unchanged now keeps the value decoded before, the same way `ExpoFabricView.updateProps` already worked for UIKit views. ([#48426](https://github.com/expo/expo/pull/48426) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed `matchContents` hosts sometimes being laid out at a stale size. Regression from [#48059](https://github.com/expo/expo/pull/48059). ([#49211](https://github.com/expo/expo/pull/49211) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewComponentDescriptor.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewComponentDescriptor.cpp
@@ -30,13 +30,20 @@ react::Props::Shared AndroidExpoViewComponentDescriptor::cloneProps(
 
   rawProps.parse(rawPropsParser_);
 
+  const auto &sourceProps = props
+    ? dynamic_cast<const AndroidExpoViewProps &>(*props)
+    : *ExpoViewShadowNode<AndroidExpoViewProps>::defaultSharedProps();
+
   auto shadowNodeProps = std::make_shared<AndroidExpoViewProps>(
     context,
-    props ? dynamic_cast<const AndroidExpoViewProps &>(*props)
-      : *ExpoViewShadowNode<AndroidExpoViewProps>::defaultSharedProps(),
+    sourceProps,
     rawProps,
     filterObjectKeys_
   );
+
+#ifdef RN_SERIALIZABLE_STATE
+  shadowNodeProps->initializeDynamicProps(sourceProps, rawProps, filterObjectKeys_);
+#endif
 
   // TODO(@lukmccall): We probably can remove this loop
   if (react::ReactNativeFeatureFlags::enableCppPropsIteratorSetter()) {


### PR DESCRIPTION
# Why

In BareExpo the `expo-modules` views are not rendering, that is because they stopped receiving props on Android after React Native 0.87 moved dynamic prop initialization from the `Props` constructor to the standard component descriptor. We use a custom descriptor, leaving `rawProps` empty and native views mounted and laid out but blank.

Should fix android e2e tests on main unless there is something else also causing fails.

# How

Initialize dynamic props in `AndroidExpoViewComponentDescriptor::cloneProps` using the previous props and existing state prop filter before the map is consumed by Android view manager.

# Test Plan

Run BareExpo - ExpoModules views now render correctly.