### PR TITLE
[docs] Use sentence case for the site name in page titles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Expo Documentation
+# Expo documentation
 
 This is the public documentation for **Expo**, its SDK, client, and services (**EAS**). This documentation is built using Next.js and you can access it online at https://docs.expo.dev/.
 

--- a/docs/common/i18n.ts
+++ b/docs/common/i18n.ts
@@ -120,7 +120,7 @@ export const OG_LOCALES: Record<SupportedLocale, string> = {
 };
 
 export const SITE_NAMES: Record<SupportedLocale, string> = {
-  en: 'Expo Documentation',
+  en: 'Expo documentation',
   ja: 'Expo ドキュメント',
 };
 

--- a/docs/constants/structured-data.ts
+++ b/docs/constants/structured-data.ts
@@ -67,7 +67,7 @@ export function buildFAQPageSchema(items: FAQItem[]) {
 export const websiteSchema = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
-  name: 'Expo Documentation',
+  name: 'Expo documentation',
   description: BASE_DESCRIPTIONS.en,
   url: 'https://docs.expo.dev',
   publisher: {

--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -11,7 +11,7 @@ import { WHEN_TO_USE_SECTION } from './transforms/when-to-use.js';
 
 const OUTPUT_DIRECTORY_NAME = 'public';
 const OUTPUT_FILENAME_LLMS_TXT = 'llms.txt';
-const TITLE = 'Expo Documentation';
+const TITLE = 'Expo documentation';
 
 function isOverviewItem(item) {
   return item.overview === true || item.url.endsWith('/overview.md');


### PR DESCRIPTION
# Why

Every docs page title ends with "Expo Documentation". Our style guide uses sentence case for titles and headings, so the suffix should read "Expo documentation".

# How

Changed the English site name from "Expo Documentation" to "Expo documentation" in the four places it is defined:

- `docs/common/i18n.ts`: `SITE_NAMES.en`. This drives the `<title>` tag, the `og:site_name` meta tag, and the fallback OG image title on every page.
- `docs/constants/structured-data.ts`: the `WebSite` schema `name`, so structured data matches the site name.
- `docs/scripts/generate-llms/llms-txt.js`: the H1 title written to the generated `llms.txt`.
- `docs/README.md`: the top heading.

The Japanese site name is unchanged. The style guide file name "Expo Documentation Writing Style Guide" is unchanged because it is a file name.

# Test Plan

From `docs/`:

- `pnpm test -- common constants/structured-data generate-llms` passes.
- `pnpm test:worker` passes.
- `NODE_ENV=production pnpm lint --max-warnings 0` passes (oxlint, tsc, eslint).
- `pnpm lint-prose` passes with 0 errors.
- `git grep -i "expo documentation"` across the repo finds no remaining title-cased uses other than the style guide file name.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) (not applicable, docs only)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). (not applicable)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
