### PR TITLE
[router][android] Make @expo/ui an optional peer dependency

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Remove the `onReady` container prop and the `ready` container event. ([#49845](https://github.com/expo/expo/pull/49845) by [@Ubax](https://github.com/Ubax))
 - Remove `createStackNavigator` from `expo-router/js-stack`. Use `unstable_createStandardStackNavigator` with `unstable_integrateWithRouter` instead. ([#49209](https://github.com/expo/expo/pull/49209) by [@Ubax](https://github.com/Ubax))
-- Make `@expo/ui` an optional peer dependency. Install it to use `Stack.Toolbar` on Android.
+- Make `@expo/ui` an optional peer dependency. Install it to use `Stack.Toolbar` on Android. ([#49737](https://github.com/expo/expo/pull/49737) by [@Ubax](https://github.com/Ubax))
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove the `onReady` container prop and the `ready` container event. ([#49845](https://github.com/expo/expo/pull/49845) by [@Ubax](https://github.com/Ubax))
 - Remove `createStackNavigator` from `expo-router/js-stack`. Use `unstable_createStandardStackNavigator` with `unstable_integrateWithRouter` instead. ([#49209](https://github.com/expo/expo/pull/49209) by [@Ubax](https://github.com/Ubax))
+- Make `@expo/ui` an optional peer dependency. Install it to use `Stack.Toolbar` on Android.
 - Remove `UNSTABLE_UnhandledLinkingContext` from `expo-router/react-navigation`. ([#49616](https://github.com/expo/expo/pull/49616) by [@Ubax](https://github.com/Ubax))
 - Remove `BaseNavigationContainer` export from `expo-router/react-navigation`. ([#49587](https://github.com/expo/expo/pull/49587) by [@Ubax](https://github.com/Ubax))
 - Dispatch queued navigation actions in React transitions. The current screen stays visible while the destination suspends, so `SuspenseFallback` no longer renders for navigation-triggered suspense. ([#49448](https://github.com/expo/expo/pull/49448) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -283,7 +283,6 @@
     "@expo/log-box": "workspace:^",
     "@expo/metro-runtime": "workspace:^",
     "@expo/schema-utils": "workspace:^",
-    "@expo/ui": "workspace:^",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-tabs": "^1.1.12",
     "@react-native-masked-view/masked-view": "^0.3.2",
@@ -308,6 +307,7 @@
     "standard-navigation": "^0.0.5"
   },
   "devDependencies": {
+    "@expo/ui": "workspace:^",
     "@jest/globals": "^29.7.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.9.1",
@@ -336,6 +336,7 @@
   "peerDependencies": {
     "@expo/log-box": "workspace:^",
     "@expo/metro-runtime": "workspace:^",
+    "@expo/ui": "workspace:^",
     "@testing-library/react-native": ">= 13.2.0",
     "expo": "*",
     "expo-constants": "workspace:^",
@@ -351,6 +352,9 @@
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
   "peerDependenciesMeta": {
+    "@expo/ui": {
+      "optional": true
+    },
     "@testing-library/react-native": {
       "optional": true
     },

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.android.tsx
@@ -2,8 +2,16 @@ import { render, screen, within } from '@testing-library/react-native';
 import React from 'react';
 
 import { NativeMenuContext } from '../../../link/NativeMenuContext';
+import { requireExpoUI } from '../../../optional-libraries/expo-ui';
 import { ToolbarColorContext, ToolbarPlacementContext } from '../toolbar/context';
 import { processHeaderItemsForPlatform } from '../toolbar/processHeaderItemsForPlatform';
+
+jest.mock('../../../optional-libraries/expo-ui', () => ({
+  requireExpoUI: jest.fn(() => ({
+    expoUI: jest.requireMock('@expo/ui/jetpack-compose'),
+    modifiers: jest.requireMock('@expo/ui/jetpack-compose/modifiers'),
+  })),
+}));
 
 jest.mock('@expo/ui/jetpack-compose', () => {
   const { View }: typeof import('react-native') = jest.requireActual('react-native');
@@ -76,12 +84,29 @@ const { Row } = jest.requireMock(
   '@expo/ui/jetpack-compose'
 ) as typeof import('@expo/ui/jetpack-compose');
 const MockedRow = Row as jest.MockedFunction<typeof Row>;
+const mockedRequireExpoUI = jest.mocked(requireExpoUI);
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockedRequireExpoUI.mockImplementation(() => ({
+    expoUI: jest.requireMock('@expo/ui/jetpack-compose'),
+    modifiers: jest.requireMock('@expo/ui/jetpack-compose/modifiers'),
+  }));
 });
 
 describe('processHeaderItemsForPlatform', () => {
+  it("throws when @expo/ui isn't installed", () => {
+    mockedRequireExpoUI.mockImplementation(() => {
+      throw new Error(
+        "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+      );
+    });
+
+    expect(() => processHeaderItemsForPlatform(<></>, 'left')).toThrow(
+      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+    );
+  });
+
   it('returns null for bottom placement', () => {
     const result = processHeaderItemsForPlatform(<></>, 'bottom');
     expect(result).toBeNull();

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.android.tsx
@@ -105,6 +105,9 @@ describe('processHeaderItemsForPlatform', () => {
     expect(() => processHeaderItemsForPlatform(<></>, 'left')).toThrow(
       "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
     );
+    expect(mockedRequireExpoUI).toHaveBeenCalledWith(
+      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+    );
   });
 
   it('returns null for bottom placement', () => {

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { Icon, IconButton } from '@expo/ui/jetpack-compose';
 
+import { requireExpoUI } from '../../../../optional-libraries/expo-ui';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
 import { getBadgeContentDescription, ToolbarItemBadge } from '../ToolbarItemBadge';
 import { useToolbarColors } from '../context';
@@ -22,6 +22,9 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
     }
     return null;
   }
+  const {
+    expoUI: { Icon, IconButton },
+  } = requireExpoUI();
 
   // `tint={null}` tells `<Icon>` to draw the source in its original colors.
   // `undefined` would fall back to `LocalContentColor`, i.e. the IconButton's

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarButton/native.android.tsx
@@ -24,7 +24,9 @@ export const NativeToolbarButton: React.FC<NativeToolbarButtonProps> = (props) =
   }
   const {
     expoUI: { Icon, IconButton },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
 
   // `tint={null}` tells `<Icon>` to draw the source in its original colors.
   // `undefined` would fall back to `LocalContentColor`, i.e. the IconButton's

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
@@ -1,15 +1,7 @@
 'use client';
-import {
-  DropdownMenu,
-  DropdownMenuItem,
-  HorizontalDivider,
-  Icon,
-  IconButton,
-  Text as ComposeText,
-} from '@expo/ui/jetpack-compose';
-import { background } from '@expo/ui/jetpack-compose/modifiers';
 import { createContext, use, useCallback, useState } from 'react';
 
+import { requireExpoUI } from '../../../../optional-libraries/expo-ui';
 import { Label } from '../../../../primitives';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
 import { getFirstChildOfType } from '../../../../utils/children';
@@ -37,6 +29,17 @@ const ToolbarMenuCloseContext = createContext<(() => void) | null>(null);
  * Renders as a DropdownMenu with IconButton trigger (root) or DropdownMenuItem trigger (nested).
  */
 export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
+  const {
+    expoUI: {
+      DropdownMenu,
+      DropdownMenuItem,
+      HorizontalDivider,
+      Icon,
+      IconButton,
+      Text: ComposeText,
+    },
+    modifiers: { background },
+  } = requireExpoUI();
   const [expanded, setExpanded] = useState(false);
   const parentClose = use(ToolbarMenuCloseContext);
   const isNested = parentClose !== null;
@@ -168,6 +171,10 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
  * Renders as a DropdownMenuItem.
  */
 export const NativeToolbarMenuAction: React.FC<NativeToolbarMenuActionProps> = (props) => {
+  const {
+    expoUI: { DropdownMenuItem, Icon, Text: ComposeText },
+    modifiers: { background },
+  } = requireExpoUI();
   const closeMenu = use(ToolbarMenuCloseContext);
   const toolbarColors = useToolbarColors();
   const tintColor = props.destructive

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarMenu/native.android.tsx
@@ -39,7 +39,9 @@ export const NativeToolbarMenu: React.FC<NativeToolbarMenuProps> = (props) => {
       Text: ComposeText,
     },
     modifiers: { background },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   const [expanded, setExpanded] = useState(false);
   const parentClose = use(ToolbarMenuCloseContext);
   const isNested = parentClose !== null;
@@ -174,7 +176,9 @@ export const NativeToolbarMenuAction: React.FC<NativeToolbarMenuActionProps> = (
   const {
     expoUI: { DropdownMenuItem, Icon, Text: ComposeText },
     modifiers: { background },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   const closeMenu = use(ToolbarMenuCloseContext);
   const toolbarColors = useToolbarColors();
   const tintColor = props.destructive

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarSpacer/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarSpacer/native.android.tsx
@@ -1,7 +1,6 @@
 'use client';
-import { Box } from '@expo/ui/jetpack-compose';
-import { width } from '@expo/ui/jetpack-compose/modifiers';
 
+import { requireExpoUI } from '../../../../optional-libraries/expo-ui';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
 import type { NativeToolbarSpacerProps } from './types';
 
@@ -13,6 +12,10 @@ export const NativeToolbarSpacer: React.FC<NativeToolbarSpacerProps> = (props) =
   if (!props.width) {
     return null;
   }
+  const {
+    expoUI: { Box },
+    modifiers: { width },
+  } = requireExpoUI();
 
   return (
     <AnimatedItemContainer visible={!props.hidden}>

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarSpacer/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarSpacer/native.android.tsx
@@ -15,7 +15,9 @@ export const NativeToolbarSpacer: React.FC<NativeToolbarSpacerProps> = (props) =
   const {
     expoUI: { Box },
     modifiers: { width },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
 
   return (
     <AnimatedItemContainer visible={!props.hidden}>

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarView/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarView/native.android.tsx
@@ -1,16 +1,17 @@
 'use client';
-import { Box, RNHostView } from '@expo/ui/jetpack-compose';
-import { fillMaxHeight } from '@expo/ui/jetpack-compose/modifiers';
 
+import { requireExpoUI } from '../../../../optional-libraries/expo-ui';
 import { AnimatedItemContainer } from '../../../../toolbar/AnimatedItemContainer';
 import { useToolbarPlacement } from '../context';
 import type { NativeToolbarViewProps } from './types';
 
-const bottomPlacementModifiers = [fillMaxHeight()];
-
 export const NativeToolbarView: React.FC<NativeToolbarViewProps> = ({ children, hidden }) => {
+  const {
+    expoUI: { Box, RNHostView },
+    modifiers: { fillMaxHeight },
+  } = requireExpoUI();
   const placement = useToolbarPlacement();
-  const modifiers = placement === 'bottom' ? bottomPlacementModifiers : undefined;
+  const modifiers = placement === 'bottom' ? [fillMaxHeight()] : undefined;
 
   return (
     <Box contentAlignment="center" modifiers={modifiers}>

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarView/native.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/StackToolbarView/native.android.tsx
@@ -9,7 +9,9 @@ export const NativeToolbarView: React.FC<NativeToolbarViewProps> = ({ children, 
   const {
     expoUI: { Box, RNHostView },
     modifiers: { fillMaxHeight },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   const placement = useToolbarPlacement();
   const modifiers = placement === 'bottom' ? [fillMaxHeight()] : undefined;
 

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
@@ -1,8 +1,7 @@
 'use client';
-import { Badge, Box, Text as ComposeText } from '@expo/ui/jetpack-compose';
-import { alpha as alphaModifier } from '@expo/ui/jetpack-compose/modifiers';
 import type { ReactElement, ReactNode } from 'react';
 
+import { requireExpoUI } from '../../../optional-libraries/expo-ui';
 import type { NativeStackHeaderItemButton } from '../../../react-navigation/native-stack';
 import { convertFontWeightToComposeFontWeight } from '../../../utils/font';
 
@@ -45,6 +44,10 @@ export function ToolbarItemBadge({
   if (!badge) {
     return <>{children}</>;
   }
+  const {
+    expoUI: { Badge, Box, Text: ComposeText },
+    modifiers: { alpha: alphaModifier },
+  } = requireExpoUI();
   return (
     <Box contentAlignment="topEnd">
       {children}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/ToolbarItemBadge.android.tsx
@@ -47,7 +47,9 @@ export function ToolbarItemBadge({
   const {
     expoUI: { Badge, Box, Text: ComposeText },
     modifiers: { alpha: alphaModifier },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   return (
     <Box contentAlignment="topEnd">
       {children}

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/processHeaderItemsForPlatform.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/processHeaderItemsForPlatform.android.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { Host, Row } from '@expo/ui/jetpack-compose';
 import { type ReactNode, useMemo } from 'react';
 
 import { NativeMenuContext } from '../../../link/NativeMenuContext';
+import { requireExpoUI } from '../../../optional-libraries/expo-ui';
 import type {
   NativeStackHeaderItemProps,
   NativeStackNavigationOptions,
@@ -27,6 +27,7 @@ export function processHeaderItemsForPlatform(
   if (placement !== 'left' && placement !== 'right') {
     return null;
   }
+  requireExpoUI();
 
   const headerContent = (props: NativeStackHeaderItemProps) => (
     <HeaderToolbarHostBase placement={placement} colors={colors} headerProps={props}>
@@ -58,6 +59,9 @@ function HeaderToolbarHostBase({
   colors?: ToolbarColors;
   headerProps?: NativeStackHeaderItemProps;
 }) {
+  const {
+    expoUI: { Host, Row },
+  } = requireExpoUI();
   const stableColors = useMemo(
     () => ({
       tintColor: colors?.tintColor ?? headerProps?.tintColor,

--- a/packages/expo-router/src/layouts/stack-utils/toolbar/processHeaderItemsForPlatform.android.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/toolbar/processHeaderItemsForPlatform.android.tsx
@@ -27,7 +27,9 @@ export function processHeaderItemsForPlatform(
   if (placement !== 'left' && placement !== 'right') {
     return null;
   }
-  requireExpoUI();
+  requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
 
   const headerContent = (props: NativeStackHeaderItemProps) => (
     <HeaderToolbarHostBase placement={placement} colors={colors} headerProps={props}>
@@ -61,7 +63,9 @@ function HeaderToolbarHostBase({
 }) {
   const {
     expoUI: { Host, Row },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   const stableColors = useMemo(
     () => ({
       tintColor: colors?.tintColor ?? headerProps?.tintColor,

--- a/packages/expo-router/src/optional-libraries/__tests__/expo-ui.test.android.tsx
+++ b/packages/expo-router/src/optional-libraries/__tests__/expo-ui.test.android.tsx
@@ -1,0 +1,30 @@
+describe('requireExpoUI', () => {
+  afterEach(() => {
+    jest.dontMock('@expo/ui/jetpack-compose');
+  });
+
+  it('returns the installed library', () => {
+    jest.isolateModules(() => {
+      const { requireExpoUI } = require('../expo-ui');
+
+      expect(requireExpoUI()).toEqual({
+        expoUI: require('@expo/ui/jetpack-compose'),
+        modifiers: require('@expo/ui/jetpack-compose/modifiers'),
+      });
+    });
+  });
+
+  it('throws when the library is not installed', () => {
+    jest.doMock('@expo/ui/jetpack-compose', () => {
+      throw new Error("Cannot find module '@expo/ui/jetpack-compose'");
+    });
+
+    jest.isolateModules(() => {
+      const { requireExpoUI } = require('../expo-ui');
+
+      expect(requireExpoUI).toThrow(
+        "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+      );
+    });
+  });
+});

--- a/packages/expo-router/src/optional-libraries/__tests__/expo-ui.test.android.tsx
+++ b/packages/expo-router/src/optional-libraries/__tests__/expo-ui.test.android.tsx
@@ -23,8 +23,9 @@ describe('requireExpoUI', () => {
       const { requireExpoUI } = require('../expo-ui');
 
       expect(requireExpoUI).toThrow(
-        "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+        "The '@expo/ui' package needs to be installed in order to use this feature."
       );
+      expect(() => requireExpoUI('Custom error message')).toThrow('Custom error message');
     });
   });
 });

--- a/packages/expo-router/src/optional-libraries/expo-ui.ts
+++ b/packages/expo-router/src/optional-libraries/expo-ui.ts
@@ -1,0 +1,21 @@
+type ExpoUI = typeof import('@expo/ui/jetpack-compose');
+type ExpoUIModifiers = typeof import('@expo/ui/jetpack-compose/modifiers');
+
+let expoUI: ExpoUI | undefined;
+let modifiers: ExpoUIModifiers | undefined;
+
+try {
+  const loadedExpoUI: ExpoUI = require('@expo/ui/jetpack-compose');
+  const loadedModifiers: ExpoUIModifiers = require('@expo/ui/jetpack-compose/modifiers');
+  expoUI = loadedExpoUI;
+  modifiers = loadedModifiers;
+} catch {}
+
+export function requireExpoUI(): { expoUI: ExpoUI; modifiers: ExpoUIModifiers } {
+  if (!expoUI || !modifiers) {
+    throw new Error(
+      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+    );
+  }
+  return { expoUI, modifiers };
+}

--- a/packages/expo-router/src/optional-libraries/expo-ui.ts
+++ b/packages/expo-router/src/optional-libraries/expo-ui.ts
@@ -11,11 +11,11 @@ try {
   modifiers = loadedModifiers;
 } catch {}
 
-export function requireExpoUI(): { expoUI: ExpoUI; modifiers: ExpoUIModifiers } {
+export function requireExpoUI(
+  errorMessage = "The '@expo/ui' package needs to be installed in order to use this feature."
+): { expoUI: ExpoUI; modifiers: ExpoUIModifiers } {
   if (!expoUI || !modifiers) {
-    throw new Error(
-      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
-    );
+    throw new Error(errorMessage);
   }
   return { expoUI, modifiers };
 }

--- a/packages/expo-router/src/toolbar/AnimatedItemContainer.android.tsx
+++ b/packages/expo-router/src/toolbar/AnimatedItemContainer.android.tsx
@@ -1,5 +1,6 @@
-import { AnimatedVisibility, EnterTransition, ExitTransition } from '@expo/ui/jetpack-compose';
 import type { ReactNode } from 'react';
+
+import { requireExpoUI } from '../optional-libraries/expo-ui';
 
 /**
  * Shared animated container for Android toolbar items.
@@ -11,6 +12,10 @@ export function AnimatedItemContainer({
   visible: boolean;
   children: ReactNode;
 }) {
+  const {
+    expoUI: { AnimatedVisibility, EnterTransition, ExitTransition },
+  } = requireExpoUI();
+
   return (
     <AnimatedVisibility
       // As mentioned in the docs, `scaleIn` does not animate layout, so we need to combine it with `expandIn` to get the layout animation as well. The same applies to `scaleOut` and `shrinkOut`.

--- a/packages/expo-router/src/toolbar/AnimatedItemContainer.android.tsx
+++ b/packages/expo-router/src/toolbar/AnimatedItemContainer.android.tsx
@@ -14,7 +14,9 @@ export function AnimatedItemContainer({
 }) {
   const {
     expoUI: { AnimatedVisibility, EnterTransition, ExitTransition },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
 
   return (
     <AnimatedVisibility

--- a/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
+++ b/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
@@ -1,7 +1,15 @@
 import { render, within } from '@testing-library/react-native';
 import { Text } from 'react-native';
 
+import { requireExpoUI } from '../../optional-libraries/expo-ui';
 import { RouterToolbarHost } from '../native';
+
+jest.mock('../../optional-libraries/expo-ui', () => ({
+  requireExpoUI: jest.fn(() => ({
+    expoUI: jest.requireMock('@expo/ui/jetpack-compose'),
+    modifiers: jest.requireMock('@expo/ui/jetpack-compose/modifiers'),
+  })),
+}));
 
 jest.mock('@expo/ui/jetpack-compose', () => {
   const { View }: typeof import('react-native') = jest.requireActual('react-native');
@@ -27,8 +35,28 @@ jest.mock('react-native-safe-area-context', () => ({
 
 const flatten = (style: unknown) =>
   Object.assign({}, ...(Array.isArray(style) ? style : [style]).filter(Boolean));
+const mockedRequireExpoUI = jest.mocked(requireExpoUI);
+
+beforeEach(() => {
+  mockedRequireExpoUI.mockImplementation(() => ({
+    expoUI: jest.requireMock('@expo/ui/jetpack-compose'),
+    modifiers: jest.requireMock('@expo/ui/jetpack-compose/modifiers'),
+  }));
+});
 
 describe('RouterToolbarHost (Android bottom toolbar)', () => {
+  it("throws when @expo/ui isn't installed", () => {
+    mockedRequireExpoUI.mockImplementation(() => {
+      throw new Error(
+        "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+      );
+    });
+
+    expect(() => render(<RouterToolbarHost />)).toThrow(
+      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+    );
+  });
+
   it('does not cover the full screen so touches above the toolbar pass through', () => {
     const { getByTestId } = render(
       <RouterToolbarHost>

--- a/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
+++ b/packages/expo-router/src/toolbar/__tests__/native.test.android.tsx
@@ -55,6 +55,9 @@ describe('RouterToolbarHost (Android bottom toolbar)', () => {
     expect(() => render(<RouterToolbarHost />)).toThrow(
       "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
     );
+    expect(mockedRequireExpoUI).toHaveBeenCalledWith(
+      "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+    );
   });
 
   it('does not cover the full screen so touches above the toolbar pass through', () => {

--- a/packages/expo-router/src/toolbar/native.android.tsx
+++ b/packages/expo-router/src/toolbar/native.android.tsx
@@ -1,12 +1,15 @@
-import { Host, HorizontalFloatingToolbar, Box } from '@expo/ui/jetpack-compose';
-import { fillMaxWidth, height, padding, imePadding } from '@expo/ui/jetpack-compose/modifiers';
 import { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { requireExpoUI } from '../optional-libraries/expo-ui';
 import type { RouterToolbarHostProps } from './native.types';
 
 export function RouterToolbarHost(props: RouterToolbarHostProps) {
+  const {
+    expoUI: { Host, HorizontalFloatingToolbar, Box },
+    modifiers: { fillMaxWidth, height, padding, imePadding },
+  } = requireExpoUI();
   const insets = useSafeAreaInsets();
 
   const modifiers = useMemo(() => {

--- a/packages/expo-router/src/toolbar/native.android.tsx
+++ b/packages/expo-router/src/toolbar/native.android.tsx
@@ -9,7 +9,9 @@ export function RouterToolbarHost(props: RouterToolbarHostProps) {
   const {
     expoUI: { Host, HorizontalFloatingToolbar, Box },
     modifiers: { fillMaxWidth, height, padding, imePadding },
-  } = requireExpoUI();
+  } = requireExpoUI(
+    "Stack.Toolbar on Android requires '@expo/ui'. Install it with `npx expo install @expo/ui` and rebuild your app."
+  );
   const insets = useSafeAreaInsets();
 
   const modifiers = useMemo(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5442,9 +5442,6 @@ importers:
       '@expo/schema-utils':
         specifier: workspace:^
         version: link:../@expo/schema-utils
-      '@expo/ui':
-        specifier: workspace:^
-        version: link:../expo-ui
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.3)
@@ -5530,6 +5527,9 @@ importers:
         specifier: ^0.0.5
         version: 0.0.5
     devDependencies:
+      '@expo/ui':
+        specifier: workspace:^
+        version: link:../expo-ui
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0


### PR DESCRIPTION
# Why

Remove hard dependency on `@expo/ui` since it is only used for Android toolbar. Make it optional, so that only people using toolbar actually install it.

# How

1. `packages/expo-router/src/optional-libraries/expo-ui.ts` which uses `try { require } catch` pattern for optional dependency
2. Replace every import of `@expo/ui` with that file

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)