### PR TITLE
[JSI][iOS] Transcode short UTF-16 strings by hand instead of through transcode()

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors by removing the per-call weak and unowned runtime reference traffic on the call path. ([#49631](https://github.com/expo/expo/pull/49631) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made passing strings between JavaScript and Swift faster, up to ~3.8× for long strings. ([#49678](https://github.com/expo/expo/pull/49678) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Values returned to Swift from property reads, array reads and function calls are now taken over instead of cloned through the engine, making `toJavaScriptValue(in:)` ~1.16× faster. ([#49688](https://github.com/expo/expo/pull/49688) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Made decoding non-ASCII JS strings up to 512 UTF-16 code units long ~1.5× faster. ([#49691](https://github.com/expo/expo/pull/49691) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/StringConversionBenchmarks.swift
@@ -114,6 +114,44 @@ extension JSIBenchmarks {
     }
   }
 
+  /// Sizes below the 512-code-unit threshold, where UTF-16 is transcoded by hand instead of by
+  /// `String(decoding:as:)`.
+  @Test
+  func `64 non-ASCII chars from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'zażółć gęślą jaźń '.repeat(4).slice(0, 64)")
+      try benchmark("String.fromJavaScriptValue(): 64 non-ASCII chars", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `256 non-ASCII chars from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'zażółć gęślą jaźń '.repeat(16).slice(0, 256)")
+      try benchmark("String.fromJavaScriptValue(): 256 non-ASCII chars", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `128 emoji from JavaScriptValue via JavaScriptRepresentable`() async throws {
+    try await benchmarkCase { runtime in
+      let value = try runtime.eval("'🎉'.repeat(128)")
+      try benchmark("String.fromJavaScriptValue(): 128 emoji (256 code units)", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = String.fromJavaScriptValue(value)
+        }
+      }
+    }
+  }
+
   @Test
   func `string to JavaScriptValue via JavaScriptRepresentable`() async throws {
     try await benchmarkCase { runtime in

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/String+JSI.swift
@@ -62,19 +62,17 @@ private func appendEngineStringChunk(ctx: UnsafeMutableRawPointer?, ascii: Bool,
   } else {
     let units = UnsafeBufferPointer(start: data.assumingMemoryBound(to: UInt16.self), count: count)
     if count < 512 {
-      // Short strings: transcode straight into the string's UTF-8 storage. `String(decoding:as:)`
-      // carries a fixed setup cost of a few hundred nanoseconds that dominates below this size.
-      // Worst case is 3 UTF-8 bytes per UTF-16 code unit (a surrogate pair is 4 bytes for 2 units).
+      // Short strings: transcode straight into the string's UTF-8 storage, sized for the worst case
+      // of 3 UTF-8 bytes per UTF-16 code unit (a surrogate pair is 4 bytes for 2 units). This is
+      // 1.5-1.6x faster than `String(decoding:as:)` up to a few hundred code units, which carries a
+      // fixed setup cost of a few hundred nanoseconds.
       chunk = String(unsafeUninitializedCapacity: count * 3) { buffer in
-        var written = 0
-        _ = transcode(units.makeIterator(), from: UTF16.self, to: UTF8.self, stoppingOnError: false) { byte in
-          buffer[written] = byte
-          written += 1
-        }
-        return written
+        return transcodeUTF16(units, into: buffer)
       }
     } else {
-      // Long strings: the standard library's bulk decoder is faster per code unit.
+      // Long strings: the loop and the standard library's bulk decoder run at the same speed here,
+      // but the bulk decoder sizes the storage exactly, while the string above keeps its 3x worst-case
+      // capacity. That matters once strings are kilobytes rather than bytes.
       chunk = String(decoding: units, as: UTF16.self)
     }
   }
@@ -83,4 +81,50 @@ private func appendEngineStringChunk(ctx: UnsafeMutableRawPointer?, ascii: Bool,
   } else {
     out.pointee += chunk
   }
+}
+
+/// Writes the UTF-8 encoding of `units` into `buffer` and returns the number of bytes written.
+/// Unpaired surrogates become U+FFFD, one per code unit, which is what `String(decoding:as:)` and
+/// `transcode(stoppingOnError: false)` produce. It replaces the standard library's `transcode`, which
+/// calls back once per output byte; this loop writes each scalar's bytes directly.
+/// `buffer` must hold at least 3 bytes per code unit.
+private func transcodeUTF16(
+  _ units: UnsafeBufferPointer<UInt16>,
+  into buffer: UnsafeMutableBufferPointer<UInt8>
+) -> Int {
+  var index = 0
+  var written = 0
+  while index < units.count {
+    let unit = UInt32(units[index])
+    index += 1
+    let scalar: UInt32
+    if unit < 0xD800 || unit > 0xDFFF {
+      scalar = unit
+    } else if unit < 0xDC00, index < units.count, (0xDC00...0xDFFF).contains(units[index]) {
+      scalar = 0x10000 + ((unit - 0xD800) << 10) + (UInt32(units[index]) - 0xDC00)
+      index += 1
+    } else {
+      scalar = 0xFFFD
+    }
+    if scalar < 0x80 {
+      buffer[written] = UInt8(scalar)
+      written += 1
+    } else if scalar < 0x800 {
+      buffer[written] = UInt8(0xC0 | (scalar >> 6))
+      buffer[written + 1] = UInt8(0x80 | (scalar & 0x3F))
+      written += 2
+    } else if scalar < 0x10000 {
+      buffer[written] = UInt8(0xE0 | (scalar >> 12))
+      buffer[written + 1] = UInt8(0x80 | ((scalar >> 6) & 0x3F))
+      buffer[written + 2] = UInt8(0x80 | (scalar & 0x3F))
+      written += 3
+    } else {
+      buffer[written] = UInt8(0xF0 | (scalar >> 18))
+      buffer[written + 1] = UInt8(0x80 | ((scalar >> 12) & 0x3F))
+      buffer[written + 2] = UInt8(0x80 | ((scalar >> 6) & 0x3F))
+      buffer[written + 3] = UInt8(0x80 | (scalar & 0x3F))
+      written += 4
+    }
+  }
+  return written
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
@@ -158,6 +158,23 @@ struct JavaScriptValueTests {
   }
 
   @Test
+  func `getString repairs lone surrogates the same way as the standard library`() throws {
+    // High surrogate followed by a non-surrogate, a stray low surrogate, and a high surrogate at the
+    // very end each become one U+FFFD, exactly like `String(decoding:as: UTF16.self)`.
+    let value = try runtime.eval("'a\\uD800b\\uDC00c\\uD83C\\uDF89\\uD800'")
+    let units: [UInt16] = [0x61, 0xD800, 0x62, 0xDC00, 0x63, 0xD83C, 0xDF89, 0xD800]
+    #expect(value.getString() == String(decoding: units, as: UTF16.self))
+    #expect(value.getString() == "a\u{FFFD}b\u{FFFD}c🎉\u{FFFD}")
+  }
+
+  @Test
+  func `getString covers every UTF-8 width below the bulk threshold`() throws {
+    let value = try runtime.eval("'a\\u00E9\\u4E2D\\uD83C\\uDF89'.repeat(100)")
+    #expect(value.getString() == String(repeating: "aé中🎉", count: 100))
+    #expect(value.getString().utf8.count == 1000)
+  }
+
+  @Test
   func `getString handles long non-ASCII string`() throws {
     let value = try runtime.eval("'ą'.repeat(2000)")
     #expect(value.getString() == String(repeating: "ą", count: 2000))


### PR DESCRIPTION
# Why

Strings up to 512 UTF-16 code units are transcoded to UTF-8 by the standard library's `transcode(_:from:to:stoppingOnError:into:)`, which calls its sink closure once per output byte. For non-ASCII text that closure call is most of the decode cost.

# How

A hand-written loop over the UTF-16 code units writes each scalar's UTF-8 bytes directly into the string's storage. It pairs surrogates itself and turns each unpaired one into U+FFFD, the same repair `String(decoding:as:)` and `transcode(stoppingOnError: false)` perform, so the result is byte-for-byte identical.

The 512-unit threshold stays, but for a different reason than before: the loop and the standard library's bulk decoder now run at the same speed above it, while the bulk decoder sizes the storage exactly and the loop keeps its 3x worst-case capacity. The comments in `String+JSI.swift` say so.

# Test Plan

New tests pin the repair behavior against `String(decoding:as:)` directly (high surrogate followed by a non-surrogate, stray low surrogate, high surrogate at the end) and cover all four UTF-8 widths below the threshold. The existing lone-surrogate, surrogate-pair, mixed-script, embedded-NUL and long-string tests still pass under `pnpm test:integration`.

Benchmarks were added at 64 and 256 characters and 128 emoji, since the existing non-ASCII cases were 12 bytes and 4 KB. Median ns/op from `pnpm benchmark` (Mac Catalyst, Release), stable across two runs:

| `String.fromJavaScriptValue` input | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| 12 non-ASCII chars | 67 | 55 | 1.2x |
| 64 non-ASCII chars | 179 | 123 | 1.45x |
| 256 non-ASCII chars | 583 | 360 | 1.6x |
| 128 emoji (256 code units) | 806 | 502 | 1.6x |
| 4 KB non-ASCII, host function concat | 15552 | 15565 | 1.00x |

`getPropertyNames()` with non-ASCII keys gained 5-8% as a side effect.
