### PR TITLE
[prebuild-config][iOS] Fix dead docs link in the ios.backgroundColor warning

### DIFF
--- a/packages/@expo/prebuild-config/CHANGELOG.md
+++ b/packages/@expo/prebuild-config/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Generated iOS projects now include a `SceneDelegate` and `UIApplicationSceneManifest` for the scene-based life cycle. ([#46734](https://github.com/expo/expo/pull/46734) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Write the `RCTMetroPort` Info.plist key so bare dev builds resolve their own Metro port instead of defaulting to 8081. ([#48098](https://github.com/expo/expo/pull/48098) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Keep the Xcode project in sync when the app icon switches between a Liquid Glass `.icon` package and a PNG icon. ([#46070](https://github.com/expo/expo/pull/46070) by [@debugtheworldbot](https://github.com/debugtheworldbot))
+- [iOS] Point the `ios.backgroundColor` prebuild warning at the `expo-system-ui` reference instead of the removed `build-reference/migrating` page, which returns a 404. ([#49791](https://github.com/expo/expo/pull/49791) by [@dennytosp](https://github.com/dennytosp))
 
 ### 💡 Others
 

--- a/packages/@expo/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosRootViewBackgroundColor.ts
+++ b/packages/@expo/prebuild-config/src/plugins/unversioned/expo-system-ui/withIosRootViewBackgroundColor.ts
@@ -40,7 +40,7 @@ export function warnSystemUIMissing(
     WarningAggregator.addWarningIOS(
       'ios.backgroundColor',
       'Install expo-system-ui to enable this feature',
-      'https://docs.expo.dev/build-reference/migrating/#expo-config--backgroundcolor--depends-on'
+      'https://docs.expo.dev/versions/latest/sdk/system-ui/'
     );
   }
 }


### PR DESCRIPTION
# Why

`warnSystemUIMissing` points users at a page that no longer exists:

```
https://docs.expo.dev/build-reference/migrating/#expo-config--backgroundcolor--depends-on   404
https://docs.expo.dev/versions/latest/sdk/system-ui/                                        200
```

`docs/pages/build-reference/migrating.mdx` was deleted in `18e4a53a868` ("[docs] no more migrators from expo build (#26961)"). This warning kept the link, and it is the only remaining reference to that path anywhere in the repo.

The replacement is the page the deleted section itself pointed at — its line 105 read `[expo-system-ui](/versions/latest/sdk/system-ui)`.

This reaches real users: `expo-system-ui` is a default unversioned plugin (`withDefaultPlugins.ts:128`), and the warning fires during `npx expo prebuild` for any SDK ≥ 44 project that sets `ios.backgroundColor` without the package installed.

# How

Swap the URL. No behaviour change.

# Test Plan

```
npx jest src/plugins/unversioned/expo-system-ui
  Test Suites: 4 passed, Tests: 21 passed
```

Identical before and after. Both HTTP status codes above were measured against the live site.