### PR TITLE
[config-plugins][iOS] Skip empty locales instead of stopping at one

### DIFF
--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Fix `getApplicationIdAsync` and `setPackageInBuildGradle` failing with the Gradle assignment syntax (`applicationId = '...'`). ([#47711](https://github.com/expo/expo/pull/47711) by [@idoyana](https://github.com/idoyana))
 - [iOS] Quote and escape keys and values written to `.strings` files. ([#49605](https://github.com/expo/expo/pull/49605) by [@jakex7](https://github.com/jakex7))
+- [iOS] Keep writing `locales` after one that has no `Info.plist` keys. ([#49777](https://github.com/expo/expo/pull/49777) by [@giaBaoJS](https://github.com/giaBaoJS))
 
 ### 💡 Others
 

--- a/packages/@expo/config-plugins/src/ios/Locales.ts
+++ b/packages/@expo/config-plugins/src/ios/Locales.ts
@@ -37,7 +37,7 @@ export async function writeStringsFile({
   project: XcodeProject;
 }) {
   for (const [lang, localizationObj] of Object.entries(localesMap)) {
-    if (Object.entries(localizationObj).length === 0) return project;
+    if (Object.entries(localizationObj).length === 0) continue;
     const dir = path.join(supportingDirectory, `${lang}.lproj`);
     await fs.promises.mkdir(dir, { recursive: true });
 

--- a/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -157,3 +157,53 @@ describe('e2e: iOS locales', () => {
     );
   });
 });
+
+describe('e2e: iOS locales with no Info.plist keys', () => {
+  const projectRoot = '/app';
+  beforeAll(async () => {
+    vol.fromJSON(
+      {
+        'ios/testproject.xcodeproj/project.pbxproj':
+          rnFixture['ios/HelloWorld.xcodeproj/project.pbxproj'],
+        'ios/testproject/AppDelegate.m': '',
+        // Android-only, so this resolves to an empty map on iOS.
+        'lang/de.json': JSON.stringify({
+          android: {
+            app_name: 'de-name',
+          },
+        }),
+        'lang/fr.json': JSON.stringify({
+          ios: {
+            CFBundleDisplayName: 'french-name',
+          },
+        }),
+      },
+      projectRoot
+    );
+  });
+
+  afterAll(() => {
+    vol.reset();
+  });
+
+  it('writes locales listed after one that has no Info.plist keys', async () => {
+    let project = getPbxproj(projectRoot);
+
+    project = await setLocalesAsync(
+      {
+        locales: {
+          de: 'lang/de.json',
+          fr: 'lang/fr.json',
+        },
+      },
+      { project, projectRoot }
+    );
+    fs.writeFileSync(project.filepath, project.writeSync());
+
+    const after = getDirFromFS(vol.toJSON(), projectRoot);
+    const infoPlists = Object.keys(after).filter((value) => value.endsWith('InfoPlist.strings'));
+
+    expect(infoPlists).toStrictEqual(['ios/testproject/Supporting/fr.lproj/InfoPlist.strings']);
+    expect(after[infoPlists[0]!]).toMatchInlineSnapshot(`""CFBundleDisplayName" = "french-name";"`);
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Locales-test.ts
@@ -95,6 +95,8 @@ describe('e2e: iOS locales', () => {
       {
         locales: {
           fr: 'lang/fr.json',
+          // no Info.plist keys, must not stop the locales listed after it
+          de: 'lang/de.json',
           // doesn't exist
           xx: 'lang/xx.json',
 
@@ -104,8 +106,6 @@ describe('e2e: iOS locales', () => {
           // support backwards compatibility for `locales` structure without platform keys.
           en: 'lang/en.json',
           ar: 'lang/ar.json',
-          // shouldn't have an infoPlist
-          de: 'lang/de.json',
         },
       },
       { project, projectRoot }
@@ -155,55 +155,5 @@ describe('e2e: iOS locales', () => {
       'Failed to parse JSON of locale file for language: xx',
       'https://docs.expo.dev/guides/localization/#translating-app-metadata'
     );
-  });
-});
-
-describe('e2e: iOS locales with no Info.plist keys', () => {
-  const projectRoot = '/app';
-  beforeAll(async () => {
-    vol.fromJSON(
-      {
-        'ios/testproject.xcodeproj/project.pbxproj':
-          rnFixture['ios/HelloWorld.xcodeproj/project.pbxproj'],
-        'ios/testproject/AppDelegate.m': '',
-        // Android-only, so this resolves to an empty map on iOS.
-        'lang/de.json': JSON.stringify({
-          android: {
-            app_name: 'de-name',
-          },
-        }),
-        'lang/fr.json': JSON.stringify({
-          ios: {
-            CFBundleDisplayName: 'french-name',
-          },
-        }),
-      },
-      projectRoot
-    );
-  });
-
-  afterAll(() => {
-    vol.reset();
-  });
-
-  it('writes locales listed after one that has no Info.plist keys', async () => {
-    let project = getPbxproj(projectRoot);
-
-    project = await setLocalesAsync(
-      {
-        locales: {
-          de: 'lang/de.json',
-          fr: 'lang/fr.json',
-        },
-      },
-      { project, projectRoot }
-    );
-    fs.writeFileSync(project.filepath, project.writeSync());
-
-    const after = getDirFromFS(vol.toJSON(), projectRoot);
-    const infoPlists = Object.keys(after).filter((value) => value.endsWith('InfoPlist.strings'));
-
-    expect(infoPlists).toStrictEqual(['ios/testproject/Supporting/fr.lproj/InfoPlist.strings']);
-    expect(after[infoPlists[0]!]).toMatchInlineSnapshot(`""CFBundleDisplayName" = "french-name";"`);
   });
 });


### PR DESCRIPTION
# Why

On iOS, a single `locales` entry that resolves to no `Info.plist` keys silently stops every locale listed after it from being written.

`writeStringsFile` skips empty locale maps with `return project` instead of `continue`, so the first empty entry aborts the whole loop.

An entry resolves to an empty map whenever the locale JSON has no top-level or `ios` keys left after resolution, which happens for a file that only carries `android` keys, or (since #39022) one whose `ios` block only holds `Localizable.strings`.

Minimal reproduction, `app.json`:

```json
{ "locales": { "de": "lang/de.json", "fr": "lang/fr.json" } }
```

`lang/de.json`:

```json
{ "android": { "app_name": "de-name" } }
```

`lang/fr.json`:

```json
{ "ios": { "CFBundleDisplayName": "french-name" } }
```

After `npx expo prebuild -p ios`, `ios/<project>/Supporting/fr.lproj/InfoPlist.strings` is missing. Swapping the order of `de` and `fr` in `app.json` makes it appear, which is the giveaway. The Android sibling, `packages/@expo/config-plugins/src/android/Locales.ts`, loops over every locale with no early return and is not affected.

# How

Changed the `return project` guard to `continue` so an empty locale is skipped rather than ending the loop. Skipping is still the right behavior for an empty entry: it avoids creating an empty `.lproj` directory and an empty `.strings` file.

# Test Plan

modified existing test case that'd fail before the fix



# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
