### PR TITLE
[JSI][iOS] Install promise `then` callbacks on the first `await`

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Values returned to Swift from property reads, array reads and function calls are now taken over instead of cloned through the engine, making `toJavaScriptValue(in:)` ~1.16× faster. ([#49688](https://github.com/expo/expo/pull/49688) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made decoding non-ASCII JS strings up to 512 UTF-16 code units long ~1.5× faster. ([#49691](https://github.com/expo/expo/pull/49691) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made creating a deferred `JavaScriptPromise` ~1.2× faster by building it from a cached JavaScript closure instead of a host function executor. ([#49714](https://github.com/expo/expo/pull/49714) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `JavaScriptPromise` now installs its `then` callbacks on the first `await()` instead of at construction, making promises returned by async functions ~2.5× cheaper to create and ~3.9× cheaper to settle. ([#49718](https://github.com/expo/expo/pull/49718) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -11,7 +11,6 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
   private weak let runtime: JavaScriptRuntime?
-  private let deferredPromise = DeferredPromise()
 
   /// Owns the promise's JSI values (the object and, for a deferred promise, its resolve/reject
   /// functions). Registered with the runtime's ``LongLivedObjectCollection`` so they're released on
@@ -35,6 +34,11 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     let object = JavaScriptValue.Ref()
     let resolveFunction = JavaScriptValue.Ref()
     let rejectFunction = JavaScriptValue.Ref()
+    /// The Swift-side receiver `await()` suspends on, created together with the `then` callbacks that
+    /// feed it on the first `await()`. Not created at construction: a promise that is only handed to
+    /// JavaScript and settled from Swift never needs it, and the callbacks are two host functions plus
+    /// a `then` call per promise. Its presence is what marks the callbacks as installed.
+    var deferredPromise: DeferredPromise?
 
     func allowRelease() {
       object.release()
@@ -67,11 +71,13 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) throws {
     self.runtime = runtime
+    // Reject a non-thenable here rather than at the first `await()`, which is where the `then`
+    // callbacks are actually installed (see `deferredPromiseForAwait()`).
+    _ = try object.getPropertyAsFunction(.cached(runtime, "then"))
     longLivedState.object.reset(object.asValue())
-    try setUpCallbacks()
-    // Register only after setup succeeds, so a failed initializer (e.g. `then` unavailable) doesn't
-    // leave the state pinned in the collection until teardown. Owns the promise's JSI values from
-    // here until teardown (see `LongLivedState`).
+    // Register only after validation succeeds, so a failed initializer doesn't leave the state pinned
+    // in the collection until teardown. Owns the promise's JSI values from here until teardown (see
+    // `LongLivedState`).
     runtime.longLivedObjects.add(longLivedState)
   }
 
@@ -89,10 +95,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     longLivedState.object.reset(try triple.getValue(at: 0))
     longLivedState.resolveFunction.reset(try triple.getValue(at: 1))
     longLivedState.rejectFunction.reset(try triple.getValue(at: 2))
-    try setUpCallbacks()
-    // Register only after setup succeeds, so a failed initializer (e.g. `then` unavailable) doesn't
-    // leave the state pinned in the collection until teardown. Owns the promise's JSI values from
-    // here until teardown (see `LongLivedState`).
+    // Owns the promise's JSI values from here until teardown (see `LongLivedState`).
     runtime.longLivedObjects.add(longLivedState)
   }
 
@@ -107,6 +110,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
 
   @JavaScriptActor
   public func `await`() async throws -> JavaScriptValue {
+    let deferredPromise = try deferredPromiseForAwait()
     return try await deferredPromise.getValue()
   }
 
@@ -136,8 +140,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
         return
       }
       do {
-        // Call the actual resolver given in the Promise setup.
-        // This will also call `deferredPromise.resolve` in the `then` handler.
+        // Call the actual resolver. If `await()` has installed the `then` callbacks, they forward
+        // the settlement to `deferredPromise`.
         _ = try resolver.getFunction().call(arguments: value)
 
         // The rejecter can't be called anymore. The state stays registered so it keeps owning the
@@ -175,7 +179,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       }
       do {
         let encoded = try V.encode(value, in: runtime)
-        // Call the actual resolver, which also calls `deferredPromise.resolve` in the `then` handler.
+        // Call the actual resolver. If `await()` has installed the `then` callbacks, they forward
+        // the settlement to `deferredPromise`.
         _ = try resolver.getFunction().call(arguments: encoded)
         // The state stays registered so it keeps owning the object until the wrapper is dropped.
         longLivedState.rejectFunction.release()
@@ -207,8 +212,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       // is not lost on async rejection. See `JavaScriptError.from(_:in:)`.
       let errorValue = JavaScriptError.from(error, in: runtime).toValue()
 
-      // Call the actual rejecter given in the Promise setup.
-      // This will also call `deferredPromise.reject` in the `then` handler.
+      // Call the actual rejecter. If `await()` has installed the `then` callbacks, they forward the
+      // settlement to `deferredPromise`.
       // The call can realistically only throw when the runtime is being torn down, where dropping
       // the settle is harmless because the JS world is going away.
       _ = try? rejecter.getFunction().call(arguments: errorValue)
@@ -219,10 +224,19 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     }
   }
 
+  /// The receiver `await()` suspends on. Created on the first call, together with the `then`
+  /// callbacks that forward the promise's settlement to it; later calls return the same instance.
+  /// Installing on an already settled promise is fine: `then` schedules the matching callback for it.
   @JavaScriptActor
-  private func setUpCallbacks() throws {
+  private func deferredPromiseForAwait() throws -> DeferredPromise {
+    if let deferredPromise = longLivedState.deferredPromise {
+      return deferredPromise
+    }
+    let deferredPromise = DeferredPromise()
     guard let runtime else {
-      return
+      // Without a runtime nothing can settle the promise; keep `await()` suspending as it always did.
+      longLivedState.deferredPromise = deferredPromise
+      return deferredPromise
     }
     let onFulfilled = runtime.createFunction { [weak deferredPromise] this, arguments in
       guard let deferredPromise else { return .undefined }
@@ -249,6 +263,10 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
         onRejected.asValue()
       )
     }
+    // Stored only once the callbacks are in place, so a failed install (e.g. `then` unavailable) is
+    // retried by the next `await()` instead of leaving a receiver nothing will ever settle.
+    longLivedState.deferredPromise = deferredPromise
+    return deferredPromise
   }
 }
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -49,6 +49,36 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
+  func `creating and settling a deferred promise installs no then handlers until awaited`() async throws {
+    let runtime = JavaScriptRuntime()
+    try runtime.eval(
+      """
+      globalThis.thenCalls = 0;
+      const originalThen = Promise.prototype.then;
+      Promise.prototype.then = function (...args) {
+        globalThis.thenCalls++;
+        return originalThen.apply(this, args);
+      };
+      """
+    )
+    let promise = try JavaScriptPromise(runtime)
+    promise.resolve(42.0)
+    #expect(try runtime.eval("globalThis.thenCalls").getInt() == 0)
+    #expect(try await promise.await().getInt() == 42)
+    #expect(try runtime.eval("globalThis.thenCalls").getInt() == 1)
+  }
+
+  @Test
+  func `awaiting a deferred promise that settled long before delivers the value`() async throws {
+    let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(runtime)
+    promise.resolve("late")
+    // Let the settle run and the engine drain its reactions before anything is awaited.
+    try runtime.eval("for (let i = 0; i < 10; i++) {}")
+    #expect(try await promise.await().getString() == "late")
+  }
+
+  @Test
   func `deferred promise construction throws when Promise constructor is unavailable`() throws {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.Promise = undefined")


### PR DESCRIPTION
# Why

Every `JavaScriptPromise` installed its `then` callbacks at construction: two host functions and a `then` call, which also makes the engine allocate a derived promise. Those callbacks exist only so Swift can `await()` the promise. A promise created by an async host function, or by encoding a `Task`, is handed to JavaScript and settled from Swift; nothing on the Swift side ever awaits it, so on that path the wiring was pure overhead, at construction and again at settle time when the two callbacks fired.

# How

The callbacks are installed on the first `await()` instead, together with the `DeferredPromise` actor they feed, which was also allocated for every promise before and is only ever read by `await()`. Its presence is what marks the callbacks as installed. `then` on an already settled promise schedules the matching callback, so awaiting after the settle works the same as before. The wrapping initializer keeps rejecting a non-thenable early with the same error, through a property check instead of installing the callbacks. Resolve and reject are unchanged.

# Test Plan

New tests: creating and settling a deferred promise makes zero `then` calls until `await()` is called, then exactly one (red before this change); and awaiting a promise that settled long before still delivers the value. The existing promise, runtime and codable-task suites pass, including the wrapped-promise and then-unavailable cases.

Promise benchmarks, median ns/op from `pnpm benchmark` (Mac Catalyst, Release), on top of the cached-factory change this PR is stacked on:

| Benchmark | Before | After | Change |
| --- | ---: | ---: | ---: |
| engine floor: `new Promise` from JS | 99 | 98 | reference |
| `JavaScriptPromise(runtime)`: create deferred | 2035 | 827 | 2.5x |
| `JavaScriptPromise(runtime)`: create and resolve | 4703 | 1196 | 3.9x |

Every async host function call and every `Task` encode creates one of these.
