### PR TITLE
[ui][ios] Measure RNHostView content from the Host's own frame

### DIFF
--- a/apps/test-suite/tests/ExpoUIMeasurement.ios.tsx
+++ b/apps/test-suite/tests/ExpoUIMeasurement.ios.tsx
@@ -1,7 +1,8 @@
 import { BottomSheet, Host, HStack, RNHostView, VStack } from '@expo/ui/swift-ui';
-import { padding } from '@expo/ui/swift-ui/modifiers';
+import { onGeometryChange, padding } from '@expo/ui/swift-ui/modifiers';
 import React from 'react';
-import { ScrollView, View } from 'react-native';
+import { Modal, ScrollView, View } from 'react-native';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 // React Native types `View` as a function component, so the instance type is its ref type.
 type ViewRef = React.ComponentRef<typeof View>;
@@ -17,6 +18,7 @@ const SHORT = 30;
 const SCROLL_LEAD = 80;
 const SCROLL_TAIL = 2000;
 const SCROLL_BY = 60;
+const INSET_HOST_HEIGHT = 120;
 
 type Measurement = {
   x: number;
@@ -37,6 +39,22 @@ function measureAsync(ref: React.RefObject<ViewRef | null>, label = 'view'): Pro
     node.measure((x, y, width, height, pageX, pageY) =>
       resolve({ x, y, width, height, pageX, pageY })
     );
+  });
+}
+
+type WindowFrame = { x: number; y: number; width: number; height: number };
+
+function measureInWindowAsync(
+  ref: React.RefObject<ViewRef | null>,
+  label = 'view'
+): Promise<WindowFrame> {
+  return new Promise((resolve, reject) => {
+    const node = ref.current;
+    if (!node) {
+      reject(new Error(`Cannot measure ${label} in the window: it is not mounted`));
+      return;
+    }
+    node.measureInWindow((x, y, width, height) => resolve({ x, y, width, height }));
   });
 }
 
@@ -66,10 +84,134 @@ async function measureWhenPresented(
   throw new Error(`Timed out waiting for ${label} to be presented and laid out`);
 }
 
+type InsetFixture = {
+  host: WindowFrame;
+  hosted: WindowFrame;
+  drawn: WindowFrame;
+  /** The top safe-area inset of the modal window. */
+  insetTop: number;
+  /** Where the Host wrapper starts, so the Host is still partly under the status bar. */
+  wrapperTop: number;
+};
+
+type InsetHostProps = {
+  safeArea: boolean;
+  hostWrapperRef: React.RefObject<ViewRef | null>;
+  hostedRef: React.RefObject<ViewRef | null>;
+  drawnRef: { current: WindowFrame | null };
+  geometryRef: { current: { insetTop: number; wrapperTop: number } | null };
+  onLaidOut: () => void;
+};
+
+function InsetHost({
+  safeArea,
+  hostWrapperRef,
+  hostedRef,
+  drawnRef,
+  geometryRef,
+  onLaidOut,
+}: InsetHostProps) {
+  const insets = useSafeAreaInsets();
+  const wrapperTop = Math.round(insets.top / 2);
+  geometryRef.current = { insetTop: insets.top, wrapperTop };
+  return (
+    <View
+      ref={hostWrapperRef}
+      collapsable={false}
+      style={{
+        position: 'absolute',
+        top: wrapperTop,
+        left: 0,
+        right: 0,
+        height: INSET_HOST_HEIGHT,
+      }}>
+      <Host
+        style={{ flex: 1 }}
+        ignoreSafeArea={safeArea ? 'none' : undefined}
+        onLayoutContent={() => onLaidOut()}>
+        <VStack>
+          <VStack modifiers={[onGeometryChange((frame) => (drawnRef.current = frame))]}>
+            <RNHostView matchContents>
+              <View ref={hostedRef} style={{ width: BOX, height: BOX }} />
+            </RNHostView>
+          </VStack>
+        </VStack>
+      </Host>
+    </View>
+  );
+}
+
+/**
+ * Mounts a fill `Host` partly under the status bar of a full-screen modal and measures the hosted
+ * box against where SwiftUI drew it.
+ */
+function makeInsetFixture(setPortalChild: any) {
+  return async ({ safeArea }: { safeArea: boolean }): Promise<InsetFixture> => {
+    const hostWrapperRef = React.createRef<ViewRef>();
+    const hostedRef = React.createRef<ViewRef>();
+    const geometryRef: { current: { insetTop: number; wrapperTop: number } | null } = {
+      current: null,
+    };
+
+    let onShown: () => void;
+    const shown = new Promise<void>((resolve) => {
+      onShown = resolve;
+    });
+    let onLaidOut: () => void;
+    const laidOut = new Promise<void>((resolve) => {
+      onLaidOut = resolve;
+    });
+    // Where SwiftUI actually placed the hosted view, in window coordinates.
+    const drawnRef: { current: WindowFrame | null } = { current: null };
+
+    setPortalChild(
+      <Modal visible presentationStyle="fullScreen" animationType="none" onShow={() => onShown()}>
+        {/* The modal is its own window, so it needs its own provider to report that window's insets. */}
+        <SafeAreaProvider>
+          <InsetHost
+            safeArea={safeArea}
+            hostWrapperRef={hostWrapperRef}
+            hostedRef={hostedRef}
+            drawnRef={drawnRef}
+            geometryRef={geometryRef}
+            onLaidOut={() => onLaidOut()}
+          />
+        </SafeAreaProvider>
+      </Modal>
+    );
+
+    await Promise.all([shown, laidOut]);
+
+    let result: InsetFixture | null = null;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const drawn = drawnRef.current;
+      if (drawn != null) {
+        const host = await measureInWindowAsync(hostWrapperRef, 'the Host wrapper');
+        const hosted = await measureInWindowAsync(hostedRef, 'the hosted box');
+        const geometry = geometryRef.current;
+        if (geometry == null) {
+          throw new Error('The safe-area insets of the modal were never reported');
+        }
+        result = { host, hosted, drawn, ...geometry };
+        if (Math.abs(hosted.x - drawn.x) < 0.5 && Math.abs(hosted.y - drawn.y) < 0.5) {
+          break;
+        }
+      }
+      await delay(50);
+    }
+    if (result == null) {
+      throw new Error('SwiftUI never reported where it drew the hosted view');
+    }
+    return result;
+  };
+}
+
 export async function test(
   { it, describe, expect, afterEach }: any,
   { setPortalChild, cleanupPortal }: any
 ) {
+  const mountInsetFixture = makeInsetFixture(setPortalChild);
+
   afterEach(async () => {
     await cleanupPortal();
   });
@@ -296,6 +438,40 @@ export async function test(
       // while the differences above stay right, because those two views scroll together.
       expect(hostedAfter.pageX - viewport.pageX).toBe(PADDING);
       expect(hostedAfter.pageY - viewport.pageY).toBe(SCROLL_LEAD + PADDING - SCROLL_BY);
+    });
+
+    // The Host starts halfway down the status bar. With `ignoreSafeArea="none"`, SwiftUI insets the
+    // content of this fill host by the rest of the bar while Yoga's frame for the host starts higher.
+    it('measures a hosted view where SwiftUI drew it when the Host is inset by the safe area', async () => {
+      const { host, hosted, drawn, insetTop, wrapperTop } = await mountInsetFixture({
+        safeArea: true,
+      });
+      if (insetTop === 0) {
+        // No status bar, for example an iPhone in landscape: nothing to inset, so the two coordinate
+        // spaces coincide and the fixture cannot tell them apart.
+        return;
+      }
+
+      // The fixture only proves something if SwiftUI really inset the content: the box must sit
+      // below the top of the host's frame by the part of the status bar the host is still under.
+      expect(drawn.y - host.y).toBeCloseTo(insetTop - wrapperTop, 0);
+
+      // measure() must report the position the content occupies on screen, not the position it
+      // would have had without the inset.
+      expect(hosted.x).toBeCloseTo(drawn.x, 0);
+      expect(hosted.y).toBeCloseTo(drawn.y, 0);
+      expect(hosted.width).toBeCloseTo(BOX, 0);
+      expect(hosted.height).toBeCloseTo(BOX, 0);
+    });
+
+    it('applies no safe-area inset to a Host by default', async () => {
+      const { host, hosted, drawn } = await mountInsetFixture({ safeArea: false });
+
+      // Same fixture with the default `ignoreSafeArea`: the content starts at the frame origin.
+      expect(drawn.x - host.x).toBeCloseTo(0, 0);
+      expect(drawn.y - host.y).toBeCloseTo(0, 0);
+      expect(hosted.x).toBeCloseTo(drawn.x, 0);
+      expect(hosted.y).toBeCloseTo(drawn.y, 0);
     });
 
     // A sheet content uses RootNodeKind trait so measurement happens relative to the RNHostView and not the RN's root surface.

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [iOS] Added `none` to `ExpoSwiftUI.IgnoreSafeArea`. Content-sized hosting views grow by the container insets SwiftUI applies. ([#49708](https://github.com/expo/expo/pull/49708) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `updateLayoutMetrics(_:oldFrame:)` to `ExpoFabricView`, called after React Native applies a new frame. ([#49708](https://github.com/expo/expo/pull/49708) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Added the `expoHostingView` SwiftUI environment value, a weak reference to the UIKit view hosting a SwiftUI tree. ([#49726](https://github.com/expo/expo/pull/49726) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Added a `loadImageForManipulationFromURL` overload to `ImageLoaderInterface` that decodes the image within the given `maxWidth`/`maxHeight` bounds. ([#47877](https://github.com/expo/expo/pull/47877) by [@jiunshinn](https://github.com/jiunshinn))
 - Add `useReleasingSharedObjectWithLifecycle` hook. ([#46494](https://github.com/expo/expo/pull/46494) by [@behenate](https://github.com/behenate))
 - Added `ArrayBuffer` as the preferred safe native module argument and return type, and deprecated `NativeArrayBuffer` in favor of it. ([#47106](https://github.com/expo/expo/pull/47106) by [@barthap](https://github.com/barthap))

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -31,6 +31,27 @@ extension ExpoSwiftUI {
 }
 
 extension ExpoSwiftUI {
+  /**
+   A weak handle to the UIKit view that hosts a SwiftUI tree. Exposed through the environment so RNHostView
+   can convert its geometry into the coordinate space of the view Yoga laid out.
+   */
+  public final class HostingViewReference: @unchecked Sendable {
+    public internal(set) weak var view: UIView?
+  }
+
+  internal struct HostingViewEnvironmentKey: EnvironmentKey {
+    static let defaultValue: HostingViewReference? = nil
+  }
+}
+
+extension EnvironmentValues {
+  public var expoHostingView: ExpoSwiftUI.HostingViewReference? {
+    get { self[ExpoSwiftUI.HostingViewEnvironmentKey.self] }
+    set { self[ExpoSwiftUI.HostingViewEnvironmentKey.self] = newValue }
+  }
+}
+
+extension ExpoSwiftUI {
   internal typealias AnyHostingView = AnyExpoSwiftUIHostingView
 
   /**
@@ -66,11 +87,18 @@ extension ExpoSwiftUI {
     private var requestedStyleSize: (width: NSNumber?, height: NSNumber?)?
 
     /**
+     Handed to the SwiftUI root through the environment, so RNHostView content can convert its geometry
+     into this view's coordinate space.
+     */
+    private let hostingViewReference = HostingViewReference()
+
+    /**
      Initializes a SwiftUI hosting view with the given SwiftUI view type.
      */
     init(viewType: ContentView.Type, props: Props, appContext: AppContext) {
-      self.contentView = ContentView(props: props)
-      let rootView = AnyView(contentView)
+      let content = ContentView(props: props)
+      self.contentView = content
+      let rootView = AnyView(content.environment(\.expoHostingView, hostingViewReference))
       self.props = props
       let controller = UIHostingController(rootView: rootView)
 
@@ -80,6 +108,8 @@ extension ExpoSwiftUI {
       self.hostingController = controller
 
       super.init(appContext: appContext)
+
+      hostingViewReference.view = self
 
       // Initialise with default props
       if let safeAreaProps = props as? SafeAreaControllable {

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `measure()` and touch targets of views hosted in `RNHostView` when SwiftUI insets the content, for example on a `Host` with `ignoreSafeArea="none"`. ([#49726](https://github.com/expo/expo/pull/49726) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fixed a `Text` or an `Icon` with no explicit color rendering black inside `Host`, which made it unreadable in the dark color scheme. `Host` now provides `LocalContentColor` from the color scheme. ([#49697](https://github.com/expo/expo/pull/49697) by [@expo-bot](https://github.com/expo-bot))
 - [iOS][Android] Fixed a `matchContents` `RNHostView` inside a `matchContents` `Host` growing the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix modifier application rebuilding a fresh `AnyViewModifier` every body evaluation, which defeated AttributeGraph subtree pruning during scroll. ([#48426](https://github.com/expo/expo/pull/48426) by [@wielski](https://github.com/wielski))

--- a/packages/expo-ui/ios/HostView.swift
+++ b/packages/expo-ui/ios/HostView.swift
@@ -3,11 +3,6 @@
 import SwiftUI
 import ExpoModulesCore
 
-/// Coordinate space anchored at the `Host`, so hosted React Native views can report where SwiftUI
-/// actually placed them. Name it last in the chain: Yoga measures a hosted view from the `Host`
-/// component view, so any `Host` inset or alignment has to be inside this space, not outside it.
-internal let expoHostCoordinateSpace = "expo.ui.host"
-
 internal enum ExpoColorScheme: String, Enumerable {
   case light
   case dark
@@ -76,7 +71,6 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
       )
       .modifier(GeometryChangeModifier(props: props))
       .modifier(FillAlignmentModifier(alignment: alignment, fillHorizontal: fillHorizontal, fillVertical: fillVertical))
-      .coordinateSpace(name: expoHostCoordinateSpace)
     } else {
       ZStack(alignment: alignment) {
         Children()
@@ -92,7 +86,6 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
       )
       .modifier(GeometryChangeModifier(props: props))
       .modifier(FillAlignmentModifier(alignment: alignment, fillHorizontal: fillHorizontal, fillVertical: fillVertical))
-      .coordinateSpace(name: expoHostCoordinateSpace)
     }
   }
 

--- a/packages/expo-ui/ios/RNHostView.swift
+++ b/packages/expo-ui/ios/RNHostView.swift
@@ -93,18 +93,26 @@ struct RNHostView: ExpoSwiftUI.View {
 }
 
 // Publishes where SwiftUI placed this view inside its `Host`, so `measure()` reports the position
-// the hosted content actually occupies.
+// the hosted content actually occupies. The position is converted with UIKit into the `Host`
+// component view, whose frame is the one Yoga laid out. A SwiftUI coordinate space would start at
+// the safe region SwiftUI lays the root out in, which is inset from that frame whenever the host
+// touches a screen edge or the keyboard.
 private struct PublishContentOriginModifier: ViewModifier {
   let shadowNodeProxy: ExpoSwiftUI.ShadowNodeProxy
   let isEnabled: Bool
+  @Environment(\.expoHostingView) private var hostingView
 
   func body(content: Content) -> some View {
     if isEnabled {
       content
-        .onGeometryChange(for: CGRect.self) { proxy in
-          proxy.frame(in: .named(expoHostCoordinateSpace))
-        } action: { frame in
-          shadowNodeProxy.setContentOrigin?(frame.origin)
+        // Track the converted origin, not the window frame: when the host moves under a fixed inset
+        // the content can stay put in the window while its position inside the host changes.
+        .onGeometryChange(for: CGPoint?.self) { proxy in
+          originInHost(of: proxy.frame(in: .global))
+        } action: { origin in
+          if let origin {
+            shadowNodeProxy.setContentOrigin?(origin)
+          }
         }
         .onDisappear {
           shadowNodeProxy.clearContentOrigin?()
@@ -112,6 +120,15 @@ private struct PublishContentOriginModifier: ViewModifier {
     } else {
       content
     }
+  }
+
+  /// SwiftUI's global space is the window, so the origin only has to be converted into the host.
+  /// `nil` while the host is not in a window, when there is no window space to convert from.
+  private func originInHost(of frameInWindow: CGRect) -> CGPoint? {
+    guard let hostView = hostingView?.view, let window = hostView.window else {
+      return nil
+    }
+    return hostView.convert(frameInWindow.origin, from: window)
   }
 }
 


### PR DESCRIPTION
# Why

`RNHostView` published its content origin in a coordinate space named on the Host's SwiftUI root. With `safeArea` on, that root sits inside the safe region, so `measure()` and touch targets of hosted React Native views were off by the inset.

Stacked on #49708.

# How

Measure the distance of `RNHostView` from UIKit Host view instead of SwiftUI Host so it includes the inset offsets. This makes sure we report the Yoga frame relative content origin to RN's `measure` function.

# Test Plan

New `ExpoUIMeasurement` fixture mounts a `Host` under the status bar, with and without safe area, and checks the RN hosted view's `measure()` against where SwiftUI drew it.
