### PR TITLE
[core][iOS] Allow ExpoSwiftUI child collections to reconcile children using a string-based identity

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Removed Quick and Nimble in favor of Swift Testing. ([#48530](https://github.com/expo/expo/pull/48530) by [@tsapeta](https://github.com/tsapeta))
 - Migrated from deprecated react-native-worklets WorkletRuntime API `executeSync` to up-to-date `runSync`. `runSync` is available since 0.7.0. ([#48691](https://github.com/expo/expo/pull/48691) by [@tjzel](https://github.com/tjzel))
 - Added internal `ExpoModulesProviderModuleName` lookup key for `ExpoModulesProvider` class. ([#49539](https://github.com/expo/expo/pull/49539) by [@kudo](https://github.com/kudo))
+- [iOS] Allow ExpoSwiftUI child collections to reconcile children using a string-based identity. ([#49701](https://github.com/expo/expo/pull/49701) by [@jakex7](https://github.com/jakex7))
 
 ## 57.0.8 - 2026-07-29
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/AnyChild.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/AnyChild.swift
@@ -15,6 +15,21 @@ extension ExpoSwiftUI {
 
     // The underlying UIKit view, if this child wraps one. Returns `nil` for pure SwiftUI child.
     var uiView: UIView? { get }
+
+    // Identity used to reconcile child collections. Defaults to object identity.
+    var childIdentity: ExpoSwiftUI.ChildIdentity { get }
+  }
+
+  /**
+   An `AnyChild` that provides a string-based identity for child collections.
+   */
+  public protocol StringIdentityChild: AnyChild {
+    var stringIdentity: String? { get }
+  }
+
+  public enum ChildIdentity: Hashable {
+    case object(ObjectIdentifier)
+    case string(String)
   }
 }
 
@@ -29,5 +44,20 @@ public extension ExpoSwiftUI.AnyChild where Self == ChildViewType {
 
   var uiView: UIView? {
     nil
+  }
+}
+
+public extension ExpoSwiftUI.AnyChild {
+  var childIdentity: ExpoSwiftUI.ChildIdentity {
+    .object(id)
+  }
+}
+
+public extension ExpoSwiftUI.AnyChild where Self: ExpoSwiftUI.StringIdentityChild {
+  var childIdentity: ExpoSwiftUI.ChildIdentity {
+    if let stringIdentity {
+      return .string(stringIdentity)
+    }
+    return .object(id)
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -19,8 +19,8 @@ extension ExpoSwiftUIView {
    Returns React's children as SwiftUI views.
    */
   // swiftlint:disable:next identifier_name
-  public func Children() -> ForEach<[any ExpoSwiftUI.AnyChild], ObjectIdentifier, AnyView> {
-    ForEach(props.children ?? [], id: \.id) { child in
+  public func Children() -> ForEach<[any ExpoSwiftUI.AnyChild], ExpoSwiftUI.ChildIdentity, AnyView> {
+    ForEach(props.children ?? [], id: \.childIdentity) { child in
       let view: any View = child.childView
       AnyView(view)
     }
@@ -145,4 +145,3 @@ extension ExpoSwiftUI {
       } as [String]
     }
   }
-


### PR DESCRIPTION
# Why

Alternative approach to <https://github.com/expo/expo/pull/49244>
Expo widgets needs a way of keeping stable identity by string, not by reference.

# How

Add `ExpoSwiftUI.AnyChild.StringIdentity` protocol that provides a string-based identity.

# Test Plan

* CI should pass
* Tested SwiftUI views manually in Bare Expo.

# Checklist

* [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
* [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>