### PR TITLE
feat(expo-image): support synced frames on animated images

### DIFF
--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -36,6 +36,13 @@ export const ImageScreens = [
     },
   },
   {
+    name: 'Synchronized animation',
+    route: 'image/synchronized-animation',
+    getComponent() {
+      return optionalRequire(() => require('./ImageSynchronizedAnimationScreen'));
+    },
+  },
+  {
     name: 'List with thousands images',
     route: 'image/flashlist',
     options: {},

--- a/apps/native-component-list/src/screens/Image/ImageSynchronizedAnimationScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageSynchronizedAnimationScreen.tsx
@@ -1,0 +1,102 @@
+import { useTheme } from 'ThemeProvider';
+import { Image } from 'expo-image';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import Button from '../../components/Button';
+import { ScrollPage } from '../../components/Page';
+import TitledSwitch from '../../components/TitledSwitch';
+
+const animatedImage = 'https://cdn.7tv.app/emote/01F9DGR2YG000E7SC8F959BREV/4x.gif';
+
+const copies = 3;
+const staggerMs = 500; // represents rendering at different times
+
+export default function ImageSynchronizedAnimationScreen() {
+  const { theme } = useTheme();
+  const [synchronizedAnimation, setSynchronizedAnimation] = useState(true);
+  const [generation, setGeneration] = useState(0);
+  const [staggered, setStaggered] = useState(false);
+
+  const remount = (nextStaggered: boolean) => {
+    setStaggered(nextStaggered);
+    setGeneration((value) => value + 1);
+  };
+
+  return (
+    <ScrollPage>
+      <Text style={[styles.hint, { color: theme.text.secondary }]}>
+        All images below load the same animated image. With synchronizedAnimation on, they show the
+        same frame no matter when they were rendered. Turn it off and press "Staggered remount" to
+        see them drift apart.
+      </Text>
+      <TitledSwitch
+        title="synchronizedAnimation"
+        value={synchronizedAnimation}
+        setValue={setSynchronizedAnimation}
+      />
+      <View style={styles.buttons}>
+        <Button title="Remount" onPress={() => remount(false)} />
+        <Button title="Staggered remount" onPress={() => remount(true)} />
+      </View>
+      <View style={styles.grid}>
+        {Array.from({ length: copies }, (_, index) => (
+          <ImageCell
+            key={`${generation}:${index}`}
+            delayMs={staggered ? index * staggerMs : 0}
+            synchronizedAnimation={synchronizedAnimation}
+          />
+        ))}
+      </View>
+    </ScrollPage>
+  );
+}
+
+type ImageCellProps = {
+  delayMs: number;
+  synchronizedAnimation: boolean;
+};
+
+function ImageCell({ delayMs, synchronizedAnimation }: ImageCellProps) {
+  const [visible, setVisible] = useState(delayMs === 0);
+
+  useEffect(() => {
+    if (delayMs === 0) {
+      return;
+    }
+    const timeout = setTimeout(() => setVisible(true), delayMs);
+    return () => clearTimeout(timeout);
+  }, [delayMs]);
+
+  if (!visible) {
+    return <View style={styles.imageCell} />;
+  }
+
+  return (
+    <Image
+      style={styles.imageCell}
+      source={{ uri: animatedImage }}
+      synchronizedAnimation={synchronizedAnimation}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  hint: {
+    marginTop: 12,
+  },
+  buttons: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 12,
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  imageCell: {
+    width: 100,
+    height: 100,
+  },
+});

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS][Android] Added a `synchronizedAnimation` prop that keeps every animated image with the same source on the same frame, no matter when each one was rendered. ([#](https://github.com/expo/expo/pull/49674) by [@luke-h1](https://github.com/luke-h1))
+- [iOS][Android] Added a `synchronizedAnimation` prop that keeps every animated image with the same source on the same frame, no matter when each one was rendered. ([#49674](https://github.com/expo/expo/pull/49674) by [@luke-h1](https://github.com/luke-h1))
 - Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 - [iOS][Android] Added a `skipOnCacheHit` field to `transition` that skips the fade the first time a cached image appears (`'memory'` for memory-cache hits, `'all'` for any cache hit), so already-loaded images don't re-animate on mount, tab change, or when scrolling back into view. A transition from a `source` change still plays. ([#48181](https://github.com/expo/expo/pull/48181) by [@janicduplessis](https://github.com/janicduplessis))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- [iOS][Android] Added a `synchronizedAnimation` prop that keeps every animated image with the same source on the same frame, no matter when each one was rendered. ([#45760](https://github.com/expo/expo/pull/45760) by [@luke-h1](https://github.com/luke-h1))
 - Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 - [iOS][Android] Added a `skipOnCacheHit` field to `transition` that skips the fade the first time a cached image appears (`'memory'` for memory-cache hits, `'all'` for any cache hit), so already-loaded images don't re-animate on mount, tab change, or when scrolling back into view. A transition from a `source` change still plays. ([#48181](https://github.com/expo/expo/pull/48181) by [@janicduplessis](https://github.com/janicduplessis))

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS][Android] Added a `synchronizedAnimation` prop that keeps every animated image with the same source on the same frame, no matter when each one was rendered. ([#45760](https://github.com/expo/expo/pull/45760) by [@luke-h1](https://github.com/luke-h1))
+- [iOS][Android] Added a `synchronizedAnimation` prop that keeps every animated image with the same source on the same frame, no matter when each one was rendered. ([#](https://github.com/expo/expo/pull/49674) by [@luke-h1](https://github.com/luke-h1))
 - Added an `imageLoaded` module event emitted with the decoded pixel size from every load path. ([#47337](https://github.com/expo/expo/pull/47337) by [@Ubax](https://github.com/Ubax))
 - add expo-observe integration ([#47145](https://github.com/expo/expo/pull/47145) by [@Ubax](https://github.com/Ubax))
 - [iOS][Android] Added a `skipOnCacheHit` field to `transition` that skips the fade the first time a cached image appears (`'memory'` for memory-cache hits, `'all'` for any cache hit), so already-loaded images don't re-animate on mount, tab change, or when scrolling back into view. A transition from a `source` change still plays. ([#48181](https://github.com/expo/expo/pull/48181) by [@janicduplessis](https://github.com/janicduplessis))

--- a/packages/expo-image/android/build.gradle
+++ b/packages/expo-image/android/build.gradle
@@ -58,5 +58,6 @@ dependencies {
   implementation "jp.wasabeef:glide-transformations:4.3.0"
 
   testImplementation 'junit:junit:4.13.2'
+  testImplementation 'io.mockk:mockk:1.13.11'
   testImplementation 'org.robolectric:robolectric:4.16'
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageModule.kt
@@ -396,6 +396,10 @@ class ExpoImageModule : Module() {
         view.autoplay = autoplay != false
       }
 
+      Prop("synchronizedAnimation") { view: ExpoImageViewWrapper, synchronizedAnimation: Boolean? ->
+        view.synchronizedAnimation = synchronizedAnimation == true
+      }
+
       Prop("decodeFormat") { view: ExpoImageViewWrapper, format: DecodeFormat? ->
         view.decodeFormat = format ?: DecodeFormat.ARGB_8888
       }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageView.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.graphics.transform
 import androidx.core.view.isVisible
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.github.penfeizhou.animation.FrameAnimationDrawable
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.records.ContentPosition
 
@@ -22,6 +23,15 @@ class ExpoImageView(
 ) : AppCompatImageView(context) {
   var currentTarget: ImageViewWrapperTarget? = null
   var isPlaceholder: Boolean = false
+
+  override fun setImageDrawable(newDrawable: Drawable?) {
+    // Take the outgoing drawable off the shared animation.
+    val previous = drawable
+    if (previous is FrameAnimationDrawable<*> && previous !== newDrawable) {
+      SharedAnimationDriver.onAnimatableReleased(previous)
+    }
+    super.setImageDrawable(newDrawable)
+  }
 
   fun recycleView(): ImageViewWrapperTarget? {
     setImageDrawable(null)

--- a/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/ExpoImageViewWrapper.kt
@@ -18,7 +18,7 @@ import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.RequestOptions
-import com.github.penfeizhou.animation.gif.GifDrawable
+import com.github.penfeizhou.animation.FrameAnimationDrawable
 import expo.modules.image.enums.ContentFit
 import expo.modules.image.enums.ImageCacheType
 import expo.modules.image.enums.Priority
@@ -28,11 +28,13 @@ import expo.modules.image.okhttp.GlideUrlWrapper
 import expo.modules.image.records.CachePolicy
 import expo.modules.image.records.ContentPosition
 import expo.modules.image.records.DecodeFormat
+import expo.modules.image.records.DecodedSource
 import expo.modules.image.records.ImageErrorEvent
 import expo.modules.image.records.ImageLoadEvent
 import expo.modules.image.records.ImageProgressEvent
 import expo.modules.image.records.ImageTransition
 import expo.modules.image.records.Source
+import expo.modules.image.records.SourceMap
 import expo.modules.image.svg.SVGPictureDrawable
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.tracing.beginAsyncTraceBlock
@@ -164,6 +166,36 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
   internal var autoplay: Boolean = true
 
+  /**
+   * Whether the animation is kept in step with other views of the same image by [SharedAnimationDriver].
+   */
+  internal var synchronizedAnimation: Boolean = false
+    set(value) {
+      if (field == value) {
+        return
+      }
+      field = value
+      val drawable = activeView.drawable as? FrameAnimationDrawable<*> ?: return
+      if (value) {
+        sharedAnimationKey(activeView.isPlaceholder)?.let {
+          SharedAnimationDriver.onAnimatableDisplayed(drawable, it)
+        }
+      } else {
+        SharedAnimationDriver.onAnimatableReleased(drawable)
+      }
+    }
+
+  /**
+   * Identifies the image behind the displayed drawable for [SharedAnimationDriver].
+   */
+  private fun sharedAnimationKey(isPlaceholder: Boolean): String? {
+    return when (val source = if (isPlaceholder) bestPlaceholder else bestSource) {
+      is SourceMap -> source.cacheKey ?: source.uri
+      is DecodedSource -> "decoded:${System.identityHashCode(source.drawable)}"
+      else -> null
+    }
+  }
+
   internal var lockResource: Boolean = false
 
   internal var priority: Priority = Priority.NORMAL
@@ -174,17 +206,25 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
     // So we check first if the resource is a GifDrawable, because it can continue
     // from where it was paused.
     when (val resource = activeView.drawable) {
-      is GifDrawable -> setIsAnimating(resource, setAnimating)
+      is FrameAnimationDrawable<*> -> setIsAnimating(resource, setAnimating)
       is Animatable -> setIsAnimating(resource, setAnimating)
     }
   }
 
-  private fun setIsAnimating(resource: GifDrawable, setAnimating: Boolean) {
+  private fun setIsAnimating(resource: FrameAnimationDrawable<*>, setAnimating: Boolean) {
     if (setAnimating) {
       if (resource.isPaused) {
         resource.resume()
+        if (synchronizedAnimation) {
+          SharedAnimationDriver.onAnimatableResumed(resource)
+        }
       } else {
         resource.start()
+        if (synchronizedAnimation) {
+          sharedAnimationKey(activeView.isPlaceholder)?.let {
+            SharedAnimationDriver.onAnimatableDisplayed(resource, it)
+          }
+        }
       }
     } else {
       resource.pause()
@@ -400,6 +440,11 @@ class ExpoImageViewWrapper(context: Context, appContext: AppContext) : ExpoView(
 
     if (resource is Animatable) {
       resource.start()
+      if (synchronizedAnimation && resource is FrameAnimationDrawable<*>) {
+        sharedAnimationKey(isPlaceholder)?.let {
+          SharedAnimationDriver.onAnimatableDisplayed(resource, it)
+        }
+      }
     }
   }
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/SharedAnimationDriver.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/SharedAnimationDriver.kt
@@ -1,0 +1,160 @@
+package expo.modules.image
+
+import android.os.SystemClock
+import com.github.penfeizhou.animation.FrameAnimationDrawable
+import com.github.penfeizhou.animation.decode.FrameSeqDecoder
+import java.lang.ref.WeakReference
+import java.nio.ByteBuffer
+
+/**
+ * Keeps every [FrameAnimationDrawable] of the same image in step.
+ *
+ * Glide skips the memory cache with the default cache policy, so each view has its own [FrameSeqDecoder]
+ * and the animations drift apart. Drawables are grouped by an image key and the one playing the longest is
+ * the 'leader'. After rendering a frame, a 'follower' compares itself with the leader: if it is behind it renders the next frame right away, if it is ahead it pauses on its frame until the leader gets there.
+ * Decoders call back on their worker threads, so every entry point is synchronized.
+ */
+internal object SharedAnimationDriver {
+  private class Member(drawable: FrameAnimationDrawable<*>) : FrameSeqDecoder.RenderListener {
+    private val drawableRef = WeakReference(drawable)
+
+    val drawable: FrameAnimationDrawable<*>?
+      get() = drawableRef.get()
+
+    val decoder: FrameSeqDecoder<*, *>?
+      get() = drawable?.frameSeqDecoder
+
+    val isPlaying: Boolean
+      get() = drawable?.let { it.isRunning && !it.isPaused } ?: false
+
+    var playingSince: Long = SystemClock.uptimeMillis()
+
+    // Frame the member paused on while it waits for the leader, or -1.
+    var waitingOnFrame: Int = -1
+
+    override fun onStart() = Unit
+
+    override fun onRender(byteBuffer: ByteBuffer?) = onFrameRendered(this)
+
+    override fun onEnd() = Unit
+  }
+
+  private val groups = HashMap<String, MutableList<Member>>()
+
+  // Puts the drawable into the group of the image identified by [key].
+  @Synchronized
+  fun onAnimatableDisplayed(drawable: FrameAnimationDrawable<*>, key: String) {
+    val existing = findMember(drawable)
+    if (existing != null && existing.first == key) {
+      existing.second.playingSince = SystemClock.uptimeMillis()
+      return
+    }
+    if (existing != null) {
+      remove(existing.first, existing.second)
+    }
+
+    val member = Member(drawable)
+    groups.getOrPut(key) { mutableListOf() }.add(member)
+    drawable.frameSeqDecoder.addRenderListener(member)
+  }
+
+  // A resumed drawable is out of phase, so it must not lead until it has caught up.
+  @Synchronized
+  fun onAnimatableResumed(drawable: FrameAnimationDrawable<*>) {
+    findMember(drawable)?.second?.apply {
+      playingSince = SystemClock.uptimeMillis()
+      waitingOnFrame = -1
+    }
+  }
+
+  @Synchronized
+  fun onAnimatableReleased(drawable: FrameAnimationDrawable<*>) {
+    findMember(drawable)?.let { (key, member) -> remove(key, member) }
+  }
+
+  @Synchronized
+  private fun onFrameRendered(member: Member) {
+    val (key, members) = groups.entries.firstOrNull { it.value.contains(member) } ?: return
+    prune(key, members)
+
+    val decoder = member.decoder ?: return
+    val leader = members.filter { it.isPlaying }.minByOrNull { it.playingSince } ?: return
+    if (leader === member) {
+      resumeFollowers(members, leader, decoder.frameIndex, decoder.frameCount)
+    } else {
+      alignWithLeader(member, decoder, leader)
+    }
+  }
+
+  // Runs on the follower's worker thread, so pausing here cancels the render it has just scheduled.
+  private fun alignWithLeader(member: Member, decoder: FrameSeqDecoder<*, *>, leader: Member) {
+    val leaderDecoder = leader.decoder ?: return
+    val frameCount = decoder.frameCount
+    if (frameCount <= 1 || leaderDecoder.frameCount != frameCount) {
+      return
+    }
+    val distance = Math.floorMod(leaderDecoder.frameIndex - decoder.frameIndex, frameCount)
+    when {
+      distance == 0 -> Unit
+      distance <= frameCount / 2 -> {
+        decoder.pause()
+        decoder.resume()
+      }
+      else -> {
+        decoder.pause()
+        member.waitingOnFrame = decoder.frameIndex
+      }
+    }
+  }
+
+  private fun resumeFollowers(members: List<Member>, leader: Member, leaderFrame: Int, frameCount: Int) {
+    if (frameCount <= 1) {
+      return
+    }
+    for (other in members) {
+      if (other === leader || other.waitingOnFrame < 0) {
+        continue
+      }
+      // Resuming renders the next frame, so wait until the leader has reached it.
+      val distance = Math.floorMod(leaderFrame - (other.waitingOnFrame + 1), frameCount)
+      if (distance <= frameCount / 2) {
+        other.waitingOnFrame = -1
+        other.decoder?.resume()
+      }
+    }
+  }
+
+  private fun findMember(drawable: FrameAnimationDrawable<*>): Pair<String, Member>? {
+    for ((key, members) in groups) {
+      val member = members.firstOrNull { it.drawable === drawable } ?: continue
+      return key to member
+    }
+    return null
+  }
+
+  private fun remove(key: String, member: Member) {
+    member.decoder?.removeRenderListener(member)
+    if (member.waitingOnFrame >= 0) {
+      member.decoder?.resume()
+    }
+    val members = groups[key] ?: return
+    members.remove(member)
+    if (members.isEmpty()) {
+      groups.remove(key)
+    } else if (members.none { it.isPlaying }) {
+      // Nobody is left to resume the waiting members.
+      members.filter { it.waitingOnFrame >= 0 }.forEach {
+        it.waitingOnFrame = -1
+        it.decoder?.resume()
+      }
+    }
+  }
+
+  // Drops members whose drawable was garbage collected.
+  private fun prune(key: String, members: MutableList<Member>) {
+    members.removeAll { it.drawable == null }
+    if (members.isEmpty()) {
+      groups.remove(key)
+    }
+  }
+}

--- a/packages/expo-image/android/src/test/java/expo/modules/image/SharedAnimationDriverTest.kt
+++ b/packages/expo-image/android/src/test/java/expo/modules/image/SharedAnimationDriverTest.kt
@@ -1,0 +1,322 @@
+package expo.modules.image
+
+import com.github.penfeizhou.animation.FrameAnimationDrawable
+import com.github.penfeizhou.animation.decode.FrameSeqDecoder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+/**
+ * A drawable whose decoder reports the frame we tell it to and records pauses and resumes,
+ * so the driver can be exercised without decoding anything.
+ */
+private class FakeAnimatable(frameCount: Int) {
+  val decoder: FrameSeqDecoder<*, *> = mockk(relaxed = true)
+  val drawable: FrameAnimationDrawable<*> = mockk(relaxed = true)
+
+  private val listeners = mutableListOf<FrameSeqDecoder.RenderListener>()
+
+  var frame = 0
+  var isPaused = false
+    private set
+  var isRunning = true
+
+  init {
+    every { drawable.frameSeqDecoder } returns decoder
+    every { drawable.isRunning } answers { isRunning }
+    every { drawable.isPaused } answers { isPaused }
+    every { decoder.frameCount } returns frameCount
+    every { decoder.frameIndex } answers { frame }
+    every { decoder.isPaused } answers { isPaused }
+    every { decoder.addRenderListener(any()) } answers { listeners.add(firstArg()) }
+    every { decoder.removeRenderListener(any()) } answers { listeners.remove(firstArg<FrameSeqDecoder.RenderListener>()) }
+    every { decoder.pause() } answers { isPaused = true }
+    every { decoder.resume() } answers { isPaused = false }
+  }
+
+  val listenerCount: Int
+    get() = listeners.size
+
+  /**
+   * Shows [frame] and notifies the driver the way the decoder's worker thread does.
+   */
+  fun render(frame: Int = this.frame) {
+    this.frame = frame
+    listeners.toList().forEach { it.onRender(null) }
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+class SharedAnimationDriverTest {
+  private val key = "https://example.com/${System.nanoTime()}.gif"
+  private val animatables = mutableListOf<FakeAnimatable>()
+
+  @After
+  fun tearDown() {
+    animatables.forEach { SharedAnimationDriver.onAnimatableReleased(it.drawable) }
+  }
+
+  /**
+   * Registers a drawable and moves the clock on, so members registered later are followers.
+   */
+  private fun display(frameCount: Int = 10, key: String = this.key): FakeAnimatable {
+    val animatable = FakeAnimatable(frameCount).also(animatables::add)
+    SharedAnimationDriver.onAnimatableDisplayed(animatable.drawable, key)
+    ShadowSystemClock.advanceBy(Duration.ofMillis(10))
+    return animatable
+  }
+
+  @Test
+  fun `the leader plays untouched`() {
+    val leader = display()
+    display()
+
+    leader.render(4)
+
+    verify(exactly = 0) { leader.decoder.pause() }
+    verify(exactly = 0) { leader.decoder.resume() }
+  }
+
+  @Test
+  fun `a follower on the same frame is left alone`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 4
+
+    follower.render(4)
+
+    verify(exactly = 0) { follower.decoder.pause() }
+    verify(exactly = 0) { follower.decoder.resume() }
+  }
+
+  @Test
+  fun `a follower behind the leader renders the next frame right away`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 5
+
+    follower.render(3)
+
+    verify(exactly = 1) { follower.decoder.pause() }
+    verify(exactly = 1) { follower.decoder.resume() }
+    assertFalse(follower.isPaused)
+  }
+
+  @Test
+  fun `a follower ahead of the leader waits for it`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 3
+
+    follower.render(5)
+
+    verify(exactly = 1) { follower.decoder.pause() }
+    verify(exactly = 0) { follower.decoder.resume() }
+    assertTrue(follower.isPaused)
+  }
+
+  @Test
+  fun `a waiting follower resumes once the leader reaches its frame`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 3
+    follower.render(5)
+    assertTrue(follower.isPaused)
+
+    // Resuming renders frame 6, so the leader showing frame 5 is still too early.
+    leader.render(5)
+    assertTrue(follower.isPaused)
+
+    leader.render(6)
+    assertFalse(follower.isPaused)
+  }
+
+  @Test
+  fun `a follower far behind takes the shorter way round the loop`() {
+    val leader = display(frameCount = 10)
+    val follower = display(frameCount = 10)
+    leader.frame = 1
+
+    // 9 -> 1 is two frames ahead, not eight behind.
+    follower.render(9)
+
+    verify(exactly = 1) { follower.decoder.pause() }
+    verify(exactly = 1) { follower.decoder.resume() }
+  }
+
+  @Test
+  fun `drawables of different images are independent`() {
+    val leader = display(key = "$key-a")
+    val other = display(key = "$key-b")
+    leader.frame = 7
+
+    other.render(1)
+
+    verify(exactly = 0) { other.decoder.pause() }
+    verify(exactly = 0) { other.decoder.resume() }
+  }
+
+  @Test
+  fun `images with a different frame count are not aligned`() {
+    val leader = display(frameCount = 10)
+    val follower = display(frameCount = 12)
+    leader.frame = 7
+
+    follower.render(1)
+
+    verify(exactly = 0) { follower.decoder.pause() }
+  }
+
+  @Test
+  fun `single frame images are not aligned`() {
+    val leader = display(frameCount = 1)
+    val follower = display(frameCount = 1)
+    leader.frame = 0
+
+    follower.render(0)
+
+    verify(exactly = 0) { follower.decoder.pause() }
+  }
+
+  @Test
+  fun `a paused member cannot lead`() {
+    val first = display()
+    val second = display()
+    first.isRunning = false
+    second.frame = 6
+
+    // With the first member stopped, the second leads and nothing pushes it around.
+    second.render(6)
+    verify(exactly = 0) { second.decoder.pause() }
+
+    // Starting again puts the first member back on the clock behind the second one.
+    first.isRunning = true
+    SharedAnimationDriver.onAnimatableDisplayed(first.drawable, key)
+    first.render(2)
+    verify(exactly = 1) { first.decoder.pause() }
+    verify(exactly = 1) { first.decoder.resume() }
+  }
+
+  @Test
+  fun `a resumed drawable follows until it has caught up`() {
+    val first = display()
+    val second = display()
+
+    SharedAnimationDriver.onAnimatableResumed(first.drawable)
+    second.frame = 6
+
+    first.render(2)
+
+    verify(exactly = 1) { first.decoder.pause() }
+    verify(exactly = 1) { first.decoder.resume() }
+    verify(exactly = 0) { second.decoder.pause() }
+  }
+
+  @Test
+  fun `resuming a waiting drawable clears its wait`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 3
+    follower.render(5)
+    assertTrue(follower.isPaused)
+
+    SharedAnimationDriver.onAnimatableResumed(follower.drawable)
+
+    // The leader reaching the frame no longer resumes it, the caller already did.
+    leader.render(6)
+    verify(exactly = 0) { follower.decoder.resume() }
+  }
+
+  @Test
+  fun `displaying the same drawable again does not register it twice`() {
+    val animatable = display()
+
+    SharedAnimationDriver.onAnimatableDisplayed(animatable.drawable, key)
+
+    assertEquals(1, animatable.listenerCount)
+  }
+
+  @Test
+  fun `displaying a drawable under a new key moves it between groups`() {
+    val leader = display(key = "$key-a")
+    val moved = display(key = "$key-a")
+    leader.frame = 7
+
+    SharedAnimationDriver.onAnimatableDisplayed(moved.drawable, "$key-b")
+    moved.render(1)
+
+    assertEquals(1, moved.listenerCount)
+    verify(exactly = 0) { moved.decoder.pause() }
+  }
+
+  @Test
+  fun `releasing a drawable stops listening to it`() {
+    val animatable = display()
+
+    SharedAnimationDriver.onAnimatableReleased(animatable.drawable)
+
+    assertEquals(0, animatable.listenerCount)
+  }
+
+  @Test
+  fun `releasing a waiting drawable resumes it`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 3
+    follower.render(5)
+    assertTrue(follower.isPaused)
+
+    SharedAnimationDriver.onAnimatableReleased(follower.drawable)
+
+    assertFalse(follower.isPaused)
+  }
+
+  @Test
+  fun `releasing the last playing member resumes the waiting ones`() {
+    val leader = display()
+    val follower = display()
+    leader.frame = 3
+    follower.render(5)
+    assertTrue(follower.isPaused)
+
+    SharedAnimationDriver.onAnimatableReleased(leader.drawable)
+
+    assertFalse(follower.isPaused)
+  }
+
+  @Test
+  fun `releasing the leader leaves the waiting members to the next leader`() {
+    val leader = display()
+    val next = display()
+    val follower = display()
+    leader.frame = 3
+    next.frame = 3
+    follower.render(5)
+    assertTrue(follower.isPaused)
+
+    SharedAnimationDriver.onAnimatableReleased(leader.drawable)
+    assertTrue(follower.isPaused)
+
+    next.render(6)
+    assertFalse(follower.isPaused)
+  }
+
+  @Test
+  fun `releasing an unknown drawable is a no-op`() {
+    val stranger = FakeAnimatable(10)
+
+    SharedAnimationDriver.onAnimatableReleased(stranger.drawable)
+    SharedAnimationDriver.onAnimatableResumed(stranger.drawable)
+
+    verify(exactly = 0) { stranger.decoder.resume() }
+  }
+}

--- a/packages/expo-image/ios/AnimatedImage.swift
+++ b/packages/expo-image/ios/AnimatedImage.swift
@@ -5,33 +5,24 @@ internal import SDWebImage
 /**
  Custom `SDAnimatedImage` that fixes issues with `images` and `duration` not being available.
  */
-final class AnimatedImage: SDAnimatedImage {
-  var frames: [SDImageFrame]?
+final class AnimatedImage: SDAnimatedImage, @unchecked Sendable {
+  /**
+   * Frame schedule for `SharedAnimationDriver`, built once per image.
+   */
+  var sharedAnimationTimeline: AnimationTimeline?
 
   // MARK: - UIImage
 
   override var images: [UIImage]? {
+    guard animatedImageFrameCount > 1 else {
+      return nil
+    }
+    // Shares SDWebImage's frame store with `SharedAnimationDriver`, so frames are decoded once.
     preloadAllFrames()
-    return frames?.map({ $0.image })
+    return (0..<animatedImageFrameCount).compactMap { animatedImageFrame(at: $0) }
   }
 
   override var duration: TimeInterval {
-    preloadAllFrames()
-    return frames?.reduce(0, { $0 + $1.duration }) ?? 0.0
-  }
-
-  // MARK: - SDAnimatedImage
-
-  override func preloadAllFrames() {
-    if frames != nil {
-      return
-    }
-    frames = [UInt](0..<animatedImageFrameCount).compactMap { index in
-      guard let image = animatedImageFrame(at: index) else {
-        return nil
-      }
-      let duration = animatedImageDuration(at: index)
-      return SDImageFrame(image: image, duration: duration)
-    }
+    return (0..<animatedImageFrameCount).reduce(0.0) { $0 + animatedImageDuration(at: $1) }
   }
 }

--- a/packages/expo-image/ios/AnimationTimeline.swift
+++ b/packages/expo-image/ios/AnimationTimeline.swift
@@ -1,0 +1,56 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+internal import SDWebImage
+
+// Maps time on the shared clock to a frame index of an animated image.
+struct AnimationTimeline {
+  // End time of each frame within one loop.
+  private let frameEndTimes: [TimeInterval]
+
+  let totalDuration: TimeInterval
+
+  var frameCount: Int {
+    return frameEndTimes.count
+  }
+
+  // Returns `nil` for images with fewer than two frames or no duration.
+  init?(image: SDAnimatedImage) {
+    let frameCount = Int(image.animatedImageFrameCount)
+    guard frameCount > 1 else {
+      return nil
+    }
+    var frameEndTimes: [TimeInterval] = []
+    frameEndTimes.reserveCapacity(frameCount)
+    var totalDuration: TimeInterval = 0
+
+    for index in 0..<frameCount {
+      totalDuration += max(image.animatedImageDuration(at: UInt(index)), 0)
+      frameEndTimes.append(totalDuration)
+    }
+    guard totalDuration > 0 else {
+      return nil
+    }
+    self.frameEndTimes = frameEndTimes
+    self.totalDuration = totalDuration
+  }
+
+  // Index of the frame visible `elapsed` seconds after the clock started. The animation loops forever.
+  func frameIndex(atElapsed elapsed: TimeInterval) -> UInt {
+    guard elapsed > 0 else {
+      return 0
+    }
+    let position = elapsed.truncatingRemainder(dividingBy: totalDuration)
+    var low = 0
+    var high = frameEndTimes.count - 1
+
+    while low < high {
+      let middle = (low + high) / 2
+      if frameEndTimes[middle] > position {
+        high = middle
+      } else {
+        low = middle + 1
+      }
+    }
+    return UInt(low)
+  }
+}

--- a/packages/expo-image/ios/Image.swift
+++ b/packages/expo-image/ios/Image.swift
@@ -1,6 +1,7 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+internal import SDWebImage
 
 internal final class Image: SharedRef<UIImage> {
   override var nativeRefType: String {
@@ -8,6 +9,9 @@ internal final class Image: SharedRef<UIImage> {
   }
 
   var isAnimated: Bool {
+    if let animatedImage = ref as? SDAnimatedImage {
+      return animatedImage.animatedImageFrameCount > 1
+    }
     return !(ref.images?.isEmpty ?? true)
   }
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -121,6 +121,10 @@ public final class ImageModule: Module {
         view.autoplay = autoplay ?? true
       }
 
+      Prop("synchronizedAnimation", false) { (view, synchronizedAnimation: Bool) in
+        view.synchronizedAnimation = synchronizedAnimation
+      }
+
       Prop("sfEffect") { (view, sfEffect: [SFSymbolEffect]?) in
         view.sfEffect = sfEffect
       }
@@ -150,6 +154,8 @@ public final class ImageModule: Module {
       AsyncFunction("startAnimating") { (view: ImageView) in
         if view.isSFSymbolSource {
           view.startSymbolAnimation()
+        } else if view.hasSharedAnimation {
+          view.startSharedAnimation()
         } else {
           view.sdImageView.startAnimating()
         }
@@ -158,6 +164,8 @@ public final class ImageModule: Module {
       AsyncFunction("stopAnimating") { (view: ImageView) in
         if view.isSFSymbolSource {
           view.stopSymbolAnimation()
+        } else if view.hasSharedAnimation {
+          view.stopSharedAnimation()
         } else {
           view.sdImageView.stopAnimating()
         }
@@ -205,7 +213,7 @@ public final class ImageModule: Module {
             failed = true
             promise.resolve(false)
           } else {
-            imagesLoaded = imagesLoaded + 1
+            imagesLoaded += 1
             if imagesLoaded == urls.count {
               promise.resolve(true)
             }
@@ -216,24 +224,32 @@ public final class ImageModule: Module {
 
     AsyncFunction("generateBlurhashAsync") { (source: Either<Image, URL>, numberOfComponents: CGSize, promise: Promise) in
       let parsedNumberOfComponents = (width: Int(numberOfComponents.width), height: Int(numberOfComponents.height))
-      generatePlaceholder(source: source, onFailure: {
-        promise.reject(BlurhashGenerationException())
-      }, generator: { (image: UIImage) in
-        if let blurhashString = blurhash(fromImage: image, numberOfComponents: parsedNumberOfComponents) {
-          promise.resolve(blurhashString)
-        } else {
+      generatePlaceholder(
+        source: source,
+        onFailure: {
           promise.reject(BlurhashGenerationException())
+        },
+        generator: { (image: UIImage) in
+          if let blurhashString = blurhash(fromImage: image, numberOfComponents: parsedNumberOfComponents) {
+            promise.resolve(blurhashString)
+          } else {
+            promise.reject(BlurhashGenerationException())
+          }
         }
-      })
+      )
     }
 
     AsyncFunction("generateThumbhashAsync") { (source: Either<Image, URL>, promise: Promise) in
-      generatePlaceholder(source: source, onFailure: {
-        promise.reject(ThumbhashGenerationException())
-      }, generator: { (image: UIImage) in
-        let blurhashString = thumbHash(fromImage: image)
-        promise.resolve(blurhashString.base64EncodedString())
-      })
+      generatePlaceholder(
+        source: source,
+        onFailure: {
+          promise.reject(ThumbhashGenerationException())
+        },
+        generator: { (image: UIImage) in
+          let blurhashString = thumbHash(fromImage: image)
+          promise.resolve(blurhashString.base64EncodedString())
+        }
+      )
     }
 
     AsyncFunction("clearMemoryCache") { () -> Bool in
@@ -308,7 +324,7 @@ public final class ImageModule: Module {
 
     AsyncFunction("loadAsync") { [weak appContext = self.appContext] (source: ImageSource, options: ImageLoadOptions?) -> Image? in
       let image = try await ImageLoadTask(source, options: options ?? ImageLoadOptions()).load()
-      // Going through the `appContext` instead of capturing `self` keeps this `@Sendable async` closure from forcing 
+      // Going through the `appContext` instead of capturing `self` keeps this `@Sendable async` closure from forcing
       // the whole module to be Sendable.
       appContext?.moduleRegistry.getModule(implementing: ImageModule.self)?.emitImageLoaded(
         url: source.uri?.absoluteString ?? "",

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -9,7 +9,6 @@ import VisionKit
 
 typealias SDWebImageContext = [SDWebImageContextOption: Any]
 
-// swiftlint:disable:next type_body_length
 public final class ImageView: ExpoView {
   nonisolated static let contextSourceKey = SDWebImageContextOption(rawValue: "source")
   nonisolated static let screenScaleKey = SDWebImageContextOption(rawValue: "screenScale")
@@ -66,6 +65,7 @@ public final class ImageView: ExpoView {
   var recyclingKey: String? {
     didSet {
       if oldValue != nil && recyclingKey != oldValue {
+        leaveSharedAnimation()
         sdImageView.image = nil
         placeholderImage = nil
         sourceImage = nil
@@ -76,6 +76,25 @@ public final class ImageView: ExpoView {
   var autoplay: Bool = true
 
   var sfEffect: [SFSymbolEffect]?
+
+  // Whether the animation is driven by `SharedAnimationDriver`, so every view of the same image shows the same frame.
+  var synchronizedAnimation: Bool = false {
+    didSet {
+      guard oldValue != synchronizedAnimation else {
+        return
+      }
+      if synchronizedAnimation {
+        joinSharedAnimationIfPossible()
+      } else {
+        leaveSharedAnimation()
+      }
+    }
+  }
+
+  // The image whose frames are driven by the shared clock.
+  private var sharedAnimationImage: SDAnimatedImage?
+
+  private var sharedAnimationTimeline: AnimationTimeline?
 
   var symbolWeight: String?
 
@@ -538,10 +557,13 @@ public final class ImageView: ExpoView {
   private func setImage(_ image: UIImage?, contentFit: ContentFit, isPlaceholder: Bool) {
     sdImageView.contentMode = contentFit.toContentMode()
 
+    let sharedAnimation = drivableAnimatedImage(image, isPlaceholder: isPlaceholder)
+
     if isPlaceholder {
       sdImageView.autoPlayAnimatedImage = true
     } else {
-      sdImageView.autoPlayAnimatedImage = autoplay
+      // Views on the shared clock don't run their own player.
+      sdImageView.autoPlayAnimatedImage = sharedAnimation == nil && autoplay
     }
 
     // Remove any existing symbol effects before setting new image
@@ -577,6 +599,8 @@ public final class ImageView: ExpoView {
       }
     }
 
+    updateSharedAnimation(with: sharedAnimation)
+
     if !isPlaceholder {
       onDisplay()
     }
@@ -586,6 +610,116 @@ public final class ImageView: ExpoView {
       analyzeImage()
     }
 #endif
+  }
+
+  // MARK: - Shared animation
+
+  // Whether the displayed image is driven by the shared clock.
+  var hasSharedAnimation: Bool {
+    return sharedAnimationTimeline != nil
+  }
+
+  /**
+   * Returns the image if the shared clock can drive it. Placeholders, tinted images and SF Symbols are excluded.
+   * A downscaling `animationTransformer` is fine because `SDAnimatedImageView` applies it when seeking.
+   */
+  private func drivableAnimatedImage(_ image: UIImage?, isPlaceholder: Bool) -> SDAnimatedImage? {
+    guard synchronizedAnimation,
+      !isPlaceholder,
+      !isSFSymbolSource,
+      imageTintColor == nil,
+      let animatedImage = image as? SDAnimatedImage,
+      animatedImage.animatedImageLoopCount == 0,
+      SharedAnimationDriver.shared.canDrive(animatedImage)
+    else {
+      return nil
+    }
+    return animatedImage
+  }
+
+  private func updateSharedAnimation(with image: SDAnimatedImage?) {
+    guard let image, let timeline = SharedAnimationDriver.shared.timeline(for: image) else {
+      leaveSharedAnimation()
+      return
+    }
+    sharedAnimationImage = image
+    sharedAnimationTimeline = timeline
+
+    if autoplay {
+      startSharedAnimation()
+    } else {
+      SharedAnimationDriver.shared.unregister(self)
+    }
+  }
+
+  /**
+   * Moves a view that already displays its image onto the shared clock.
+   */
+  private func joinSharedAnimationIfPossible() {
+    guard !hasSharedAnimation,
+      let sourceImage,
+      sdImageView.image === sourceImage,
+      let image = drivableAnimatedImage(sourceImage, isPlaceholder: false)
+    else {
+      return
+    }
+    sdImageView.stopAnimating()
+    sdImageView.autoPlayAnimatedImage = false
+    updateSharedAnimation(with: image)
+  }
+
+  func startSharedAnimation() {
+    guard let sharedAnimationImage else {
+      return
+    }
+    if !SharedAnimationDriver.shared.register(self, image: sharedAnimationImage) {
+      // No room for this image's frames, fall back to the view's own player.
+      leaveSharedAnimation()
+      if !autoplay {
+        sdImageView.startAnimating()
+      }
+    }
+  }
+
+  func stopSharedAnimation() {
+    SharedAnimationDriver.shared.unregister(self)
+  }
+
+  /**
+   * Hands the view back to its own player.
+   */
+  func leaveSharedAnimation() {
+    guard sharedAnimationTimeline != nil else {
+      return
+    }
+    SharedAnimationDriver.shared.unregister(self)
+    sharedAnimationImage = nil
+    sharedAnimationTimeline = nil
+    sdImageView.autoPlayAnimatedImage = autoplay
+    if autoplay {
+      sdImageView.startAnimating()
+    }
+  }
+
+  /**
+   * Seeks to the frame the shared clock is on.
+   */
+  func renderSharedAnimationFrame(elapsed: TimeInterval) {
+    // `SDAnimatedImageView` only skips hidden views when it plays them itself.
+    guard window != nil, !isHidden, alpha > 0 else {
+      return
+    }
+    guard let sharedAnimationTimeline,
+      let sharedAnimationImage,
+      SharedAnimationDriver.shared.isReady(sharedAnimationImage),
+      let player = sdImageView.player
+    else {
+      return
+    }
+    let frameIndex = sharedAnimationTimeline.frameIndex(atElapsed: elapsed)
+    if player.currentFrameIndex != frameIndex {
+      player.seekToFrame(at: frameIndex, loopCount: 0)
+    }
   }
 
   // MARK: - Symbol Effects

--- a/packages/expo-image/ios/SharedAnimationDriver.swift
+++ b/packages/expo-image/ios/SharedAnimationDriver.swift
@@ -1,0 +1,198 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import QuartzCore
+internal import SDWebImage
+
+/**
+ * Runs one clock for every `ImageView` with `synchronizedAnimation` enabled and tells them which frame to show on each display refresh.
+ * Frames of a driven image are decoded once and held while any view is registered for it.
+ */
+@MainActor
+final class SharedAnimationDriver {
+  static let shared = SharedAnimationDriver()
+
+  // Images with more decoded frame bytes than this are left to SDWebImage's bounded frame buffer.
+  static let maxBytesPerImage = 64 * 1024 * 1024 // 64mb
+
+  // Upper bound for decoded frames held across all images.
+  static let maxTotalBytes = 192 * 1024 * 1024 // 192mb
+
+  private struct WeakView {
+    weak var view: ImageView?
+  }
+
+  private final class Entry {
+    let image: SDAnimatedImage
+    let timeline: AnimationTimeline
+    let byteSize: Int
+    var views: [WeakView] = []
+    var isReady = false
+    var isPreloading = false
+
+    init(image: SDAnimatedImage, timeline: AnimationTimeline, byteSize: Int) {
+      self.image = image
+      self.timeline = timeline
+      self.byteSize = byteSize
+    }
+  }
+
+  private var entries: [ObjectIdentifier: Entry] = [:]
+  private var displayLink: CADisplayLink?
+  private var clockStart: CFTimeInterval = 0
+
+  private var heldBytes: Int {
+    return entries.values.reduce(0) { $0 + $1.byteSize }
+  }
+
+  private init() {}
+
+  // MARK: - Queries
+
+  // Whether the image is small enough for its frames to be held.
+  func canDrive(_ image: SDAnimatedImage) -> Bool {
+    guard image.animatedImageFrameCount > 1 else {
+      return false
+    }
+    return Self.byteSize(of: image) <= Self.maxBytesPerImage
+  }
+
+  // The frame schedule of the image, cached on `AnimatedImage` instances.
+  func timeline(for image: SDAnimatedImage) -> AnimationTimeline? {
+    if let entry = entries[ObjectIdentifier(image)] {
+      return entry.timeline
+    }
+    guard let animatedImage = image as? AnimatedImage else {
+      return AnimationTimeline(image: image)
+    }
+    if let timeline = animatedImage.sharedAnimationTimeline {
+      return timeline
+    }
+    let timeline = AnimationTimeline(image: image)
+    animatedImage.sharedAnimationTimeline = timeline
+    return timeline
+  }
+
+  // Whether all frames of the image are decoded.
+  func isReady(_ image: SDAnimatedImage) -> Bool {
+    return entries[ObjectIdentifier(image)]?.isReady ?? false
+  }
+
+  // MARK: - Registration
+
+  // Puts the view on the shared clock. Returns `false` when the driver cannot hold the image's frames.
+  @discardableResult
+  func register(_ view: ImageView, image: SDAnimatedImage) -> Bool {
+    let key = ObjectIdentifier(image)
+    // A view drives at most one image at a time.
+    unregister(view)
+
+    if let entry = entries[key] {
+      entry.views.append(WeakView(view: view))
+    } else {
+      guard let timeline = timeline(for: image) else {
+        return false
+      }
+      let byteSize = Self.byteSize(of: image)
+      guard byteSize <= Self.maxBytesPerImage, heldBytes + byteSize <= Self.maxTotalBytes else {
+        return false
+      }
+      let entry = Entry(image: image, timeline: timeline, byteSize: byteSize)
+      entry.views.append(WeakView(view: view))
+      entries[key] = entry
+      preloadFrames(of: entry)
+    }
+    startDisplayLinkIfNeeded()
+    return true
+  }
+
+  // Takes the view off the shared clock and releases frames nobody shows anymore.
+  func unregister(_ view: ImageView) {
+    for (key, entry) in entries {
+      entry.views.removeAll { $0.view == nil || $0.view === view }
+      if entry.views.isEmpty {
+        release(key)
+      }
+    }
+    stopDisplayLinkIfIdle()
+  }
+
+  // MARK: - Frames
+
+  private func preloadFrames(of entry: Entry) {
+    entry.isPreloading = true
+    let image = entry.image
+
+    DispatchQueue.global(qos: .userInitiated).async {
+      image.preloadAllFrames()
+      Task { @MainActor in
+        SharedAnimationDriver.shared.finishPreloading(image)
+      }
+    }
+  }
+
+  private func finishPreloading(_ image: SDAnimatedImage) {
+    guard let entry = entries[ObjectIdentifier(image)] else {
+      // Every view left while the frames were decoding.
+      image.unloadAllFrames()
+      return
+    }
+    entry.isPreloading = false
+    entry.isReady = image.isAllFramesLoaded
+  }
+
+  private func release(_ key: ObjectIdentifier) {
+    guard let entry = entries.removeValue(forKey: key) else {
+      return
+    }
+    // A running preload unloads the frames itself when it finishes.
+    if !entry.isPreloading {
+      entry.image.unloadAllFrames()
+    }
+  }
+
+  private static func byteSize(of image: SDAnimatedImage) -> Int {
+    let width = Int(image.size.width * image.scale)
+    let height = Int(image.size.height * image.scale)
+    return Int(image.animatedImageFrameCount) * width * height * 4
+  }
+
+  // MARK: - Clock
+
+  private func startDisplayLinkIfNeeded() {
+    guard displayLink == nil, !entries.isEmpty else {
+      return
+    }
+    clockStart = CACurrentMediaTime()
+    let displayLink = CADisplayLink(target: self, selector: #selector(handleDisplayLink(_:)))
+    displayLink.add(to: .main, forMode: .common)
+    self.displayLink = displayLink
+  }
+
+  private func stopDisplayLinkIfIdle() {
+    guard entries.isEmpty else {
+      return
+    }
+    displayLink?.invalidate()
+    displayLink = nil
+  }
+
+  @objc
+  private func handleDisplayLink(_ displayLink: CADisplayLink) {
+    let elapsed = displayLink.targetTimestamp - clockStart
+
+    for (key, entry) in entries {
+      entry.views.removeAll { $0.view == nil }
+      if entry.views.isEmpty {
+        release(key)
+        continue
+      }
+      guard entry.isReady else {
+        continue
+      }
+      for holder in entry.views {
+        holder.view?.renderSharedAnimationFrame(elapsed: elapsed)
+      }
+    }
+    stopDisplayLinkIfIdle()
+  }
+}

--- a/packages/expo-image/ios/Tests/SharedAnimationTests.swift
+++ b/packages/expo-image/ios/Tests/SharedAnimationTests.swift
@@ -1,0 +1,400 @@
+import ExpoModulesCore
+import Foundation
+import ImageIO
+internal import SDWebImage
+import Testing
+import UniformTypeIdentifiers
+
+@testable import ExpoImage
+
+// MARK: - Fixtures
+
+// An animated image whose frames are declared instead of decoded, so the schedule can be shaped per test.
+private final class StubAnimatedImage: SDAnimatedImage, @unchecked Sendable {
+  private var durations: [TimeInterval] = []
+  private var pixelSize = CGSize(width: 2, height: 2)
+
+  convenience init(durations: [TimeInterval], pixelSize: CGSize = CGSize(width: 2, height: 2)) {
+    self.init()
+    self.durations = durations
+    self.pixelSize = pixelSize
+  }
+
+  override var animatedImageFrameCount: UInt {
+    return UInt(durations.count)
+  }
+
+  override func animatedImageDuration(at index: UInt) -> TimeInterval {
+    return durations[Int(index)]
+  }
+
+  override var size: CGSize {
+    return pixelSize
+  }
+
+  override var scale: CGFloat {
+    return 1
+  }
+}
+
+/**
+ * A decoded GIF that reports a single loop.
+ */
+private final class FiniteLoopAnimatedImage: SDAnimatedImage, @unchecked Sendable {
+  override var animatedImageLoopCount: UInt {
+    return 1
+  }
+}
+
+/**
+ * Encodes a real GIF with one solid frame per duration.
+ */
+private func makeGIF(frameDurations: [TimeInterval], size: CGSize = CGSize(width: 4, height: 4)) -> Data {
+  let data = NSMutableData()
+  guard
+    let destination = CGImageDestinationCreateWithData(
+      data,
+      UTType.gif.identifier as CFString,
+      frameDurations.count,
+      nil
+    )
+  else {
+    fatalError("Couldn't create a GIF destination")
+  }
+  CGImageDestinationSetProperties(
+    destination,
+    [
+      kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: 0]
+    ] as CFDictionary
+  )
+
+  let renderer = UIGraphicsImageRenderer(size: size)
+  for (index, duration) in frameDurations.enumerated() {
+    let image = renderer.image { context in
+      UIColor(hue: CGFloat(index) / CGFloat(frameDurations.count), saturation: 1, brightness: 1, alpha: 1).setFill()
+      context.fill(CGRect(origin: .zero, size: size))
+    }
+    guard let cgImage = image.cgImage else {
+      fatalError("Couldn't render a GIF frame")
+    }
+    CGImageDestinationAddImage(
+      destination,
+      cgImage,
+      [
+        kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: duration]
+      ] as CFDictionary
+    )
+  }
+  CGImageDestinationFinalize(destination)
+  return data as Data
+}
+
+private func makeAnimatedImage(frameDurations: [TimeInterval] = [0.1, 0.2, 0.3]) -> AnimatedImage {
+  guard let image = AnimatedImage(data: makeGIF(frameDurations: frameDurations)) else {
+    fatalError("SDWebImage couldn't decode the generated GIF")
+  }
+  return image
+}
+
+@MainActor
+private func waitUntil(timeout: TimeInterval = 5, _ condition: () -> Bool) async throws {
+  let deadline = Date().addingTimeInterval(timeout)
+  while !condition() {
+    try #require(Date() < deadline, "Timed out waiting for the condition")
+    try await Task.sleep(nanoseconds: 10_000_000)
+  }
+}
+
+// MARK: - AnimationTimeline
+
+@Suite("animation timeline")
+struct AnimationTimelineTests {
+  @Test
+  func `is nil for a single frame image`() {
+    #expect(AnimationTimeline(image: StubAnimatedImage(durations: [0.5])) == nil)
+  }
+
+  @Test
+  func `is nil for an image without frames`() {
+    #expect(AnimationTimeline(image: StubAnimatedImage(durations: [])) == nil)
+  }
+
+  @Test
+  func `is nil when every frame has no duration`() {
+    #expect(AnimationTimeline(image: StubAnimatedImage(durations: [0, 0, 0])) == nil)
+  }
+
+  @Test
+  func `sums the frame durations`() throws {
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [0.1, 0.2, 0.3])))
+    #expect(timeline.frameCount == 3)
+    #expect(abs(timeline.totalDuration - 0.6) < 0.0001)
+  }
+
+  @Test
+  func `ignores negative durations`() throws {
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [-1, 0.5])))
+    #expect(timeline.totalDuration == 0.5)
+  }
+
+  @Test
+  func `starts on the first frame`() throws {
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [0.1, 0.2, 0.3])))
+    #expect(timeline.frameIndex(atElapsed: 0) == 0)
+    #expect(timeline.frameIndex(atElapsed: -1) == 0)
+    #expect(timeline.frameIndex(atElapsed: 0.05) == 0)
+  }
+
+  @Test
+  func `advances when a frame ends`() throws {
+    // Durations that add up exactly in binary, so the boundaries are not subject to rounding.
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [0.25, 0.5, 0.25])))
+    #expect(timeline.frameIndex(atElapsed: 0.25) == 1)
+    #expect(timeline.frameIndex(atElapsed: 0.5) == 1)
+    #expect(timeline.frameIndex(atElapsed: 0.75) == 2)
+    #expect(timeline.frameIndex(atElapsed: 0.99) == 2)
+  }
+
+  @Test
+  func `loops forever`() throws {
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [0.25, 0.5, 0.25])))
+    #expect(timeline.frameIndex(atElapsed: 1) == 0)
+    #expect(timeline.frameIndex(atElapsed: 1.1) == 0)
+    #expect(timeline.frameIndex(atElapsed: 2.3) == 1)
+    #expect(timeline.frameIndex(atElapsed: 100.8) == 2)
+  }
+
+  @Test
+  func `skips over frames without duration`() throws {
+    let timeline = try #require(AnimationTimeline(image: StubAnimatedImage(durations: [0, 0.1, 0])))
+    #expect(timeline.frameIndex(atElapsed: 0) == 0)
+    #expect(timeline.frameIndex(atElapsed: 0.05) == 1)
+  }
+
+  @Test
+  func `reads the schedule of a decoded GIF`() throws {
+    let timeline = try #require(AnimationTimeline(image: makeAnimatedImage(frameDurations: [0.1, 0.2, 0.3])))
+    #expect(timeline.frameCount == 3)
+    #expect(abs(timeline.totalDuration - 0.6) < 0.0001)
+    #expect(timeline.frameIndex(atElapsed: 0.15) == 1)
+  }
+}
+
+// MARK: - AnimatedImage
+
+@Suite("animated image")
+struct AnimatedImageTests {
+  @Test
+  func `exposes every decoded frame`() {
+    let image = makeAnimatedImage(frameDurations: [0.1, 0.2, 0.3])
+    #expect(image.images?.count == 3)
+    #expect(abs(image.duration - 0.6) < 0.0001)
+  }
+
+  @Test
+  func `has no frames when it is not animated`() {
+    #expect(makeAnimatedImage(frameDurations: [0.5]).images == nil)
+  }
+
+  @Test
+  func `is reported as animated by the shared ref`() {
+    #expect(Image(makeAnimatedImage()).isAnimated)
+    #expect(!Image(makeAnimatedImage(frameDurations: [0.5])).isAnimated)
+    #expect(!Image(UIImage()).isAnimated)
+  }
+}
+
+// MARK: - SharedAnimationDriver
+
+@Suite("shared animation driver", .serialized)
+@MainActor
+struct SharedAnimationDriverTests {
+  let driver = SharedAnimationDriver.shared
+
+  @Test
+  func `drives small multi-frame images only`() {
+    #expect(driver.canDrive(makeAnimatedImage()))
+    #expect(!driver.canDrive(StubAnimatedImage(durations: [0.5])))
+
+    let oversized = StubAnimatedImage(
+      durations: Array(repeating: 0.1, count: 200),
+      pixelSize: CGSize(width: 1000, height: 1000)
+    )
+    #expect(!driver.canDrive(oversized))
+  }
+
+  @Test
+  func `caches the timeline on the image`() throws {
+    let image = makeAnimatedImage()
+    #expect(image.sharedAnimationTimeline == nil)
+
+    let timeline = try #require(driver.timeline(for: image))
+    #expect(image.sharedAnimationTimeline?.frameCount == timeline.frameCount)
+    #expect(driver.timeline(for: image)?.totalDuration == timeline.totalDuration)
+  }
+
+  @Test
+  func `has no timeline for images it cannot drive`() {
+    #expect(driver.timeline(for: StubAnimatedImage(durations: [0.5])) == nil)
+  }
+
+  @Test
+  func `decodes the frames once a view registers`() async throws {
+    let image = makeAnimatedImage()
+    let view = ImageView(appContext: AppContext())
+    #expect(!driver.isReady(image))
+
+    #expect(driver.register(view, image: image))
+    try await waitUntil { driver.isReady(image) }
+    #expect(image.isAllFramesLoaded)
+
+    driver.unregister(view)
+    #expect(!driver.isReady(image))
+  }
+
+  @Test
+  func `keeps the frames while any view is registered`() async throws {
+    let image = makeAnimatedImage()
+    let first = ImageView(appContext: AppContext())
+    let second = ImageView(appContext: AppContext())
+
+    driver.register(first, image: image)
+    driver.register(second, image: image)
+    try await waitUntil { driver.isReady(image) }
+
+    driver.unregister(first)
+    #expect(driver.isReady(image))
+
+    driver.unregister(second)
+    #expect(!driver.isReady(image))
+  }
+
+  @Test
+  func `moves a view between images`() async throws {
+    let first = makeAnimatedImage(frameDurations: [0.1, 0.1])
+    let second = makeAnimatedImage(frameDurations: [0.2, 0.2])
+    let view = ImageView(appContext: AppContext())
+
+    driver.register(view, image: first)
+    try await waitUntil { driver.isReady(first) }
+
+    driver.register(view, image: second)
+    #expect(!driver.isReady(first))
+    try await waitUntil { driver.isReady(second) }
+
+    driver.unregister(view)
+  }
+
+  @Test
+  func `refuses images over the frame budget`() {
+    let view = ImageView(appContext: AppContext())
+    let oversized = StubAnimatedImage(
+      durations: Array(repeating: 0.1, count: 200),
+      pixelSize: CGSize(width: 1000, height: 1000)
+    )
+
+    #expect(!driver.register(view, image: oversized))
+    #expect(!driver.isReady(oversized))
+  }
+
+  @Test
+  func `ignores unregistering a view that never joined`() {
+    driver.unregister(ImageView(appContext: AppContext()))
+  }
+}
+
+// MARK: - ImageView
+
+@Suite("image view shared animation", .serialized)
+@MainActor
+struct ImageViewSharedAnimationTests {
+  private func displayedView(_ image: UIImage) -> ImageView {
+    let view = ImageView(appContext: AppContext())
+    view.sourceImage = image
+    view.sdImageView.image = image
+    return view
+  }
+
+  @Test
+  func `joins the shared clock when the prop turns on`() async throws {
+    let image = makeAnimatedImage()
+    let view = displayedView(image)
+    #expect(!view.hasSharedAnimation)
+
+    view.synchronizedAnimation = true
+
+    #expect(view.hasSharedAnimation)
+    #expect(!view.sdImageView.autoPlayAnimatedImage)
+    try await waitUntil { SharedAnimationDriver.shared.isReady(image) }
+
+    view.leaveSharedAnimation()
+  }
+
+  @Test
+  func `hands the view back to its own player when the prop turns off`() {
+    let image = makeAnimatedImage()
+    let view = displayedView(image)
+    view.synchronizedAnimation = true
+    #expect(view.hasSharedAnimation)
+
+    view.synchronizedAnimation = false
+
+    #expect(!view.hasSharedAnimation)
+    #expect(view.sdImageView.autoPlayAnimatedImage)
+    #expect(!SharedAnimationDriver.shared.isReady(image))
+  }
+
+  @Test
+  func `leaves the shared clock when it is recycled`() {
+    let image = makeAnimatedImage()
+    let view = displayedView(image)
+    view.recyclingKey = "first"
+    view.synchronizedAnimation = true
+    #expect(view.hasSharedAnimation)
+
+    view.recyclingKey = "second"
+
+    #expect(!view.hasSharedAnimation)
+    #expect(view.sdImageView.image == nil)
+  }
+
+  @Test
+  func `stays on its own player for still images`() {
+    let view = displayedView(UIImage())
+    view.synchronizedAnimation = true
+    #expect(!view.hasSharedAnimation)
+  }
+
+  @Test
+  func `stays on its own player for tinted images`() {
+    let view = displayedView(makeAnimatedImage())
+    view.imageTintColor = .red
+    view.synchronizedAnimation = true
+    #expect(!view.hasSharedAnimation)
+  }
+
+  @Test
+  func `stays on its own player for images that do not loop`() throws {
+    let image = try #require(FiniteLoopAnimatedImage(data: makeGIF(frameDurations: [0.1, 0.2])))
+    let view = displayedView(image)
+    view.synchronizedAnimation = true
+    #expect(!view.hasSharedAnimation)
+  }
+
+  @Test
+  func `stops and starts on the shared clock`() async throws {
+    let image = makeAnimatedImage()
+    let view = displayedView(image)
+    view.synchronizedAnimation = true
+    try await waitUntil { SharedAnimationDriver.shared.isReady(image) }
+
+    view.stopSharedAnimation()
+    #expect(view.hasSharedAnimation)
+    #expect(!SharedAnimationDriver.shared.isReady(image))
+
+    view.startSharedAnimation()
+    try await waitUntil { SharedAnimationDriver.shared.isReady(image) }
+
+    view.leaveSharedAnimation()
+  }
+}

--- a/packages/expo-image/src/Image.types.ts
+++ b/packages/expo-image/src/Image.types.ts
@@ -282,6 +282,20 @@ export interface ImageProps extends Omit<ViewProps, 'style' | 'children'> {
   recyclingKey?: string | null;
 
   /**
+   * Keeps the playback of every animated image with the same source in sync, no matter when each one
+   * was rendered. All of them show the same frame at the same time, like animated emotes in a chat.
+   * Without it, each image starts its animation from the beginning when it appears.
+   *
+   * The frames of a synchronized image are decoded once and kept in memory as long as one of the
+   * images is visible. Very large animations, animations that don't loop forever, tinted images
+   * and SF Symbols play on their own.
+   * @default false
+   * @platform android
+   * @platform ios
+   */
+  synchronizedAnimation?: boolean;
+
+  /**
    * Determines if an image should automatically begin playing if it is an
    * animated image.
    * @default true


### PR DESCRIPTION
# Why

Rendering an animated image (webp, GIF etc.) in several expo `<Image />` components at different times plays each copy from frame 0. When copies of these images are rendered at different times (i.e. a stream chat, animated reaction in a slack chat on different messages etc.) they play at different intervals (so it makes them appear out of step). The way platforms such as Discord and Twitch handle this is by tracking the frame count so that no matter when an animated image is rendered, they can keep them synced to play at the exact frame. 

To enable this behaviour, consumers can now pass `synchronizedAnimation` to expo-image (no-op on web). Every animated image with the same source will then show the same frame, no matter when subsequent images were rendered at. 

# demo

Android:

https://github.com/user-attachments/assets/89b304fe-49e1-4560-b511-3453cbb1be65


IOS: 

https://github.com/user-attachments/assets/d99585fb-2686-4fa6-9e2e-365bcd1e8e09



 
Closes: https://expo.canny.io/feature-requests/p/expo-image-sync-all-animated-images-playback


**heads up**  We've been using a patched version of expo image containing this feature for some time now (https://github.com/luke-h1/foam/blob/main/patches/expo-image%4057.0.3.patch) and all has been well in terms of performance and stability. 


# How

**IOS** 
- `SharedAnimationDriver` - singleton which runs on every view. On each tick it maps the elapsed time on a shared clock to a frame index and then seeks each view's `SDAnimatedImageView` player to that specific frame, with the prop `autoPlayAnimatedImage` off so we don't fight `SDWebImage`'s own player

- `AnimationTimeline` - responsible for the frame schedule. It's built once per image and cached on `AnimatedImage`
- frames of an image are decoded once and held while any view renders it. This is to prevent memory leaks. 
- `AnimatedImage` now reads frames from SDWebImage's frame store instead of its own frames array
- Views leave the clock when the prop is off, on recycle or when the image source changes. 

**Android** 
* `SharedAnimationDriver` - groups drawables by image, keyed by the image sources cache key or uri. Within a given group, the drawable that has been playing for the longest is the 'leader' and any subsequent images are the 'followers'. 
* Each member listens to its decoder's render cb. After a 'follower' renders, it measures the distance to the leader's frame via `floorMod`. 

I went with this approach rather than sharing one drawable/player across views because it meant making changes to Glide / SDWebImage which I didn't feel too comfortable with. 

# Test Plan

* created a demo screen to verify the changes work 
* added unit tests for IOS and Android 

**Manual** 
* go to `apps/native-component-list`
* prop turned off  -> press staggered remount -> you should observe the gifs drifting apart
* prop turned on -> all three gifs show the same frame


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)