### PR TITLE
fix(babel-preset-expo): Preserve Platform.select initializer side effects

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Preserve `Platform.select` argument side effects during production minification.
 - Escape backslashes when serializing `'widget'` functions so escape sequences like `\n` in a widget layout survive the template-literal round-trip instead of corrupting the stored function and crashing the widget with `SyntaxError: Unexpected EOF`. ([#47626](https://github.com/expo/expo/pull/47626) by [@alecmolloy](https://github.com/alecmolloy))
 - Fix legacy decorators on class properties when corresponding class transforms are disabled, which the decorators plugin relies on ([#47724](https://github.com/expo/expo/pull/47724) by [@Gitarcitano](https://github.com/Gitarcitano), [@kitten](https://github.com/kitten))
 - Disable `@babel/plugin-transform-object-rest-spread` in Hermes v1 and Modern Web sub-presets. The ordering dependence on `@babel/plugin-transform-destructuring` could cause computed exclusion to be missed ([#49278](https://github.com/expo/expo/pull/49278) by [@kitten](https://github.com/kitten))

--- a/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/platform-shaking.test.ts
@@ -462,6 +462,17 @@ it(`removes Platform module usage on native`, () => {
   );
 });
 
+it(`does not discard impure Platform.select initializers`, () => {
+  const options = {
+    ...DEFAULT_OPTS,
+    caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'ios', isDev: false }),
+  };
+
+  expect(
+    babel.transform(`Platform.select({ ios: selected(), android: discarded() });`, options)!.code
+  ).toEqual(`Platform.select({ios:selected(),android:discarded()});`);
+});
+
 describe('__DEV__', () => {
   it(`removes __DEV__ usage`, () => {
     const options = {

--- a/packages/babel-preset-expo/src/plugins/minify-platform-select-plugin.ts
+++ b/packages/babel-preset-expo/src/plugins/minify-platform-select-plugin.ts
@@ -64,7 +64,7 @@ export default function minifyPlatformSelectPlugin({
         const arg = node.arguments[0];
         const opts = state.opts as { platform: string };
         if (isPlatformSelect(path) && t.isObjectExpression(arg)) {
-          if (hasStaticProperties(arg)) {
+          if (hasStaticProperties(arg) && path.get('arguments.0').isPure()) {
             let fallback: any;
             if (opts.platform === 'web') {
               fallback = () => findProperty(arg, 'default', () => t.identifier('undefined'));


### PR DESCRIPTION
# Why

`babel-preset-expo` replaces `Platform.select({...})` with the selected property during production transforms. JavaScript evaluates every object property initializer before calling `Platform.select`, so this can silently remove side effects from non-selected properties.

For example:

```js
Platform.select({
  ios: selected(),
  android: discarded(),
});
```

JavaScript would run both side effects, `selected()` and `discarded()`. The plugin's current behavior removes `discarded` however.

# How

Use Babel's purity analysis before inlining the object argument.

# Test Plan

- Added a regression test that fails on `main`, where the transform emits only `selected()`.
- The regression confirms that an impure `Platform.select` call remains intact.
- Existing tests, linter, formatter all pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
