### PR TITLE
[docs] Render every paragraph of a typed callout

### DIFF
--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -5,6 +5,7 @@ import { InfoCircleDuotoneIcon } from '@expo/styleguide-icons/duotone/InfoCircle
 import { XSquareDuotoneIcon } from '@expo/styleguide-icons/duotone/XSquareDuotoneIcon';
 import {
   Children,
+  cloneElement,
   HTMLAttributes,
   isValidElement,
   ReactElement,
@@ -38,7 +39,8 @@ const extractType = (childrenArray: ReactNode[]) => {
 };
 
 export const InlineHelp = ({ type = 'default', size = 'md', icon, children, className }: Props) => {
-  const content = Children.toArray(children).filter(child => isValidElement(child))[0];
+  const childrenArray = Children.toArray(children);
+  const content = childrenArray.find(child => isValidElement(child));
   const contentChildren = Children.toArray(
     isValidElement<PropsWithChildren>(content) && content?.props?.children
   );
@@ -48,6 +50,19 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
     ? extractedType
     : type;
   const Icon = icon ?? getCalloutIcon(finalType);
+
+  // A type marker sits inside the first child, so drop the marker from that child and keep
+  // every later child. Rendering only the first child's remainder loses the rest of the callout.
+  const renderedChildren =
+    type === finalType
+      ? children
+      : childrenArray.map(child =>
+          child === content && isValidElement<PropsWithChildren>(child)
+            ? cloneElement(child, {
+                children: contentChildren.filter((_, index) => index !== 0),
+              })
+            : child
+        );
 
   return (
     <blockquote
@@ -79,7 +94,7 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
           'last:mb-0',
           size === 'sm' && 'text-sm [&_code]:text-[90%] [&_p]:text-sm'
         )}>
-        {type === finalType ? children : contentChildren.filter((_, i) => i !== 0)}
+        {renderedChildren}
       </div>
     </blockquote>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26363

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Keep every child of a typed callout in `ui/components/InlineHelp/index.tsx` and strip the marker from the first child with `cloneElement`, instead of rendering only that child's remainder.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1567" height="525" alt="eng-26363-typed-callout-before-after" src="https://github.com/user-attachments/assets/de4c91a4-9c95-4bda-85ec-08e835ee3659" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
