### PR TITLE
[docs] Serve markdown for two .md URLs shadowed by stale redirects

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -273,12 +273,10 @@
 /workflow/build/building-on-ci/ /build/building-on-ci 301
 /task-manager /versions/latest/sdk/task-manager 301
 /task-manager/ /versions/latest/sdk/task-manager 301
-/versions/latest/sdk/filesystem.md /versions/latest/sdk/filesystem 301
 /guides/how-expo-works /faq 301
 /guides/how-expo-works/ /faq 301
 /config/app /workflow/configuration 301
 /config/app/ /workflow/configuration 301
-/guides/authentication.md /guides/authentication 301
 /versions/latest/workflow/linking /guides/linking 301
 /versions/latest/workflow/linking/ /guides/linking 301
 /versions/latest/sdk/overview /versions/latest 301


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-26364

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove two redirects so markdown URLs can be served for the pages instead of redirecting to their HTML page.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
