### PR TITLE
[JSI][iOS] Take over fresh JSI values instead of cloning them

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [iOS] Added an opt-in benchmark target that measures value access, host function calls, and JS function calls; run it with `pnpm benchmark`. ([#49579](https://github.com/expo/expo/pull/49579) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors by removing the per-call weak and unowned runtime reference traffic on the call path. ([#49631](https://github.com/expo/expo/pull/49631) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made passing strings between JavaScript and Swift faster, up to ~3.8× for long strings. ([#49678](https://github.com/expo/expo/pull/49678) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Values returned to Swift from property reads, array reads and function calls are now taken over instead of cloned through the engine, making `toJavaScriptValue(in:)` ~1.16× faster. ([#49688](https://github.com/expo/expo/pull/49688) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Benchmarks/ValueAccessBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/ValueAccessBenchmarks.swift
@@ -66,6 +66,32 @@ extension JSIBenchmarks {
     }
   }
 
+  /// Unlike a number, a string or object property is a pointer value: wrapping it in a
+  /// ``JavaScriptValue`` must not clone the engine handle it already owns.
+  @Test
+  func `object string property by name`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval("({ answer: 'forty-two' })").getObject()
+      try benchmark("JavaScriptObject.getProperty(_:): string value", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.getProperty("answer")
+        }
+      }
+    }
+  }
+
+  @Test
+  func `object object property by name`() async throws {
+    try await benchmarkCase { runtime in
+      let object = try runtime.eval("({ answer: { value: 42 } })").getObject()
+      try benchmark("JavaScriptObject.getProperty(_:): object value", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = object.getProperty("answer")
+        }
+      }
+    }
+  }
+
   @Test
   func `nested property traversal`() async throws {
     try await benchmarkCase { runtime in

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -73,7 +73,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   public subscript(index: Int) -> JavaScriptValue {
-    return JavaScriptValue(runtime, bufferPointer[index])
+    return JavaScriptValue(runtime, copying: bufferPointer[index])
   }
 
   /// Returns a non-owning, non-copyable value borrowing the element at `index` for the zero-copy decode

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptUnownedValue.swift
@@ -49,7 +49,7 @@ public struct JavaScriptUnownedValue: ~Copyable {
       Unmanaged.passUnretained(runtime.pointee).toOpaque() == Unmanaged.passUnretained(self.runtime).toOpaque(),
       "`copied(in:)` must be passed the runtime that owns the borrowed value"
     )
-    return JavaScriptValue(runtime, pointer.pointee)
+    return JavaScriptValue(runtime, copying: pointer.pointee)
   }
 
   // MARK: - Type checks

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -10,14 +10,26 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Value
 
-  /// Initializer from the existing JSI value.
+  /// Takes ownership of the given JSI value. Only runtime-free values (undefined, null, booleans and
+  /// numbers) pass `nil` here.
   internal init(_ runtime: JavaScriptRuntime?, _ pointee: consuming facebook.jsi.Value) {
     self.runtime = runtime
     self.pointee = pointee
   }
 
-  /// Copy initializer from the existing JSI value.
-  internal init(_ runtime: JavaScriptRuntime, _ pointee: borrowing facebook.jsi.Value) {
+  /// Takes ownership of the given JSI value. Same as the optional-runtime overload, but the exact
+  /// parameter type keeps the caller from promoting its runtime to an optional, which costs a
+  /// retain/release pair around every call on the hot paths (property reads, function results).
+  internal init(_ runtime: JavaScriptRuntime, _ pointee: consuming facebook.jsi.Value) {
+    self.runtime = runtime
+    self.pointee = pointee
+  }
+
+  /// Copies the given JSI value, which asks the engine to clone the handle for pointer values.
+  /// The `copying:` label keeps this initializer from being picked for temporaries: with a plain
+  /// second argument, a non-optional runtime used to win overload resolution over the consuming
+  /// initializer above, cloning every freshly returned value instead of taking it over.
+  internal init(_ runtime: JavaScriptRuntime, copying pointee: borrowing facebook.jsi.Value) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(runtime.pointee, pointee)
   }


### PR DESCRIPTION
# Why

`JavaScriptValue` had two internal initializers taking a `jsi::Value`: a consuming one with an optional runtime and a borrowing "copy" one with a non-optional runtime. When a call site passed a non-optional runtime and a temporary value, which is what every property read, array element read and function result does, Swift picked the borrowing one, because an exact type match ranks above an optional promotion. So each of those values was cloned through the engine and the temporary destroyed, instead of being taken over.

# How

The copy initializer is now labeled `copying:`, and only the two places that copy a value they don't own use it (the values-buffer subscript and `JavaScriptUnownedValue.copied(in:)`). Temporaries fall through to a consuming initializer. That initializer also gets a non-optional-runtime overload: with only the optional one, the promotion cost a `swift_retain`/`swift_release` pair around every call, which the disassembly showed and which made property reads slower than the copy they replaced.

# Test Plan

`pnpm test:integration` passes. Two benchmarks were added that read a string and an object property by name, since the existing one reads a number and a number clone is trivial. Median ns/op from `pnpm benchmark` (Mac Catalyst, Release):

| Operation | Before | After | Change |
| --- | ---: | ---: | ---: |
| `String.toJavaScriptValue(in:)`, 22 B | 51 | 44 | 1.16x |
| `String.toJavaScriptValue(in:)`, 256 B | 67 | 58 | 1.16x |
| `getProperty(_:)`, string value | 93 | 91 | 1.02x |
| `getProperty(_:)`, object value | 93 | 91 | 1.02x |
| `getProperty(_:)`, number value | 86 | 88 | 0.98x |
| `JavaScriptArray.getValue(at:)` | 70 | 71 | 0.98x |

The clone itself turned out to be cheap in Hermes (a reference count increment), so the property-read gain is small. The measurable win is on `toJavaScriptValue(in:)`, which every `JavaScriptRepresentable` encode goes through.
