### PR TITLE
[ui][iOS] Expose Overlay, Background, Mask and SlotView with stable child identities

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -65,6 +65,7 @@
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix `Host` color scheme type errors on React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fixed `PlatformColor` and `DynamicColorIOS` values dropping the `backgroundColor` and `borderColor` of a universal component. Both were stringified to `"[object Object]"`, which the native color converter rejects, so the modifier was discarded without a trace. ([#49746](https://github.com/expo/expo/pull/49746) by [@Den1Marshall](https://github.com/Den1Marshall))
+- [iOS] Preserve string-based child identities in `Overlay`, `Background`, and `Mask`. ([#49734](https://github.com/expo/expo/pull/49734) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/BackgroundView.swift
+++ b/packages/expo-ui/ios/BackgroundView.swift
@@ -19,7 +19,7 @@ internal struct BackgroundView: ExpoSwiftUI.View {
 
   @ViewBuilder
   private var baseContent: some View {
-    ForEach(props.children?.withoutSlots() ?? [], id: \.id) { child in
+    ForEach(props.children?.withoutSlots() ?? [], id: \.childIdentity) { child in
       let view: any View = child.childView
       AnyView(view)
     }

--- a/packages/expo-ui/ios/BackgroundView.swift
+++ b/packages/expo-ui/ios/BackgroundView.swift
@@ -3,14 +3,18 @@
 import ExpoModulesCore
 import SwiftUI
 
-internal class BackgroundViewProps: UIBaseViewProps {
+public final class BackgroundViewProps: UIBaseViewProps {
   @Field var alignment: AlignmentOptions?
 }
 
-internal struct BackgroundView: ExpoSwiftUI.View {
-  @ObservedObject var props: BackgroundViewProps
+public struct BackgroundView: ExpoSwiftUI.View {
+  @ObservedObject public var props: BackgroundViewProps
 
-  var body: some View {
+  public init(props: BackgroundViewProps) {
+    self.props = props
+  }
+
+  public var body: some View {
     baseContent
       .background(alignment: props.alignment?.toAlignment() ?? .center) {
         backgroundContent

--- a/packages/expo-ui/ios/MaskView.swift
+++ b/packages/expo-ui/ios/MaskView.swift
@@ -22,7 +22,7 @@ internal struct MaskView: ExpoSwiftUI.View {
 
   @ViewBuilder
   private var baseContent: some View {
-    ForEach(props.children?.withoutSlots() ?? [], id: \.id) { child in
+    ForEach(props.children?.withoutSlots() ?? [], id: \.childIdentity) { child in
       let view: any View = child.childView
       AnyView(view)
     }

--- a/packages/expo-ui/ios/MaskView.swift
+++ b/packages/expo-ui/ios/MaskView.swift
@@ -3,14 +3,18 @@
 import ExpoModulesCore
 import SwiftUI
 
-internal class MaskViewProps: UIBaseViewProps {
+public final class MaskViewProps: UIBaseViewProps {
   @Field var alignment: AlignmentOptions?
 }
 
-internal struct MaskView: ExpoSwiftUI.View {
-  @ObservedObject var props: MaskViewProps
+public struct MaskView: ExpoSwiftUI.View {
+  @ObservedObject public var props: MaskViewProps
 
-  var body: some View {
+  public init(props: MaskViewProps) {
+    self.props = props
+  }
+
+  public var body: some View {
     if let mask = props.children?.slot("content") {
       baseContent.mask(alignment: props.alignment?.toAlignment() ?? .center) {
         mask

--- a/packages/expo-ui/ios/OverlayView.swift
+++ b/packages/expo-ui/ios/OverlayView.swift
@@ -19,7 +19,7 @@ internal struct OverlayView: ExpoSwiftUI.View {
 
   @ViewBuilder
   private var baseContent: some View {
-    ForEach(props.children?.withoutSlots() ?? [], id: \.id) { child in
+    ForEach(props.children?.withoutSlots() ?? [], id: \.childIdentity) { child in
       let view: any View = child.childView
       AnyView(view)
     }

--- a/packages/expo-ui/ios/OverlayView.swift
+++ b/packages/expo-ui/ios/OverlayView.swift
@@ -3,14 +3,18 @@
 import ExpoModulesCore
 import SwiftUI
 
-internal class OverlayViewProps: UIBaseViewProps {
+public final class OverlayViewProps: UIBaseViewProps {
   @Field var alignment: AlignmentOptions?
 }
 
-internal struct OverlayView: ExpoSwiftUI.View {
-  @ObservedObject var props: OverlayViewProps
+public struct OverlayView: ExpoSwiftUI.View {
+  @ObservedObject public var props: OverlayViewProps
 
-  var body: some View {
+  public init(props: OverlayViewProps) {
+    self.props = props
+  }
+
+  public var body: some View {
     baseContent
       .overlay(alignment: props.alignment?.toAlignment() ?? .center) {
         overlayContent

--- a/packages/expo-ui/ios/SlotView.swift
+++ b/packages/expo-ui/ios/SlotView.swift
@@ -3,19 +3,19 @@
 import SwiftUI
 import ExpoModulesCore
 
-internal final class SlotViewProps: ExpoSwiftUI.ViewProps {
+public final class SlotViewProps: ExpoSwiftUI.ViewProps {
   @Field var name: String = ""
   @Field var extraProps: [String: Any]?
 }
 
-internal struct SlotView: ExpoSwiftUI.View {
-  @ObservedObject var props: SlotViewProps
+public struct SlotView: ExpoSwiftUI.View {
+  @ObservedObject public var props: SlotViewProps
 
-  init(props: SlotViewProps) {
+  public init(props: SlotViewProps) {
     self.props = props
   }
 
-  var body: some View {
+  public var body: some View {
     Children()
   }
 


### PR DESCRIPTION
# Why

`Overlay`, `Background`, and `Mask` need to preserve the string identities supplied by `expo-widgets` when rendering their base children. Their native SwiftUI implementations and `SlotView` also need to be accessible from the widgets module.

# How

- Reconcile base children through `childIdentity` from #49701.
- Expose the native `Overlay`, `Background`, `Mask`, and `SlotView` view types, their props, and their initializers for reuse by Expo modules.

# Test Plan

* CI should pass
* tested manually in Bare Expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>