### PR TITLE
[docs] Document EAS workflows `run_name` config

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -40,13 +40,42 @@ Below is a reference for the syntax of the workflow configuration file.
 
 ## `name`
 
-The human-friendly name of the workflow. This is displayed on the EAS dashboard on the workflows list page and is the title of the workflow's detail page.
+The human-friendly name of the workflow. This is displayed on the EAS dashboard on the workflows list page and is the title of the workflow's detail page. To set a title for each individual run, use [`run_name`](#run_name).
 
 ```yaml
 # @info #
 name: My workflow
 # @end #
 ```
+
+## `run_name`
+
+The title of an individual workflow run. This is separate from [`name`](#name), which labels the workflow itself.
+
+```yaml
+name: Deploy
+# @info #
+run_name: Deploy ${{ inputs.environment }}
+# @end #
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        options:
+          - preview
+          - production
+        required: true
+```
+
+The value is a string. It can include `${{ }}` expressions. EAS renders the template when it creates the run, before any job starts.
+
+The expression can use the [`github`](#github), [`app_store_connect`](#app_store_connect), `inputs`, [`workflow`](#workflow), `app`, and `account` contexts. It supports all [context functions](#context-functions) except `success()`, `failure()`, and `hashFiles()`. Those functions need a job or step that has already run.
+
+Job-level contexts such as `needs`, `steps`, and `env` are not available. If the template references an unsupported context, the run fails. EAS stores an error and does not store a custom title.
+
+If the rendered text is longer than 255 characters, EAS truncates it to 254 characters and appends an ellipsis.
 
 ## `on`
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Workflows are now possible to configure with `run_name` to assign a custom name to a workflow run. This PR adds the user-facing documentation for this feature.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add the `run_name` section in EAS Workflows Syntax docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="796" height="723" alt="Screenshot 2026-09-04 at 12 46 59" src="https://github.com/user-attachments/assets/ce22753f-9a26-42b0-988d-e07877570204" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
