### PR TITLE
[expo-video][web] Handle the play() promise so teardown is not an uncaught error

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Handle the `HTMLMediaElement.play()` promise so that removing a playing element — what a route change does to a feed video that just started — no longer reaches the app as an uncaught `AbortError`. ([#49753](https://github.com/expo/expo/pull/49753) by [@NateIsern](https://github.com/NateIsern))
 - [Android] Fix `VideoPlayer` constructor throwing `MissingActivity` when the player is created while the `Activity` is briefly unavailable. ([#48914](https://github.com/expo/expo/pull/48914) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a data race on the video cache's open-file registry, which could crash the app while the cache was being trimmed. ([#49286](https://github.com/expo/expo/pull/49286) by [@huextrat](https://github.com/huextrat))
 - [iOS] Fixed a crash when the device runs out of storage while writing to the video cache. `FileHandle.writeData:` raises an uncatchable Objective-C `NSFileHandleOperationException` on `ENOSPC`; the throwing Swift APIs are now used so the error is caught and logged instead. ([#49284](https://github.com/expo/expo/pull/49284) by [@huextrat](https://github.com/huextrat))

--- a/packages/expo-video/src/VideoPlayer.web.tsx
+++ b/packages/expo-video/src/VideoPlayer.web.tsx
@@ -70,6 +70,24 @@ export function createVideoPlayer(source: VideoSource): VideoPlayer {
   return new VideoPlayerWeb(parsedSource);
 }
 
+/**
+ * `HTMLMediaElement.play()` returns a promise that rejects with `AbortError` when the element
+ * leaves the document, is paused, or has its source reloaded before the request settles. All
+ * three are ordinary teardown — a React view unmounting while a video is starting is the common
+ * one — so dropping the promise turns routine navigation into an uncaught rejection that surfaces
+ * as an app-level error.
+ *
+ * Only `AbortError` is absorbed. Every other rejection is rethrown, leaving it exactly as
+ * unhandled as before, so an autoplay-policy refusal (`NotAllowedError`) still surfaces.
+ */
+function playIgnoringTeardownAbort(video: HTMLVideoElement): void {
+  video.play().catch((error) => {
+    if ((error as DOMException | undefined)?.name !== 'AbortError') {
+      throw error;
+    }
+  });
+}
+
 export default class VideoPlayerWeb
   extends globalThis.expo.SharedObject<VideoPlayerEvents>
   implements VideoPlayer
@@ -311,7 +329,7 @@ export default class VideoPlayerWeb
 
   play(): void {
     this._mountedVideos.forEach((video) => {
-      video.play();
+      playIgnoringTeardownAbort(video);
     });
   }
 
@@ -328,7 +346,7 @@ export default class VideoPlayerWeb
       if (uri) {
         video.setAttribute('src', uri);
         video.load();
-        video.play();
+        playIgnoringTeardownAbort(video);
       } else {
         video.removeAttribute('src');
         video.load();
@@ -355,7 +373,7 @@ export default class VideoPlayerWeb
   replay(): void {
     this._mountedVideos.forEach((video) => {
       video.currentTime = 0;
-      video.play();
+      playIgnoringTeardownAbort(video);
     });
     this.playing = true;
   }
@@ -371,7 +389,7 @@ export default class VideoPlayerWeb
     if (firstVideo.paused) {
       video.pause();
     } else {
-      video.play();
+      playIgnoringTeardownAbort(video);
     }
     video.currentTime = firstVideo.currentTime;
     video.volume = firstVideo.volume;
@@ -403,7 +421,7 @@ export default class VideoPlayerWeb
       this.playing = true;
       this._mountedVideos.forEach((mountedVideo) => {
         if (e.target !== mountedVideo) {
-          mountedVideo.play();
+          playIgnoringTeardownAbort(mountedVideo);
         }
       });
     };


### PR DESCRIPTION
# Why

`VideoPlayerWeb` calls `HTMLMediaElement.play()` in five places and drops the returned promise. When the element leaves the document, is paused, or has its source reloaded before that request settles, the browser rejects with `AbortError`, and with no handler attached it reaches the app as an uncaught error:

```
uncaught AbortError: The play() request was interrupted because the media was removed from the document. https://goo.gl/LdLk22
```

The ordinary case is a React view unmounting while a video is starting: a feed video autoplays as it scrolls into view, the reader opens a post, and the route change removes the element mid-request. This showed up as a hard failure in an app's release gate, which asserts that a route transition leaves no uncaught errors behind.

Consumers cannot fix it themselves — `VideoPlayer.play()` returns `void`, so there is no promise to attach to.

# How

A small module-level helper wraps the five calls and absorbs **only** `AbortError`. Every other rejection is rethrown, which leaves it exactly as unhandled as it is today, so an autoplay-policy refusal (`NotAllowedError`) still surfaces rather than being silently swallowed.

# Test Plan

Measured in Chromium against a real media element (same teardown in each case):

| scenario | unhandled rejection |
| --- | --- |
| raw `video.play()` + immediate removal | `AbortError: The play() request was interrupted because the media was removed from the document.` |
| wrapped + immediate removal | none |
| wrapped, unsupported source | `NotSupportedError: Failed to load because no supported source was found.` |

Reproduced end to end in a production Expo Router web app: with `expo-video@57.0.3` patched this way, the uncaught `AbortError` stops reaching the page during feed → post navigation.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (`eas build`).