### PR TITLE
[core][android] Re-register activity result launchers dropped by Activity recreation

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [iOS] Measure hosted React Native views where SwiftUI placed them, instead of at their Yoga box. ([#48969](https://github.com/expo/expo/pull/48969) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Measure hosted React Native views where Jetpack Compose placed them, instead of at their Yoga box. ([#48970](https://github.com/expo/expo/pull/48970) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Bump the Gradle plugin's Kotlin version to 2.2.21. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fixed `ActivityResultLauncher.launch()` throwing `IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher` after the Activity is recreated, by registering the launcher again against the live Activity. ([#49634](https://github.com/expo/expo/pull/49634) by [@idoyana](https://github.com/idoyana))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultRegistry.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/activityresult/AppContextActivityResultRegistry.kt
@@ -29,6 +29,7 @@ import expo.modules.kotlin.safeGetParcelable
 import expo.modules.kotlin.safeGetParcelableExtra
 import java.io.Serializable
 import java.util.Random
+import java.util.concurrent.CountDownLatch
 
 private const val TAG = "ActivityResultRegistry"
 
@@ -222,6 +223,7 @@ class AppContextActivityResultRegistry(
     return object : AppContextActivityResultLauncher<I, O>() {
       override fun launch(input: I, callback: ActivityResultCallback<O>) {
         val requestCode = keyToRequestCode[key]
+          ?: reregister(key, contract, fallbackCallback)
           ?: throw IllegalStateException("Attempting to launch an unregistered ActivityResultLauncher with contract $contract and input $input. You must ensure the ActivityResultLauncher is registered before calling launch()")
 
         keyToCallbacksAndContract[key] = CallbacksAndContract(fallbackCallback, callback, contract)
@@ -238,6 +240,39 @@ class AppContextActivityResultRegistry(
 
       override val contract = contract
     }
+  }
+
+  /**
+   * A registration is bound to one Activity's lifecycle and dropped by its ON_DESTROY,
+   * while launchers outlive the Activity inside the AppContext. Registers [key] again
+   * against the live Activity and returns its request code. register() adds a lifecycle
+   * observer, which androidx requires on the main thread; launch() runs on the module's
+   * IO dispatcher, so the call is marshalled there.
+   */
+  private fun <I : Serializable, O> reregister(
+    key: String,
+    contract: AppContextActivityResultContract<I, O>,
+    fallbackCallback: AppContextActivityResultFallbackCallback<I, O>
+  ): Int? {
+    val liveActivity = activity
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      register(key, liveActivity, contract, fallbackCallback)
+    } else {
+      val registered = CountDownLatch(1)
+      var failure: Throwable? = null
+      Handler(Looper.getMainLooper()).post {
+        try {
+          register(key, liveActivity, contract, fallbackCallback)
+        } catch (e: Throwable) {
+          failure = e
+        } finally {
+          registered.countDown()
+        }
+      }
+      registered.await()
+      failure?.let { throw it }
+    }
+    return keyToRequestCode[key]
   }
 
   /**


### PR DESCRIPTION
# Why

On Android, a launcher obtained from `AppContextActivityResultCaller.registerForActivityResult` stops working for the rest of the process after the Activity is recreated. Every later `launch()` throws:

```
java.lang.IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher with contract expo.modules.imagepicker.contracts.CameraContract@… You must ensure the ActivityResultLauncher is registered before calling launch()
```

Mechanism, all in `expo-modules-core`:

1. `AppContextActivityResultRegistry.register()` observes the lifecycle of the Activity that is current at registration time, and its `ON_DESTROY` branch calls `unregister(key)`, which removes `keyToRequestCode[key]`.
2. The launcher object itself lives in the module — e.g. `expo-image-picker` keeps `cameraLauncher` / `imageLibraryLauncher` / `cropImageLauncher` as `lateinit var`s assigned once in `RegisterActivityContracts` — and survives the Activity because the `AppContext` does.
3. `launch()` reads `keyToRequestCode[key]` and throws when it is gone.

Any Activity recreation triggers it: a configuration change not declared in `android:configChanges` (Expo's default manifest omits `fontScale`, `density`, `colorMode`), or a memory-pressure recreate. Once it happens, camera, image library, and crop are dead until the user kills the app. The `hostWasDestroyed` re-registration in `AppContext.onHostResume` does not recover from it — the contract object's identity hash stays constant across a full destroy → create → resume cycle, so `RegisterActivityContracts` is never re-run.

We hit this in production on Pixel 9 Pro XL and Pixel 10 Pro (Android 16/17), across several SDK 57 patch releases; `expo-modules-core` 57.0.8 → 57.0.15 and `main` all carry the same code.

# How

Make `launch()` self-healing at the point that fails:

```kotlin
val requestCode = keyToRequestCode[key]
  ?: reregister(key, contract, fallbackCallback)
  ?: throw IllegalStateException(…)   // unchanged
```

`reregister()` calls `register()` again for the same key against the live Activity (`currentActivityProvider.currentActivity`) and returns the new request code. `register()` is idempotent for this purpose — it keeps an existing request code, replaces the callbacks, and attaches a fresh lifecycle observer — so a healthy launcher never enters the new path (the first branch short-circuits), and a repaired one delivers results through the normal `dispatchResult` → `mainCallback` route.

Threading: `register()` adds a `LifecycleEventObserver`, which androidx requires on the main thread, while `launch()` is reached from module coroutines on the IO dispatcher (`ImagePickerModule.launchPicker` runs under `withContext(Dispatchers.IO)`). The re-registration is therefore posted to the main looper and awaited with a `CountDownLatch`; a failure inside it is rethrown on the caller so it surfaces as a rejected promise exactly like the original exception, never as an uncaught main-thread crash. If `launch()` is already on the main thread the call is made inline.

The original exception is kept as the last resort so a residual failure still reports with the same message.

# Test Plan

Deterministic reproduction, no app changes needed (any app using `expo-image-picker`):

1. Open the app to a screen with a camera or image-library button. Tap it → picker opens (baseline).
2. With the app in the foreground, force an Activity recreation:
   `adb shell settings put system font_scale 1.15`
   Confirm with `adb logcat -b events | grep -E "wm_on_(destroy|create)_called"` — destroy → create, same pid.
3. Tap the button again.
   - **Before:** nothing opens; the promise rejects with the `IllegalStateException` above.
   - **After:** the picker opens.
4. `adb shell settings put system font_scale 1.0` to restore.

Verified on a Pixel 10 Pro (Android 17) with a debug build of an SDK 57 app carrying this change as a patch to `expo-modules-core@57.0.11`: camera and image library open after the recreation, after three further recreations in a row, and after a plain background/foreground cycle (where the new path is not entered); the unpatched build of the same app fails step 3 on the same device.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — the change is Kotlin-only, so there are no generated package sources to rebuild.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — no docs changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
