### PR TITLE
[expo-task-manager] Hold registered task managers strongly on Android

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Hold registered task managers strongly, so a garbage collection can no longer silently stop delivering background task events (geofencing, background location) while the app is running. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@chazyarbro](https://github.com/chazyarbro))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Hold registered task managers strongly, so a garbage collection can no longer silently stop delivering background task events (geofencing, background location) while the app is running. ([#PRNUM](https://github.com/expo/expo/pull/PRNUM) by [@chazyarbro](https://github.com/chazyarbro))
+- [Android] Hold registered task managers strongly, so a garbage collection can no longer silently stop delivering background task events (geofencing, background location) while the app is running. ([#49747](https://github.com/expo/expo/pull/49747) by [@chazyarbro](https://github.com/chazyarbro))
 - [Android] Clear headless task manager on context destroy ([#47958](https://github.com/expo/expo/pull/47958) by [@Wenszel](https://github.com/Wenszel))
 - [Android] Fix a crash on Android 9 when delivering a task event through `JobScheduler` (geofencing, background location), where the job was built without the scheduling constraint that `JobInfo.Builder.build()` requires. ([#48305](https://github.com/expo/expo/pull/48305) by [@rvaccone](https://github.com/rvaccone))
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -62,11 +62,19 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
   private WeakReference<Context> mContextRef;
   private TaskManagerUtilsInterface mTaskManagerUtils;
 
-  // Map with task managers of running (foregrounded) apps. { "<appScopeKey>": WeakReference(TaskManagerInterface) }
-  private static final Map<String, WeakReference<TaskManagerInterface>> sTaskManagers = new HashMap<>();
+  // Map with task managers of running (foregrounded) apps. { "<appScopeKey>": TaskManagerInterface }
+  //
+  // Held strongly. These used to be WeakReferences, but nothing else retains the task
+  // manager, so a GC could clear one while its app was running: getTaskManager() then
+  // returned null, executeTask() took its "app is not fully loaded" path, and the event
+  // was queued for a headless load of an app that was already running — silently dropping
+  // every background task event from that point on. Entries are removed explicitly in
+  // setTaskManager(null, ...) when the host activity is destroyed, so the weak reference
+  // was never what released them.
+  private static final Map<String, TaskManagerInterface> sTaskManagers = new HashMap<>();
 
   // Same as above but for headless (backgrounded) apps.
-  private static final Map<String, WeakReference<TaskManagerInterface>> sHeadlessTaskManagers = new HashMap<>();
+  private static final Map<String, TaskManagerInterface> sHeadlessTaskManagers = new HashMap<>();
 
   // { "<appScopeKey>": List(eventIds...) }
   private static final Map<String, List<String>> sEvents = new HashMap<>();
@@ -250,10 +258,10 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
     // Having two tables for them is to prevent race condition problems,
     // when both foreground and background apps are launching at the same time.
     boolean isHeadless = isStartedByHeadlessLoader(appScopeKey);
-    Map<String, WeakReference<TaskManagerInterface>> taskManagers = isHeadless ? sHeadlessTaskManagers : sTaskManagers;
+    Map<String, TaskManagerInterface> taskManagers = isHeadless ? sHeadlessTaskManagers : sTaskManagers;
 
     // Set task manager in appropriate map.
-    taskManagers.put(appScopeKey, new WeakReference<>(taskManager));
+    taskManagers.put(appScopeKey, taskManager);
 
     // Execute events waiting for the task manager.
     List<Bundle> eventsQueue = mTasksAndEventsRepository.getEvents(appScopeKey);
@@ -600,13 +608,12 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
    */
   @Nullable
   private TaskManagerInterface getTaskManager(String appScopeKey) {
-    WeakReference<TaskManagerInterface> weakRef = sTaskManagers.get(appScopeKey);
-    TaskManagerInterface taskManager = weakRef == null ? null : weakRef.get();
+    TaskManagerInterface taskManager = sTaskManagers.get(appScopeKey);
 
     if (taskManager == null) {
-      weakRef = sHeadlessTaskManagers.get(appScopeKey);
+      taskManager = sHeadlessTaskManagers.get(appScopeKey);
     }
-    return weakRef == null ? null : weakRef.get();
+    return taskManager;
   }
 
   private void invalidateAppRecord(String appScopeKey) {


### PR DESCRIPTION
# Why

On Android, `TaskService` stored each app's `TaskManagerInterface` in static maps of
`WeakReference`s:

```java
private static final Map<String, WeakReference<TaskManagerInterface>> sTaskManagers = new HashMap<>();
private static final Map<String, WeakReference<TaskManagerInterface>> sHeadlessTaskManagers = new HashMap<>();
```

Nothing else retains that module, so a garbage collection can clear one **while its app is
running normally**. `getTaskManager()` then returns `null`, and `executeTask()` takes its
"app is not fully loaded" branch:

```java
if (taskManager != null) {
  taskManager.executeTaskWithBody(body);
  return;
}
// The app is not fully loaded as its task manager is not there yet.
mTasksAndEventsRepository.putEventForAppScopeKey(appScopeKey, body);
getAppLoader().loadApp(...);   // starts an app that is already running
```

The event is queued, the headless loader is asked to launch an already-running app, and
nothing is delivered. The queue only drains on the next `setTaskManager()` call.

**Nothing is logged at any layer.** `TaskManagerInternalModule.emitEvent`'s
`"EmitEventWrapper is not set"` branch is never reached, and neither is the JS side's
`"was requested but looks like it is not defined"` warning — so from the app's point of
view background task events simply stop, with no diagnostic anywhere.

Net effect: a task event arriving shortly after launch is delivered, and every event after
the first GC is dropped permanently. This presents as "background tasks / geofencing work
at first, then randomly stop", which I believe is the underlying cause of #23559 ("works
fine when you first open the app, but after reopening the apps and switching to the
background, the taskExecutor never fires again") and possibly #22183. #23559 was closed as
outdated without a root cause.

# How

Hold the task managers strongly and let the existing explicit unregister release them.

The lifecycle is already explicit — `TaskManagerInternalModule` calls
`setTaskManager(null, ...)` on destroy, and `setTaskManager` removes both entries for that
scope. So the `WeakReference` was never what released the registration; it only allowed GC
to revoke one that was still live.

This also simplifies `getTaskManager()`, which previously had to re-check `.get()` after
falling through to the headless map.

**Trade-off worth reviewing:** an app scope whose module is destroyed without
`setTaskManager(null, ...)` ever being called would now retain one `TaskManagerInterface`
per scope instead of being collected. In a standalone app that is a single entry,
overwritten on re-registration, and the module holds its `Context` weakly so no Activity is
retained. If you'd rather not change the semantics for multi-experience hosts, an
alternative is to keep the `WeakReference` maps and add a parallel strong-reference map
consulted only when the weak lookups fail — happy to switch to that shape if preferred.

# Test Plan

Reproduced and verified on a physical Pixel 7 (Android 17), Expo SDK 57,
expo-task-manager 57.0.15, react-native 0.86.2 with the New Architecture enabled, in a
development build via `expo run:android`.

**To reproduce the bug (before this change):**

1. `defineTask` a geofencing task via `Location.startGeofencingAsync` (a background
   location task shows it too).
2. Confirm delivery works right after launch — task events reach the JS executor.
3. Force the GC that clears the weak reference, rather than waiting minutes:
   ```
   adb shell am send-trim-memory <your.package.name> RUNNING_CRITICAL
   ```
4. Trigger a task event — cross the geofence, or move to produce a location update.
5. The event never reaches the JS task and nothing is logged.

Instrumenting `getTaskManager()` shows it returning `null` at step 5 while the app and its
JS runtime are alive and healthy.

**Before**, with the native path instrumented — Play Services delivers, the consumer maps
and schedules it, the payload survives, `task.execute()` is called, and then it vanishes:

```
broadcast: transition=1 state=INSIDE eventType=1 triggering=1 known=7
scheduled job for a34e3f74… eventType=1
TaskService: Handling job with task name 'trakr-geofence-crossings'
didExecuteJob: 1 item(s) extracted from job params
-> task.execute for a34e3f74… eventType=1
TaskService: Started headless task 3 to keep JS timers alive
   <no emit, no JS execution, no error>
```

**After**, the same crossing on the same device and build:

```
[geofence] OS reported entry for a34e3f74 (outcome: transition)
[geofence] Recorded entry alert for a34e3f74.
[geofence] OS reported exit for a34e3f74 (outcome: transition)
[geofence] Recorded exit alert for a34e3f74.
```

Verified across repeated real geofence entry/exit crossings, and with an intermediate
build that logged whenever the weak references had been cleared — they were cleared on
every one of the three deliveries in the confirming run, each of which then succeeded via
the strong reference.
