### PR TITLE
[router-server] Keep files outside the app root out of typed routes on Windows

### DIFF
--- a/packages/@expo/router-server/CHANGELOG.md
+++ b/packages/@expo/router-server/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Keep files outside the app root out of the typed routes declaration on Windows, and key files inside it with forward slashes. ([#49629](https://github.com/expo/expo/pull/49629) by [@LizunovSergey](https://github.com/LizunovSergey))
+
 ### 💡 Others
 
 - [Internal] Inject CSS and JavaScript bundle tags within `getStaticContent()`. ([#47006](https://github.com/expo/expo/pull/47006) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/router-server/src/typed-routes/__tests__/type-generation.test.node.ts
+++ b/packages/@expo/router-server/src/typed-routes/__tests__/type-generation.test.node.ts
@@ -1,7 +1,8 @@
 import { inMemoryContext, requireContext } from 'expo-router/internal/testing';
+import path from 'node:path';
 
 import { getTypedRoutesDeclarationFile } from '../generate';
-import { getWatchHandler } from '../index';
+import { getRouteContextKey, getWatchHandler } from '../index';
 
 function getGeneratedRoutes(
   context: ReturnType<typeof inMemoryContext>,
@@ -203,6 +204,56 @@ describe(getWatchHandler, () => {
     handler(`/other-directory/apple.ts`, 'add');
 
     expect(fn).not.toHaveBeenCalled();
+  });
+});
+
+describe(getRouteContextKey, () => {
+  // `path.relative` answers with the host separator, so a POSIX-only check
+  // admits every file in the workspace once the host is Windows.
+  const windows = path.win32;
+  const posix = path.posix;
+
+  it('keys a file inside the app root', () => {
+    expect(
+      getRouteContextKey('/User/expo/project/app', '/User/expo/project/app/fruit/banana.ts', posix)
+    ).toBe('./fruit/banana.ts');
+    expect(
+      getRouteContextKey(
+        String.raw`C:\repo\apps\expo\src\app`,
+        String.raw`C:\repo\apps\expo\src\app\fruit\banana.ts`,
+        windows
+      )
+    ).toBe('./fruit/banana.ts');
+  });
+
+  it('rejects a file outside the app root', () => {
+    expect(
+      getRouteContextKey('/User/expo/project/app', '/User/expo/project/packages/api/seed.ts', posix)
+    ).toBeNull();
+    expect(
+      getRouteContextKey(
+        String.raw`C:\repo\apps\expo\src\app`,
+        String.raw`C:\repo\packages\api\src\seed.ts`,
+        windows
+      )
+    ).toBeNull();
+  });
+
+  it('rejects the app root itself and a sibling that shares its prefix', () => {
+    expect(getRouteContextKey('/User/expo/project/app', '/User/expo/project', posix)).toBeNull();
+    expect(
+      getRouteContextKey('/User/expo/project/app', '/User/expo/project/apple/index.ts', posix)
+    ).toBeNull();
+  });
+
+  it('rejects a path on another Windows drive, which has no relative form', () => {
+    expect(
+      getRouteContextKey(
+        String.raw`C:\repo\apps\expo\src\app`,
+        String.raw`D:\elsewhere\seed.ts`,
+        windows
+      )
+    ).toBeNull();
   });
 });
 

--- a/packages/@expo/router-server/src/typed-routes/index.ts
+++ b/packages/@expo/router-server/src/typed-routes/index.ts
@@ -17,6 +17,38 @@ export type { RequireContextPonyFill } from 'expo-router/internal/testing';
 export const version = 52;
 
 /**
+ * The `require.context` key for a file watched by Metro, or `null` when the file
+ * sits outside the app root and is not a route at all.
+ *
+ * Keys are POSIX and root-relative (`./fruit/banana.ts`), while `path.relative`
+ * answers with the host separator. Both differences matter on Windows: the
+ * escape marker is `..\`, not `../`, and a key holding backslashes matches
+ * nothing in the context.
+ *
+ * `pathModule` is injected by the tests so both platforms can be covered from
+ * either host.
+ */
+export function getRouteContextKey(
+  appRoot: string,
+  filePath: string,
+  pathModule: Pick<path.PlatformPath, 'relative' | 'isAbsolute' | 'sep'> = path
+): string | null {
+  const relativePath = pathModule.relative(appRoot, filePath);
+
+  // A path on another Windows drive has no relative form, so `relative` hands
+  // back the absolute one rather than a `..` chain.
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${pathModule.sep}`) ||
+    pathModule.isAbsolute(relativePath)
+  ) {
+    return null;
+  }
+
+  return `./${relativePath.split(pathModule.sep).join('/')}`;
+}
+
+/**
  * Generate a Metro watch handler that regenerates the typed routes declaration file
  */
 export function getWatchHandler(
@@ -30,14 +62,11 @@ export function getWatchHandler(
     if (!process.env.EXPO_ROUTER_APP_ROOT) return;
 
     let shouldRegenerate = false;
-    let relativePath = path.relative(process.env.EXPO_ROUTER_APP_ROOT, filePath);
-    const isInsideAppRoot = !relativePath.startsWith('../');
-    const basename = path.basename(relativePath);
+    const relativePath = getRouteContextKey(process.env.EXPO_ROUTER_APP_ROOT, filePath);
 
-    if (!isInsideAppRoot) return;
+    if (relativePath === null) return;
 
-    // require.context paths always start with './' when relative to the root
-    relativePath = `./${relativePath}`;
+    const basename = path.posix.basename(relativePath);
 
     if (type === 'delete') {
       ctx.__delete(relativePath);


### PR DESCRIPTION
# Why

Fixes #49622.

`getWatchHandler` decides whether a changed file belongs to the app root by testing what `path.relative()` returns against the POSIX-only prefix `'../'` ([`typed-routes/index.ts#L33-L37`](https://github.com/expo/expo/blob/main/packages/%40expo/router-server/src/typed-routes/index.ts#L33-L37)):

```ts
let relativePath = path.relative(process.env.EXPO_ROUTER_APP_ROOT, filePath);
const isInsideAppRoot = !relativePath.startsWith('../');
```

On Windows that answer comes back separator-delimited with backslashes — `..\..\packages\api\src\seed.ts` — so the check never matches and every file Metro watches is accepted as a route. Metro watches the workspace root in a monorepo, so with `expo start` running, editing any file anywhere writes it into `.expo/types/router.d.ts`, and every real route then fails to typecheck against the poisoned union. The reporter hit 19 such errors across 11 routes.

The same assumption breaks the other half of the function, which the issue does not mention. Five lines further down the `require.context` key is built as:

```ts
relativePath = `./${relativePath}`;
```

Context keys are POSIX (`./fruit/banana.ts`), so on Windows a file genuinely *inside* the app root is keyed `./fruit\banana.ts` and matches nothing: `routeFiles.has(...)` misses on every change, and an `add` inserts a backslash-bearing key into the context. Fixing only the guard would leave the handler still wrong on Windows, in the opposite direction, so this fixes both.

# How

One helper, `getRouteContextKey`, now owns the decision and returns the key or `null`:

- rejects the escape marker for the **host** separator (`..${path.sep}`) rather than a hardcoded `../`, and rejects a bare `..` — the app root's own parent;
- rejects an **absolute** answer, which is what `path.win32.relative` returns for two paths on different drives, where no relative form exists at all;
- joins the remainder with forward slashes, so the key matches what `require.context` produced.

The path module is a parameter defaulting to `node:path`. That is what makes the regression testable: `path.win32` and `path.posix` can both be exercised from a macOS or Linux CI runner, which is the reason this bug survived — the existing `will ignore files outside the app dir` test passes on every platform while covering only the POSIX branch.

`basename` now comes from `path.posix.basename`, since by that point the value is a POSIX key by construction.

# Test Plan

`packages/@expo/router-server`, on macOS:

```
yarn jest src/typed-routes   # 3 suites, 17 tests passed
yarn lint                    # clean
yarn typecheck               # clean
```

The four added cases fail against the current logic and pass with the change — checked by reverting the helper body to the original two lines and rerunning: `Tests: 4 failed, 13 passed`.

| case | before | after |
| --- | --- | --- |
| win32, file inside the app root | `./fruit\banana.ts` | `./fruit/banana.ts` |
| win32, file outside the app root (the reported bug) | accepted | rejected |
| posix, the app root's own parent | `./..` | rejected |
| win32, path on another drive | `./D:\elsewhere\seed.ts` | rejected |

I did not reproduce it end to end on a Windows host — I do not have one. The unit tests stand in for that by driving `path.win32` directly, which is the same `path.relative` implementation Node uses there; the issue carries the end-to-end reproduction on real hardware.

# Checklist

- [x] `CHANGELOG.md` entry added.
- [ ] Not applicable: no module plugin or prebuild behaviour is touched.
- [ ] Not applicable: no documentation changes.
