### PR TITLE
[JSI][iOS] Decode JS strings through getStringData instead of utf8()

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [iOS] `JavaScriptValue.undefined` and `JavaScriptValue.null` now return shared immortal instances instead of allocating a new value on each access, removing one allocation from every void-returning host call. ([#49545](https://github.com/expo/expo/pull/49545) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added an opt-in benchmark target that measures value access, host function calls, and JS function calls; run it with `pnpm benchmark`. ([#49579](https://github.com/expo/expo/pull/49579) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors by removing the per-call weak and unowned runtime reference traffic on the call path. ([#49631](https://github.com/expo/expo/pull/49631) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Made passing strings between JavaScript and Swift faster, up to ~3.8× for long strings. ([#49678](https://github.com/expo/expo/pull/49678) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Benchmarks/HostFunctionBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/HostFunctionBenchmarks.swift
@@ -86,4 +86,132 @@ extension JSIBenchmarks {
       }
     }
   }
+
+  // MARK: - Unowned-this form with string arguments
+
+  @Test
+  func `concat two strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        """
+        (function(n) { for (var i = 0; i < n; i++) benchFn('expo ', 'modules'); })
+        """
+      ).getFunction()
+      try benchmark("host function: concat two strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  /// Like `concat two strings unowned-this`, with inputs and result longer than libc++'s 22-byte
+  /// `std::string` inline capacity, so every `std::string` on the path has to allocate.
+  @Test
+  func `concat two long strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        """
+        (function(n) {
+          for (var i = 0; i < n; i++) benchFn('expo modules are quite fast, ', 'and this string is also long');
+        })
+        """
+      ).getFunction()
+      try benchmark("host function: concat two long strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  @Test
+  func `concat two 256B strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        "(function(n) { var a = 'a'.repeat(128); var b = 'b'.repeat(128); for (var i = 0; i < n; i++) benchFn(a, b); })"
+      ).getFunction()
+      try benchmark("host function: concat two 256B strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  @Test
+  func `concat two 4KB strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        """
+        (function(n) { var a = 'a'.repeat(2048); var b = 'b'.repeat(2048); for (var i = 0; i < n; i++) benchFn(a, b); })
+        """
+      ).getFunction()
+      try benchmark("host function: concat two 4KB strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  @Test
+  func `concat two 4KB non-ASCII strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        """
+        (function(n) { var a = 'ą'.repeat(2048); var b = 'ą'.repeat(2048); for (var i = 0; i < n; i++) benchFn(a, b); })
+        """
+      ).getFunction()
+      try benchmark("host function: concat two 4KB non-ASCII strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  @Test
+  func `concat two 12B non-ASCII strings unowned-this`() async throws {
+    try await benchmarkCase { runtime in
+      let fn = runtime.createFunction("concat") {
+        [runtime] (this: borrowing JavaScriptUnownedValue, arguments: consuming JavaScriptValuesBuffer) in
+        let a = try String.decode(arguments.unownedValue(at: 0), in: runtime)
+        let b = try String.decode(arguments.unownedValue(at: 1), in: runtime)
+        return try String.encode(a + b, in: runtime)
+      }
+      runtime.global().setProperty("benchFn", value: fn)
+      let driver = try runtime.eval(
+        "(function(n) { var a = 'ąęó'.repeat(2); var b = 'ąęó'.repeat(2); for (var i = 0; i < n; i++) benchFn(a, b); })"
+      ).getFunction()
+      try benchmark("host function: concat two 12B non-ASCII strings unowned-this", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
 }

--- a/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
@@ -1,0 +1,169 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Testing
+
+/// Benchmarks for the places where strings cross between the engine and Swift outside of plain
+/// `getString()`: property name enumeration, the `JavaScriptRepresentable` conformance of `String`,
+/// and `JavaScriptPropNameID`. Each one isolates a single conversion so regressions can be
+/// attributed precisely.
+extension JSIBenchmarks {
+  // MARK: - Property names
+
+  @Test
+  func `property names of an object with ASCII keys`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval(
+        "({ alpha: 1, beta: 2, gamma: 3, delta: 4, epsilon: 5, zeta: 6, eta: 7, theta: 8, iota: 9, kappa: 10 })"
+      ).getObject()
+      try benchmark("JavaScriptObject.getPropertyNames(): 10 ASCII keys", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.getPropertyNames()
+        }
+      }
+    }
+  }
+
+  @Test
+  func `property names of an object with non-ASCII keys`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval(
+        "({ 'ąlpha': 1, 'bęta': 2, 'gąmma': 3, 'dęlta': 4, 'ępsilon': 5, 'zęta': 6, 'ęta': 7, 'thęta': 8, 'iotą': 9, 'kąppa': 10 })"
+      ).getObject()
+      try benchmark("JavaScriptObject.getPropertyNames(): 10 non-ASCII keys", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.getPropertyNames()
+        }
+      }
+    }
+  }
+
+  // MARK: - String as JavaScriptRepresentable
+
+  @Test
+  func `string from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'benchmark string value'")
+      try benchmark("String.fromJavaScriptValue(): 22B ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `256B string from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'a'.repeat(256)")
+      try benchmark("String.fromJavaScriptValue(): 256B ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `non-ASCII string from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'ąęó'.repeat(4)")
+      try benchmark("String.fromJavaScriptValue(): 12 non-ASCII chars", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `string to JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let string = "benchmark string value"
+      try benchmark("String.toJavaScriptValue(in:): 22B ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = string.toJavaScriptValue(in: runtime)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `256B string to JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let string = String(repeating: "a", count: 256)
+      try benchmark("String.toJavaScriptValue(in:): 256B ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = string.toJavaScriptValue(in: runtime)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `string dictionary from JavaScriptValue`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval(
+        """
+        ({ alpha: 'one', beta: 'two', gamma: 'three', delta: 'four', epsilon: 'five',
+           zeta: 'six', eta: 'seven', theta: 'eight', iota: 'nine', kappa: 'ten' })
+        """
+      )
+      try benchmark("[String: String].fromJavaScriptValue(): 10 entries", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = [String: String].fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  // MARK: - PropNameID
+
+  @Test
+  func `PropNameID to string`() async throws {
+    try await benchmarkCase { runtime in
+      let propName = JavaScriptPropNameID(runtime, string: "propertyName")
+      try benchmark("JavaScriptPropNameID.utf8(): ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = propName.utf8()
+        }
+      }
+    }
+  }
+
+  @Test
+  func `non-ASCII PropNameID to string`() async throws {
+    try await benchmarkCase { runtime in
+      let propName = JavaScriptPropNameID(runtime, string: "właściwość")
+      try benchmark("JavaScriptPropNameID.utf8(): non-ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = propName.utf8()
+        }
+      }
+    }
+  }
+
+  @Test
+  func `PropNameID to string via utf16`() async throws {
+    try await benchmarkCase { runtime in
+      let propName = JavaScriptPropNameID(runtime, string: "propertyName")
+      try benchmark("JavaScriptPropNameID.utf16(): ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = propName.utf16()
+        }
+      }
+    }
+  }
+
+  @Test
+  func `PropNameID from string`() async throws {
+    try await benchmarkCase { runtime in
+      let string = "propertyName"
+      try benchmark("JavaScriptPropNameID(runtime, string:): ASCII", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = JavaScriptPropNameID(runtime, string: string)
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -84,11 +84,25 @@ extension CGFloat: JSIRepresentableNumber {}
 
 extension String: JSIRepresentable {
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> String {
-    return String(value.getString(runtime).utf8(runtime))
+    return String(jsiString: value.getString(runtime), in: runtime)
   }
 
   func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
-    return facebook.jsi.Value(runtime, facebook.jsi.String.createFromUtf8(runtime, std.string(self)))
+    // Hand JSI the Swift string's own UTF-8 storage instead of going through `std::string`: the engine
+    // copies the bytes into its heap right away, so the intermediate `std::string` was one extra
+    // allocation, copy and free per string. `withUTF8` is mutating (it makes a bridged string
+    // contiguous first), hence the local copy; native strings are already contiguous and pay nothing.
+    // The value is moved out through a local because `withUTF8` needs a `Copyable` closure result.
+    var string = self
+    var value = facebook.jsi.Value.undefined()
+    string.withUTF8 { utf8 in
+      guard let base = utf8.baseAddress else {
+        value = facebook.jsi.Value(runtime, facebook.jsi.String.createFromAscii(runtime, "", 0))
+        return
+      }
+      value = facebook.jsi.Value(runtime, facebook.jsi.String.createFromUtf8(runtime, base, utf8.count))
+    }
+    return value
   }
 }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
@@ -15,27 +15,40 @@ public final class JavaScriptPropNameID: JavaScriptType {
   /// Creates a PropNameID from the string.
   public init(_ runtime: JavaScriptRuntime, string: String) {
     self.runtime = runtime
-    // Use the `std::string` overload rather than the `(pointer, length)` one: the latter needs a
-    // UTF-8 *byte* count, but `String.count` is the grapheme-cluster count, which truncates any
-    // non-ASCII key (e.g. `"café"` reports 4 for 5 UTF-8 bytes). `std.string` carries the full
-    // UTF-8 bytes and their exact length.
-    self.pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, std.string(string))
+    // Hand JSI the string's own UTF-8 storage, skipping the `std::string` copy. The `(pointer, length)`
+    // overload needs the UTF-8 *byte* count, which `withUTF8` provides exactly; `String.count` would
+    // be wrong here because it counts grapheme clusters (e.g. `"café"` reports 4 for 5 UTF-8 bytes).
+    // `withUTF8` is mutating (it makes a bridged string contiguous first), hence the local copy, and
+    // the result leaves the closure through an optional because it has to be a `Copyable` type.
+    var string = string
+    var pointee: facebook.jsi.PropNameID? = nil
+    string.withUTF8 { utf8 in
+      guard let base = utf8.baseAddress else {
+        pointee = facebook.jsi.PropNameID.forAscii(runtime.pointee, "", 0)
+        return
+      }
+      pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, base, utf8.count)
+    }
+    self.pointee = pointee.take()!
   }
 
-  /// Copies the data in a PropNameID as UTF8 into a string.
+  /// Copies the contents of the PropNameID into a string.
   public func utf8() -> String {
     guard let runtime else {
       FatalError.runtimeLost()
     }
+    // Property names are almost always short ASCII identifiers, and the engine's own `utf8()` is the
+    // fastest way to read those: the `std::string` stays inline and so does the resulting Swift
+    // string. Reading the internal representation through `getPropNameIdData`, as `String(jsiString:in:)`
+    // does for regular strings, measured about 40% slower for this case.
     return String(pointee.utf8(runtime.pointee))
   }
 
-  /// Copies the data in a PropNameID as UTF16 into a string.
+  /// Copies the contents of the PropNameID into a string. Same result as ``utf8()``.
   public func utf16() -> String {
-    guard let runtime else {
-      FatalError.runtimeLost()
-    }
-    return String(pointee.utf16(runtime.pointee))
+    // The engine's `utf16()` builds a `std::u16string` that Swift then has to transcode, which is
+    // several times slower than going through UTF-8 for the same result.
+    return utf8()
   }
 
   // MARK: - JavaScriptType

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
@@ -231,8 +231,7 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     guard radix >= 2 && radix <= 36 else {
       throw BigIntConversionError.invalidRadix(radix)
     }
-    let jsiString = pointee.toString(runtime.pointee, Int32(radix))
-    return String(jsiString.utf16(runtime.pointee))
+    return String(jsiString: pointee.toString(runtime.pointee, Int32(radix)), in: runtime.pointee)
   }
 
   // MARK: - JavaScriptType

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -163,7 +163,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     let count = propertyNames.size(jsiRuntime)
 
     return (0..<count).map { i in
-      return String(propertyNames.getValueAtIndex(jsiRuntime, i).getString(jsiRuntime).utf8(jsiRuntime))
+      return String(jsiString: propertyNames.getValueAtIndex(jsiRuntime, i).getString(jsiRuntime), in: jsiRuntime)
     }
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -109,7 +109,7 @@ public struct JavaScriptUnownedValue: ~Copyable {
   /// Returns the value as a string, or asserts if not a string.
   public func getString() -> String {
     assert(isString(), "Value is not a string")
-    return String(pointer.pointee.getString(runtime).utf8(runtime))
+    return String(jsiString: pointer.pointee.getString(runtime), in: runtime)
   }
 
   /// Returns the value as a ``JavaScriptObject`` *without* materializing an owning ``JavaScriptValue``

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -31,21 +31,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
   /// Creates a string JS value.
   public init(_ runtime: JavaScriptRuntime, _ string: String) {
     self.runtime = runtime
-    // Hand JSI the Swift string's own UTF-8 storage instead of going through `std::string`: the engine
-    // copies the bytes into its heap right away, so the intermediate `std::string` was one extra
-    // allocation, copy and free per string. `withUTF8` is mutating (it makes a bridged string
-    // contiguous first), hence the local copy; native strings are already contiguous and pay nothing.
-    // The value is moved out through a local because `withUTF8` needs a `Copyable` closure result.
-    var string = string
-    var value = facebook.jsi.Value.undefined()
-    string.withUTF8 { utf8 in
-      guard let base = utf8.baseAddress else {
-        value = facebook.jsi.Value(runtime.pointee, facebook.jsi.String.createFromAscii(runtime.pointee, "", 0))
-        return
-      }
-      value = facebook.jsi.Value(runtime.pointee, facebook.jsi.String.createFromUtf8(runtime.pointee, base, utf8.count))
-    }
-    self.pointee = value
+    self.pointee = string.toJSIValue(in: runtime.pointee)
   }
 
   /// Creates a BigInt JS value from an Int64.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -31,10 +31,21 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
   /// Creates a string JS value.
   public init(_ runtime: JavaScriptRuntime, _ string: String) {
     self.runtime = runtime
-    self.pointee = facebook.jsi.Value(
-      runtime.pointee,
-      facebook.jsi.String.createFromUtf8(runtime.pointee, std.string(string))
-    )
+    // Hand JSI the Swift string's own UTF-8 storage instead of going through `std::string`: the engine
+    // copies the bytes into its heap right away, so the intermediate `std::string` was one extra
+    // allocation, copy and free per string. `withUTF8` is mutating (it makes a bridged string
+    // contiguous first), hence the local copy; native strings are already contiguous and pay nothing.
+    // The value is moved out through a local because `withUTF8` needs a `Copyable` closure result.
+    var string = string
+    var value = facebook.jsi.Value.undefined()
+    string.withUTF8 { utf8 in
+      guard let base = utf8.baseAddress else {
+        value = facebook.jsi.Value(runtime.pointee, facebook.jsi.String.createFromAscii(runtime.pointee, "", 0))
+        return
+      }
+      value = facebook.jsi.Value(runtime.pointee, facebook.jsi.String.createFromUtf8(runtime.pointee, base, utf8.count))
+    }
+    self.pointee = value
   }
 
   /// Creates a BigInt JS value from an Int64.
@@ -253,7 +264,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
       FatalError.runtimeLost()
     }
     assert(isString(), "Value is not a string")
-    return String(pointee.getString(jsiRuntime).utf8(jsiRuntime))
+    return String(jsiString: pointee.getString(jsiRuntime), in: jsiRuntime)
   }
 
   /// Returns the value as a BigInt, or asserts if not a BigInt.
@@ -420,7 +431,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
     }
-    return String(pointee.toString(jsiRuntime).utf8(jsiRuntime))
+    return String(jsiString: pointee.toString(jsiRuntime), in: jsiRuntime)
   }
 
   /// Converts the JavaScript value to a JSON string representation.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
@@ -17,45 +17,49 @@ extension String {
   internal init(jsiString: borrowing facebook.jsi.String, in runtime: facebook.jsi.IRuntime) {
     var result = ""
     withUnsafeMutablePointer(to: &result) { resultPtr in
-      runtime.getStringData(jsiString, UnsafeMutableRawPointer(resultPtr)) { ctx, ascii, data, count in
-        guard count > 0, let data else {
-          // An empty chunk adds nothing to the result. Guarding here also keeps the pointer
-          // arithmetic below free of optionals on both paths.
-          return
-        }
-        let out = ctx!.assumingMemoryBound(to: String.self)
-        let chunk: String
-        if ascii {
-          let bytes = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt8.self), count: Int(count))
-          chunk = String(unsafeUninitializedCapacity: Int(count)) { buffer in
-            return buffer.initialize(fromContentsOf: bytes)
-          }
-        } else {
-          let units = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt16.self), count: Int(count))
-          if count < 512 {
-            // Short strings: transcode straight into the string's UTF-8 storage. `String(decoding:as:)`
-            // carries a fixed setup cost of a few hundred nanoseconds that dominates below this size.
-            // Worst case is 3 UTF-8 bytes per UTF-16 code unit (a surrogate pair is 4 bytes for 2 units).
-            chunk = String(unsafeUninitializedCapacity: Int(count) * 3) { buffer in
-              var written = 0
-              _ = transcode(units.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: false) { byte in
-                buffer[written] = byte
-                written += 1
-              }
-              return written
-            }
-          } else {
-            // Long strings: the standard library's bulk decoder is faster per code unit.
-            chunk = String(decoding: units, as: UTF16.self)
-          }
-        }
-        if out.pointee.isEmpty {
-          out.pointee = chunk
-        } else {
-          out.pointee += chunk
-        }
-      }
+      runtime.getStringData(jsiString, UnsafeMutableRawPointer(resultPtr), appendEngineStringChunk)
     }
     self = result
+  }
+}
+
+/// Callback for `getStringData`. `ctx` points at the Swift `String` being built; each call appends
+/// one chunk of the engine's internal representation to it.
+private func appendEngineStringChunk(ctx: UnsafeMutableRawPointer?, ascii: Bool, data: UnsafeRawPointer?, count: Int) {
+  guard count > 0, let data else {
+    // An empty chunk adds nothing to the result. Guarding here also keeps the pointer
+    // arithmetic below free of optionals on both paths.
+    return
+  }
+  let out = ctx!.assumingMemoryBound(to: String.self)
+  let chunk: String
+  if ascii {
+    let bytes = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt8.self), count: count)
+    chunk = String(unsafeUninitializedCapacity: count) { buffer in
+      return buffer.initialize(fromContentsOf: bytes)
+    }
+  } else {
+    let units = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt16.self), count: count)
+    if count < 512 {
+      // Short strings: transcode straight into the string's UTF-8 storage. `String(decoding:as:)`
+      // carries a fixed setup cost of a few hundred nanoseconds that dominates below this size.
+      // Worst case is 3 UTF-8 bytes per UTF-16 code unit (a surrogate pair is 4 bytes for 2 units).
+      chunk = String(unsafeUninitializedCapacity: count * 3) { buffer in
+        var written = 0
+        _ = transcode(units.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: false) { byte in
+          buffer[written] = byte
+          written += 1
+        }
+        return written
+      }
+    } else {
+      // Long strings: the standard library's bulk decoder is faster per code unit.
+      chunk = String(decoding: units, as: UTF16.self)
+    }
+  }
+  if out.pointee.isEmpty {
+    out.pointee = chunk
+  } else {
+    out.pointee += chunk
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
@@ -1,0 +1,61 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+internal import ExpoModulesJSI_Cxx
+import Foundation
+internal import jsi
+
+extension String {
+  /// Builds a Swift `String` from a `jsi::String` by reading the engine's internal representation
+  /// through `getStringData`, without materializing a `std::string` first.
+  ///
+  /// Hermes stores strings as either ASCII bytes or UTF-16 code units and hands over whichever it
+  /// has, chunk by chunk (only rope strings arrive in several chunks). ASCII bytes are valid UTF-8 and
+  /// are copied as-is with no validation. UTF-16 is transcoded to UTF-8 on the Swift side, which is
+  /// several times cheaper than letting the engine produce UTF-8 through `utf8()` and validating it
+  /// again in Swift. Measured against `utf8()`: 12-byte ASCII unchanged, 4 KB ASCII 3.7x faster,
+  /// 4 KB non-ASCII 2.4x faster, 12-byte non-ASCII unchanged.
+  internal init(jsiString: borrowing facebook.jsi.String, in runtime: facebook.jsi.IRuntime) {
+    var result = ""
+    withUnsafeMutablePointer(to: &result) { resultPtr in
+      runtime.getStringData(jsiString, UnsafeMutableRawPointer(resultPtr)) { ctx, ascii, data, count in
+        guard count > 0, let data else {
+          // An empty chunk adds nothing to the result. Guarding here also keeps the pointer
+          // arithmetic below free of optionals on both paths.
+          return
+        }
+        let out = ctx!.assumingMemoryBound(to: String.self)
+        let chunk: String
+        if ascii {
+          let bytes = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt8.self), count: Int(count))
+          chunk = String(unsafeUninitializedCapacity: Int(count)) { buffer in
+            return buffer.initialize(fromContentsOf: bytes)
+          }
+        } else {
+          let units = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt16.self), count: Int(count))
+          if count < 512 {
+            // Short strings: transcode straight into the string's UTF-8 storage. `String(decoding:as:)`
+            // carries a fixed setup cost of a few hundred nanoseconds that dominates below this size.
+            // Worst case is 3 UTF-8 bytes per UTF-16 code unit (a surrogate pair is 4 bytes for 2 units).
+            chunk = String(unsafeUninitializedCapacity: Int(count) * 3) { buffer in
+              var written = 0
+              _ = transcode(units.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: false) { byte in
+                buffer[written] = byte
+                written += 1
+              }
+              return written
+            }
+          } else {
+            // Long strings: the standard library's bulk decoder is faster per code unit.
+            chunk = String(decoding: units, as: UTF16.self)
+          }
+        }
+        if out.pointee.isEmpty {
+          out.pointee = chunk
+        } else {
+          out.pointee += chunk
+        }
+      }
+    }
+    self = result
+  }
+}

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -32,6 +32,12 @@ struct JavaScriptObjectTests {
     #expect(object.getProperty("score").getInt() == 100)
   }
 
+  @Test
+  func `get property names preserves non-ASCII and empty keys`() throws {
+    let object = try runtime.eval("({ 'café': 1, '日本語': 2, '🎉': 3, '': 4 })").getObject()
+    #expect(object.getPropertyNames() == ["café", "日本語", "🎉", ""])
+  }
+
   // MARK: - Property Access Tests
 
   @Suite("Property Access")
@@ -197,6 +203,20 @@ struct JavaScriptObjectTests {
       let object = JavaScriptObject(runtime)
       object.setProperty("pi", value: 3.14159)
       #expect(object.getProperty("pi").getDouble() == 3.14159)
+    }
+
+    @Test
+    func `set property with non-ASCII string`() {
+      let object = JavaScriptObject(runtime)
+      object.setProperty("greeting", value: "żółć 世界 🎉")
+      #expect(object.getProperty("greeting").getString() == "żółć 世界 🎉")
+    }
+
+    @Test
+    func `set property with empty string`() {
+      let object = JavaScriptObject(runtime)
+      object.setProperty("empty", value: "")
+      #expect(object.getProperty("empty").getString() == "")
     }
 
     @Test

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPropNameIDTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPropNameIDTests.swift
@@ -37,6 +37,21 @@ struct JavaScriptPropNameIDTests {
     #expect(propName.utf16() == key)
   }
 
+  @Test
+  func `round-trips an empty string`() {
+    let propName = JavaScriptPropNameID(runtime, string: "")
+    #expect(propName.utf8() == "")
+    #expect(propName.utf16() == "")
+  }
+
+  @Test
+  func `round-trips a long non-ASCII string`() {
+    let key = String(repeating: "ą", count: 2000)
+    let propName = JavaScriptPropNameID(runtime, string: key)
+    #expect(propName.utf8() == key)
+    #expect(propName.utf16() == key)
+  }
+
   // MARK: - Caching
 
   @Test
@@ -72,6 +87,20 @@ struct JavaScriptPropNameIDTests {
     // A different non-ASCII key must not collide with `café` via truncated bytes.
     #expect(object.getProperty(JavaScriptPropNameID(runtime, string: "caff")).isUndefined() == true)
     #expect(object.getProperty(JavaScriptPropNameID(runtime, string: "naïve")).isUndefined() == true)
+  }
+
+  @Test
+  func `property type errors report the non-ASCII property name`() throws {
+    let object = try runtime.eval("({ 'café': 42 })").getObject()
+    let propName = JavaScriptPropNameID(runtime, string: "café")
+    let notObject = #expect(throws: JavaScriptObject.PropertyNotObjectError.self) {
+      try object.getPropertyAsObject(propName)
+    }
+    #expect(notObject?.description == "Property 'café' is not an object")
+    let notFunction = #expect(throws: JavaScriptObject.PropertyNotFunctionError.self) {
+      try object.getPropertyAsFunction(propName)
+    }
+    #expect(notFunction?.description == "Property 'café' is not a function")
   }
 
   // Second `forUtf8(pointer, length)` call site: the array's string-keyed subscript getter.

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptUnownedValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptUnownedValueTests.swift
@@ -27,6 +27,15 @@ struct JavaScriptUnownedValueTests {
   }
 
   @Test
+  func `getString preserves non-ASCII, empty and long strings`() {
+    let long = String(repeating: "ą", count: 2000)
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: "żółć 世界 🎉", "", long)
+    #expect(buffer.unownedValue(at: 0).getString() == "żółć 世界 🎉")
+    #expect(buffer.unownedValue(at: 1).getString() == "")
+    #expect(buffer.unownedValue(at: 2).getString() == long)
+  }
+
+  @Test
   func `recognizes null and undefined`() {
     let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: JavaScriptValue.null, JavaScriptValue.undefined)
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
@@ -1,4 +1,5 @@
 import ExpoModulesJSI
+import Foundation
 import Testing
 
 @Suite
@@ -154,6 +155,70 @@ struct JavaScriptValueTests {
     let value = try runtime.eval("'\\uD800'")
     let result = value.getString()
     #expect(result == "\u{FFFD}")
+  }
+
+  @Test
+  func `getString handles long non-ASCII string`() throws {
+    let value = try runtime.eval("'ą'.repeat(2000)")
+    #expect(value.getString() == String(repeating: "ą", count: 2000))
+  }
+
+  @Test
+  func `getString handles string built by concatenation`() throws {
+    let value = try runtime.eval(
+      "(() => { let s = ''; for (let i = 0; i < 300; i++) s += i % 2 ? 'abc' : 'żółć🎉'; return s; })()"
+    )
+    let expected = (0..<300).map { $0 % 2 == 1 ? "abc" : "żółć🎉" }.joined()
+    #expect(value.getString() == expected)
+  }
+
+  @Test
+  func `String(runtime, ...) round-trips an empty string`() {
+    let value = JavaScriptValue(runtime, "")
+    #expect(value.isString() == true)
+    #expect(value.getString() == "")
+  }
+
+  @Test
+  func `String(runtime, ...) round-trips a bridged string`() {
+    let bridged = NSString(string: "café 世界 🎉") as String
+    let value = JavaScriptValue(runtime, bridged)
+    #expect(value.getString() == "café 世界 🎉")
+  }
+
+  @Test
+  func `String(runtime, ...) round-trips a long non-ASCII string`() {
+    let long = String(repeating: "ż", count: 5_000)
+    let value = JavaScriptValue(runtime, long)
+    #expect(value.getString() == long)
+  }
+
+  // MARK: - String as JavaScriptRepresentable
+
+  @Test
+  func `String.fromJavaScriptValue preserves non-ASCII`() throws {
+    let value = try runtime.eval("'żółć 世界 🎉'")
+    #expect(String.fromJavaScriptValue(value) == "żółć 世界 🎉")
+  }
+
+  @Test
+  func `String.toJavaScriptValue preserves non-ASCII`() {
+    let value = "żółć 世界 🎉".toJavaScriptValue(in: runtime)
+    #expect(value.getString() == "żółć 世界 🎉")
+  }
+
+  @Test
+  func `dictionary with ASCII keys and non-ASCII values round-trips through JavaScriptRepresentable`() throws {
+    let value = try runtime.eval("({ a: 'żółć', b: '🎉' })")
+    let dictionary = [String: String].fromJavaScriptValue(value)
+    #expect(dictionary == ["a": "żółć", "b": "🎉"])
+  }
+
+  @Test
+  func `dictionary with an empty key round-trips through JavaScriptRepresentable`() throws {
+    let value = try runtime.eval("({ '': 'empty' })")
+    let dictionary = [String: String].fromJavaScriptValue(value)
+    #expect(dictionary == ["": "empty"])
   }
 
   // MARK: - Type Checking Tests


### PR DESCRIPTION
# Why

Reading a JS string in Swift went through `utf8()`, which makes Hermes transcode into a `std::string` that Swift then validates and copies again. For string-heavy host functions that round trip is most of the call.

# How

`String(jsiString:in:)` reads the engine's internal representation through `getStringData` instead. ASCII bytes are already valid UTF-8 and get copied as-is. UTF-16 is transcoded on the Swift side, which is several times cheaper than letting the engine produce UTF-8 and validating it again. The threshold and capacity choices are explained in the doc comments.

On the encode side, `String.toJSIValue(in:)` hands the Swift string's UTF-8 storage straight to `createFromUtf8`, skipping the intermediate `std::string`, and `JavaScriptValue.init` reuses it.

The same two paths now back every place a string crosses over: `getPropertyNames()`, the `JavaScriptRepresentable` conformance of `String` (so dictionaries, arrays and `setProperty` with string values), and the `JavaScriptPropNameID` constructor, which passes its UTF-8 bytes to `forUtf8` directly. `JavaScriptPropNameID.utf8()` deliberately stays on the engine's `utf8()`: property names are short ASCII identifiers, and for those the inline `std::string` beat `getPropNameIdData` by about 40% when I measured it. `utf16()` now shares that path instead of transcoding a `std::u16string`.

# Test Plan

Existing string tests pass with `pnpm test:integration`, plus new ones covering non-ASCII, empty, long, concatenated and bridged strings on each of these paths. This also adds benchmarks. Numbers below are median ns/op from `pnpm benchmark` (Mac Catalyst, Release), before and after this change.

Host function that decodes two strings and encodes the concatenation:

| Inputs | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 12 B ASCII | 183 | 168 | 1.09x |
| 28 B ASCII | 284 | 249 | 1.14x |
| 256 B ASCII | 1147 | 543 | 2.1x |
| 4 KB ASCII | 16984 | 4516 | 3.8x |
| 12 B non-ASCII | 333 | 311 | 1.07x |
| 4 KB non-ASCII | 36884 | 15357 | 2.4x |

Single conversions:

| Conversion | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `getPropertyNames()`, 10 ASCII keys | 572 | 517 | 1.11x |
| `getPropertyNames()`, 10 non-ASCII keys | 717 | 689 | 1.04x |
| `String.fromJavaScriptValue`, 22 B ASCII | 40 | 38 | 1.05x |
| `String.fromJavaScriptValue`, 256 B ASCII | 920 | 315 | 2.9x |
| `String.fromJavaScriptValue`, 12 non-ASCII chars | 136 | 65 | 2.1x |
| `String.toJavaScriptValue`, 22 B ASCII | 60 | 48 | 1.25x |
| `String.toJavaScriptValue`, 256 B ASCII | 80 | 67 | 1.2x |
| `[String: String].fromJavaScriptValue`, 10 entries | 3799 | 3638 | 1.04x |
| `JavaScriptPropNameID(runtime, string:)`, ASCII | 91 | 72 | 1.26x |
| `JavaScriptPropNameID.utf16()`, ASCII | 140 | 20 | 7x |
