### PR TITLE
[expo-location][Android] Don't require FOREGROUND_SERVICE_LOCATION when not using a foreground service

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Android] Fix `timeInterval` and `distanceInterval` being ignored for background location updates. ([#46788](https://github.com/expo/expo/issues/46788) by [@doshisunny](https://github.com/doshisunny))
 - [iOS] Fix incorrect default value for `pausesUpdatesAutomatically` to match docs. ([#47008](https://github.com/expo/expo/pull/47008) by [@Ignigena](https://github.com/Ignigena))
 - [Android] Fix leaking watches ([#48294](https://github.com/expo/expo/pull/48294) by [@Wenszel](https://github.com/Wenszel))
+- [Android] Fix `startLocationUpdatesAsync` requiring `FOREGROUND_SERVICE_LOCATION` (Android 14+) even when no `foregroundService` option is passed. ([#49641](https://github.com/expo/expo/issues/49641) by [@aamagda](https://github.com/aamagda))
 
 ### 💡 Others
 

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -331,7 +331,7 @@ class LocationModule : Module(), SensorEventListener, ActivityEventListener {
         throw ForegroundServiceStartNotAllowedException()
       }
 
-      if (!hasForegroundServicePermissions()) {
+      if (shouldUseForegroundService && !hasForegroundServicePermissions()) {
         throw ForegroundServicePermissionsException()
       }
 


### PR DESCRIPTION
## Why

`startLocationUpdatesAsync` calls `hasForegroundServicePermissions()`
unconditionally, regardless of whether `options.foregroundService` was
passed. On Android 14+ that hard-requires `FOREGROUND_SERVICE_LOCATION`
to be granted even for the plain "background location service" mode
(`ACCESS_BACKGROUND_LOCATION` only), contradicting the comment directly
above the check that describes the two supported start modes:

https://github.com/expo/expo/blob/main/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt#L318-L336

This forces apps that never start a foreground service to still declare
`FOREGROUND_SERVICE_LOCATION` in their manifest, which in turn triggers
Google Play Console's "Foreground service: location" permission
declaration requirement for a permission they don't actually use.

Fixes #49641

## How

Gate the `hasForegroundServicePermissions()` check on
`shouldUseForegroundService`, matching the code's own documented intent.

## Test plan

Repro app (config plugin strips `FOREGROUND_SERVICE_LOCATION` from the
merged manifest, mirroring a real app that avoids the Play Console
declaration form): https://github.com/aamagda/expo-location-fgs-repro

- Before this change: `startLocationUpdatesAsync` (no `foregroundService`
  option) throws `ForegroundServicePermissionsException` on Android 14+.
- After this change: same call succeeds, background location task
  registers and receives updates normally.
