### PR TITLE
[sdk-57][core][Android] Pass -fno-pch-timestamp so ccache can reuse the PCH

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Pass `-Xclang -fno-pch-timestamp` when building the precompiled header so the `.pch` is byte-stable across checkouts and ccache can reuse it. ([#49757](https://github.com/expo/expo/pull/49757) by [@janicduplessis](https://github.com/janicduplessis))
+
 ## 57.0.16 — 2026-09-04
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-core/android/cmake/common.cmake
+++ b/packages/expo-modules-core/android/cmake/common.cmake
@@ -24,6 +24,14 @@ target_compile_options(
   ${ADDITIONAL_CXX_FLAGS}
 )
 
+# Drop the timestamp embedded in the .pch so it stays bit-for-bit stable across
+# rebuilds. Without this, the PCH timestamp changes every build and ccache can't reuse it.
+target_compile_options(
+  EXPO_COMMON
+  INTERFACE
+  "$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>"
+)
+
 target_link_libraries(
   EXPO_COMMON
   INTERFACE


### PR DESCRIPTION
# Why

Backport of the `-fno-pch-timestamp` part of #47133 to `sdk-57`. The rest of #47133 (the shared `expo-modules-pch` owner target and `worklets.cmake`) does not cherry-pick cleanly onto this branch, so this is the flag alone, placed where `sdk-57` declares the PCH.

Clang embeds the mtime of every header it read into a `.pch`. Any compiler cache keyed on PCH content (ccache with `sloppiness=pch_defines,time_macros`, the setup `CONTRIBUTING.md` documents) sees a different PCH after every fresh `npm install` or checkout, reports `Precompiled header ... has a new mtime`, rebuilds the PCH, and then misses on every translation unit that includes it. On SDK 57 that is all 60 `expo-modules-core` objects plus the two `cmake_pch.hxx.pch` compiles, on every new checkout, even when nothing in the package changed.

The flag cannot be injected from the app side: with AGP and NDK 27 the legacy toolchain file resets `CMAKE_CXX_FLAGS`, so the fix has to live in the library's CMake. react-native-reanimated ships the same flag on its PCH target (software-mansion/react-native-reanimated#9749, backported to its 4.4 and 4.5 stable branches).

# How

Adds one `target_compile_options` entry to `EXPO_COMMON`:

```cmake
"$<$<COMPILE_LANGUAGE:CXX>:-Xclang;-fno-pch-timestamp>"
```

It is the same generator expression `main` uses on `expo-modules-pch` (`common.cmake`, #47133). On `sdk-57` the PCH is an `INTERFACE` property of `EXPO_COMMON`, and each consumer (`expo-modules-jsi`, `expo-modules-core`) builds its own `cmake_pch.hxx.pch`, so the option goes on `EXPO_COMMON INTERFACE` and reaches both.

- Without a compiler cache the flag changes nothing: the compiler output is identical apart from the timestamp field in the `.pch`.
- `-Xclang` is clang-only. This CMake is only ever driven by the NDK toolchain, which ships only clang; the `COMPILE_LANGUAGE:CXX` guard keeps it off C sources.
- Header edits still invalidate the PCH and every dependent object (see test plan).

# Test Plan

Measured on an app built against `expo-modules-core` 57.0.14 with this exact hunk applied to `node_modules/expo-modules-core/android/cmake/common.cmake` (the file is byte-identical to `sdk-57`), NDK 27.1.12297006, CMake 3.22.1, ccache 4.12.3, `arm64-v8a`, `./gradlew assembleDebug`:

```
CMAKE_C_COMPILER_LAUNCHER=ccache CMAKE_CXX_COMPILER_LAUNCHER=ccache
CCACHE_NOHASHDIR=true CCACHE_SLOPPINESS=pch_defines,time_macros
```

1. `ccache -z`, fresh checkout, `npm ci`, build: 368 misses, 0 real hits (cold cache). Build succeeded.
2. Remove the checkout, fresh checkout again, new `npm ci` (header mtimes change, e.g. `ExpoHeader.pch` 1788589256 -> 1788589427), build: 380/380 direct hits, 0 misses, 0 `new mtime` lines in `CCACHE_LOGFILE`; `expo-modules-core` 60/60 objects and both `cmake_pch.hxx.pch` compiles hit; the restored `.pch` files are byte-identical to the first build's (`cmp`). Whole build 57 s -> 16 s. Before this change the same second build missed all 60 `expo-modules-core` objects and both PCHs while react-native-reanimated (which already has the flag) hit 106/106.
3. Freshness: append `#define UPSTREAM_PCH_PROBE 1` to `src/main/cpp/ExpoHeader.pch` and rebuild: both PCHs and all 60 dependent objects recompile (62 ninja entries, 0 hits), build succeeds.

To reproduce: set the environment above, `ccache -z`, build any SDK 57 app once, then build it again from a fresh checkout (or after `rm -rf node_modules && npm install`) and compare `ccache -s`; grep the ccache log for `new mtime`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (CMake-only change, no sources to rebuild)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
