### PR TITLE
[test-suite] Skip network-dependent specs when their host is unreachable

### DIFF
--- a/apps/test-suite/tests/AppMetrics.ts
+++ b/apps/test-suite/tests/AppMetrics.ts
@@ -9,6 +9,7 @@ import AppMetrics, {
 import { fetch } from 'expo/fetch';
 
 import type { JasmineInterface } from '../types';
+import { gateOnHostAsync } from '../utils/HostReachability';
 
 export const name = 'AppMetrics';
 
@@ -126,7 +127,9 @@ function uniqueLabel(prefix: string): string {
   return `${prefix}-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
 }
 
-export function test({ describe, expect, it, afterEach }: JasmineInterface) {
+export async function test({ describe, expect, it, afterEach, ...t }: JasmineInterface) {
+  const httpbin = await gateOnHostAsync({ describe, it, pending: t.pending }, `${TEST_HOST}/get`);
+
   describe('getMainSession', () => {
     it('returns a non-null main session with the documented shape', () => {
       const session = AppMetrics.getMainSession();
@@ -290,7 +293,7 @@ export function test({ describe, expect, it, afterEach }: JasmineInterface) {
     });
   });
 
-  describe('NetworkRequestObserver', () => {
+  httpbin.describe('NetworkRequestObserver', () => {
     it('emits requestStarted with the documented field shape', async () => {
       const url = `${TEST_HOST}/get?case=started-shape`;
       const { capture, release } = captureEvents((u) => u === url);

--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -3,12 +3,18 @@ import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
 import type { JasmineInterface } from '../types';
+import { gateOnHostAsync } from '../utils/HostReachability';
 import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'Fetch';
 
-export function test({ describe, expect, it, ...t }: JasmineInterface) {
-  describe('Response types', () => {
+export async function test({ describe, expect, it, ...t }: JasmineInterface) {
+  const httpbin = await gateOnHostAsync(
+    { describe, it, pending: t.pending },
+    'https://httpbin.io/get'
+  );
+
+  httpbin.describe('Response types', () => {
     setupTestTimeout(t);
 
     it('should support redirect and contain basic properties', async () => {
@@ -86,7 +92,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Response clone', () => {
+  httpbin.describe('Response clone', () => {
     setupTestTimeout(t);
 
     it('should clone a response and read both bodies independently', async () => {
@@ -168,7 +174,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Redirect handling', () => {
+  httpbin.describe('Redirect handling', () => {
     setupTestTimeout(t);
 
     it('should follow redirects by default', async () => {
@@ -245,7 +251,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Request body', () => {
+  httpbin.describe('Request body', () => {
     setupTestTimeout(t);
 
     it('should post with json', async () => {
@@ -303,7 +309,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Headers', () => {
+  httpbin.describe('Headers', () => {
     setupTestTimeout(t);
 
     it('should process request and response headers', async () => {
@@ -318,7 +324,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Cookies', () => {
+  httpbin.describe('Cookies', () => {
     setupTestTimeout(t);
 
     it('should include cookies when credentials are set to include', async () => {
@@ -339,7 +345,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Error handling', () => {
+  httpbin.describe('Error handling', () => {
     setupTestTimeout(t);
 
     it('should process 404', async () => {
@@ -461,7 +467,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Streaming', () => {
+  httpbin.describe('Streaming', () => {
     setupTestTimeout(t);
 
     it('should stream response', async () => {
@@ -524,7 +530,7 @@ export function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
   });
 
-  describe('Concurrent requests', () => {
+  httpbin.describe('Concurrent requests', () => {
     setupTestTimeout(t);
 
     it('should process multiple requests concurrently', async () => {
@@ -638,7 +644,7 @@ function setupTestTimeout(t: Record<string, any>, timeout: number = 30000) {
   let originalTimeout: number;
 
   t.beforeAll(() => {
-    // Increase the timeout in general because httpbin.test.k6.io can be slow.
+    // Increase the timeout in general because httpbin.io can be slow.
     originalTimeout = t.jasmine.DEFAULT_TIMEOUT_INTERVAL;
     t.jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout;
   });

--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -7,6 +7,7 @@ import { fetch } from 'expo/fetch';
 import { Platform } from 'react-native';
 
 import type { JasmineInterface } from '../types';
+import { gateOnHostAsync } from '../utils/HostReachability';
 import { requireNotNull } from '../utils/requireNotNull';
 
 export const name = 'FileSystem';
@@ -17,6 +18,10 @@ function delay(ms: number): Promise<void> {
 }
 
 export async function test({ describe, expect, it, ...t }: JasmineInterface) {
+  const httpbingo = await gateOnHostAsync(
+    { describe, it, pending: t.pending },
+    'https://httpbingo.org/get'
+  );
   const describeWithPermissions = shouldSkipTestsRequiringPermissions ? t.xdescribe : describe;
 
   const testDirectory = FS.documentDirectory + 'tests/';
@@ -1607,7 +1612,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(await src.digest('MD5')).toEqual(md5);
       });
 
-      it('reports download progress via onProgress callback', async () => {
+      httpbingo.it('reports download progress via onProgress callback', async () => {
         // Use a ~100KB file so progress events fire reliably
         const url = 'https://httpbingo.org/bytes/102400';
         const file = new File(testDirectory, 'progress_test.bin');
@@ -1634,7 +1639,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(lastUpdate.bytesWritten).toBe(file.size);
       });
 
-      it('reports monotonically increasing bytesWritten in progress', async () => {
+      httpbingo.it('reports monotonically increasing bytesWritten in progress', async () => {
         const url = 'https://httpbingo.org/bytes/102400';
         const file = new File(testDirectory, 'progress_monotonic.bin');
         const progressUpdates: { bytesWritten: number; totalBytes: number }[] = [];
@@ -1653,7 +1658,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         }
       });
 
-      it('totalBytes matches content-length when server provides it', async () => {
+      httpbingo.it('totalBytes matches content-length when server provides it', async () => {
         const url = 'https://httpbingo.org/bytes/51200';
         const file = new File(testDirectory, 'progress_total.bin');
         const progressUpdates: { bytesWritten: number; totalBytes: number }[] = [];
@@ -1671,7 +1676,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         }
       });
 
-      it('downloads with onProgress and custom headers together', async () => {
+      httpbingo.it('downloads with onProgress and custom headers together', async () => {
         const url = 'https://httpbingo.org/bytes/10240';
         const file = new File(testDirectory, 'progress_headers.bin');
         const progressUpdates: { bytesWritten: number; totalBytes: number }[] = [];
@@ -1688,7 +1693,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(progressUpdates.length).toBeGreaterThan(0);
       });
 
-      it('can cancel a download with AbortSignal', async () => {
+      httpbingo.it('can cancel a download with AbortSignal', async () => {
         // Use a slow-streaming endpoint to ensure the download is still in-flight when we cancel.
         // Note: httpbingo.org/bytes has a 524288 byte limit and returns 400 for larger values.
         const url = 'https://httpbingo.org/drip?numbytes=51200&duration=5&delay=0';
@@ -1711,7 +1716,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(error.message).toBe('The operation was aborted.');
       });
 
-      it('rejects immediately when signal is already aborted', async () => {
+      httpbingo.it('rejects immediately when signal is already aborted', async () => {
         const url = 'https://httpbingo.org/bytes/1024';
         const file = new File(testDirectory, 'already_aborted.bin');
         const controller = new AbortController();
@@ -1732,7 +1737,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(file.exists).toBe(false);
       });
 
-      it('can use onProgress and signal together', async () => {
+      httpbingo.it('can use onProgress and signal together', async () => {
         // /drip streams data over 5s, so progress events fire before the download completes.
         const url = 'https://httpbingo.org/drip?numbytes=51200&duration=5&delay=0';
         const file = new File(testDirectory, 'progress_and_cancel.bin');
@@ -1772,7 +1777,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
         expect(output.uri).toBe(file.uri);
       });
 
-      it('overwrites existing file with idempotent and onProgress', async () => {
+      httpbingo.it('overwrites existing file with idempotent and onProgress', async () => {
         const url = 'https://httpbingo.org/bytes/10240';
         const file = new File(testDirectory, 'idempotent_progress.bin');
         file.create();
@@ -2327,7 +2332,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
 
     // You can also use something like container twostoryrobot/simple-file-upload to test if the file is saved correctly
-    it('Supports sending a file using blob', async () => {
+    httpbingo.it('Supports sending a file using blob', async () => {
       const src = new File(testDirectory, 'file.txt');
       src.writeSync('abcde');
 
@@ -2340,7 +2345,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
     });
 
     // You can also use this docker image: twostoryrobot/simple-file-upload to test e2e blob upload.
-    it('Supports sending a file using blob with formdata', async () => {
+    httpbingo.it('Supports sending a file using blob with formdata', async () => {
       const src = new File(testDirectory, 'file.txt');
       src.writeSync('abcde');
 
@@ -2356,7 +2361,7 @@ export async function test({ describe, expect, it, ...t }: JasmineInterface) {
       expect(body.files.data[0]).toEqual('abcde');
     });
 
-    it('Supports sending a named file blob using blob with formdata', async () => {
+    httpbingo.it('Supports sending a named file blob using blob with formdata', async () => {
       const src = new File(testDirectory, 'file.txt');
       src.writeSync('abcde');
 

--- a/apps/test-suite/utils/HostReachability.ts
+++ b/apps/test-suite/utils/HostReachability.ts
@@ -1,0 +1,121 @@
+import type { JasmineInterface } from '../types';
+
+export type HostReachabilityOptions = {
+  /**
+   * How long a single probe request may take before it is aborted.
+   */
+  timeoutMs?: number;
+  /**
+   * How many times the probe is attempted before the host is considered unreachable.
+   */
+  attempts?: number;
+};
+
+/**
+ * The subset of the Jasmine interface the gate needs. Callers that destructure `describe` and `it`
+ * out of the interface can pass them back in together with `pending`.
+ */
+export type HostGateJasmine = Pick<JasmineInterface, 'describe' | 'it' | 'pending'>;
+
+/**
+ * `describe` and `it` replacements that register the real specs when the probed host answered,
+ * and a single pending spec naming the host when it did not.
+ */
+export type HostGate = {
+  reachable: boolean;
+  describe: JasmineInterface['describe'];
+  it: JasmineInterface['it'];
+};
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_ATTEMPTS = 2;
+
+const reachabilityByProbeUrl = new Map<string, Promise<boolean>>();
+
+/**
+ * Probes `probeUrl` with a GET request and resolves to `true` when it answers with a 2xx status.
+ * The result is cached per URL for the lifetime of the JS context, so several test modules that
+ * depend on the same host share one probe. Unreachable hosts are reported once with `console.warn`.
+ */
+export function isHostReachableAsync(
+  probeUrl: string,
+  options: HostReachabilityOptions = {}
+): Promise<boolean> {
+  let pending = reachabilityByProbeUrl.get(probeUrl);
+  if (!pending) {
+    pending = probeAsync(probeUrl, options);
+    reachabilityByProbeUrl.set(probeUrl, pending);
+  }
+  return pending;
+}
+
+/**
+ * Probes the host behind `probeUrl` and returns `describe` and `it` to register specs that need
+ * it. When the host is unreachable, gated blocks collapse into one pending spec so the run still
+ * completes and the skip stays visible in the report.
+ */
+export async function gateOnHostAsync(
+  t: HostGateJasmine,
+  probeUrl: string,
+  options: HostReachabilityOptions = {}
+): Promise<HostGate> {
+  const reachable = await isHostReachableAsync(probeUrl, options);
+  if (reachable) {
+    return { reachable, describe: t.describe, it: t.it };
+  }
+  const host = hostOf(probeUrl);
+  const reason = `${host} is unreachable, skipping specs that depend on it`;
+  const pendingSpec = () => {
+    t.pending(reason);
+  };
+  return {
+    reachable,
+    describe(description) {
+      t.describe(description, () => {
+        t.it(`skipped: ${host} is unreachable`, pendingSpec);
+      });
+    },
+    it(expectation) {
+      t.it(expectation, pendingSpec);
+    },
+  };
+}
+
+/**
+ * Clears the cached probe results. Only meant for unit tests of this module.
+ */
+export function resetHostReachabilityCache() {
+  reachabilityByProbeUrl.clear();
+}
+
+async function probeAsync(probeUrl: string, options: HostReachabilityOptions): Promise<boolean> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  let lastFailure = 'no response';
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(probeUrl, { method: 'GET', signal: controller.signal });
+      if (response.ok) {
+        return true;
+      }
+      lastFailure = `HTTP ${response.status}`;
+    } catch (error) {
+      lastFailure = controller.signal.aborted
+        ? `no response within ${timeoutMs}ms`
+        : String((error as Error)?.message ?? error);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  console.warn(
+    `[test-suite] ${hostOf(probeUrl)} is unreachable (${lastFailure} after ${attempts} attempt(s)), skipping specs that depend on it.`
+  );
+  return false;
+}
+
+function hostOf(url: string): string {
+  const match = url.match(/^[a-z]+:\/\/([^/?#]+)/i);
+  return match ? match[1] : url;
+}

--- a/apps/test-suite/utils/__tests__/HostReachability.test.ts
+++ b/apps/test-suite/utils/__tests__/HostReachability.test.ts
@@ -1,0 +1,168 @@
+import {
+  gateOnHostAsync,
+  isHostReachableAsync,
+  resetHostReachabilityCache,
+  type HostGateJasmine,
+} from '../HostReachability';
+
+const PROBE_URL = 'https://httpbin.io/get';
+
+type FetchMock = jest.Mock<Promise<Partial<Response>>, [string, RequestInit?]>;
+
+function mockFetch(
+  implementation: (url: string, init?: RequestInit) => Promise<Partial<Response>>
+) {
+  const mock = jest.fn(implementation) as FetchMock;
+  (globalThis as any).fetch = mock;
+  return mock;
+}
+
+function okResponse(): Promise<Partial<Response>> {
+  return Promise.resolve({ ok: true, status: 200 });
+}
+
+function failedResponse(status: number): Promise<Partial<Response>> {
+  return Promise.resolve({ ok: false, status });
+}
+
+function neverResolvesUntilAborted(_url: string, init?: RequestInit): Promise<Partial<Response>> {
+  return new Promise((_resolve, reject) => {
+    init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
+  });
+}
+
+function createJasmineMock() {
+  return {
+    describe: jest.fn(),
+    it: jest.fn(),
+    pending: jest.fn(),
+  } as unknown as HostGateJasmine & {
+    describe: jest.Mock;
+    it: jest.Mock;
+    pending: jest.Mock;
+  };
+}
+
+describe('isHostReachableAsync', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    resetHostReachabilityCache();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    delete (globalThis as any).fetch;
+  });
+
+  it('is reachable when the probe responds with 2xx', async () => {
+    mockFetch(okResponse);
+    expect(await isHostReachableAsync(PROBE_URL)).toBe(true);
+  });
+
+  it('is unreachable when the probe responds with a server error', async () => {
+    mockFetch(() => failedResponse(503));
+    expect(await isHostReachableAsync(PROBE_URL, { attempts: 1 })).toBe(false);
+  });
+
+  it('is unreachable when fetch rejects on every attempt', async () => {
+    const fetch = mockFetch(() => Promise.reject(new Error('Network request failed')));
+    expect(await isHostReachableAsync(PROBE_URL, { attempts: 2 })).toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('is unreachable when the probe does not answer within the timeout', async () => {
+    mockFetch(neverResolvesUntilAborted);
+    expect(await isHostReachableAsync(PROBE_URL, { timeoutMs: 10, attempts: 1 })).toBe(false);
+  });
+
+  it('retries and succeeds when a later attempt responds', async () => {
+    let calls = 0;
+    const fetch = mockFetch(() => {
+      calls++;
+      return calls === 1 ? Promise.reject(new Error('reset by peer')) : okResponse();
+    });
+    expect(await isHostReachableAsync(PROBE_URL, { attempts: 2 })).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('probes each URL once and caches the result', async () => {
+    const fetch = mockFetch(okResponse);
+    await isHostReachableAsync(PROBE_URL);
+    await isHostReachableAsync(PROBE_URL);
+    await isHostReachableAsync('https://httpbingo.org/get');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns once per unreachable host', async () => {
+    mockFetch(() => failedResponse(503));
+    await isHostReachableAsync(PROBE_URL, { attempts: 1 });
+    await isHostReachableAsync(PROBE_URL, { attempts: 1 });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('httpbin.io');
+  });
+
+  it('does not warn when the host is reachable', async () => {
+    mockFetch(okResponse);
+    await isHostReachableAsync(PROBE_URL);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('gateOnHostAsync', () => {
+  beforeEach(() => {
+    resetHostReachabilityCache();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete (globalThis as any).fetch;
+  });
+
+  it('passes describe and it through when the host is reachable', async () => {
+    mockFetch(okResponse);
+    const t = createJasmineMock();
+    const gate = await gateOnHostAsync(t, PROBE_URL);
+    expect(gate.reachable).toBe(true);
+    expect(gate.describe).toBe(t.describe);
+    expect(gate.it).toBe(t.it);
+  });
+
+  it('replaces a gated describe with one pending spec when the host is unreachable', async () => {
+    mockFetch(() => failedResponse(503));
+    const t = createJasmineMock();
+    const gate = await gateOnHostAsync(t, PROBE_URL, { attempts: 1 });
+    expect(gate.reachable).toBe(false);
+    const body = jest.fn();
+    gate.describe('NetworkRequestObserver', body);
+    expect(body).not.toHaveBeenCalled();
+    expect(t.describe).toHaveBeenCalledTimes(1);
+    expect(t.describe.mock.calls[0][0]).toBe('NetworkRequestObserver');
+    // Run the registered describe body: it must register exactly one pending spec.
+    t.describe.mock.calls[0][1]();
+    expect(t.it).toHaveBeenCalledTimes(1);
+    const [specName, specFn] = t.it.mock.calls[0];
+    expect(specName).toMatch(/skipped/);
+    expect(specName).toContain('httpbin.io');
+    specFn();
+    expect(t.pending).toHaveBeenCalledTimes(1);
+    expect(t.pending.mock.calls[0][0]).toContain('httpbin.io');
+  });
+
+  it('replaces a gated it with a pending spec of the same name when the host is unreachable', async () => {
+    mockFetch(() => failedResponse(503));
+    const t = createJasmineMock();
+    const gate = await gateOnHostAsync(t, PROBE_URL, { attempts: 1 });
+    const body = jest.fn();
+    gate.it('downloads a file', body, 30000);
+    expect(body).not.toHaveBeenCalled();
+    expect(t.it).toHaveBeenCalledTimes(1);
+    const [specName, specFn] = t.it.mock.calls[0];
+    expect(specName).toBe('downloads a file');
+    specFn();
+    expect(t.pending).toHaveBeenCalledTimes(1);
+    expect(t.pending.mock.calls[0][0]).toContain('httpbin.io');
+  });
+});


### PR DESCRIPTION
# Why

Every "Test Suite e2e" run since Aug 28 fails in the `AppMetrics` suite, in the `NetworkRequestObserver` block, on both platforms and on every branch. Those specs fetch from httpbin.io, and `AppMetrics` is the first suite in the flow, so when that host misbehaves nothing else in the test suite runs either. The same dependency exists in `Fetch` (httpbin.io) and `FileSystem` (httpbingo.org).

# How

A small helper in `apps/test-suite/utils/HostReachability.ts` probes a URL once per JS context and hands back `describe` and `it` replacements. When the host answers, they're the real Jasmine functions. When it doesn't, a gated block collapses into one pending spec that names the host, and a gated spec becomes pending under its own name. The runner only counts passed and failed specs, so the summary stays "All tests passed!" and Maestro keeps going.

The probe runs at the top of each module's `test()`. That works because `TestScreen` awaits every module's `test()` before it executes the Jasmine env, which is the same trick `Brightness.ts` already uses for permission-gated suites.

This only covers a host that's down or unreachable. If httpbin.io answers `/get` but breaks on other endpoints, the specs still run.

# Test Plan

Unit tests for the helper in `apps/test-suite/utils/__tests__` cover 2xx, 5xx, rejected fetch, timeout, retry, per-URL caching, the single warning, and both gate modes (`pnpm -C apps/test-suite test`). To see the skip on a device, run `bareexpo://test-suite/run?tests=AppMetrics,Fetch,FileSystem` with httpbin.io blocked and check for the pending "skipped: httpbin.io is unreachable" specs plus the green summary.
