### PR TITLE
[JSI][iOS] Freeze JavaScriptValuesBuffer so host function closures destroy it directly

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [iOS] Made creating a deferred `JavaScriptPromise` ~1.2× faster by building it from a cached JavaScript closure instead of a host function executor. ([#49714](https://github.com/expo/expo/pull/49714) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] `JavaScriptPromise` now installs its `then` callbacks on the first `await()` instead of at construction, making promises returned by async functions ~2.5× cheaper to create and ~3.9× cheaper to settle. ([#49718](https://github.com/expo/expo/pull/49718) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Reduced the native overhead of synchronous host function calls and host object property accessors that return `undefined`, `null`, a boolean or a number: the result is written into the engine's slot without engine calls, and errors are reported only when one was actually thrown instead of being checked on every call. ([#49761](https://github.com/expo/expo/pull/49761) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Reduced the native overhead of synchronous host function calls whose closure receives `this` as a `JavaScriptValue`, by letting the calling module destroy the arguments buffer directly. ([#49769](https://github.com/expo/expo/pull/49769) by [@tsapeta](https://github.com/tsapeta))
 
 ## 57.0.4 — 2026-07-22
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -3,24 +3,44 @@ internal import jsi
 /// A buffer that stores instances of `facebook.jsi.Value` with the ability to convert them to `JavaScriptValue` on element access
 /// without the need to create a new container (e.g. `std.vector<facebook.jsi.Value>` or `[JavaScriptValue]`).
 /// Used mainly to pass function arguments from C++ to Swift.
+// `@frozen` so client modules, which consume a buffer in every host function closure, can destroy it
+// with a direct call to its `deinit` instead of a metadata accessor plus a value witness dispatch.
+@frozen
 public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
-  // Safe to use unowned — the buffer's lifetime is scoped to a host function call,
+  // MARK: - Layout
+
+  // Every stored property below is part of the frozen layout: adding, removing or reordering one
+  // changes the ABI that client modules compiled against, and each type has to be public, which is
+  // why the storage is kept as a raw pointer and rebuilt into its C++ view on access.
+
+  // Safe to use unowned: the buffer's lifetime is scoped to a host function call,
   // so the runtime is always alive while the buffer exists.
   //
   // `unowned(unsafe)` rather than `unowned`: the runtime object carries a refcount side table (other
   // wrappers hold it `weak`), so a safe `unowned` retain/release on it takes the slow side-table path
   // on every buffer construction and destruction. Profiling showed that pair as roughly a third of the
-  // native-side cost of a no-op `@JS` host call. `unowned(unsafe)` is a plain pointer store/load.
+  // native-side cost of a no-op host function call. `unowned(unsafe)` is a plain pointer store/load.
   internal unowned(unsafe) let runtime: JavaScriptRuntime
 
-  // The raw `facebook.jsi.IRuntime`, cached alongside the `JavaScriptRuntime` wrapper. `IRuntime` is
-  // an immortal reference (`jsi.apinotes`), so reading it costs no ARC, whereas reading `.pointee`
-  // off the `unowned` wrapper emits an unowned retain/release on every access. The hot decode path
-  // (`unownedValue(at:)`, `set`) reads this; `subscript`/`copy` still need the wrapper.
-  internal nonisolated(unsafe) let iRuntime: facebook.jsi.IRuntime
+  // The start of the storage, type-erased because `facebook.jsi.Value` is not a public type.
+  internal nonisolated(unsafe) let start: UnsafeMutableRawPointer?
 
-  internal nonisolated(unsafe) let bufferPointer: UnsafeMutableBufferPointer<facebook.jsi.Value>
-  private let ownsMemory: Bool
+  /// The number of values in the buffer.
+  public let count: Int
+
+  internal let ownsMemory: Bool
+
+  // MARK: - C++ views
+
+  // `IRuntime` is an immortal reference (`jsi.apinotes`) and `runtime` is `unowned(unsafe)`, so this is
+  // two plain loads with no reference counting.
+  internal var iRuntime: facebook.jsi.IRuntime {
+    return runtime.pointee
+  }
+
+  internal var bufferPointer: UnsafeMutableBufferPointer<facebook.jsi.Value> {
+    return UnsafeMutableBufferPointer(start: start?.assumingMemoryBound(to: facebook.jsi.Value.self), count: count)
+  }
 
   /// A pointer to the first value of the buffer.
   /// If the baseAddress of this buffer is `nil`, the `count` is zero.
@@ -32,12 +52,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   /// passing across Swift/ObjC++ boundaries where `facebook.jsi.Value` cannot
   /// appear in a public signature.
   public var rawBaseAddress: UnsafeRawPointer? {
-    return baseAddress.map { UnsafeRawPointer($0) }
-  }
-
-  /// The number of values in the buffer.
-  public var count: Int {
-    return bufferPointer.count
+    return start.map { UnsafeRawPointer($0) }
   }
 
   internal init(
@@ -46,8 +61,8 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     ownsMemory: Bool = false
   ) {
     self.runtime = runtime
-    self.iRuntime = runtime.pointee
-    self.bufferPointer = buffer
+    self.start = UnsafeMutableRawPointer(buffer.baseAddress)
+    self.count = buffer.count
     self.ownsMemory = ownsMemory
   }
 


### PR DESCRIPTION
Stacked on #49761.

# Why

The one row that #49761 made slower, the owning-this host call, stalls on how the calling module destroys the arguments buffer. This PR changes that, and the change is also explained in the comment above the struct.

# How

**Destroying the arguments buffer.** Every host function closure consumes its `JavaScriptValuesBuffer`, and that closure lives in the calling module. For a resilient struct, a client can only destroy it through the type's metadata accessor and an indirect value-witness call, and a profile showed that indirect call sitting right before the shared `undefined` getter and stalling there. The struct is now `@frozen`, so clients call its `deinit` directly.

**Keeping C++ types out of the frozen layout.** A frozen layout may only use public types, and the storage is a pointer to `jsi::Value`s, so it is kept as a raw pointer and rebuilt into its C++ view on access. The buffer also no longer caches the `IRuntime` next to the runtime wrapper: with the wrapper held `unowned(unsafe)`, reading it is two plain loads, so the layout is down to the runtime, the storage pointer, the count and the ownership flag.

# Test Plan

`pnpm test:integration` passes. `pnpm benchmark` (Release, Mac Catalyst, coverage off), two interleaved rounds against the base branch:

- no-op owning-this host call: 66 to 51 ns
- no-op unowned-this host call: 26 ns, unchanged
- add two numbers: 256 to 247 ns
- concat two strings, unowned-this: 161 to 159 ns
- concat two strings, owning-this: 347 to 353 ns

The last row reads slightly slower while its closure compiles to strictly less code than before (two calls fewer, same accessors), so that is code placement rather than a cost in this change; it stays 12 ns below main.
