### PR TITLE
[expo-go] Replace deprecated profilePhoto and runtimeVersion

### DIFF
--- a/apps/expo-go/android/expoview/src/main/graphql/fragments/CurrentUserActorData.fragment.graphql
+++ b/apps/expo-go/android/expoview/src/main/graphql/fragments/CurrentUserActorData.fragment.graphql
@@ -4,7 +4,7 @@ fragment CurrentUserActorData on UserActor {
   username
   firstName
   lastName
-  profilePhoto
+  primaryAccountProfileImageUrl
   bestContactEmail
   accounts {
     id
@@ -12,7 +12,7 @@ fragment CurrentUserActorData on UserActor {
     ownerUserActor {
       id
       username
-      profilePhoto
+      primaryAccountProfileImageUrl
       firstName
       fullName
       lastName

--- a/apps/expo-go/android/expoview/src/main/graphql/fragments/UpdateData.fragment.graphql
+++ b/apps/expo-go/android/expoview/src/main/graphql/fragments/UpdateData.fragment.graphql
@@ -3,7 +3,6 @@ fragment UpdateData on Update {
   group
   message
   createdAt
-  runtimeVersion
   expoGoSDKVersion
   platform
   manifestPermalink

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountHeaderAction.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountHeaderAction.kt
@@ -41,7 +41,7 @@ fun AccountHeaderAction(
 
   // Show account info
   AsyncImage(
-    model = account.ownerUserActor.profilePhoto,
+    model = account.ownerUserActor.primaryAccountProfileImageUrl,
     contentDescription = "Avatar",
     modifier = Modifier
       .size(24.dp)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/AccountScreen.kt
@@ -133,7 +133,7 @@ private fun AccountRow(
     icon = {
       if (owner != null) {
         AsyncImage(
-          model = owner.profilePhoto,
+          model = owner.primaryAccountProfileImageUrl,
           contentDescription = "Account icon",
           modifier = Modifier
             .size(24.dp)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
@@ -15,9 +15,12 @@ import host.exp.exponent.generated.ExponentBuildConstants
 import host.exp.exponent.graphql.BranchDetailsQuery
 import host.exp.exponent.graphql.BranchesForProjectQuery
 
-private fun isUpdateCompatible(sdkVersion: String?): Boolean {
+internal fun isSdkVersionCompatible(
+  sdkVersion: String?,
+  expoGoSdkVersion: String = ExponentBuildConstants.TEMPORARY_SDK_VERSION
+): Boolean {
   if (sdkVersion == null) return false
-  val expoGoMajorVersion = ExponentBuildConstants.TEMPORARY_SDK_VERSION.split(".").firstOrNull()
+  val expoGoMajorVersion = expoGoSdkVersion.split(".").firstOrNull()
   val updateMajorVersion = sdkVersion.split(".").firstOrNull()
   return expoGoMajorVersion != null && expoGoMajorVersion == updateMajorVersion
 }
@@ -43,10 +46,10 @@ private fun openUpdateManifestPermalink(
 private fun UpdateRowContents(
   message: String?,
   createdAt: String?,
-  runtimeVersion: String?,
+  sdkVersion: String?,
   omitCompatibility: Boolean
 ) {
-  val isCompatible = isUpdateCompatible(runtimeVersion)
+  val isCompatible = isSdkVersionCompatible(sdkVersion)
 
   Text(
     text = message ?: "No message",
@@ -73,7 +76,7 @@ fun UpdateRow(
   omitCompatibility: Boolean = false
 ) {
   val uriHandler = LocalUriHandler.current
-  val isCompatible = isUpdateCompatible(update.updateData.runtimeVersion)
+  val isCompatible = isSdkVersionCompatible(update.updateData.expoGoSDKVersion)
 
   val modifier = if (isCompatible) {
     Modifier.clickable {
@@ -89,7 +92,7 @@ fun UpdateRow(
     UpdateRowContents(
       message = update.updateData.message,
       createdAt = update.updateData.createdAt as? String,
-      runtimeVersion = update.updateData.runtimeVersion,
+      sdkVersion = update.updateData.expoGoSDKVersion,
       omitCompatibility = omitCompatibility
     )
   }
@@ -101,7 +104,7 @@ fun UpdateRow(
   omitCompatibility: Boolean = false
 ) {
   val uriHandler = LocalUriHandler.current
-  val isCompatible = isUpdateCompatible(update.updateData.runtimeVersion)
+  val isCompatible = isSdkVersionCompatible(update.updateData.expoGoSDKVersion)
 
   val modifier = if (isCompatible) {
     Modifier.clickable {
@@ -117,7 +120,7 @@ fun UpdateRow(
     UpdateRowContents(
       message = update.updateData.message,
       createdAt = update.updateData.createdAt as? String,
-      runtimeVersion = update.updateData.runtimeVersion,
+      sdkVersion = update.updateData.expoGoSDKVersion,
       omitCompatibility = omitCompatibility
     )
   }

--- a/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/home/UpdateCompatibilityTest.kt
+++ b/apps/expo-go/android/expoview/src/test/java/host/exp/exponent/home/UpdateCompatibilityTest.kt
@@ -1,0 +1,27 @@
+package host.exp.exponent.home
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UpdateCompatibilityTest {
+  @Test
+  fun matchingMajorIsCompatible() {
+    assertTrue(isSdkVersionCompatible("57.0.0", expoGoSdkVersion = "57.0.0"))
+  }
+
+  @Test
+  fun differentMajorIsNotCompatible() {
+    assertFalse(isSdkVersionCompatible("56.0.0", expoGoSdkVersion = "57.0.0"))
+  }
+
+  @Test
+  fun nullSdkVersionIsNotCompatible() {
+    assertFalse(isSdkVersionCompatible(null, expoGoSdkVersion = "57.0.0"))
+  }
+
+  @Test
+  fun runtimeVersionStringIsNotAnSdkVersion() {
+    assertFalse(isSdkVersionCompatible("exposdk:57.0.0", expoGoSdkVersion = "57.0.0"))
+  }
+}

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Models.swift
@@ -53,7 +53,7 @@ struct UserActor: Codable {
   let username: String
   let firstName: String?
   let lastName: String?
-  let profilePhoto: String?
+  let primaryAccountProfileImageUrl: String?
   let bestContactEmail: String?
   let accounts: [Account]
   let fullName: String?
@@ -64,7 +64,7 @@ struct UserActor: Codable {
     case username
     case firstName
     case lastName
-    case profilePhoto
+    case primaryAccountProfileImageUrl
     case bestContactEmail
     case accounts
     case fullName
@@ -88,7 +88,7 @@ struct Account: Codable {
 struct UserActorSimple: Codable {
   let id: String
   let username: String
-  let profilePhoto: String?
+  let primaryAccountProfileImageUrl: String?
   let firstName: String?
   let fullName: String?
   let lastName: String?
@@ -125,7 +125,6 @@ struct AppUpdate: Identifiable, Codable, Equatable {
   let group: String?
   let message: String?
   let createdAt: String
-  let runtimeVersion: String?
   let expoGoSDKVersion: String?
   let platform: String
   let manifestPermalink: String

--- a/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/GraphQL/Queries.swift
@@ -16,7 +16,7 @@ struct Queries {
           ownerUserActor {
             id
             username
-            profilePhoto
+            primaryAccountProfileImageUrl
             firstName
             fullName
             lastName
@@ -26,7 +26,7 @@ struct Queries {
           username
           firstName
           lastName
-          profilePhoto
+          primaryAccountProfileImageUrl
           bestContactEmail
         }
         ... on PartnerActor {
@@ -59,7 +59,6 @@ struct Queries {
                 group
                 message
                 createdAt
-                runtimeVersion
                 expoGoSDKVersion
                 platform
                 manifestPermalink
@@ -95,7 +94,6 @@ struct Queries {
               group
               message
               createdAt
-              runtimeVersion
               expoGoSDKVersion
               platform
               manifestPermalink
@@ -151,7 +149,6 @@ struct Queries {
                 group
                 message
                 createdAt
-                runtimeVersion
                 expoGoSDKVersion
                 platform
                 manifestPermalink
@@ -189,7 +186,6 @@ struct Queries {
               group
               message
               createdAt
-              runtimeVersion
               expoGoSDKVersion
               platform
               manifestPermalink
@@ -217,7 +213,6 @@ struct Queries {
               group
               message
               createdAt
-              runtimeVersion
               expoGoSDKVersion
               platform
               manifestPermalink

--- a/apps/expo-go/ios/Tests/ActorDecodingTests.swift
+++ b/apps/expo-go/ios/Tests/ActorDecodingTests.swift
@@ -23,7 +23,7 @@ final class ActorDecodingTests: XCTestCase {
     XCTAssertEqual(actor.typename, "PartnerActor")
     XCTAssertEqual(actor.username, "partner-private-test")
     XCTAssertNil(actor.firstName)
-    XCTAssertNil(actor.profilePhoto)
+    XCTAssertNil(actor.primaryAccountProfileImageUrl)
     XCTAssertNil(actor.bestContactEmail)
     XCTAssertEqual(actor.accounts.count, 1)
     XCTAssertEqual(actor.accounts[0].name, "partner-private-test")
@@ -38,10 +38,10 @@ final class ActorDecodingTests: XCTestCase {
       "username":"alanhughes",
       "firstName":"Alan",
       "lastName":"Hughes",
-      "profilePhoto":"https://example.test/a.png",
+      "primaryAccountProfileImageUrl":"https://example.test/a.png",
       "bestContactEmail":"alan@expo.dev",
       "accounts":[{"id":"acc-2","name":"alanhughes","profileImageUrl":"https://example.test/b.png",
-        "ownerUserActor":{"id":"actor-2","username":"alanhughes","profilePhoto":null,
+        "ownerUserActor":{"id":"actor-2","username":"alanhughes","primaryAccountProfileImageUrl":null,
           "firstName":"Alan","fullName":"Alan Hughes","lastName":"Hughes"}}]
     }}}
     """)
@@ -50,6 +50,7 @@ final class ActorDecodingTests: XCTestCase {
     XCTAssertEqual(actor.username, "alanhughes")
     XCTAssertEqual(actor.firstName, "Alan")
     XCTAssertEqual(actor.accounts[0].ownerUserActor?.username, "alanhughes")
+    XCTAssertEqual(actor.primaryAccountProfileImageUrl, "https://example.test/a.png")
   }
 
   func testDecodesNullActor() throws {
@@ -63,5 +64,10 @@ final class ActorDecodingTests: XCTestCase {
     XCTAssertTrue(query.contains("... on UserActor"))
     XCTAssertTrue(query.contains("... on PartnerActor"))
     XCTAssertFalse(query.contains("meUserActor"))
+  }
+
+  func testQueriesDoNotSelectDeprecatedProfilePhoto() {
+    XCTAssertFalse(Queries.getCurrentUser().contains("profilePhoto"))
+    XCTAssertTrue(Queries.getCurrentUser().contains("primaryAccountProfileImageUrl"))
   }
 }

--- a/apps/expo-go/ios/Tests/HomeScreenDataDecodingTests.swift
+++ b/apps/expo-go/ios/Tests/HomeScreenDataDecodingTests.swift
@@ -31,4 +31,16 @@ final class HomeScreenDataDecodingTests: XCTestCase {
   func testHomeScreenQueryDoesNotSelectOwnerUserActor() {
     XCTAssertFalse(Queries.getHomeScreenData().contains("ownerUserActor"))
   }
+
+  func testQueriesDoNotSelectDeprecatedRuntimeVersion() {
+    for query in [
+      Queries.getHomeScreenData(),
+      Queries.getProjectsList(),
+      Queries.getProjectDetails(),
+      Queries.getBranchesList(),
+      Queries.getBranchDetails()
+    ] {
+      XCTAssertFalse(query.contains("runtimeVersion"), query)
+    }
+  }
 }


### PR DESCRIPTION
# Why
Supersedes #47268

Two of the four deprecated GraphQL fields Expo Go still uses. User.profilePhoto is replaced by primaryAccountProfileImageUrl. Update.runtimeVersion is replaced by  runtime { version }. 

# How

Both platforms select primaryAccountProfileImageUrl. iOS never read runtimeVersion, so the selection is dropped. Android read it only in the update compatibility check, which split it on . and compared the first segment to the SDK major. Runtime versions for Expo Go projects look like exposdk:57.0.0, so that check could not match. It now uses expoGoSDKVersion, which the fragment already fetched and which iOS already uses.

# Test Plan
Expo go
ActorDecodingTests follow the rename.