### PR TITLE
[sqlite] Fix shared prepared statement cursors corrupting each other's reads

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 - Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
+- Fixed concurrent reads of a shared prepared statement returning each other's rows, and guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49794](https://github.com/expo/expo/pull/49794) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 - Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
-- Fixed concurrent reads of a shared prepared statement returning each other's rows, and made a result whose statement has run again throw instead of returning the later run's rows. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49796](https://github.com/expo/expo/pull/49796) by [@tsapeta](https://github.com/tsapeta))
+- Fixed reading a prepared statement result after the same statement ran again returning the later run's rows instead of throwing. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49796](https://github.com/expo/expo/pull/49796) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 - Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
-- Fixed concurrent reads of a shared prepared statement returning each other's rows, and made a result whose statement has run again throw instead of returning the later run's rows. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49794](https://github.com/expo/expo/pull/49794) by [@tsapeta](https://github.com/tsapeta))
+- Fixed concurrent reads of a shared prepared statement returning each other's rows, and made a result whose statement has run again throw instead of returning the later run's rows. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49796](https://github.com/expo/expo/pull/49796) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
 - Fixed the devtools plugin bundle missing its `wa-sqlite.wasm` asset. ([#48542](https://github.com/expo/expo/pull/48542) by [@kudo](https://github.com/kudo))
 - Fixed `SQLiteStorage` permanently throwing `no such table: storage` when the synchronous and asynchronous APIs raced the first-run migration. ([#48878](https://github.com/expo/expo/pull/48878) by [@giaBaoJS](https://github.com/giaBaoJS))
-- Fixed concurrent reads of a shared prepared statement returning each other's rows, and guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49794](https://github.com/expo/expo/pull/49794) by [@tsapeta](https://github.com/tsapeta))
+- Fixed concurrent reads of a shared prepared statement returning each other's rows, and made a result whose statement has run again throw instead of returning the later run's rows. Also guarded `step`, `getAll`, `reset` and `finalize` with the same per-statement lock that `run` takes. ([#49794](https://github.com/expo/expo/pull/49794) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -418,40 +418,52 @@ class SQLiteModule : Module() {
   private fun step(statement: NativeStatement, database: NativeDatabase): SQLiteColumnValues? {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    val ret = statement.ref.sqlite3_step()
-    if (ret == NativeDatabaseBinding.SQLITE_ROW) {
-      return statement.getTransformedColumnValues()
+
+    // Guard the stateful statement, see `run` above.
+    synchronized(statement) {
+      val ret = statement.ref.sqlite3_step()
+      if (ret == NativeDatabaseBinding.SQLITE_ROW) {
+        return statement.getTransformedColumnValues()
+      }
+      if (ret != NativeDatabaseBinding.SQLITE_DONE) {
+        throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+      }
+      return null
     }
-    if (ret != NativeDatabaseBinding.SQLITE_DONE) {
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
-    }
-    return null
   }
 
   @Throws(AccessClosedResourceException::class, InvalidConvertibleException::class, SQLiteErrorException::class)
   private fun getAll(statement: NativeStatement, database: NativeDatabase): List<SQLiteColumnValues> {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    val columnValuesList = mutableListOf<SQLiteColumnValues>()
-    while (true) {
-      val ret = statement.ref.sqlite3_step()
-      if (ret == NativeDatabaseBinding.SQLITE_ROW) {
-        columnValuesList.add(statement.getTransformedColumnValues())
-        continue
-      } else if (ret == NativeDatabaseBinding.SQLITE_DONE) {
-        break
+
+    // Guard the stateful statement, see `run` above.
+    synchronized(statement) {
+      val columnValuesList = mutableListOf<SQLiteColumnValues>()
+      while (true) {
+        val ret = statement.ref.sqlite3_step()
+        if (ret == NativeDatabaseBinding.SQLITE_ROW) {
+          columnValuesList.add(statement.getTransformedColumnValues())
+          continue
+        } else if (ret == NativeDatabaseBinding.SQLITE_DONE) {
+          break
+        }
+        throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
       }
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+      return columnValuesList
     }
-    return columnValuesList
   }
 
   @Throws(AccessClosedResourceException::class, SQLiteErrorException::class)
   private fun reset(statement: NativeStatement, database: NativeDatabase) {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    if (statement.ref.sqlite3_reset() != NativeDatabaseBinding.SQLITE_OK) {
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+
+    // Guard the stateful statement, see `run` above.
+    synchronized(statement) {
+      if (statement.ref.sqlite3_reset() != NativeDatabaseBinding.SQLITE_OK) {
+        throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+      }
     }
   }
 
@@ -459,10 +471,14 @@ class SQLiteModule : Module() {
   private fun finalize(statement: NativeStatement, database: NativeDatabase) {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    if (statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
-      throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+
+    // Guard the stateful statement, see `run` above.
+    synchronized(statement) {
+      if (statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
+        throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
+      }
+      statement.isFinalized = true
     }
-    statement.isFinalized = true
   }
 
   private fun addUpdateHook(database: NativeDatabase) {

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -428,6 +428,13 @@ public final class SQLiteModule: Module {
   private func step(statement: NativeStatement, database: NativeDatabase) throws -> SQLiteColumnValues? {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    // Guard the stateful statement, see `run` above.
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+
     let ret = exsqlite3_step(statement.pointer)
     if ret == SQLITE_ROW {
       return try getColumnValues(statement: statement)
@@ -441,6 +448,13 @@ public final class SQLiteModule: Module {
   private func getAll(statement: NativeStatement, database: NativeDatabase) throws -> [SQLiteColumnValues] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    // Guard the stateful statement, see `run` above.
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+
     var columnValuesList: [SQLiteColumnValues] = []
     while true {
       let ret = exsqlite3_step(statement.pointer)
@@ -459,6 +473,13 @@ public final class SQLiteModule: Module {
   private func reset(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    // Guard the stateful statement, see `run` above.
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+
     if exsqlite3_reset(statement.pointer) != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
@@ -467,6 +488,13 @@ public final class SQLiteModule: Module {
   private func finalize(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    // Guard the stateful statement, see `run` above.
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+
     if exsqlite3_finalize(statement.pointer) != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }

--- a/packages/expo-sqlite/ios/Tests/StatementLockTests.swift
+++ b/packages/expo-sqlite/ios/Tests/StatementLockTests.swift
@@ -1,0 +1,87 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import Testing
+
+@testable import ExpoSQLite
+
+/// Exercises the per-statement critical section that `SQLiteModule` takes around every call that
+/// touches a `sqlite3_stmt`. The module runs those calls on a concurrent queue, so a shared
+/// statement really is reached from several threads at once.
+@Suite("StatementLock")
+final class StatementLockTests {
+  private var database: OpaquePointer?
+
+  init() throws {
+    #expect(exsqlite3_open(":memory:", &database) == SQLITE_OK)
+    let setup = """
+      CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+      INSERT INTO test (id, value) VALUES (1, 'one');
+      INSERT INTO test (id, value) VALUES (2, 'two');
+      INSERT INTO test (id, value) VALUES (3, 'three');
+      """
+    #expect(exsqlite3_exec(database, setup, nil, nil, nil) == SQLITE_OK)
+  }
+
+  deinit {
+    exsqlite3_close(database)
+  }
+
+  private func makeStatement(_ source: String) throws -> NativeStatement {
+    let statement = NativeStatement()
+    #expect(exsqlite3_prepare_v2(database, source, -1, &statement.pointer, nil) == SQLITE_OK)
+    return statement
+  }
+
+  /// Binds `id` and reads the first row, the way `run` does: one critical section per native
+  /// call, which is what the module takes. The row read belongs to whichever caller bound the
+  /// statement last, so callers assert only that a value the table holds comes back.
+  private func runAndReadFirstRow(of statement: NativeStatement, id: Int32) -> String? {
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+    exsqlite3_reset(statement.pointer)
+    exsqlite3_clear_bindings(statement.pointer)
+    exsqlite3_bind_int(statement.pointer, 1, id)
+    guard exsqlite3_step(statement.pointer) == SQLITE_ROW,
+      let text = exsqlite3_column_text(statement.pointer, 0)
+    else {
+      return nil
+    }
+    return String(cString: text)
+  }
+
+  /// Drains the cursor in its own critical section, the way `getAll` does.
+  private func drain(_ statement: NativeStatement) {
+    statement.lock.wait()
+    defer {
+      statement.lock.signal()
+    }
+    while exsqlite3_step(statement.pointer) == SQLITE_ROW {}
+  }
+
+  @Test
+  func `hammering one shared statement never reads a torn value`() throws {
+    let statement = try makeStatement("SELECT value FROM test WHERE id = ?")
+    let stored: Set<String> = ["one", "two", "three"]
+    let readValues = Mutex<Set<String>>([])
+    // Without the lock on `step`, one thread resets and rebinds the statement while another is
+    // mid-step, which is the shape that produced a null `TEXT` column in a field report.
+    // Removing the lock from the helpers above fails this test, so it does catch its absence.
+    DispatchQueue.concurrentPerform(iterations: 500) { iteration in
+      let id = Int32(iteration % 3 + 1)
+      if let value = self.runAndReadFirstRow(of: statement, id: id) {
+        readValues.withLock { values in
+          values.insert(value)
+        }
+      }
+      self.drain(statement)
+    }
+    // Every value read has to be one the table actually holds: no nulls, no torn strings.
+    let values = readValues.withLock { $0 }
+    #expect(!values.isEmpty)
+    #expect(values.isSubset(of: stored))
+    exsqlite3_finalize(statement.pointer)
+  }
+}

--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -657,9 +657,10 @@ class SQLiteExecuteSyncResultImpl<T> {
   }
 
   resetSync(): void {
-    const result = this.statement.resetSync(this.database);
+    // Resetting a superseded result would rewind the cursor of the run that owns it now.
+    this.assertCursorOwner();
+    this.statement.resetSync(this.database);
     this.isStepCalled = false;
-    return result;
   }
 
   private popFirstRowValues(): SQLiteColumnValues | null {

--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -19,9 +19,56 @@ export type {
 type ValuesOf<T extends object> = T[keyof T][];
 
 /**
+ * A prepared statement owns a single native cursor that every execution rebinds, so a cursor's
+ * `run` and its row-fetching calls must not interleave with another execution of the same
+ * statement.
+ *
+ * Each execution takes a turn. A turn ends when the cursor has produced its rows, but a caller is
+ * free to abandon a cursor without ever reading it, so a turn also ends as soon as another
+ * execution asks for one. Waiting only for row-fetching that may never come would deadlock the
+ * statement.
+ */
+class StatementQueue {
+  private tail: Promise<void> = Promise.resolve();
+  private endCurrentTurn: (() => void) | null = null;
+
+  /**
+   * Wait for the pending turn to finish, then start one. Resolves to the callback that ends it.
+   */
+  async acquireAsync(): Promise<() => void> {
+    // Let a cursor that is still holding its turn wrap up before queuing behind it.
+    this.endCurrentTurn?.();
+
+    let endTurn!: () => void;
+    const turn = new Promise<void>((resolve) => {
+      endTurn = resolve;
+    });
+    const previous = this.tail;
+    this.tail = previous.then(() => turn);
+    await previous;
+
+    const end = () => {
+      if (this.endCurrentTurn === end) {
+        this.endCurrentTurn = null;
+      }
+      endTurn();
+    };
+    this.endCurrentTurn = end;
+    return end;
+  }
+
+  /** End the pending turn so a statement discarded mid-cursor cannot stall the queue. */
+  drain() {
+    this.endCurrentTurn?.();
+  }
+}
+
+/**
  * A prepared statement returned by [`SQLiteDatabase.prepareAsync()`](#prepareasyncsource) or [`SQLiteDatabase.prepareSync()`](#preparesyncsource) that can be binded with parameters and executed.
  */
 export class SQLiteStatement {
+  private readonly queue = new StatementQueue();
+
   constructor(
     private readonly nativeDatabase: NativeDatabase,
     private readonly nativeStatement: NativeStatement
@@ -39,10 +86,19 @@ export class SQLiteStatement {
    */
   public executeAsync<T>(...params: SQLiteVariadicBindParams): Promise<SQLiteExecuteAsyncResult<T>>;
   public async executeAsync<T>(...params: unknown[]): Promise<SQLiteExecuteAsyncResult<T>> {
-    const { lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
-      this.nativeDatabase,
-      ...normalizeParams(...params)
-    );
+    const release = await this.queue.acquireAsync();
+    let lastInsertRowId: number;
+    let changes: number;
+    let firstRowValues: SQLiteColumnValues;
+    try {
+      ({ lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
+        this.nativeDatabase,
+        ...normalizeParams(...params)
+      ));
+    } catch (e) {
+      release();
+      throw e;
+    }
     return createSQLiteExecuteAsyncResult<T>(
       this.nativeDatabase,
       this.nativeStatement,
@@ -51,7 +107,8 @@ export class SQLiteStatement {
         rawResult: false,
         lastInsertRowId,
         changes,
-      }
+      },
+      release
     );
   }
 
@@ -71,10 +128,19 @@ export class SQLiteStatement {
   public async executeForRawResultAsync<T extends object>(
     ...params: unknown[]
   ): Promise<SQLiteExecuteAsyncResult<ValuesOf<T>>> {
-    const { lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
-      this.nativeDatabase,
-      ...normalizeParams(...params)
-    );
+    const release = await this.queue.acquireAsync();
+    let lastInsertRowId: number;
+    let changes: number;
+    let firstRowValues: SQLiteColumnValues;
+    try {
+      ({ lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
+        this.nativeDatabase,
+        ...normalizeParams(...params)
+      ));
+    } catch (e) {
+      release();
+      throw e;
+    }
     return createSQLiteExecuteAsyncResult<ValuesOf<T>>(
       this.nativeDatabase,
       this.nativeStatement,
@@ -83,7 +149,8 @@ export class SQLiteStatement {
         rawResult: true,
         lastInsertRowId,
         changes,
-      }
+      },
+      release
     );
   }
 
@@ -103,6 +170,8 @@ export class SQLiteStatement {
    * > You can use the `try...finally` statement to ensure that prepared statements are finalized even if an error occurs.
    */
   public async finalizeAsync(): Promise<void> {
+    // A caller may finalize without ever reading the last cursor's rows.
+    this.queue.drain();
     await this.nativeStatement.finalizeAsync(this.nativeDatabase);
   }
 
@@ -357,13 +426,15 @@ async function createSQLiteExecuteAsyncResult<T>(
   database: SQLiteAnyDatabase,
   statement: NativeStatement,
   firstRowValues: SQLiteColumnValues | null,
-  options: SQLiteExecuteResultOptions
+  options: SQLiteExecuteResultOptions,
+  release: () => void
 ): Promise<SQLiteExecuteAsyncResult<T>> {
   const instance = new SQLiteExecuteAsyncResultImpl<T>(
     database,
     statement,
     firstRowValues ? processNativeRow(firstRowValues) : null,
-    options
+    options,
+    release
   );
   const generator = instance.generatorAsync();
   Object.defineProperties(generator, {
@@ -447,13 +518,26 @@ function createSQLiteExecuteSyncResult<T>(
 class SQLiteExecuteAsyncResultImpl<T> {
   private columnNames: string[] | null = null;
   private isStepCalled = false;
+  private isReleased = false;
 
   constructor(
     private readonly database: SQLiteAnyDatabase,
     private readonly statement: NativeStatement,
     private firstRowValues: SQLiteColumnValues | null,
-    public readonly options: SQLiteExecuteResultOptions
+    public readonly options: SQLiteExecuteResultOptions,
+    private readonly release: () => void
   ) {}
+
+  /**
+   * Let the next execution of this statement rebind the native cursor. Called once this cursor
+   * will not step again, so an abandoned cursor cannot hold the statement forever.
+   */
+  private releaseOnce() {
+    if (!this.isReleased) {
+      this.isReleased = true;
+      this.release();
+    }
+  }
 
   async getFirstAsync(): Promise<T | null> {
     if (this.isStepCalled) {
@@ -462,15 +546,19 @@ class SQLiteExecuteAsyncResultImpl<T> {
       );
     }
     this.isStepCalled = true;
-    const columnNames = await this.getColumnNamesAsync();
-    const firstRowValues = this.popFirstRowValues();
-    if (firstRowValues != null) {
-      return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
+    try {
+      const columnNames = await this.getColumnNamesAsync();
+      const firstRowValues = this.popFirstRowValues();
+      if (firstRowValues != null) {
+        return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
+      }
+      const firstRow = await this.statement.stepAsync(this.database);
+      return firstRow != null
+        ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
+        : null;
+    } finally {
+      this.releaseOnce();
     }
-    const firstRow = await this.statement.stepAsync(this.database);
-    return firstRow != null
-      ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
-      : null;
   }
 
   async getAllAsync(): Promise<T[]> {
@@ -480,44 +568,62 @@ class SQLiteExecuteAsyncResultImpl<T> {
       );
     }
     this.isStepCalled = true;
-    const firstRowValues = this.popFirstRowValues();
-    if (firstRowValues == null) {
-      // If the first row is empty, this SQL query may be a write operation. We should not call `statement.getAllAsync()` to write again.
-      return [];
+    try {
+      const firstRowValues = this.popFirstRowValues();
+      if (firstRowValues == null) {
+        // If the first row is empty, this SQL query may be a write operation. We should not call `statement.getAllAsync()` to write again.
+        return [];
+      }
+      const columnNames = await this.getColumnNamesAsync();
+      const nativeRows = await this.statement.getAllAsync(this.database);
+      const allRows = processNativeRows(nativeRows);
+      if (firstRowValues.length > 0) {
+        return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, [
+          firstRowValues,
+          ...allRows,
+        ]);
+      }
+      return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, allRows);
+    } finally {
+      this.releaseOnce();
     }
-    const columnNames = await this.getColumnNamesAsync();
-    const nativeRows = await this.statement.getAllAsync(this.database);
-    const allRows = processNativeRows(nativeRows);
-    if (firstRowValues != null && firstRowValues.length > 0) {
-      return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, [
-        firstRowValues,
-        ...allRows,
-      ]);
-    }
-    return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, allRows);
   }
 
   async *generatorAsync(): AsyncIterableIterator<T> {
     this.isStepCalled = true;
-    const columnNames = await this.getColumnNamesAsync();
-    const firstRowValues = this.popFirstRowValues();
-    if (firstRowValues != null) {
-      yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
-    }
-
-    let result;
-    do {
-      result = await this.statement.stepAsync(this.database);
-      if (result != null) {
-        yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(result));
+    try {
+      const columnNames = await this.getColumnNamesAsync();
+      const firstRowValues = this.popFirstRowValues();
+      if (firstRowValues != null) {
+        yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
       }
-    } while (result != null);
+
+      let result;
+      do {
+        result = await this.statement.stepAsync(this.database);
+        if (result != null) {
+          yield composeRowIfNeeded<T>(
+            this.options.rawResult,
+            columnNames,
+            processNativeRow(result)
+          );
+        }
+      } while (result != null);
+    } finally {
+      this.releaseOnce();
+    }
   }
 
-  resetAsync(): Promise<void> {
-    const result = this.statement.resetAsync(this.database);
+  async resetAsync(): Promise<void> {
+    if (this.isReleased) {
+      // Another execution has rebound the statement, so this cursor's rows are gone for good.
+      // Resetting now would rewind that execution's cursor instead of this one's.
+      throw new Error(
+        'This SQLite cursor can no longer be reset because the prepared statement has been executed again. Await the rows of an execution before executing the same statement another time.'
+      );
+    }
+    await this.statement.resetAsync(this.database);
     this.isStepCalled = false;
-    return result;
   }
 
   private popFirstRowValues(): SQLiteColumnValues | null {

--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -69,10 +69,26 @@ class StatementQueue {
 export class SQLiteStatement {
   private readonly queue = new StatementQueue();
 
+  /**
+   * The cursor that currently owns the underlying `sqlite3_stmt`. A prepared statement has exactly
+   * one cursor, so running the statement again invalidates the cursor of every earlier run.
+   */
+  private currentCursor: object | null = null;
+
   constructor(
     private readonly nativeDatabase: NativeDatabase,
     private readonly nativeStatement: NativeStatement
   ) {}
+
+  /**
+   * Make the run that just finished the owner of the statement cursor, and return a predicate
+   * that tells whether it still is.
+   */
+  private claimCursor(): () => boolean {
+    const cursor = {};
+    this.currentCursor = cursor;
+    return () => this.currentCursor === cursor;
+  }
 
   //#region Asynchronous API
 
@@ -108,7 +124,8 @@ export class SQLiteStatement {
         lastInsertRowId,
         changes,
       },
-      release
+      release,
+      this.claimCursor()
     );
   }
 
@@ -150,7 +167,8 @@ export class SQLiteStatement {
         lastInsertRowId,
         changes,
       },
-      release
+      release,
+      this.claimCursor()
     );
   }
 
@@ -202,7 +220,8 @@ export class SQLiteStatement {
         rawResult: false,
         lastInsertRowId,
         changes,
-      }
+      },
+      this.claimCursor()
     );
   }
 
@@ -234,7 +253,8 @@ export class SQLiteStatement {
         rawResult: true,
         lastInsertRowId,
         changes,
-      }
+      },
+      this.claimCursor()
     );
   }
 
@@ -416,6 +436,12 @@ interface SQLiteExecuteResultOptions {
   changes: number;
 }
 
+const SUPERSEDED_CURSOR_MESSAGE =
+  'This result is no longer readable because the prepared statement ran again. ' +
+  'A prepared statement holds a single SQLite cursor, so a later run rebinds the parameters and moves that cursor, ' +
+  'and this result would return the rows of the later run. ' +
+  'Read a result to the end before you run the same statement again, or prepare a separate statement for each reader.';
+
 /**
  * Create the `SQLiteExecuteAsyncResult` instance.
  *
@@ -427,14 +453,16 @@ async function createSQLiteExecuteAsyncResult<T>(
   statement: NativeStatement,
   firstRowValues: SQLiteColumnValues | null,
   options: SQLiteExecuteResultOptions,
-  release: () => void
+  release: () => void,
+  isCursorOwner: () => boolean
 ): Promise<SQLiteExecuteAsyncResult<T>> {
   const instance = new SQLiteExecuteAsyncResultImpl<T>(
     database,
     statement,
     firstRowValues ? processNativeRow(firstRowValues) : null,
     options,
-    release
+    release,
+    isCursorOwner
   );
   const generator = instance.generatorAsync();
   Object.defineProperties(generator, {
@@ -475,13 +503,15 @@ function createSQLiteExecuteSyncResult<T>(
   database: SQLiteAnyDatabase,
   statement: NativeStatement,
   firstRowValues: SQLiteColumnValues | null,
-  options: SQLiteExecuteResultOptions
+  options: SQLiteExecuteResultOptions,
+  isCursorOwner: () => boolean
 ): SQLiteExecuteSyncResult<T> {
   const instance = new SQLiteExecuteSyncResultImpl<T>(
     database,
     statement,
     firstRowValues ? processNativeRow(firstRowValues) : firstRowValues,
-    options
+    options,
+    isCursorOwner
   );
   const generator = instance.generatorSync();
   Object.defineProperties(generator, {
@@ -525,8 +555,16 @@ class SQLiteExecuteAsyncResultImpl<T> {
     private readonly statement: NativeStatement,
     private firstRowValues: SQLiteColumnValues | null,
     public readonly options: SQLiteExecuteResultOptions,
-    private readonly release: () => void
+    private readonly release: () => void,
+    private readonly isCursorOwner: () => boolean
   ) {}
+
+  /** Throw rather than step a cursor that a later run of the same statement has taken over. */
+  private assertCursorOwner() {
+    if (!this.isCursorOwner()) {
+      throw new Error(SUPERSEDED_CURSOR_MESSAGE);
+    }
+  }
 
   /**
    * Let the next execution of this statement rebind the native cursor. Called once this cursor
@@ -552,6 +590,7 @@ class SQLiteExecuteAsyncResultImpl<T> {
       if (firstRowValues != null) {
         return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
       }
+      this.assertCursorOwner();
       const firstRow = await this.statement.stepAsync(this.database);
       return firstRow != null
         ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
@@ -575,6 +614,7 @@ class SQLiteExecuteAsyncResultImpl<T> {
         return [];
       }
       const columnNames = await this.getColumnNamesAsync();
+      this.assertCursorOwner();
       const nativeRows = await this.statement.getAllAsync(this.database);
       const allRows = processNativeRows(nativeRows);
       if (firstRowValues.length > 0) {
@@ -600,6 +640,7 @@ class SQLiteExecuteAsyncResultImpl<T> {
 
       let result;
       do {
+        this.assertCursorOwner();
         result = await this.statement.stepAsync(this.database);
         if (result != null) {
           yield composeRowIfNeeded<T>(
@@ -651,8 +692,16 @@ class SQLiteExecuteSyncResultImpl<T> {
     private readonly database: SQLiteAnyDatabase,
     private readonly statement: NativeStatement,
     private firstRowValues: SQLiteColumnValues | null,
-    public readonly options: SQLiteExecuteResultOptions
+    public readonly options: SQLiteExecuteResultOptions,
+    private readonly isCursorOwner: () => boolean
   ) {}
+
+  /** Throw rather than step a cursor that a later run of the same statement has taken over. */
+  private assertCursorOwner() {
+    if (!this.isCursorOwner()) {
+      throw new Error(SUPERSEDED_CURSOR_MESSAGE);
+    }
+  }
 
   getFirstSync(): T | null {
     if (this.isStepCalled) {
@@ -665,6 +714,7 @@ class SQLiteExecuteSyncResultImpl<T> {
     if (firstRowValues != null) {
       return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
     }
+    this.assertCursorOwner();
     const firstRow = this.statement.stepSync(this.database);
     return firstRow != null
       ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
@@ -683,6 +733,7 @@ class SQLiteExecuteSyncResultImpl<T> {
       return [];
     }
     const columnNames = this.getColumnNamesSync();
+    this.assertCursorOwner();
     const nativeRows = this.statement.getAllSync(this.database);
     const allRows = processNativeRows(nativeRows);
     if (firstRowValues != null && firstRowValues.length > 0) {
@@ -702,6 +753,7 @@ class SQLiteExecuteSyncResultImpl<T> {
     }
     let result;
     do {
+      this.assertCursorOwner();
       result = this.statement.stepSync(this.database);
       if (result != null) {
         yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(result));

--- a/packages/expo-sqlite/src/SQLiteStatement.ts
+++ b/packages/expo-sqlite/src/SQLiteStatement.ts
@@ -19,56 +19,9 @@ export type {
 type ValuesOf<T extends object> = T[keyof T][];
 
 /**
- * A prepared statement owns a single native cursor that every execution rebinds, so a cursor's
- * `run` and its row-fetching calls must not interleave with another execution of the same
- * statement.
- *
- * Each execution takes a turn. A turn ends when the cursor has produced its rows, but a caller is
- * free to abandon a cursor without ever reading it, so a turn also ends as soon as another
- * execution asks for one. Waiting only for row-fetching that may never come would deadlock the
- * statement.
- */
-class StatementQueue {
-  private tail: Promise<void> = Promise.resolve();
-  private endCurrentTurn: (() => void) | null = null;
-
-  /**
-   * Wait for the pending turn to finish, then start one. Resolves to the callback that ends it.
-   */
-  async acquireAsync(): Promise<() => void> {
-    // Let a cursor that is still holding its turn wrap up before queuing behind it.
-    this.endCurrentTurn?.();
-
-    let endTurn!: () => void;
-    const turn = new Promise<void>((resolve) => {
-      endTurn = resolve;
-    });
-    const previous = this.tail;
-    this.tail = previous.then(() => turn);
-    await previous;
-
-    const end = () => {
-      if (this.endCurrentTurn === end) {
-        this.endCurrentTurn = null;
-      }
-      endTurn();
-    };
-    this.endCurrentTurn = end;
-    return end;
-  }
-
-  /** End the pending turn so a statement discarded mid-cursor cannot stall the queue. */
-  drain() {
-    this.endCurrentTurn?.();
-  }
-}
-
-/**
  * A prepared statement returned by [`SQLiteDatabase.prepareAsync()`](#prepareasyncsource) or [`SQLiteDatabase.prepareSync()`](#preparesyncsource) that can be binded with parameters and executed.
  */
 export class SQLiteStatement {
-  private readonly queue = new StatementQueue();
-
   /**
    * The cursor that currently owns the underlying `sqlite3_stmt`. A prepared statement has exactly
    * one cursor, so running the statement again invalidates the cursor of every earlier run.
@@ -102,19 +55,10 @@ export class SQLiteStatement {
    */
   public executeAsync<T>(...params: SQLiteVariadicBindParams): Promise<SQLiteExecuteAsyncResult<T>>;
   public async executeAsync<T>(...params: unknown[]): Promise<SQLiteExecuteAsyncResult<T>> {
-    const release = await this.queue.acquireAsync();
-    let lastInsertRowId: number;
-    let changes: number;
-    let firstRowValues: SQLiteColumnValues;
-    try {
-      ({ lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
-        this.nativeDatabase,
-        ...normalizeParams(...params)
-      ));
-    } catch (e) {
-      release();
-      throw e;
-    }
+    const { lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
+      this.nativeDatabase,
+      ...normalizeParams(...params)
+    );
     return createSQLiteExecuteAsyncResult<T>(
       this.nativeDatabase,
       this.nativeStatement,
@@ -124,7 +68,6 @@ export class SQLiteStatement {
         lastInsertRowId,
         changes,
       },
-      release,
       this.claimCursor()
     );
   }
@@ -145,19 +88,10 @@ export class SQLiteStatement {
   public async executeForRawResultAsync<T extends object>(
     ...params: unknown[]
   ): Promise<SQLiteExecuteAsyncResult<ValuesOf<T>>> {
-    const release = await this.queue.acquireAsync();
-    let lastInsertRowId: number;
-    let changes: number;
-    let firstRowValues: SQLiteColumnValues;
-    try {
-      ({ lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
-        this.nativeDatabase,
-        ...normalizeParams(...params)
-      ));
-    } catch (e) {
-      release();
-      throw e;
-    }
+    const { lastInsertRowId, changes, firstRowValues } = await this.nativeStatement.runAsync(
+      this.nativeDatabase,
+      ...normalizeParams(...params)
+    );
     return createSQLiteExecuteAsyncResult<ValuesOf<T>>(
       this.nativeDatabase,
       this.nativeStatement,
@@ -167,7 +101,6 @@ export class SQLiteStatement {
         lastInsertRowId,
         changes,
       },
-      release,
       this.claimCursor()
     );
   }
@@ -188,8 +121,6 @@ export class SQLiteStatement {
    * > You can use the `try...finally` statement to ensure that prepared statements are finalized even if an error occurs.
    */
   public async finalizeAsync(): Promise<void> {
-    // A caller may finalize without ever reading the last cursor's rows.
-    this.queue.drain();
     await this.nativeStatement.finalizeAsync(this.nativeDatabase);
   }
 
@@ -453,7 +384,6 @@ async function createSQLiteExecuteAsyncResult<T>(
   statement: NativeStatement,
   firstRowValues: SQLiteColumnValues | null,
   options: SQLiteExecuteResultOptions,
-  release: () => void,
   isCursorOwner: () => boolean
 ): Promise<SQLiteExecuteAsyncResult<T>> {
   const instance = new SQLiteExecuteAsyncResultImpl<T>(
@@ -461,7 +391,6 @@ async function createSQLiteExecuteAsyncResult<T>(
     statement,
     firstRowValues ? processNativeRow(firstRowValues) : null,
     options,
-    release,
     isCursorOwner
   );
   const generator = instance.generatorAsync();
@@ -548,14 +477,12 @@ function createSQLiteExecuteSyncResult<T>(
 class SQLiteExecuteAsyncResultImpl<T> {
   private columnNames: string[] | null = null;
   private isStepCalled = false;
-  private isReleased = false;
 
   constructor(
     private readonly database: SQLiteAnyDatabase,
     private readonly statement: NativeStatement,
     private firstRowValues: SQLiteColumnValues | null,
     public readonly options: SQLiteExecuteResultOptions,
-    private readonly release: () => void,
     private readonly isCursorOwner: () => boolean
   ) {}
 
@@ -566,17 +493,6 @@ class SQLiteExecuteAsyncResultImpl<T> {
     }
   }
 
-  /**
-   * Let the next execution of this statement rebind the native cursor. Called once this cursor
-   * will not step again, so an abandoned cursor cannot hold the statement forever.
-   */
-  private releaseOnce() {
-    if (!this.isReleased) {
-      this.isReleased = true;
-      this.release();
-    }
-  }
-
   async getFirstAsync(): Promise<T | null> {
     if (this.isStepCalled) {
       throw new Error(
@@ -584,20 +500,16 @@ class SQLiteExecuteAsyncResultImpl<T> {
       );
     }
     this.isStepCalled = true;
-    try {
-      const columnNames = await this.getColumnNamesAsync();
-      const firstRowValues = this.popFirstRowValues();
-      if (firstRowValues != null) {
-        return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
-      }
-      this.assertCursorOwner();
-      const firstRow = await this.statement.stepAsync(this.database);
-      return firstRow != null
-        ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
-        : null;
-    } finally {
-      this.releaseOnce();
+    const columnNames = await this.getColumnNamesAsync();
+    const firstRowValues = this.popFirstRowValues();
+    if (firstRowValues != null) {
+      return composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
     }
+    this.assertCursorOwner();
+    const firstRow = await this.statement.stepAsync(this.database);
+    return firstRow != null
+      ? composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(firstRow))
+      : null;
   }
 
   async getAllAsync(): Promise<T[]> {
@@ -607,62 +519,45 @@ class SQLiteExecuteAsyncResultImpl<T> {
       );
     }
     this.isStepCalled = true;
-    try {
-      const firstRowValues = this.popFirstRowValues();
-      if (firstRowValues == null) {
-        // If the first row is empty, this SQL query may be a write operation. We should not call `statement.getAllAsync()` to write again.
-        return [];
-      }
-      const columnNames = await this.getColumnNamesAsync();
-      this.assertCursorOwner();
-      const nativeRows = await this.statement.getAllAsync(this.database);
-      const allRows = processNativeRows(nativeRows);
-      if (firstRowValues.length > 0) {
-        return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, [
-          firstRowValues,
-          ...allRows,
-        ]);
-      }
-      return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, allRows);
-    } finally {
-      this.releaseOnce();
+    const firstRowValues = this.popFirstRowValues();
+    if (firstRowValues == null) {
+      // If the first row is empty, this SQL query may be a write operation. We should not call `statement.getAllAsync()` to write again.
+      return [];
     }
+    const columnNames = await this.getColumnNamesAsync();
+    this.assertCursorOwner();
+    const nativeRows = await this.statement.getAllAsync(this.database);
+    const allRows = processNativeRows(nativeRows);
+    if (firstRowValues.length > 0) {
+      return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, [
+        firstRowValues,
+        ...allRows,
+      ]);
+    }
+    return composeRowsIfNeeded<T>(this.options.rawResult, columnNames, allRows);
   }
 
   async *generatorAsync(): AsyncIterableIterator<T> {
     this.isStepCalled = true;
-    try {
-      const columnNames = await this.getColumnNamesAsync();
-      const firstRowValues = this.popFirstRowValues();
-      if (firstRowValues != null) {
-        yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
-      }
-
-      let result;
-      do {
-        this.assertCursorOwner();
-        result = await this.statement.stepAsync(this.database);
-        if (result != null) {
-          yield composeRowIfNeeded<T>(
-            this.options.rawResult,
-            columnNames,
-            processNativeRow(result)
-          );
-        }
-      } while (result != null);
-    } finally {
-      this.releaseOnce();
+    const columnNames = await this.getColumnNamesAsync();
+    const firstRowValues = this.popFirstRowValues();
+    if (firstRowValues != null) {
+      yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, firstRowValues);
     }
+
+    let result;
+    do {
+      this.assertCursorOwner();
+      result = await this.statement.stepAsync(this.database);
+      if (result != null) {
+        yield composeRowIfNeeded<T>(this.options.rawResult, columnNames, processNativeRow(result));
+      }
+    } while (result != null);
   }
 
   async resetAsync(): Promise<void> {
-    if (this.isReleased) {
-      // Another execution has rebound the statement, so this cursor's rows are gone for good.
-      // Resetting now would rewind that execution's cursor instead of this one's.
-      throw new Error(
-        'This SQLite cursor can no longer be reset because the prepared statement has been executed again. Await the rows of an execution before executing the same statement another time.'
-      );
-    }
+    // Resetting a superseded result would rewind the cursor of the run that owns it now.
+    this.assertCursorOwner();
     await this.statement.resetAsync(this.database);
     this.isStepCalled = false;
   }

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -253,6 +253,65 @@ INSERT INTO users (name) VALUES ('aaa');
     // We still need to wait for promise1 to finish for promise1 to finalize the transaction.
     await promise1;
   }, 10000);
+
+  it('concurrent statement shorthands should each return their own rows', async () => {
+    db = await openDatabaseAsync(':memory:');
+    await db.execAsync(`
+CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+INSERT INTO test (id, value) VALUES (1, 'one');
+INSERT INTO test (id, value) VALUES (2, 'two');
+INSERT INTO test (id, value) VALUES (3, 'three');
+`);
+    // Each shorthand prepares its own statement, so concurrent callers must not share a cursor.
+    const rows = await Promise.all([
+      db.getAllAsync<{ value: string }>('SELECT value FROM test WHERE id = ?', 1),
+      db.getAllAsync<{ value: string }>('SELECT value FROM test WHERE id = ?', 2),
+      db.getAllAsync<{ value: string }>('SELECT value FROM test WHERE id = ?', 3),
+      db.getAllAsync<{ value: string }>('SELECT value FROM test WHERE id = ?', 1),
+    ]);
+    expect(rows.map((result) => result.map((row) => row.value))).toEqual([
+      ['one'],
+      ['two'],
+      ['three'],
+      ['one'],
+    ]);
+  });
+
+  it('concurrent writes and reads through the shorthands should all apply', async () => {
+    db = await openDatabaseAsync(':memory:');
+    await db.execAsync('CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL)');
+    await Promise.all([
+      db.runAsync('INSERT INTO test (value) VALUES (?)', ['a']),
+      db.runAsync('INSERT INTO test (value) VALUES (?)', ['b']),
+      db.runAsync('INSERT INTO test (value) VALUES (?)', ['c']),
+    ]);
+    const values = await db.getAllAsync<{ value: string }>('SELECT value FROM test ORDER BY id');
+    expect(values.map((row) => row.value).sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('getEachAsync should yield every row when abandoned partway and re-run', async () => {
+    db = await openDatabaseAsync(':memory:');
+    await db.execAsync(`
+CREATE TABLE test (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+INSERT INTO test (id, value) VALUES (1, 'one');
+INSERT INTO test (id, value) VALUES (2, 'two');
+INSERT INTO test (id, value) VALUES (3, 'three');
+`);
+    // Breaking out of the loop finalizes the statement mid-cursor.
+    for await (const row of db.getEachAsync<{ value: string }>(
+      'SELECT value FROM test ORDER BY id'
+    )) {
+      expect(row.value).toBe('one');
+      break;
+    }
+    const all: string[] = [];
+    for await (const row of db.getEachAsync<{ value: string }>(
+      'SELECT value FROM test ORDER BY id'
+    )) {
+      all.push(row.value);
+    }
+    expect(all).toEqual(['one', 'two', 'three']);
+  });
 });
 
 describe('Database - Synchronous calls', () => {

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -158,99 +158,6 @@ describe(SQLiteStatement, () => {
     await statement.finalizeAsync();
   });
 
-  it('concurrent reads over one shared statement should not corrupt each other', async () => {
-    await db.execAsync(`
-  CREATE TABLE IF NOT EXISTS shared (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
-  INSERT INTO shared (id, value) VALUES (1, 'one');
-  INSERT INTO shared (id, value) VALUES (2, 'two');
-  INSERT INTO shared (id, value) VALUES (3, 'three');
-  `);
-    const statement = await db.prepareAsync('SELECT value FROM shared WHERE id = ?');
-    const readAsync = async (id: number) => {
-      const result = await statement.executeAsync<{ value: string }>(id);
-      const rows = await result.getAllAsync();
-      return rows.map((row) => row.value);
-    };
-    const [first, second, third] = await Promise.all([readAsync(1), readAsync(2), readAsync(3)]);
-    expect(first).toEqual(['one']);
-    expect(second).toEqual(['two']);
-    expect(third).toEqual(['three']);
-    await statement.finalizeAsync();
-  });
-
-  it('a cursor abandoned without reading rows should not block later executions', async () => {
-    const statement = await db.prepareAsync('SELECT value FROM test WHERE intValue = ?');
-    // Never read the rows of the first execution.
-    await statement.executeAsync<TestEntity>(123);
-    const result = await statement.executeAsync<TestEntity>(456);
-    expect(await result.getAllAsync()).toEqual([{ value: 'test1' }]);
-    await statement.finalizeAsync();
-  });
-
-  it('a partially iterated cursor should not block later executions', async () => {
-    const statement = await db.prepareAsync('SELECT intValue FROM test ORDER BY intValue ASC');
-    const result = await statement.executeAsync<TestEntity>();
-    for await (const row of result) {
-      expect(row.intValue).toBe(123);
-      break;
-    }
-    const second = await statement.executeAsync<TestEntity>();
-    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([123, 456, 789]);
-    await statement.finalizeAsync();
-  });
-
-  it('a failed execution should not block later executions', async () => {
-    const statement = await db.prepareAsync('SELECT value FROM test WHERE intValue = ?');
-    await expect(statement.executeAsync<TestEntity>(Symbol('bad') as any)).rejects.toThrow();
-    const result = await statement.executeAsync<TestEntity>(123);
-    expect(await result.getAllAsync()).toEqual([{ value: 'test1' }]);
-    await statement.finalizeAsync();
-  });
-
-  it('an execution started while another cursor is mid-fetch should still be serialized', async () => {
-    await db.execAsync(`
-  CREATE TABLE IF NOT EXISTS wide (id INTEGER PRIMARY KEY NOT NULL, tag TEXT NOT NULL);
-  INSERT INTO wide (id, tag) VALUES (1, 'a1');
-  INSERT INTO wide (id, tag) VALUES (2, 'a2');
-  INSERT INTO wide (id, tag) VALUES (3, 'b1');
-  `);
-    const statement = await db.prepareAsync('SELECT tag FROM wide WHERE tag LIKE ?');
-    const first = await statement.executeAsync<{ tag: string }>('a%');
-    // Start a second execution without awaiting, while the first cursor is unread.
-    const secondPromise = statement.executeAsync<{ tag: string }>('b%');
-    const firstRows = (await first.getAllAsync()).map((row) => row.tag);
-    const secondRows = (await (await secondPromise).getAllAsync()).map((row) => row.tag);
-    expect(firstRows).toEqual(['a1', 'a2']);
-    expect(secondRows).toEqual(['b1']);
-    await statement.finalizeAsync();
-  });
-
-  it('resetAsync on a cursor superseded by another execution should throw', async () => {
-    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
-    const first = await statement.executeAsync<TestEntity>(123);
-    expect((await first.getAllAsync()).map((row) => row.intValue)).toEqual([123]);
-    const second = await statement.executeAsync<TestEntity>(456);
-    // Resetting the stale cursor would rewind the second execution instead of the first.
-    await expect(first.resetAsync()).rejects.toThrow('can no longer be reset');
-    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([456]);
-    await statement.finalizeAsync();
-  });
-
-  it('several executions queued behind one unread cursor should each get their own rows', async () => {
-    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
-    const first = await statement.executeAsync<TestEntity>(123);
-    // Queue two more executions while the first cursor is still unread.
-    const secondPromise = statement.executeAsync<TestEntity>(456);
-    const thirdPromise = statement.executeAsync<TestEntity>(789);
-    const firstRows = (await first.getAllAsync()).map((row) => row.intValue);
-    const secondRows = (await (await secondPromise).getAllAsync()).map((row) => row.intValue);
-    const thirdRows = (await (await thirdPromise).getAllAsync()).map((row) => row.intValue);
-    expect(firstRows).toEqual([123]);
-    expect(secondRows).toEqual([456]);
-    expect(thirdRows).toEqual([789]);
-    await statement.finalizeAsync();
-  });
-
   it('reading a result after the statement ran again should throw, not return the later rows', async () => {
     const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
     const first = await statement.executeAsync<TestEntity>(123);
@@ -285,6 +192,41 @@ describe(SQLiteStatement, () => {
     const first = statement.executeSync<TestEntity>(123);
     statement.executeSync<TestEntity>(789);
     expect(() => first.getAllSync()).toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
+
+  it('concurrent reads over one shared statement should not return another reader rows', async () => {
+    await db.execAsync(`
+  CREATE TABLE IF NOT EXISTS shared (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+  INSERT INTO shared (id, value) VALUES (1, 'one');
+  INSERT INTO shared (id, value) VALUES (2, 'two');
+  INSERT INTO shared (id, value) VALUES (3, 'three');
+  `);
+    const statement = await db.prepareAsync('SELECT value FROM shared WHERE id = ?');
+    const readAsync = async (id: number) => {
+      const result = await statement.executeAsync<{ value: string }>(id);
+      try {
+        return (await result.getAllAsync()).map((row) => row.value);
+      } catch {
+        return 'superseded';
+      }
+    };
+    const results = await Promise.all([readAsync(1), readAsync(2), readAsync(3)]);
+    // One reader owns the cursor and the rest say so, but no reader gets another reader rows.
+    for (const result of results) {
+      expect(result === 'superseded' || result.length === 1).toBe(true);
+    }
+    expect(results.filter((result) => result !== 'superseded')).toHaveLength(1);
+    await statement.finalizeAsync();
+  });
+
+  it('resetAsync on a superseded result should throw', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    const second = await statement.executeAsync<TestEntity>(789);
+    // Resetting the stale result would rewind the cursor that `second` owns now.
+    await expect(first.resetAsync()).rejects.toThrow(/prepared statement ran again/);
+    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([789]);
     await statement.finalizeAsync();
   });
 });

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -322,4 +322,33 @@ describe(SQLiteStatement, () => {
     }
     await statement.finalizeAsync();
   });
+
+  it('concurrent writes over one shared statement should all apply', async () => {
+    // A write takes one native call and caches no rows, so the ownership check must not reject
+    // the reuse pattern that write-heavy callers rely on.
+    const statement = await db.prepareAsync('INSERT INTO test (value, intValue) VALUES (?, ?)');
+    await Promise.all([
+      statement.executeAsync('written', 1),
+      statement.executeAsync('written', 2),
+      statement.executeAsync('written', 3),
+    ]);
+    await statement.finalizeAsync();
+    const written = await db.getAllAsync<TestEntity>(
+      'SELECT intValue FROM test WHERE value = ? ORDER BY intValue ASC',
+      'written'
+    );
+    expect(written.map((row) => row.intValue)).toEqual([1, 2, 3]);
+  });
+
+  it('a write statement reused in a loop should keep returning its own row', async () => {
+    const statement = await db.prepareAsync(
+      'INSERT INTO test (value, intValue) VALUES (?, ?) RETURNING intValue'
+    );
+    for (const intValue of [11, 22, 33]) {
+      const result = await statement.executeAsync<TestEntity>('looped', intValue);
+      // `run` cached this row, so reading it steps no cursor even once superseded.
+      expect((await result.getFirstAsync())?.intValue).toBe(intValue);
+    }
+    await statement.finalizeAsync();
+  });
 });

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -250,4 +250,41 @@ describe(SQLiteStatement, () => {
     expect(thirdRows).toEqual([789]);
     await statement.finalizeAsync();
   });
+
+  it('reading a result after the statement ran again should throw, not return the later rows', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    const second = await statement.executeAsync<TestEntity>(789);
+    // `first` no longer owns the one native cursor, so it must not step `second`'s rows.
+    await expect(first.getAllAsync()).rejects.toThrow(/prepared statement ran again/);
+    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([789]);
+    await statement.finalizeAsync();
+  });
+
+  it('a superseded result that must step for its first row should throw', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue > ?');
+    // No row matches, so this result has no cached row and has to step the cursor.
+    const first = await statement.executeAsync<TestEntity>(1000);
+    await statement.executeAsync<TestEntity>(0);
+    await expect(first.getFirstAsync()).rejects.toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
+
+  it('a superseded result should still serve the first row it was already given', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    const second = await statement.executeAsync<TestEntity>(789);
+    // `run` handed each result its own first row, and serving it steps no cursor.
+    expect((await first.getFirstAsync())?.intValue).toBe(123);
+    expect((await second.getFirstAsync())?.intValue).toBe(789);
+    await statement.finalizeAsync();
+  });
+
+  it('executeSync results should be guarded the same way', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = statement.executeSync<TestEntity>(123);
+    statement.executeSync<TestEntity>(789);
+    expect(() => first.getAllSync()).toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
 });

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -157,4 +157,97 @@ describe(SQLiteStatement, () => {
     expect(row?.intValue).toBe(123);
     await statement.finalizeAsync();
   });
+
+  it('concurrent reads over one shared statement should not corrupt each other', async () => {
+    await db.execAsync(`
+  CREATE TABLE IF NOT EXISTS shared (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL);
+  INSERT INTO shared (id, value) VALUES (1, 'one');
+  INSERT INTO shared (id, value) VALUES (2, 'two');
+  INSERT INTO shared (id, value) VALUES (3, 'three');
+  `);
+    const statement = await db.prepareAsync('SELECT value FROM shared WHERE id = ?');
+    const readAsync = async (id: number) => {
+      const result = await statement.executeAsync<{ value: string }>(id);
+      const rows = await result.getAllAsync();
+      return rows.map((row) => row.value);
+    };
+    const [first, second, third] = await Promise.all([readAsync(1), readAsync(2), readAsync(3)]);
+    expect(first).toEqual(['one']);
+    expect(second).toEqual(['two']);
+    expect(third).toEqual(['three']);
+    await statement.finalizeAsync();
+  });
+
+  it('a cursor abandoned without reading rows should not block later executions', async () => {
+    const statement = await db.prepareAsync('SELECT value FROM test WHERE intValue = ?');
+    // Never read the rows of the first execution.
+    await statement.executeAsync<TestEntity>(123);
+    const result = await statement.executeAsync<TestEntity>(456);
+    expect(await result.getAllAsync()).toEqual([{ value: 'test1' }]);
+    await statement.finalizeAsync();
+  });
+
+  it('a partially iterated cursor should not block later executions', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test ORDER BY intValue ASC');
+    const result = await statement.executeAsync<TestEntity>();
+    for await (const row of result) {
+      expect(row.intValue).toBe(123);
+      break;
+    }
+    const second = await statement.executeAsync<TestEntity>();
+    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([123, 456, 789]);
+    await statement.finalizeAsync();
+  });
+
+  it('a failed execution should not block later executions', async () => {
+    const statement = await db.prepareAsync('SELECT value FROM test WHERE intValue = ?');
+    await expect(statement.executeAsync<TestEntity>(Symbol('bad') as any)).rejects.toThrow();
+    const result = await statement.executeAsync<TestEntity>(123);
+    expect(await result.getAllAsync()).toEqual([{ value: 'test1' }]);
+    await statement.finalizeAsync();
+  });
+
+  it('an execution started while another cursor is mid-fetch should still be serialized', async () => {
+    await db.execAsync(`
+  CREATE TABLE IF NOT EXISTS wide (id INTEGER PRIMARY KEY NOT NULL, tag TEXT NOT NULL);
+  INSERT INTO wide (id, tag) VALUES (1, 'a1');
+  INSERT INTO wide (id, tag) VALUES (2, 'a2');
+  INSERT INTO wide (id, tag) VALUES (3, 'b1');
+  `);
+    const statement = await db.prepareAsync('SELECT tag FROM wide WHERE tag LIKE ?');
+    const first = await statement.executeAsync<{ tag: string }>('a%');
+    // Start a second execution without awaiting, while the first cursor is unread.
+    const secondPromise = statement.executeAsync<{ tag: string }>('b%');
+    const firstRows = (await first.getAllAsync()).map((row) => row.tag);
+    const secondRows = (await (await secondPromise).getAllAsync()).map((row) => row.tag);
+    expect(firstRows).toEqual(['a1', 'a2']);
+    expect(secondRows).toEqual(['b1']);
+    await statement.finalizeAsync();
+  });
+
+  it('resetAsync on a cursor superseded by another execution should throw', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    expect((await first.getAllAsync()).map((row) => row.intValue)).toEqual([123]);
+    const second = await statement.executeAsync<TestEntity>(456);
+    // Resetting the stale cursor would rewind the second execution instead of the first.
+    await expect(first.resetAsync()).rejects.toThrow('can no longer be reset');
+    expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([456]);
+    await statement.finalizeAsync();
+  });
+
+  it('several executions queued behind one unread cursor should each get their own rows', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    // Queue two more executions while the first cursor is still unread.
+    const secondPromise = statement.executeAsync<TestEntity>(456);
+    const thirdPromise = statement.executeAsync<TestEntity>(789);
+    const firstRows = (await first.getAllAsync()).map((row) => row.intValue);
+    const secondRows = (await (await secondPromise).getAllAsync()).map((row) => row.intValue);
+    const thirdRows = (await (await thirdPromise).getAllAsync()).map((row) => row.intValue);
+    expect(firstRows).toEqual([123]);
+    expect(secondRows).toEqual([456]);
+    expect(thirdRows).toEqual([789]);
+    await statement.finalizeAsync();
+  });
 });

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -229,4 +229,97 @@ describe(SQLiteStatement, () => {
     expect((await second.getAllAsync()).map((row) => row.intValue)).toEqual([789]);
     await statement.finalizeAsync();
   });
+
+  it('a superseded result should throw from the async generator mid-iteration', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test ORDER BY intValue ASC');
+    const first = await statement.executeAsync<TestEntity>();
+    const iterator = first[Symbol.asyncIterator]();
+    expect((await iterator.next()).value?.intValue).toBe(123);
+    // Supersede the result while it is still part-way through its rows.
+    await statement.executeAsync<TestEntity>();
+    await expect(iterator.next()).rejects.toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
+
+  it('a superseded result should throw from the sync generator mid-iteration', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test ORDER BY intValue ASC');
+    const first = statement.executeSync<TestEntity>();
+    const iterator = first[Symbol.iterator]();
+    expect(iterator.next().value?.intValue).toBe(123);
+    statement.executeSync<TestEntity>();
+    expect(() => iterator.next()).toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
+
+  it('getFirstSync on a superseded result should throw', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue > ?');
+    // No row matches, so this result has no cached row and has to step the cursor.
+    const first = statement.executeSync<TestEntity>(1000);
+    statement.executeSync<TestEntity>(0);
+    expect(() => first.getFirstSync()).toThrow(/prepared statement ran again/);
+    await statement.finalizeAsync();
+  });
+
+  it('resetSync on a superseded result should throw', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = statement.executeSync<TestEntity>(123);
+    const second = statement.executeSync<TestEntity>(789);
+    // Resetting the stale result would rewind the cursor that `second` owns now.
+    expect(() => first.resetSync()).toThrow(/prepared statement ran again/);
+    expect(second.getAllSync().map((row) => row.intValue)).toEqual([789]);
+    await statement.finalizeAsync();
+  });
+
+  it('executeForRawResultAsync results should be guarded the same way', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeForRawResultAsync<TestEntity>(123);
+    const second = await statement.executeForRawResultAsync<TestEntity>(789);
+    await expect(first.getAllAsync()).rejects.toThrow(/prepared statement ran again/);
+    expect(await second.getAllAsync()).toEqual([[789]]);
+    await statement.finalizeAsync();
+  });
+
+  it('only the last of several executions should own the cursor', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const first = await statement.executeAsync<TestEntity>(123);
+    const second = await statement.executeAsync<TestEntity>(456);
+    const third = await statement.executeAsync<TestEntity>(789);
+    await expect(first.getAllAsync()).rejects.toThrow(/prepared statement ran again/);
+    await expect(second.getAllAsync()).rejects.toThrow(/prepared statement ran again/);
+    expect((await third.getAllAsync()).map((row) => row.intValue)).toEqual([789]);
+    await statement.finalizeAsync();
+  });
+
+  it('executions queued with no read between them should all settle', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    // A result left unread must not keep later executions from resolving.
+    await statement.executeAsync<TestEntity>(123);
+    const queued = [
+      statement.executeAsync<TestEntity>(456),
+      statement.executeAsync<TestEntity>(789),
+      statement.executeAsync<TestEntity>(123),
+    ];
+    await expect(Promise.all(queued)).resolves.toHaveLength(3);
+    await statement.finalizeAsync();
+  });
+
+  it('a sync execution should supersede an earlier async result', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const asyncResult = await statement.executeAsync<TestEntity>(123);
+    const syncResult = statement.executeSync<TestEntity>(789);
+    await expect(asyncResult.getAllAsync()).rejects.toThrow(/prepared statement ran again/);
+    expect(syncResult.getAllSync().map((row) => row.intValue)).toEqual([789]);
+    await statement.finalizeAsync();
+  });
+
+  it('a statement should stay usable across many executions', async () => {
+    const statement = await db.prepareAsync('SELECT intValue FROM test WHERE intValue = ?');
+    const values = [123, 456, 789] as const;
+    for (let index = 0; index < 60; index++) {
+      const intValue = values[index % values.length] as number;
+      const result = await statement.executeAsync<TestEntity>(intValue);
+      expect((await result.getAllAsync()).map((row) => row.intValue)).toEqual([intValue]);
+    }
+    await statement.finalizeAsync();
+  });
 });


### PR DESCRIPTION
Fixes #49787. Supersedes #49795.

# Why

A `SQLiteStatement` wraps one `sqlite3_stmt`, so it has one cursor, but every `executeAsync` hands back a new result that shares it. Reading all the rows takes two native calls, `run` and then `getAll`, and a second execution in between rebinds that cursor. The earlier result steps the later run's rows and returns them as its own, silently.

No concurrency is needed. Run the statement twice, read both results, and the first gives you the second's rows. A step past `SQLITE_DONE` makes SQLite reset and re-run the query under the current bindings, which is where the duplicated row comes from.

There's a second defect in the same area: `run` takes `statement.lock` but `step`, `getAll`, `reset` and `finalize` don't, and `moduleQueue` is concurrent, so those calls do reach one `sqlite3_stmt` from several threads.

# How

The statement records which result owns its cursor, and a superseded result throws instead of returning another run's rows. The check sits right before a native step, so a result serving the first row `run` already gave it keeps working, since that path steps nothing. Both resets are guarded too, because resetting a stale result would rewind the cursor the current run owns. It's all shared JS, so Android and web get it as well.

The four native functions take the same per-statement lock `run` does, on both platforms. `finalize` is in there because it frees a `sqlite3_stmt` other threads may still be stepping.

One consequence: concurrent readers of a single shared statement get an error rather than wrong rows. Making them all succeed would mean holding the cursor across `run` and the fetching that follows, and nothing at that point tells us whether a caller will ever read its result, so one unread cursor would stall every execution behind it. A statement per reader stays the pattern that works.

# Test Plan

`et check-packages expo-sqlite` is green, covering both corruption shapes, the guarded surfaces on the sync and async APIs, both generators mid-iteration, and the write paths the check must not reject.

On iOS, `et native-unit-tests --packages expo-sqlite` drives one shared statement from 500 concurrent callers and asserts every value read is one the table holds. Both suites fail if you take the respective guard back out, so they pin the fix rather than passing alongside it.
