### PR TITLE
[create-expo-module] Add expo-modules-core to the module template's devDependencies

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -576,6 +576,38 @@ describe('non-interactive defaults warning', () => {
   });
 });
 
+describe('--features option', () => {
+  // The SharedObject snippet is the only template file that imports from
+  // `expo-modules-core` directly. Under an isolated node_modules layout (pnpm)
+  // that package is not hoisted, so the module only builds when the template
+  // declares it as a dev dependency of its own. See #49658.
+  it('builds a module with --features SharedObject under pnpm', async () => {
+    const projectName = 'features-shared-object';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name',
+      'FeatureTest',
+      '--package',
+      'com.test.sharedobject',
+      '--features',
+      'SharedObject',
+      '--package-manager',
+      'pnpm',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const packageJson = readJson(projectName, 'package.json');
+    expect(packageJson.devDependencies).toHaveProperty('expo-modules-core');
+
+    // `prepare` runs `tsc` after installing, so a build artifact proves that
+    // the `expo-modules-core` import resolved.
+    expectFileExists(projectName, 'build/FeatureTestModuleSharedObject.js');
+  });
+});
+
 describe('add-platform-support', () => {
   const localTemplatePath = path.resolve(__dirname, '../../../expo-module-template');
 

--- a/packages/expo-module-template/$package.json
+++ b/packages/expo-module-template/$package.json
@@ -38,6 +38,7 @@
     "eslint": "~9.39.4",
     "eslint-config-universe": "^15.0.3",
     "expo": "^56.0.5",
+    "expo-modules-core": "^56.0.5",
     "jest": "^29.7.0",
     "jest-expo": "~55.0.9",
     "prettier": "^3.0.0",


### PR DESCRIPTION
# Why

Fixes #49658.

`create-expo-module` fails during the install step whenever pnpm is the package manager and the `SharedObject` feature is selected:

```
✖ Installing module dependencies
Error: pnpm install exited with non-zero code: 2
```

Running `pnpm install` inside the generated module shows the real error:

```
src/MyModuleSharedObject.ts(1,56): error TS2307: Cannot find module 'expo-modules-core' or its corresponding type declarations.
```

The issue was reported on Windows, but this is not platform-specific — it reproduces on macOS too. It is specific to pnpm.

`snippets/SharedObject/sharedObject.ts.ejs` is the only template file that imports from `expo-modules-core` directly (everything else imports from `expo`), but the generated `package.json` never declares `expo-modules-core`. npm and yarn hoist it out of `expo`'s dependency tree, so `tsc` resolves it by accident. pnpm's isolated `node_modules` does not — the package is installed under `node_modules/.pnpm/expo-modules-core@57.0.15…` with no top-level link — so `prepare` fails, `pnpm install` exits 2, and module creation aborts with a half-created directory.

Two things suggest this is a missed entry rather than a deliberate removal:

- `expo-module-template@10.14.7` (SDK 51) listed `"expo-modules-core": "^1.12.9"` in `devDependencies`. It disappeared by SDK 55, when the rest of the template migrated its imports to `expo` — but this snippet was not migrated with them.
- `tools/src/publish-packages/tasks/updateModuleTemplate.ts` already has `PACKAGES_TO_UPDATE = ['expo-modules-core', 'expo-module-scripts', 'expo']`, so the release tooling is trying to keep an `expo-modules-core` entry version-synced. Its regex just never matches, because the entry is gone.

# How

Re-adds `expo-modules-core` to the template's `devDependencies`, next to `expo` and with a matching range. Because it is already in `PACKAGES_TO_UPDATE`, `updateModuleTemplate` will keep the version in sync from here on without further intervention.

I also considered the other direction — changing the snippet to `import { SharedObject, useReleasingSharedObject } from 'expo'`, which would match the rest of the template and add no dependency. I did not go that way because `expo` only re-exports `useReleasingSharedObject` on `main` (#45987, still under **Unpublished**); it is not in `expo@57.0.19`. That fix could not be backported to `sdk-56`/`sdk-57`, which is where users are hitting this today. Happy to switch if you would rather take that shape on `main` and leave the release branches alone.

The second commit hunk adds an e2e test for `--features SharedObject` under pnpm. The e2e suite already runs under pnpm (`resolvePackageManager` reads `npm_config_user_agent`), so the only reason CI stayed green is that no existing test selects this feature with a full install. Worth noting the workflow is also path-filtered to `packages/create-expo-module/**`, so a template-only change would not have run CI at all.

# Test Plan

**Reproduction, before the fix**

```
npx create-expo-module@latest my-module \
  --name MyModule --package expo.modules.mymodule \
  --features SharedObject --package-manager pnpm --no-example
```

```
✔ Created the module from template files
✖ Installing module dependencies
Error: pnpm install exited with non-zero code: 2
```

**After the fix**, same command against the patched template via `--source`:

```
✔ Installed module dependencies
✔ Compiled TypeScript files
✅ Successfully created Expo module
```

`build/MyModuleSharedObject.js` is emitted as expected.

**New e2e test**, in `packages/create-expo-module`:

```
$ pnpm test:e2e -t "SharedObject"

  --features option
    ✓ builds a module with --features SharedObject under pnpm (23220 ms)
  add-platform-support
    ✓ adds android support to an apple-only module with SharedObject (160 ms)

Tests:       33 skipped, 2 passed, 35 total
```

Reverting just the one-line `$package.json` change and re-running confirms the test guards the regression rather than restating the diff:

```
  ✕ builds a module with --features SharedObject under pnpm (27552 ms)
  ● --features option › builds a module with --features SharedObject under pnpm
    + Error: pnpm install exited with non-zero code: 2

Tests:       1 failed, 34 skipped, 35 total
```

`pnpm run lint`, `pnpm run typecheck` and `pnpm run format` are all clean.

Verified on macOS 26.6, Node 24.19.0, pnpm 11.25.0 for the reproduction and pnpm 10.33.0 for the monorepo test run.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - `packages/expo-module-template` has no `CHANGELOG.md` — only the templated `$CHANGELOG.md` that ships inside generated modules — so there was nowhere to add an entry. Let me know if you would like one under `packages/create-expo-module` instead.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
