### PR TITLE
[ios][screen-capture] Render recording and privacy overlays in a window above the key window

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [iOS] Fixed the screen-recording overlay staying attached (permanent black screen) after `allowScreenCaptureAsync` is called while a recording is active. ([#48000](https://github.com/expo/expo/pull/48000) by [@bluespore](https://github.com/bluespore))
 - [iOS] Fixed screenshot prevention and the recording overlay attaching to a window in a background scene rather than the one on screen. ([#48372](https://github.com/expo/expo/pull/48372) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed a repeated `preventScreenCaptureAsync` call with a new key corrupting the layer hierarchy and permanently black-screening the app, and made `preventScreenCaptureAsync` reject instead of silently leaving the app unprotected when the secure canvas cannot attach. ([#49372](https://github.com/expo/expo/pull/49372) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed the screen-recording overlay and the app-switcher blur not covering modally presented screens. Both now render in a dedicated window layered above the key window. ([#49722](https://github.com/expo/expo/pull/49722) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/ios/OverlayWindow.swift
+++ b/packages/expo-screen-capture/ios/OverlayWindow.swift
@@ -1,0 +1,30 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import UIKit
+
+/// UIKit hosts a presented view controller in a sibling of the root view, so no subview of the
+/// root view can cover it.
+internal final class OverlayWindow {
+  let window: UIWindow
+  private let rootViewController = UIViewController()
+
+  var contentView: UIView {
+    return rootViewController.view
+  }
+
+  init(above keyWindow: UIWindow) {
+    if let scene = keyWindow.windowScene {
+      window = UIWindow(windowScene: scene)
+    } else {
+      window = UIWindow(frame: keyWindow.frame)
+    }
+    window.frame = keyWindow.frame
+    window.windowLevel = .alert + 1
+    window.rootViewController = rootViewController
+    window.isHidden = false
+  }
+
+  func dismiss() {
+    window.isHidden = true
+  }
+}

--- a/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
+++ b/packages/expo-screen-capture/ios/ScreenCaptureModule.swift
@@ -5,9 +5,9 @@ let onScreenshotEventName = "onScreenshot"
 public final class ScreenCaptureModule: Module {
   private var isBeingObserved = false
   private var isListening = false
-  private var blockView: UIView?
+  private var recordingOverlay: OverlayWindow?
   private var secureCanvas: SecureWindowCanvas?
-  private var blurEffectView: AnimatedBlurEffectView?
+  private var privacyOverlay: OverlayWindow?
   private var blurIntensity: CGFloat = 0.5
   private var keyWindow: UIWindow? {
     return SceneGeometry.keyWindow()
@@ -23,6 +23,7 @@ public final class ScreenCaptureModule: Module {
       self.secureCanvas = nil
       DispatchQueue.main.async {
         canvas?.restore()
+        self.hideRecordingOverlay()
       }
       disableAppSwitcherProtection()
     }
@@ -49,7 +50,7 @@ public final class ScreenCaptureModule: Module {
 
     AsyncFunction("allowScreenCapture") {
       self.allowScreenshots()
-      self.blockView?.removeFromSuperview()
+      self.hideRecordingOverlay()
 
       NotificationCenter.default.removeObserver(
         self,
@@ -92,15 +93,12 @@ public final class ScreenCaptureModule: Module {
 
   @objc
   func preventScreenRecording() {
-    guard let keyWindow = keyWindow,
-      let visibleView = keyWindow.subviews.first else { return }
-    let blockView = getOrCreateBlockView()
-
-    let isCaptured = UIScreen.main.isCaptured
-    if isCaptured {
-      visibleView.addSubview(blockView)
-    } else {
-      blockView.removeFromSuperview()
+    guard let keyWindow else { return }
+    hideRecordingOverlay()
+    if UIScreen.main.isCaptured {
+      let overlay = OverlayWindow(above: keyWindow)
+      overlay.contentView.backgroundColor = .black
+      recordingOverlay = overlay
     }
   }
 
@@ -111,17 +109,9 @@ public final class ScreenCaptureModule: Module {
     ])
   }
 
-  private func getOrCreateBlockView() -> UIView {
-    guard let blockView else {
-      let view = UIView()
-      let boundLength = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
-      view.frame = CGRect(x: 0, y: 0, width: boundLength, height: boundLength)
-      view.backgroundColor = .black
-
-      self.blockView = view
-      return view
-    }
-    return blockView
+  private func hideRecordingOverlay() {
+    recordingOverlay?.dismiss()
+    recordingOverlay = nil
   }
 
   private func preventScreenshots() throws {
@@ -191,35 +181,26 @@ public final class ScreenCaptureModule: Module {
   }
 
   private func showPrivacyOverlay() {
-    // Don't add a new blur view if one already exists
-    guard self.blurEffectView == nil,
-      let keyWindow = keyWindow,
-      let rootView = keyWindow.subviews.first else {
+    guard privacyOverlay == nil, let keyWindow else {
       return
     }
-
-    let blurEffectView = AnimatedBlurEffectView(style: .light, intensity: self.blurIntensity)
-    blurEffectView.frame = rootView.bounds
+    let overlay = OverlayWindow(above: keyWindow)
+    let blurEffectView = AnimatedBlurEffectView(style: .light, intensity: blurIntensity)
+    blurEffectView.frame = overlay.contentView.bounds
     blurEffectView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-    blurEffectView.alpha = 0
-
-    rootView.addSubview(blurEffectView)
-    self.blurEffectView = blurEffectView
+    overlay.contentView.addSubview(blurEffectView)
+    overlay.contentView.alpha = 0
+    privacyOverlay = overlay
 
     blurEffectView.setupBlur()
 
-    UIView.animate(
-      withDuration: 0.3,
-      delay: 0,
-      options: [.curveEaseOut],
-      animations: {
-        blurEffectView.alpha = 1.0
-      }
-    )
+    UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseOut]) {
+      overlay.contentView.alpha = 1
+    }
   }
 
   private func removePrivacyOverlay() {
-    guard let blurEffectView = self.blurEffectView else {
+    guard let overlay = privacyOverlay else {
       return
     }
     UIView.animate(
@@ -227,11 +208,11 @@ public final class ScreenCaptureModule: Module {
       delay: 0,
       options: [.curveEaseIn],
       animations: {
-        blurEffectView.alpha = 0
+        overlay.contentView.alpha = 0
       },
       completion: { _ in
-        blurEffectView.removeFromSuperview()
-        self.blurEffectView = nil
+        overlay.dismiss()
+        self.privacyOverlay = nil
       }
     )
   }

--- a/packages/expo-screen-capture/ios/Tests/OverlayWindowTests.swift
+++ b/packages/expo-screen-capture/ios/Tests/OverlayWindowTests.swift
@@ -1,0 +1,56 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import Testing
+import UIKit
+
+@testable import ExpoScreenCapture
+
+@Suite("OverlayWindow", .serialized)
+@MainActor
+struct OverlayWindowTests {
+  private func makeKeyWindow() -> UIWindow {
+    let window = UIWindow(frame: UIScreen.main.bounds)
+    window.rootViewController = UIViewController()
+    window.makeKeyAndVisible()
+    return window
+  }
+
+  @Test
+  func `overlay is a separate visible window layered above the key window`() {
+    let keyWindow = makeKeyWindow()
+
+    let overlay = OverlayWindow(above: keyWindow)
+
+    #expect(overlay.window !== keyWindow)
+    #expect(!overlay.contentView.isDescendant(of: keyWindow))
+    #expect(overlay.window.windowLevel > keyWindow.windowLevel)
+    #expect(!overlay.window.isHidden)
+    #expect(overlay.window.frame == keyWindow.frame)
+  }
+
+  @Test
+  func `overlay stays above content added to the key window after it was created`() throws {
+    let keyWindow = makeKeyWindow()
+    let root = try #require(keyWindow.rootViewController)
+    let overlay = OverlayWindow(above: keyWindow)
+
+    // Stands in for a presented view controller, which UIKit hosts as a sibling of the root view.
+    let presentedContent = UIView(frame: keyWindow.bounds)
+    keyWindow.addSubview(presentedContent)
+
+    #expect(presentedContent.window === keyWindow)
+    #expect(!presentedContent.isDescendant(of: root.view))
+    #expect(!overlay.contentView.isDescendant(of: keyWindow))
+    #expect(overlay.window.windowLevel > keyWindow.windowLevel)
+  }
+
+  @Test
+  func `dismiss hides the overlay window`() {
+    let keyWindow = makeKeyWindow()
+    let overlay = OverlayWindow(above: keyWindow)
+
+    overlay.dismiss()
+
+    #expect(overlay.window.isHidden)
+  }
+}


### PR DESCRIPTION
# Why

A bug report against `expo-screen-capture` 57.0.0 showed that `preventScreenCaptureAsync()` does not black out the screen during a screen recording when a modally presented view controller is on screen. The app looks protected while the recording captures the real content. The app-switcher blur has the same gap.

Root cause: `preventScreenRecording()` added the black view as a subview of `keyWindow.subviews.first`, the root view controller's view. UIKit hosts a presented view controller in a `UITransitionView` that is a sibling of the root view, above it. The black view never covered it. `showPrivacyOverlay()` attached the blur to the same root view.

A related defect in the report, the block view never being removed by `allowScreenCapture`, was already fixed by #48000 and shipped in 57.0.2.

# How

A new `OverlayWindow` type owns a `UIWindow` attached to the key window's scene at level `.alert + 1`. The recording overlay and the app-switcher blur render into its content view instead of the root view. Window level beats subview order, so the overlay also covers modals presented after it was shown. The reporter's minimal fix, adding the black view to the window itself, would not cover those.

`OnDestroy` now also dismisses the recording overlay. Before, a module reload during a recording could leave the black view behind.

# Test Plan

Native unit tests in `packages/expo-screen-capture/ios/Tests/OverlayWindowTests.swift`:

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
