### PR TITLE
[router-tester] add eas config

### DIFF
--- a/apps/router-tester/app.json
+++ b/apps/router-tester/app.json
@@ -7,7 +7,10 @@
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
     "ios": {
-      "bundleIdentifier": "dev.expo.routertester"
+      "bundleIdentifier": "dev.expo.routertester",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "dev.expo.routertester",
@@ -16,7 +19,9 @@
         "backgroundColor": "#FFFFFF"
       }
     },
-    "plugins": ["expo-router"],
+    "plugins": [
+      "expo-router"
+    ],
     "experiments": {
       "typedRoutes": true
     },

--- a/apps/router-tester/app.json
+++ b/apps/router-tester/app.json
@@ -19,6 +19,13 @@
     "plugins": ["expo-router"],
     "experiments": {
       "typedRoutes": true
-    }
+    },
+    "extra": {
+      "router": {},
+      "eas": {
+        "projectId": "0a92f596-9ce2-4793-8e36-d51059238417"
+      }
+    },
+    "owner": "expo"
   }
 }

--- a/apps/router-tester/eas.json
+++ b/apps/router-tester/eas.json
@@ -1,0 +1,38 @@
+{
+  "cli": {
+    "version": ">= 21.3.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "pnpm": "10.33.0",
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "android-apk": {
+      "pnpm": "10.33.0",
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "ios-simulator": {
+      "pnpm": "10.33.0",
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "ios-testflight": {
+      "pnpm": "10.33.0",
+      "distribution": "store",
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "ios-testflight": {}
+  }
+}


### PR DESCRIPTION
# Why

Add eas config for router-tester app, with different build profiles

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>