### PR TITLE
[expo-updates][Android] Prevent emergency launch after request header override

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49505](https://github.com/expo/expo/pull/49505) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Pick up `rootProject.ext.ndkVersion` so the module's `android.ndkVersion` matches the host project's NDK; otherwise AGP falls back to its own preferred version and reports `[CXX1104] NDK ... disagrees with android.ndkVersion`. ([#45759](https://github.com/expo/expo/pull/45759) by [@xxih](https://github.com/xxih))
+- [Android] Fix failing to launch the embedded update after overriding update request headers at runtime. (foo by [@roitium](https://github.com/roitium))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [iOS] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49504](https://github.com/expo/expo/pull/49504) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Adopt the existing asset row when registering a new asset whose key is already in the database, instead of replacing it, which cascade-deleted every update referencing that asset. ([#49505](https://github.com/expo/expo/pull/49505) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Pick up `rootProject.ext.ndkVersion` so the module's `android.ndkVersion` matches the host project's NDK; otherwise AGP falls back to its own preferred version and reports `[CXX1104] NDK ... disagrees with android.ndkVersion`. ([#45759](https://github.com/expo/expo/pull/45759) by [@xxih](https://github.com/xxih))
-- [Android] Fix failing to launch the embedded update after overriding update request headers at runtime. (foo by [@roitium](https://github.com/roitium))
+- [Android] Fix failing to launch the embedded update after overriding update request headers at runtime. ([#49732](https://github.com/expo/expo/pull/49732) by [@roitium](https://github.com/roitium))
 
 ### 💡 Others
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/launcher/DatabaseLauncher.kt
@@ -173,7 +173,14 @@ class DatabaseLauncher(
       filteredLaunchableUpdates.add(update)
     }
     val manifestFilters = ManifestMetadata.getManifestFilters(database, configuration)
-    return selectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters)
+    val selectedUpdate = selectionPolicy.selectUpdateToLaunch(filteredLaunchableUpdates, manifestFilters)
+    if (selectedUpdate != null) {
+      return selectedUpdate
+    }
+
+    // Fall back to this binary's embedded update when no configuration match exists.
+    val embeddedUpdateId = embeddedUpdate?.updateEntity?.id
+    return filteredLaunchableUpdates.firstOrNull { it.id == embeddedUpdateId }
   }
 
   private fun embeddedAssetFileMap(): MutableMap<AssetEntity, String> {


### PR DESCRIPTION
# Why

Runtime update request-header overrides using `Updates.setUpdateRequestHeadersOverride(requestHeaders)` can prevent the embedded update from matching the effective configuration on a later cold start, causing an unnecessary **emergency launch**.

# How

Keep the normal selection policy unchanged. When it finds no matching update, fall back only to the update embedded in the current binary.

# Test Plan

I applied this patch to my app's expo-updates; it compiled successfully, and the bug got fixed. 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
