### PR TITLE
[core][Android] Apply Expo Modules v2 plugin automatically

### DIFF
--- a/apps/bare-expo/modules/expo-v2-demo/android/build.gradle
+++ b/apps/bare-expo/modules/expo-v2-demo/android/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+group = 'host.exp.exponent'
+version = '1.0.0'
+
+expoModule {
+  canBePublished false
+  v2 true
+}
+
+android {
+  namespace "expo.modules.v2demo"
+  defaultConfig {
+    versionCode 1
+    versionName '1.0.0'
+  }
+}

--- a/apps/bare-expo/modules/expo-v2-demo/android/src/main/java/expo/modules/v2demo/ExpoV2Demo.kt
+++ b/apps/bare-expo/modules/expo-v2-demo/android/src/main/java/expo/modules/v2demo/ExpoV2Demo.kt
@@ -1,0 +1,20 @@
+package expo.modules.v2demo
+
+import io.github.expo.modules.v2.annotations.JS
+import io.github.expo.modules.v2.annotations.Record
+import io.github.expo.modules.v2.modules.Module
+
+@Record
+data class Point(val x: Int, val y: Int)
+
+@JS
+object ExpoV2Demo : Module() {
+  @JS
+  fun add(a: Int, b: Int): Int = a + b
+
+  @JS
+  fun greet(name: String): String = "hello $name from Expo Modules v2"
+
+  @JS
+  fun translate(point: Point, dx: Int, dy: Int): Point = Point(point.x + dx, point.y + dy)
+}

--- a/apps/bare-expo/modules/expo-v2-demo/expo-module.config.json
+++ b/apps/bare-expo/modules/expo-v2-demo/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["android"],
+  "android": {
+    "modulesV2": ["expo.modules.v2demo.ExpoV2Demo"]
+  }
+}

--- a/apps/bare-expo/modules/expo-v2-demo/package.json
+++ b/apps/bare-expo/modules/expo-v2-demo/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "expo-v2-demo",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Demo module written against the Expo Modules API v2, to exercise v2 autolinking",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "homepage": "https://expo.dev",
+  "author": "650 Industries, Inc.",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "expo": "workspace:*",
+    "react": "*",
+    "react-native": "*"
+  }
+}

--- a/apps/bare-expo/modules/expo-v2-demo/src/index.ts
+++ b/apps/bare-expo/modules/expo-v2-demo/src/index.ts
@@ -1,0 +1,11 @@
+export type Point = { x: number; y: number };
+
+export type ExpoV2DemoModule = {
+  add(a: number, b: number): number;
+  greet(name: string): string;
+  translate(point: Point, dx: number, dy: number): Point;
+};
+
+export function getExpoV2Demo(): ExpoV2DemoModule | null {
+  return (globalThis as any).expoV2?.modules?.ExpoV2Demo ?? null;
+}

--- a/apps/bare-expo/tsconfig.json
+++ b/apps/bare-expo/tsconfig.json
@@ -6,6 +6,7 @@
     "paths": {
       "ThemeProvider": ["../common/ThemeProvider"],
       "benchmark-helper": ["./modules/benchmark-helper"],
+      "expo-v2-demo": ["./modules/expo-v2-demo"],
       "benchmarking": ["./modules/benchmarking"],
       "worklets-tester": ["./modules/worklets-tester"],
       "test-expo-ui": ["./modules/test-expo-ui"]

--- a/apps/native-component-list/src/screens/ModulesCore/ExpoModulesV2Screen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ExpoModulesV2Screen.tsx
@@ -1,0 +1,47 @@
+import { getExpoV2Demo } from 'expo-v2-demo';
+import { ScrollView, StyleSheet } from 'react-native';
+
+import HeadingText from '../../components/HeadingText';
+import MonoText from '../../components/MonoText';
+
+function describeExpoV2Demo(): string {
+  const demo = getExpoV2Demo();
+  if (!demo) {
+    return 'expoV2.modules.ExpoV2Demo is not installed';
+  }
+
+  try {
+    const point = demo.translate({ x: 1, y: 2 }, 10, 20);
+
+    return [
+      `add(2, 3) = ${demo.add(2, 3)}`,
+      `greet('native-component-list') = ${demo.greet('native-component-list')}`,
+      `translate({ x: 1, y: 2 }, 10, 20) = { x: ${point.x}, y: ${point.y} }`,
+    ].join('\n');
+  } catch (error: any) {
+    return `failed: ${error?.message ?? String(error)}`;
+  }
+}
+
+export default function ExpoModulesV2Screen() {
+  return (
+    <ScrollView style={styles.scrollView}>
+      <HeadingText>ExpoV2Demo</HeadingText>
+      <MonoText>{describeExpoV2Demo()}</MonoText>
+
+      <HeadingText>Runtime globals</HeadingText>
+      <MonoText>
+        {[
+          `typeof expoV2.modules = ${typeof (globalThis as any).expoV2?.modules}`,
+          `typeof expo.modules = ${typeof (globalThis as any).expo?.modules}`,
+        ].join('\n')}
+      </MonoText>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    padding: 10,
+  },
+});

--- a/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/ModulesCoreScreen.tsx
@@ -1,4 +1,5 @@
 import { isRunningInExpoGo } from 'expo';
+import { Platform } from 'react-native';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { apiScreensToListElements } from '../ComponentListScreen';
@@ -26,6 +27,16 @@ export const ModulesCoreScreens = [
     },
   },
 ];
+
+if (Platform.OS === 'android') {
+  ModulesCoreScreens.push({
+    name: 'Expo modules v2',
+    route: 'modulescore/expo-modules-v2',
+    getComponent() {
+      return optionalRequire(() => require('./ExpoModulesV2Screen'));
+    },
+  });
+}
 
 if (!isRunningInExpoGo()) {
   ModulesCoreScreens.push({

--- a/apps/native-component-list/tsconfig.json
+++ b/apps/native-component-list/tsconfig.json
@@ -10,6 +10,7 @@
     "paths": {
       "ThemeProvider": ["../common/ThemeProvider"],
       "benchmarking": ["../bare-expo/modules/benchmarking"],
+      "expo-v2-demo": ["../bare-expo/modules/expo-v2-demo"],
       "worklets-tester": ["../bare-expo/modules/worklets-tester"],
       "test-expo-ui": ["../bare-expo/modules/test-expo-ui"]
     },

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -78,7 +78,7 @@ if (workletsProject != null) {
 
 def reactNativeWorkletsRootDir = workletsProject?.projectDir?.parentFile
 
-def expoModulesV2Version = "0.1.1"
+def expoModulesV2Version = "0.1.2"
 
 configurations {
   // Artifact-only: the C++ sources, not something to put on any classpath.

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
   implementation("io.github.expo.pika:pika-gradle:1.0.0")
+  implementation("io.github.expo:expo-modules-v2-gradle-plugin:0.1.2")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -29,6 +29,10 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
       extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl {
         configurePika(shouldBeEnabled = expoModuleExtension.enableCompileTimeOptimization)
 
+        if (expoModuleExtension.v2) {
+          applyExpoModulesV2Plugin()
+        }
+
         applyPublishing(expoModuleExtension)
       }
     }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -40,6 +40,10 @@ internal fun Project.applyPikaPlugin() {
   pika.introspectableAnnotation("expo.modules.kotlin.views.OptimizedComposeProps")
 }
 
+internal fun Project.applyExpoModulesV2Plugin() {
+  applyPluginIfNeeded("io.github.expo.modules.v2")
+}
+
 private fun Project.applyPluginIfNeeded(id: String) {
   if (!plugins.hasPlugin(id)) {
     plugins.apply(id)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -46,6 +46,8 @@ open class ExpoModuleExtension(val project: Project) {
 
   var canBePublished: Boolean = true
 
+  var v2: Boolean = false
+
   var enableCompileTimeOptimization: Boolean =
     findBoolProperty("expo.enableCompileTimeOptimization", default = true)
 


### PR DESCRIPTION
# Why

Automatically applies the Expo Modules v2 plugin to packages with v2 set to true.

# How

- Introduced `expoModule { v2 = true }`
- Applied `io.github.expo.modules.v2` compiler plugin automatically. 
- Added module example 

# Test Plan

- NCL ✅ 
