### PR TITLE
[JSI][iOS] Create deferred promises from a cached JS closure

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [iOS] Made passing strings between JavaScript and Swift faster, up to ~3.8× for long strings. ([#49678](https://github.com/expo/expo/pull/49678) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Values returned to Swift from property reads, array reads and function calls are now taken over instead of cloned through the engine, making `toJavaScriptValue(in:)` ~1.16× faster. ([#49688](https://github.com/expo/expo/pull/49688) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made decoding non-ASCII JS strings up to 512 UTF-16 code units long ~1.5× faster. ([#49691](https://github.com/expo/expo/pull/49691) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Made creating a deferred `JavaScriptPromise` ~1.2× faster by building it from a cached JavaScript closure instead of a host function executor. ([#49714](https://github.com/expo/expo/pull/49714) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Benchmarks/PromiseBenchmarks.swift
+++ b/packages/expo-modules-jsi/apple/Benchmarks/PromiseBenchmarks.swift
@@ -1,0 +1,43 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+import Testing
+
+/// Benchmarks for creating and settling deferred promises from Swift. The engine floor is measured
+/// from JavaScript for comparison, so the wrapper's own overhead can be read off directly.
+extension JSIBenchmarks {
+  @Test
+  func `engine floor: new Promise from JavaScript`() async throws {
+    try await benchmarkCase { runtime in
+      let driver = try runtime.eval(
+        "(function(n) { for (var i = 0; i < n; i++) new Promise(function (a, b) {}); })"
+      ).getFunction()
+      try benchmark("engine floor: new Promise from JS", runtime: runtime) { iterations in
+        _ = try driver.call(arguments: iterations)
+      }
+    }
+  }
+
+  @Test
+  func `create deferred promise`() async throws {
+    try await benchmarkCase { runtime in
+      try benchmark("JavaScriptPromise(runtime): create deferred", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          _ = try JavaScriptPromise(runtime)
+        }
+      }
+    }
+  }
+
+  @Test
+  func `create and resolve deferred promise`() async throws {
+    try await benchmarkCase { runtime in
+      try benchmark("JavaScriptPromise(runtime): create and resolve", runtime: runtime) { iterations in
+        for _ in 0..<iterations {
+          let promise = try JavaScriptPromise(runtime)
+          promise.resolve(42.0)
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -133,6 +133,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     // when the last reference is gone. `deinit` is `nonisolated`, so it can touch the actor-isolated
     // registry directly given that exclusive access.
     propNameIdsRegistry.removeAll()
+    cachedDeferredPromiseFactory = nil
     expo.destroyRuntime(runtimePointee)
   }
 
@@ -733,6 +734,13 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
   @JavaScriptActor
   internal var propNameIdsRegistry: [String: JavaScriptPropNameID] = [:]
 
+  // MARK: - Deferred promise factory
+
+  /// The JavaScript function ``JavaScriptPromise`` uses to create deferred promises, built on first
+  /// use and released with the runtime. See `JavaScriptPromise.init(_:)` for why it exists.
+  @JavaScriptActor
+  internal var cachedDeferredPromiseFactory: JavaScriptValue?
+
   // MARK: - Long-lived objects
 
   /// Registry of JSI objects (such as in-flight promises) that must outlive the native call that
@@ -763,11 +771,12 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
         // hop back to the JavaScript thread first.
         JavaScriptActor.assumeIsolated {
           longLivedObjects.clear()
-          // Also flush the cached `jsi::PropNameID`s: a non-owning wrapper can outlive its runtime
-          // (e.g. captured by a task abandoned on reload) and would otherwise destroy them against
-          // the freed runtime when it deallocates. `self` is weak so the teardown object doesn't
-          // retain the wrapper; the owning wrapper clears its own registry in `deinit`.
+          // Also flush the cached `jsi::PropNameID`s and the deferred-promise factory: a non-owning
+          // wrapper can outlive its runtime (e.g. captured by a task abandoned on reload) and would
+          // otherwise destroy them against the freed runtime when it deallocates. `self` is weak so
+          // the teardown object doesn't retain the wrapper; the owning wrapper clears both in `deinit`.
           self?.propNameIdsRegistry.removeAll()
+          self?.cachedDeferredPromiseFactory = nil
         }
       }
       let object = createObject()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -80,19 +80,15 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
 
-    // Create function that is the promise setup. It is called immediately on `callAsConstructor`.
-    let setup = runtime.createFunction { [weak longLivedState] this, arguments in
-      longLivedState?.resolveFunction.reset(arguments[0])
-      longLivedState?.rejectFunction.reset(arguments[1])
-      return .undefined
-    }
-
-    let object =
-      try runtime
-      .global()
-      .getPropertyAsFunction(.cached(runtime, "Promise"))
-      .callAsConstructor(setup.asValue())
-    longLivedState.object.reset(object)
+    // The promise and its two settle functions come from a JavaScript closure that returns all three
+    // at once, rather than from `new Promise(executor)` with a host function as the executor. The
+    // host function route costs a native function and a Swift context object per promise, a re-entry
+    // from the engine into Swift while the constructor runs, and an owning copy of each settle
+    // function on the way back. The closure route is one JS call and three array reads.
+    let triple = try runtime.deferredPromiseFactory().getFunction().call().getArray()
+    longLivedState.object.reset(try triple.getValue(at: 0))
+    longLivedState.resolveFunction.reset(try triple.getValue(at: 1))
+    longLivedState.rejectFunction.reset(try triple.getValue(at: 2))
     try setUpCallbacks()
     // Register only after setup succeeds, so a failed initializer (e.g. `then` unavailable) doesn't
     // leave the state pinned in the collection until teardown. Owns the promise's JSI values from
@@ -253,5 +249,31 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
         onRejected.asValue()
       )
     }
+  }
+}
+
+// MARK: - Deferred promise factory
+
+extension JavaScriptRuntime {
+  /// Returns the cached `() => [promise, resolve, reject]` function as a value, creating it on first use.
+  /// Evaluated from source so it captures nothing native; it is plain JavaScript the engine can
+  /// optimize like any other closure.
+  @JavaScriptActor
+  fileprivate func deferredPromiseFactory() throws -> JavaScriptValue {
+    if let factory = cachedDeferredPromiseFactory {
+      return factory
+    }
+    let factory = try eval(
+      label: "expo-modules-jsi/deferred-promise.js",
+      """
+      (function () {
+        let resolve, reject;
+        const promise = new Promise(function (a, b) { resolve = a; reject = b; });
+        return [promise, resolve, reject];
+      })
+      """
+    )
+    cachedDeferredPromiseFactory = factory
+    return factory
   }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -23,6 +23,32 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
+  func `deferred promises from separate runtimes settle independently`() async throws {
+    let first = JavaScriptRuntime()
+    let second = JavaScriptRuntime()
+    let firstPromise = try JavaScriptPromise(first)
+    let secondPromise = try JavaScriptPromise(second)
+    firstPromise.resolve(1.0)
+    secondPromise.resolve(2.0)
+    #expect(try await firstPromise.await().getDouble() == 1.0)
+    #expect(try await secondPromise.await().getDouble() == 2.0)
+  }
+
+  @Test
+  func `creating many deferred promises reuses one runtime-level helper`() throws {
+    let runtime = JavaScriptRuntime()
+    for _ in 0..<1_000 {
+      let promise = try JavaScriptPromise(runtime)
+      promise.resolve(42.0)
+    }
+    // The only object the wrapper may leave on `globalThis` is the long-lived-objects anchor; a
+    // per-promise helper leaking into the global scope would show up as extra own properties.
+    let ownGlobals = try runtime.eval("Object.getOwnPropertyNames(globalThis).length").getInt()
+    let freshGlobals = try JavaScriptRuntime().eval("Object.getOwnPropertyNames(globalThis).length").getInt()
+    #expect(ownGlobals - freshGlobals <= 1)
+  }
+
+  @Test
   func `deferred promise construction throws when Promise constructor is unavailable`() throws {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.Promise = undefined")


### PR DESCRIPTION
# Why

Creating a deferred `JavaScriptPromise` went through `new Promise(executor)` with a host function as the executor. Per promise that meant a native function and a Swift context object for the executor, a re-entry from the engine into Swift while the constructor ran, and an owning copy of each settle function on the way back out. The engine itself makes a promise in about 100 ns; the wrapper took 2.5 µs.

# How

The promise and its two settle functions now come from a small JavaScript closure, `() => [promise, resolve, reject]`, evaluated once per runtime and cached on it. Creating a deferred promise is one JS call and three array reads. This is the same approach the Android side takes in `AsyncRuntimeState`. The cached function is released with the runtime, and for a non-owning wrapper it is flushed by the same teardown sweep that flushes the cached PropNameIDs, so a wrapper outliving its runtime never destroys it against freed memory.

The eager `then` wiring in `setUpCallbacks()` is unchanged and is now most of what remains; making it lazy is a separate change.

# Test Plan

Existing promise tests pass, including the non-owning-wrapper teardown test, which caught the cache not being swept in the first version. Two tests were added: promises from separate runtimes settle independently, and creating many deferred promises leaves no per-promise helper behind on `globalThis`. `pnpm test:integration` passes on the full target.

New benchmarks in `PromiseBenchmarks.swift`, median ns/op from `pnpm benchmark` (Mac Catalyst, Release):

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| engine floor: `new Promise` from JS | 104 | 99 | reference |
| `JavaScriptPromise(runtime)`: create deferred | 2517 | 2035 | 1.24x |
| `JavaScriptPromise(runtime)`: create and resolve | 5184 | 4703 | 1.10x |
