### PR TITLE
 [router][web] Preserve streamed `Suspense` content during hydration

### DIFF
--- a/apps/router-e2e/__e2e__/static-rendering/app/streaming.tsx
+++ b/apps/router-e2e/__e2e__/static-rendering/app/streaming.tsx
@@ -1,0 +1,111 @@
+import { useLocalSearchParams } from 'expo-router';
+import { Suspense, use, useEffect, useState } from 'react';
+
+// Streaming SSR store page: two Suspense boundaries the server completes after `?delay=<ms>` and
+// `delay + 1500`. The client promises never resolve, so streamed content can only come from the server.
+
+const PRODUCT = { title: 'Aeropress Go Travel Press', price: '$39.95', stock: 12 };
+const REVIEWS = [
+  { id: 'r1', author: 'Dana K.', body: 'Packs smaller than my mug.' },
+  { id: 'r2', author: 'Marco P.', body: 'Great on flights. Stiff plunger.' },
+  { id: 'r3', author: 'Yuki T.', body: 'Three years of daily use.' },
+];
+const RELATED = [
+  { id: 'p1', title: 'Burr Hand Grinder', price: '$59.00' },
+  { id: 'p2', title: 'Metal Filter Disc', price: '$14.50' },
+];
+
+function resolveOnServerAfter<T>(value: T, delayMs: number): Promise<T> {
+  if (typeof window === 'undefined') {
+    return new Promise((resolve) => setTimeout(() => resolve(value), delayMs));
+  }
+  return new Promise(() => {});
+}
+
+export default function StreamingStorePage() {
+  const { delay } = useLocalSearchParams<{ delay?: string }>();
+  const reviewsDelay = Number(delay) || 1000;
+  // Created in the parent, which never suspends, so each promise is made once per request.
+  const [reviews] = useState(() => resolveOnServerAfter(REVIEWS, reviewsDelay));
+  const [related] = useState(() => resolveOnServerAfter(RELATED, reviewsDelay + 1500));
+
+  return (
+    <main data-testid="streaming-page">
+      <header>
+        <h1 data-testid="streaming-header">{PRODUCT.title}</h1>
+        <p>{PRODUCT.price}</p>
+        <p>{PRODUCT.stock} in stock</p>
+        {/* Not next to a boundary: a pending update beside one hides the failure this page tests. */}
+        <HydrationMarker />
+      </header>
+
+      <section>
+        <h2>Reviews</h2>
+        <Suspense fallback={<ReviewsSkeleton />}>
+          <Reviews promise={reviews} />
+        </Suspense>
+      </section>
+
+      <section>
+        <h2>Related products</h2>
+        <Suspense fallback={<RelatedSkeleton />}>
+          <Related promise={related} />
+        </Suspense>
+      </section>
+    </main>
+  );
+}
+
+function HydrationMarker() {
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+  return hydrated ? <span data-testid="streaming-hydrated">Hydrated</span> : null;
+}
+
+function Reviews({ promise }: { promise: Promise<typeof REVIEWS> }) {
+  const reviews = use(promise);
+  return (
+    <ul data-testid="streaming-reviews">
+      {reviews.map((review) => (
+        <li key={review.id}>
+          <strong>{review.author}</strong> {review.body}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Related({ promise }: { promise: Promise<typeof RELATED> }) {
+  const related = use(promise);
+  return (
+    <ul data-testid="streaming-related">
+      {related.map((item) => (
+        <li key={item.id}>
+          {item.title} {item.price}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ReviewsSkeleton() {
+  return (
+    <ul data-testid="streaming-reviews-skeleton">
+      {REVIEWS.map((review) => (
+        <li key={review.id}>…</li>
+      ))}
+    </ul>
+  );
+}
+
+function RelatedSkeleton() {
+  return (
+    <ul data-testid="streaming-related-skeleton">
+      {RELATED.map((item) => (
+        <li key={item.id}>…</li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
+++ b/packages/@expo/cli/e2e/__tests__/export/static-splitting.test.ts
@@ -100,6 +100,7 @@ describe('exports static with bundle splitting', () => {
         'about',
         'asset',
         'links',
+        'streaming',
         'styled',
         'metadata',
         '\\[id\\]',

--- a/packages/@expo/cli/e2e/playwright/prod/server-rendering.test.ts
+++ b/packages/@expo/cli/e2e/playwright/prod/server-rendering.test.ts
@@ -71,4 +71,60 @@ test.describe('server rendering in production', () => {
     ).toBe('alive');
     expect(pageErrors.all).toEqual([]);
   });
+
+  test('streams two pending Suspense boundaries and completes them later', async ({ page }) => {
+    const response = await page.request.get(new URL('/streaming?delay=300', expoServe.url).href);
+    const html = await response.text();
+
+    expect(html.match(/<!--\$\?-->/g)).toHaveLength(2);
+    expect(html.match(/\$RC\(/g)).toHaveLength(2);
+    expect(html).toContain('Dana K.');
+    expect(html).toContain('Burr Hand Grinder');
+  });
+
+  test('adopts streamed Suspense content during hydration', async ({ page }) => {
+    const pageErrors = pageCollectErrors(page);
+
+    // Runs before the client bundle, so the flag marks the server-rendered node.
+    await page.addInitScript(() => {
+      const observer = new MutationObserver(() => {
+        const header = document.querySelector('[data-testid="streaming-header"]');
+        if (header) {
+          (header as any).__fromServer = true;
+          observer.disconnect();
+        }
+      });
+      observer.observe(document, { childList: true, subtree: true });
+    });
+
+    // `load` fires only when the stream ends; `commit` lets us observe hydration while pending.
+    await page.goto(new URL('/streaming?delay=4000', expoServe.url).href, {
+      waitUntil: 'commit',
+    });
+    await page.waitForSelector('[data-testid="streaming-hydrated"]');
+
+    // Hydration must happen while both are pending, or the test proves nothing.
+    await expect(page.getByTestId('streaming-reviews-skeleton')).toHaveCount(1);
+    await expect(page.getByTestId('streaming-related-skeleton')).toHaveCount(1);
+    await expect(page.getByTestId('streaming-reviews')).toHaveCount(0);
+    await expect(page.getByTestId('streaming-related')).toHaveCount(0);
+
+    // The client promises never resolve, so this content can only come from the server stream.
+    await expect(page.getByTestId('streaming-reviews')).toContainText('Dana K.', {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('streaming-reviews-skeleton')).toHaveCount(0);
+    await expect(page.getByTestId('streaming-related')).toContainText('Burr Hand Grinder', {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId('streaming-related-skeleton')).toHaveCount(0);
+
+    const headerFromServer = await page.evaluate(
+      () =>
+        (document.querySelector('[data-testid="streaming-header"]') as any)?.__fromServer === true
+    );
+    expect(headerFromServer).toBe(true);
+
+    expect(pageErrors.all).toEqual([]);
+  });
 });

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -85,6 +85,7 @@
 - Prevent `useLoaderData()` from re-rendering readers of unrelated loader paths ([#48523](https://github.com/expo/expo/pull/48523) by [@hassankhan](https://github.com/hassankhan))
 - Fix package export for `expo-router/unstable-split-view` ([#49001](https://github.com/expo/expo/pull/49001) by [@hassankhan](https://github.com/hassankhan))
 - [ios][native-tabs] Fix a `[RNScreens] icon and selectedIcon must be same type.` crash when the normal and selected icons resolved to different rendering modes. ([#48302](https://github.com/expo/expo/pull/48302) by [@CavalcanteLeo](https://github.com/CavalcanteLeo))
+- Preserve streamed Suspense content during SSR hydration
 
 ### 💡 Others
 

--- a/packages/expo-router/src/ExpoRoot.tsx
+++ b/packages/expo-router/src/ExpoRoot.tsx
@@ -21,6 +21,7 @@ import type { LinkingOptions } from './react-navigation/native';
 import { StackRouter, useNavigationBuilder } from './react-navigation/native';
 import { initScreensFeatureFlags } from './screensFeatureFlags';
 import type { RequireContext } from './types';
+import { getInitialSafeAreaMetrics } from './utils/safeAreaMetrics';
 import { maybeHideSplashScreen } from './utils/splash';
 import { parseUrlUsingCustomBase } from './utils/url';
 import { RootUnmatched } from './views/RootUnmatched';
@@ -43,13 +44,10 @@ export type NativeIntent = {
 
 const isTestEnv = process.env.NODE_ENV === 'test';
 
+// NOTE(@hassankhan): Web is seeded with its own measurement so a context value
+// change doesn't occur during hydration. Native measures itself.
 const INITIAL_METRICS =
-  Platform.OS === 'web' || isTestEnv
-    ? {
-        frame: { x: 0, y: 0, width: 0, height: 0 },
-        insets: { top: 0, left: 0, right: 0, bottom: 0 },
-      }
-    : undefined;
+  Platform.OS === 'web' || isTestEnv ? getInitialSafeAreaMetrics() : undefined;
 
 /**
  * @hidden

--- a/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/routerRegistry.test.ios.tsx
@@ -149,19 +149,52 @@ describe(RouterRegistryProvider, () => {
     expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
   });
 
-  it('preserves map identity when registration does not change', () => {
+  it('keeps one map identity for the life of the provider', () => {
     const registries: RouterRegistry[] = [];
 
-    render(
+    const result = render(
       <RouterRegistryProvider>
         <RegistryProbe onRender={(registry) => registries.push(registry)} />
         <Registrant entry={firstEntry} />
         <Registrant entry={firstEntry} />
       </RouterRegistryProvider>
     );
+    result.rerender(
+      <RouterRegistryProvider>
+        <RegistryProbe onRender={(registry) => registries.push(registry)} />
+        <Registrant entry={secondEntry} />
+      </RouterRegistryProvider>
+    );
 
-    expect(new Set(registries).size).toBe(2);
-    expect(registries.at(-1)?.get(state.key)).toBe(firstEntry);
+    expect(new Set(registries).size).toBe(1);
+    expect(registries.at(-1)?.get(state.key)).toBe(secondEntry);
+  });
+
+  it('reports a change only when the map changes', () => {
+    const onChange = jest.fn();
+    function ChangeRegistrant({ entry }: { entry: RouterRegistryEntry }) {
+      useRegisterRouter(state.key, entry, onChange);
+      return null;
+    }
+
+    const result = render(
+      <RouterRegistryProvider>
+        <ChangeRegistrant entry={firstEntry} />
+      </RouterRegistryProvider>
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(state.key, firstEntry, true);
+
+    result.rerender(
+      <RouterRegistryProvider>
+        <ChangeRegistrant entry={firstEntry} />
+      </RouterRegistryProvider>
+    );
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    result.rerender(<RouterRegistryProvider />);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(state.key, firstEntry, false);
   });
 });
 
@@ -212,22 +245,23 @@ describe('navigation builder registration', () => {
     expect(registry.size).toBe(3);
   });
 
-  it('notifies consumers when a navigator mounts and unmounts', () => {
+  it('reflects navigator mounts and unmounts in the shared map without re-rendering consumers', () => {
     renderRouter({
       _layout: () => <Stack />,
       index: Probe,
       'nested/_layout': () => <Stack />,
       'nested/index': () => <Text testID="nested" />,
     });
+    const initialRegistry = registry;
     const initialRenders = registryRenders;
 
     act(() => router.push('/nested'));
-    expect(registryRenders).toBeGreaterThan(initialRenders);
+    expect(registry.size).toBe(3);
 
-    const mountedRenders = registryRenders;
     act(() => router.back());
-    expect(registryRenders).toBeGreaterThan(mountedRenders);
     expect(registry.size).toBe(2);
+    expect(registry).toBe(initialRegistry);
+    expect(registryRenders).toBe(initialRenders);
   });
 
   it('reduces actions with the registered router configuration', () => {

--- a/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
+++ b/packages/expo-router/src/global-state/__tests__/useNavigationTreeReducer.test.ios.tsx
@@ -232,6 +232,28 @@ it('reduces consecutive actions against accumulated state with one committed upd
   ]);
 });
 
+it('snapshots the mutable registry at dispatch', () => {
+  const reduceAtDispatch = jest.fn((state: NavigationState) => ({
+    state,
+    affectedRouteKey: state.routes[state.index]!.key,
+  }));
+  const reduceAfterDispatch = jest.fn((state: NavigationState) => ({
+    state,
+    affectedRouteKey: state.routes[state.index]!.key,
+  }));
+  const registry = new Map([['root', entry(reduceAtDispatch)]]);
+  const result = renderReducer({ registry });
+
+  act(() => {
+    result.result.current.handleAction({ type: 'NEXT' });
+    // The shared map is mutated in place before React processes the queued action.
+    registry.set('root', entry(reduceAfterDispatch));
+  });
+
+  expect(reduceAtDispatch).toHaveBeenCalledTimes(1);
+  expect(reduceAfterDispatch).not.toHaveBeenCalled();
+});
+
 it('assigns increasing ids to events across actions', () => {
   const result = renderReducer({
     registry: new Map([
@@ -428,16 +450,37 @@ it('resets a state slice when its router unregisters', () => {
     registry: new Map([['root', registryEntry]]),
   });
 
-  result.rerender({
-    registry: new Map(),
-    routesWithRemovalPrevented: new Set(),
-  });
+  act(() => result.result.current.onRegistryChange('root', registryEntry, true));
+  expect(result.result.current.registeredKeys.has('root')).toBe(true);
 
+  act(() => result.result.current.onRegistryChange('root', registryEntry, false));
+
+  expect(result.result.current.registeredKeys.has('root')).toBe(false);
   expect(result.result.current.state).toMatchObject({
     index: 0,
     routeNames: ['second', 'first', 'third'],
     routes: [{ name: 'second' }],
   });
+});
+
+it('keeps the state slice when a router re-registers the same key in one commit', () => {
+  const routeNode = node('root', [node('first'), node('second'), node('third')]);
+  routeNode.initialRouteName = 'second';
+  const registryEntry = { ...entry(() => null), routeNode };
+  const nextEntry = { ...entry(() => null), routeNode };
+  const result = renderReducer({
+    registry: new Map([['root', registryEntry]]),
+  });
+  act(() => result.result.current.onRegistryChange('root', registryEntry, true));
+  const stateBefore = result.result.current.state;
+
+  act(() => {
+    result.result.current.onRegistryChange('root', registryEntry, false);
+    result.result.current.onRegistryChange('root', nextEntry, true);
+  });
+
+  expect(result.result.current.registeredKeys.has('root')).toBe(true);
+  expect(result.result.current.state).toBe(stateBefore);
 });
 
 it('resets a state slice when its router type changes', () => {

--- a/packages/expo-router/src/global-state/routerRegistry.tsx
+++ b/packages/expo-router/src/global-state/routerRegistry.tsx
@@ -23,41 +23,42 @@ export type RouterRegistryEntry = {
 // Entries appear after the first commit and state keys can change when navigation state is reset.
 export type RouterRegistry = ReadonlyMap<string, RouterRegistryEntry>;
 
+export type RouterRegistryChange = (
+  stateKey: string,
+  entry: RouterRegistryEntry,
+  registered: boolean
+) => void;
+
 type RouterRegistrySetters = {
-  register: (stateKey: string, entry: RouterRegistryEntry) => void;
-  unregister: (stateKey: string, entry: RouterRegistryEntry) => void;
+  register: (stateKey: string, entry: RouterRegistryEntry) => boolean;
+  unregister: (stateKey: string, entry: RouterRegistryEntry) => boolean;
 };
 
-// React components read this map during render, so React state is intentional.
+// One Map for the life of the provider, mutated in place. A new context value here during the
+// hydration commit makes React drop every streamed Suspense boundary that is still pending.
 export const RouterRegistryContext = createContext<RouterRegistry | undefined>(undefined);
 const RouterRegistrySettersContext = createContext<RouterRegistrySetters | undefined>(undefined);
 
 export function RouterRegistryProvider({ children }: PropsWithChildren) {
-  const [registry, setRegistry] = useState<RouterRegistry>(() => new Map());
+  const [registry] = useState(() => new Map<string, RouterRegistryEntry>());
   const setters = useMemo<RouterRegistrySetters>(
     () => ({
       register(stateKey, entry) {
-        setRegistry((previous) => {
-          if (previous.get(stateKey) === entry) {
-            return previous;
-          }
-
-          return new Map(previous).set(stateKey, entry);
-        });
+        if (registry.get(stateKey) === entry) {
+          return false;
+        }
+        registry.set(stateKey, entry);
+        return true;
       },
       unregister(stateKey, entry) {
-        setRegistry((previous) => {
-          if (previous.get(stateKey) !== entry) {
-            return previous;
-          }
-
-          const next = new Map(previous);
-          next.delete(stateKey);
-          return next;
-        });
+        if (registry.get(stateKey) !== entry) {
+          return false;
+        }
+        registry.delete(stateKey);
+        return true;
       },
     }),
-    []
+    [registry]
   );
 
   return (
@@ -67,7 +68,15 @@ export function RouterRegistryProvider({ children }: PropsWithChildren) {
   );
 }
 
-export function useRegisterRouter(stateKey: string, entry: RouterRegistryEntry): void {
+/**
+ * Registers a navigator's router from a layout effect. `onChange` is the only signal consumers get,
+ * because the map identity never changes; pass a stable callback.
+ */
+export function useRegisterRouter(
+  stateKey: string,
+  entry: RouterRegistryEntry,
+  onChange?: RouterRegistryChange
+): void {
   const setters = use(RouterRegistrySettersContext);
 
   useClientLayoutEffect(() => {
@@ -80,7 +89,13 @@ export function useRegisterRouter(stateKey: string, entry: RouterRegistryEntry):
       return;
     }
 
-    setters.register(stateKey, entry);
-    return () => setters.unregister(stateKey, entry);
-  }, [entry, setters, stateKey]);
+    if (setters.register(stateKey, entry)) {
+      onChange?.(stateKey, entry, true);
+    }
+    return () => {
+      if (setters.unregister(stateKey, entry)) {
+        onChange?.(stateKey, entry, false);
+      }
+    };
+  }, [entry, onChange, setters, stateKey]);
 }

--- a/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
+++ b/packages/expo-router/src/global-state/useNavigationTreeReducer.ts
@@ -16,7 +16,7 @@ import {
 } from './createSeededNavigationState';
 import { getNavigateAction } from './getNavigationAction';
 import { indexNavigationTree, reduceNavigationTree, resolveOrigin } from './reduceNavigationTree';
-import type { RouterRegistry } from './routerRegistry';
+import type { RouterRegistry, RouterRegistryChange } from './routerRegistry';
 import type { RoutingIntent } from './routingQueue';
 import { resetNavigatorState } from './stateUtils';
 import type { StoreRedirects } from './types';
@@ -327,14 +327,38 @@ export function useNavigationTreeReducer({
       return { state: deepFreeze(value), report: undefined, eventSeq: 0 };
     }
   );
-  const previousRegistryRef = React.useRef(registry);
+  // The registry map is mutated in place, so renders derive from this state instead. Unregistered
+  // route nodes wait until the commit settles, so a same-key re-registration is not an unmount.
+  const [registeredKeys, setRegisteredKeys] = React.useState<ReadonlySet<string>>(EMPTY_SET);
+  const unregisteredRouteNodesRef = React.useRef(new Map<string, RouteNode>());
+  const onRegistryChange = React.useCallback<RouterRegistryChange>(
+    (stateKey, entry, registered) => {
+      if (!registered && entry.routeNode) {
+        unregisteredRouteNodesRef.current.set(stateKey, entry.routeNode);
+      }
+      setRegisteredKeys((previous) => {
+        if (registered && previous.has(stateKey)) {
+          return previous;
+        }
+        const next = new Set(previous);
+        if (registered) {
+          next.add(stateKey);
+        } else {
+          // Always a new set on removal, so the effect below runs for the pending route node.
+          next.delete(stateKey);
+        }
+        return next;
+      });
+    },
+    []
+  );
 
   const processAction = React.useCallback(
     (operation: TreeOperation) =>
       reactDispatch({
         operation,
         config: {
-          registry,
+          registry: new Map(registry),
           routesWithRemovalPrevented,
           routeNode,
           linking,
@@ -373,21 +397,20 @@ export function useNavigationTreeReducer({
   }, [result.state]);
 
   useClientLayoutEffect(() => {
-    const previousRegistry = previousRegistryRef.current;
-    previousRegistryRef.current = registry;
-    for (const [stateKey, entry] of previousRegistry) {
-      if (!registry.has(stateKey) && entry.routeNode) {
+    const unregistered = unregisteredRouteNodesRef.current;
+    if (unregistered.size === 0) {
+      return;
+    }
+    unregisteredRouteNodesRef.current = new Map();
+    for (const [stateKey, routeNode] of unregistered) {
+      if (!registeredKeys.has(stateKey)) {
         // This runs inside an effect; the rule doesn't recognize the `useClientLayoutEffect`
         // wrapper as one.
         // oxlint-disable-next-line react-hooks/rules-of-hooks
-        process({
-          type: 'NAVIGATOR_UNMOUNTED',
-          stateKey,
-          routeNode: entry.routeNode,
-        });
+        process({ type: 'NAVIGATOR_UNMOUNTED', stateKey, routeNode });
       }
     }
-  }, [registry]);
+  }, [registeredKeys]);
 
   return {
     state: result.state,
@@ -396,6 +419,9 @@ export function useNavigationTreeReducer({
     resetNavigator,
     handleAction,
     processIntent,
+    /** State keys of the navigators currently registered with the router registry. */
+    registeredKeys,
+    onRegistryChange,
   };
 }
 

--- a/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
+++ b/packages/expo-router/src/react-navigation/core/BaseNavigationContainer.tsx
@@ -91,15 +91,23 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   const emitter = useEventEmitter<NavigationContainerEventMap>();
 
   // TODO(@ubax): consider moving this state to ExpoRoot.
-  const { state, report, consumeReportEvents, resetNavigator, handleAction, processIntent } =
-    useNavigationTreeReducer({
-      initialState,
-      routeNode: UNSTABLE_routeNode,
-      registry,
-      routesWithRemovalPrevented,
-      linking: routerConfig?.linking,
-      redirects: routerConfig?.redirects,
-    });
+  const {
+    state,
+    report,
+    consumeReportEvents,
+    resetNavigator,
+    handleAction,
+    processIntent,
+    registeredKeys,
+    onRegistryChange,
+  } = useNavigationTreeReducer({
+    initialState,
+    routeNode: UNSTABLE_routeNode,
+    registry,
+    routesWithRemovalPrevented,
+    linking: routerConfig?.linking,
+    redirects: routerConfig?.redirects,
+  });
   useNavigationTreeReportEvents(report, consumeReportEvents);
 
   const { listeners, addListener } = useChildListeners();
@@ -148,7 +156,9 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
   });
 
   // TODO(@ubax): check if this is still needed anywhere
-  const isReady = useLatestCallback(() => listeners.focus[0] != null && registry.has(state.key));
+  const isReady = useLatestCallback(
+    () => listeners.focus[0] != null && registeredKeys.has(state.key)
+  );
 
   const { addOptionsGetter, getCurrentOptions } = useOptionsGetters({});
 
@@ -194,8 +204,9 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
       addListener,
       handleAction,
       resetNavigator,
+      onRegistryChange,
     }),
-    [addListener, handleAction, resetNavigator]
+    [addListener, handleAction, onRegistryChange, resetNavigator]
   );
 
   const context = React.useMemo(
@@ -230,7 +241,7 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
       onReadyRef.current?.();
       emitter.emit({ type: 'ready' });
     }
-  }, [state, registry, isReady, emitter]);
+  }, [state, registeredKeys, isReady, emitter]);
 
   React.useEffect(() => {
     const hydratedState = getRootState();
@@ -311,7 +322,10 @@ export function BaseNavigationContainer(props: InternalNavigationContainerProps)
               <EnsureSingleNavigator>
                 <ThemeProvider value={theme}>{children}</ThemeProvider>
               </EnsureSingleNavigator>
-              <RoutingQueueDrainer ready={registry.has(state.key)} processIntent={processIntent} />
+              <RoutingQueueDrainer
+                ready={registeredKeys.has(state.key)}
+                processIntent={processIntent}
+              />
             </RootNavigationStateContext.Provider>
           </RouteInfoContext.Provider>
         </NavigationStateContext.Provider>

--- a/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
+++ b/packages/expo-router/src/react-navigation/core/NavigationBuilderContext.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as React from 'react';
 
+import type { RouterRegistryChange } from '../../global-state/routerRegistry';
 import type { NavigationAction, ParamListBase } from '../routers';
 import type { NavigationHelpers } from './types';
 
@@ -24,6 +25,8 @@ export const NavigationBuilderContext = React.createContext<{
   handleAction: (action: NavigationAction, originKey?: string) => void;
   resetNavigator: (stateKey: string, routerType: string | undefined) => void;
   addListener?: AddListener;
+  /** Called after a navigator's entry is added to or removed from the router registry. */
+  onRegistryChange?: RouterRegistryChange;
 }>({
   handleAction: () => undefined,
   resetNavigator: () => undefined,

--- a/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
+++ b/packages/expo-router/src/react-navigation/core/useDescriptors.tsx
@@ -103,7 +103,7 @@ export function useDescriptors<
 }: Options<State, ScreenOptions, EventMap>) {
   const theme = use(ThemeContext);
   const [options, setOptions] = React.useState<Record<string, ScreenOptions>>({});
-  const { handleAction, resetNavigator } = use(NavigationBuilderContext);
+  const { handleAction, resetNavigator, onRegistryChange } = use(NavigationBuilderContext);
 
   const context = React.useMemo(
     () => ({
@@ -111,8 +111,9 @@ export function useDescriptors<
       handleAction,
       resetNavigator,
       addListener,
+      onRegistryChange,
     }),
-    [navigation, handleAction, resetNavigator, addListener]
+    [navigation, handleAction, resetNavigator, addListener, onRegistryChange]
   );
 
   const getNavigation = useNavigationCache<State, ScreenOptions, EventMap, ActionHelpers>({

--- a/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
+++ b/packages/expo-router/src/react-navigation/core/useNavigationBuilder.tsx
@@ -326,7 +326,7 @@ export function useNavigationBuilder<
   const { state: currentState } = use(NavigationStateContext);
   const rootState = use(RootNavigationStateContext);
 
-  const { resetNavigator, handleAction } = use(NavigationBuilderContext);
+  const { resetNavigator, handleAction, onRegistryChange } = use(NavigationBuilderContext);
   if (
     currentState === undefined ||
     currentState.stale !== false ||
@@ -456,7 +456,7 @@ export function useNavigationBuilder<
     [reduce, routeNode, routeNamesKey, router]
   );
 
-  useRegisterRouter(committedState.key, registryEntry);
+  useRegisterRouter(committedState.key, registryEntry, onRegistryChange);
 
   useClientLayoutEffect(() => {
     if (isForeignType) {

--- a/packages/expo-router/src/utils/safeAreaMetrics.ts
+++ b/packages/expo-router/src/utils/safeAreaMetrics.ts
@@ -1,0 +1,68 @@
+import type { Metrics } from 'react-native-safe-area-context';
+
+const ZERO_METRICS: Metrics = {
+  frame: { x: 0, y: 0, width: 0, height: 0 },
+  insets: { top: 0, left: 0, right: 0, bottom: 0 },
+};
+
+/**
+ * Web has no `initialWindowMetrics`, so this measures what the web
+ * `SafeAreaProvider` will measure on mount. Seeding it keeps it stable through
+ * hydration; unstable values cause a re-render which drops streamed `Suspense`
+ * boundaries that are still pending. Values are set to zero on the server or
+ * when measuring fails.
+ *
+ * @privateRemarks This is pretty hacky and subject to change in the next
+ * version of `react-native-safe-area-context`
+ *
+ * @see https://github.com/AppAndFlow/react-native-safe-area-context/blob/e0b35d24cfe72812f5d32e4576195693abbcda20/src/NativeSafeAreaProvider.web.tsx#L36
+ */
+export function getInitialSafeAreaMetrics(): Metrics {
+  if (typeof document === 'undefined' || typeof window === 'undefined' || !document.body) {
+    return ZERO_METRICS;
+  }
+
+  try {
+    const element = document.createElement('div');
+    const { style } = element;
+    style.position = 'fixed';
+    style.left = '0';
+    style.top = '0';
+    style.width = '0';
+    style.height = '0';
+    style.zIndex = '-1';
+    style.overflow = 'hidden';
+    style.visibility = 'hidden';
+    const env = getSupportedEnv();
+    style.paddingTop = `${env}(safe-area-inset-top)`;
+    style.paddingBottom = `${env}(safe-area-inset-bottom)`;
+    style.paddingLeft = `${env}(safe-area-inset-left)`;
+    style.paddingRight = `${env}(safe-area-inset-right)`;
+    document.body.appendChild(element);
+    const { paddingTop, paddingBottom, paddingLeft, paddingRight } =
+      window.getComputedStyle(element);
+    document.body.removeChild(element);
+
+    return {
+      insets: {
+        top: paddingTop ? parseInt(paddingTop, 10) : 0,
+        bottom: paddingBottom ? parseInt(paddingBottom, 10) : 0,
+        left: paddingLeft ? parseInt(paddingLeft, 10) : 0,
+        right: paddingRight ? parseInt(paddingRight, 10) : 0,
+      },
+      frame: {
+        x: 0,
+        y: 0,
+        width: document.documentElement.offsetWidth,
+        height: document.documentElement.offsetHeight,
+      },
+    };
+  } catch {
+    return ZERO_METRICS;
+  }
+}
+
+function getSupportedEnv(): 'constant' | 'env' {
+  const { CSS } = window;
+  return CSS?.supports?.('top: constant(safe-area-inset-top)') ? 'constant' : 'env';
+}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
