### PR TITLE
[android][navigation-bar] Restore the navigation bar when a hidden NavigationBar unmounts

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Prevent unhandled promise rejections when declarative navigation bar updates race with Android activity teardown. ([#48097](https://github.com/expo/expo/pull/48097) by [@zoontek](https://github.com/zoontek))
+- [Android] Fixed unmounting a `NavigationBar` component with `hidden` not restoring the navigation bar. ([#49715](https://github.com/expo/expo/pull/49715) by [@harshasiddartha](https://github.com/harshasiddartha))
 
 ### 💡 Others
 

--- a/packages/expo-navigation-bar/package.json
+++ b/packages/expo-navigation-bar/package.json
@@ -50,6 +50,7 @@
     "debug": "^4.3.2"
   },
   "devDependencies": {
+    "@testing-library/react-native": "^13.3.0",
     "@types/debug": "^4.1.7",
     "@types/jest": "^29.2.1",
     "@types/node": "^22.14.0",

--- a/packages/expo-navigation-bar/src/NavigationBar.android.ts
+++ b/packages/expo-navigation-bar/src/NavigationBar.android.ts
@@ -34,20 +34,18 @@ const defaultProps: Required<NavigationBarProps> = {
   hidden: false,
 };
 
-// Merges the entries stack
-function mergeEntriesStack(entriesStack: NavigationBarProps[]) {
-  return entriesStack.reduce<{
-    style: NavigationBarStyle | undefined;
-    hidden: boolean | undefined;
-  }>(
+// Merges the entries stack over the default values, so that a key that no mounted entry
+// specifies falls back to the default instead of being left at whatever was applied last.
+function mergeEntriesStack(
+  entriesStack: NavigationBarProps[],
+  defaultValues: Required<NavigationBarProps>
+): Required<NavigationBarProps> {
+  return entriesStack.reduce<Required<NavigationBarProps>>(
     (prev, cur) => ({
       style: cur.style ?? prev.style,
       hidden: cur.hidden ?? prev.hidden,
     }),
-    {
-      style: undefined,
-      hidden: undefined,
-    }
+    { ...defaultValues }
   );
 }
 
@@ -70,9 +68,9 @@ const currentValues: {
   hidden: undefined,
 };
 
-export function setStyle(style: NavigationBarStyle) {
-  defaultProps.style = style;
-
+// Applies the values to the native module. These must not touch `defaultProps`, otherwise
+// mounting a component would overwrite the defaults that seed the merge.
+function applyStyle(style: NavigationBarStyle) {
   const resolvedStyle = resolveStyle(style);
 
   if (resolvedStyle !== currentValues.style) {
@@ -81,13 +79,21 @@ export function setStyle(style: NavigationBarStyle) {
   }
 }
 
-function setHidden(hidden: boolean) {
-  defaultProps.hidden = hidden;
-
+function applyHidden(hidden: boolean) {
   if (hidden !== currentValues.hidden) {
     currentValues.hidden = hidden;
     ExpoNavigationBar.setHidden(hidden).catch(() => {});
   }
+}
+
+export function setStyle(style: NavigationBarStyle) {
+  defaultProps.style = style;
+  applyStyle(style);
+}
+
+function setHidden(hidden: boolean) {
+  defaultProps.hidden = hidden;
+  applyHidden(hidden);
 }
 
 // Updates the native navigation bar with the entries from the stack
@@ -97,19 +103,10 @@ function updateEntriesStack() {
   }
 
   updateImmediate = setImmediate(() => {
-    if (entriesStack.length === 0) {
-      setStyle(defaultProps.style);
-      setHidden(defaultProps.hidden);
-    } else {
-      const { style, hidden } = mergeEntriesStack(entriesStack);
+    const { style, hidden } = mergeEntriesStack(entriesStack, defaultProps);
 
-      if (style != null) {
-        setStyle(style);
-      }
-      if (hidden != null) {
-        setHidden(hidden);
-      }
-    }
+    applyStyle(style);
+    applyHidden(hidden);
   });
 }
 

--- a/packages/expo-navigation-bar/src/__tests__/NavigationBar-test.android.tsx
+++ b/packages/expo-navigation-bar/src/__tests__/NavigationBar-test.android.tsx
@@ -1,0 +1,103 @@
+import type { render as renderComponent } from '@testing-library/react-native/pure';
+
+import type ExpoNavigationBar from '../ExpoNavigationBar';
+import type { NavigationBar as NavigationBarComponent } from '../NavigationBar';
+
+jest.mock('../ExpoNavigationBar', () => ({
+  __esModule: true,
+  default: {
+    setStyle: jest.fn(() => Promise.resolve()),
+    setHidden: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+// The entries stack, the defaults and the last values sent to the native module are module-level
+// state, so every case loads its own copy of the module registry to stay independent from the
+// others. `render` is loaded from that same copy because the component and the renderer have to
+// share one instance of React; it comes from the `pure` entry point because the default one
+// registers an `afterEach` cleanup hook, which Jest does not allow from inside a test.
+function loadNavigationBar() {
+  let modules!: {
+    render: typeof renderComponent;
+    NavigationBar: typeof NavigationBarComponent;
+    native: jest.Mocked<typeof ExpoNavigationBar>;
+  };
+
+  jest.isolateModules(() => {
+    modules = {
+      render: require('@testing-library/react-native/pure').render,
+      NavigationBar: require('../NavigationBar').NavigationBar,
+      native: require('../ExpoNavigationBar').default,
+    };
+  });
+
+  return modules;
+}
+
+describe('NavigationBar', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('restores the navigation bar when a component with `hidden` unmounts', () => {
+    const { render, NavigationBar, native } = loadNavigationBar();
+
+    const { unmount } = render(<NavigationBar hidden />);
+    jest.runAllTimers();
+    expect(native.setHidden).toHaveBeenLastCalledWith(true);
+
+    unmount();
+    jest.runAllTimers();
+    expect(native.setHidden).toHaveBeenLastCalledWith(false);
+  });
+
+  it('restores the default style when a component with `style` unmounts', () => {
+    const { render, NavigationBar, native } = loadNavigationBar();
+
+    const { unmount } = render(<NavigationBar style="dark" />);
+    jest.runAllTimers();
+    expect(native.setStyle).toHaveBeenLastCalledWith('dark');
+
+    unmount();
+    jest.runAllTimers();
+    expect(native.setStyle).toHaveBeenLastCalledWith('light');
+  });
+
+  it('restores the navigation bar when a component with `hidden` unmounts and another stays mounted', () => {
+    const { render, NavigationBar, native } = loadNavigationBar();
+
+    // The documented multi-screen pattern: a long-lived bar at the app root and a screen that
+    // hides the bar while it is on screen.
+    render(<NavigationBar style="dark" />);
+    const screen = render(<NavigationBar hidden />);
+    jest.runAllTimers();
+    expect(native.setStyle).toHaveBeenLastCalledWith('dark');
+    expect(native.setHidden).toHaveBeenLastCalledWith(true);
+
+    screen.unmount();
+    jest.runAllTimers();
+    // The remaining entry does not specify `hidden`, so the default has to be restored, while
+    // the style it does specify stays applied.
+    expect(native.setHidden).toHaveBeenLastCalledWith(false);
+    expect(native.setStyle).toHaveBeenLastCalledWith('dark');
+  });
+
+  it('restores the value set with `NavigationBar.setHidden` when a component unmounts', () => {
+    const { render, NavigationBar, native } = loadNavigationBar();
+
+    NavigationBar.setHidden(true);
+    expect(native.setHidden).toHaveBeenLastCalledWith(true);
+
+    const { unmount } = render(<NavigationBar hidden={false} />);
+    jest.runAllTimers();
+    expect(native.setHidden).toHaveBeenLastCalledWith(false);
+
+    unmount();
+    jest.runAllTimers();
+    expect(native.setHidden).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5297,6 +5297,9 @@ importers:
         specifier: 0.87.0
         version: 0.87.0(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3)
     devDependencies:
+      '@testing-library/react-native':
+        specifier: ^13.3.0
+        version: 13.3.3(jest@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.20.1)(typescript@6.0.3)))(react-native@0.87.0(@babel/core@7.29.7)(@react-native/metro-config@0.87.0(@babel/core@7.29.7))(@types/react@19.2.14)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/debug':
         specifier: ^4.1.7
         version: 4.1.12


### PR DESCRIPTION
## Why

Fixes #49648.

On Android, unmounting a `<NavigationBar hidden />` left the bar hidden instead of restoring it. Two things were wrong:

1. `updateEntriesStack` applied merged values through `setStyle`/`setHidden`, the same functions the imperative API uses. Those write `defaultProps`, so mounting a component overwrote the very defaults that were supposed to be restored later.
2. `mergeEntriesStack` seeded its reduce with `{ style: undefined, hidden: undefined }` and the defaults were only consulted in a separate `entriesStack.length === 0` branch. Whenever any other `NavigationBar` stayed mounted, a key that no mounted entry specified was never applied at all. With the documented multi-screen pattern, `<NavigationBar style="dark" />` at the app root and `<NavigationBar hidden />` on one screen, unmounting that screen leaves `[{ style: 'dark', hidden: undefined }]`, so `hidden` was never restored and the bar stayed hidden.

## How

Split applying a value to the native module (`applyStyle`/`applyHidden`) from writing the defaults, so only `NavigationBar.setStyle`/`NavigationBar.setHidden` change `defaultProps`.

Then collapse the two branches in `updateEntriesStack` and always seed the merge with the defaults. This matches React Native's `StatusBar`, which has no empty-stack special case: `_updatePropsStack` always calls `mergePropsStack(_propsStack, _defaultProps)`, and `mergePropsStack` reduces onto `{...defaultValues}`. Its imperative setters likewise write `_defaultProps` and talk to the native module directly rather than going through the stack update.

## Test Plan

Added `src/__tests__/NavigationBar-test.android.tsx` covering: unmounting a `hidden` bar, unmounting a `style` bar, unmounting a `hidden` bar while a style-only bar stays mounted, and unmounting after `NavigationBar.setHidden`. All four fail on `main`; the multi-component case is the one that isolates the merge-seeding half of the fix.

`pnpm test` in `packages/expo-navigation-bar`: 18 tests passing across both projects. `pnpm lint` clean.

Adds `@testing-library/react-native` to the package's devDependencies, matching the version other packages in the repo already use.
