### PR TITLE
[JSI][iOS] Fix non-ASCII property names in String-keyed APIs

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] `JavaScriptPromise` no longer traps when a resolve or reject call throws, which can realistically only happen against a runtime that is being torn down: a failed resolver call rejects the promise instead and a failed rejecter call is dropped. ([#47862](https://github.com/expo/expo/pull/47862) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed the xcframework prebuild failing under Xcode 27 due to new foreign reference ownership warnings emitted for `RuntimeScheduler` constructors. ([#49120](https://github.com/expo/expo/pull/49120) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed the prebuilt `ExpoModulesJSI.xcframework` shipping with code coverage instrumentation: building through the auto-generated SwiftPM scheme made Xcode pass `-profile-generate -profile-coverage-mapping` to swiftc even for a plain Release `build`, adding a counter increment to every function on the host function call path and about 40% to the binary size. The benchmark target had the same instrumentation and now runs without it. ([#49637](https://github.com/expo/expo/pull/49637) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed property names with non-ASCII characters being mangled when accessed by name from Swift, such as `getProperty`, `setProperty`, `hasProperty`, the array string subscript and dictionary conversions. ([#49679](https://github.com/expo/expo/pull/49679) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
@@ -38,6 +38,44 @@ extension JSIBenchmarks {
     }
   }
 
+  // MARK: - Property access by name
+
+  @Test
+  func `object property by non-ASCII name`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval("({ 'odpowiedź': 42 })").getObject()
+      try benchmark("JavaScriptObject.getProperty(_:): non-ASCII name", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.getProperty("odpowiedź")
+        }
+      }
+    }
+  }
+
+  @Test
+  func `has object property by name`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval("({ answer: 42 })").getObject()
+      try benchmark("JavaScriptObject.hasProperty(_:)", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.hasProperty("answer")
+        }
+      }
+    }
+  }
+
+  @Test
+  func `set object property by name`() async throws {
+    try await benchmarkCase { runtime in
+      let object = JavaScriptObject(runtime)
+      try benchmark("JavaScriptObject.setProperty(_:value:): double", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          object.setProperty("answer", value: 42.0)
+        }
+      }
+    }
+  }
+
   // MARK: - String as JavaScriptRepresentable
 
   @Test

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -39,11 +39,13 @@ inline jsi::Value valueFromFunction(jsi::IRuntime &runtime, const jsi::Function 
 }
 
 // `jsi::Object::setProperty` is a template function that Swift does not support. We need to provide specialized versions.
-inline void setProperty(jsi::IRuntime &runtime, const jsi::Object &object, const char *name, const jsi::Value value) {
+// They take a `jsi::PropNameID` rather than a `const char *`: JSI treats a `const char *` name as ASCII,
+// which mangles non-ASCII property names coming from Swift strings.
+inline void setProperty(jsi::IRuntime &runtime, const jsi::Object &object, const jsi::PropNameID &name, const jsi::Value &value) {
   object.setProperty(runtime, name, value);
 }
 
-inline void setProperty(jsi::IRuntime &runtime, const jsi::Array &array, const char *name, const jsi::Value &value) {
+inline void setProperty(jsi::IRuntime &runtime, const jsi::Array &array, const jsi::PropNameID &name, const jsi::Value &value) {
   array.setProperty(runtime, name, value);
 }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -151,16 +151,10 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     var result: Self = [:]
 
     for index in 0..<size {
-      let jsiKey = propertyNames.getValueAtIndex(runtime, index)
-      let key = String.fromJSIValue(jsiKey, in: runtime)
-      #if os(macOS)
-      // TODO: remove when bumping to react-native-macos 0.85
-      let jsiValue = expo.getProperty(runtime, object, key)
-      #else
+      // Look the value up by the key string the engine handed back, so any name round-trips exactly.
+      let jsiKey = propertyNames.getValueAtIndex(runtime, index).getString(runtime)
       let jsiValue = object.getProperty(runtime, jsiKey)
-      #endif
-
-      result[key] = Value.fromJSIValue(jsiValue, in: runtime)
+      result[String(jsiString: jsiKey, in: runtime)] = Value.fromJSIValue(jsiValue, in: runtime)
     }
     return result
   }
@@ -169,8 +163,7 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     let object = facebook.jsi.Object(runtime)
 
     for (key, value) in self {
-      let keyString = String(describing: key)
-      expo.setProperty(runtime, object, keyString, value.toJSIValue(in: runtime))
+      expo.setProperty(runtime, object, key.toJSIPropNameID(in: runtime), value.toJSIValue(in: runtime))
     }
     return facebook.jsi.Value(runtime, object)
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
@@ -39,11 +39,23 @@ extension Array: JavaScriptRepresentable where Element: JavaScriptRepresentable 
 
 extension Dictionary: JavaScriptRepresentable where Key == String, Value: JavaScriptRepresentable {
   public static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
-    let object = value.getObject()
+    guard let runtime = value.runtime else {
+      FatalError.runtimeLost()
+    }
+    let jsiRuntime = runtime.pointee
+    let object = value.pointee.getObject(jsiRuntime)
+    let propertyNames = object.getPropertyNames(jsiRuntime)
+    let size = propertyNames.size(jsiRuntime)
     var result: Self = [:]
 
-    for key in object.getPropertyNames() {
-      result[key] = Value.fromJavaScriptValue(object.getProperty(key))
+    result.reserveCapacity(size)
+
+    for index in 0..<size {
+      // Look the value up by the key string the engine handed back instead of re-encoding the Swift
+      // key: it skips one engine string allocation per entry and round-trips any name exactly.
+      let jsiKey = propertyNames.getValueAtIndex(jsiRuntime, index).getString(jsiRuntime)
+      let jsiValue = JavaScriptValue(runtime, object.getProperty(jsiRuntime, jsiKey))
+      result[String(jsiString: jsiKey, in: jsiRuntime)] = Value.fromJavaScriptValue(jsiValue)
     }
     return result
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
@@ -15,21 +15,7 @@ public final class JavaScriptPropNameID: JavaScriptType {
   /// Creates a PropNameID from the string.
   public init(_ runtime: JavaScriptRuntime, string: String) {
     self.runtime = runtime
-    // Hand JSI the string's own UTF-8 storage, skipping the `std::string` copy. The `(pointer, length)`
-    // overload needs the UTF-8 *byte* count, which `withUTF8` provides exactly; `String.count` would
-    // be wrong here because it counts grapheme clusters (e.g. `"café"` reports 4 for 5 UTF-8 bytes).
-    // `withUTF8` is mutating (it makes a bridged string contiguous first), hence the local copy, and
-    // the result leaves the closure through an optional because it has to be a `Copyable` type.
-    var string = string
-    var pointee: facebook.jsi.PropNameID? = nil
-    string.withUTF8 { utf8 in
-      guard let base = utf8.baseAddress else {
-        pointee = facebook.jsi.PropNameID.forAscii(runtime.pointee, "", 0)
-        return
-      }
-      pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, base, utf8.count)
-    }
-    self.pointee = pointee.take()!
+    self.pointee = string.toJSIPropNameID(in: runtime.pointee)
   }
 
   /// Copies the contents of the PropNameID into a string.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -404,9 +404,7 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
       guard let runtime else {
         FatalError.runtimeLost()
       }
-      // `std.string` carries the exact UTF-8 byte length; the `(pointer, length)` overload with
-      // `key.count` would pass the grapheme-cluster count and truncate non-ASCII keys.
-      let jsiValue = expo.getProperty(runtime.pointee, pointee, .forUtf8(runtime.pointee, std.string(key)))
+      let jsiValue = expo.getProperty(runtime.pointee, pointee, key.toJSIPropNameID(in: runtime.pointee))
       return JavaScriptValue(runtime, jsiValue)
     }
     nonmutating set(newValue) {
@@ -414,7 +412,7 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
         FatalError.runtimeLost()
       }
       let jsiValue = newValue.toJSIValue(in: runtime.pointee)
-      expo.setProperty(runtime.pointee, pointee, key, jsiValue)
+      expo.setProperty(runtime.pointee, pointee, key.toJSIPropNameID(in: runtime.pointee), jsiValue)
     }
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -105,7 +105,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    return pointee.hasProperty(runtime.pointee, name)
+    return pointee.hasProperty(runtime.pointee, name.toJSIPropNameID(in: runtime.pointee))
   }
 
   /// Returns the property of the object with the given name,
@@ -114,7 +114,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    return JavaScriptValue(runtime, pointee.getProperty(runtime.pointee, name))
+    return JavaScriptValue(runtime, pointee.getProperty(runtime.pointee, name.toJSIPropNameID(in: runtime.pointee)))
   }
 
   /// Returns the property of the object with the given prop name id,
@@ -230,7 +230,12 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
       FatalError.runtimeLost()
     }
     // This specialization is to avoid copying the value; `asValue()` on `JavaScriptValue` needs to do a copy.
-    expo.setProperty(runtime.pointee, pointee, name, value.toJSIValue(in: runtime.pointee))
+    expo.setProperty(
+      runtime.pointee,
+      pointee,
+      name.toJSIPropNameID(in: runtime.pointee),
+      value.toJSIValue(in: runtime.pointee)
+    )
   }
 
   public func setProperty<T: JavaScriptRepresentable & ~Copyable>(_ name: String, value: consuming T) {
@@ -238,7 +243,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
       FatalError.runtimeLost()
     }
     let jsiValue = value.toJavaScriptValue(in: runtime).toJSIValue(in: runtime.pointee)
-    expo.setProperty(runtime.pointee, pointee, name, jsiValue)
+    expo.setProperty(runtime.pointee, pointee, name.toJSIPropNameID(in: runtime.pointee), jsiValue)
   }
 
   internal func setProperty<T: JavaScriptRepresentable>(_ name: String, value: consuming T) where T: JSIRepresentable {
@@ -246,14 +251,19 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
       FatalError.runtimeLost()
     }
     let jsiValue = value.toJSIValue(in: runtime.pointee)
-    expo.setProperty(runtime.pointee, pointee, name, jsiValue)
+    expo.setProperty(runtime.pointee, pointee, name.toJSIPropNameID(in: runtime.pointee), jsiValue)
   }
 
   public func setProperty(_ name: String, _ object: consuming JavaScriptObject) {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    expo.setProperty(runtime.pointee, pointee, name, facebook.jsi.Value(runtime.pointee, object.pointee))
+    expo.setProperty(
+      runtime.pointee,
+      pointee,
+      name.toJSIPropNameID(in: runtime.pointee),
+      facebook.jsi.Value(runtime.pointee, object.pointee)
+    )
   }
 
   /// Sets a property to a synchronous host function created from the given closure. The function
@@ -307,7 +317,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    pointee.deleteProperty(runtime.pointee, name)
+    pointee.deleteProperty(runtime.pointee, name.toJSIPropNameID(in: runtime.pointee))
   }
   #endif
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
@@ -21,6 +21,27 @@ extension String {
     }
     self = result
   }
+
+  /// Builds a `jsi::PropNameID` from the string's UTF-8 bytes. This is how every String-keyed
+  /// property API turns its name into a key: JSI's `const char*` overloads treat the bytes as ASCII
+  /// and would mangle any non-ASCII name.
+  internal func toJSIPropNameID(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.PropNameID {
+    // The `(pointer, length)` overload needs the UTF-8 *byte* count, which `withUTF8` provides
+    // exactly; `String.count` would be wrong here because it counts grapheme clusters (e.g. `"café"`
+    // reports 4 for 5 UTF-8 bytes). `withUTF8` is mutating (it makes a bridged string contiguous
+    // first), hence the local copy, and the result leaves the closure through an optional because
+    // it has to be a `Copyable` type.
+    var string = self
+    var propNameID: facebook.jsi.PropNameID? = nil
+    string.withUTF8 { utf8 in
+      guard let base = utf8.baseAddress else {
+        propNameID = facebook.jsi.PropNameID.forAscii(runtime, "", 0)
+        return
+      }
+      propNameID = facebook.jsi.PropNameID.forUtf8(runtime, base, utf8.count)
+    }
+    return propNameID.take()!
+  }
 }
 
 /// Callback for `getStringData`. `ctx` points at the Swift `String` being built; each call appends

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -38,6 +38,65 @@ struct JavaScriptObjectTests {
     #expect(object.getPropertyNames() == ["café", "日本語", "🎉", ""])
   }
 
+  // MARK: - Non-ASCII property names
+
+  @Test
+  func `getProperty finds non-ASCII and empty names`() throws {
+    let object = try runtime.eval("({ 'café': 42, '日本語': 'ok', '🎉': true, '': 'empty' })").getObject()
+    #expect(object.getProperty("café").isNumber() == true)
+    #expect(object.getProperty("日本語").isString() == true)
+    #expect(object.getProperty("🎉").isBool() == true)
+    #expect(object.getProperty("").isString() == true)
+    #expect(object.getProperty("cafe").isUndefined() == true)
+  }
+
+  @Test
+  func `hasProperty finds non-ASCII and empty names`() throws {
+    let object = try runtime.eval("({ 'café': 42, '': 'empty' })").getObject()
+    #expect(object.hasProperty("café") == true)
+    #expect(object.hasProperty("") == true)
+    #expect(object.hasProperty("cafe") == false)
+    #expect(object.hasProperty("naïve") == false)
+  }
+
+  @Test
+  func `setProperty with a non-ASCII name is visible to JavaScript`() throws {
+    let object = JavaScriptObject(runtime)
+    object.setProperty("café", value: 42.0)
+    object.setProperty("日本語", value: JavaScriptValue(runtime, "ok"))
+    object.setProperty("🎉", JavaScriptObject(runtime))
+    object.setProperty("", value: true)
+    runtime.global().setProperty("obj", object)
+    #expect(try runtime.eval("obj['café'] === 42 && obj['日本語'] === 'ok' && obj[''] === true").getBool() == true)
+    #expect(try runtime.eval("typeof obj['🎉']").getString() == "object")
+    #expect(try runtime.eval("Object.keys(obj).join(',')").getString() == "café,日本語,🎉,")
+  }
+
+  @Test
+  func `deleteProperty removes a non-ASCII name`() throws {
+    let object = try runtime.eval("({ 'café': 42, 'cafe': 1 })").getObject()
+    object.deleteProperty("café")
+    #expect(object.hasProperty("café") == false)
+    #expect(object.hasProperty("cafe") == true)
+    runtime.global().setProperty("obj", object)
+    #expect(try runtime.eval("'café' in obj").getBool() == false)
+  }
+
+  @Test
+  func `defineProperty with a non-ASCII name is visible to JavaScript`() throws {
+    let object = JavaScriptObject(runtime)
+    object.defineProperty("café", value: 42.0, options: [.enumerable])
+    runtime.global().setProperty("obj", object)
+    #expect(try runtime.eval("obj['café']").getInt() == 42)
+  }
+
+  @Test
+  func `getPropertyAsFunction finds a non-ASCII name`() throws {
+    let object = try runtime.eval("({ 'zażółć': () => 'gęślą jaźń' })").getObject()
+    let function = try object.getPropertyAsFunction("zażółć")
+    #expect(try function.call().getString() == "gęślą jaźń")
+  }
+
   // MARK: - Property Access Tests
 
   @Suite("Property Access")

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPropNameIDTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPropNameIDTests.swift
@@ -112,4 +112,12 @@ struct JavaScriptPropNameIDTests {
     #expect(array["café"].getInt() == 42)
     #expect(array["🎉"].getString() == "party")
   }
+
+  @Test
+  func `array string subscript writes a non-ASCII custom property`() throws {
+    let array = try runtime.eval("[1, 2]").getArray()
+    array["café"] = JavaScriptValue(runtime, "party")
+    runtime.global().setProperty("arr", value: array.asValue())
+    #expect(try runtime.eval("arr['café'] === 'party'").getBool() == true)
+  }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
@@ -215,6 +215,26 @@ struct JavaScriptValueTests {
   }
 
   @Test
+  func `dictionary with non-ASCII keys round-trips through JavaScriptRepresentable`() throws {
+    let value = try runtime.eval("({ 'café': 'one', '日本語': 'two' })")
+    let dictionary = [String: String].fromJavaScriptValue(value)
+    #expect(dictionary == ["café": "one", "日本語": "two"])
+  }
+
+  @Test
+  func `dictionary with non-ASCII keys encodes to JavaScript`() throws {
+    let value = ["café": "one", "": "empty"].toJavaScriptValue(in: runtime)
+    runtime.global().setProperty("dict", value: value)
+    #expect(try runtime.eval("dict['café'] === 'one' && dict[''] === 'empty'").getBool() == true)
+  }
+
+  @Test
+  func `array of non-ASCII strings round-trips through JavaScriptRepresentable`() throws {
+    let value = try runtime.eval("['café', '日本語', '']")
+    #expect([String].fromJavaScriptValue(value) == ["café", "日本語", ""])
+  }
+
+  @Test
   func `dictionary with an empty key round-trips through JavaScriptRepresentable`() throws {
     let value = try runtime.eval("({ '': 'empty' })")
     let dictionary = [String: String].fromJavaScriptValue(value)


### PR DESCRIPTION
# Why

The String-keyed property APIs on `JavaScriptObject` (`getProperty`, `hasProperty`, `setProperty`, `deleteProperty`), the `JavaScriptArray` string subscript setter and the dictionary conversions handed the name to JSI as `const char*`. JSI treats that as ASCII, so a name like `café` was stored and looked up under mangled bytes: JavaScript never saw the property, and decoding a dictionary with such a key tripped the `isString()` assertion. Found while writing tests for #49678.

# How

Every String-keyed API now builds a `jsi::PropNameID` from the string's UTF-8 bytes through one internal `String.toJSIPropNameID(in:)`, and the C++ `setProperty` helpers take a `PropNameID` instead of `const char*`. Skipping the intermediate `std::string` and the ASCII engine string makes these paths faster too.

Dictionary decoding (both the `JavaScriptRepresentable` and the `JSIRepresentable` conformance) walks the engine's property names and looks each value up by the key string it got back, instead of converting to a Swift `String`, re-encoding it and materializing a `[String]` first. That also removes the macOS-only `const char*` fallback.

# Test Plan

New tests cover non-ASCII and empty names on `getProperty`, `hasProperty`, `setProperty` (value, object and `JavaScriptValue` variants), `deleteProperty`, `defineProperty`, `getPropertyAsFunction`, the array string subscript setter, and dictionary round-trips in both directions. Where the bug was visible from JavaScript, the tests assert from JavaScript. `pnpm test:integration` passes.

Benchmarks from `pnpm benchmark` (Mac Catalyst, Release), median ns/op before and after:

| Operation | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `getProperty(_:)`, ASCII name | 106 | 88 | 1.21x |
| `getProperty(_:)`, non-ASCII name | 109 | 105 | 1.04x |
| `hasProperty(_:)` | 77 | 63 | 1.21x |
| `setProperty(_:value:)`, double | 120 | 83 | 1.44x |
| `[String: String].fromJavaScriptValue`, 10 entries | 3670 | 2395 | 1.53x |

`getPropertyNames()` and the `JavaScriptPropNameID` constructor are unchanged.
