### PR TITLE
[ios][video] Prevent playbackRate from starting playback

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3935,7 +3935,7 @@ SPEC CHECKSUMS:
   ExpoTaskManager: d52427f67bf8f00fa56d52f9603919049c67cfc5
   ExpoTrackingTransparency: 43401b22cf6aed3a4a35e0c24d0b320905acc477
   ExpoUI: 62ef3713d3cce9736b063fe4edf8cb9c611a36d5
-  ExpoVideo: 9a992d457d2f856e392af6baaf092af778decf95
+  ExpoVideo: e64ef565d46be6383c34f6b5a2343c413523a76d
   ExpoVideoDashSupportModule: a8197584e7b7e533a67e75d3349c5fa827358ad6
   ExpoVideoThumbnails: 0a7d37113fe51af5c302461ad0344dc529161316
   ExpoWebBrowser: 9b98d939d5f1c5dd8f523f0a0683056fb1204434

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Prevent setting `playbackRate` from starting playback on a paused player.
+- [iOS] Prevent setting `playbackRate` from starting playback on a paused player. ([#49611](https://github.com/expo/expo/pull/49611) by [@shubh73](https://github.com/shubh73))
 - [Android] Fix `VideoPlayer` constructor throwing `MissingActivity` when the player is created while the `Activity` is briefly unavailable. ([#48914](https://github.com/expo/expo/pull/48914) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a data race on the video cache's open-file registry, which could crash the app while the cache was being trimmed. ([#49286](https://github.com/expo/expo/pull/49286) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Prevent setting `playbackRate` from starting playback on a paused player.
 - [Android] Fix `VideoPlayer` constructor throwing `MissingActivity` when the player is created while the `Activity` is briefly unavailable. ([#48914](https://github.com/expo/expo/pull/48914) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a data race on the video cache's open-file registry, which could crash the app while the cache was being trimmed. ([#49286](https://github.com/expo/expo/pull/49286) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-video/ios/ExpoVideo.podspec
+++ b/packages/expo-video/ios/ExpoVideo.podspec
@@ -28,5 +28,8 @@ Pod::Spec.new do |s|
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests'
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '$(inherited) -lc++'
+    }
   end
 end

--- a/packages/expo-video/ios/Tests/VideoPlayerPlaybackRateTests.swift
+++ b/packages/expo-video/ios/Tests/VideoPlayerPlaybackRateTests.swift
@@ -65,6 +65,11 @@ private final class TestAVPlayer: AVPlayer {
     }
     set {
       simulatedRate = newValue
+      if newValue == 0 {
+        simulatedTimeControlStatus = .paused
+      } else if simulatedTimeControlStatus == .paused {
+        simulatedTimeControlStatus = .waitingToPlayAtSpecifiedRate
+      }
     }
   }
 
@@ -84,11 +89,6 @@ private final class TestAVPlayer: AVPlayer {
   override func play() {
     simulatedTimeControlStatus = .playing
     rate = defaultRate
-  }
-
-  override func pause() {
-    simulatedTimeControlStatus = .paused
-    rate = 0
   }
 
   func waitToPlay(at rate: Float) {

--- a/packages/expo-video/ios/Tests/VideoPlayerPlaybackRateTests.swift
+++ b/packages/expo-video/ios/Tests/VideoPlayerPlaybackRateTests.swift
@@ -1,0 +1,98 @@
+import AVFoundation
+import Testing
+
+@testable import ExpoVideo
+
+@Suite("VideoPlayer playback rate")
+struct VideoPlayerPlaybackRateTests {
+  @Test
+  func `setting playback rate while paused does not request playback`() throws {
+    let ref = TestAVPlayer()
+    let player = try VideoPlayer(ref, initialSource: nil)
+
+    player.playbackRate = 1.5
+
+    #expect(ref.timeControlStatus == .paused)
+    #expect(ref.rate == 0)
+    #expect(ref.defaultRate == 1.5)
+  }
+
+  @Test
+  func `explicit play uses the configured playback rate`() throws {
+    let ref = TestAVPlayer()
+    let player = try VideoPlayer(ref, initialSource: nil)
+    player.playbackRate = 1.5
+
+    ref.play()
+
+    #expect(ref.timeControlStatus == .playing)
+    #expect(ref.rate == 1.5)
+  }
+
+  @Test
+  func `setting playback rate while playing applies immediately`() throws {
+    let ref = TestAVPlayer()
+    let player = try VideoPlayer(ref, initialSource: nil)
+    ref.play()
+
+    player.playbackRate = 2
+
+    #expect(ref.timeControlStatus == .playing)
+    #expect(ref.rate == 2)
+  }
+
+  @Test
+  func `setting playback rate while waiting applies to the pending playback request`() throws {
+    let ref = TestAVPlayer()
+    let player = try VideoPlayer(ref, initialSource: nil)
+    ref.waitToPlay(at: 1)
+
+    player.playbackRate = 1.75
+
+    #expect(ref.timeControlStatus == .waitingToPlayAtSpecifiedRate)
+    #expect(ref.rate == 1.75)
+  }
+}
+
+private final class TestAVPlayer: AVPlayer {
+  private var simulatedRate: Float = 0
+  private var simulatedDefaultRate: Float = 1
+  private var simulatedTimeControlStatus: AVPlayer.TimeControlStatus = .paused
+
+  override var rate: Float {
+    get {
+      return simulatedRate
+    }
+    set {
+      simulatedRate = newValue
+    }
+  }
+
+  override var defaultRate: Float {
+    get {
+      return simulatedDefaultRate
+    }
+    set {
+      simulatedDefaultRate = newValue
+    }
+  }
+
+  override var timeControlStatus: AVPlayer.TimeControlStatus {
+    return simulatedTimeControlStatus
+  }
+
+  override func play() {
+    simulatedTimeControlStatus = .playing
+    rate = defaultRate
+  }
+
+  override func pause() {
+    simulatedTimeControlStatus = .paused
+    rate = 0
+  }
+
+  func waitToPlay(at rate: Float) {
+    simulatedTimeControlStatus = .waitingToPlayAtSpecifiedRate
+    self.rate = rate
+  }
+}

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -35,7 +35,9 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
       if #available(iOS 16.0, tvOS 16.0, *) {
         ref.defaultRate = playbackRate
       }
-      ref.rate = playbackRate
+      if ref.rate != 0 {
+        ref.rate = playbackRate
+      }
     }
   }
 


### PR DESCRIPTION
# Why

Setting `playbackRate` on iOS currently starts playback when the player is paused. The existing guard against this was removed in #27632.

# How

Restore the guard so changing the rate does not change the paused state. `defaultRate` still stores the configured speed for the next `play()`, while playing and waiting players update immediately.

Add native regression tests for paused, playing, and waiting states.

# Test Plan

- `pnpm exec et check-packages expo-video`
- `pnpm expotools native-unit-tests --platform ios --packages expo-video`
- Verified the paused regression test fails when the guard is removed.
