### PR TITLE
[JSI][iOS] Remove per-call runtime refcount traffic from host callbacks

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [iOS] `JavaScriptActor.assumeIsolated` no longer heap-allocates a closure box per call by keeping its `operation` non-escaping, making synchronous host calls ~1.6× faster. ([#47837](https://github.com/expo/expo/pull/47837) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptValue.undefined` and `JavaScriptValue.null` now return shared immortal instances instead of allocating a new value on each access, removing one allocation from every void-returning host call. ([#49545](https://github.com/expo/expo/pull/49545) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added an opt-in benchmark target that measures value access, host function calls, and JS function calls; run it with `pnpm benchmark`. ([#49579](https://github.com/expo/expo/pull/49579) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors by removing the per-call weak and unowned runtime reference traffic on the call path. ([#49631](https://github.com/expo/expo/pull/49631) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
@@ -12,7 +12,10 @@ namespace expo {
  */
 class HostFunctionClosure final : public RetainedSwiftPointer {
 public:
-  using Closure = facebook::jsi::Value(Context context, const facebook::jsi::Value *_Nonnull thisValue, const facebook::jsi::Value *_Nonnull args, size_t count);
+  // The result travels through an out-parameter instead of a return value: the Swift side can then
+  // write it straight into the caller's slot from inside its guaranteed-reference scope, with no
+  // placeholder value to construct and no extra move of the `jsi::Value`.
+  using Closure = void(Context context, const facebook::jsi::Value *_Nonnull thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value *_Nonnull result);
 
   explicit HostFunctionClosure(Context context, Closure closure, Deallocator deallocator) : RetainedSwiftPointer(context, deallocator), _closure(closure) {};
 
@@ -23,8 +26,8 @@ public:
   /**
    Calls the Swift closure with given `this` value and arguments.
    */
-  inline facebook::jsi::Value call(const facebook::jsi::Value &thisValue, const facebook::jsi::Value *_Nonnull args, size_t count) const {
-    return _closure(_context, &thisValue, args, count);
+  inline void call(const facebook::jsi::Value &thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value &result) const {
+    _closure(_context, &thisValue, args, count, &result);
   }
 
 private:

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
@@ -23,7 +23,8 @@ public:
   }
 
   inline jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override {
-    auto result = _callbacks.get(name.utf8(runtime).c_str());
+    jsi::Value result;
+    _callbacks.get(name.utf8(runtime).c_str(), result);
     // If the Swift getter stored a pending error, rethrow its JSError directly
     // to preserve all properties (message, code, stack, etc.).
     if (auto *error = CppError::getCurrent()) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
@@ -16,7 +16,9 @@ class HostObjectCallbacks final {
 public:
   using Context = void *_Nonnull;
   using PropNameIds = std::vector<facebook::jsi::PropNameID>;
-  using Getter = facebook::jsi::Value(Context, const char *_Nonnull name);
+  // The getter writes its result through an out-parameter, like `HostFunctionClosure`, so the
+  // Swift side can fill the caller's slot from inside its guaranteed-reference scope.
+  using Getter = void(Context, const char *_Nonnull name, facebook::jsi::Value *_Nonnull result);
   using Setter = void(Context, const char *_Nonnull name, void *_Nonnull value);
   using PropertyNamesGetter = PropNameIds(Context);
   using Deallocator = void(Context);
@@ -24,8 +26,8 @@ public:
   explicit HostObjectCallbacks(Context context, Getter getter, Setter *_Nullable setter, PropertyNamesGetter propertyNamesGetter, Deallocator deallocator)
   : _context(context), _getter(getter), _setter(setter), _propertyNamesGetter(propertyNamesGetter), _deallocator(deallocator) {}
 
-  inline facebook::jsi::Value get(const char *_Nonnull name) const {
-    return _getter(_context, name);
+  inline void get(const char *_Nonnull name, facebook::jsi::Value &result) const {
+    _getter(_context, name, &result);
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -100,7 +100,8 @@ inline std::shared_ptr<const jsi::Buffer> makeSharedStringBuffer(const std::stri
 inline jsi::Function createHostFunction(jsi::IRuntime &runtime, const jsi::PropNameID &propName, HostFunctionClosure *closure) {
   auto closurePtr = std::shared_ptr<HostFunctionClosure>(closure);
   return jsi::Function::createFromHostFunction(runtime, propName, 0, [closurePtr](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *_Nonnull args, size_t count) -> jsi::Value {
-    auto result = closurePtr->call(thisValue, args, count);
+    jsi::Value result;
+    closurePtr->call(thisValue, args, count, result);
 
     // If the Swift closure stored a pending error, rethrow its JSError directly
     // to preserve all properties (message, code, stack, etc.).

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostCallbackContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostCallbackContext.swift
@@ -1,0 +1,28 @@
+/// A context object handed to JSI as an opaque pointer, owned by the JSI host function or host
+/// object it was created for and freed from that owner's deallocate callback.
+internal protocol HostCallbackContext: AnyObject {
+  /// The runtime the owner was installed in. Stored as `Unmanaged` rather than `weak`: the owner
+  /// lives in the runtime's heap, so a callback can only run while the runtime is alive and
+  /// executing JS, and a `weak` load plus a strong release per call was the largest single cost
+  /// of a no-op host call.
+  var runtime: Unmanaged<JavaScriptRuntime> { get }
+}
+
+/// Runs `body` with guaranteed references to the context behind `pointer` and to its runtime.
+/// `_withUnsafeGuaranteedRef` promises the compiler that both objects outlive the closure, so no
+/// retain or release is emitted for either. Both promises hold for a JSI callback: the JSI owner
+/// of the context is the caller, and a synchronous callback runs while the runtime executes JS,
+/// with the wrapper owned for the runtime's whole lifetime. The body returns nothing because
+/// `_withUnsafeGuaranteedRef` needs a `Copyable` result; callbacks write their `jsi::Value`
+/// result into the slot the C++ caller provides instead.
+@inline(__always)
+internal func withGuaranteedContext<Context: HostCallbackContext>(
+  _ pointer: UnsafeMutableRawPointer,
+  _ body: (_ context: Context, _ runtime: JavaScriptRuntime) -> Void
+) {
+  Unmanaged<Context>.fromOpaque(pointer)._withUnsafeGuaranteedRef { context in
+    context.runtime._withUnsafeGuaranteedRef { runtime in
+      body(context, runtime)
+    }
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -1,5 +1,5 @@
 /// Context that captures Swift values to pass them to JSI host function as an unmanaged pointer for interoperability with C++.
-internal final class HostFunctionContext: Sendable {
+internal final class HostFunctionContext: HostCallbackContext, Sendable {
   // Stored as `Unmanaged` rather than `weak`, for the same reason as in
   // ``UnownedThisHostFunctionContext`` below: the JSI host function owns the context and cannot
   // outlive its runtime, and the per-call weak load plus strong release measured at about 10 ns
@@ -17,7 +17,7 @@ internal final class HostFunctionContext: Sendable {
 
 /// Counterpart to ``HostFunctionContext`` for host functions whose closure receives `this` as a
 /// borrowed ``JavaScriptUnownedValue`` (see ``JavaScriptRuntime/UnownedThisSyncFunctionClosure``).
-internal final class UnownedThisHostFunctionContext: Sendable {
+internal final class UnownedThisHostFunctionContext: HostCallbackContext, Sendable {
   // Stored as `Unmanaged` rather than `weak`: the context lives exactly as long as the JSI host
   // function that owns it (freed from the `deallocate` callback), and the host function cannot
   // outlive the runtime it was installed in. A `weak` reference here cost a `swift_weakLoadStrong`

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -1,11 +1,15 @@
 /// Context that captures Swift values to pass them to JSI host function as an unmanaged pointer for interoperability with C++.
 internal final class HostFunctionContext: Sendable {
-  weak let runtime: JavaScriptRuntime?
+  // Stored as `Unmanaged` rather than `weak`, for the same reason as in
+  // ``UnownedThisHostFunctionContext`` below: the JSI host function owns the context and cannot
+  // outlive its runtime, and the per-call weak load plus strong release measured at about 10 ns
+  // of a no-op call through this form.
+  let runtime: Unmanaged<JavaScriptRuntime>
   let name: String?
   let call: JavaScriptRuntime.SyncFunctionClosure
 
   init(runtime: JavaScriptRuntime, name: String? = nil, _ function: @escaping JavaScriptRuntime.SyncFunctionClosure) {
-    self.runtime = runtime
+    self.runtime = Unmanaged.passUnretained(runtime)
     self.name = name
     self.call = function
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -14,7 +14,15 @@ internal final class HostFunctionContext: Sendable {
 /// Counterpart to ``HostFunctionContext`` for host functions whose closure receives `this` as a
 /// borrowed ``JavaScriptUnownedValue`` (see ``JavaScriptRuntime/UnownedThisSyncFunctionClosure``).
 internal final class UnownedThisHostFunctionContext: Sendable {
-  weak let runtime: JavaScriptRuntime?
+  // Stored as `Unmanaged` rather than `weak`: the context lives exactly as long as the JSI host
+  // function that owns it (freed from the `deallocate` callback), and the host function cannot
+  // outlive the runtime it was installed in. A `weak` reference here cost a `swift_weakLoadStrong`
+  // plus a strong release on every host call, and profiling showed that pair as the largest single
+  // item on the no-op `@JS` call floor. Callers read it through `_withUnsafeGuaranteedRef`, which
+  // also skips the strong retain/release a plain `unowned(unsafe)` load would still emit. Those go
+  // through the refcount side table (other wrappers hold the runtime `weak`), so they were the next
+  // largest item once the weak load was gone.
+  let runtime: Unmanaged<JavaScriptRuntime>
   let name: String?
   let call: JavaScriptRuntime.UnownedThisSyncFunctionClosure
 
@@ -23,7 +31,7 @@ internal final class UnownedThisHostFunctionContext: Sendable {
     name: String? = nil,
     _ function: @escaping JavaScriptRuntime.UnownedThisSyncFunctionClosure
   ) {
-    self.runtime = runtime
+    self.runtime = Unmanaged.passUnretained(runtime)
     self.name = name
     self.call = function
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
@@ -5,7 +5,11 @@ internal final class HostObjectContext: Sendable {
   typealias PropertyNamesGetter = @JavaScriptActor () -> [String]
   typealias Deallocator = @JavaScriptActor () -> Void
 
-  weak let runtime: JavaScriptRuntime?
+  // Stored as `Unmanaged` rather than `weak`: the JSI host object owns the context (freed from the
+  // `deallocate` callback when the JS object is collected) and lives in the runtime's heap, so a
+  // getter or setter can only run while the runtime is alive and executing JS. Skips a weak load
+  // plus a strong release on every property access; see ``UnownedThisHostFunctionContext``.
+  let runtime: Unmanaged<JavaScriptRuntime>
   let get: Getter
   let set: Setter?
   let getPropertyNames: PropertyNamesGetter
@@ -18,7 +22,7 @@ internal final class HostObjectContext: Sendable {
     _ getPropertyNames: @escaping PropertyNamesGetter,
     _ dealloc: @escaping Deallocator
   ) {
-    self.runtime = runtime
+    self.runtime = Unmanaged.passUnretained(runtime)
     self.get = get
     self.set = set
     self.getPropertyNames = getPropertyNames

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
@@ -1,5 +1,5 @@
 /// Context that captures Swift types to pass them to JSI host object as an unmanaged pointer for interoperability with C++.
-internal final class HostObjectContext: Sendable {
+internal final class HostObjectContext: HostCallbackContext, Sendable {
   typealias Getter = @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue
   typealias Setter = @JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) throws -> Void
   typealias PropertyNamesGetter = @JavaScriptActor () -> [String]

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -843,12 +843,6 @@ private func createFunctionClosure(
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsCount: Int
   ) -> facebook.jsi.Value {
-    let context = Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context).takeUnretainedValue()
-
-    guard let runtime = context.runtime else {
-      FatalError.runtimeLost()
-    }
-
     // Same call-scoped reasoning as the owning-`this` overload above (see its comment) for why the
     // buffer is built inside the synchronous `assumeIsolated` closure. Here `this` is additionally
     // handed in as a borrowed `JavaScriptUnownedValue` pointing straight at the C++-owned `this` slot:
@@ -857,13 +851,24 @@ private func createFunctionClosure(
     nonisolated(unsafe) let thisPtr = thisPtr
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
 
-    return JavaScriptActor.assumeIsolated {
-      return forwardingSwiftErrorsToJS(runtime: runtime) {
-        let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
-        let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
-        return try context.call(thisValue, consume arguments).asJSIValue()
+    // `_withUnsafeGuaranteedRef` promises the compiler that the referenced object stays alive for the
+    // duration of the closure, so no retain/release is emitted for it. Both promises hold: the context
+    // is owned by the JSI host function that is calling us, and a sync host call runs while the runtime
+    // is executing JS, with the wrapper owned for the runtime's whole lifetime. The closure result must
+    // be `Copyable`, and `jsi::Value` is not, so the value is moved out through a captured local.
+    var result = facebook.jsi.Value.undefined()
+    Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
+      context.runtime._withUnsafeGuaranteedRef { runtime in
+        result = JavaScriptActor.assumeIsolated {
+          return forwardingSwiftErrorsToJS(runtime: runtime) {
+            let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
+            let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
+            return try context.call(thisValue, consume arguments).asJSIValue()
+          }
+        }
       }
     }
+    return result
   }
 
   func deallocate(context: UnsafeMutableRawPointer) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -178,19 +178,21 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     getPropertyNames: @escaping @JavaScriptActor () -> [String] = { [] },
     dealloc: @escaping @JavaScriptActor () -> Void = {}
   ) -> JavaScriptObject {
-    func getter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>) -> facebook.jsi.Value {
+    func getter(
+      context: UnsafeMutableRawPointer,
+      propertyName: UnsafePointer<CChar>,
+      resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
+    ) {
       let propertyName = String(cString: propertyName)
+      nonisolated(unsafe) let resultPtr = resultPtr
 
-      // The result leaves through a captured local because `jsi::Value` is not `Copyable`.
-      var result = facebook.jsi.Value.undefined()
       withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
-        result = JavaScriptActor.assumeIsolated {
+        resultPtr.pointee = JavaScriptActor.assumeIsolated {
           return forwardingSwiftErrorsToJS(runtime: runtime) {
             return try context.get(propertyName).asJSIValue()
           }
         }
       }
-      return result
     }
 
     func setter(

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -798,8 +798,9 @@ private func createFunctionClosure(
     context: UnsafeMutableRawPointer,
     thisPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
-    argumentsCount: Int
-  ) -> facebook.jsi.Value {
+    argumentsCount: Int,
+    resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
+  ) {
     // `assumeIsolated` runs `operation` synchronously, in this very scope — it never escapes and never
     // hops threads (see `JavaScriptActor.assumeIsolated`). So rather than materializing the move-only
     // `JavaScriptValuesBuffer` out here and smuggling it across the closure boundary through a
@@ -811,13 +812,13 @@ private func createFunctionClosure(
     // floor.
     nonisolated(unsafe) let thisPtr = thisPtr
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
+    nonisolated(unsafe) let resultPtr = resultPtr
 
     // See the unowned-`this` overload below for why the context and runtime are read through
-    // `_withUnsafeGuaranteedRef` and the result leaves through a captured local.
-    var result = facebook.jsi.Value.undefined()
+    // `_withUnsafeGuaranteedRef`.
     Unmanaged<HostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
       context.runtime._withUnsafeGuaranteedRef { runtime in
-        result = JavaScriptActor.assumeIsolated {
+        resultPtr.pointee = JavaScriptActor.assumeIsolated {
           return forwardingSwiftErrorsToJS(runtime: runtime) {
             let this = UnsafeMutablePointer(mutating: thisPtr).move()
             let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
@@ -827,7 +828,6 @@ private func createFunctionClosure(
         }
       }
     }
-    return result
   }
 
   func deallocate(context: UnsafeMutableRawPointer) {
@@ -848,8 +848,9 @@ private func createFunctionClosure(
     context: UnsafeMutableRawPointer,
     thisPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
-    argumentsCount: Int
-  ) -> facebook.jsi.Value {
+    argumentsCount: Int,
+    resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
+  ) {
     // Same call-scoped reasoning as the owning-`this` overload above (see its comment) for why the
     // buffer is built inside the synchronous `assumeIsolated` closure. Here `this` is additionally
     // handed in as a borrowed `JavaScriptUnownedValue` pointing straight at the C++-owned `this` slot:
@@ -857,16 +858,17 @@ private func createFunctionClosure(
     // per-call `weak`-runtime form/destroy and heap object that the owning `this` pays.
     nonisolated(unsafe) let thisPtr = thisPtr
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
+    nonisolated(unsafe) let resultPtr = resultPtr
 
     // `_withUnsafeGuaranteedRef` promises the compiler that the referenced object stays alive for the
     // duration of the closure, so no retain/release is emitted for it. Both promises hold: the context
     // is owned by the JSI host function that is calling us, and a sync host call runs while the runtime
     // is executing JS, with the wrapper owned for the runtime's whole lifetime. The closure result must
-    // be `Copyable`, and `jsi::Value` is not, so the value is moved out through a captured local.
-    var result = facebook.jsi.Value.undefined()
+    // be `Copyable`, and `jsi::Value` is not, so the value is written to the caller's result slot
+    // instead of being returned.
     Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
       context.runtime._withUnsafeGuaranteedRef { runtime in
-        result = JavaScriptActor.assumeIsolated {
+        resultPtr.pointee = JavaScriptActor.assumeIsolated {
           return forwardingSwiftErrorsToJS(runtime: runtime) {
             let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
             let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
@@ -875,7 +877,6 @@ private func createFunctionClosure(
         }
       }
     }
-    return result
   }
 
   func deallocate(context: UnsafeMutableRawPointer) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -181,15 +181,12 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     func getter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>) -> facebook.jsi.Value {
       let propertyName = String(cString: propertyName)
 
-      // Same shape as the host function entry points: guaranteed references to the context and
-      // the runtime, and a captured local because `jsi::Value` is not `Copyable`.
+      // The result leaves through a captured local because `jsi::Value` is not `Copyable`.
       var result = facebook.jsi.Value.undefined()
-      Unmanaged<HostObjectContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
-        context.runtime._withUnsafeGuaranteedRef { runtime in
-          result = JavaScriptActor.assumeIsolated {
-            return forwardingSwiftErrorsToJS(runtime: runtime) {
-              return try context.get(propertyName).asJSIValue()
-            }
+      withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
+        result = JavaScriptActor.assumeIsolated {
+          return forwardingSwiftErrorsToJS(runtime: runtime) {
+            return try context.get(propertyName).asJSIValue()
           }
         }
       }
@@ -203,7 +200,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     ) {
       let propertyName = String(cString: propertyName)
 
-      Unmanaged<HostObjectContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
+      withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
         guard let set = context.set else {
           // Unreachable in practice: when the user passed `nil` for `set`, the call site
           // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
@@ -212,13 +209,11 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
           // swallow assignments.
           FatalError.readOnlyHostObjectSetterInvoked()
         }
-        context.runtime._withUnsafeGuaranteedRef { runtime in
-          let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
+        let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
 
-          JavaScriptActor.assumeIsolated {
-            forwardingSwiftErrorsToJS(runtime: runtime) {
-              try set(propertyName, value)
-            }
+        JavaScriptActor.assumeIsolated {
+          forwardingSwiftErrorsToJS(runtime: runtime) {
+            try set(propertyName, value)
           }
         }
       }
@@ -814,17 +809,15 @@ private func createFunctionClosure(
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
     nonisolated(unsafe) let resultPtr = resultPtr
 
-    // See the unowned-`this` overload below for why the context and runtime are read through
-    // `_withUnsafeGuaranteedRef`.
-    Unmanaged<HostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
-      context.runtime._withUnsafeGuaranteedRef { runtime in
-        resultPtr.pointee = JavaScriptActor.assumeIsolated {
-          return forwardingSwiftErrorsToJS(runtime: runtime) {
-            let this = UnsafeMutablePointer(mutating: thisPtr).move()
-            let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
-            let thisValue = JavaScriptValue(runtime, this)
-            return try context.call(thisValue, consume arguments).asJSIValue()
-          }
+    // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
+    // why the result is written to the caller's slot instead of being returned.
+    withGuaranteedContext(context) { (context: HostFunctionContext, runtime) in
+      resultPtr.pointee = JavaScriptActor.assumeIsolated {
+        return forwardingSwiftErrorsToJS(runtime: runtime) {
+          let this = UnsafeMutablePointer(mutating: thisPtr).move()
+          let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
+          let thisValue = JavaScriptValue(runtime, this)
+          return try context.call(thisValue, consume arguments).asJSIValue()
         }
       }
     }
@@ -860,20 +853,14 @@ private func createFunctionClosure(
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
     nonisolated(unsafe) let resultPtr = resultPtr
 
-    // `_withUnsafeGuaranteedRef` promises the compiler that the referenced object stays alive for the
-    // duration of the closure, so no retain/release is emitted for it. Both promises hold: the context
-    // is owned by the JSI host function that is calling us, and a sync host call runs while the runtime
-    // is executing JS, with the wrapper owned for the runtime's whole lifetime. The closure result must
-    // be `Copyable`, and `jsi::Value` is not, so the value is written to the caller's result slot
-    // instead of being returned.
-    Unmanaged<UnownedThisHostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
-      context.runtime._withUnsafeGuaranteedRef { runtime in
-        resultPtr.pointee = JavaScriptActor.assumeIsolated {
-          return forwardingSwiftErrorsToJS(runtime: runtime) {
-            let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
-            let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
-            return try context.call(thisValue, consume arguments).asJSIValue()
-          }
+    // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
+    // why the result is written to the caller's slot instead of being returned.
+    withGuaranteedContext(context) { (context: UnownedThisHostFunctionContext, runtime) in
+      resultPtr.pointee = JavaScriptActor.assumeIsolated {
+        return forwardingSwiftErrorsToJS(runtime: runtime) {
+          let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
+          let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
+          return try context.call(thisValue, consume arguments).asJSIValue()
         }
       }
     }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -179,17 +179,21 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     dealloc: @escaping @JavaScriptActor () -> Void = {}
   ) -> JavaScriptObject {
     func getter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>) -> facebook.jsi.Value {
-      let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
       let propertyName = String(cString: propertyName)
 
-      guard let runtime = context.runtime else {
-        FatalError.runtimeLost()
-      }
-      return JavaScriptActor.assumeIsolated {
-        return forwardingSwiftErrorsToJS(runtime: runtime) {
-          return try context.get(propertyName).asJSIValue()
+      // Same shape as the host function entry points: guaranteed references to the context and
+      // the runtime, and a captured local because `jsi::Value` is not `Copyable`.
+      var result = facebook.jsi.Value.undefined()
+      Unmanaged<HostObjectContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
+        context.runtime._withUnsafeGuaranteedRef { runtime in
+          result = JavaScriptActor.assumeIsolated {
+            return forwardingSwiftErrorsToJS(runtime: runtime) {
+              return try context.get(propertyName).asJSIValue()
+            }
+          }
         }
       }
+      return result
     }
 
     func setter(
@@ -197,34 +201,35 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       propertyName: UnsafePointer<CChar>,
       valuePointer: UnsafeMutableRawPointer
     ) {
-      let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
-
-      guard let runtime = context.runtime else {
-        FatalError.runtimeLost()
-      }
-      guard let set = context.set else {
-        // Unreachable in practice: when the user passed `nil` for `set`, the call site
-        // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
-        // `HostObjectCallbacks::set` throws a `jsi::JSError` directly instead of
-        // calling back into Swift. Trap loudly so a future C++ refactor can't silently
-        // swallow assignments.
-        FatalError.readOnlyHostObjectSetterInvoked()
-      }
-      let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
       let propertyName = String(cString: propertyName)
 
-      JavaScriptActor.assumeIsolated {
-        forwardingSwiftErrorsToJS(runtime: runtime) {
-          try set(propertyName, value)
+      Unmanaged<HostObjectContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
+        guard let set = context.set else {
+          // Unreachable in practice: when the user passed `nil` for `set`, the call site
+          // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
+          // `HostObjectCallbacks::set` throws a `jsi::JSError` directly instead of
+          // calling back into Swift. Trap loudly so a future C++ refactor can't silently
+          // swallow assignments.
+          FatalError.readOnlyHostObjectSetterInvoked()
+        }
+        context.runtime._withUnsafeGuaranteedRef { runtime in
+          let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
+
+          JavaScriptActor.assumeIsolated {
+            forwardingSwiftErrorsToJS(runtime: runtime) {
+              try set(propertyName, value)
+            }
+          }
         }
       }
     }
 
     func propertyNamesGetter(context: UnsafeMutableRawPointer) -> expo.HostObjectCallbacks.PropNameIds {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
-
-      guard let runtime = context.runtime else {
-        FatalError.runtimeLost()
+      // `IRuntime` is an immortal reference, so reading it through the guaranteed wrapper
+      // reference costs no reference counting here either.
+      let iRuntime = context.runtime._withUnsafeGuaranteedRef { runtime in
+        return runtime.pointee
       }
       // Get property names within the actor isolation, but build the vector outside
       // to avoid returning a non-copyable C++ type through `assumeIsolated`
@@ -237,7 +242,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       vector.reserve(propertyNames.count)
 
       for propertyName in propertyNames {
-        let propNameId = facebook.jsi.PropNameID.forUtf8(runtime.pointee, std.string(propertyName))
+        let propNameId = facebook.jsi.PropNameID.forUtf8(iRuntime, std.string(propertyName))
         vector.push_back(consuming: propNameId)
       }
       return vector
@@ -795,12 +800,6 @@ private func createFunctionClosure(
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsCount: Int
   ) -> facebook.jsi.Value {
-    let context = Unmanaged<HostFunctionContext>.fromOpaque(context).takeUnretainedValue()
-
-    guard let runtime = context.runtime else {
-      FatalError.runtimeLost()
-    }
-
     // `assumeIsolated` runs `operation` synchronously, in this very scope — it never escapes and never
     // hops threads (see `JavaScriptActor.assumeIsolated`). So rather than materializing the move-only
     // `JavaScriptValuesBuffer` out here and smuggling it across the closure boundary through a
@@ -813,14 +812,22 @@ private func createFunctionClosure(
     nonisolated(unsafe) let thisPtr = thisPtr
     nonisolated(unsafe) let argumentsPtr = argumentsPtr
 
-    return JavaScriptActor.assumeIsolated {
-      return forwardingSwiftErrorsToJS(runtime: runtime) {
-        let this = UnsafeMutablePointer(mutating: thisPtr).move()
-        let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
-        let thisValue = JavaScriptValue(runtime, this)
-        return try context.call(thisValue, consume arguments).asJSIValue()
+    // See the unowned-`this` overload below for why the context and runtime are read through
+    // `_withUnsafeGuaranteedRef` and the result leaves through a captured local.
+    var result = facebook.jsi.Value.undefined()
+    Unmanaged<HostFunctionContext>.fromOpaque(context)._withUnsafeGuaranteedRef { context in
+      context.runtime._withUnsafeGuaranteedRef { runtime in
+        result = JavaScriptActor.assumeIsolated {
+          return forwardingSwiftErrorsToJS(runtime: runtime) {
+            let this = UnsafeMutablePointer(mutating: thisPtr).move()
+            let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
+            let thisValue = JavaScriptValue(runtime, this)
+            return try context.call(thisValue, consume arguments).asJSIValue()
+          }
+        }
       }
     }
+    return result
   }
 
   func deallocate(context: UnsafeMutableRawPointer) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -6,7 +6,12 @@ internal import jsi
 public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   // Safe to use unowned — the buffer's lifetime is scoped to a host function call,
   // so the runtime is always alive while the buffer exists.
-  internal unowned let runtime: JavaScriptRuntime
+  //
+  // `unowned(unsafe)` rather than `unowned`: the runtime object carries a refcount side table (other
+  // wrappers hold it `weak`), so a safe `unowned` retain/release on it takes the slow side-table path
+  // on every buffer construction and destruction. Profiling showed that pair as roughly a third of the
+  // native-side cost of a no-op `@JS` host call. `unowned(unsafe)` is a plain pointer store/load.
+  internal unowned(unsafe) let runtime: JavaScriptRuntime
 
   // The raw `facebook.jsi.IRuntime`, cached alongside the `JavaScriptRuntime` wrapper. `IRuntime` is
   // an immortal reference (`jsi.apinotes`), so reading it costs no ARC, whereas reading `.pointee`


### PR DESCRIPTION
# Why

Profiling the no-op `@JS` host call showed most of its native time going to Swift reference counting of the runtime wrapper rather than to JSI.

# How

`JavaScriptValuesBuffer` now holds the runtime `unowned(unsafe)`, and the host function and host object contexts hold it as `Unmanaged` and read it through a shared guaranteed-reference helper, so the success path of a host call or a host object property access emits no retain or release at all. The lifetime argument lives on that helper. Since a guaranteed-reference scope cannot return a non-copyable value, the callbacks now hand their `jsi::Value` result back through an out-parameter instead of returning it.

# Test Plan

`pnpm test:integration` passes. `pnpm benchmark` (Release, Mac Catalyst), using the unowned-this case and the coverage-free benchmark build from the base PR:

- no-op unowned-this host call: from 64.2 to 34.0 ns
- no-op owning-this host call: from 89 to 59 ns



