### PR TITLE
[docs] Stop the markdown pipeline from dropping page content

### DIFF
--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -643,7 +643,7 @@ describe('terminal snippet labels', () => {
     expect(md).toContain('yarn add expo');
     expect(md).toContain('pnpm add expo');
     expect(md).toContain('bun add expo');
-    expect(md).not.toContain('# npm comment');
+    expect(md).toContain('# npm comment');
   });
 
   it('skips empty/comment-only manager sections, ignores unknown keys, and preserves angle brackets', () => {

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -69,6 +69,20 @@ export function extractFrontmatter(mdxPath: string): string | null {
   return '---\n' + filtered + '---\n';
 }
 
+const HEADING_NODE_NAMES = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];
+const BLOCK_SELECTOR = 'p, div, h1, h2, h3, h4, h5, h6';
+
+function findAncestor(node: HTMLElement, nodeNames: string[]): HTMLElement | null {
+  let current = node.parentNode as HTMLElement | null;
+  while (current) {
+    if (nodeNames.includes(current.nodeName)) {
+      return current;
+    }
+    current = current.parentNode as HTMLElement | null;
+  }
+  return null;
+}
+
 function createTurndownService(): TurndownService {
   const turndown = new TurndownService({
     headingStyle: 'atx',
@@ -85,14 +99,27 @@ function createTurndownService(): TurndownService {
       const lang =
         node.getAttribute('data-md-lang') ?? code.className?.match(/language-(\w+)/)?.[1] ?? '';
       const text = code.textContent ?? '';
-      return `\n\n\`\`\`${lang}\n${text.trim()}\n\`\`\`\n\n`;
+      const info = [lang, node.getAttribute('data-md-label')].filter(Boolean).join(' ');
+      return `\n\n\`\`\`${info}\n${text.trim()}\n\`\`\`\n\n`;
     },
   });
 
-  // Remove images — they reference local/CDN paths that won't work in plain markdown
+  // Drop the image itself — the local/CDN path won't resolve in plain markdown — but keep
+  // the alt text, which is the only part of an image a text consumer can read. Icons inside
+  // headings are chrome, and an image inside a link supplies that link's text.
   turndown.addRule('images', {
     filter: 'img',
-    replacement: () => '',
+    replacement: (_content: string, node: HTMLElement) => {
+      const alt = (node.getAttribute('alt') ?? '').trim();
+      if (!alt || findAncestor(node, HEADING_NODE_NAMES)) {
+        return '';
+      }
+      const link = findAncestor(node, ['A']);
+      if (link) {
+        return (link.textContent ?? '').trim() ? '' : alt;
+      }
+      return `\n\nImage: ${alt}\n\n`;
+    },
   });
 
   // The @expo/ui component index renders as a card grid on the web. Its thumbnails are
@@ -125,6 +152,26 @@ function createTurndownService(): TurndownService {
 const turndown = createTurndownService();
 // Keep in sync with ui/components/Snippet/blocks/packageManagerStore.ts.
 const PACKAGE_MANAGER_MARKDOWN_ORDER = ['npm', 'yarn', 'pnpm', 'bun'] as const;
+
+function toTerminalLines(rawLines: unknown): string[] {
+  if (!Array.isArray(rawLines)) {
+    return [];
+  }
+  const lines = rawLines
+    .filter((line): line is string => typeof line === 'string')
+    .map(line => line.replace(/^\$\s*/, '').trim());
+  while (lines.length > 0 && lines[0] === '') {
+    lines.shift();
+  }
+  while (lines.length > 0 && lines.at(-1) === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+function hasTerminalCommand(lines: string[]): boolean {
+  return lines.some(line => line !== '' && !line.startsWith('#'));
+}
 
 /**
  * Recursively find all index.html files in a directory, skipping internal directories.
@@ -383,7 +430,44 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   });
 
   // Remove interactive/decorative elements
-  main.find('button').remove();
+  // Most buttons are UI chrome, but some wrap page content: a selectable card carries a
+  // title and a description, and a lightbox button wraps a ContentSpotlight image. Tab
+  // labels come from the tabs rule above, and toggles, snippet actions and skip-marked
+  // buttons hold nothing worth keeping.
+  main.find('button').each((_, el) => {
+    const $button = $(el);
+    const isControl =
+      $button.attr('role') === 'tab' ||
+      $button.attr('aria-pressed') !== undefined ||
+      $button.closest('[data-md="skip"], [data-md="snippet-header"], [data-md="terminal"]').length >
+        0;
+    if (isControl) {
+      $button.remove();
+      return;
+    }
+    const textBlocks = $button
+      .find(BLOCK_SELECTOR)
+      .filter(
+        (_, block) => $(block).find(BLOCK_SELECTOR).length === 0 && $(block).text().trim() !== ''
+      ).length;
+    if ($button.parent().is('figure') || textBlocks > 1) {
+      $button.replaceWith($button.contents());
+      return;
+    }
+    $button.remove();
+  });
+
+  // Light and dark variants of one image repeat the same alt text; keep the first.
+  let previousImageAlt = '';
+  main.find('img').each((_, el) => {
+    const $img = $(el);
+    const alt = ($img.attr('alt') ?? '').trim();
+    if (alt && alt === previousImageAlt) {
+      $img.remove();
+      return;
+    }
+    previousImageAlt = alt;
+  });
   main.find('style').remove();
 
   // Preserve semantic SVG icons as text before blanket SVG removal.
@@ -563,53 +647,19 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     }
   });
 
-  // Remove snippet headers (file labels, "Terminal" labels above code blocks).
+  // Move snippet header labels (file names, example captions) onto the code block so the
+  // fence keeps them, then drop the header. Terminal headers carry no label worth keeping.
   // data-md="snippet-header" is the stable marker (from SnippetHeader component).
-  main.find('[data-md="snippet-header"]').remove();
-
-  // Convert tabbed Terminal blocks (package manager variants) into a single shell block.
-  // data-md="terminal" is the stable marker; data-md-commands contains all manager commands.
-  main.find('[data-md="terminal"][data-md-commands]').each((_, el) => {
-    const $el = $(el);
-    const commandsJson = $el.attr('data-md-commands');
-    if (!commandsJson) {
-      return;
-    }
-
-    const commands = JSON.parse(commandsJson) as Record<string, unknown>;
-    const lines: string[] = [];
-
-    for (const manager of PACKAGE_MANAGER_MARKDOWN_ORDER) {
-      const rawCommands = commands[manager];
-      if (!Array.isArray(rawCommands) || rawCommands.length === 0) {
-        continue;
+  main.find('[data-md="snippet-header"]').each((_, el) => {
+    const $header = $(el);
+    if ($header.closest('[data-md="terminal"]').length === 0) {
+      const label = $header.text().trim();
+      const $pre = $header.parent().find('pre').first();
+      if (label && $pre.length > 0) {
+        $pre.attr('data-md-label', label);
       }
-
-      const managerLines = rawCommands
-        .filter((line): line is string => typeof line === 'string')
-        .map(line => line.replace(/^\$\s*/, '').trim())
-        // Preserve existing terminal behavior: drop source comment lines.
-        .filter(line => line.length > 0 && !line.startsWith('#'));
-
-      // Skip heading-only sections (for example, comment-only manager arrays).
-      if (managerLines.length === 0) {
-        continue;
-      }
-
-      if (lines.length > 0) {
-        lines.push('');
-      }
-      lines.push(`# ${manager}`);
-      lines.push(...managerLines);
     }
-
-    if (lines.length > 0) {
-      const $pre = $('<pre></pre>');
-      const $code = $('<code class="language-sh"></code>');
-      $code.text(lines.join('\n'));
-      $pre.append($code);
-      $el.replaceWith($pre);
-    }
+    $header.remove();
   });
 
   // Remove orphaned step numbers: replace step containers with just the content.
@@ -789,11 +839,23 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
 
     // data-md="callout" — inline the callout text (e.g. deprecation warnings).
     // The callout's visible text (like "Deprecated: use X instead") is already meaningful;
-    // just extract it and drop the blockquote/svg/div wrapper structure.
-    // Target the <p> inside the callout to avoid picking up SVG alt text.
+    // just extract it and drop the blockquote/svg/div wrapper structure. Every paragraph and
+    // list item counts, and a callout whose body is bare inline markup has neither.
     $cell.find('[data-md="callout"]').each((_, el) => {
-      const text = $(el).find('p').first().text().trim();
-      $(el).replaceWith(text ? text + ' ' : '');
+      const $callout = $(el);
+      const $blocks = $callout.find('p, li');
+      const text = (
+        $blocks.length > 0
+          ? $blocks
+              .map((_, block) => $(block).text().trim())
+              .get()
+              .filter(Boolean)
+              .join(' ')
+          : $callout.text()
+      )
+        .replace(/\s+/g, ' ')
+        .trim();
+      $callout.replaceWith(text ? '. ' + escapeHtml(text) + ' ' : '');
     });
 
     // Generic block flattening — loop until stable since nested divs require multiple passes.
@@ -869,7 +931,52 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
       }
     });
     if (lines.length > 0) {
-      $table.replaceWith(`<pre><code class="language-diff">${lines.join('\n')}</code></pre>`);
+      const $pre = $('<pre></pre>');
+      const $code = $('<code class="language-diff"></code>');
+      $code.text(lines.join('\n'));
+      $pre.append($code);
+      $table.replaceWith($pre);
+    }
+  });
+
+  // Convert Terminal blocks into a single shell block, rebuilt from the author's own lines.
+  // data-md="terminal" is the stable marker; data-md-commands holds the cmd prop, either a
+  // plain line array or one array per package manager.
+  main.find('[data-md="terminal"][data-md-commands]').each((_, el) => {
+    const $el = $(el);
+    const commandsJson = $el.attr('data-md-commands');
+    if (!commandsJson) {
+      return;
+    }
+
+    const commands = JSON.parse(commandsJson) as unknown;
+    const lines: string[] = [];
+
+    if (Array.isArray(commands)) {
+      lines.push(...toTerminalLines(commands));
+    } else {
+      for (const manager of PACKAGE_MANAGER_MARKDOWN_ORDER) {
+        const managerLines = toTerminalLines((commands as Record<string, unknown>)[manager]);
+
+        // Skip heading-only sections (for example, comment-only manager arrays).
+        if (!hasTerminalCommand(managerLines)) {
+          continue;
+        }
+
+        if (lines.length > 0 && lines.at(-1) !== '') {
+          lines.push('');
+        }
+        lines.push(`# ${manager}`);
+        lines.push(...managerLines);
+      }
+    }
+
+    if (lines.length > 0) {
+      const $pre = $('<pre></pre>');
+      const $code = $('<code class="language-sh"></code>');
+      $code.text(lines.join('\n'));
+      $pre.append($code);
+      $el.replaceWith($pre);
     }
   });
 
@@ -885,7 +992,11 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
       }
     });
     if (codeTexts.length > 0) {
-      $el.replaceWith(`<pre><code class="language-sh">${codeTexts.join('\n')}</code></pre>`);
+      const $pre = $('<pre></pre>');
+      const $code = $('<code class="language-sh"></code>');
+      $code.text(codeTexts.join('\n'));
+      $pre.append($code);
+      $el.replaceWith($pre);
     }
   });
 }

--- a/docs/scripts/generate-markdown-pages-utils.ts
+++ b/docs/scripts/generate-markdown-pages-utils.ts
@@ -375,6 +375,9 @@ export function convertMdxInstructionToMarkdown(
  * Clean up the HTML before conversion: remove non-content elements,
  * normalize terminal blocks, and strip decorative artifacts.
  */
+const DARK_IMAGE_VARIANTS =
+  'img[class~="light:hidden"], picture[class~="light:hidden"] img, img[class~="hidden"][class~="dark:block"]';
+
 export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
   // Keep every tab panel, each prefixed with its label as an h4 (ENG-21907).
   // Must run before the button removal below, since labels live in the buttons.
@@ -457,17 +460,7 @@ export function cleanHtml($: CheerioAPI, main: Cheerio<AnyNode>): void {
     $button.remove();
   });
 
-  // Light and dark variants of one image repeat the same alt text; keep the first.
-  let previousImageAlt = '';
-  main.find('img').each((_, el) => {
-    const $img = $(el);
-    const alt = ($img.attr('alt') ?? '').trim();
-    if (alt && alt === previousImageAlt) {
-      $img.remove();
-      return;
-    }
-    previousImageAlt = alt;
-  });
+  main.find(DARK_IMAGE_VARIANTS).remove();
   main.find('style').remove();
 
   // Preserve semantic SVG icons as text before blanket SVG removal.

--- a/docs/ui/components/Snippet/Terminal.test.tsx
+++ b/docs/ui/components/Snippet/Terminal.test.tsx
@@ -145,7 +145,7 @@ describe(Terminal, () => {
     expect(screen.getByRole<HTMLTextAreaElement>('textbox').value).toBe('yarn add expo');
   });
 
-  it('adds data-md-commands only for package-manager command maps', () => {
+  it('adds data-md-commands for both command maps and plain command arrays', () => {
     render(
       <>
         <Terminal
@@ -160,8 +160,10 @@ describe(Terminal, () => {
 
     const terminals = screen.getAllByRole('generic').filter(el => el.dataset.md === 'terminal');
     expect(terminals.length).toBe(2);
-    expect(terminals[0].getAttribute('data-md-commands')).not.toBeNull();
-    expect(terminals[1].getAttribute('data-md-commands')).toBeNull();
+    expect(terminals[0].getAttribute('data-md-commands')).toBe(
+      '{"npm":["$ npm install expo"],"bun":["$ bun add expo"]}'
+    );
+    expect(terminals[1].getAttribute('data-md-commands')).toBe('["$ npx expo start"]');
   });
 
   it('renders browser action when provided', async () => {

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -102,7 +102,7 @@ export const Terminal = ({
   return (
     <Snippet
       data-md="terminal"
-      data-md-commands={packageManagers ? JSON.stringify(packageManagers) : undefined}
+      data-md-commands={JSON.stringify(cmd)}
       className={mergeClasses('terminal-snippet [li_&]:mt-4', className)}>
       <SnippetHeader
         alwaysDark


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The generated `.md` served to agents and LLMs silently dropped content that the rendered page shows. Fix ENG-26357, ENG-26358, ENG-26359, ENG-26360, ENG-26361, ENG-26362.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Build diff and terminal code blocks with cheerio's `.text()` setter in `cleanHtml` instead of interpolating decoded text into HTML, which restores 172 lines of argument placeholders such as `[--limit <value>]` (ENG-26357).
- Carry the `data-md="snippet-header"` label onto the code block as `data-md-label` and append it to the fence info string, restoring 4909 file names and captions (ENG-26359).
- Serialize the whole `cmd` prop into `data-md-commands` in `ui/components/Snippet/blocks/Terminal.tsx` and rebuild every terminal from the author's own lines, keeping 277 comment lines and 252 blank separators (ENG-26358).
- Return the `alt` text from the turndown `images` rule and unwrap ContentSpotlight lightbox buttons, restoring 960 screenshot descriptions while skipping heading icons and light or dark duplicates (ENG-26360).
- Read every paragraph and list item of a `data-md="callout"` in a table cell, and escape the result before re-injecting it, restoring 150 notes that were deleted or truncated (ENG-26361).
- Unwrap buttons that hold a title and a description, so the build-method and environment cards reach the markdown instead of being removed as UI chrome (ENG-26362).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1567" height="425" alt="md-fix-1-eng-26357-angle-brackets" src="https://github.com/user-attachments/assets/29582a96-69d2-47d6-9dd2-4ba28d996d5a" />

<img width="1568" height="485" alt="md-fix-2-eng-26359-snippet-labels" src="https://github.com/user-attachments/assets/e152b88c-0dba-4ba8-8c54-2440cff15f86" />

<img width="1568" height="573" alt="md-fix-3-eng-26358-terminal-comments" src="https://github.com/user-attachments/assets/c7f90e5b-3b60-4975-89c3-0dd5d3bf7c31" />

<img width="1568" height="573" alt="md-fix-4-eng-26360-image-alt-text" src="https://github.com/user-attachments/assets/fe22fdbb-57b6-4080-8e6b-6514e23505f3" />


<img width="1567" height="514" alt="md-fix-5-eng-26361-table-callouts" src="https://github.com/user-attachments/assets/46acde75-b54d-4d12-986a-133e755aa280" />

<img width="1470" height="812" alt="md-fix-6-eng-26362-card-content" src="https://github.com/user-attachments/assets/8618efc6-8ab2-4ceb-a261-f81b98cfa4f3" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
