### PR TITLE
[JSI][iOS] Remove four fixed per-call costs from synchronous host callbacks

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [iOS] Made decoding non-ASCII JS strings up to 512 UTF-16 code units long ~1.5× faster. ([#49691](https://github.com/expo/expo/pull/49691) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Made creating a deferred `JavaScriptPromise` ~1.2× faster by building it from a cached JavaScript closure instead of a host function executor. ([#49714](https://github.com/expo/expo/pull/49714) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptPromise` now installs its `then` callbacks on the first `await()` instead of at construction, making promises returned by async functions ~2.5× cheaper to create and ~3.9× cheaper to settle. ([#49718](https://github.com/expo/expo/pull/49718) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors that return `undefined`, `null`, a boolean or a number: the result is written into the engine's slot without engine calls, and errors are reported only when one was actually thrown instead of being checked on every call. ([#49761](https://github.com/expo/expo/pull/49761) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostFunctionClosure.h
@@ -15,7 +15,9 @@ public:
   // The result travels through an out-parameter instead of a return value: the Swift side can then
   // write it straight into the caller's slot from inside its guaranteed-reference scope, with no
   // placeholder value to construct and no extra move of the `jsi::Value`.
-  using Closure = void(Context context, const facebook::jsi::Value *_Nonnull thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value *_Nonnull result);
+  // Returns whether the Swift side stored an error in `CppError`'s thread-local slot. Reporting that
+  // through the return value spares the caller a thread-local read on every successful call.
+  using Closure = bool(Context context, const facebook::jsi::Value *_Nonnull thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value *_Nonnull result);
 
   explicit HostFunctionClosure(Context context, Closure closure, Deallocator deallocator) : RetainedSwiftPointer(context, deallocator), _closure(closure) {};
 
@@ -26,8 +28,8 @@ public:
   /**
    Calls the Swift closure with given `this` value and arguments.
    */
-  inline void call(const facebook::jsi::Value &thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value &result) const {
-    _closure(_context, &thisValue, args, count, &result);
+  inline bool call(const facebook::jsi::Value &thisValue, const facebook::jsi::Value *_Nonnull args, size_t count, facebook::jsi::Value &result) const {
+    return _closure(_context, &thisValue, args, count, &result);
   }
 
 private:

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
@@ -24,11 +24,12 @@ public:
 
   inline jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override {
     jsi::Value result;
-    _callbacks.get(name.utf8(runtime).c_str(), result);
     // If the Swift getter stored a pending error, rethrow its JSError directly
     // to preserve all properties (message, code, stack, etc.).
-    if (auto *error = CppError::getCurrent()) {
-      throw error->release();
+    if (_callbacks.get(name.utf8(runtime).c_str(), result)) {
+      if (auto *error = CppError::getCurrent()) {
+        throw error->release();
+      }
     }
     return result;
   }
@@ -38,9 +39,10 @@ public:
     // `jsi::JSError` directly and the `CppError` check below is never reached.
     // For writable host objects, a throwing Swift setter routes its error through
     // `CppError`'s thread-local slot, which we drain and rethrow here.
-    _callbacks.set(runtime, name.utf8(runtime).c_str(), value);
-    if (auto *error = CppError::getCurrent()) {
-      throw error->release();
+    if (_callbacks.set(runtime, name.utf8(runtime).c_str(), value)) {
+      if (auto *error = CppError::getCurrent()) {
+        throw error->release();
+      }
     }
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
@@ -18,16 +18,18 @@ public:
   using PropNameIds = std::vector<facebook::jsi::PropNameID>;
   // The getter writes its result through an out-parameter, like `HostFunctionClosure`, so the
   // Swift side can fill the caller's slot from inside its guaranteed-reference scope.
-  using Getter = void(Context, const char *_Nonnull name, facebook::jsi::Value *_Nonnull result);
-  using Setter = void(Context, const char *_Nonnull name, void *_Nonnull value);
+  // Both return whether the Swift side stored an error in `CppError`'s thread-local slot, so the
+  // caller reads that slot only when needed.
+  using Getter = bool(Context, const char *_Nonnull name, facebook::jsi::Value *_Nonnull result);
+  using Setter = bool(Context, const char *_Nonnull name, void *_Nonnull value);
   using PropertyNamesGetter = PropNameIds(Context);
   using Deallocator = void(Context);
 
   explicit HostObjectCallbacks(Context context, Getter getter, Setter *_Nullable setter, PropertyNamesGetter propertyNamesGetter, Deallocator deallocator)
   : _context(context), _getter(getter), _setter(setter), _propertyNamesGetter(propertyNamesGetter), _deallocator(deallocator) {}
 
-  inline void get(const char *_Nonnull name, facebook::jsi::Value &result) const {
-    _getter(_context, name, &result);
+  inline bool get(const char *_Nonnull name, facebook::jsi::Value &result) const {
+    return _getter(_context, name, &result);
   }
 
   /**
@@ -39,7 +41,7 @@ public:
    JSI call frame above this on the stack; calling outside that context will surface
    the throw as an unhandled C++ exception.
    */
-  inline void set(facebook::jsi::Runtime &runtime, const char *_Nonnull name, const facebook::jsi::Value &value) const {
+  inline bool set(facebook::jsi::Runtime &runtime, const char *_Nonnull name, const facebook::jsi::Value &value) const {
     if (_setter == nullptr) {
       throw facebook::jsi::JSError(
         runtime,
@@ -48,7 +50,7 @@ public:
           "Pass a `set` closure to `createHostObject` to make this property writable."
       );
     }
-    _setter(_context, name, (void *)(&value));
+    return _setter(_context, name, (void *)(&value));
   }
 
   inline PropNameIds getPropertyNames() const {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -105,12 +105,12 @@ inline jsi::Function createHostFunction(jsi::IRuntime &runtime, const jsi::PropN
   auto closurePtr = std::shared_ptr<HostFunctionClosure>(closure);
   return jsi::Function::createFromHostFunction(runtime, propName, 0, [closurePtr](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *_Nonnull args, size_t count) -> jsi::Value {
     jsi::Value result;
-    closurePtr->call(thisValue, args, count, result);
-
     // If the Swift closure stored a pending error, rethrow its JSError directly
     // to preserve all properties (message, code, stack, etc.).
-    if (auto *error = CppError::getCurrent()) {
-      throw error->release();
+    if (closurePtr->call(thisValue, args, count, result)) {
+      if (auto *error = CppError::getCurrent()) {
+        throw error->release();
+      }
     }
     return result;
   });

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -1,8 +1,10 @@
 // Copyright 2022-present 650 Industries. All rights reserved.
 
 #pragma once
+
 #ifdef __cplusplus
 
+#include <new>
 #include <TargetConditionals.h>
 
 // `jsi.h` only forward-declares `jsi::Instrumentation`.
@@ -150,6 +152,33 @@ inline jsi::Value evaluateJavaScript(jsi::IRuntime &runtime, const std::shared_p
 // `jsi::Instrumentation` is not imported into Swift, so reach it from here.
 inline void collectGarbage(jsi::IRuntime &runtime, const std::string &cause) {
   runtime.instrumentation().collectGarbage(cause);
+}
+
+// MARK: - Result slots
+
+// Construct a host callback's result in place in the engine's result slot. `::new (slot) T(...)` is
+// placement new: it runs the constructor on existing memory and allocates nothing. These `jsi::Value`
+// constructors are inline, so each helper is two stores, whereas a move-assignment into the slot
+// calls `Value::~Value()` and `Value::Value(Value&&)`, both out-of-line in the engine library.
+//
+// Placement new does not destroy the slot's previous contents, so the slot must hold a value that
+// owns nothing; an object or string there would leak its engine handle. Both callers,
+// `createHostFunction` and `HostObject::get`, pass a default-constructed slot. The Swift side picks
+// the helper by kind in `JavaScriptValue.writeJSIValue(to:)` and moves everything else.
+inline void emplaceUndefined(jsi::Value *_Nonnull slot) noexcept {
+  ::new (slot) jsi::Value();
+}
+
+inline void emplaceNull(jsi::Value *_Nonnull slot) noexcept {
+  ::new (slot) jsi::Value(nullptr);
+}
+
+inline void emplaceBool(jsi::Value *_Nonnull slot, bool value) noexcept {
+  ::new (slot) jsi::Value(value);
+}
+
+inline void emplaceNumber(jsi::Value *_Nonnull slot, double value) noexcept {
+  ::new (slot) jsi::Value(value);
 }
 
 inline jsi::Value callFunction(jsi::IRuntime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostCallbackContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostCallbackContext.swift
@@ -12,17 +12,17 @@ internal protocol HostCallbackContext: AnyObject {
 /// `_withUnsafeGuaranteedRef` promises the compiler that both objects outlive the closure, so no
 /// retain or release is emitted for either. Both promises hold for a JSI callback: the JSI owner
 /// of the context is the caller, and a synchronous callback runs while the runtime executes JS,
-/// with the wrapper owned for the runtime's whole lifetime. The body returns nothing because
-/// `_withUnsafeGuaranteedRef` needs a `Copyable` result; callbacks write their `jsi::Value`
-/// result into the slot the C++ caller provides instead.
+/// with the wrapper owned for the runtime's whole lifetime. The body's result must be `Copyable`
+/// because `_withUnsafeGuaranteedRef` requires it; callbacks write their `jsi::Value` result into the
+/// slot the C++ caller provides and return only whether an error was stored.
 @inline(__always)
-internal func withGuaranteedContext<Context: HostCallbackContext>(
+internal func withGuaranteedContext<Context: HostCallbackContext, Result>(
   _ pointer: UnsafeMutableRawPointer,
-  _ body: (_ context: Context, _ runtime: JavaScriptRuntime) -> Void
-) {
-  Unmanaged<Context>.fromOpaque(pointer)._withUnsafeGuaranteedRef { context in
-    context.runtime._withUnsafeGuaranteedRef { runtime in
-      body(context, runtime)
+  _ body: (_ context: Context, _ runtime: JavaScriptRuntime) -> Result
+) -> Result {
+  return Unmanaged<Context>.fromOpaque(pointer)._withUnsafeGuaranteedRef { context in
+    return context.runtime._withUnsafeGuaranteedRef { runtime in
+      return body(context, runtime)
     }
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -183,13 +183,13 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       context: UnsafeMutableRawPointer,
       propertyName: UnsafePointer<CChar>,
       resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
-    ) {
+    ) -> Bool {
       let propertyName = String(cString: propertyName)
       nonisolated(unsafe) let resultPtr = resultPtr
 
-      withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
-        JavaScriptActor.assumeIsolated {
-          forwardingSwiftErrorsToJS(runtime: runtime) {
+      return withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
+        return JavaScriptActor.assumeIsolated {
+          return forwardingSwiftErrorsToJS(runtime: runtime) {
             try context.get(propertyName).writeJSIValue(to: resultPtr)
           }
         }
@@ -200,10 +200,10 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       context: UnsafeMutableRawPointer,
       propertyName: UnsafePointer<CChar>,
       valuePointer: UnsafeMutableRawPointer
-    ) {
+    ) -> Bool {
       let propertyName = String(cString: propertyName)
 
-      withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
+      return withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
         guard let set = context.set else {
           // Unreachable in practice: when the user passed `nil` for `set`, the call site
           // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
@@ -214,8 +214,8 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
         }
         let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
 
-        JavaScriptActor.assumeIsolated {
-          forwardingSwiftErrorsToJS(runtime: runtime) {
+        return JavaScriptActor.assumeIsolated {
+          return forwardingSwiftErrorsToJS(runtime: runtime) {
             try set(propertyName, value)
           }
         }
@@ -256,7 +256,7 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
     let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc))
       .toOpaque()
     let setterPointer:
-      (@convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>, UnsafeMutableRawPointer) -> Void)? = setter
+      (@convention(c) (UnsafeMutableRawPointer, UnsafePointer<CChar>, UnsafeMutableRawPointer) -> Bool)? = setter
     // Pass a null setter to C++ when the Swift setter is nil so that JS assignment
     // raises a `jsi::JSError` directly, without crossing the Swift boundary.
     let callbacks = expo.HostObjectCallbacks(
@@ -806,7 +806,7 @@ private func createFunctionClosure(
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsCount: Int,
     resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
-  ) {
+  ) -> Bool {
     // `assumeIsolated` runs `operation` synchronously, in this very scope — it never escapes and never
     // hops threads (see `JavaScriptActor.assumeIsolated`). So rather than materializing the move-only
     // `JavaScriptValuesBuffer` out here and smuggling it across the closure boundary through a
@@ -822,9 +822,9 @@ private func createFunctionClosure(
 
     // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
     // why the result is written to the caller's slot instead of being returned.
-    withGuaranteedContext(context) { (context: HostFunctionContext, runtime) in
-      JavaScriptActor.assumeIsolated {
-        forwardingSwiftErrorsToJS(runtime: runtime) {
+    return withGuaranteedContext(context) { (context: HostFunctionContext, runtime) in
+      return JavaScriptActor.assumeIsolated {
+        return forwardingSwiftErrorsToJS(runtime: runtime) {
           let this = UnsafeMutablePointer(mutating: thisPtr).move()
           let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
           let thisValue = JavaScriptValue(runtime, this)
@@ -854,7 +854,7 @@ private func createFunctionClosure(
     argumentsPtr: UnsafePointer<facebook.jsi.Value>,
     argumentsCount: Int,
     resultPtr: UnsafeMutablePointer<facebook.jsi.Value>
-  ) {
+  ) -> Bool {
     // Same call-scoped reasoning as the owning-`this` overload above (see its comment) for why the
     // buffer is built inside the synchronous `assumeIsolated` closure. Here `this` is additionally
     // handed in as a borrowed `JavaScriptUnownedValue` pointing straight at the C++-owned `this` slot:
@@ -866,9 +866,9 @@ private func createFunctionClosure(
 
     // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
     // why the result is written to the caller's slot instead of being returned.
-    withGuaranteedContext(context) { (context: UnownedThisHostFunctionContext, runtime) in
-      JavaScriptActor.assumeIsolated {
-        forwardingSwiftErrorsToJS(runtime: runtime) {
+    return withGuaranteedContext(context) { (context: UnownedThisHostFunctionContext, runtime) in
+      return JavaScriptActor.assumeIsolated {
+        return forwardingSwiftErrorsToJS(runtime: runtime) {
           let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
           let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
           try context.call(thisValue, consume arguments).writeJSIValue(to: resultPtr)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -188,9 +188,9 @@ open class JavaScriptRuntime: Equatable, Identifiable, @unchecked Sendable {
       nonisolated(unsafe) let resultPtr = resultPtr
 
       withGuaranteedContext(context) { (context: HostObjectContext, runtime) in
-        resultPtr.pointee = JavaScriptActor.assumeIsolated {
-          return forwardingSwiftErrorsToJS(runtime: runtime) {
-            return try context.get(propertyName).asJSIValue()
+        JavaScriptActor.assumeIsolated {
+          forwardingSwiftErrorsToJS(runtime: runtime) {
+            try context.get(propertyName).writeJSIValue(to: resultPtr)
           }
         }
       }
@@ -823,12 +823,12 @@ private func createFunctionClosure(
     // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
     // why the result is written to the caller's slot instead of being returned.
     withGuaranteedContext(context) { (context: HostFunctionContext, runtime) in
-      resultPtr.pointee = JavaScriptActor.assumeIsolated {
-        return forwardingSwiftErrorsToJS(runtime: runtime) {
+      JavaScriptActor.assumeIsolated {
+        forwardingSwiftErrorsToJS(runtime: runtime) {
           let this = UnsafeMutablePointer(mutating: thisPtr).move()
           let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
           let thisValue = JavaScriptValue(runtime, this)
-          return try context.call(thisValue, consume arguments).asJSIValue()
+          try context.call(thisValue, consume arguments).writeJSIValue(to: resultPtr)
         }
       }
     }
@@ -867,11 +867,11 @@ private func createFunctionClosure(
     // See `withGuaranteedContext` for why neither the context nor the runtime is retained here, and
     // why the result is written to the caller's slot instead of being returned.
     withGuaranteedContext(context) { (context: UnownedThisHostFunctionContext, runtime) in
-      resultPtr.pointee = JavaScriptActor.assumeIsolated {
-        return forwardingSwiftErrorsToJS(runtime: runtime) {
+      JavaScriptActor.assumeIsolated {
+        forwardingSwiftErrorsToJS(runtime: runtime) {
           let arguments = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount)
           let thisValue = JavaScriptUnownedValue(runtime.pointee, thisPtr)
-          return try context.call(thisValue, consume arguments).asJSIValue()
+          try context.call(thisValue, consume arguments).writeJSIValue(to: resultPtr)
         }
       }
     }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -517,6 +517,24 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
     return copy()
   }
 
+  /// Writes this value into a host callback's result slot. Undefined, null, booleans and numbers are
+  /// emplaced with the engine's inline constructors, so the common results skip the out-of-line
+  /// `jsi::Value` move and destroy that assigning to the slot would cost; everything else is copied
+  /// through ``asJSIValue()``. The slot must hold a value with nothing to release (see `emplaceUndefined`).
+  internal func writeJSIValue(to slot: UnsafeMutablePointer<facebook.jsi.Value>) {
+    if pointee.isUndefined() {
+      expo.emplaceUndefined(slot)
+    } else if pointee.isNumber() {
+      expo.emplaceNumber(slot, pointee.getNumber())
+    } else if pointee.isBool() {
+      expo.emplaceBool(slot, pointee.getBool())
+    } else if pointee.isNull() {
+      expo.emplaceNull(slot)
+    } else {
+      slot.pointee = asJSIValue()
+    }
+  }
+
   internal func asJSIValue() -> facebook.jsi.Value {
     if let runtime {
       return facebook.jsi.Value(runtime.pointee, pointee)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -633,21 +633,27 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable {
   // immutable and these carry no runtime and a trivial `jsi::Value`, so one instance can be safely
   // handed out from any isolation context. Every void-returning `@JS` function returns `.undefined`,
   // so a computed getter here would allocate on every host call.
-  private static let sharedUndefined = JavaScriptValue(nil, facebook.jsi.Value.undefined())
-  private static let sharedNull = JavaScriptValue(nil, facebook.jsi.Value.null())
+  //
+  // The instances live in the module-level globals below rather than in static properties: the
+  // `undefined` and `null` accessors are `@inlinable`, and an inlined body reaches a global through its
+  // addressor alone, whereas a class static, even a `@usableFromInline` one, goes through a getter
+  // that takes the class metatype, which costs the caller a metadata accessor call (`objc_opt_self`)
+  // on every access. Every void host function call accesses `undefined`.
 
   /// This is a lightweight way to create an undefined value that can be used in contexts
   /// where a runtime is not available or needed. The resulting value can be passed to
   /// JavaScript functions or used in comparisons.
+  @inlinable
   public static var undefined: JavaScriptValue {
-    return sharedUndefined
+    return sharedUndefinedValue
   }
 
   /// This is a lightweight way to create a null value that can be used in contexts
   /// where a runtime is not available or needed. The resulting value represents
   /// JavaScript's `null`, which is distinct from `undefined`.
+  @inlinable
   public static var null: JavaScriptValue {
-    return sharedNull
+    return sharedNullValue
   }
 
   /// This is a lightweight way to create a boolean true value that can be used in contexts
@@ -715,3 +721,10 @@ extension JavaScriptValue {
     }
   }
 }
+
+// Shared instances behind `JavaScriptValue.undefined` and `JavaScriptValue.null`; see the comment on
+// those accessors for why these are globals.
+@usableFromInline
+internal let sharedUndefinedValue = JavaScriptValue(nil, facebook.jsi.Value.undefined())
+@usableFromInline
+internal let sharedNullValue = JavaScriptValue(nil, facebook.jsi.Value.null())

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
@@ -32,20 +32,10 @@ internal func forwardingSwiftErrorsToJS(
 ) -> facebook.jsi.Value {
   do {
     return try body()
-  } catch let jsError as JavaScriptError {
-    // Relay the wrapped `jsi::JSError` directly so the thrown value reaches JS as-is, which may be
-    // an arbitrary value rather than an `Error` instance.
-    expo.CppError.setCurrent(jsError.toJSError())
-  } catch let throwable as JavaScriptThrowable {
-    expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
-  } catch let cppError as expo.CppError {
-    // Re-thrown by `capturingCppErrors` when nested JSI work raised a JS error; relay
-    // the original so its `jsi::JSError` (with stack, code, custom properties) survives.
-    expo.CppError.setCurrent(cppError)
-  } catch let error {
-    expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
+  } catch {
+    storeSwiftError(error, runtime: runtime)
+    return .undefined()
   }
-  return .undefined()
 }
 
 /// Overload for trampolines that write their result into the caller's slot themselves. Returns
@@ -59,16 +49,30 @@ internal func forwardingSwiftErrorsToJS(
   do {
     try body()
     return false
-  } catch let jsError as JavaScriptError {
+  } catch {
+    storeSwiftError(error, runtime: runtime)
+    return true
+  }
+}
+
+/// Stores an error thrown by a host callback in `expo::CppError`'s thread-local slot for the C++
+/// side to rethrow as a `jsi::JSError`. Kept out of line on purpose: the trampolines above inline
+/// into every host callback, and with the error handling in their bodies the hot path carried the
+/// stack frame and register saves that only these branches need.
+@inline(never)
+internal func storeSwiftError(_ error: any Error, runtime: JavaScriptRuntime) {
+  switch error {
+  case let jsError as JavaScriptError:
     // Relay the wrapped `jsi::JSError` directly so the thrown value reaches JS as-is, which may be
     // an arbitrary value rather than an `Error` instance.
     expo.CppError.setCurrent(jsError.toJSError())
-  } catch let throwable as JavaScriptThrowable {
+  case let throwable as JavaScriptThrowable:
     expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
-  } catch let cppError as expo.CppError {
+  case let cppError as expo.CppError:
+    // Re-thrown by `capturingCppErrors` when nested JSI work raised a JS error; relay
+    // the original so its `jsi::JSError` (with stack, code, custom properties) survives.
     expo.CppError.setCurrent(cppError)
-  } catch let error {
+  default:
     expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
   }
-  return true
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
@@ -48,15 +48,17 @@ internal func forwardingSwiftErrorsToJS(
   return .undefined()
 }
 
-/// Void overload of `forwardingSwiftErrorsToJS` for host object setter trampolines, which
-/// have no return value to propagate.
+/// Overload for trampolines that write their result into the caller's slot themselves. Returns
+/// whether an error was stored, so the C++ caller reads the thread-local error slot only then and
+/// skips the thread-local access on every successful call.
 @_transparent
 internal func forwardingSwiftErrorsToJS(
   runtime: JavaScriptRuntime,
   _ body: () throws -> Void
-) {
+) -> Bool {
   do {
     try body()
+    return false
   } catch let jsError as JavaScriptError {
     // Relay the wrapped `jsi::JSError` directly so the thrown value reaches JS as-is, which may be
     // an arbitrary value rather than an `Error` instance.
@@ -68,4 +70,5 @@ internal func forwardingSwiftErrorsToJS(
   } catch let error {
     expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
   }
+  return true
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -632,6 +632,19 @@ struct JavaScriptRuntimeTests {
     #expect(result.getInt() == 42)
   }
 
+  @Test
+  func `host function results of primitive kinds reach JavaScript unchanged`() throws {
+    runtime.global().setProperty("yes", value: runtime.createFunction("yes") { _, _ in .true() }.asValue())
+    runtime.global().setProperty("no", value: runtime.createFunction("no") { _, _ in .false() }.asValue())
+    runtime.global().setProperty("nothing", value: runtime.createFunction("nothing") { _, _ in .null }.asValue())
+    runtime.global().setProperty("half", value: runtime.createFunction("half") { _, _ in .number(0.5) }.asValue())
+    let result = try runtime.eval("[yes() === true, no() === false, nothing() === null, half() === 0.5]").getArray()
+    #expect(result[0].getBool() == true)
+    #expect(result[1].getBool() == true)
+    #expect(result[2].getBool() == true)
+    #expect(result[3].getBool() == true)
+  }
+
   // MARK: - Async functions
 
   @Test


### PR DESCRIPTION
# Why

After #49631, a no-op `@JS` call still paid for four things on every call, whatever its result. This PR takes them out one by one; each change is also explained in the comment next to it.

# How

**Moving the result into the engine's slot.** Assigning the `jsi::Value` result into the slot called the engine's out-of-line move constructor and destructor on every call, even for `undefined`. Void and primitive results are now constructed in place through the inline `jsi::Value` constructors, and only objects and strings still take the move.

**Reaching the shared `undefined`.** The shared instances were class statics, and in a resilient module a client reads those through a getter that takes the class metatype, so every access ran the class metadata accessor first. They now live in module globals behind inlinable accessors, which a client reaches with one call.

**Checking for an error.** The C++ side read a thread-local after every call to see whether Swift had stored an error. The thunks now return whether they stored one, and the thread-local is read only in that case.

**A thunk sized for its error path.** The error handling helper inlines into every thunk, and its catch clauses gave the thunk's inner closure a 544-byte frame and six register-pair saves. The catch bodies moved into one out-of-line function, and the closure is now 40 instructions with a 128-byte frame instead of 256 with 544.

# Test Plan

`pnpm test:integration` passes. `pnpm benchmark` (Release, Mac Catalyst, coverage off), two interleaved rounds against main:

- no-op unowned-this host call: 34 to 26 ns
- add two numbers: 264 to 256 ns
- concat two strings, unowned-this: 174 to 161 ns
- concat two strings, owning-this: 365 to 347 ns
- no-op owning-this host call: 60 to 66 ns

The last row is slower because of a stall in the client closure's destroy of the arguments buffer, not a cost in this code: the indirect value-witness call now sits right before the shared `undefined` getter. #49769, stacked on this PR, makes the buffer frozen so the client calls its `deinit` directly, and that row goes to 51 ns.
