### PR TITLE
[router] re-export JavaScript stack API

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,7 +70,7 @@
 
 ### 🐛 Bug fixes
 
-- Re-export the vendored JavaScript stack API from `expo-router/js-stack`.
+- Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### 🐛 Bug fixes
 
+- Re-export the vendored JavaScript stack API from `expo-router/js-stack`.
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))
 - Prevent unfocused nested native tab navigators from redirecting global router state. ([#48257](https://github.com/expo/expo/pull/48257) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/layouts/JSStack.tsx
+++ b/packages/expo-router/src/layouts/JSStack.tsx
@@ -10,6 +10,8 @@ import { Protected } from '../views/Protected';
 import { Screen } from '../views/Screen';
 import { withLayoutContext } from './withLayoutContext';
 
+export * from '../react-navigation/stack';
+
 const JSStackNavigator = createStackNavigator().Navigator;
 
 // TODO(@ubax): Update docs/pages/router/migrate/from-react-navigation.mdx:387 for the removed prop.

--- a/packages/expo-router/src/layouts/__tests__/JSStack-exports.test.tsx
+++ b/packages/expo-router/src/layouts/__tests__/JSStack-exports.test.tsx
@@ -1,0 +1,16 @@
+import * as VendoredStack from '../../react-navigation/stack';
+import * as JSStackEntry from '../JSStack';
+
+describe('expo-router/js-stack re-exports', () => {
+  it('re-exports every value from ../react-navigation/stack', () => {
+    const missing = Object.keys(VendoredStack).filter((key) => !(key in JSStackEntry));
+    expect(missing).toEqual([]);
+  });
+
+  it('exports the Stack navigator with its static components', () => {
+    expect(JSStackEntry.Stack).toBeDefined();
+    expect(JSStackEntry.default).toBe(JSStackEntry.Stack);
+    expect(JSStackEntry.Stack.Screen).toBeDefined();
+    expect(JSStackEntry.Stack.Protected).toBeDefined();
+  });
+});

--- a/packages/expo-router/src/react-navigation/stack/index.tsx
+++ b/packages/expo-router/src/react-navigation/stack/index.tsx
@@ -6,6 +6,11 @@ import * as TransitionSpecs from './TransitionConfigs/TransitionSpecs';
 /**
  * Navigators
  */
+/**
+ * @deprecated Reserved for libraries that ship a self-contained navigator, which the `Stack` layout
+ * cannot express. There is no stable replacement yet, so expect this factory to change or be removed
+ * in a future release. App code should use `Stack` from `expo-router`.
+ */
 export { createStackNavigator } from './navigators/createStackNavigator';
 
 /**

--- a/packages/expo-router/src/react-navigation/stack/index.tsx
+++ b/packages/expo-router/src/react-navigation/stack/index.tsx
@@ -9,7 +9,7 @@ import * as TransitionSpecs from './TransitionConfigs/TransitionSpecs';
 /**
  * @deprecated Reserved for libraries that ship a self-contained navigator, which the `Stack` layout
  * cannot express. There is no stable replacement yet, so expect this factory to change or be removed
- * in a future release. App code should use `Stack` from `expo-router`.
+ * in a future release. App code should use `Stack` from `expo-router/js-stack`.
  */
 export { createStackNavigator } from './navigators/createStackNavigator';
 


### PR DESCRIPTION
🤖 Agent PR for ENG-25817 from Expo CLI feedback.

## Agent feedback

<details>
<summary>Feedback 1</summary>

The migration table maps `@react-navigation/stack` to `expo-router/js-stack` and says the runtime API is unchanged. In expo-router 56.2.18, `js-stack` only exports the `Stack` layout and its default export. It does not export `createStackNavigator`, `CardStyleInterpolators`, `TransitionPresets`, or `HeaderStyleInterpolators`. Apps that create an independent navigation tree must use a deep import from `expo-router/build/react-navigation/stack`.

</details>

<details>
<summary>Feedback 2</summary>

The migration reference and `sdk-56-expo-router-react-navigation-replace` codemod map `@react-navigation/stack` to `expo-router/js-stack`. In expo-router 57.0.9, `build/layouts/JSStack.js` only exports `Stack` and `default`. It imports the internal stack module but does not re-export it. The tabs entry point does re-export its navigation module, so the matching bottom-tabs migration works.

</details>

<details>
<summary>Feedback 3</summary>

On SDK 57.0.8, `createStackNavigator` is undefined when imported from `expo-router/js-stack` after running the codemod. Importing it from `expo-router/build/react-navigation/stack` works around the problem.

</details>

## Why

`expo-router/js-stack` only exports the route layout. The codemod moves imports from `@react-navigation/stack` to this entry point. After that change, imports such as `createStackNavigator`, `CardStyleInterpolators`, and `TransitionPresets` are undefined.

This bug is in the SDK source, so this PR fixes the entry point itself. A docs or skills change would only work around the bug.

## What changed

- Re-export all JavaScript stack values and types from `expo-router/js-stack`.
- Mark `createStackNavigator` as deprecated. App code should use `Stack` from `expo-router/js-stack`.
- Add a test that checks every stack export is available.
- Add a changelog entry.

## Tests

- `pnpm test src/layouts/__tests__/JSStack-exports.test.tsx --runInBand`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run format --check`
- `pnpm run build`

Fixes ENG-25817
