### PR TITLE
[sqlite] Only roll back a transaction the call itself began

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 - Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
 - Fixed reading a prepared statement result after the same statement ran again returning the later run's rows instead of throwing. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49796](https://github.com/expo/expo/pull/49796) by [@tsapeta](https://github.com/tsapeta))
+- Fixed `withTransactionAsync`, `withTransactionSync` and `withExclusiveTransactionAsync` issuing `ROLLBACK` when their own `BEGIN` failed, ending a transaction another code path had open on the same connection. ([#49727](https://github.com/expo/expo/pull/49727) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/src/SQLiteDatabase.ts
+++ b/packages/expo-sqlite/src/SQLiteDatabase.ts
@@ -138,12 +138,18 @@ export class SQLiteDatabase {
    * @param task An async function to execute within a transaction.
    */
   public async withTransactionAsync(task: () => Promise<void>): Promise<void> {
+    // `BEGIN` stays outside the `try`: when it fails this call never opened a transaction, and
+    // rolling back anyway would discard a transaction another code path owns on this connection.
+    await this.execAsync('BEGIN');
     try {
-      await this.execAsync('BEGIN');
       await task();
       await this.execAsync('COMMIT');
     } catch (e) {
-      await this.execAsync('ROLLBACK');
+      try {
+        await this.execAsync('ROLLBACK');
+      } catch {
+        // Keep the original error: it explains why the transaction had to be rolled back.
+      }
       throw e;
     }
   }
@@ -180,13 +186,22 @@ export class SQLiteDatabase {
     }
     const transaction = await Transaction.createAsync(this);
     let error;
+    let began = false;
     try {
       await transaction.execAsync('BEGIN');
+      began = true;
       await task(transaction);
       await transaction.execAsync('COMMIT');
     } catch (e) {
-      await transaction.execAsync('ROLLBACK');
       error = e;
+      // See `withTransactionAsync`: only roll back a transaction this call actually began.
+      if (began) {
+        try {
+          await transaction.execAsync('ROLLBACK');
+        } catch {
+          // Keep the original error: it explains why the transaction had to be rolled back.
+        }
+      }
     } finally {
       await transaction.closeAsync();
     }
@@ -296,12 +311,17 @@ export class SQLiteDatabase {
    * @param task An async function to execute within a transaction.
    */
   public withTransactionSync(task: () => void): void {
+    // See `withTransactionAsync`: only roll back a transaction this call actually began.
+    this.execSync('BEGIN');
     try {
-      this.execSync('BEGIN');
       task();
       this.execSync('COMMIT');
     } catch (e) {
-      this.execSync('ROLLBACK');
+      try {
+        this.execSync('ROLLBACK');
+      } catch {
+        // Keep the original error: it explains why the transaction had to be rolled back.
+      }
       throw e;
     }
   }

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -175,6 +175,28 @@ describe('Database', () => {
     expect(results.length).toBe(0);
   });
 
+  it('withTransactionAsync should not roll back an outer transaction when its own BEGIN fails', async () => {
+    db = await openDatabaseAsync(':memory:');
+    await db.execAsync(
+      'CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER)'
+    );
+
+    // Another code path already owns an open transaction on this connection.
+    await db.execAsync('BEGIN');
+    await db.runAsync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'outer', 123);
+
+    // The nested BEGIN fails, so this call never started a transaction of its own.
+    await expect(
+      db.withTransactionAsync(async () => {
+        await db?.runAsync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'inner', 456);
+      })
+    ).rejects.toThrow(/cannot start a transaction within a transaction/);
+
+    const results = await db.getAllAsync<TestEntity>('SELECT * FROM test');
+    expect(results.length).toBe(1);
+    expect(results[0]?.value).toBe('outer');
+  });
+
   it('withTransactionAsync could possibly have other async queries interrupted inside the transaction', async () => {
     db = await openDatabaseAsync('test.db');
     await db.execAsync(`
@@ -385,6 +407,28 @@ describe('Database - Synchronous calls', () => {
 
     const results = db.getAllSync<TestEntity>('SELECT * FROM test');
     expect(results.length).toBe(0);
+  });
+
+  it('withTransactionSync should not roll back an outer transaction when its own BEGIN fails', () => {
+    db = openDatabaseSync(':memory:');
+    db.execSync(
+      'CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL, intValue INTEGER)'
+    );
+
+    // Another code path already owns an open transaction on this connection.
+    db.execSync('BEGIN');
+    db.runSync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'outer', 123);
+
+    // The nested BEGIN fails, so this call never started a transaction of its own.
+    expect(() => {
+      db?.withTransactionSync(() => {
+        db?.runSync('INSERT INTO test (value, intValue) VALUES (?, ?)', 'inner', 456);
+      });
+    }).toThrow(/cannot start a transaction within a transaction/);
+
+    const results = db.getAllSync<TestEntity>('SELECT * FROM test');
+    expect(results.length).toBe(1);
+    expect(results[0]?.value).toBe('outer');
   });
 });
 


### PR DESCRIPTION
# Why

`withTransactionAsync`, `withTransactionSync` and `withExclusiveTransactionAsync` wrap `BEGIN` inside the same `try` block as the task:

```ts
try {
  await this.execAsync('BEGIN');
  await task();
  await this.execAsync('COMMIT');
} catch (e) {
  await this.execAsync('ROLLBACK');
  throw e;
}
```

If `BEGIN` itself fails, the call never opened a transaction, but control still lands in the `catch` and issues `ROLLBACK`. On a connection where another code path already has a transaction open, that `ROLLBACK` is not a no-op: it ends *that* transaction and throws away its uncommitted work, then rethrows the original `BEGIN` error so the damage is invisible at the call site.

`BEGIN` failing on a busy connection is the normal way this happens. SQLite rejects a nested `BEGIN` with `cannot start a transaction within a transaction`, and `SQLiteDatabase` hands the same connection to every caller unless `useNewConnection` is set. This is the step that leaves the kv-store with `user_version` ahead of its schema, which I fixed the downstream symptom of in #48878.

Two smaller problems in the same code: a failing `ROLLBACK` replaces the error the caller actually needs to see, and in `withExclusiveTransactionAsync` a throwing `ROLLBACK` escapes the `catch` before `error` is assigned, so the caller gets the rollback failure instead of the real cause.

# How

`BEGIN` now sits outside the `try`, so only a transaction the call actually started can reach `ROLLBACK`. `withExclusiveTransactionAsync` keeps its existing `try`/`finally` shape (the connection must still be closed), so it tracks the same thing with a `began` flag.

`ROLLBACK` is wrapped so that its own failure cannot mask the error being propagated.

The successful-`BEGIN` path is unchanged: a task that throws after `BEGIN` succeeded still rolls back and still rethrows.

# Test Plan

Added two regression tests to `SQLiteDatabase-test.ios.ts`, one for `withTransactionAsync` and one for `withTransactionSync`. Each opens a transaction on the connection, writes a row inside it, then calls the wrapper so that its own `BEGIN` fails, and asserts the outer row survives.

Against `main` both fail because the spurious `ROLLBACK` discards the other transaction's row:

```
● Database › withTransactionAsync should not roll back an outer transaction when its own BEGIN fails
  expect(received).toBe(expected) // Object.is equality
  Expected: 1
  Received: 0
```

With the fix, `pnpm test` in `packages/expo-sqlite` is green: 10 suites, 198 tests.

The other direction is covered by the existing `withTransactionAsync/withTransactionSync should rollback changes when exceptions happen` tests, which stay green here. I confirmed they are load-bearing by removing the `ROLLBACK` calls from the patched code, which turns both red (`Expected: 0, Received: 1`).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
