### PR TITLE
[app-metrics][Android] Register NetworkRequestObserver with the monitor eagerly

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -90,6 +90,7 @@ jobs:
             "packages/expo-modules-core/**/android/**",
             "packages/expo-modules-autolinking/**/android/**",
             "packages/expo/**/android/**",
+            "packages/expo-app-metrics/**/android/**",
             "packages/expo-constants/**/android/**",
             "packages/expo-crypto/**/android/**",
             "packages/expo-file-system/**/android/**",

--- a/packages/expo-app-metrics/CHANGELOG.md
+++ b/packages/expo-app-metrics/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed network request observers emitting duplicate events or continuing after their listeners were removed. ([#49609](https://github.com/expo/expo/pull/49609) by [@behenate](https://github.com/behenate))
+- [Android] Fix `NetworkRequestObserver` emitting duplicate events when a response was read and closed on different threads. ([#49609](https://github.com/expo/expo/pull/49609) by [@behenate](https://github.com/behenate), [#49743](https://github.com/expo/expo/pull/49743) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Preserve millisecond precision in log event timestamps. ([#49141](https://github.com/expo/expo/pull/49141) by [@Ubax](https://github.com/Ubax))
 - [android] Fix `UnsupportedOperationException` and `NoSuchMethodError` on Android 7.x ([#48577](https://github.com/expo/expo/pull/48577) by [@Ubax](https://github.com/Ubax))
 - [iOS] Retry the OTA `AppInfo` patch on updates state changes, so a launch where the module registry is created before `expo-updates` has assigned its startup procedure no longer keeps the embedded build's update attribution for the whole session. ([#48899](https://github.com/expo/expo/pull/48899) by [@spsaucier](https://github.com/spsaucier))

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserver.kt
@@ -14,9 +14,15 @@ internal const val REQUEST_COMPLETED_EVENT = "requestCompleted"
 
 /**
  * JS-facing `SharedObject` that bridges per-instance JS subscriptions to the singleton
- * `NetworkRequestMonitor`. Each JS `new NetworkRequestObserver()` allocates one of these. It is
- * registered as a delegate while it has event listeners and is unregistered after its last
- * listener is removed or the shared object is released.
+ * `NetworkRequestMonitor`. Each JS `new NetworkRequestObserver()` allocates one of these and
+ * registers it as a delegate right away, whether or not JS has attached listeners yet; the
+ * registration is dropped when the shared object is released. This matches the iOS observer.
+ *
+ * Because registration doesn't track JS listeners, an observer whose listeners were all removed
+ * still pays one `emit` per matching request until JS releases it. Gating on listener count would
+ * need `onStartListeningToEvent`/`onStopListeningToEvent`, and the runtime only wires those up for
+ * classes that declare `Events(...)` in their module definition, which this one deliberately
+ * doesn't.
  *
  * The class only forwards events — it doesn't store request history. Use
  * `NetworkRequestMonitor.shared.recent` for that.
@@ -36,37 +42,18 @@ class NetworkRequestObserver private constructor(
   // monitor's fan-out (`shouldObserveRequest`) and the swap from `setFilter` are atomic: a
   // `setFilter` call never leaves a request observed under a half-applied filter.
   private val filter = AtomicReference(filter)
-  private val observing = AtomicBoolean(false)
-  private val listenerLock = Any()
-  private val listenedEvents = mutableSetOf<String>()
 
-  override fun onStartListeningToEvent(eventName: String) {
-    if (eventName != REQUEST_STARTED_EVENT && eventName != REQUEST_COMPLETED_EVENT) {
-      return
-    }
-    synchronized(listenerLock) {
-      listenedEvents.add(eventName)
-      if (observing.compareAndSet(false, true)) {
-        monitor.addDelegate(this)
-      }
-    }
-  }
+  // Flipped once on release. The monitor holds delegates weakly and prunes them on the next
+  // fan-out, so a request evaluated in that window must still be rejected here.
+  private val released = AtomicBoolean(false)
 
-  override fun onStopListeningToEvent(eventName: String) {
-    synchronized(listenerLock) {
-      listenedEvents.remove(eventName)
-      if (listenedEvents.isEmpty() && observing.compareAndSet(true, false)) {
-        monitor.removeDelegate(this)
-      }
-    }
+  init {
+    monitor.addDelegate(this)
   }
 
   override fun sharedObjectDidRelease() {
-    synchronized(listenerLock) {
-      listenedEvents.clear()
-      observing.set(false)
-      monitor.removeDelegate(this)
-    }
+    released.set(true)
+    monitor.removeDelegate(this)
     super.sharedObjectDidRelease()
   }
 
@@ -78,23 +65,15 @@ class NetworkRequestObserver private constructor(
   }
 
   override fun shouldObserveRequest(url: String, method: String): Boolean {
-    return observing.get() && (filter.get()?.matches(url, method) ?: true)
+    return !released.get() && (filter.get()?.matches(url, method) ?: true)
   }
 
   override fun onNetworkRequestStarted(request: NetworkRequestStarted) {
-    if (isListeningTo(REQUEST_STARTED_EVENT)) {
-      emit(REQUEST_STARTED_EVENT, startedPayload(request))
-    }
+    emit(REQUEST_STARTED_EVENT, startedPayload(request))
   }
 
   override fun onNetworkRequestCompleted(request: NetworkRequest) {
-    if (isListeningTo(REQUEST_COMPLETED_EVENT)) {
-      emit(REQUEST_COMPLETED_EVENT, completedPayload(request))
-    }
-  }
-
-  private fun isListeningTo(eventName: String): Boolean = synchronized(listenerLock) {
-    observing.get() && listenedEvents.contains(eventName)
+    emit(REQUEST_COMPLETED_EVENT, completedPayload(request))
   }
 
   companion object {

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/networkrequests/NetworkRequestObserverTest.kt
@@ -18,22 +18,13 @@ import java.util.UUID
  */
 class NetworkRequestObserverTest {
   @Test
-  fun `registers only while it has event listeners`() {
+  fun `registers with the monitor on construction, regardless of JS listeners`() {
     val appContext = mockk<AppContext>(relaxed = true)
     val monitor = NetworkRequestMonitor()
     val observer = NetworkRequestObserver.forTesting(appContext, monitor)
 
-    assertEquals(0, monitor.delegateCount)
-
-    observer.onStartListeningToEvent(REQUEST_STARTED_EVENT)
-    observer.onStartListeningToEvent(REQUEST_COMPLETED_EVENT)
     assertEquals(1, monitor.delegateCount)
-
-    observer.onStopListeningToEvent(REQUEST_STARTED_EVENT)
-    assertEquals(1, monitor.delegateCount)
-
-    observer.onStopListeningToEvent(REQUEST_COMPLETED_EVENT)
-    assertEquals(0, monitor.delegateCount)
+    assertTrue(observer.shouldObserveRequest("https://expo.dev", "GET"))
   }
 
   @Test
@@ -41,7 +32,6 @@ class NetworkRequestObserverTest {
     val appContext = mockk<AppContext>(relaxed = true)
     val monitor = NetworkRequestMonitor()
     val observer = NetworkRequestObserver.forTesting(appContext, monitor)
-    observer.onStartListeningToEvent(REQUEST_COMPLETED_EVENT)
 
     observer.sharedObjectDidRelease()
 


### PR DESCRIPTION
# Why

Since #49609 the Android `NetworkRequestObserver` registered with the monitor only from `onStartListeningToEvent`, when JS adds its first listener. That hook is attached to a shared object class only if its definition declares `Events(...)`, which this class doesn't, so the observer never registered and no request event reached JS. This is why the `AppMetrics` suite fails in the Android e2e job on main with eleven 5 second timeouts, and why every later suite in that job is skipped.

We also want the observer to watch requests regardless of whether JS has listeners attached, which is how the iOS observer already behaves.

# How

Register the observer as a monitor delegate in its constructor and unregister it in `sharedObjectDidRelease`, the same lifecycle as iOS. The listener-count bookkeeping goes away; a `released` flag keeps `shouldObserveRequest` false in the window before the monitor prunes the weak reference. The delegate dedupe in `NetworkRequestMonitor` and the complete-once guard in the interceptor from #49609 stay.

The e2e workflow's Android path filter didn't list `expo-app-metrics` (the iOS one does), so Android-only changes to the package never ran the suite that exercises it on a PR. That's how #49609 landed without a signal. This PR adds the path so the Android e2e job runs here and for future app-metrics changes.

# Test Plan

Unit tests updated to pin the eager registration (`et native-unit-tests -p android --packages expo-app-metrics`). On a physical Android device with a debug bare-expo build, `bareexpo://test-suite/run?tests=AppMetrics` went from 15/24 passed (all eleven `NetworkRequestObserver` specs timing out) to 24/24 passed. With the workflow change, the Android e2e job on this PR runs the native modules suite, so `AppMetrics` passing there is the CI confirmation.
