### PR TITLE
[ui] Fix community/bottom-sheet content shrinking to its own width

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android][iOS] Fix `community/bottom-sheet` content shrinking to its own width instead of filling the sheet when the sheet sizes to its content. ([#49742](https://github.com/expo/expo/issues/49742) by [@agung-adhinata](https://github.com/agung-adhinata)) ([#49762](https://github.com/expo/expo/pull/49762) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fixed a `Text` or an `Icon` with no explicit color rendering black inside `Host`, which made it unreadable in the dark color scheme. `Host` now provides `LocalContentColor` from the color scheme. ([#49697](https://github.com/expo/expo/pull/49697) by [@expo-bot](https://github.com/expo-bot))
 - [iOS][Android] Fixed a `matchContents` `RNHostView` inside a `matchContents` `Host` growing the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix modifier application rebuilding a fresh `AnyViewModifier` every body evaluation, which defeated AttributeGraph subtree pruning during scroll. ([#48426](https://github.com/expo/expo/pull/48426) by [@wielski](https://github.com/wielski))

--- a/packages/expo-ui/src/__mocks__/expo.ts
+++ b/packages/expo-ui/src/__mocks__/expo.ts
@@ -10,7 +10,10 @@ export function findNativeViewProps(viewName: string) {
   return call?.[1];
 }
 
-export const requireNativeModule = jest.fn(() => ({}));
+export const requireNativeModule = jest.fn(() => ({
+  // The Android `Host` reads the Material palette on render.
+  getMaterialColors: jest.fn(() => ({})),
+}));
 
 export const requireNativeView = jest.fn((moduleName: string, viewName: string) => {
   return function MockNativeView(props: Record<string, any>) {

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.android.tsx
@@ -200,9 +200,11 @@ export function BottomSheet(props: BottomSheetProps) {
               shouldDismissOnClickOutside: enablePanDownToClose,
             }}>
             <RNHostView matchContents={fitToContents}>
-              {/* flexGrow:1 + height:0 (flex-basis 0) fills RNHostView's measured height without
-                  inheriting the scrollable child's content height, which would block scrolling to the end. */}
-              <View style={fitToContents ? undefined : { flexGrow: 1, height: 0 }}>
+              {/* With matchContents, RNHostView lays the hosted view out at its own size, so `width` gives it
+                  the sheet width while its height stays content-sized. Otherwise flexGrow:1 + height:0
+                  (flex-basis 0) fills RNHostView's measured height without inheriting the scrollable
+                  child's content height, which would block scrolling to the end. */}
+              <View style={fitToContents ? { width } : { flexGrow: 1, height: 0 }}>
                 <SheetScrollContextReset>{children}</SheetScrollContextReset>
               </View>
             </RNHostView>

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
@@ -234,12 +234,13 @@ export function BottomSheet(props: BottomSheetProps) {
               <RNHostView matchContents={fitToContents}>
                 {/* paddingTop compensates for tighter spacing between native drag indicator and content
                     compared to gorhom's handle. flexGrow:1 + height:0 (flex-basis 0) fills the snap-point
-                    height without inheriting the scrollable child's intrinsic content height. Omitted for fitToContents
-                    so RNHostView can measure natural content height. */}
+                    height without inheriting the scrollable child's intrinsic content height. With matchContents,
+                    RNHostView lays the hosted view out at its own size, so `width` gives it the sheet width
+                    while its height stays content-sized. */}
                 <View
                   style={
                     fitToContents
-                      ? { paddingTop: handleComponent !== null ? 16 : 0 }
+                      ? { width, paddingTop: handleComponent !== null ? 16 : 0 }
                       : { flexGrow: 1, height: 0, paddingTop: handleComponent !== null ? 16 : 0 }
                   }>
                   <SheetScrollContextReset>{children}</SheetScrollContextReset>

--- a/packages/expo-ui/src/community/bottom-sheet/__tests__/BottomSheet.test.native.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/__tests__/BottomSheet.test.native.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react-native';
+import { isValidElement, type ReactNode } from 'react';
+import { Dimensions, StyleSheet, View } from 'react-native';
+
+import { findNativeViewProps } from '../../../__mocks__/expo';
+import { BottomSheet } from '../BottomSheet';
+
+jest.mock('expo', () => jest.requireActual('../../../__mocks__/expo'));
+
+// The view `RNHostView` hosts: its first descendant that is a React Native `View`.
+function hostedViewStyle() {
+  let node: ReactNode = findNativeViewProps('RNHostView')?.children;
+  while (isValidElement(node) && node.type !== View) {
+    node = (node.props as { children?: ReactNode }).children;
+  }
+  return isValidElement(node) ? StyleSheet.flatten((node.props as any).style) : undefined;
+}
+
+describe('BottomSheet', () => {
+  it('gives the hosted content the sheet width when the sheet sizes to its content', () => {
+    render(
+      <BottomSheet index={0}>
+        <View />
+      </BottomSheet>
+    );
+
+    expect(findNativeViewProps('RNHostView')?.matchContents).toBe(true);
+    expect(hostedViewStyle()?.width).toBe(Dimensions.get('window').width);
+  });
+
+  it('fills the snap point height when snap points are set', () => {
+    render(
+      <BottomSheet index={0} snapPoints={['50%']}>
+        <View />
+      </BottomSheet>
+    );
+
+    expect(findNativeViewProps('RNHostView')?.matchContents).toBe(false);
+    expect(hostedViewStyle()).toEqual(expect.objectContaining({ flexGrow: 1, height: 0 }));
+  });
+});


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/49742

Since #49483 a `matchContents` `RNHostView` lays its hosted content out at the content's own size on both axes. `community/bottom-sheet` uses `matchContents` for dynamic sizing and relied on the hosted view stretching to the `Host` width, so its content shrank to the widest line and left a gap on the right (Android) or on both sides (iOS).

Later we can add `vertical` and `horizontal` options to RNHostView's `matchContents`

# How

- Give the `fitToContents` wrapper view the sheet width (`useWindowDimensions().width`, which the `Host` already uses). Yoga then lays the hosted content out at that width while its height stays content-sized. The snap-point branch is unchanged.
- Add a Jest test for both platform files. The shared `expo` mock's native module now provides `getMaterialColors`, which the Android `Host` calls on render.

# Test Plan

- `src/community/bottom-sheet/__tests__/BottomSheet.test.native.tsx` fails before and passes after, on both Jest platform projects.
- Ran the issue's repro in the bare-expo Playground on an Android emulator and an iPhone 17 Pro Max simulator. Before: the red content view is narrower than the sheet. After: it spans the full sheet width, as in `@expo/ui` 57.0.14.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
