### PR TITLE
[docs] Remove sign.expo.dev references

### DIFF
--- a/docs/pages/develop/development-builds/faq.mdx
+++ b/docs/pages/develop/development-builds/faq.mdx
@@ -70,7 +70,7 @@ Both [Android App Links](/linking/android-app-links/) and [iOS Universal Links](
 
 Each build of Expo Go supports one SDK version. The project and Expo Go SDK versions must match.
 
-On an Android device, Android Emulator, or iOS Simulator, install a compatible version from [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli). On a physical iPhone or iPad, projects using SDK 55 or later can install a compatible build from [sign.expo.dev](https://sign.expo.dev/).
+On an Android device, Android Emulator, or iOS Simulator, install a compatible version from [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli).
 
 See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) for platform-specific instructions.
 

--- a/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
+++ b/docs/pages/troubleshooting/expo-go-version-mismatch.mdx
@@ -29,11 +29,7 @@ Use the instructions for the device where you are testing your project.
 
 ### Physical iPhone or iPad
 
-For projects using SDK 55 or later, open [sign.expo.dev](https://sign.expo.dev/), select the SDK version used by your project, and follow the steps to install that Expo Go build on your device.
-
-This installer uses your Apple ID's free developer provisioning, so it does not require a paid Apple Developer Program membership. The certificate is valid for about seven days. Return to [sign.expo.dev](https://sign.expo.dev/) to re-sign and reinstall Expo Go when the certificate expires.
-
-For projects using SDK 54, install Expo Go from the Apple App Store. You can also use [`eas go`](https://expo.fyi/deploy-expo-go-testflight) to build Expo Go for SDK 54 or later and distribute it through your TestFlight internal team, which needs an Apple Developer Program membership.
+For projects using SDK 54 or later, use [`eas go`](https://expo.fyi/deploy-expo-go-testflight) to build Expo Go and distribute it through your TestFlight internal team, which needs an Apple Developer Program membership. For projects using SDK 54, you can also install Expo Go from the Apple App Store.
 
 For projects using SDK 53 or earlier, you cannot install an older version of Expo Go on a physical iOS device. Upgrade the project, use an Android device or iOS Simulator, or create a development build.
 

--- a/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
+++ b/docs/pages/workflow/upgrading-expo-sdk-walkthrough.mdx
@@ -12,7 +12,7 @@ import { Step } from '~/ui/components/Step';
 
 With a new SDK release, the latest version enters the current release status. This applies to Expo Go as it only supports the latest SDK version and previous versions are no longer supported. We recommend using [development builds](/develop/development-builds/introduction/) for production apps as the backwards compatibility for older SDK versions on EAS services tends to be much longer, but not forever.
 
-If you are looking to install a specific version of Expo Go on an Android device, Android Emulator, or iOS Simulator, visit [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli). On a physical iPhone or iPad, projects using SDK 55 or later can install a compatible build from [sign.expo.dev](https://sign.expo.dev/). See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) for more information.
+If you are looking to install a specific version of Expo Go on an Android device, Android Emulator, or iOS Simulator, visit [expo.dev/go](https://expo.dev/go) or use the [`expo-go` CLI](/develop/tools/#expo-go-cli). See [Troubleshoot an Expo Go version mismatch](/troubleshooting/expo-go-version-mismatch/) for more information.
 
 ## How to upgrade to the latest SDK version
 


### PR DESCRIPTION
# Why

#48255 added [sign.expo.dev](https://sign.expo.dev/) to the docs, but we were not ready to document it officially yet. Listing it in the docs drove a large increase in usage that caught us by surprise, so we are removing the references for now. We can add them back once the tool is ready for broader adoption.

# How

Removed all mentions of sign.expo.dev the docs

# Test Plan

n / a
