### PR TITLE
[expo-router] Don't derive tab detach state from an animated value

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 - Oder tabs by `.Trigger` order during initial render ([#49848](https://github.com/expo/expo/pull/49848) by [@Ubax](https://github.com/Ubax))
 - Prevent Native Tabs from remounting the focused tab while preloading other tabs after a cold-start deep link. (by [@Ubax](https://github.com/Ubax)) ([#49811](https://github.com/expo/expo/pull/49811) by [@Ubax](https://github.com/Ubax))
+- Keep the outgoing tab attached until its transition settles, instead of deriving the screen detach state from a native-driven animated value. ([#49778](https://github.com/expo/expo/pull/49778) by [@LizunovSergey](https://github.com/LizunovSergey))
 - Re-export the vendored JavaScript stack API from `expo-router/js-stack`. ([#49657](https://github.com/expo/expo/pull/49657) by [@davidmokos](https://github.com/davidmokos))
 - Fix `useLoaderData()` throwing "Update hook called on initial render" when React replays a suspended route after its loader settles during a transition. ([#49351](https://github.com/expo/expo/pull/49351) by [@Ubax](https://github.com/Ubax))
 - Make layouts with explicitly declared screens honor `unstable_settings.initialRouteName` instead of declaration order, which can change deep-link back stacks. ([#48708](https://github.com/expo/expo/pull/48708) by [@Ubax](https://github.com/Ubax))

--- a/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx
@@ -12,7 +12,7 @@ import {
 import { router } from '../../../imperative-api';
 import { Stack } from '../../../layouts/Stack';
 import { Tabs } from '../../../layouts/Tabs';
-import { act, renderRouter, screen } from '../../../testing-library';
+import { act, fireEvent, renderRouter, screen } from '../../../testing-library';
 import { useNavigation } from '../../../useNavigation';
 import { Text } from '../../elements';
 import type { ParamListBase } from '../../native';
@@ -648,4 +648,68 @@ test('resets a nested stack when its tab loses focus with popToTopOnBlur', async
   // Without `popToTopOnBlur`, the details screen would still be active.
   expect(screen.getByTestId('one-index')).toBeVisible();
   expect(screen.queryByTestId('one-details')).toBeNull();
+});
+
+// Mirrors the activity states `BottomTabView` hands to `MaybeScreen`.
+const STATE_INACTIVE = 0;
+const STATE_TRANSITIONING_OR_BELOW_TOP = 1;
+const STATE_ON_TOP = 2;
+
+/** Reads the activity state of the screen container wrapping `text`. */
+function getActivityState(text: string) {
+  let node = screen.getByText(text, { includeHiddenElements: true }).parent;
+
+  while (node && node.props.activityState === undefined) {
+    node = node.parent;
+  }
+
+  return node?.props.activityState;
+}
+
+test('keeps the outgoing tab attached until its transition has settled', async () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs screenOptions={{ animation: 'fade' }}>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+      </Tabs>
+    ),
+    index: () => <Text>Screen index</Text>,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  expect(getActivityState('Screen index')).toBe(STATE_ON_TOP);
+
+  fireEvent.press(screen.getByRole('button', { name: 'second, tab, 2 of 2' }));
+
+  // The outgoing screen has to stay attached for the whole transition, otherwise
+  // it is detached mid-animation and the arriving tab renders blank.
+  expect(getActivityState('Screen index')).toBe(STATE_TRANSITIONING_OR_BELOW_TOP);
+  expect(getActivityState('Screen second')).toBe(STATE_ON_TOP);
+
+  // Once the animation finishes, the delayed clear detaches it.
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  expect(getActivityState('Screen index')).toBe(STATE_INACTIVE);
+  expect(getActivityState('Screen second')).toBe(STATE_ON_TOP);
+});
+
+test('detaches the outgoing tab immediately when the transition is not animated', async () => {
+  renderRouter({
+    _layout: () => (
+      <Tabs screenOptions={{ animation: 'none' }}>
+        <Tabs.Screen name="index" />
+        <Tabs.Screen name="second" />
+      </Tabs>
+    ),
+    index: () => <Text>Screen index</Text>,
+    second: () => <Text>Screen second</Text>,
+  });
+
+  fireEvent.press(screen.getByRole('button', { name: 'second, tab, 2 of 2' }));
+
+  expect(getActivityState('Screen index')).toBe(STATE_INACTIVE);
+  expect(getActivityState('Screen second')).toBe(STATE_ON_TOP);
 });

--- a/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
+++ b/packages/expo-router/src/react-navigation/bottom-tabs/views/BottomTabView.tsx
@@ -30,7 +30,6 @@ type Props = BottomTabNavigationConfig & {
   popNestedStackToTop: (routeKey: string) => void;
 };
 
-const EPSILON = 1e-5;
 const STATE_INACTIVE = 0;
 const STATE_TRANSITIONING_OR_BELOW_TOP = 1;
 const STATE_ON_TOP = 2;
@@ -80,12 +79,31 @@ export function BottomTabView(props: Props) {
   const previousRouteKeyRef = React.useRef(focusedRouteKey);
   const tabAnims = useAnimatedHashMap(state);
 
+  const [lastUpdate, setLastUpdate] = React.useState<{
+    current: string;
+    previous?: string;
+    animating: boolean;
+  }>({
+    current: focusedRouteKey,
+    animating: false,
+  });
+
+  if (lastUpdate.current !== focusedRouteKey) {
+    setLastUpdate({
+      current: focusedRouteKey,
+      previous: lastUpdate.current,
+      animating: true,
+    });
+  }
+
   React.useEffect(() => {
     const previousRouteKey = previousRouteKeyRef.current;
 
     const shouldPopPreviousToTop =
       previousRouteKey !== focusedRouteKey &&
       !!descriptors[previousRouteKey]?.options.popToTopOnBlur;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
 
     const animateToIndex = () => {
       if (previousRouteKey !== focusedRouteKey) {
@@ -134,12 +152,28 @@ export function BottomTabView(props: Props) {
             target: focusedRouteKey,
           });
         }
+
+        if (finished) {
+          // Delay clearing so the previous screen stays attached
+          // This will give time for any native logic to run
+          timer = setTimeout(() => {
+            setLastUpdate((update) =>
+              update.animating ? { ...update, animating: false } : update
+            );
+          }, 32);
+        }
       });
     };
 
     animateToIndex();
 
     previousRouteKeyRef.current = focusedRouteKey;
+
+    return () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    };
   }, [
     descriptors,
     focusedRouteKey,
@@ -240,18 +274,14 @@ export function BottomTabView(props: Props) {
             }) ?? {};
 
           const animationEnabled = hasAnimation(descriptor.options);
+          const isAnimatingRoute =
+            lastUpdate.animating &&
+            (lastUpdate.previous === route.key || lastUpdate.current === route.key);
+
           const activityState = isFocused
             ? STATE_ON_TOP // the screen is on top after the transition
-            : animationEnabled // is animation is not enabled, immediately move to inactive state
-              ? tabAnims[route.key]!.interpolate({
-                  inputRange: [0, 1 - EPSILON, 1],
-                  outputRange: [
-                    STATE_TRANSITIONING_OR_BELOW_TOP, // screen visible during transition
-                    STATE_TRANSITIONING_OR_BELOW_TOP,
-                    STATE_INACTIVE, // the screen is detached after transition
-                  ],
-                  extrapolate: 'extend',
-                })
+            : animationEnabled && isAnimatingRoute // if animation is not enabled, immediately move to inactive state
+              ? STATE_TRANSITIONING_OR_BELOW_TOP // screen visible during transition
               : STATE_INACTIVE;
 
           return (


### PR DESCRIPTION
# Why

Fixes #49681. `expo-router`'s vendored `BottomTabView` was branched from a pre-fix snapshot of React Navigation's, and still derives the screen detach state by interpolating the tab's `Animated.Value`:

```ts
const activityState = isFocused
  ? STATE_ON_TOP
  : animationEnabled
    ? tabAnims[route.key]!.interpolate({
        inputRange: [0, 1 - EPSILON, 1],
        outputRange: [STATE_TRANSITIONING_OR_BELOW_TOP, STATE_TRANSITIONING_OR_BELOW_TOP, STATE_INACTIVE],
        extrapolate: 'extend',
      })
    : STATE_INACTIVE;
```

That value runs on the native driver (`useNativeDriver = Platform.OS !== 'web'`), so the detach decision is made natively while the transition is still in flight, and the arriving tab can come up blank.

React Navigation removed exactly this pattern in [react-navigation/react-navigation@9bfc8d0](https://github.com/react-navigation/react-navigation/commit/9bfc8d0f65eddbb434f94709b139f0fc2da62463) ("fix: don't derive screen detach state from animated value", fixes react-navigation/react-navigation#12755), released in `@react-navigation/bottom-tabs@7.18.8`.

**This is a regression introduced by the decoupling, not a pre-existing bug.** SDK 55 resolves `@react-navigation/bottom-tabs` to a version that already carries the fix; upgrading to SDK 56/57 swaps in the fork's pre-fix copy, so apps that were fine on SDK 55 start hitting it again.

# How

Port the upstream commit into the fork:

- Track the transition in plain JS state (`lastUpdate` — `current`, `previous`, `animating`) instead of interpolating an animated value.
- Clear `animating` on a 32ms delay once the animation reports `finished`, so the outgoing screen stays attached long enough for the arriving one to take over, and clean the timer up on unmount.
- Derive `activityState` from that state: `animationEnabled && isAnimatingRoute ? STATE_TRANSITIONING_OR_BELOW_TOP : STATE_INACTIVE`.

`EPSILON` is dropped with the interpolation, its only consumer.

The port is deliberately behaviour-only — I kept the fork's own divergences (`emitter.emit` rather than `navigation.emit`, `popNestedStackToTop` rather than a `popToTopAction` dispatch, the non-null assertions) and left upstream's cosmetic rewrite of the `Animated.parallel` block alone, so the diff shows just the fix.

# Test Plan

Two tests in `src/react-navigation/bottom-tabs/__tests__/index.test.ios.tsx`, asserting through the public API — they read the `activityState` that `BottomTabView` hands to the screen container after driving a real tab press with `renderRouter`.

| test | before this PR | after |
|---|---|---|
| outgoing tab stays attached, then detaches once the transition settles | **fails** — `Expected: 0, Received: 1` | passes |
| non-animated transition detaches the outgoing tab immediately | passes | passes |

The first is the witness for the fix. Pre-fix, the outgoing tab reports `STATE_TRANSITIONING_OR_BELOW_TOP` and stays there indefinitely on the JS side, because the native-driven value never propagates back; post-fix it goes `1 → 0` once the animation settles.

The second guards the `animationEnabled` half of the new condition rather than the port itself — dropping `animationEnabled &&` from it makes that test fail (`Expected: 0, Received: 1`), so the branch is covered rather than merely present.

Package gates, all from `packages/expo-router`:

```
yarn jest        402 suites, 5153 passed / 12 skipped, 257 snapshots — green
yarn typecheck   green
yarn lint        green (oxlint)
yarn format      green (oxfmt)
```

I could not reproduce the on-device blank screen itself — it is a native timing race, and the linked repros need a release build on a device. What is verified here is the contract the upstream fix establishes: detach state is decided in JS, deterministically, instead of by a native-driven animated value.
