### PR TITLE
[ios][expo-go] Fix home screen for organization accounts

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -42,7 +42,6 @@ struct AccountQuery: Codable {
 struct AccountByName: Codable {
   let id: String
   let name: String
-  let ownerUserActor: UserActor
   let apps: [App]
   let snacks: [Snack]
   let appCount: Int

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
@@ -136,28 +136,6 @@ struct Queries {
         byName(accountName: $accountName) {
           id
           name
-          ownerUserActor {
-            __typename
-            id
-            username
-            firstName
-            lastName
-            profilePhoto
-            bestContactEmail
-            accounts {
-              id
-              name
-              profileImageUrl
-              ownerUserActor {
-                id
-                username
-                profilePhoto
-                firstName
-                fullName
-                lastName
-              }
-            }
-          }
           apps(limit: 5, offset: 0, includeUnpublished: true) {
             id
             name

--- a/apps/expo-go/ios/Tests/HomeScreenDataDecodingTests.swift
+++ b/apps/expo-go/ios/Tests/HomeScreenDataDecodingTests.swift
@@ -1,0 +1,34 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import XCTest
+@testable import Expo_Go
+
+final class HomeScreenDataDecodingTests: XCTestCase {
+  func testDecodesOrganizationAccountWithoutOwnerUserActor() throws {
+    let json = """
+    {"data":{"account":{"byName":{
+      "id":"acc-org",
+      "name":"myorg",
+      "ownerUserActor":null,
+      "apps":[{
+        "id":"app-1","name":"myapp","fullName":"@myorg/myapp",
+        "ownerAccount":{"name":"myorg"},
+        "firstTwoBranches":[]
+      }],
+      "snacks":[],
+      "appCount":1
+    }}}}
+    """
+    let data = try XCTUnwrap(json.data(using: .utf8))
+
+    let response = try JSONDecoder().decode(HomeScreenDataResponse.self, from: data)
+
+    XCTAssertEqual(response.data.account.byName.apps.count, 1)
+    XCTAssertEqual(response.data.account.byName.apps[0].fullName, "@myorg/myapp")
+    XCTAssertEqual(response.data.account.byName.appCount, 1)
+  }
+
+  func testHomeScreenQueryDoesNotSelectOwnerUserActor() {
+    XCTAssertFalse(Queries.getHomeScreenData().contains("ownerUserActor"))
+  }
+}


### PR DESCRIPTION
# Why
Closes #49695
Home showed "No projects yet" for every organization account. AccountByName.ownerUserActor was a non-optional UserActor, but the schema declares Account.ownerUserActor nullable and it is null for organizations. JSONDecoder rejected the whole response, the error was never rendered, and the section fell through to the empty state.

# How
The field was never read, so drop it from the model and from the home screen query instead of making it optional. This also removes a nested accounts selection from a query polled every 10 seconds.

# Test Plan

New HomeScreenDataDecodingTests decodes an organization payload with ownerUserActor: null and asserts the query no longer selects the field. Verified on device, switching between a personal and an organization account lists projects for both.
