### PR TITLE
[router] Add public native-stack subpath

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -64,7 +64,7 @@
 - Hide the splash screen when the built-in `+not-found` screen renders ([#48721](https://github.com/expo/expo/pull/48721) by [@Ubax](https://github.com/Ubax))
 - Honor loader `Cache-Control` headers via the platform HTTP cache instead of caching loader data in memory ([#48087](https://github.com/expo/expo/pull/48087) by [@hassankhan](https://github.com/hassankhan))
 - Cancel pending loader requests when their routes are removed during navigation ([#48451](https://github.com/expo/expo/pull/48451) by [@hassankhan](https://github.com/hassankhan))
-- Add a public `expo-router/native-stack` subpath so `createNativeStackNavigator` can be imported without a deep `build/` path.
+- Add a public `expo-router/native-stack` subpath so `createNativeStackNavigator` can be imported without a deep `build/` path. ([#49604](https://github.com/expo/expo/pull/49604) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Hide the splash screen when the built-in `+not-found` screen renders ([#48721](https://github.com/expo/expo/pull/48721) by [@Ubax](https://github.com/Ubax))
 - Honor loader `Cache-Control` headers via the platform HTTP cache instead of caching loader data in memory ([#48087](https://github.com/expo/expo/pull/48087) by [@hassankhan](https://github.com/hassankhan))
 - Cancel pending loader requests when their routes are removed during navigation ([#48451](https://github.com/expo/expo/pull/48451) by [@hassankhan](https://github.com/hassankhan))
+- Add a public `expo-router/native-stack` subpath so `createNativeStackNavigator` can be imported without a deep `build/` path.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -146,6 +146,14 @@
       "expo-source": "./src/layouts/TopTabs.tsx",
       "default": "./build/layouts/TopTabs.js"
     },
+    "./native-stack": {
+      "types": {
+        "expo-source": "./src/react-navigation/native-stack/index.tsx",
+        "default": "./build/react-navigation/native-stack/index.d.ts"
+      },
+      "expo-source": "./src/react-navigation/native-stack/index.tsx",
+      "default": "./build/react-navigation/native-stack/index.js"
+    },
     "./react-navigation": {
       "types": {
         "expo-source": "./src/react-navigation/index.ts",

--- a/packages/expo-router/src/react-navigation/native-stack/index.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/index.tsx
@@ -1,6 +1,11 @@
 /**
  * Navigators
  */
+/**
+ * @deprecated Reserved for libraries that ship a self-contained navigator, which the `Stack` layout
+ * cannot express. There is no stable replacement yet, so expect this factory to change or be removed
+ * in a future release. App code should use `Stack` from `expo-router`.
+ */
 export { createNativeStackNavigator } from './navigators/createNativeStackNavigator';
 
 /**


### PR DESCRIPTION
# Why
We don't currently expose subpaths for native-stack, forcing people to import from a build path

# How
Add the native-stack entry to the exports map

# Test Plan


