### PR TITLE
[expo-modules-core][Android] Warn when installModules() gives up waiting for an active ReactInstance

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Warn instead of failing silently when `installModules()` gives up waiting for an active `ReactInstance`. Previously JSI interop was installed into a context with no active instance and the method still returned `true`, so the first visible symptom was `globalThis.expo` being undefined in JS. ([#49800](https://github.com/expo/expo/issues/49800) by [@JeffreyKlug](https://github.com/JeffreyKlug))
 - [iOS] Fixed the tap that closes a SwiftUI menu still sending `touchStart`, `onPressIn` and `onPressOut` to the React Native view underneath it. React Native's touch handler is now told to skip that tap before UIKit delivers it, instead of being cancelled afterwards. ([#48419](https://github.com/expo/expo/issues/48419) by [@nahooni0511](https://github.com/nahooni0511), [#49775](https://github.com/expo/expo/pull/49775) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [Android] Fix Expo module views not receiving props with React Native 0.87.
 - [iOS][Android] Fixed a `matchContents` `RNHostView` and the `matchContents` host around it feeding each other's size back and forth, which grew the layout on every pass. ([#49483](https://github.com/expo/expo/pull/49483) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ExpoBridgeModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin
 
+import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
@@ -20,8 +21,19 @@ class ExpoBridgeModule(
   fun installModules(): Boolean {
     // Bridgeless ReactHostImpl may have BridgelessReactContext ready but not ReactInstance.
     // Try to busy wait until ReactInstance is available so we could get the javaScriptContextHolder.
-    tryWaitSync(waitMs = 100, retries = 10) {
+    val ready = tryWaitSync(waitMs = 100, retries = 10) {
       reactApplicationContext.hasActiveReactInstance()
+    }
+    if (!ready) {
+      // Don't fall through silently: without an active ReactInstance, installJSIInterop()
+      // below installs nothing into the runtime and this method still returns true, so the
+      // first visible symptom is JS reading `globalThis.expo` as undefined ("Cannot read
+      // property 'EventEmitter' of undefined") — far from the cause.
+      Log.w(
+        "ExpoBridgeModule",
+        "hasActiveReactInstance() is still false after waiting; installing JSI interop anyway. " +
+          "globalThis.expo will most likely be missing in the JS runtime."
+      )
     }
     val kotlinInterop = nativeModulesProxy.get()?.kotlinInteropModuleRegistry
       ?: throw IllegalStateException("Couldn't find KotlinInteropModuleRegistry")
@@ -30,12 +42,16 @@ class ExpoBridgeModule(
     return true
   }
 
-  private fun tryWaitSync(waitMs: Long, retries: Int, predicate: () -> Boolean) {
-    repeat(retries) inner@{
+  /**
+   * Returns whether the predicate became true within the given budget.
+   */
+  private fun tryWaitSync(waitMs: Long, retries: Int, predicate: () -> Boolean): Boolean {
+    repeat(retries) {
       if (predicate()) {
-        return
+        return true
       }
       Thread.sleep(waitMs)
     }
+    return predicate()
   }
 }


### PR DESCRIPTION
# Why

On Android with bridgeless enabled, `ExpoBridgeModule.installModules()` busy-waits for `hasActiveReactInstance()` (100 ms × 10). When that budget expires, the method currently **falls through silently**: `installJSIInterop()` runs against a context with no active `ReactInstance`, installs nothing into the runtime, and `installModules()` still returns `true`.

The first visible symptom is then in JS, far from the cause: `ensureNativeModulesAreInstalled` proceeds, `globalThis.expo` is undefined, and the app dies with `Cannot read property 'EventEmitter' of undefined`. Under a test runner (Detox in our case) even that is swallowed, and the whole failure surfaces as "can't connect to the app" — we spent three separate investigations chasing wrong suspects before adding this one log line locally.

Context and logs in #49800 (closed for lacking a minimal repro — the trigger is a timing race on slow/emulated hosts and isn't deterministically reproducible from a fresh scaffold, which is exactly why the silent path is worth fixing: when it does fire, nothing points at it).

This PR deliberately does **not** widen the timeout. We measured a 10 s budget on the affected emulator: the instance was still inactive after 10 s on both a loaded and a quiet host, while real hardware passes the stock 1 s wait — it's not a race a bigger budget wins. The defect worth fixing upstream is the silence.

# How

- `tryWaitSync` now returns whether the predicate became true within the budget (with one final re-check after the last sleep).
- When the wait expires, `installModules()` logs a `Log.w` naming the actual condition (`hasActiveReactInstance()` still false) and the consequence (`globalThis.expo` will most likely be missing), then proceeds exactly as before.

No behavior change on the success path; the failure path gains one warning.

# Test Plan

- Failing emulator (Android API 35 AVD where the instance never activates): the warning appears in logcat immediately before the JS `EventEmitter of undefined` error, correctly naming the cause.
- Real hardware (LG LM-G850, Android 10) and healthy emulators: predicate passes within the wait, no log emitted, behavior unchanged.
- Running as a patch-package equivalent against expo-modules-core 57.0.6 across a 7-app monorepo since 2026-09-05.

# Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
