### PR TITLE
[ui][ios] Keep object colors intact when deriving modifiers from styles

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -58,7 +58,7 @@
 - [iOS] Fix `ColorPicker` reporting every color one value too low, because `colorToHex` truncated instead of rounding. Apps feed the reported value back into `selection`, so the error compounded and each interaction moved all three channels down by one. ([#49356](https://github.com/expo/expo/pull/49356) by [@batuhandemir98](https://github.com/batuhandemir98))
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix `Host` color scheme type errors on React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Fixed `PlatformColor` and `DynamicColorIOS` values dropping the `backgroundColor` and `borderColor` of a universal component. Both were stringified to `"[object Object]"`, which the native color converter rejects, so the modifier was discarded without a trace. (by [@Den1Marshall](https://github.com/Den1Marshall))
+- [iOS] Fixed `PlatformColor` and `DynamicColorIOS` values dropping the `backgroundColor` and `borderColor` of a universal component. Both were stringified to `"[object Object]"`, which the native color converter rejects, so the modifier was discarded without a trace. ([#49746](https://github.com/expo/expo/pull/49746) by [@Den1Marshall](https://github.com/Den1Marshall))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -58,6 +58,7 @@
 - [iOS] Fix `ColorPicker` reporting every color one value too low, because `colorToHex` truncated instead of rounding. Apps feed the reported value back into `selection`, so the error compounded and each interaction moved all three channels down by one. ([#49356](https://github.com/expo/expo/pull/49356) by [@batuhandemir98](https://github.com/batuhandemir98))
 - [Android] Explicitly enable `buildFeatures.buildConfig`, required by AGP 9. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix `Host` color scheme type errors on React Native 0.87. ([#47729](https://github.com/expo/expo/pull/47729) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Fixed `PlatformColor` and `DynamicColorIOS` values dropping the `backgroundColor` and `borderColor` of a universal component. Both were stringified to `"[object Object]"`, which the native color converter rejects, so the modifier was discarded without a trace. (by [@Den1Marshall](https://github.com/Den1Marshall))
 
 ### 💡 Others
 

--- a/packages/expo-ui/src/universal/__tests__/transformStyle.test.ios.ts
+++ b/packages/expo-ui/src/universal/__tests__/transformStyle.test.ios.ts
@@ -1,4 +1,13 @@
-import { background, disabled, font, onTapGesture, padding } from '../../swift-ui/modifiers';
+import type { ColorValue } from 'react-native';
+
+import {
+  background,
+  border,
+  disabled,
+  font,
+  onTapGesture,
+  padding,
+} from '../../swift-ui/modifiers';
 import { transformToModifiers } from '../transformStyle';
 
 describe('transformToModifiers (iOS)', () => {
@@ -12,6 +21,16 @@ describe('transformToModifiers (iOS)', () => {
     expect(
       transformToModifiers({ backgroundColor: 'red', padding: 8 }, {}, [padding({ top: 4 })])
     ).toEqual([background('red'), padding({ top: 4 })]);
+  });
+
+  it('forwards object colors untouched, so PlatformColor values survive', () => {
+    const nativeColor = { semantic: ['systemBackground'] } as unknown as ColorValue;
+    expect(
+      transformToModifiers(
+        { backgroundColor: nativeColor, borderColor: nativeColor, borderWidth: 1 },
+        {}
+      )
+    ).toEqual([background(nativeColor), border({ color: nativeColor, width: 1 })]);
   });
 
   it('drops textStyle-derived modifiers the user overrides', () => {

--- a/packages/expo-ui/src/universal/transformStyle.ios.ts
+++ b/packages/expo-ui/src/universal/transformStyle.ios.ts
@@ -131,12 +131,12 @@ export function transformToModifiers(
 
     // Background (fills the frame area including padding)
     if (style.backgroundColor) {
-      mods.push(background(String(style.backgroundColor)));
+      mods.push(background(style.backgroundColor));
     }
 
     // Border (before clip so the clip rounds the border corners too)
     if (style.borderWidth != null && style.borderColor != null) {
-      mods.push(border({ color: String(style.borderColor), width: style.borderWidth }));
+      mods.push(border({ color: style.borderColor, width: style.borderWidth }));
     }
 
     // Clip (border radius — rounds both background and border)


### PR DESCRIPTION
## Why

`transformToModifiers` turns a universal component's React Native style into SwiftUI modifiers, and it stringified colors:

```ts
mods.push(background(String(style.backgroundColor)));
mods.push(border({ color: String(style.borderColor), width: style.borderWidth }));
```

But `ColorValue` is not always a string. [`PlatformColor`](https://reactnative.dev/docs/platformcolor) and [`DynamicColorIOS`](https://reactnative.dev/docs/dynamiccolorios) return objects — `{ semantic: [...] }` and `{ dynamic: { light, dark } }` — and `String()` turns those into `"[object Object]"`.

The native color converter rejects that string and throws, `StableViewModifier` swallows the error with `try?`, and the modifier is dropped. The background or border simply never appears, with nothing in the logs to explain it. That hits exactly the colors people reach for when they want a view to follow the system light and dark appearance.

## How

Both values are passed through untouched. `background` and `border` already accept `Color`, which is `string | ColorValue | NamedColor`, so the object reaches the native side whole, where `UIColor.convert(from:)` understands both the `semantic` and the `dynamic` dictionaries — the same path `foregroundStyle` already relies on.

## Test Plan

Added a case to `transformStyle.test.ios.ts` that passes an object color as `backgroundColor` and `borderColor`. I confirmed it fails before the fix, with both modifiers carrying `"[object Object]"`.

`et check-packages @expo/ui` passes.

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build
- [x] Conforms with the Documentation Writing Style Guide