### PR TITLE
[docs] Drop useOnlyUserDefinedScreens from the custom navigators page

### DIFF
--- a/docs/pages/router/advanced/custom-navigators.mdx
+++ b/docs/pages/router/advanced/custom-navigators.mdx
@@ -111,12 +111,10 @@ function TabsContent({ emitter }: TabsContentProps) {
 
 Both `unstable_createStandardRouterNavigator` and `unstable_integrateWithRouter` accept an optional `options` object as their third argument:
 
-- **`useOnlyUserDefinedScreens`**: when `true`, only screens you declare with `<Navigator.Screen>` are rendered. Expo Router ignores routes discovered from the filesystem that you did not declare. Defaults to `false`, where Expo Router also renders routes discovered from the filesystem alongside your declared screens.
 - **`createProps`**: derives extra props for `NavigatorContent` from the underlying router state. Use this for router-specific information that is not part of the standard `state` and `actions`.
 
 ```tsx
 export const Tabs = unstable_createStandardRouterNavigator(TabsContent, TabRouter, {
-  useOnlyUserDefinedScreens: true,
   createProps: ({ state, dispatch }) => ({
     activeRouteKey: state.routes[state.index].key,
     preload: (name: string) => dispatch({ type: 'PRELOAD', payload: { name } }),


### PR DESCRIPTION
# Why

`docs/pages/router/advanced/custom-navigators.mdx` documents `useOnlyUserDefinedScreens` as an option of `unstable_createStandardRouterNavigator` / `unstable_integrateWithRouter`, and uses it in the copy-pasteable sample below the list.

It was removed in `d0d499239f4` — "[router] Remove `useOnlyUserDefinedScreens` from `withLayoutContext` (#47983)". `IntegrateWithRouterOptions` (`packages/expo-router/src/standard-navigation/types.ts:102-142`) now declares only `createProps`, `processState`, `processDescriptors` and `processScreens`.

Because the options object is typed, anyone copying that snippet gets a compile error rather than a silently ignored key. Outside `docs/`, the only remaining mention in the repo is the CHANGELOG line recording its removal.

# How

Drop the bullet and the line in the sample. Docs only.

# Test Plan

`grep -rn useOnlyUserDefinedScreens packages/expo-router/src` → no matches, both before and after.