### PR TITLE
[windows][cli] Fix browser-open crash/truncation when URL contains &

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix opening a browser on Windows (`expo login --browser`, `expo start`, etc.) crashing or opening a truncated URL when the target contains `&`, such as OAuth login URLs with multiple query parameters. `cmd.exe /c start` re-tokenizes its joined argument list as a single command line regardless of how the target is quoted, so any `&` in the URL is treated as a command separator; `spawnWindowsStartAsync` and the WSL browser-open path now use `powershell.exe`'s `Start-Process` instead, which isn't subject to the same class of bug.
 - Stop writing DOM component source maps into the app binary during `expo export:embed`, so Android release builds no longer ship `www.bundle` source maps with the original app source. ([#49480](https://github.com/expo/expo/pull/49480) by [@expo-bot](https://github.com/expo-bot))
 - Serve relative manifest URLs only when the client itself sends the RFC 7239 `Forwarded` header, so that proxied requests from clients without relative-URL support, like released Expo Go versions through the WS tunnel, keep absolute URLs. ([#48997](https://github.com/expo/expo/pull/48997) by [@expo-bot](https://github.com/expo-bot))
 - Fail when `--private-key-path` is passed without `updates.codeSigningCertificate` in the resolved app config, instead of ignoring the flag and continuing without signing.

--- a/packages/@expo/cli/src/utils/__tests__/open-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/open-test.ts
@@ -1,0 +1,67 @@
+import spawnAsync from '@expo/spawn-async';
+
+import { openBrowserAsync } from '../open';
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
+beforeEach(() => {
+  delete process.env.BROWSER;
+  delete process.env.BROWSER_ARGS;
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+describe('openBrowserAsync on Windows', () => {
+  it('opens a plain URL via powershell Start-Process instead of cmd.exe start', async () => {
+    setPlatform('win32');
+
+    // A real Expo CLI login URL shape - the `&` characters here are exactly what broke
+    // the old `cmd.exe /c start` implementation, since cmd.exe treats an unquoted `&`
+    // as a command separator no matter how the target argument itself was quoted.
+    const target =
+      'https://expo.dev/login?client_id=expo-cli&redirect_uri=http://localhost:8081/auth/callback&state=abc123';
+
+    await openBrowserAsync(target);
+
+    expect(spawnAsync).toHaveBeenCalledTimes(1);
+    const [command, args] = jest.mocked(spawnAsync).mock.calls[0]!;
+    expect(command).toMatch(/powershell\.exe$/i);
+    expect(command).not.toMatch(/cmd\.exe$/i);
+    // The URL must survive completely intact as a single argument value - not split on `&`.
+    expect(args).toContain('-Command');
+    const psCommand = (args as string[]).find((arg) => arg.includes('Start-Process'));
+    expect(psCommand).toBe(`Start-Process -FilePath '${target}'`);
+  });
+
+  it('quotes a literal single quote in the URL so it cannot break out of the PowerShell string', async () => {
+    setPlatform('win32');
+    const target = "https://example.com/?name=O'Brien";
+
+    await openBrowserAsync(target);
+
+    const [, args] = jest.mocked(spawnAsync).mock.calls[0]!;
+    const psCommand = (args as string[]).find((arg) => arg.includes('Start-Process'));
+    expect(psCommand).toBe("Start-Process -FilePath 'https://example.com/?name=O''Brien'");
+  });
+
+  it('routes the target through a BROWSER override app, forwarding BROWSER_ARGS ahead of it', async () => {
+    setPlatform('win32');
+    process.env.BROWSER = 'C:\\Program Files\\Firefox\\firefox.exe';
+    process.env.BROWSER_ARGS = '-private -foreground';
+    const target = 'https://expo.dev/login?a=1&b=2';
+
+    await openBrowserAsync(target);
+
+    const [, args] = jest.mocked(spawnAsync).mock.calls[0]!;
+    const psCommand = (args as string[]).find((arg) => arg.includes('Start-Process'));
+    expect(psCommand).toBe(
+      "Start-Process -FilePath 'C:\\Program Files\\Firefox\\firefox.exe' -ArgumentList '-private','-foreground','https://expo.dev/login?a=1&b=2'"
+    );
+  });
+});

--- a/packages/@expo/cli/src/utils/open.ts
+++ b/packages/@expo/cli/src/utils/open.ts
@@ -156,18 +156,49 @@ export async function openBrowserAsync(target: string): Promise<boolean> {
     return true;
   }
 
-  // WSL: when the user hasn't overridden BROWSER, route through Windows `cmd.exe` so
+  // WSL: when the user hasn't overridden BROWSER, route through Windows PowerShell so
   // the URL opens in the user's Windows browser. Falls through to `xdg-open` otherwise.
   if (!browserApp && isWsl()) {
-    await spawnAsync('/mnt/c/Windows/System32/cmd.exe', ['/c', 'start', '""', target], {
-      stdio: 'ignore',
-    });
+    await spawnAsync(
+      '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+      buildStartProcessArgs(target, undefined, []),
+      { stdio: 'ignore' }
+    );
     return true;
   }
 
   const command = browserApp ?? 'xdg-open';
   await spawnAsync(command, [...browserArgs, target], { stdio: 'ignore' });
   return true;
+}
+
+/** Escapes a value for safe interpolation inside a PowerShell single-quoted string literal. */
+function escapePowerShellSingleQuoted(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Builds the `powershell.exe` argv that opens `target` via `Start-Process`, optionally through
+ * a specific `browserApp` with `browserArgs`.
+ *
+ * Deliberately not `cmd.exe /c start`: `cmd.exe`'s `/c` flag re-tokenizes its entire argument
+ * list as a single command line, so any shell metacharacter in the URL - most commonly `&` in a
+ * query string - gets treated as a command separator no matter how the target argument itself is
+ * quoted. That silently truncates the URL (opening a broken partial one) and then crashes the
+ * whole process when the leftover fragments fail to run as bogus commands. `Start-Process`
+ * receives its `-FilePath`/`-ArgumentList` as genuine parameter values instead of reparsing a
+ * joined string, so it isn't subject to the same class of bug.
+ */
+function buildStartProcessArgs(
+  target: string,
+  browserApp: string | undefined,
+  browserArgs: string[]
+): string[] {
+  const quote = (value: string) => `'${escapePowerShellSingleQuoted(value)}'`;
+  const psCommand = browserApp
+    ? `Start-Process -FilePath ${quote(browserApp)} -ArgumentList ${[...browserArgs, target].map(quote).join(',')}`
+    : `Start-Process -FilePath ${quote(target)}`;
+  return ['-NoProfile', '-NonInteractive', '-Command', psCommand];
 }
 
 async function spawnWindowsStartAsync(
@@ -177,13 +208,16 @@ async function spawnWindowsStartAsync(
 ): Promise<void> {
   // Windows preserves env var case in Node, but the OS variable is `SystemRoot`.
   const systemRoot = process.env.SYSTEMROOT ?? process.env.SystemRoot ?? 'C:\\Windows';
-  const cmd = path.join(systemRoot, 'System32', 'cmd.exe');
-  // `start ""` — the empty quoted string is the window title, so the URL isn't
-  // interpreted as a title argument.
-  const startArgs = ['/c', 'start', '""'];
-  if (browserApp) startArgs.push(browserApp);
-  startArgs.push(target, ...browserArgs);
-  await spawnAsync(cmd, startArgs, { stdio: 'ignore' });
+  const powershell = path.join(
+    systemRoot,
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  );
+  await spawnAsync(powershell, buildStartProcessArgs(target, browserApp, browserArgs), {
+    stdio: 'ignore',
+  });
 }
 
 function isWsl(): boolean {


### PR DESCRIPTION
## Summary

`spawnWindowsStartAsync` (used by `expo login --browser`, `expo start`, and anything else that opens a browser on Windows) spawns `cmd.exe /c start "" <url>` with the target URL pushed as an **unquoted** argument.

`cmd.exe`'s `/c` flag re-tokenizes its entire argument list as a single command line, so any unquoted `&` in the URL's query string is treated as a command separator. This affects essentially every Expo OAuth/login URL, since they always carry multiple `&`-separated query params (`client_id`, `redirect_uri`, `code_challenge`, `state`, ...).

In practice this:
1. Opens a **truncated** URL (everything up to the first `&`) in the browser instead of the real one, so the OAuth flow is missing `redirect_uri`/`code_challenge`/`state`.
2. Then **crashes the whole CLI process** with an uncaught error, because the leftover fragments (e.g. `redirect_uri=http://localhost:PORT/auth/callback`) get executed as bogus commands and return a non-zero exit code, which `spawnAsync` throws on.

Quoting only the target argument does **not** fix this — `cmd.exe /c` re-tokenizes the joined line regardless of how any single argument was quoted, so the same crash still happens even with a fully-quoted URL.

The WSL browser-open path (`isWsl()` branch) has the identical issue, invoking `cmd.exe` via the `/mnt/c` interop path with the same unquoted target.

## Fix

Replaced both call sites with `powershell.exe`'s `Start-Process`, invoked directly (no `cmd.exe` involved at all). A normal Win32 executable like `powershell.exe` receives its argv elements as genuine discrete parameter values — `-FilePath`/`-ArgumentList` — instead of `cmd.exe /c` reparsing a joined command-line string for shell metacharacters, so this class of bug can't happen regardless of what characters the URL contains.

Extracted the shared PowerShell-argument-building logic into `buildStartProcessArgs`, with a small helper to correctly escape a literal single quote inside a PowerShell single-quoted string literal (`'` → `''`).

## Test plan

- **Repro'd against a real failure**: hit this exact crash running `expo login --browser` on Windows 11 with a real `expo.dev/login?...` URL (multiple `&`-separated params) — confirmed the browser opened a truncated URL and the CLI crashed with the reported error before the fix, and completes the login correctly after.
- **Added `src/utils/__tests__/open-test.ts`** (3 tests, all passing):
  - A URL with multiple `&`-separated query params reaches `Start-Process` fully intact as a single argument value, and `powershell.exe` (not `cmd.exe`) is the spawned command.
  - A URL containing a literal single quote is escaped correctly so it can't break out of the PowerShell string.
  - `BROWSER`/`BROWSER_ARGS` overrides still route through a specific browser app, with args forwarded ahead of the target, matching the previous behavior.
- Ran `pnpm test`, `pnpm lint` (oxlint), and `pnpm format --check` for `packages/@expo/cli` — all clean.
- Ran `pnpm typecheck` for the package — pre-existing, unrelated errors only (missing type declarations for other workspace packages not linked in my local checkout); zero errors in `open.ts` or the new test file.
