### PR TITLE
[cli][metro-config] Declare Expo's Metro type extensions explicitly

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Discover `.ts`, `.mts`, and `.cts` ESLint configs as well when checking for prerequisites for ESLint ([#46225](https://github.com/expo/expo/pull/46225) by [@claritystorm](https://github.com/claritystorm))
 - Bump to `@expo/metro@56.0.2` and `metro@0.84.5` ([#49161](https://github.com/expo/expo/pull/49161) by [@kitten](https://github.com/kitten))
 - [Internal] Align local annotations in the Metro integration with Metro's own types. ([#49669](https://github.com/expo/expo/pull/49669) by [@robhogan](https://github.com/robhogan))
+- [Internal] Import Expo's Metro type extensions from `@expo/metro-config` instead of relying on global type augmentations. ([#49670](https://github.com/expo/expo/pull/49670) by [@robhogan](https://github.com/robhogan))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/src/start/server/metro/ExpoMetroConfig.ts
+++ b/packages/@expo/cli/src/start/server/metro/ExpoMetroConfig.ts
@@ -1,0 +1,10 @@
+import type { ExpoJsTransformerConfigExtensions } from '@expo/metro-config';
+import type { ConfigT } from '@expo/metro/metro-config';
+
+/** Metro's hydrated configuration, plus the fields Expo adds. */
+export type ExpoMetroConfig = Omit<ConfigT, 'resolver' | 'transformer'> & {
+  resolver: ConfigT['resolver'] & {
+    unstable_onDemandFilesystem?: boolean | 'UNSTABLE_ALLOW_ALL';
+  };
+  transformer: ConfigT['transformer'] & ExpoJsTransformerConfigExtensions;
+};

--- a/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroTerminalReporter.ts
@@ -1,5 +1,6 @@
 import { events } from '2g';
 import type { SpanEnd } from '2g';
+import type { ExpoCustomTransformOptions } from '@expo/metro-config';
 import type { Terminal } from '@expo/metro/metro-core';
 import chalk from 'chalk';
 import path from 'path';
@@ -446,24 +447,27 @@ export class MetroTerminalReporter extends TerminalReporter {
   #captureLog(evt: TerminalReportableEvent) {
     switch (evt.type) {
       case 'bundle_build_started': {
+        const customTransformOptions = evt.bundleDetails?.customTransformOptions as
+          | ExpoCustomTransformOptions
+          | undefined;
         const entry =
-          typeof evt.bundleDetails?.customTransformOptions?.dom === 'string' &&
-          evt.bundleDetails.customTransformOptions.dom.includes(path.sep)
-            ? evt.bundleDetails.customTransformOptions.dom.replace(/^(\.?\.[\\/])+/, '')
+          typeof customTransformOptions?.dom === 'string' &&
+          customTransformOptions.dom.includes(path.sep)
+            ? customTransformOptions.dom.replace(/^(\.?\.[\\/])+/, '')
             : this.#normalizePath(evt.bundleDetails.entryFile);
         this.#bundleSpans.set(evt.buildID, {
           end: event.span(),
           start: {
             id: evt.buildID,
             platform: evt.bundleDetails.platform ?? null,
-            environment: evt.bundleDetails.customTransformOptions?.environment ?? null,
+            environment: customTransformOptions?.environment ?? null,
             entry,
           },
         });
         event('bundling:start', {
           id: evt.buildID ?? null,
           platform: evt.bundleDetails.platform ?? null,
-          environment: evt.bundleDetails.customTransformOptions?.environment ?? null,
+          environment: customTransformOptions?.environment ?? null,
           entry,
           bundleType: evt.bundleDetails.bundleType,
           dev: evt.bundleDetails.dev,
@@ -651,17 +655,17 @@ function getPlatformTagForBuildDetails(bundleDetails?: BundleDetails | null): st
 /** @returns platform specific tag for a `BundleDetails` object */
 function getEnvironmentForBuildDetails(bundleDetails?: BundleDetails | null): string {
   // Expo CLI will pass `customTransformOptions.environment = 'node'` when bundling for the server.
-  const env = bundleDetails?.customTransformOptions?.environment ?? null;
+  const customTransformOptions = bundleDetails?.customTransformOptions as
+    | ExpoCustomTransformOptions
+    | undefined;
+  const env = customTransformOptions?.environment ?? null;
   if (env === 'node') {
     return chalk.bold('λ') + ' ';
   } else if (env === 'react-server') {
     return chalk.bold(`RSC(${getPlatformTagForBuildDetails(bundleDetails).trim()})`) + ' ';
   }
 
-  if (
-    bundleDetails?.customTransformOptions?.dom &&
-    typeof bundleDetails?.customTransformOptions?.dom === 'string'
-  ) {
+  if (customTransformOptions?.dom && typeof customTransformOptions.dom === 'string') {
     return chalk.bold(`DOM`) + ' ';
   }
 

--- a/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
@@ -5,14 +5,14 @@
 // and redirects to `@expo/metro-file-map`
 
 import FileMap, { DependencyPlugin, DiskCacheManager, HastePlugin } from '@expo/metro-file-map';
-import type { ConfigT } from '@expo/metro/metro-config';
 import type MetroServer from '@expo/metro/metro/Server';
 import ciInfo from 'ci-info';
 import path from 'node:path';
 
 import { composeMetroIgnorePatterns } from '../../../utils/composeMetroIgnorePatterns';
+import type { ExpoMetroConfig } from './ExpoMetroConfig';
 
-function getIgnorePattern(config: ConfigT): RegExp {
+function getIgnorePattern(config: ExpoMetroConfig): RegExp {
   const { blockList, blacklistRE } = config.resolver;
   return composeMetroIgnorePatterns(blacklistRE || blockList);
 }
@@ -28,7 +28,7 @@ interface CreateFileMapOptions {
  * Creates a `FileMap` using `@expo/metro-file-map`, matching the same config
  * interpretation as Metro's original `createFileMap`.
  */
-export default function createFileMap(config: ConfigT, options?: CreateFileMapOptions) {
+export default function createFileMap(config: ExpoMetroConfig, options?: CreateFileMapOptions) {
   const watch = options?.watch == null ? !ciInfo.isCI : options.watch;
 
   const { enabled: autoSaveEnabled, ...autoSaveOpts } = config.watcher.unstable_autoSaveCache ?? {};

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -1,7 +1,7 @@
 import { events } from '2g';
 import { type ExpoConfig, getConfig, getPlatformsFromConfig } from '@expo/config';
 import { getMetroServerRoot } from '@expo/config/paths';
-import type { createStableModuleIdFactory } from '@expo/metro-config';
+import type { createStableModuleIdFactory, ExpoCustomTransformOptions } from '@expo/metro-config';
 import { loadUserConfig } from '@expo/metro-config';
 import { patchTransformFileForPackedMaps } from '@expo/metro-config/build/serializer/packedMap';
 import { patchMetroSourceMapStringForPackedMaps } from '@expo/metro-config/build/serializer/sourceMap';
@@ -31,6 +31,7 @@ import { createJsInspectorMiddleware } from '../middleware/inspector/createJsIns
 import { prependMiddleware } from '../middleware/mutations';
 import { getPlatformBundlers } from '../platformBundlers';
 import { createDevToolsPluginWebsocketEndpoint } from './DevToolsPluginWebsocketEndpoint';
+import type { ExpoMetroConfig } from './ExpoMetroConfig';
 import type { MetroBundlerDevServer } from './MetroBundlerDevServer';
 import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { replaceMetroFileMap } from './createFileMap-fork';
@@ -230,7 +231,7 @@ export async function loadMetroConfigAsync(
 
   const terminalReporter = new MetroTerminalReporter(serverRoot, terminal);
 
-  let config = await loadUserConfig({
+  let config: ExpoMetroConfig = await loadUserConfig({
     projectRoot,
     serverRoot,
     // NOTE: Allow external tools to override the metro config. This is considered internal and unstable
@@ -551,7 +552,8 @@ export async function instantiateMetroAsync(
     const ctx = {
       // TODO(@kitten): Increase type-safety here
       platform: graph.transformOptions.platform!,
-      environment: graph.transformOptions.customTransformOptions?.environment,
+      environment: (graph.transformOptions.customTransformOptions as ExpoCustomTransformOptions | undefined)
+        ?.environment,
     };
     // Assign IDs to modules in a consistent order
     for (const module of modules) {
@@ -611,7 +613,9 @@ export async function instantiateMetroAsync(
         const moduleIdContext = {
           // TODO(@kitten): Increase type-safety here
           platform: revision.graph.transformOptions.platform!,
-          environment: revision.graph.transformOptions.customTransformOptions?.environment,
+          environment: (
+            revision.graph.transformOptions.customTransformOptions as ExpoCustomTransformOptions
+          )?.environment,
         };
         const hmrUpdate = hmrJSBundle(delta, revision.graph, {
           clientUrl: group.clientUrl,

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -25,6 +25,7 @@ import { isPathInside } from '../../../utils/dir';
 import { env } from '../../../utils/env';
 import { isServerEnvironment } from '../middleware/metroOptions';
 import type { PlatformBundlers } from '../platformBundlers';
+import type { ExpoMetroConfig } from './ExpoMetroConfig';
 import type {
   AutolinkingModuleResolverInput,
   AutolinkingPlatform,
@@ -1012,7 +1013,7 @@ export async function withMetroMultiPlatformAsync(
 
     getMetroBundler,
   }: {
-    config: ConfigT;
+    config: ExpoMetroConfig;
     exp: ExpoConfig;
     isTsconfigPathsEnabled: boolean;
     platformBundlers: PlatformBundlers;

--- a/packages/@expo/cli/src/start/server/metro/withMetroSupervisingTransformWorker.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroSupervisingTransformWorker.ts
@@ -1,13 +1,7 @@
 import { unstable_transformerPath, internal_supervisingTransformerPath } from '@expo/metro-config';
-import type { ConfigT as MetroConfig } from '@expo/metro/metro-config';
 
+import type { ExpoMetroConfig } from './ExpoMetroConfig';
 import { debugEvent } from './metroDebugEvents';
-
-declare module '@expo/metro/metro-transform-worker' {
-  export interface JsTransformerConfig {
-    expo_customTransformerPath?: string | false;
-  }
-}
 
 // The default babel transformer is either `@expo/metro-config/babel-transformer` set by the user
 // or @expo/metro-config/build/babel-transformer
@@ -39,7 +33,7 @@ const defaultBabelTransformerPaths = [
  * versions of Metro. This is unsupported and undefined behavior and will lead to
  * bugs and errors.
  */
-export function withMetroSupervisingTransformWorker(config: MetroConfig): MetroConfig {
+export function withMetroSupervisingTransformWorker(config: ExpoMetroConfig): ExpoMetroConfig {
   // NOTE: This is usually a required property, but we don't always set it in mocks
   const originalBabelTransformerPath = config.transformer?.babelTransformerPath;
   const originalTransformerPath = config.transformerPath;

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - [Internal] Deduplicate find-up `package.json` search utilities ([#47127](https://github.com/expo/expo/pull/47127) by [@kitten](https://github.com/kitten))
+- [Internal] Declare Expo's Metro type extensions explicitly. ([#49670](https://github.com/expo/expo/pull/49670) by [@robhogan](https://github.com/robhogan))
 - Add `woff` and `woff2` to default list of `assetExts` ([#47565](https://github.com/expo/expo/pull/47565) by [@kitten](https://github.com/kitten))
 - [Internal] Migrate an initial set of events to `2g` ([#47655](https://github.com/expo/expo/pull/47655) by [@kitten](https://github.com/kitten))
 - Expand `skipCache` flag to data and support `prewarm` custom transform option ([#48836](https://github.com/expo/expo/pull/48836) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
+++ b/packages/@expo/metro-config/src/__tests__/babel-transformer.test.ts
@@ -5,8 +5,9 @@ import { vol } from 'memfs';
 import * as babel from '../babel-core';
 // eslint-disable-next-line import/namespace
 import * as untypedTransformer from '../babel-transformer';
+import type { ExpoBabelTransformer } from '../babel-transformer';
 
-const transformer = untypedTransformer as BabelTransformer;
+const transformer = untypedTransformer as ExpoBabelTransformer;
 
 jest.mock('../babel-core', () => {
   const babel = jest.requireActual('../babel-core');
@@ -185,7 +186,7 @@ describe('getCacheKey', () => {
     }
     return {
       loadPartialConfigSync: mockLoadPartialConfigSync,
-      transformer: require('../babel-transformer') as BabelTransformer,
+      transformer: require('../babel-transformer') as ExpoBabelTransformer,
     };
   }
 

--- a/packages/@expo/metro-config/src/babel-transformer.ts
+++ b/packages/@expo/metro-config/src/babel-transformer.ts
@@ -45,6 +45,28 @@ export type ExpoBabelCaller = TransformOptions['caller'] & {
   isDomComponent?: boolean;
 };
 
+export type ExpoBabelTransformerCacheKeyOptions = BabelTransformerCacheKeyOptions & {
+  extendsBabelConfigPath?: string;
+};
+
+/**
+ * Metro's Babel transformer options plus the fields Metro's transform worker passes through
+ * from `JsTransformOptions` without declaring them on the Babel transformer's own type.
+ */
+export type ExpoBabelTransformerOptions = BabelTransformerArgs['options'] & {
+  /** The kind of file being transformed, forwarded from `JsTransformOptions['type']`. */
+  type?: 'script' | 'module' | 'asset';
+};
+
+export type ExpoBabelTransformerArgs = Omit<BabelTransformerArgs, 'options'> & {
+  options: ExpoBabelTransformerOptions;
+};
+
+export type ExpoBabelTransformer = Omit<BabelTransformer, 'getCacheKey'> & {
+  getCacheKey?: (options?: ExpoBabelTransformerCacheKeyOptions) => string;
+  isDefaultConfig: typeof isDefaultConfig;
+};
+
 function isCustomTruthy(value: any): boolean {
   return String(value) === 'true';
 }
@@ -69,7 +91,7 @@ const memoizeWarning = memoize((message: string) => {
 function getBabelCaller({
   filename,
   options,
-}: Pick<BabelTransformerArgs, 'filename' | 'options'>): ExpoBabelCaller {
+}: Pick<ExpoBabelTransformerArgs, 'filename' | 'options'>): ExpoBabelCaller {
   const isNodeModule = filename.includes('node_modules');
   const isReactServer = options.customTransformOptions?.environment === 'react-server';
   const isGenericServer = options.customTransformOptions?.environment === 'node';
@@ -383,7 +405,7 @@ const transform: BabelTransformer['transform'] = ({
  *
  * This is called once by the main thread (not on worker instances).
  */
-function getCacheKey(options?: BabelTransformerCacheKeyOptions): string {
+function getCacheKey(options?: ExpoBabelTransformerCacheKeyOptions): string {
   if (options?.projectRoot == null || options.enableBabelRCLookup === false) {
     return '';
   }
@@ -411,9 +433,7 @@ function getCacheKey(options?: BabelTransformerCacheKeyOptions): string {
   return getFileCacheKey([...files].sort());
 }
 
-const babelTransformer: BabelTransformer & {
-  isDefaultConfig: typeof isDefaultConfig;
-} = {
+const babelTransformer: ExpoBabelTransformer = {
   transform,
   getCacheKey,
   // This is an Expo extension consumed by the matching Metro worker.

--- a/packages/@expo/metro-config/src/config/loadUserConfig.ts
+++ b/packages/@expo/metro-config/src/config/loadUserConfig.ts
@@ -2,6 +2,7 @@ import { mergeConfig, type ConfigT } from '@expo/metro/metro-config';
 
 import { getDefaultConfig } from '../ExpoMetroConfig';
 import { resolveBabelrcName } from '../loadBabelConfig';
+import type { ExpoJsTransformerConfig } from '../transform-worker/types';
 import { type LoadMetroConfigParams, resolveMetroUserConfig } from './resolveMetroUserConfig';
 
 export type { LoadMetroConfigParams } from './resolveMetroUserConfig';
@@ -28,7 +29,7 @@ export async function loadUserConfig(params: LoadMetroConfigParams): Promise<Con
   };
 
   // NOTE(@kitten): Pass a hint to the transformer on where to find the Babel config
-  asWritable(config.transformer).extendsBabelConfigPath =
+  asWritable(config.transformer as ExpoJsTransformerConfig).extendsBabelConfigPath =
     config.transformer.enableBabelRCLookup !== false
       ? resolveBabelrcName(params.projectRoot)
       : undefined;

--- a/packages/@expo/metro-config/src/index.ts
+++ b/packages/@expo/metro-config/src/index.ts
@@ -1,2 +1,8 @@
 export * from './config/loadUserConfig';
 export * from './ExpoMetroConfig';
+export type {
+  ExpoBabelFileMetadata,
+  ExpoCustomTransformOptions,
+  ExpoJsTransformerConfig,
+  ExpoJsTransformerConfigExtensions,
+} from './transform-worker/types';

--- a/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/__tests__/mini-metro.ts
@@ -1,6 +1,6 @@
 import metroConfigDefaults from '@expo/metro/metro-config/defaults';
 import type {
-  Dependency,
+  Dependency as MetroDependency,
   MixedOutput,
   Module,
   ReadOnlyGraph,
@@ -9,6 +9,7 @@ import type {
 import CountingSet from '@expo/metro/metro/lib/CountingSet';
 import * as path from 'path';
 
+import type { Dependency as ExpoTransformDependency } from '../../../transform-worker/collect-dependencies';
 import type { JsTransformOptions } from '../../../transform-worker/metro-transform-worker';
 import * as expoMetroTransformWorker from '../../../transform-worker/transform-worker';
 import { wrapTransformResultMaps } from '../../packedMap';
@@ -17,7 +18,11 @@ export const projectRoot = '/app';
 
 const METRO_CONFIG_DEFAULTS = metroConfigDefaults.getDefaultValues(null);
 
-function toDependencyMap(...deps: Dependency[]): Map<string, Dependency> {
+type ExpoResolvedDependency = Omit<MetroDependency, 'data'> & {
+  data: ExpoTransformDependency;
+};
+
+function toDependencyMap(...deps: ExpoResolvedDependency[]): Map<string, MetroDependency> {
   const map = new Map();
 
   for (const dep of deps) {

--- a/packages/@expo/metro-config/src/serializer/fork/js.ts
+++ b/packages/@expo/metro-config/src/serializer/fork/js.ts
@@ -17,6 +17,7 @@ import assert from 'assert';
 import jscSafeUrl from 'jsc-safe-url';
 import path from 'path';
 
+import type { AsyncDependencyType } from '../../transform-worker/collect-dependencies';
 import { toPosixPath as normalizePathSeparatorsToPosix } from '../../utils/filePath';
 
 export type Options = {
@@ -102,7 +103,7 @@ export function getModuleParams(
           // most parameters from the main bundle's URL.
 
           const { searchParams } = new URL(jscSafeUrl.toNormalUrl(options.sourceUrl));
-          if (dependency.data.data.asyncType === 'worker') {
+          if ((dependency.data.data.asyncType as AsyncDependencyType | null) === 'worker') {
             // Include all modules and run the module when of type worker.
             searchParams.set('modulesOnly', 'false');
             searchParams.set('runModule', 'true');

--- a/packages/@expo/metro-config/src/serializer/serializeChunks.ts
+++ b/packages/@expo/metro-config/src/serializer/serializeChunks.ts
@@ -17,7 +17,9 @@ import { isResolvedDependency } from '@expo/metro/metro/lib/isResolvedDependency
 import assert from 'assert';
 import path from 'path';
 
+import type { AsyncDependencyType } from '../transform-worker/collect-dependencies';
 import getMetroAssets from '../transform-worker/getAssets';
+import type { ExpoCustomTransformOptions } from '../transform-worker/types';
 import { toPosixPath } from '../utils/filePath';
 import { precomputeChunkFilenames } from './computeChunkFilenames';
 import { stringToUUID } from './debugId';
@@ -142,8 +144,10 @@ export async function graphToSerialAssetsAsync(
   const baseUrl = getBaseUrlOption(graph, { serializerOptions: serializeChunkOptions });
   const assetPublicUrl = (baseUrl.replace(/\/+$/, '') ?? '') + '/assets';
   const platform = getPlatformOption(graph, options) ?? 'web';
-  const isHosted =
-    platform === 'web' || (graph.transformOptions?.customTransformOptions?.hosted && isExporting);
+  const customTransformOptions = graph.transformOptions?.customTransformOptions as
+    | ExpoCustomTransformOptions
+    | undefined;
+  const isHosted = platform === 'web' || (customTransformOptions?.hosted && isExporting);
   const publicPath = isExporting
     ? isHosted
       ? `/assets?export_path=${assetPublicUrl}`
@@ -720,7 +724,7 @@ function gatherChunks(
   function includeModule(entryModule: Module<MixedOutput>) {
     const splitChunks = entryChunk.options.serializerOptions?.splitChunks !== false;
     for (const dependency of entryModule.dependencies.values()) {
-      const asyncType = dependency.data.data.asyncType;
+      const asyncType = dependency.data.data.asyncType as AsyncDependencyType | null;
       const isWorker = asyncType === 'worker';
       if (!isResolvedDependency(dependency)) {
         continue;

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-transform-worker.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/noxcturnal/metro-transform-worker.test.ts
@@ -22,9 +22,15 @@ it('falls back after one full native attempt without producing an intermediate t
     config: {} as JsTransformerConfig,
     projectRoot: '/app',
     options: {
+      dev: true,
+      minify: false,
+      inlinePlatform: false,
+      inlineRequires: false,
+      platform: null,
       type: 'module',
+      unstable_transformProfile: 'default',
       customTransformOptions: { engine: 'hermes' },
-    } as JsTransformOptions,
+    } satisfies JsTransformOptions,
   };
   const completeFullTransform = jest.fn();
 

--- a/packages/@expo/metro-config/src/transform-worker/asset-transformer.ts
+++ b/packages/@expo/metro-config/src/transform-worker/asset-transformer.ts
@@ -16,6 +16,7 @@ import url from 'node:url';
 
 import { toPosixPath } from '../utils/filePath';
 import { getUniversalAssetData } from './getAssets';
+import type { ExpoCustomTransformOptions } from './types';
 
 // Register client components for assets in server component environments.
 const buildClientReferenceRequire = template.statement(
@@ -58,14 +59,17 @@ export async function transform(
     projectRoot: '',
   };
 
+  const customTransformOptions = options.customTransformOptions as
+    | ExpoCustomTransformOptions
+    | undefined;
+
   // Is bundling for webview.
-  const isDomComponent = options.platform === 'web' && options.customTransformOptions?.dom;
-  const useMd5Filename = options.customTransformOptions?.useMd5Filename;
+  const isDomComponent = options.platform === 'web' && customTransformOptions?.dom;
+  const useMd5Filename = customTransformOptions?.useMd5Filename;
   const isExport = options.publicPath.includes('?export_path=');
-  const isHosted =
-    options.platform === 'web' || (options.customTransformOptions?.hosted && isExport);
-  const isReactServer = options.customTransformOptions?.environment === 'react-server';
-  const isServerEnv = isReactServer || options.customTransformOptions?.environment === 'node';
+  const isHosted = options.platform === 'web' || (customTransformOptions?.hosted && isExport);
+  const isReactServer = customTransformOptions?.environment === 'react-server';
+  const isServerEnv = isReactServer || customTransformOptions?.environment === 'node';
 
   const absolutePath = path.resolve(options.projectRoot, filename);
 

--- a/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
+++ b/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
@@ -8,6 +8,7 @@
 import { traverse, template, types as t } from '@babel/core';
 import type { NodePath } from '@babel/core';
 import generate from '@babel/generator';
+import type { AsyncDependencyType as MetroAsyncDependencyType } from '@expo/metro/metro/DeltaBundler/types';
 import assert from 'node:assert';
 import * as crypto from 'node:crypto';
 
@@ -25,7 +26,7 @@ function nullthrows<T extends object>(x: T | null, message?: string): NonNullabl
   return x;
 }
 
-export type AsyncDependencyType = 'weak' | 'maybeSync' | 'async' | 'prefetch' | 'worker';
+export type AsyncDependencyType = MetroAsyncDependencyType | 'worker';
 
 type AllowOptionalDependenciesWithOptions = {
   exclude: string[];

--- a/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/metro-transform-worker.ts
@@ -30,6 +30,7 @@ import {
 } from '@expo/metro/metro/ModuleGraph/worker/importLocationsPlugin';
 import assert from 'node:assert';
 
+import type { ExpoBabelTransformer as ExpoBabelTransformerWithCacheKey } from '../babel-transformer';
 import type { ExpoJsOutput, ReconcileTransformSettings } from '../serializer/jsOutput';
 import {
   countLinesAndTerminateSourceMap,
@@ -65,6 +66,7 @@ import {
 } from './noxcturnal/metro-transform-worker';
 import { type NoxcturnalMetroTransformAttempt } from './noxcturnal/noxcturnal-transformer';
 import { shouldMinify } from './resolveOptions';
+import type { ExpoBabelFileMetadata, ExpoJsTransformerConfig } from './types';
 import { getMinifier, resolveMinifier } from './utils/getMinifier';
 
 export { JsTransformOptions };
@@ -104,7 +106,7 @@ interface JSONFile extends BaseFile {
 }
 
 interface TransformationContext {
-  readonly config: JsTransformerConfig;
+  readonly config: ExpoJsTransformerConfig;
   readonly projectRoot: string;
   readonly options: JsTransformOptions;
 }
@@ -909,6 +911,7 @@ async function transformJSWithBabelFallback(
       importLocationsPlugin,
     ])
   );
+  const metadata = transformResult.metadata as ExpoBabelFileMetadata | undefined;
 
   const jsFile: JSFile = {
     ...file,
@@ -920,12 +923,12 @@ async function transformJSWithBabelFallback(
       null,
     unstable_importDeclarationLocs:
       transformResult?.metadata?.metro?.unstable_importDeclarationLocs,
-    hasCjsExports: transformResult.metadata?.hasCjsExports,
-    reactServerReference: transformResult.metadata?.reactServerReference,
-    reactClientReference: transformResult.metadata?.reactClientReference,
-    expoDomComponentReference: transformResult.metadata?.expoDomComponentReference,
-    loaderReference: transformResult.metadata?.loaderReference,
-    performConstantFolding: transformResult.metadata?.performConstantFolding,
+    hasCjsExports: metadata?.hasCjsExports,
+    reactServerReference: metadata?.reactServerReference,
+    reactClientReference: metadata?.reactClientReference,
+    expoDomComponentReference: metadata?.expoDomComponentReference,
+    loaderReference: metadata?.loaderReference,
+    performConstantFolding: metadata?.performConstantFolding,
   };
 
   return await transformJS(jsFile, context);
@@ -1002,7 +1005,7 @@ function getBabelTransformArgs(
 }
 
 export async function transform(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,
@@ -1066,7 +1069,7 @@ export async function transform(
 const CACHE_VERSION = '2';
 
 export function getCacheKey(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   opts?: Readonly<{ projectRoot: string }>
 ): string {
   const {
@@ -1091,7 +1094,7 @@ export function getCacheKey(
     ...getNoxcturnalCacheKeyFiles(),
   ]);
 
-  let babelTransformer: BabelTransformer = require(babelTransformerPath);
+  let babelTransformer: ExpoBabelTransformerWithCacheKey = require(babelTransformerPath);
 
   // NOTE(@kitten): Many custom Babel transformers won't have `getCacheKey` yet and won't
   // pass ours through. We should still try to derive a cache key though, since the default

--- a/packages/@expo/metro-config/src/transform-worker/supervising-transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/supervising-transform-worker.ts
@@ -1,32 +1,28 @@
-import type { JsTransformerConfig, JsTransformOptions } from '@expo/metro/metro-transform-worker';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
 import path from 'path';
 
 import { event } from './events';
 import * as worker from './metro-transform-worker';
 import type { TransformResponse } from './transform-worker';
+import type { ExpoJsTransformerConfig } from './types';
 import { patchNodeModuleResolver } from './utils/moduleMapper';
 
 const defaultTransformer: typeof import('./transform-worker') = require('./transform-worker');
 const defaultTransformerPath = require.resolve('./transform-worker');
 
-declare module '@expo/metro/metro-transform-worker' {
-  export interface JsTransformerConfig {
-    expo_customTransformerPath?: string;
-  }
-}
-
 const getCustomTransform = (() => {
   let _transformerPath: string | undefined;
   let _transformer: typeof import('./transform-worker') | undefined;
-  return (config: JsTransformerConfig, projectRoot: string) => {
+  return (config: ExpoJsTransformerConfig, projectRoot: string) => {
     // The user's original `transformerPath` is stored on `config.transformer.expo_customTransformerPath`
-    // by @expo/cli in `withMetroSupervisingTransformWorker()`
+    // by @expo/cli in `withMetroSupervisingTransformWorker()`. `false` opts out of the
+    // supervising transformer, in which case @expo/cli never installs us in the first
+    // place, so it means the same thing as an absent path here.
+    const customTransformerPath =
+      config.expo_customTransformerPath === false ? undefined : config.expo_customTransformerPath;
     if (_transformer == null && _transformerPath == null) {
-      _transformerPath = config.expo_customTransformerPath;
-    } else if (
-      config.expo_customTransformerPath != null &&
-      _transformerPath !== config.expo_customTransformerPath
-    ) {
+      _transformerPath = customTransformerPath;
+    } else if (customTransformerPath != null && _transformerPath !== customTransformerPath) {
       throw new Error('expo_customTransformerPath must not be modified after initialization');
     }
 
@@ -67,7 +63,7 @@ const getCustomTransform = (() => {
 })();
 
 export function transform(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,

--- a/packages/@expo/metro-config/src/transform-worker/transform-worker.ts
+++ b/packages/@expo/metro-config/src/transform-worker/transform-worker.ts
@@ -6,14 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { JsTransformerConfig, JsTransformOptions } from '@expo/metro/metro-transform-worker';
-import type { TransformResultDependency } from '@expo/metro/metro/DeltaBundler';
+import type { JsTransformOptions } from '@expo/metro/metro-transform-worker';
 import countLines from '@expo/metro/metro/lib/countLines';
 import { relative, dirname } from 'node:path';
 
 import type { ExpoJsOutput } from '../serializer/jsOutput';
 import { toPosixPath } from '../utils/filePath';
 import { getBrowserslistTargets } from './browserslist';
+import type { Dependency } from './collect-dependencies';
 import { wrapDevelopmentCSS } from './css';
 import {
   collectCssImports,
@@ -27,9 +27,10 @@ import * as worker from './metro-transform-worker';
 import { transformPostCssModule } from './postcss';
 import { compileSass, matchSass } from './sass';
 import { transformShim } from './transformShim';
+import type { ExpoCustomTransformOptions, ExpoJsTransformerConfig } from './types';
 
 export interface TransformResponse {
-  readonly dependencies: readonly TransformResultDependency[];
+  readonly dependencies: readonly Dependency[];
   // `ExpoJsOutput` widens `data.map` to `SerializableSourceMap |
   // MetroSourceMapSegmentTuple[]`. Metro readers still see plain tuples
   // because the `Bundler.transformFile` wrapper swaps the
@@ -53,7 +54,7 @@ function getStringArray(value: any): string[] | undefined {
 }
 
 export async function transform(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,
@@ -62,7 +63,10 @@ export async function transform(
   const done = debugEvent.span();
   try {
     const result = await transformImpl(config, projectRoot, filename, data, options);
-    if (options.customTransformOptions?.prewarm === '1') {
+    const customTransformOptions = options.customTransformOptions as
+      | ExpoCustomTransformOptions
+      | undefined;
+    if (customTransformOptions?.prewarm === '1') {
       for (const output of result.output) {
         (output as ExpoJsOutput).data.skipCache = true;
       }
@@ -70,7 +74,7 @@ export async function transform(
     done('file', {
       file: toPosixPath(filename),
       platform: options.platform ?? null,
-      environment: options.customTransformOptions?.environment ?? null,
+      environment: customTransformOptions?.environment ?? null,
       type: options.type,
       deps: result.dependencies.length,
       cached: false,
@@ -83,7 +87,7 @@ export async function transform(
 }
 
 async function transformImpl(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,
@@ -240,7 +244,7 @@ function isReactServerEnvironment(options: JsTransformOptions): boolean {
 }
 
 async function transformCss(
-  config: JsTransformerConfig,
+  config: ExpoJsTransformerConfig,
   projectRoot: string,
   filename: string,
   data: Buffer,

--- a/packages/@expo/metro-config/src/transform-worker/types.ts
+++ b/packages/@expo/metro-config/src/transform-worker/types.ts
@@ -1,0 +1,64 @@
+import type {
+  CustomTransformOptions as MetroCustomTransformOptions,
+  MetroBabelFileMetadata,
+} from '@expo/metro/metro-babel-transformer';
+import type { JsTransformerConfig as MetroJsTransformerConfig } from '@expo/metro/metro-transform-worker';
+
+/**
+ * Metro custom transform options plus fields owned and consumed by Expo.
+ *
+ * These mirror the options built by `getMetroDirectBundleOptions()` in
+ * `@expo/cli/src/start/server/middleware/metroOptions.ts`, so the value types here are
+ * the ones that survive a round-trip through the bundle URL's query params. Most flags
+ * are therefore strings, not booleans.
+ */
+export type ExpoCustomTransformOptions = MetroCustomTransformOptions & {
+  asyncRoutes?: 'true';
+  baseUrl?: string;
+  bytecode?: '1';
+  clientBoundaries?: string[];
+  /** Absolute path to the entry file of a `"use dom"` component. */
+  dom?: string;
+  engine?: 'hermes';
+  environment?: 'node' | 'react-server' | 'client';
+  hosted?: '1';
+  isLoaderBundle?: 'true';
+  liveBindings?: 'false';
+  optimize?: boolean;
+  preserveEnvVars?: boolean;
+  /** Set by `prewarmTransformPool()`, which throws the transform result away. */
+  prewarm?: '1';
+  reactCompiler?: 'true';
+  routerRoot?: string;
+  useMd5Filename?: boolean;
+};
+
+/** Metro Babel metadata plus fields produced and consumed by Expo Babel plugins. */
+export type ExpoBabelFileMetadata = MetroBabelFileMetadata & {
+  expoDomComponentReference?: string;
+  hasCjsExports?: boolean;
+  loaderReference?: string;
+  performConstantFolding?: boolean;
+  reactClientReference?: string;
+  reactServerReference?: string;
+};
+
+/**
+ * The fields Expo adds to Metro's transformer configuration.
+ *
+ * Kept separate from {@link ExpoJsTransformerConfig} so that `@expo/cli` can intersect
+ * these onto `ConfigT['transformer']` without discarding its `readonly` modifiers.
+ */
+export type ExpoJsTransformerConfigExtensions = {
+  /** Normal path at which Babel config is found (must be relative to project root). */
+  readonly extendsBabelConfigPath?: string;
+  /**
+   * The user's own `transformerPath`, moved here by `withMetroSupervisingTransformWorker()`
+   * in `@expo/cli` so that the supervising transformer can load it. Set this to `false` in
+   * a project's Metro config to opt out of the supervising transformer when debugging.
+   */
+  expo_customTransformerPath?: string | false;
+};
+
+/** Metro transformer configuration plus fields owned and consumed by Expo. */
+export type ExpoJsTransformerConfig = MetroJsTransformerConfig & ExpoJsTransformerConfigExtensions;

--- a/packages/expo-module-scripts/CHANGELOG.md
+++ b/packages/expo-module-scripts/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 💡 Others
 
 - Added `CLAUDE.md` and `CONTRIBUTING.md` to `.npmignore` template. ([#47451](https://github.com/expo/expo/pull/47451) by [@kudo](https://github.com/kudo))
+- [Internal] Remove Expo Metro type augmentations that are now declared explicitly. ([#49670](https://github.com/expo/expo/pull/49670) by [@robhogan](https://github.com/robhogan))
 - Updated `oxlint-config-universe` to 0.2.0, which requires `oxlint` 1.79.0. ([#49241](https://github.com/expo/expo/pull/49241) by [@tsapeta](https://github.com/tsapeta))
 - Enabled the `react/use-memo`, `react/void-use-memo`, `react/purity`, `react/preserve-manual-memoization`, and `react/static-components` rules in the shared oxlint config. ([#49242](https://github.com/expo/expo/pull/49242) by [@tsapeta](https://github.com/tsapeta))
 

--- a/packages/expo-module-scripts/types/expo-metro-augmentations.d.ts
+++ b/packages/expo-module-scripts/types/expo-metro-augmentations.d.ts
@@ -12,25 +12,12 @@ declare module '@expo/metro/metro/DeltaBundler/types' {
   }
 }
 
-import * as __metroTransformWorker from '@expo/metro/metro-transform-worker';
-declare module '@expo/metro/metro-transform-worker' {
-  export interface JsTransformerConfig {
-    /** Normal path at which Babel config is found (must be relative to project root) */
-    readonly extendsBabelConfigPath?: string | undefined;
-  }
-}
-
 import * as __metroBabelTransformer from '@expo/metro/metro-babel-transformer';
 declare module '@expo/metro/metro-babel-transformer' {
   // NOTE(@kitten): Custom modification to pass this custom Babel resolution option to `getCacheKey` for consistency
   interface BabelTransformerCacheKeyOptions {
     /** Normal path at which Babel config is found (must be relative to project root) */
     readonly extendsBabelConfigPath?: string | undefined;
-  }
-
-  interface BabelTransformerOptions {
-    /** @privateRemarks Augmentation passed to the Expo Babel caller and used in `babel-preset-expo` to force `enableBabelRuntime` to `false` */
-    type?: 'script' | 'module' | 'asset';
   }
 
   interface MetroBabelFileMetadata {
@@ -46,29 +33,6 @@ declare module '@expo/metro/metro-babel-transformer' {
     performConstantFolding?: boolean;
     /** @privateRemarks Augmentation used in babel-preset-expo/src/server-data-loaders-plugin.ts */
     loaderReference?: string;
-  }
-
-  // NOTE(@kitten): Compare to `customTransformOptions` in `src/start/server/middleware/metroOptions.ts`
-  // TODO(@kitten): This needs to be strictly enforced across the codebase in the future
-  interface CustomTransformOptions {
-    [$$Key$$: string]: unknown;
-
-    optimize?: boolean | undefined;
-    engine?: 'hermes' | undefined;
-    clientBoundaries?: readonly string[] | undefined;
-    preserveEnvVars?: boolean | undefined;
-    asyncRoutes?: 'true' | undefined;
-    environment?: 'node' | 'react-server' | 'client' | undefined;
-    baseUrl?: string | undefined;
-    routerRoot?: string | undefined;
-    bytecode?: '1' | undefined;
-    reactCompiler?: 'true' | undefined;
-    dom?: string | undefined;
-    hosted?: '1' | undefined;
-    useMd5Filename?: boolean | undefined;
-    liveBindings?: 'false' | undefined;
-    isLoaderBundle?: 'true' | undefined;
-    prewarm?: '1' | undefined;
   }
 }
 
@@ -96,12 +60,4 @@ declare module '@expo/metro/metro-source-map/source-map' {
   export function toBabelSegments(sourceMap: BasicSourceMap): BabelSourceMapSegment[];
   /** @privateRemarks Augmented to switch argument type to `BabelSourceMapSegment` */
   export function toSegmentTuple(mapping: BabelSourceMapSegment): MetroSourceMapSegmentTuple;
-}
-
-import * as __metroConfigTypes from '@expo/metro/metro-config/types';
-
-declare module '@expo/metro/metro-config/types' {
-  export interface ResolverConfigT {
-    unstable_onDemandFilesystem?: unknown;
-  }
 }


### PR DESCRIPTION


# Why

Metro's bundled types are now auto-generated, and we should be consuming them directly rather than maintaining a separate generator (which currently needs significant updates to handle newer Flow syntax).

This makes most of the necessary changes to move to upstream types. The bulk of it is because we rely on declaration merging into interfaces, and the upstream types are not in fact interfaces. (I do plan to selectively make some of them interfaces in future Metro releases).

Casts to explicitly extended types are used in place of augmentations in some cases - the cast reflects that using the Metro APIs in this way isn't supported, and moves the safety opt-out close to the consumer rather than hiding it.

# How

Each field Expo adds gets a named type intersecting Metro's, declared in `@expo/metro-config` and exported from its index so `@expo/cli` shares them rather than redeclaring - the same shapes the augmentations declared, imported instead of merged in.

Values that reach us as opaque bags (`customTransformOptions` and `customResolverOptions` come off URL query params and are `unknown` either way) assert the Expo type once per read site rather than per access, which is the assertion the augmentation was making implicitly.

One runtime-visible change is left, and only because it can't be separated: unifying `expo_customTransformerPath`'s two drifted declarations gives the field the type `string | false`, so the supervising worker has to handle the `false` case, and normalises it up front - not reachable through `@expo/cli`, which doesn't install the supervisor in that case.

Four declarations come out of the augmentations file. What's left needs `babel-preset-expo`'s producers moving across, then the resolver, source map and `AsyncDependencyType` blocks; the wrapper can stop rewriting types once they're all gone.

# Test Plan

Almost entirely types, so the existing suites are the coverage.

```
$ npx turbo run typecheck test depscheck --filter=@expo/cli --filter=@expo/metro-config --force
 Tasks:    6 successful, 6 total
Cached:    0 cached, 6 total

$ et check-packages @expo/cli @expo/metro-config
🏁 All checks passed.
```

1359 tests in `@expo/metro-config` and 338 across `@expo/cli`'s `src/start/server/metro`, snapshots unchanged.
