### PR TITLE
[android] allow a custom jsRuntimeFactory in getDefaultReactHost

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [Android] Allow `getDefaultReactHost` to take a custom `jsRuntimeFactory`, so an app can run a JavaScript engine other than Hermes. ([#49686](https://github.com/expo/expo/pull/49686) by [@ammarahm-ed](https://github.com/ammarahm-ed))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix a Hermes JSI crash during reloads where two overlapping `RCTHost` runtime callbacks shared `EXReactNativeFactory`'s app context ivar, letting one callback decorate objects against the other callback's runtime. ([#48576](https://github.com/expo/expo/issues/48576) by [@LizunovSergey](https://github.com/LizunovSergey))

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -37,7 +37,8 @@ object ExpoReactHostFactory {
     override val bindingsInstaller: BindingsInstaller? = null,
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder =
       DefaultTurboModuleManagerDelegate.Builder(),
-    private val hostHandlers: List<ReactNativeHostHandler>
+    private val hostHandlers: List<ReactNativeHostHandler>,
+    private val jsRuntimeFactoryOverride: JSRuntimeFactory? = null
   ) : ReactHostDelegate {
 
     val hostDelegateJsBundleFilePath: String?
@@ -79,7 +80,7 @@ object ExpoReactHostFactory {
       }
 
     override val jsRuntimeFactory: JSRuntimeFactory
-      get() = HermesInstance()
+      get() = jsRuntimeFactoryOverride ?: HermesInstance()
 
     override val reactPackages: List<ReactPackage>
       get() = packageList
@@ -102,6 +103,7 @@ object ExpoReactHostFactory {
     jsMainModulePath: String = ".expo/.virtual-metro-entry",
     jsBundleAssetPath: String = "index.android.bundle",
     jsBundleFilePath: String? = null,
+    jsRuntimeFactory: JSRuntimeFactory? = null,
     useDevSupport: Boolean = ReactBuildConfig.DEBUG,
     bindingsInstaller: BindingsInstaller? = null
   ): ReactHost {
@@ -119,7 +121,8 @@ object ExpoReactHostFactory {
         jsBundleFilePath,
         useDevSupport,
         bindingsInstaller,
-        hostHandlers = hostHandlers
+        hostHandlers = hostHandlers,
+        jsRuntimeFactoryOverride = jsRuntimeFactory
       )
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)

--- a/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
+++ b/packages/expo/android/src/main/java/expo/modules/ExpoReactHostFactory.kt
@@ -38,7 +38,7 @@ object ExpoReactHostFactory {
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder =
       DefaultTurboModuleManagerDelegate.Builder(),
     private val hostHandlers: List<ReactNativeHostHandler>,
-    private val jsRuntimeFactoryOverride: JSRuntimeFactory? = null
+    override val jsRuntimeFactory: JSRuntimeFactory = HermesInstance()
   ) : ReactHostDelegate {
 
     val hostDelegateJsBundleFilePath: String?
@@ -78,9 +78,6 @@ object ExpoReactHostFactory {
 
         return JSBundleLoader.createAssetLoader(context, "assets://$hostDelegateJSBundleAssetPath", true)
       }
-
-    override val jsRuntimeFactory: JSRuntimeFactory
-      get() = jsRuntimeFactoryOverride ?: HermesInstance()
 
     override val reactPackages: List<ReactPackage>
       get() = packageList
@@ -122,7 +119,7 @@ object ExpoReactHostFactory {
         useDevSupport,
         bindingsInstaller,
         hostHandlers = hostHandlers,
-        jsRuntimeFactoryOverride = jsRuntimeFactory
+        jsRuntimeFactory = jsRuntimeFactory ?: HermesInstance()
       )
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)


### PR DESCRIPTION
# Why

`ExpoReactHostFactory` hardcodes the JavaScript engine:

```kotlin
override val jsRuntimeFactory: JSRuntimeFactory
  get() = HermesInstance()
```

React Native treats the engine as an extension point: `DefaultReactHost.getDefaultReactHost` takes a `jsRuntimeFactory: JSRuntimeFactory? = null`, and `JSRuntimeFactory` is public API. A bare React Native app can therefore run an alternative engine. An Expo app cannot — `ExpoReactHostDelegate` always constructs `HermesInstance()`, with no way to pass one in.

**Context.** I am working on [`react-native-quickjs/quickjs`](https://github.com/react-native-quickjs/quickjs), a JSI runtime backed by [quickjs-ng](https://github.com/quickjs-ng/quickjs) and this small fix allows me to install my custom JSRuntimeFactory. 

The alternate route is to patch `ExpoReactHostFactory.kt` during prebuild. Any `npm install` silently reverts it, and the app then launches on Hermes rather than the engine it was configured for.

# How

Threads an optional factory through to the delegate, mirroring the signature React Native already uses:

- `getDefaultReactHost` gains `jsRuntimeFactory: JSRuntimeFactory? = null`, placed exactly where `DefaultReactHost.getDefaultReactHost` puts it (after `jsBundleFilePath`, before `useDevSupport`) so the two signatures line up.
- `ExpoReactHostDelegate` gains a matching `jsRuntimeFactoryOverride` property.
- `jsRuntimeFactory` becomes `jsRuntimeFactoryOverride ?: HermesInstance()`.

Fully backward compatible: the parameter defaults to `null`, so every existing caller keeps getting `HermesInstance()`.

# Test Plan

**Compiled against `main`** (React Native 0.87.0):

```
./gradlew :expo:compileDebugKotlin   →  BUILD SUCCESSFUL
```

Confirmed the default-argument synthetic that existing callers bind to is still emitted:

```
$ javap -p expo/modules/ExpoReactHostFactory.class
getDefaultReactHost(Context, List<ReactPackage>, String, String, String,
                    JSRuntimeFactory, boolean, BindingsInstaller)
getDefaultReactHost$default(..., int, Object)
```

**Ran end to end** in an Expo SDK 57 app (`expo prebuild`, then debug and release Android builds), with this exact change applied to the installed `expo` package, passing a non-Hermes `JSRuntimeFactory`:

```kotlin
override val reactHost: ReactHost by lazy {
  getDefaultReactHost(
    context = applicationContext,
    packageList = PackageList(this).packages,
    jsRuntimeFactory = QuickJSInstance(),
  )
}
```

The app boots on QuickJS engine, and ten JSI-based libraries work unmodified: `react-native-worklets`, `react-native-reanimated`, `react-native-gesture-handler`, `react-native-mmkv`, `react-native-nitro-modules`, `react-native-nitro-sqlite`, `react-native-unistyles`, `@op-engineering/op-sqlite`, `react-native-quick-crypto` and `react-native-safe-area-context` — including worklets executing JavaScript on the UI runtime and reanimated shared values round-tripping to it.

Verified there is no regression with the parameter unset: the same app built without it still launches on Hermes.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
