### PR TITLE
[docs] EAS workflows `on.pull_request_comment` trigger documentation

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -209,6 +209,31 @@ on:
     # other labels
 ```
 
+### `on.pull_request_comment`
+
+Runs your workflow when someone creates, edits, or deletes a comment on a pull request.
+
+> **info** Only open, unmerged pull requests trigger `pull_request_comment` workflow runs. Pull requests opened from a fork of the connected repository do not trigger workflow runs.
+
+With the `types` list, you can specify which events trigger the workflow. Defaults to `['created']` when not provided. Supported event types:
+
+- `created`
+- `edited`
+- `deleted`
+
+Unlike `on.pull_request`, this trigger has no `branches` or `paths` filter.
+
+```yaml
+on:
+  # @info #
+  pull_request_comment:
+    # @end #
+    types:
+      - created
+      - edited
+      # other event types
+```
+
 ### `on.app_store_connect`
 
 Runs your workflow when one of the selected App Store Connect events occurs.
@@ -825,6 +850,10 @@ type GitHubContext = {
       merged: boolean | null;
       // ... Other fields from the GitHub Pull Request webhook payload
     };
+    comment?: {
+      body: string;
+      // ... Other fields from the GitHub issue_comment webhook payload
+    };
     changes?: {
       base?: {
         ref?: {
@@ -839,7 +868,7 @@ type GitHubContext = {
 };
 ```
 
-> **info** The `event` object contains the full [GitHub webhook payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads). For `pull_request` events, `event.pull_request` includes fields from GitHub's Pull Request webhook payload, such as `github.event.pull_request.title` and `github.event.pull_request.body`. For edited pull request events, `github.event.changes` contains the fields that changed, such as `github.event.changes.base.ref.from` when the base branch changed. The type above lists a few useful fields, but additional fields such as `user`, `labels`, `milestone`, and others are also available.
+> **info** The `event` object contains the full [GitHub webhook payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads). For `pull_request` events, `event.pull_request` includes fields from GitHub's Pull Request webhook payload, such as `github.event.pull_request.title` and `github.event.pull_request.body`. For edited pull request events, `github.event.changes` contains the fields that changed, such as `github.event.changes.base.ref.from` when the base branch changed. For `pull_request_comment` events, `event.comment.body` contains the comment text, and `event.pull_request.number` and `event.number` contain the pull request number. The type above lists a few useful fields, but additional fields such as `user`, `labels`, `milestone`, and others are also available.
 
 If a workflow run is started from `eas workflow:run`, its `event_name` will be `workflow_dispatch` and all the rest of the properties will be empty.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

We've added a new trigger to EAS workflows: `on.pull_request_comment`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added the `on.pull_request_comment` subsection to the EAS workflows syntax documentation.

Adjusted the interpolation context documentation to mention the pull request comment context.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="1001" height="595" alt="image" src="https://github.com/user-attachments/assets/e93a9bd9-8eb8-4c52-be09-5e87b1c0831a" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
