### PR TITLE
[ios][router] Fix header title not adapting to content under Liquid Glass

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix header title not adapting its color to content scrolling underneath a transparent header on iOS 26 Liquid Glass. ([#TODO](https://github.com/expo/expo/pull/TODO) by [@Jonas-C](https://github.com/Jonas-C))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fix header title not adapting its color to content scrolling underneath a transparent header on iOS 26 Liquid Glass. ([#TODO](https://github.com/expo/expo/pull/TODO) by [@Jonas-C](https://github.com/Jonas-C))
+- [ios] Fix header title not adapting its color to content scrolling underneath a transparent header on iOS 26 Liquid Glass. ([#49639](https://github.com/expo/expo/pull/49639) by [@Jonas-C](https://github.com/Jonas-C))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
@@ -142,6 +142,36 @@ describe('titleColor', () => {
     );
     expect(result.current.titleColor).toBe('orange');
   });
+
+  test('undefined when headerTransparent is true, so iOS 26 Liquid Glass can adapt it to content underneath', () => {
+    const { result } = renderHook(() =>
+      useHeaderConfigProps(defaultProps({ headerTransparent: true }))
+    );
+    expect(result.current.titleColor).toBeUndefined();
+  });
+
+  test('undefined when headerLargeTitleEnabled makes the background transparent, even without headerTransparent', () => {
+    const { result } = renderHook(() =>
+      useHeaderConfigProps(defaultProps({ headerLargeTitleEnabled: true }))
+    );
+    expect(result.current.titleColor).toBeUndefined();
+  });
+
+  test('headerTitleStyle.color still overrides when headerTransparent is true', () => {
+    const { result } = renderHook(() =>
+      useHeaderConfigProps(
+        defaultProps({ headerTransparent: true, headerTitleStyle: { color: 'orange' } })
+      )
+    );
+    expect(result.current.titleColor).toBe('orange');
+  });
+
+  test('headerTintColor is ignored when headerTransparent is true (falls back to undefined, not the tint)', () => {
+    const { result } = renderHook(() =>
+      useHeaderConfigProps(defaultProps({ headerTransparent: true, headerTintColor: 'purple' }))
+    );
+    expect(result.current.titleColor).toBeUndefined();
+  });
 });
 
 // ─── backgroundColor ────────────────────────────────────────────────────────────

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
@@ -166,11 +166,11 @@ describe('titleColor', () => {
     expect(result.current.titleColor).toBe('orange');
   });
 
-  test('headerTintColor is ignored when headerTransparent is true (falls back to undefined, not the tint)', () => {
+  test('headerTintColor is respected even when headerTransparent is true', () => {
     const { result } = renderHook(() =>
       useHeaderConfigProps(defaultProps({ headerTransparent: true, headerTintColor: 'purple' }))
     );
-    expect(result.current.titleColor).toBeUndefined();
+    expect(result.current.titleColor).toBe('purple');
   });
 });
 

--- a/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
@@ -200,6 +200,7 @@ export function useHeaderConfigProps({
 }: Props): ScreenStackHeaderConfigProps {
   const { direction } = useLocale();
   const { colors, fonts, dark } = useTheme();
+
   const tintColor = headerTintColor ?? (Platform.OS === 'ios' ? colors.primary : colors.text);
   const headerNativeProps = unstable_nativeProps?.headerConfig;
 
@@ -218,6 +219,15 @@ export function useHeaderConfigProps({
   const headerStyleFlattened = StyleSheet.flatten(headerStyle) || {};
   const headerLargeStyleFlattened = StyleSheet.flatten(headerLargeStyle) || {};
 
+  const headerBackgroundColor =
+    headerStyleFlattened.backgroundColor ??
+    (headerBackground != null ||
+    headerTransparent ||
+    // The title becomes invisible if background color is set with large title on iOS 26
+    (Platform.OS === 'ios' && headerLargeTitleEnabled)
+      ? 'transparent'
+      : colors.card);
+
   const [backTitleFontFamily, largeTitleFontFamily, titleFontFamily] = processFonts([
     headerBackTitleStyleFlattened.fontFamily,
     headerLargeTitleStyleFlattened.fontFamily,
@@ -233,7 +243,11 @@ export function useHeaderConfigProps({
   const titleColor =
     'color' in headerTitleStyleFlattened
       ? headerTitleStyleFlattened.color
-      : (headerTintColor ?? colors.text);
+      : Platform.OS === 'ios' && (headerTransparent || headerBackgroundColor === 'transparent')
+        ? // On iOS 26, we want header title to change color based on content underneath
+          // So we don't set an explicit color when header is transparent
+          undefined
+        : (headerTintColor ?? colors.text);
   const titleFontSize =
     'fontSize' in headerTitleStyleFlattened ? headerTitleStyleFlattened.fontSize : undefined;
   const titleFontWeight = headerTitleStyleFlattened.fontWeight;
@@ -260,15 +274,6 @@ export function useHeaderConfigProps({
   if (titleFontWeight != null) {
     headerTitleStyleSupported.fontWeight = titleFontWeight;
   }
-
-  const headerBackgroundColor =
-    headerStyleFlattened.backgroundColor ??
-    (headerBackground != null ||
-    headerTransparent ||
-    // The title becomes invisible if background color is set with large title on iOS 26
-    (Platform.OS === 'ios' && headerLargeTitleEnabled)
-      ? 'transparent'
-      : colors.card);
 
   const canGoBack = headerBack != null;
 

--- a/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
@@ -246,7 +246,8 @@ export function useHeaderConfigProps({
       : Platform.OS === 'ios' && (headerTransparent || headerBackgroundColor === 'transparent')
         ? // On iOS 26, we want header title to change color based on content underneath
           // So we don't set an explicit color when header is transparent
-          undefined
+          // Unless a custom tint color is explicitly provided
+          headerTintColor
         : (headerTintColor ?? colors.text);
   const titleFontSize =
     'fontSize' in headerTitleStyleFlattened ? headerTitleStyleFlattened.fontSize : undefined;

--- a/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/views/useHeaderConfigProps.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import { Platform, StyleSheet, type TextStyle, View } from 'react-native';
 import {
   type HeaderBarButtonItemMenuAction,
@@ -243,7 +244,7 @@ export function useHeaderConfigProps({
   const titleColor =
     'color' in headerTitleStyleFlattened
       ? headerTitleStyleFlattened.color
-      : Platform.OS === 'ios' && (headerTransparent || headerBackgroundColor === 'transparent')
+      : isLiquidGlassAvailable() && (headerTransparent || headerBackgroundColor === 'transparent')
         ? // On iOS 26, we want header title to change color based on content underneath
           // So we don't set an explicit color when header is transparent
           // Unless a custom tint color is explicitly provided


### PR DESCRIPTION
Fixes https://github.com/expo/expo/issues/49636

Ports the fix for this exact bug from upstream react-navigation/react-navigation@8789a3d (released in @react-navigation/
native-stack@7.14.8, software-mansion/react-native-screens#3782) into expo-router's copy of the file, which never picked it up: pass undefined for the title color on iOS when the header is transparent, so Liquid Glass can adapt it to content underneath, instead of always resolving a fixed color from the theme.

# Test Plan

You can link expo router locally against the repro provided in the issue. 

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
