### PR TITLE
[docs] Drop `@apply rounded-sm` from global CSS rules for outlines improvement

### DIFF
--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -76,7 +76,6 @@ details::details-content {
 }
 
 *:focus-visible:not(div) {
-  @apply rounded-sm;
   outline: 3px solid var(--expo-theme-icon-info);
   outline-offset: 1px;
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26312

# How

<!--
How did you build this feature or fix this bug and why?
-->

Drop @apply rounded-sm from the global rule so outlines follow each element's own radius

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->


https://github.com/user-attachments/assets/d9cbeb7b-1650-4c36-89e5-b586f30d7052



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
