### PR TITLE
[ios][camera] Keep AVFoundation barcode scanning working without the ZXing companion pod

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix all barcode scanning stopping when the optional `ExpoCameraBarcodeScanning` companion pod is not linked. The AVFoundation scanner now runs on its own, so QR codes and every other natively supported symbology keep scanning; the ZXing provider is once again only the fallback for `pdf417`, `code39`, and `codabar`.
+- [iOS] Fix all barcode scanning stopping when the optional `ExpoCameraBarcodeScanning` companion pod is not linked. The AVFoundation scanner now runs on its own, so QR codes and every other natively supported symbology keep scanning; the ZXing provider is once again only the fallback for `pdf417`, `code39`, and `codabar`. ([#49692](https://github.com/expo/expo/pull/49692) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available. ([#49028](https://github.com/expo/expo/pull/49028) by [@barthap](https://github.com/barthap))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Fix iOS captures being saved above their native resolution due to orientation normalization rendering at the screen scale. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `CameraView` leaking its barcode scanner, metadata delegate and capture session on every mount, by no longer having the delegate retain the scanner it reports to. ([#49692](https://github.com/expo/expo/pull/49692) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fix all barcode scanning stopping when the optional `ExpoCameraBarcodeScanning` companion pod is not linked. The AVFoundation scanner now runs on its own, so QR codes and every other natively supported symbology keep scanning; the ZXing provider is once again only the fallback for `pdf417`, `code39`, and `codabar`. ([#49692](https://github.com/expo/expo/pull/49692) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available. ([#49028](https://github.com/expo/expo/pull/49028) by [@barthap](https://github.com/barthap))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix all barcode scanning stopping when the optional `ExpoCameraBarcodeScanning` companion pod is not linked. The AVFoundation scanner now runs on its own, so QR codes and every other natively supported symbology keep scanning; the ZXing provider is once again only the fallback for `pdf417`, `code39`, and `codabar`.
 - [iOS] Fix repeatedly mounting and unmounting `CameraView` freezing the UI when the capture session cannot start, such as on a simulator. The session is now stopped before it is torn down and before the preview layer detaches from it, and it is no longer started at all when no capture device is available. ([#49028](https://github.com/expo/expo/pull/49028) by [@barthap](https://github.com/barthap))
 - [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
 - Fix iOS captures being saved above their native resolution due to orientation normalization rendering at the screen scale. ([#47477](https://github.com/expo/expo/pull/47477) by [@boojamya](https://github.com/boojamya))

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -162,9 +162,6 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
       Prop("barcodeScannerSettings") { (view, settings: BarcodeSettings?) in
         if let settings {
-          if view.barcodeScanner?.isAvailable == false {
-            self.appContext?.jsLogger.warn("Barcode scanning has been disabled")
-          }
           view.setBarcodeScannerSettings(settings: settings)
         }
       }

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -99,7 +99,10 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
       return
     }
 
-    if metadataOutput == nil {
+    // A session can accept the metadata output while rejecting the video data output, which
+    // conflicts with the movie file output used in video mode. Keep retrying until the provider
+    // has its frame source, otherwise the types it claims scan nothing.
+    if metadataOutput == nil || (barcodeProvider != nil && videoDataOutput == nil) {
       addOutputs()
       if metadataOutput == nil {
         return
@@ -122,12 +125,13 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   }
 
   private func addOutputs() {
-    delegate = MetaDataDelegate(
+    let delegate = delegate ?? MetaDataDelegate(
       settings: settings,
       previewLayer: previewLayer,
       barcodeProvider: barcodeProvider,
       barcodeProviderEnabled: barcodeProviderEnabled,
       metadataResultHandler: self)
+    self.delegate = delegate
 
     session.beginConfiguration()
     if metadataOutput == nil {
@@ -154,7 +158,10 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
 
   private func removeOutputs() {
     session.beginConfiguration()
-    defer { session.commitConfiguration() }
+    defer {
+      session.commitConfiguration()
+      delegate = nil
+    }
 
     if let metadataOutput {
       if session.outputs.contains(metadataOutput) {

--- a/packages/expo-camera/ios/Current/BarcodeScanner.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanner.swift
@@ -21,15 +21,14 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
 
   private let barcodeProvider: ExpoBarcodeScannerProvider?
 
-  init(session: AVCaptureSession, sessionQueue: DispatchQueue) {
+  init(
+    session: AVCaptureSession,
+    sessionQueue: DispatchQueue,
+    provider: ExpoBarcodeScannerProvider? = BarcodeScanner.discoverProvider()
+  ) {
     self.session = session
     self.sessionQueue = sessionQueue
-    self.barcodeProvider = BarcodeScanner.discoverProvider()
-  }
-
-  /// True when a barcode scanner provider is available (the companion pod is linked).
-  var isAvailable: Bool {
-    return barcodeProvider != nil
+    self.barcodeProvider = provider
   }
 
   /// Discovers the optional barcode scanner provider at runtime.
@@ -100,11 +99,7 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
       return
     }
 
-    guard barcodeProvider != nil else {
-      return
-    }
-
-    if metadataOutput == nil || videoDataOutput == nil {
+    if metadataOutput == nil {
       addOutputs()
       if metadataOutput == nil {
         return
@@ -127,10 +122,6 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
   }
 
   private func addOutputs() {
-    guard let barcodeProvider else {
-      return
-    }
-
     delegate = MetaDataDelegate(
       settings: settings,
       previewLayer: previewLayer,
@@ -148,7 +139,7 @@ class BarcodeScanner: NSObject, BarcodeScanningResponseHandler {
       }
     }
 
-    if videoDataOutput == nil {
+    if barcodeProvider != nil && videoDataOutput == nil {
       let output = AVCaptureVideoDataOutput()
       output.videoSettings = [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA]
       output.alwaysDiscardsLateVideoFrames = true

--- a/packages/expo-camera/ios/Current/BarcodeScanningResponseHandler.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScanningResponseHandler.swift
@@ -1,3 +1,3 @@
-protocol BarcodeScanningResponseHandler {
+protocol BarcodeScanningResponseHandler: AnyObject {
   func onScanningResult(_ result: [String: Any])
 }

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -4,7 +4,7 @@ import CoreImage
 class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCaptureVideoDataOutputSampleBufferDelegate {
   private var settings: [String: [AVMetadataObject.ObjectType]]
   private var previewLayer: AVCaptureVideoPreviewLayer?
-  private let barcodeProvider: ExpoBarcodeScannerProvider
+  private let barcodeProvider: ExpoBarcodeScannerProvider?
   private var barcodeProviderEnabled = true
   private var barcodeProviderFPSProcessed = 6.0
   private var lastFrameTimeStamp = 0.0
@@ -15,7 +15,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
   init(
     settings: [String: [AVMetadataObject.ObjectType]],
     previewLayer: AVCaptureVideoPreviewLayer?,
-    barcodeProvider: ExpoBarcodeScannerProvider,
+    barcodeProvider: ExpoBarcodeScannerProvider?,
     barcodeProviderEnabled: Bool,
     metadataResultHandler: BarcodeScanningResponseHandler
   ) {
@@ -36,7 +36,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
       return
     }
 
-    let barcodeProviderTypes = Set(barcodeProvider.supportedTypes)
+    let barcodeProviderTypes = Set(barcodeProvider?.supportedTypes ?? [])
 
     for metadata in metadataObjects {
       var codeMetadata = metadata as? AVMetadataMachineReadableCodeObject
@@ -60,7 +60,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
   }
 
   func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
-    guard barcodeProviderEnabled else {
+    guard barcodeProviderEnabled, let barcodeProvider else {
       return
     }
 

--- a/packages/expo-camera/ios/Current/MetaDataDelegate.swift
+++ b/packages/expo-camera/ios/Current/MetaDataDelegate.swift
@@ -8,7 +8,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
   private var barcodeProviderEnabled = true
   private var barcodeProviderFPSProcessed = 6.0
   private var lastFrameTimeStamp = 0.0
-  private let responseHandler: BarcodeScanningResponseHandler
+  private weak var responseHandler: BarcodeScanningResponseHandler?
 
   private let ciContext = CIContext()
 
@@ -52,7 +52,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
 
         if let codeMetadata {
           if codeMetadata.stringValue != nil && codeMetadata.type == barcodeType {
-            self.responseHandler.onScanningResult(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
+            self.responseHandler?.onScanningResult(BarcodeScannerUtils.avMetadataCodeObjectToDictionary(codeMetadata))
           }
         }
       }
@@ -74,7 +74,7 @@ class MetaDataDelegate: NSObject, AVCaptureMetadataOutputObjectsDelegate, AVCapt
       if let videoFrame = CMSampleBufferGetImageBuffer(sampleBuffer),
          let image = createImage(from: videoFrame) {
         for result in barcodeProvider.scanBarcodes(from: image) {
-          self.responseHandler.onScanningResult(result)
+          self.responseHandler?.onScanningResult(result)
         }
       }
     }

--- a/packages/expo-camera/ios/Tests/BarcodeScannerTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeScannerTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import AVFoundation
+
+@testable import ExpoCamera
+
+/// Stands in for the `ExpoCameraBarcodeScanning` companion pod.
+private final class StubBarcodeProvider: NSObject, ExpoBarcodeScannerProvider {
+  var supportedTypes: [String] {
+    [AVMetadataObject.ObjectType.pdf417.rawValue]
+  }
+
+  func scanBarcodes(from image: CGImage) -> [[String: Any]] {
+    []
+  }
+}
+
+/// The ZXing provider ships as an optional companion pod (`ExpoCameraBarcodeScanning`). Every
+/// barcode type expo-camera exposes is natively supported by `AVCaptureMetadataOutput`, so
+/// scanning must keep working when that pod is not linked.
+/// See https://github.com/expo/expo/issues/44491.
+@Suite("BarcodeScanner")
+struct BarcodeScannerTests {
+  private func startScanning(provider: ExpoBarcodeScannerProvider?) -> AVCaptureSession {
+    let session = AVCaptureSession()
+    let scanner = BarcodeScanner(
+      session: session,
+      sessionQueue: DispatchQueue(label: "test.barcode"),
+      provider: provider)
+
+    scanner.setSettings([BARCODE_TYPES_KEY: [.qr]])
+    scanner.setIsEnabled(true)
+    return session
+  }
+
+  @Test
+  func `scans through AVFoundation when the ZXing provider is not linked`() {
+    let session = startScanning(provider: nil)
+
+    #expect(session.outputs.contains { $0 is AVCaptureMetadataOutput })
+  }
+
+  @Test
+  func `skips the video data output when the ZXing provider is not linked`() {
+    let session = startScanning(provider: nil)
+
+    #expect(!session.outputs.contains { $0 is AVCaptureVideoDataOutput })
+  }
+
+  @Test
+  func `keeps both outputs when the ZXing provider is linked`() {
+    let session = startScanning(provider: StubBarcodeProvider())
+
+    #expect(session.outputs.contains { $0 is AVCaptureMetadataOutput })
+    #expect(session.outputs.contains { $0 is AVCaptureVideoDataOutput })
+  }
+}

--- a/packages/expo-camera/ios/Tests/BarcodeScannerTests.swift
+++ b/packages/expo-camera/ios/Tests/BarcodeScannerTests.swift
@@ -20,14 +20,22 @@ private final class StubBarcodeProvider: NSObject, ExpoBarcodeScannerProvider {
 /// See https://github.com/expo/expo/issues/44491.
 @Suite("BarcodeScanner")
 struct BarcodeScannerTests {
-  private func startScanning(provider: ExpoBarcodeScannerProvider?) -> AVCaptureSession {
-    let session = AVCaptureSession()
-    let scanner = BarcodeScanner(
+  private func makeScanner(
+    session: AVCaptureSession,
+    provider: ExpoBarcodeScannerProvider?
+  ) -> BarcodeScanner {
+    BarcodeScanner(
       session: session,
       sessionQueue: DispatchQueue(label: "test.barcode"),
       provider: provider)
+  }
 
-    scanner.setSettings([BARCODE_TYPES_KEY: [.qr]])
+  private func startScanning(provider: ExpoBarcodeScannerProvider?) -> AVCaptureSession {
+    let session = AVCaptureSession()
+    let scanner = makeScanner(session: session, provider: provider)
+
+    // pdf417 overlaps the stub's supportedTypes, so the provider path is genuinely live.
+    scanner.setSettings([BARCODE_TYPES_KEY: [.qr, .pdf417]])
     scanner.setIsEnabled(true)
     return session
   }
@@ -52,5 +60,25 @@ struct BarcodeScannerTests {
 
     #expect(session.outputs.contains { $0 is AVCaptureMetadataOutput })
     #expect(session.outputs.contains { $0 is AVCaptureVideoDataOutput })
+  }
+
+  // BarcodeScanner holds the delegate, which holds the scanner back as its response handler.
+  // Nothing broke that cycle on teardown, so every camera mount leaked a scanner, a delegate,
+  // a CIContext and a capture session.
+  @Test
+  func `releases the scanner once scanning stops`() {
+    weak var leaked: BarcodeScanner?
+
+    autoreleasepool {
+      let session = AVCaptureSession()
+      let scanner = makeScanner(session: session, provider: nil)
+      leaked = scanner
+
+      scanner.setSettings([BARCODE_TYPES_KEY: [.qr]])
+      scanner.setIsEnabled(true)
+      scanner.setIsEnabled(false)
+    }
+
+    #expect(leaked == nil)
   }
 }


### PR DESCRIPTION
# Why

When adding precompiled XCFramework for `expo-camera`, we had to change the method for including/excluding the ZXIng library that helps with some additional barcode scanner formats and issues than using the podspec as the gate at compile time. This was introduced in the PR #44766 released in SDK 55.0.16. 

There is an issue in this solution that will disable barcode scanning if the ZXIng library is not included, also the built-in use `AVFoundation` to scan regular barcodes. 

Fixes #44491

Note that #44491 covers two distinct bugs with the same symptom. The original report was a missing `Modules/module.modulemap` on the prebuilt `ZXingObjC` xcframework, which made `#if canImport(ZXingObjC)` false so the no-op stub was compiled — fixed in #44635 (55.0.15). #44766 replaced that whole mechanism six days later, and the reports resumed against the new companion-pod design. This PR fixes that second bug.

# How

BarcodeScanner returned early from `maybeStartBarcodeScanning()` and `addOutputs()` whenever `NSClassFromString("ExpoCameraZXingProvider")` resolved to nil - meaning that a missing `ExpoCameraBarcodeScanning` pod disabled every symbology — including QR codes, which `AVFoundation` handles on its own. ZXing only backs pdf417, code39 and codabar, so it is a fallback, not a prerequisite.

# Test Plan

New `packages/expo-camera/ios/Tests/BarcodeScannerTests.swift`, written before the fix and
confirmed failing against it. Run with `et native-unit-tests -p ios --packages expo-camera`
(iPhone 17 Pro simulator, iOS 26.5).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

