### PR TITLE
[expo][android] Complete loadAppReady after installing mReactDelegate on the wrapped delegate

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix crashes (e.g. `NullPointerException` in `onResume`, `onPause`, or `onWindowFocusChanged`) caused by `loadAppReady` being completed before the wrapped delegate's private `mReactDelegate` field was installed — lifecycle callbacks awaiting `loadAppReady` could run against a delegate whose react delegate was not set yet. ([#37825](https://github.com/expo/expo/issues/37825), [#37819](https://github.com/expo/expo/issues/37819), [#35676](https://github.com/expo/expo/issues/35676))
 - [iOS] Fix a Hermes JSI crash during reloads where two overlapping `RCTHost` runtime callbacks shared `EXReactNativeFactory`'s app context ivar, letting one callback decorate objects against the other callback's runtime. ([#48576](https://github.com/expo/expo/issues/48576) by [@LizunovSergey](https://github.com/LizunovSergey))
 - [iOS] Fix `expo/fetch` streaming race between URLSession delegate callbacks and `startStreaming()` that could deliver an empty body on a 200 response, drop chunks, or leave the body stream open. ([#47796](https://github.com/expo/expo/pull/47796) by [@idoyana](https://github.com/idoyana))
 - Fix `expo/fetch` body-stream teardown races: aborting via an `AbortSignal` now rejects the in-flight read with an `AbortError` instead of hanging forever, and late native events no longer throw `The stream is not in a state that permits enqueue`/`close` from outside any consumer `try`/`catch`. ([#47573](https://github.com/expo/expo/pull/47573) by [@idoyana](https://github.com/idoyana))

--- a/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ReactActivityDelegateWrapper.kt
@@ -143,7 +143,6 @@ class ReactActivityDelegateWrapper(
 
       launchLifecycleScopeWithLock(start = CoroutineStart.UNDISPATCHED) {
         awaitDelayLoadAppWhenReady(delayLoadAppHandler)
-        loadAppReady.complete(Unit)
 
         if (VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled) {
           activity.window.colorMode = ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT
@@ -160,6 +159,7 @@ class ReactActivityDelegateWrapper(
         val mReactDelegate = ReactActivityDelegate::class.java.getDeclaredField("mReactDelegate")
         mReactDelegate.isAccessible = true
         mReactDelegate.set(delegate, reactDelegate)
+        loadAppReady.complete(Unit)
         if (mainComponentName != null) {
           loadAppImpl(mainComponentName, supportsDelayLoad = false)
         }


### PR DESCRIPTION
# Why

`ReactActivityDelegateWrapper.onCreate` completes the `loadAppReady` deferred **before** the reflection block that installs the private `mReactDelegate` field on the wrapped `ReactActivityDelegate`. Every wrapper lifecycle callback that is gated on `loadAppReady` — `onResume`, `onPause`, `onUserLeaveHint`, `onDestroy`, `onActivityResult`, `onWindowFocusChanged`, `onConfigurationChanged`, `onRequestPermissionsResult`, `requestPermissions` (all via `loadAppReady.await()`), plus the synchronous `isCompleted`-gated callbacks `onKeyDown`, `onKeyUp`, `onKeyLongPress`, `onBackPressed`, `onNewIntent` — forwards to the wrapped delegate, whose `ReactActivityDelegate` implementation reads its internal `mReactDelegate` field. When those callbacks are allowed to run in the window where `loadAppReady` is completed but `mReactDelegate` has not yet been set, the field is still `null` and the call crashes with an `NullPointerException`, e.g.:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void com.facebook.react.reactdelegatereactnative.ReactDelegate.onResume()' on a null object reference
```

This matches the crash family reported in #37825, #37819 and #35676.

Fixes #37825. Fixes #37819. Fixes #35676.

# How

Move `loadAppReady.complete(Unit)` from before the wide-color-gamut / `ReactDelegate` construction block to immediately after `mReactDelegate.set(delegate, reactDelegate)`. This is a pure reordering — nothing else changes.

Nothing depends on `loadAppReady` completing *before* `mReactDelegate` is installed:

- `loadAppReady` is private and has no usages outside `ReactActivityDelegateWrapper.kt` (verified with a repo-wide grep of `packages/` and `apps/`).
- Every `await()`/`isCompleted` consumer exists precisely to avoid touching the delegate before the wrapper's `onCreate` work has finished, and the last step of that work is installing `mReactDelegate` (followed only by `loadAppImpl`, which itself reads `mReactDelegate` through `invokeDelegateMethod("loadApp", ...)` and therefore already required it to be set).
- Completing the deferred after the reflection only shrinks the window in which gated callbacks may run; `loadAppImpl` runs inside the same mutex-held coroutine, so its relative order is unchanged.
- The only other completer is `setLoadAppReadyForTesting()`, which unit tests call directly.

# Test Plan

- Existing Robolectric tests in `packages/expo/android/src/test/java/expo/modules/ReactActivityDelegateWrapperDelayLoadTest.kt` already cover the delay-load lifecycle ordering (`should proceed loadApp immediately when no delayLoadAppHandler`, `should block loadApp until delayLoadAppHandler finished`, `should call lifecycle methods in correct order with delay load`, `should have normal lifecycle when no delayLoadHandler`, `should cancel pending resume if activity destroy before delay load finished`) and are unaffected by this reordering.
- The mis-ordering itself is not deterministically observable in those tests: with `UnconfinedTestDispatcher` the `onCreate` coroutine runs to completion without suspension between `complete` and the reflection call, so the interleaving that crashes on a real main thread cannot be reproduced there. For that reason no new unit test was added and the change is verified by inspection plus the existing suite.
- Existing tests in `ReactActivityDelegateWrapperTest.kt` use `setLoadAppReadyForTesting()` and are unaffected.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)