### PR TITLE
[config-plugins][iOS] Quote and escape strings entries

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `getApplicationIdAsync` and `setPackageInBuildGradle` failing with the Gradle assignment syntax (`applicationId = '...'`). ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
+- [iOS] Quote and escape keys and values written to `.strings` files. ([#49605](https://github.com/expo/expo/pull/49605) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/@expo/config-plugins/src/ios/Locales.ts
+++ b/packages/@expo/config-plugins/src/ios/Locales.ts
@@ -19,6 +19,10 @@ export const withLocales: ConfigPlugin = (config) => {
   });
 };
 
+function escapeStringsLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
 export async function writeStringsFile({
   localesMap,
   supportingDirectory,
@@ -40,7 +44,9 @@ export async function writeStringsFile({
     const strings = path.join(dir, fileName);
     const buffer = [];
     for (const [plistKey, localVersion] of Object.entries(localizationObj)) {
-      buffer.push(`${plistKey} = "${localVersion}";`);
+      buffer.push(
+        `"${escapeStringsLiteral(plistKey)}" = "${escapeStringsLiteral(String(localVersion))}";`
+      );
     }
     // Write the file to the file system.
     await fs.promises.writeFile(strings, buffer.join('\n'));

--- a/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -70,6 +70,9 @@ describe('e2e: iOS locales', () => {
           ios: {
             'Localizable.strings': {
               NOTIF_KEY: 'de-notification',
+              'Sample Widget': 'DE Sample Widget',
+              'A sample widget.': 'DE A sample widget.',
+              'A "quoted" key': 'DE A "quoted" key',
             },
           },
           android: {
@@ -125,18 +128,25 @@ describe('e2e: iOS locales', () => {
     expect(after[infoPlists[0]!]).toMatchSnapshot();
     // Test that the inlined locale is resolved.
     expect(after[infoPlists[1]!]).toMatch(/spanish-name/);
-    expect(after[infoPlists[2]!]).toMatchInlineSnapshot(`"CFBundleDisplayName = "us-name";"`);
+    expect(after[infoPlists[2]!]).toMatchInlineSnapshot(`""CFBundleDisplayName" = "us-name";"`);
     expect(after[infoPlists[3]!]).toMatchInlineSnapshot(`
-      "CFBundleDisplayName = "us-name";
-      app_name = "us-name";"
+      ""CFBundleDisplayName" = "us-name";
+      "app_name" = "us-name";"
     `);
-    expect(after[infoPlists[4]!]).toMatchInlineSnapshot(`"CFBundleDisplayName = "ar-name";"`);
+    expect(after[infoPlists[4]!]).toMatchInlineSnapshot(`""CFBundleDisplayName" = "ar-name";"`);
     expect(localizableStrings).toStrictEqual([
       'ios/testproject/Supporting/ar.lproj/Localizable.strings',
       'ios/testproject/Supporting/de.lproj/Localizable.strings',
     ]);
-    expect(after[localizableStrings[0]!]).toMatchInlineSnapshot(`"NOTIF_KEY = "ar-notification";"`);
-    expect(after[localizableStrings[1]!]).toMatchInlineSnapshot(`"NOTIF_KEY = "de-notification";"`);
+    expect(after[localizableStrings[0]!]).toMatchInlineSnapshot(
+      `""NOTIF_KEY" = "ar-notification";"`
+    );
+    expect(after[localizableStrings[1]!]).toMatchInlineSnapshot(`
+      ""NOTIF_KEY" = "de-notification";
+      "Sample Widget" = "DE Sample Widget";
+      "A sample widget." = "DE A sample widget.";
+      "A \\"quoted\\" key" = "DE A \\"quoted\\" key";"
+    `);
 
     // Test a warning is thrown for an invalid locale JSON file.
     expect(WarningAggregator.addWarningForPlatform).toHaveBeenCalledWith(

--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Locales-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Locales-test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`e2e: iOS locales writes all the image files expected 1`] = `"CFBundleDisplayName = "french-name";"`;
+exports[`e2e: iOS locales writes all the image files expected 1`] = `""CFBundleDisplayName" = "french-name";"`;

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -391,7 +391,7 @@ describe('built-in plugins', () => {
     expect(after['ios/HelloWorld/Info.plist']).toMatch('UIApplicationSceneManifest');
     expect(after['ios/HelloWorld/Info.plist']).toMatch('$(PRODUCT_MODULE_NAME).SceneDelegate');
     expect(after['ios/HelloWorld/Supporting/en.lproj/InfoPlist.strings']).toMatch(
-      /foo = "uhh bar"/
+      /"foo" = "uhh bar"/
     );
     expect(after['ios/HelloWorld/GoogleService-Info.plist']).toBe(googleServiceInfoFixture);
 


### PR DESCRIPTION
# Why

iOS `.strings` entries generated from `locales` were not safely quoted, so human-readable keys such as widget names could produce invalid files. This is the config-plugin prerequisite for #49606.

# How

Quote every key and value and escape backslashes, quotes, and newlines.

# Test Plan

Tests should pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
