### PR TITLE
[router] Replace remaining refs with useState

### DIFF
--- a/packages/expo-router/src/__tests__/navigation-events.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/navigation-events.test.ios.tsx
@@ -8,7 +8,7 @@ import { unstable_navigationEvents } from '../navigationEvents';
 import type { PageFocusedEvent } from '../navigationEvents/types';
 import { renderRouter } from '../testing-library';
 
-describe('AnalyticsListeners pageFocused timing', () => {
+describe('AnalyticsListeners event timing', () => {
   const cleanups: (() => void)[] = [];
 
   beforeAll(() => {
@@ -31,6 +31,34 @@ describe('AnalyticsListeners pageFocused timing', () => {
     cleanups.push(cleanup);
     return events;
   }
+
+  it('emits pagePreloaded after the preloaded screen content has committed', () => {
+    const order: string[] = [];
+    const cleanup = unstable_navigationEvents.addListener('pagePreloaded', () =>
+      order.push('pagePreloaded')
+    );
+    cleanups.push(cleanup);
+
+    function DetailsScreen() {
+      useLayoutEffect(() => {
+        order.push('details-committed');
+      });
+      return <Text testID="details-content">Details</Text>;
+    }
+
+    renderRouter({
+      _layout: () => <Stack />,
+      index: () => <Text testID="home-content">Home</Text>,
+      details: DetailsScreen,
+    });
+
+    act(() => router.prefetch('/details'));
+
+    const preloadIdx = order.indexOf('pagePreloaded');
+    const commitIdx = order.indexOf('details-committed');
+    expect(commitIdx).toBeGreaterThanOrEqual(0);
+    expect(preloadIdx).toBeGreaterThan(commitIdx);
+  });
 
   it('emits pageFocused after the focused screen content has committed', () => {
     const order: string[] = [];

--- a/packages/expo-router/src/head/ExpoHead.ios.tsx
+++ b/packages/expo-router/src/head/ExpoHead.ios.tsx
@@ -95,13 +95,35 @@ function serializedMetaChildren(meta: MetaNode[]): SerializedMeta[] {
   });
 }
 
+function buildUserActivity(sortedMeta: SerializedMeta[]): Partial<UserActivity> {
+  const userActivity: Partial<UserActivity> = {};
+
+  sortedMeta.forEach((child) => {
+    if (child.type === 'meta') {
+      const { property, content } = child.props;
+
+      switch (property) {
+        case 'og:description':
+          userActivity.description = content;
+          break;
+        case 'expo:handoff':
+          userActivity.isEligibleForHandoff = isTruthy(content);
+          break;
+        case 'expo:spotlight':
+          userActivity.isEligibleForSearch = isTruthy(content);
+          break;
+      }
+    }
+  });
+
+  return userActivity;
+}
+
 function useActivityFromMetaChildren(meta: MetaNode[]) {
   const { url: href, pathname } = useAddressableLink();
 
-  const previousMeta = React.useRef<SerializedMeta[]>([]);
-  const cachedActivity = React.useRef<Partial<UserActivity>>({});
-
   const sortedMeta = React.useMemo(() => serializedMetaChildren(meta), [meta]);
+  const activity = React.useMemo(() => buildUserActivity(sortedMeta), [sortedMeta]);
 
   const url = React.useMemo(() => {
     const urlMeta = sortedMeta.find(
@@ -132,51 +154,6 @@ function useActivityFromMetaChildren(meta: MetaNode[]) {
 
     return getLastSegment(pathname);
   }, [sortedMeta, pathname]);
-
-  const activity = React.useMemo(() => {
-    if (
-      !!previousMeta.current &&
-      !!cachedActivity.current &&
-      deepObjectCompare(previousMeta.current, sortedMeta)
-    ) {
-      return cachedActivity.current;
-    }
-    previousMeta.current = sortedMeta;
-
-    const userActivity: Partial<UserActivity> = {};
-
-    sortedMeta.forEach((child) => {
-      if (
-        // <meta />
-        child.type === 'meta'
-      ) {
-        const { property, content } = child.props;
-
-        switch (property) {
-          case 'og:description':
-            userActivity.description = content;
-            break;
-          // Custom properties
-          case 'expo:handoff':
-            userActivity.isEligibleForHandoff = isTruthy(content);
-            break;
-          case 'expo:spotlight':
-            userActivity.isEligibleForSearch = isTruthy(content);
-            break;
-        }
-
-        // // <meta name="keywords" content="foo,bar,baz" />
-        // if (["keywords"].includes(name)) {
-        //   userActivity.keywords = Array.isArray(content)
-        //     ? content
-        //     : content.split(",");
-        // }
-      }
-    });
-
-    cachedActivity.current = userActivity;
-    return userActivity;
-  }, [meta, pathname, href]);
 
   const parsedActivity: UserActivity = {
     keywords: [title],

--- a/packages/expo-router/src/hooks/useSearchParams.ts
+++ b/packages/expo-router/src/hooks/useSearchParams.ts
@@ -7,9 +7,9 @@ import { useLocalSearchParams } from './useLocalSearchParams';
 
 // TODO(@ubax): Add missing JSDoc
 export function useSearchParams({ global = false } = {}): URLSearchParams {
-  const globalRef = React.useRef(global);
+  const [initialGlobal] = React.useState(global);
   if (process.env.NODE_ENV !== 'production') {
-    if (global !== globalRef.current) {
+    if (global !== initialGlobal) {
       console.warn(
         `Detected change in 'global' option of useSearchParams. This value cannot change between renders`
       );

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -446,14 +446,13 @@ function AnalyticsListeners({
   };
   screenId: string;
 }) {
-  const isFirstRenderRef = React.useRef(true);
+  const hasEmittedPagePreloadedRef = React.useRef(false);
   const hasBlurredRef = React.useRef(true);
   const routeInfo = useCurrentRouteInfo();
 
   const isFocused = navigation.isFocused();
 
-  if (isFirstRenderRef.current) {
-    isFirstRenderRef.current = false;
+  const emitPagePreloaded = React.useEffectEvent(() => {
     if (routeInfo && !isFocused) {
       unstable_navigationEvents.emit('pagePreloaded', {
         pathname: routeInfo.pathname,
@@ -462,7 +461,15 @@ function AnalyticsListeners({
         screenId,
       });
     }
-  }
+  });
+
+  useEffect(() => {
+    // We only one to emit once
+    if (!hasEmittedPagePreloadedRef.current) {
+      hasEmittedPagePreloadedRef.current = true;
+      emitPagePreloaded();
+    }
+  }, []);
 
   useEffect(() => {
     if (routeInfo) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
