### PR TITLE
[android][expo-go] Exclude Stripe's private Tap and Pay dependency from lint resolution

### DIFF
--- a/apps/expo-go/android/build.gradle
+++ b/apps/expo-go/android/build.gradle
@@ -89,6 +89,9 @@ allprojects {
       libs.fresco.imagepipeline.okhttp3,
       libs.fresco.ui.common
     )
+    // Stripe's optional push-provisioning SDK pulls in Google's private play-services-tapandpay,
+    // which AGP 9's lint classpath tries to resolve. Expo Go never uses push provisioning.
+    exclude group: "com.google.android.gms", module: "play-services-tapandpay"
   }
 }
 


### PR DESCRIPTION
# Why
Release builds fail in `:stripe_stripe-react-native:lintVitalAnalyzeRelease`. Stripe's optional push-provisioning SDK is a compileOnly dependency of `stripe-react-native`, and its POM lists Google's private Tap and Pay artifact with runtime scope. AGP 9 puts a library's compileOnly dependencies on the lint checks classpath and resolves their runtime-scope transitives, so lint tries to fetch an artifact no public repository serves. Compile classpaths skip runtime-scope transitives, which is why compiling was never affected.

# How
Exclude play-services-tapandpay from all configurations.

# Test Plan
Release build of Expo Go

