### PR TITLE
[image-picker] correct the microphonePermission entry in the README

### DIFF
--- a/packages/expo-image-picker/README.md
+++ b/packages/expo-image-picker/README.md
@@ -80,7 +80,7 @@ The plugin provides props for extra customization. Every time you change the pro
 
 - `photosPermission` (_string | false_): Sets the iOS `NSPhotoLibraryUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission on iOS and **does not** skip the permission on Android. Defaults to `Allow $(PRODUCT_NAME) to access your photos`.
 - `cameraPermission` (_string | false_): Sets the iOS `NSCameraUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission on iOS and **does not** skip the permission on Android. Defaults to `Allow $(PRODUCT_NAME) to access your camera`.
-- `microphonePermission` (_string | false_): Sets the iOS `NSCameraUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission on iOS and skips adding the `android.permission.RECORD_AUDIO` Android permission. Defaults to `Allow $(PRODUCT_NAME) to access your photos`.
+- `microphonePermission` (_string | false_): Sets the iOS `NSMicrophoneUsageDescription` permission message to the `Info.plist`. Setting `false` will skip adding the permission on iOS and skips adding the `android.permission.RECORD_AUDIO` Android permission. Defaults to `Allow $(PRODUCT_NAME) to access your microphone`.
 
 ### Example
 


### PR DESCRIPTION
# Why

`packages/expo-image-picker/README.md` describes `microphonePermission` as setting `NSCameraUsageDescription`, defaulting to `Allow $(PRODUCT_NAME) to access your photos`. Both are wrong:

- `plugin/src/withImagePicker.ts:123` passes it as `NSMicrophoneUsageDescription`
- `plugin/src/withImagePicker.ts:15` defines the default as `MICROPHONE_USAGE = 'Allow $(PRODUCT_NAME) to access your microphone'`

The JSDoc on the option itself (`withImagePicker.ts:44-46`) and the docs site already say microphone — only the README drifted, so it looks like the entry was copy-pasted from the `cameraPermission` and `photosPermission` bullets directly above it.

# How

Name the key and default the plugin actually uses. README only.

# Test Plan

None needed — documentation. Both claims are quoted from the plugin source above.