### PR TITLE
[expo-web-browser][iOS] Let the module recover from a presentation that never happened

### DIFF
--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed `toolbarColor` being applied as the secondary toolbar color, and being discarded entirely when `secondaryToolbarColor` was also set. ([#48900](https://github.com/expo/expo/issues/48900) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
+- [iOS] Fixed a failed presentation leaving the module unable to open a browser again, with every later `openBrowserAsync` resolving `{ type: 'locked' }` until the app was restarted. ([#49749](https://github.com/expo/expo/issues/49749) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fixed `toolbarColor` being applied as the secondary toolbar color, and being discarded entirely when `secondaryToolbarColor` was also set. ([#48900](https://github.com/expo/expo/issues/48900) by [@MUSE-CODE-SPACE](https://github.com/MUSE-CODE-SPACE))
-- [iOS] Fixed a failed presentation leaving the module unable to open a browser again, with every later `openBrowserAsync` resolving `{ type: 'locked' }` until the app was restarted. ([#49749](https://github.com/expo/expo/issues/49749) by [@LizunovSergey](https://github.com/LizunovSergey))
+- [iOS] Fixed a failed presentation leaving the module locked, with every later `openBrowserAsync` resolving `{ type: 'locked' }` until `dismissBrowser` was called or the app restarted. The promise of the failed call now resolves instead of hanging. ([#49756](https://github.com/expo/expo/pull/49756) by [@LizunovSergey](https://github.com/LizunovSergey))
 
 ### 💡 Others
 

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -20,6 +20,11 @@ final public class WebBrowserModule: Module {
       if vcDidPresent {
         self.currentWebBrowserSession = nil
         vcDidPresent = false
+      } else if currentWebBrowserSession?.isPresented == false {
+        // The previous session never reached the screen, so neither `didPresent` nor any of the
+        // delegate callbacks can fire for it and nothing else will ever release it. Without this the
+        // module answers "locked" to every later call for the lifetime of the process.
+        self.currentWebBrowserSession = nil
       }
 
       guard self.currentWebBrowserSession == nil else {

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -20,11 +20,11 @@ final public class WebBrowserModule: Module {
       if vcDidPresent {
         self.currentWebBrowserSession = nil
         vcDidPresent = false
-      } else if currentWebBrowserSession?.isPresented == false {
+      } else if let session = currentWebBrowserSession, !session.isPresented {
         // The previous session never reached the screen, so neither `didPresent` nor any of the
-        // delegate callbacks can fire for it and nothing else will ever release it. Without this the
-        // module answers "locked" to every later call for the lifetime of the process.
-        self.currentWebBrowserSession = nil
+        // delegate callbacks can fire for it. Resolve its promise and release it here, otherwise the
+        // module answers "locked" to every later call until `dismissBrowser` runs or the app restarts.
+        session.onDismiss("cancel")
       }
 
       guard self.currentWebBrowserSession == nil else {

--- a/packages/expo-web-browser/ios/WebBrowserModule.swift
+++ b/packages/expo-web-browser/ios/WebBrowserModule.swift
@@ -21,9 +21,7 @@ final public class WebBrowserModule: Module {
         self.currentWebBrowserSession = nil
         vcDidPresent = false
       } else if let session = currentWebBrowserSession, !session.isPresented {
-        // The previous session never reached the screen, so neither `didPresent` nor any of the
-        // delegate callbacks can fire for it. Resolve its promise and release it here, otherwise the
-        // module answers "locked" to every later call until `dismissBrowser` runs or the app restarts.
+        // The presentation was dropped, so no delegate callback will ever release this session.
         session.onDismiss("cancel")
       }
 

--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -34,20 +34,35 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
     while currentViewController?.presentedViewController != nil {
       currentViewController = currentViewController?.presentedViewController
     }
+
+    guard let currentViewController else {
+      // Without a presenter nothing will call `didPresent` or any of the delegate methods, so report
+      // the session as finished here. Staying silent leaves the module holding a session it can
+      // never release.
+      onDismiss("cancel")
+      return
+    }
+
     if UIDevice.current.userInterfaceIdiom == .pad {
-      let viewFrame = currentViewController?.view.frame
+      let viewFrame = currentViewController.view.frame
       viewController.popoverPresentationController?.sourceRect = CGRect(
-        x: viewFrame?.midX ?? 0,
-        y: viewFrame?.maxY ?? 0,
+        x: viewFrame.midX,
+        y: viewFrame.maxY,
         width: 0,
         height: 0
       )
-      viewController.popoverPresentationController?.sourceView = currentViewController?.view
+      viewController.popoverPresentationController?.sourceView = currentViewController.view
     }
 
-    currentViewController?.present(viewController, animated: true) {
+    currentViewController.present(viewController, animated: true) {
       self.didPresent()
     }
+  }
+
+  /// Whether the browser is on screen. A controller whose presentation never went through, or that
+  /// has already been dismissed, has no presenting controller.
+  var isPresented: Bool {
+    return viewController.presentingViewController != nil
   }
 
   func dismiss(completion: ((String) -> Void)? = nil) {
@@ -130,6 +145,12 @@ internal class WebBrowserSession: NSObject, WKNavigationDelegate, WKUIDelegate, 
     let type = "dismiss"
     finish(type: type)
     completion?(type)
+  }
+
+  /// Whether the browser is on screen. Mirrors the iOS session so the module can drop a session that
+  /// never opened.
+  var isPresented: Bool {
+    return window?.isVisible == true
   }
 
   // MARK: - WKNavigationDelegate

--- a/packages/expo-web-browser/ios/WebBrowserSession.swift
+++ b/packages/expo-web-browser/ios/WebBrowserSession.swift
@@ -36,9 +36,6 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
     }
 
     guard let currentViewController else {
-      // Without a presenter nothing will call `didPresent` or any of the delegate methods, so report
-      // the session as finished here. Staying silent leaves the module holding a session it can
-      // never release.
       onDismiss("cancel")
       return
     }
@@ -59,8 +56,6 @@ internal class WebBrowserSession: NSObject, SFSafariViewControllerDelegate, UIAd
     }
   }
 
-  /// Whether the browser is on screen. A controller whose presentation never went through, or that
-  /// has already been dismissed, has no presenting controller.
   var isPresented: Bool {
     return viewController.presentingViewController != nil
   }
@@ -147,8 +142,6 @@ internal class WebBrowserSession: NSObject, WKNavigationDelegate, WKUIDelegate, 
     completion?(type)
   }
 
-  /// Whether the browser is on screen. Mirrors the iOS session so the module can drop a session that
-  /// never opened.
   var isPresented: Bool {
     return window?.isVisible == true
   }


### PR DESCRIPTION
# Why

Fixes #49749.

`openBrowserAsync` can present the Safari view controller onto a controller that is mid-dismissal. This happens when a call lands right after the user taps Done on the previous browser. UIKit drops that presentation and never runs the `present` completion block. The module is then left with `currentWebBrowserSession != nil` and `vcDidPresent == false`, which its guard reads as "locked":

```swift
if vcDidPresent {
  self.currentWebBrowserSession = nil
  vcDidPresent = false
}
guard self.currentWebBrowserSession == nil else {
  promise.resolve(["type": "locked"])
  return
}
```

Nothing clears that state on its own. `vcDidPresent` can only be set from the completion block that never ran. The `SFSafariViewControllerDelegate` and `UIAdaptivePresentationControllerDelegate` callbacks belong to a controller that was never presented. So every later `openBrowserAsync` resolves `{ type: 'locked' }`. Because it resolves rather than throws, users see links that silently stop opening.

The state is recoverable from JS today. Calling `WebBrowser.dismissBrowser()` runs the dismiss completion and releases the session, and the next `openBrowserAsync` opens a browser. An app that only calls `openBrowserAsync` has no way out.

The same wedge occurs when `UIApplication.shared.keyWindow?.rootViewController` is `nil`. The optional-chained `present` call is then a no-op. This path is fixed here too, but it is not the trigger reproduced from the issue.

# How

Both changes keep one invariant: the module must never hold a session that nothing can release.

1. **The module releases a session whose browser never reached the screen.** A new `isPresented` (`viewController.presentingViewController != nil`) lets `openBrowserAsync` recognise a stored session that is not on screen. It calls that session's `onDismiss("cancel")`. This resolves the promise of the failed call, which previously never settled, and clears the session. The branch runs only when `vcDidPresent` is `false`, so a browser that is currently on screen answers exactly as before. `present(_:animated:completion:)` sets `presentingViewController` before the animation ends, so a presentation that is still animating still answers `locked`.

2. **`WebBrowserSession.open()` reports failure when there is no presenter.** `guard let currentViewController else { onDismiss("cancel"); return }`. Unwrapping once also removes the `?`/`?? 0` fallbacks in the iPad popover block.

The macOS `WebBrowserSession` gets a matching `isPresented` (`window?.isVisible == true`) so the shared module compiles there. macOS `open()` calls `didPresent()` synchronously, so the new branch cannot run on that platform.

**Scope.** The issue also suggests waiting on the presenter's `transitionCoordinator` so a call landing mid-dismissal succeeds. That is not in this PR. A call that races a dismissal still comes back `cancel` or `locked` once. The next call works.

# Test Plan

Verified on an iOS 26 simulator with two EAS builds of the same app, one on the PR base and one on the PR head, compiled from source (see the verification comment on this PR for the tally and screenshots):

- Unpatched: after the mid-dismissal race, three later `openBrowserAsync` calls all resolve `locked`.
- Patched: the same three calls open a browser and resolve `cancel` on Done.
- Two calls in one tick: the second resolves `locked` in both builds. The new branch does not drop a live session.
- Unpatched: `dismissBrowser()` clears the locked state.

Not covered by measurement: the `keyWindow == nil` guard, the iPad popover block, physical devices, and macOS. `expo-web-browser` ships no iOS unit tests. `ExpoWebBrowser` compiles from source in this tree.

# Checklist

- [x] Added a `CHANGELOG.md` entry.
- [ ] Verified with `npx expo prebuild` & EAS Build: EAS Build only, via the verification above.
- [x] Follows the documentation style guide.
