### PR TITLE
[cli][metro-config] Apply DOM component html renames to serialized JS before Hermes compilation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo export` corrupting Hermes bytecode when renaming DOM component html assets: the rename is now applied to the serialized JS and bytecode compilation is deferred until after DOM component exports. Previously the placeholder filename was binary-patched inside the compiled `.hbc`, which could overwrite bytes of neighbouring overlap-packed strings (e.g. unrelated string literals such as API keys). ([#49627](https://github.com/expo/expo/pull/49627) by [@ibrahimchraibi](https://github.com/ibrahimchraibi))
+
 - Stop writing DOM component source maps into the app binary during `expo export:embed`, so Android release builds no longer ship `www.bundle` source maps with the original app source. ([#49480](https://github.com/expo/expo/pull/49480) by [@expo-bot](https://github.com/expo-bot))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.

--- a/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/exportDomComponents-test.ts
@@ -219,6 +219,46 @@ __d((function(g,r,i,a,m,e,d){m.exports={uri:"assets/assets/images/react-logo.d88
     expect(nativeJsContents).not.toEqual(nativeBundle1Chunk);
     expect(nativeJsContents).toContain('MOCK_CONTENTS_MD5_HASH');
   });
+
+  it('should throw when the native bundle is already compiled Hermes bytecode', () => {
+    const domComponentReference = 'file:///app/components/DomView.tsx';
+    const htmlOutputName = 'www.bundle/dom1.html';
+    const nativeBundle: BundleOutput = {
+      artifacts: [
+        {
+          filename: '_expo/static/js/ios/entry-native1.hbc',
+          originFilename: 'node_modules/expo-router/entry.js',
+          type: 'js',
+          metadata: {},
+          source: '',
+        },
+      ],
+      assets: [],
+    };
+    const files: ExportAssetMap = new Map([
+      [
+        '_expo/static/js/ios/entry-native1.hbc',
+        {
+          contents: Buffer.from([0xc6, 0x1f, 0xbc, 0x03]),
+        },
+      ],
+      [
+        htmlOutputName,
+        {
+          contents: '<html></html>',
+        },
+      ],
+    ]);
+
+    expect(() =>
+      transformNativeBundleForMd5Filename({
+        domComponentReference,
+        nativeBundle,
+        files,
+        htmlOutputName,
+      })
+    ).toThrow(/compiled Hermes bytecode/);
+  });
 });
 
 describe('Multiple DOM components metadata accumulation', () => {

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -31,6 +31,7 @@ import { env } from '../../utils/env';
 import { ensureProcessExitsAfterDelay } from '../../utils/exit';
 import { debugEvent } from '../events';
 import { exportDomComponentAsync } from '../exportDomComponents';
+import { transformJsAssetToHermesBytecodeAsync } from '@expo/metro-config/build/serializer/serializeChunks';
 import { isEnableHermesManaged } from '../exportHermes';
 import { persistMetroAssetsAsync } from '../persistMetroAssets';
 import { copyPublicFolderAsync, getPublicFolderPath } from '../publicFolder';
@@ -278,6 +279,37 @@ export async function exportEmbedBundleAndAssetsAsync(
           }
         })
       );
+    }
+
+    // Compile any bytecode the serializer deferred (chunks containing DOM
+    // component references). `export:embed` does not rename the DOM html
+    // assets, so this runs immediately after the DOM component exports.
+    for (const artifact of bundles.artifacts) {
+      if (artifact.type !== 'js' || !artifact.metadata.deferredHermesBytecode) {
+        continue;
+      }
+      delete artifact.metadata.deferredHermesBytecode;
+      const prevJsFilename = artifact.filename;
+      const mapArtifact =
+        bundles.artifacts.find(
+          (asset) => asset.type === 'map' && asset.filename === `${prevJsFilename}.map`
+        ) ?? null;
+      const prevMapFilename = mapArtifact?.filename;
+      const jsEntry = files.get(prevJsFilename);
+      const mapEntry = prevMapFilename ? files.get(prevMapFilename) : null;
+      await transformJsAssetToHermesBytecodeAsync({
+        projectRoot,
+        jsAsset: artifact,
+        mapAsset: mapArtifact,
+      });
+      if (jsEntry) {
+        files.delete(prevJsFilename);
+        files.set(artifact.filename, { ...jsEntry, contents: artifact.source });
+      }
+      if (mapArtifact && mapEntry && prevMapFilename) {
+        files.delete(prevMapFilename);
+        files.set(mapArtifact.filename, { ...mapEntry, contents: mapArtifact.source });
+      }
     }
 
     return {

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -1,6 +1,7 @@
 import { getConfig } from '@expo/config';
 import type { Platform } from '@expo/config';
 import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { transformJsAssetToHermesBytecodeAsync } from '@expo/metro-config/build/serializer/serializeChunks';
 import type { SerialAsset } from '@expo/metro-config/build/serializer/serializerAssets';
 import { createFaviconAsString } from '@expo/router-server/build/utils/html';
 import chalk from 'chalk';
@@ -268,6 +269,49 @@ export async function exportAppAsync(
               ];
             })
           );
+
+          // Compile any bytecode the serializer deferred (chunks containing DOM
+          // component references) now that the DOM html renames have been
+          // applied to the serialized JS.
+          {
+            for (const artifact of bundle.artifacts) {
+              if (artifact.type !== 'js' || !artifact.metadata.deferredHermesBytecode) {
+                continue;
+              }
+              delete artifact.metadata.deferredHermesBytecode;
+              const prevJsFilename = artifact.filename;
+              const jsEntry = files.get(prevJsFilename);
+              // DOM component renames mutate the `files` entry; sync it back to
+              // the artifact before compiling.
+              if (jsEntry && typeof jsEntry.contents === 'string') {
+                artifact.source = jsEntry.contents;
+              }
+              const mapArtifact =
+                bundle.artifacts.find(
+                  (asset) => asset.type === 'map' && asset.filename === `${prevJsFilename}.map`
+                ) ?? null;
+              const prevMapFilename = mapArtifact?.filename;
+              const mapEntry = prevMapFilename ? files.get(prevMapFilename) : null;
+              if (mapArtifact && mapEntry) {
+                mapArtifact.source = mapEntry.contents.toString();
+              }
+
+              await transformJsAssetToHermesBytecodeAsync({
+                projectRoot,
+                jsAsset: artifact,
+                mapAsset: mapArtifact,
+              });
+
+              if (jsEntry) {
+                files.delete(prevJsFilename);
+                files.set(artifact.filename, { ...jsEntry, contents: artifact.source });
+              }
+              if (mapArtifact && mapEntry && prevMapFilename) {
+                files.delete(prevMapFilename);
+                files.set(mapArtifact.filename, { ...mapEntry, contents: mapArtifact.source });
+              }
+            }
+          }
 
           if (platform === 'web') {
             const faviconAsset = await generateFaviconAssetAsync(projectRoot, {

--- a/packages/@expo/cli/src/export/exportDomComponents.ts
+++ b/packages/@expo/cli/src/export/exportDomComponents.ts
@@ -177,14 +177,16 @@ export function transformNativeBundleForMd5Filename({
     const assetEntity = files.get(artifact.filename);
     assert(assetEntity);
     if (Buffer.isBuffer(assetEntity.contents)) {
-      const searchBuffer = Buffer.from(`${hash}.html`, 'utf8');
-      const replaceBuffer = Buffer.from(`${htmlMd5}.html`, 'utf8');
-      assert(searchBuffer.length === replaceBuffer.length);
-      let index = assetEntity.contents.indexOf(searchBuffer, 0);
-      while (index !== -1) {
-        replaceBuffer.copy(assetEntity.contents, index);
-        index = assetEntity.contents.indexOf(searchBuffer, index + searchBuffer.length);
-      }
+      // Renaming inside compiled Hermes bytecode is unsound: hermesc
+      // overlap-packs strings that share suffix/prefix bytes, so a same-length
+      // in-place replacement can overwrite bytes owned by a neighbouring
+      // string (this silently corrupted unrelated string literals such as API
+      // keys in exported bundles). Bytecode compilation is deferred until
+      // after this rename (see exportApp), so this should never be reached.
+      throw new Error(
+        `Cannot rename DOM component asset "${htmlOutputName}" inside the compiled Hermes bytecode of "${artifact.filename}". ` +
+          'DOM component html renames must be applied to the serialized JS before bytecode compilation.'
+      );
     } else {
       const search = `${hash}.html`;
       const replace = `${htmlMd5}.html`;

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Extract the chunk Hermes bytecode step into `transformJsAssetToHermesBytecodeAsync` so `expo export` can defer bytecode compilation until after DOM component html renames. ([#49627](https://github.com/expo/expo/pull/49627) by [@ibrahimchraibi](https://github.com/ibrahimchraibi))
+
 - Depend on `@react-native/js-polyfills` directly for `getPolyfills` instead of the `react-native/rn-get-polyfills` subpath removed in React Native 0.88. ([#48034](https://github.com/expo/expo/pull/48034) by [@alanjhughes](https://github.com/alanjhughes))
 - Fix source line counts after environment serializer plugins modify virtual modules ([#48835](https://github.com/expo/expo/pull/48835) by [@kitten](https://github.com/kitten))
 - Seal web worker chunks to prevent common chunk splitting from applying to them ([#49227](https://github.com/expo/expo/pull/49227) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -528,54 +528,23 @@ export class Chunk {
     }
 
     if (this.boolishTransformOption('bytecode') && this.isHermesEnabled()) {
-      const adjustedSource = jsAsset.source.replace(
-        /^\/\/# (sourceMappingURL)=(.*)$/gm,
-        (...props) => {
-          if (props[1] === 'sourceMappingURL') {
-            const mapName = props[2].replace(/\.js\.map$/, '.hbc.map');
-            return `//# ${props[1]}=` + mapName;
-          }
-          return '';
-        }
-      );
-
-      // TODO: Generate hbc for each chunk
-      const hermesBundleOutput = await getBuildHermesBundleAsync()({
-        projectRoot: this.options.projectRoot,
-        filename: this.name,
-        code: adjustedSource,
-        map: assets[1] ? assets[1].source : null,
-        // TODO: Maybe allow prod + no minify.
-        minify: true, //!this.options.dev,
-      });
-
-      if (hermesBundleOutput.hbc) {
-        // TODO: Unclear if we should add multiple assets, link the assets, or mutate the first asset.
-        // jsAsset.metadata.hbc = hermesBundleOutput.hbc;
-        // @ts-expect-error: TODO
-        jsAsset.source = hermesBundleOutput.hbc;
-        jsAsset.filename = jsAsset.filename.replace(/\.js$/, '.hbc');
-
-        // Replace mappings with hbc
-        if (jsAsset.metadata.paths) {
-          jsAsset.metadata.paths = Object.fromEntries(
-            Object.entries(jsAsset.metadata.paths).map(([key, value]) => [
-              key,
-              Object.fromEntries(
-                Object.entries(value).map(([key, value]) => [
-                  key,
-                  value ? value.replace(/\.js$/, '.hbc') : value,
-                ])
-              ),
-            ])
-          );
-        }
-      }
-      if (assets[1] && hermesBundleOutput.sourcemap) {
-        assets[1].source = debugId
-          ? appendDebugIdToSourceMap(hermesBundleOutput.sourcemap, debugId)
-          : hermesBundleOutput.sourcemap;
-        assets[1].filename = assets[1].filename.replace(/\.js\.map$/, '.hbc.map');
+      if (jsAsset.metadata.expoDomComponentReferences?.length) {
+        // Defer bytecode compilation: the DOM component export renames each
+        // wrapper html to its content-hashed filename inside this bundle, and
+        // that rename must be applied to the serialized JS. Patching the name
+        // into compiled bytecode is unsound (hermesc overlap-packs strings
+        // sharing suffix/prefix bytes, so a same-length in-place replacement
+        // can corrupt neighbouring strings). The export commands compile
+        // deferred assets via `transformJsAssetToHermesBytecodeAsync` after
+        // the renames.
+        jsAsset.metadata.deferredHermesBytecode = true;
+      } else {
+        await transformJsAssetToHermesBytecodeAsync({
+          projectRoot: this.options.projectRoot,
+          jsAsset,
+          mapAsset: assets[1] ?? null,
+          filename: this.name,
+        });
       }
     }
 
@@ -933,4 +902,80 @@ async function serializeChunksAsync(
 
   await Promise.all(serializeTasks);
   return jsAssets;
+}
+
+/**
+ * Compile a serialized JS asset to Hermes bytecode in place, renaming the
+ * asset (`.js` -> `.hbc`), rewriting its chunk paths metadata, and replacing
+ * the source map with the Hermes-composed one.
+ *
+ * This runs as a standalone step (rather than inline in the chunk serializer)
+ * so `expo export` can defer it until after DOM component exports have
+ * renamed the DOM html assets inside the serialized JS. Renaming inside
+ * already-compiled bytecode is unsound: hermesc overlap-packs strings that
+ * share suffix/prefix bytes, so a same-length in-place replacement can
+ * overwrite bytes belonging to a neighbouring string.
+ */
+export async function transformJsAssetToHermesBytecodeAsync({
+  projectRoot,
+  jsAsset,
+  mapAsset,
+  filename,
+}: {
+  projectRoot: string;
+  jsAsset: SerialAsset;
+  mapAsset?: SerialAsset | null;
+  filename?: string;
+}): Promise<void> {
+  const debugId = stringToUUID(
+    path.basename(jsAsset.filename, path.extname(jsAsset.filename))
+  );
+  const adjustedSource = jsAsset.source.replace(
+    /^\/\/# (sourceMappingURL)=(.*)$/gm,
+    (...props) => {
+      if (props[1] === 'sourceMappingURL') {
+        const mapName = props[2].replace(/\.js\.map$/, '.hbc.map');
+        return `//# ${props[1]}=` + mapName;
+      }
+      return '';
+    }
+  );
+
+  // TODO: Generate hbc for each chunk
+  const hermesBundleOutput = await getBuildHermesBundleAsync()({
+    projectRoot,
+    filename: filename ?? jsAsset.originFilename,
+    code: adjustedSource,
+    map: mapAsset ? mapAsset.source : null,
+    // TODO: Maybe allow prod + no minify.
+    minify: true,
+  });
+
+  if (hermesBundleOutput.hbc) {
+    // TODO: Unclear if we should add multiple assets, link the assets, or mutate the first asset.
+    // @ts-expect-error: TODO
+    jsAsset.source = hermesBundleOutput.hbc;
+    jsAsset.filename = jsAsset.filename.replace(/\.js$/, '.hbc');
+
+    // Replace mappings with hbc
+    if (jsAsset.metadata.paths) {
+      jsAsset.metadata.paths = Object.fromEntries(
+        Object.entries(jsAsset.metadata.paths).map(([key, value]) => [
+          key,
+          Object.fromEntries(
+            Object.entries(value).map(([key, value]) => [
+              key,
+              value ? value.replace(/\.js$/, '.hbc') : value,
+            ])
+          ),
+        ])
+      );
+    }
+  }
+  if (mapAsset && hermesBundleOutput.sourcemap) {
+    mapAsset.source = debugId
+      ? appendDebugIdToSourceMap(hermesBundleOutput.sourcemap, debugId)
+      : hermesBundleOutput.sourcemap;
+    mapAsset.filename = mapAsset.filename.replace(/\.js\.map$/, '.hbc.map');
+  }
 }

--- a/packages/@expo/metro-config/src/serializer/serializerAssets.ts
+++ b/packages/@expo/metro-config/src/serializer/serializerAssets.ts
@@ -20,6 +20,8 @@ export type SerialAsset = {
     reactClientReferences?: string[];
     // DOM Component references from the static babel pass.
     expoDomComponentReferences?: string[];
+    /** Set when Hermes bytecode compilation was deferred so DOM component html renames can be applied to the serialized JS first (see `transformJsAssetToHermesBytecodeAsync`). */
+    deferredHermesBytecode?: boolean;
     // File paths of route modules that have loader exports.
     loaderReferences?: string[];
     requires?: string[];


### PR DESCRIPTION
# Why

Fixes #49626.

`expo export` renames each `'use dom'` component's wrapper html to its content-hashed filename **after** the native bundle is compiled, by a same-length binary find-and-replace inside the Hermes bytecode (`transformNativeBundleForMd5Filename`, `Buffer.isBuffer` branch). hermesc's string table overlap-packs strings sharing suffix/prefix bytes, so that in-place write can overwrite bytes belonging to a **neighbouring** string — silently corrupting unrelated string literals in production bundles. In our app it clipped the last 3 bytes of an API client key in every iOS OTA update. The linked issue has a one-command deterministic repro.

# How

The content-hashed filename must stay (it's load-bearing: `expo/dom/base.ts` serves OTA dom assets from expo-updates' flat content-hash-keyed store), so the rename is moved to where it is sound — the serialized JS, before bytecode exists:

- **`@expo/metro-config`**: the chunk serializer's bytecode step is extracted verbatim into an exported `transformJsAssetToHermesBytecodeAsync`. When a chunk contains DOM component references (`metadata.expoDomComponentReferences`), the serializer **defers** compilation by setting `metadata.deferredHermesBytecode` instead of compiling inline. **The bundle request is untouched, so transform-level behaviour is byte-identical** (`bytecode` also gates `shouldMinify` — hermes+bytecode skips JS minification in favour of `hermesc -O`; deferring via `bytecode: false` would have double-minified, which is why the deferral lives inside the serializer). Chunks without DOM refs — the overwhelming majority of apps — compile exactly as before.
- **`@expo/cli` `exportApp`**: after the DOM component exports have applied their renames via the existing (sound) text branch, deferred artifacts are compiled through the extracted function, and the `files` map entries are updated to the `.hbc`/`.hbc.map` names.
- **`@expo/cli` `export:embed`**: also compiles deferred artifacts after its DOM component exports (embed doesn't rename, so this is a pass-through to preserve behaviour when `--bytecode` is used with DOM components).
- **`transformNativeBundleForMd5Filename`** now throws if handed compiled bytecode, so the unsound path can't silently return.

# Test Plan

- New unit test: `transformNativeBundleForMd5Filename` throws on `Buffer` contents; existing string-branch tests unchanged.
- Validated against the repro in #49626 by porting exactly this design onto the published CLI's build output: flips the repro from `FAIL` (planted literal corrupted) to `PASS` — and the emitted bytecode is **1,458,932 bytes vs stock's 1,458,920** (Δ12 bytes = the renamed html string), confirming the deferred compile consumes byte-equivalent JS. (An earlier `bytecode: false`-based attempt produced a 13 KB-smaller bundle from double minification — the metadata-deferral approach exists precisely to avoid that.)
- The core operation this PR relies on — applying the same-length rename to the *serialized JS* and then compiling fresh bytecode from it — was additionally validated end-to-end on a large production app (37 MB bundle, 3 DOM components) via a closely related patch-package workaround (recompile-after-rename rather than defer-before-compile): literals intact, `basename == md5(content)` for every DOM html, zero invalid string-table overlaps, OTA applies and DOM components render. To be explicit: this PR's exact defer-in-serializer implementation was validated on the minimal repro only.

**Caveats for review:** I couldn't run the monorepo's own build/CI locally. The RSC/server-hosted DOM paths are untouched by design (request unchanged, deferral only fires on chunks with DOM refs), but the `files`-map sync in `exportApp`/`export:embed` around hosted targets deserves maintainer eyes.
