### PR TITLE
[cli] Align local annotations with Metro's own types

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -64,6 +64,7 @@
 - Prewarm Metro transform workers while waiting for the first development bundle request ([#48836](https://github.com/expo/expo/pull/48836) by [@kitten](https://github.com/kitten))
 - Discover `.ts`, `.mts`, and `.cts` ESLint configs as well when checking for prerequisites for ESLint ([#46225](https://github.com/expo/expo/pull/46225) by [@claritystorm](https://github.com/claritystorm))
 - Bump to `@expo/metro@56.0.2` and `metro@0.84.5` ([#49161](https://github.com/expo/expo/pull/49161) by [@kitten](https://github.com/kitten))
+- [Internal] Align local annotations in the Metro integration with Metro's own types. ([#49669](https://github.com/expo/expo/pull/49669) by [@robhogan](https://github.com/robhogan))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -273,8 +273,8 @@ export class MetroTerminalReporter extends TerminalReporter {
     }
   }
 
-  shouldFilterClientLog(event: { type: 'client_log'; data: unknown[] }): boolean {
-    return isAppRegistryStartupMessage(event.data);
+  shouldFilterClientLog(event: TerminalReportableEvent): boolean {
+    return event.type === 'client_log' && isAppRegistryStartupMessage(event.data);
   }
 
   shouldFilterBundleEvent(event: TerminalReportableEvent): boolean {

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -151,7 +151,7 @@ function withWebPolyfills(
     ? config.serializer.getPolyfills.bind(config.serializer)
     : () => [];
 
-  const getPolyfills = (ctx: { platform?: string | null }): readonly string[] => {
+  const getPolyfills: typeof originalGetPolyfills = (ctx) => {
     const virtualEnvVarId = `\0polyfill:environment-variables`;
 
     getMetroBundlerWithVirtualModules(getMetroBundler()).setVirtualModule(
@@ -575,7 +575,10 @@ export function withExtendedResolver(
             const realPath = realModule.type === 'sourceFile' ? realModule.filePath : moduleName;
             const opaqueId = idFactory(realPath, {
               platform: platform!,
-              environment: context.customResolverOptions?.environment,
+              environment:
+                typeof context.customResolverOptions?.environment === 'string'
+                  ? context.customResolverOptions.environment
+                  : undefined,
             });
             const contents =
               typeof opaqueId === 'number'


### PR DESCRIPTION

# Why

Fix up some misalignment with Metro's canonical types ahead of moving to them.

`MetroTerminalReporter.shouldFilterClientLog` declares its parameter as `{type: 'client_log'; data: unknown[]}` - although it *should* only receive client logs the API is actually typed as any `TerminalReportableEvent`.

`withWebPolyfills` has a hand-written `(ctx: {platform?: string | null}) => readonly string[]` which varies slightly from [upstream](https://github.com/react/metro/blob/v0.84.5/packages/metro-config/src/types.js#L142) (`platform` is nullable but required).

`customResolverOptions[key]` is `unknown` upstream and needs refining to a string. Typically these are string query param values but they can also be specified programmatically.

# How

Take the type from the thing being overridden or wrapped in the first two, and narrow `environment` explicitly in the third rather than relying on the augmentation to have declared it.

# Test Plan

No behaviour change; `shouldFilterClientLog` gains the `event.type === 'client_log'` guard it was previously getting from its parameter type.

```
$ npx turbo run typecheck test depscheck --filter=@expo/cli --filter=@expo/metro-config --force
 Tasks:    6 successful, 6 total

$ yarn jest src/start/server/metro   # packages/@expo/cli
 Test Suites: 29 passed, 29 total
 Tests:       338 passed, 338 total
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [N/A] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
