### PR TITLE
[app-metrics][android] Fix network request observers threading-related issues

### DIFF
--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed network request observers emitting duplicate events or continuing after their listeners were removed. ([#49609](https://github.com/expo/expo/pull/49609) by [@behenate](https://github.com/behenate))
 - [iOS] Preserve millisecond precision in log event timestamps. ([#49141](https://github.com/expo/expo/pull/49141) by [@Ubax](https://github.com/Ubax))
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestInterceptor.kt
@@ -23,6 +23,7 @@ import java.net.Proxy
 import java.util.Date
 import java.util.UUID
 import java.util.WeakHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Sentinel header recognised by `NetworkRequestInterceptor` to skip observation. expo-observe's
@@ -509,8 +510,8 @@ private class BodyCloseSignal(
   private val delegate: ResponseBody,
   private val onComplete: () -> Unit
 ) : ResponseBody() {
-  @Volatile
-  private var completed: Boolean = false
+  // EOF and close can race when callers consume and dispose a response on different threads.
+  private val completed = AtomicBoolean(false)
 
   // OkHttp's contract returns the same `BufferedSource` on repeated `source()` calls, so we
   // cache ours too — wrapping twice would fire the completion callback twice.
@@ -538,10 +539,9 @@ private class BodyCloseSignal(
   override fun source(): BufferedSource = signalingSource
 
   private fun fireCompleteOnce() {
-    if (completed) {
+    if (!completed.compareAndSet(false, true)) {
       return
     }
-    completed = true
     onComplete()
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitor.kt
@@ -64,11 +64,20 @@ class NetworkRequestMonitor internal constructor() {
     return NetworkRequestSummary.from(inWindow)
   }
 
-  /** Adds a delegate. Held weakly - drop the reference to unsubscribe. */
+  /** Adds a delegate once. Held weakly - drop the reference to unsubscribe. */
   fun addDelegate(delegate: NetworkRequestObserverDelegate) = synchronized(lock) {
-    delegates.removeAll { it.get() == null }
+    delegates.removeAll {
+      val strongRef = it.get()
+      strongRef === delegate || strongRef == null
+    }
     delegates.add(WeakReference(delegate))
   }
+
+  internal val delegateCount: Int
+    get() = synchronized(lock) {
+      delegates.removeAll { it.get() == null }
+      delegates.size
+    }
 
   fun removeDelegate(delegate: NetworkRequestObserverDelegate) = synchronized(lock) {
     delegates.removeAll {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
@@ -5,6 +5,7 @@ package expo.modules.appmetrics.networkrequests
 import expo.modules.appmetrics.utils.TimeUtils
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.sharedobjects.SharedObject
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /** Event names emitted by `NetworkRequestObserver`, matching the keys in the JS `NetworkRequestObserverEvents` type. */
@@ -13,28 +14,59 @@ internal const val REQUEST_COMPLETED_EVENT = "requestCompleted"
 
 /**
  * JS-facing `SharedObject` that bridges per-instance JS subscriptions to the singleton
- * `NetworkRequestMonitor`. Each JS `new NetworkRequestObserver()` allocates one of these and
- * registers it as a delegate; the native instance is released when JS drops the reference, at
- * which point `sharedObjectDidRelease` removes the delegate registration.
+ * `NetworkRequestMonitor`. Each JS `new NetworkRequestObserver()` allocates one of these. It is
+ * registered as a delegate while it has event listeners and is unregistered after its last
+ * listener is removed or the shared object is released.
  *
  * The class only forwards events — it doesn't store request history. Use
  * `NetworkRequestMonitor.shared.recent` for that.
  */
-class NetworkRequestObserver(appContext: AppContext, filter: NetworkRequestFilter? = null) :
+class NetworkRequestObserver private constructor(
+  appContext: AppContext,
+  filter: NetworkRequestFilter?,
+  private val monitor: NetworkRequestMonitor // Set for testing, otherwise default singleton
+) :
   SharedObject(appContext),
   NetworkRequestObserverDelegate {
+
+  constructor(appContext: AppContext, filter: NetworkRequestFilter? = null) :
+    this(appContext, filter, NetworkRequestMonitor.shared)
 
   // The active filter, or null to observe every request. An `AtomicReference` so the read from the
   // monitor's fan-out (`shouldObserveRequest`) and the swap from `setFilter` are atomic: a
   // `setFilter` call never leaves a request observed under a half-applied filter.
   private val filter = AtomicReference(filter)
+  private val observing = AtomicBoolean(false)
+  private val listenerLock = Any()
+  private val listenedEvents = mutableSetOf<String>()
 
-  init {
-    NetworkRequestMonitor.shared.addDelegate(this)
+  override fun onStartListeningToEvent(eventName: String) {
+    if (eventName != REQUEST_STARTED_EVENT && eventName != REQUEST_COMPLETED_EVENT) {
+      return
+    }
+    synchronized(listenerLock) {
+      listenedEvents.add(eventName)
+      if (observing.compareAndSet(false, true)) {
+        monitor.addDelegate(this)
+      }
+    }
+  }
+
+  override fun onStopListeningToEvent(eventName: String) {
+    synchronized(listenerLock) {
+      listenedEvents.remove(eventName)
+      if (listenedEvents.isEmpty() && observing.compareAndSet(true, false)) {
+        monitor.removeDelegate(this)
+      }
+    }
   }
 
   override fun sharedObjectDidRelease() {
-    NetworkRequestMonitor.shared.removeDelegate(this)
+    synchronized(listenerLock) {
+      listenedEvents.clear()
+      observing.set(false)
+      monitor.removeDelegate(this)
+    }
     super.sharedObjectDidRelease()
   }
 
@@ -46,18 +78,32 @@ class NetworkRequestObserver(appContext: AppContext, filter: NetworkRequestFilte
   }
 
   override fun shouldObserveRequest(url: String, method: String): Boolean {
-    return filter.get()?.matches(url, method) ?: true
+    return observing.get() && (filter.get()?.matches(url, method) ?: true)
   }
 
   override fun onNetworkRequestStarted(request: NetworkRequestStarted) {
-    emit(REQUEST_STARTED_EVENT, startedPayload(request))
+    if (isListeningTo(REQUEST_STARTED_EVENT)) {
+      emit(REQUEST_STARTED_EVENT, startedPayload(request))
+    }
   }
 
   override fun onNetworkRequestCompleted(request: NetworkRequest) {
-    emit(REQUEST_COMPLETED_EVENT, completedPayload(request))
+    if (isListeningTo(REQUEST_COMPLETED_EVENT)) {
+      emit(REQUEST_COMPLETED_EVENT, completedPayload(request))
+    }
+  }
+
+  private fun isListeningTo(eventName: String): Boolean = synchronized(listenerLock) {
+    observing.get() && listenedEvents.contains(eventName)
   }
 
   companion object {
+    internal fun forTesting(
+      appContext: AppContext,
+      monitor: NetworkRequestMonitor,
+      filter: NetworkRequestFilter? = null
+    ) = NetworkRequestObserver(appContext, filter, monitor)
+
     /**
      * Internal so tests can assert the payload shape without going through `emit`, which needs a
      * live JS runtime. The keys here are part of the public JS contract — additions are safe but

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestMonitorTest.kt
@@ -70,6 +70,19 @@ class NetworkRequestMonitorTest {
   }
 
   @Test
+  fun `adding the same delegate again does not duplicate fan-out`() {
+    val monitor = NetworkRequestMonitor()
+    val collector = CollectingDelegate()
+    monitor.addDelegate(collector)
+    monitor.addDelegate(collector)
+
+    monitor.record(makeRequest())
+
+    assertEquals(1, monitor.delegateCount)
+    assertEquals(1, collector.completed.size)
+  }
+
+  @Test
   fun `does not fan out events the delegate filters out`() {
     val monitor = NetworkRequestMonitor()
     val collector = FilteringDelegate(allowedHost = "api.expo.dev")

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
@@ -1,6 +1,9 @@
 package expo.modules.appmetrics.networkrequests
 
+import expo.modules.kotlin.AppContext
+import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -14,6 +17,38 @@ import java.util.UUID
  * see. These tests pin that shape down so renames require a deliberate change.
  */
 class NetworkRequestObserverTest {
+  @Test
+  fun `registers only while it has event listeners`() {
+    val appContext = mockk<AppContext>(relaxed = true)
+    val monitor = NetworkRequestMonitor()
+    val observer = NetworkRequestObserver.forTesting(appContext, monitor)
+
+    assertEquals(0, monitor.delegateCount)
+
+    observer.onStartListeningToEvent(REQUEST_STARTED_EVENT)
+    observer.onStartListeningToEvent(REQUEST_COMPLETED_EVENT)
+    assertEquals(1, monitor.delegateCount)
+
+    observer.onStopListeningToEvent(REQUEST_STARTED_EVENT)
+    assertEquals(1, monitor.delegateCount)
+
+    observer.onStopListeningToEvent(REQUEST_COMPLETED_EVENT)
+    assertEquals(0, monitor.delegateCount)
+  }
+
+  @Test
+  fun `release unregisters the observer`() {
+    val appContext = mockk<AppContext>(relaxed = true)
+    val monitor = NetworkRequestMonitor()
+    val observer = NetworkRequestObserver.forTesting(appContext, monitor)
+    observer.onStartListeningToEvent(REQUEST_COMPLETED_EVENT)
+
+    observer.sharedObjectDidRelease()
+
+    assertEquals(0, monitor.delegateCount)
+    assertFalse(observer.shouldObserveRequest("https://expo.dev", "GET"))
+  }
+
   @Test
   fun `startedPayload contains the started-event keys`() {
     val id = UUID.randomUUID()


### PR DESCRIPTION
# Why

Fixes the current Android e2e failures on main.

On Android, network request listeners could receive duplicate events or continue receiving events after their JS listeners were removed. Response completion could also be reported twice when reading and closing the response happened concurrently.


# How

Register native observers only while they have active listeners and prevent duplicate delegate registrations. This should slightly improve the overall performance. Use an atomic flag to ensure each response completes only once.

Add tests to test this scenario.

# Test Plan

Run the newly added tests, run tests in NCL